### PR TITLE
fixes mysql test failure

### DIFF
--- a/mysql/ci/start-docker.sh
+++ b/mysql/ci/start-docker.sh
@@ -12,7 +12,7 @@ if docker ps | grep dd-test-mysql >/dev/null; then
   bash mysql/ci/stop-docker.sh
 fi
 
-MYSQL00_ID=$(docker run -p 3306:3306 --name $NAME -e MYSQL_ROOT_PASSWORD=datadog -d mysql:5.7)
+MYSQL00_ID=$(docker run -p $PORT:3306 --name $NAME -e MYSQL_ROOT_PASSWORD=datadog -d mysql:5.7)
 MYSQL00_IP=$(docker inspect ${MYSQL00_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 MYSQL00_IP=$(echo $MYSQL00_IP | cut -d " " -f2)
 echo 'running'

--- a/mysql/test_mysql.py
+++ b/mysql/test_mysql.py
@@ -16,7 +16,7 @@ class TestMySql(AgentCheckTest):
     CHECK_NAME = 'mysql'
 
     METRIC_TAGS = ['tag1', 'tag2']
-    SC_TAGS = ['server:localhost', 'port:3306']
+    SC_TAGS = ['server:localhost', 'port:13306']
     SC_FAILURE_TAGS = ['server:localhost', 'port:unix_socket']
 
 
@@ -24,14 +24,14 @@ class TestMySql(AgentCheckTest):
         'server': 'localhost',
         'user': 'dog',
         'pass': 'dog',
-        'port': '3306'
+        'port': '13306'
     }]
 
     MYSQL_COMPLEX_CONFIG = [{
         'server': 'localhost',
         'user': 'dog',
         'pass': 'dog',
-        'port': '3306',
+        'port': '13306',
         'options': {
             'replication': True,
             'extra_status_metrics': True,


### PR DESCRIPTION
Currently the mysql tests are failing, it's because there's a port overlap in travis. This should resolve that by changing the port the docker container broadcasts on in localhost.