### PR TITLE
[rake] Add temp task to identify checks not up-to-date with `dd-agent`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,18 @@
+# We allow longer lines in our style
+Metrics/LineLength:
+  Max: 150
+
+# TODO/FIXME:
+# At some point, we might just want to do the changes and get rid of those
+
+Metrics/ClassLength:
+  Max: 128
+
+Metrics/MethodLength:
+  Max: 20
+
+Style/Documentation:
+  Enabled: false
+
+Style/SingleLineBlockParams:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -19,14 +19,14 @@ ENV['SDK_HOME'] = File.dirname(__FILE__)
 spec = Gem::Specification.find_by_name 'datadog-sdk-testing'
 load "#{spec.gem_dir}/lib/tasks/sdk.rake"
 
-def find_check_files()
+def find_check_files
   Dir.glob("#{ENV['SDK_HOME']}/*/check.py").collect do |file_path|
     check_basename = "#{File.basename(File.dirname(file_path))}.py"
     [check_basename, file_path]
   end.entries
 end
 
-def find_yaml_confs()
+def find_yaml_confs
   yaml_confs = Dir.glob("#{ENV['SDK_HOME']}/*/conf.yaml.example").collect do |file_path|
     yaml_basename = "#{File.basename(File.dirname(file_path))}.yaml.example"
     [yaml_basename, file_path]
@@ -42,27 +42,41 @@ def find_inconsistencies(files, dd_agent_base_dir)
   inconsistencies = []
   files.each do |file_basename, file_path|
     file_content = File.read(file_path)
-    dd_agent_file_path = File.join(ENV['SDK_HOME'], 'embedded', 'dd-agent', dd_agent_base_dir, file_basename)
-    if not File.exist?(dd_agent_file_path)
+    dd_agent_file_path = File.join(
+      ENV['SDK_HOME'],
+      'embedded',
+      'dd-agent',
+      dd_agent_base_dir,
+      file_basename
+    )
+    unless File.exist?(dd_agent_file_path)
       inconsistencies << "#{file_basename} not found in dd-agent/#{dd_agent_base_dir}/"
       next
     end
-    dd_agent_file_content = File.read(dd_agent_file_path)
-    if file_content != dd_agent_file_content
+    if file_content != File.read(dd_agent_file_path)
       inconsistencies << file_basename
     end
   end
+  inconsistencies
+end
 
+def print_inconsistencies(display_name, inconsistencies)
   if inconsistencies.empty?
-    puts "No #{dd_agent_base_dir} inconsistencies found"
+    puts "No #{display_name} inconsistencies found"
   else
-    puts "## #{dd_agent_base_dir} inconsistencies:"
+    puts "## #{display_name} inconsistencies:"
     puts inconsistencies.join("\n")
   end
 end
 
 desc 'Outputs the checks/example configs of this repo that do not match the ones in `dd-agent` (temporary task)'
 task dd_agent_consistency: [:pull_latest_agent] do
-  find_inconsistencies(find_check_files(), 'checks.d')
-  find_inconsistencies(find_yaml_confs(), 'conf.d')
+  print_inconsistencies(
+    'check file',
+    find_inconsistencies(find_check_files, 'checks.d')
+  )
+  print_inconsistencies(
+    'yaml example file',
+    find_inconsistencies(find_yaml_confs, 'conf.d')
+  )
 end

--- a/Rakefile
+++ b/Rakefile
@@ -18,3 +18,51 @@ ENV['SDK_HOME'] = File.dirname(__FILE__)
 
 spec = Gem::Specification.find_by_name 'datadog-sdk-testing'
 load "#{spec.gem_dir}/lib/tasks/sdk.rake"
+
+def find_check_files()
+  Dir.glob("#{ENV['SDK_HOME']}/*/check.py").collect do |file_path|
+    check_basename = "#{File.basename(File.dirname(file_path))}.py"
+    [check_basename, file_path]
+  end.entries
+end
+
+def find_yaml_confs()
+  yaml_confs = Dir.glob("#{ENV['SDK_HOME']}/*/conf.yaml.example").collect do |file_path|
+    yaml_basename = "#{File.basename(File.dirname(file_path))}.yaml.example"
+    [yaml_basename, file_path]
+  end.entries
+  yaml_confs += Dir.glob("#{ENV['SDK_HOME']}/*/conf/*.yaml.example").collect do |file_path|
+    yaml_basename = File.basename(file_path)
+    [yaml_basename, file_path]
+  end.entries
+  yaml_confs
+end
+
+def find_inconsistencies(files, dd_agent_base_dir)
+  inconsistencies = []
+  files.each do |file_basename, file_path|
+    file_content = File.read(file_path)
+    dd_agent_file_path = File.join(ENV['SDK_HOME'], 'embedded', 'dd-agent', dd_agent_base_dir, file_basename)
+    if not File.exist?(dd_agent_file_path)
+      inconsistencies << "#{file_basename} not found in dd-agent/#{dd_agent_base_dir}/"
+      next
+    end
+    dd_agent_file_content = File.read(dd_agent_file_path)
+    if file_content != dd_agent_file_content
+      inconsistencies << file_basename
+    end
+  end
+
+  if inconsistencies.empty?
+    puts "No #{dd_agent_base_dir} inconsistencies found"
+  else
+    puts "## #{dd_agent_base_dir} inconsistencies:"
+    puts inconsistencies.join("\n")
+  end
+end
+
+desc 'Outputs the checks/example configs of this repo that do not match the ones in `dd-agent` (temporary task)'
+task dd_agent_consistency: [:pull_latest_agent] do
+  find_inconsistencies(find_check_files(), 'checks.d')
+  find_inconsistencies(find_yaml_confs(), 'conf.d')
+end


### PR DESCRIPTION
Checks that the checks and example config files in this repo match
those in dd-agent.

We shoud get rid of this task when we actually switch to the
integration sdk