### PR TITLE
[github] Adds Issue and PR Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,48 @@
+<!--
+
+This issue queue is primarily intended for tracking features, bugs and work items associated with
+the dd-agent open-source project.
+
+Prior to submitting an issue please review the following:
+
+- [ ] [Troubleshooting](https://datadog.zendesk.com/hc/en-us/sections/200766955-Troubleshooting) section of our [Knowledge base](https://datadog.zendesk.com/hc/en-us).
+- [ ] Contact our [support](http://docs.datadoghq.com/help/) and [send them your logs](https://github.com/DataDog/dd-agent/wiki/Send-logs-to-support).
+- [ ] Finally, you can open a Github issue respecting this [title convention](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md#commits-titles) (it helps us triage).
+
+If you are reporting a new issue, make sure that we do not have any duplicates
+already open. You can ensure this by searching the issue list for this
+repository. If there is a duplicate, please close your issue and add a comment
+to the existing issue instead.
+
+If you suspect your issue is a bug, please edit your issue description to
+include the BUG REPORT INFORMATION shown below.
+
+---------------------------------------------------
+BUG REPORT INFORMATION
+---------------------------------------------------
+Use the commands below to provide key information from your environment:
+You do NOT have to include this information if this is a FEATURE REQUEST
+-->
+
+**Output of the [info page](https://help.datadoghq.com/hc/en-us/articles/203764635-Agent-Status-and-Information) **
+
+```
+(paste your output here)
+```
+
+**Additional environment details (Operating System, Cloud provider, etc):**
+
+
+**Steps to reproduce the issue:**
+1.
+2.
+3.
+
+
+**Describe the results you received:**
+
+
+**Describe the results you expected:**
+
+
+**Additional information you deem important (e.g. issue happens only occasionally):**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
+if you have not yet done so.*
+
+
+### What does this PR do?
+
+A brief description of the change being made with this pull request.
+
+### Motivation
+
+What inspired you to submit this pull request?
+
+### Testing Guidelines
+
+An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
+is available in our contribution guidelines.
+
+### Additional Notes
+
+Anything else we should know when reviewing?


### PR DESCRIPTION
These need updated links before merging, however the ones we use on the dd-agent repo are basically drop in here.
