### PR TITLE
[deps] add missing pylint dependency

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ nose==1.3.4
 flake8==2.5.1
 mock==1.0.1
 pep8==1.5.7
+pylint==1.6.4


### PR DESCRIPTION
`rake lint` requires it