### PR TITLE
[manifest] adding os_supported field to manifests.

### DIFF
--- a/activemq/manifest.json
+++ b/activemq/manifest.json
@@ -6,6 +6,6 @@
   "name": "activemq",
   "short_description": "Get metrics from activemq service in real time.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/activemq/manifest.json
+++ b/activemq/manifest.json
@@ -6,5 +6,6 @@
   "name": "activemq",
   "short_description": "Get metrics from activemq service in real time.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/activemq/manifest.json
+++ b/activemq/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "activemq",

--- a/activemq_xml/manifest.json
+++ b/activemq_xml/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "activemq_xml",

--- a/activemq_xml/manifest.json
+++ b/activemq_xml/manifest.json
@@ -6,4 +6,5 @@
   "name": "activemq_xml",
   "short_description": "Get metrics from activemq service in real time.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"

--- a/activemq_xml/manifest.json
+++ b/activemq_xml/manifest.json
@@ -6,5 +6,5 @@
   "name": "activemq_xml",
   "short_description": "Get metrics from activemq service in real time.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"

--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "Apache",
   "version": "0.1.0",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",

--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -4,6 +4,7 @@
   "display_name": "Apache",
   "version": "0.1.0",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "manifest_version": "0.1.0",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",

--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "support": "core",
   "os_supported": ["linux","apple","windows"],
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
 

--- a/btrfs/manifest.json
+++ b/btrfs/manifest.json
@@ -6,6 +6,6 @@
   "name": "btrfs",
   "short_description": "btrfs description.",
   "support": "core",
-  "os_supported": ["linux","apple"],
+  "supported_os": ["linux","mac_os"],
   "version": "0.1.0"
 }

--- a/btrfs/manifest.json
+++ b/btrfs/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "btrfs",

--- a/btrfs/manifest.json
+++ b/btrfs/manifest.json
@@ -6,5 +6,6 @@
   "name": "btrfs",
   "short_description": "btrfs description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/btrfs/manifest.json
+++ b/btrfs/manifest.json
@@ -6,6 +6,6 @@
   "name": "btrfs",
   "short_description": "btrfs description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","apple"],
   "version": "0.1.0"
 }

--- a/cacti/manifest.json
+++ b/cacti/manifest.json
@@ -6,6 +6,6 @@
   "name": "cacti",
   "short_description": "Visualize Cacti metrics and correlate with the rest of your applications in Datadog.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux"],
   "version": "0.1.0"
 }

--- a/cacti/manifest.json
+++ b/cacti/manifest.json
@@ -6,5 +6,6 @@
   "name": "cacti",
   "short_description": "Visualize Cacti metrics and correlate with the rest of your applications in Datadog.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/cacti/manifest.json
+++ b/cacti/manifest.json
@@ -6,6 +6,6 @@
   "name": "cacti",
   "short_description": "Visualize Cacti metrics and correlate with the rest of your applications in Datadog.",
   "support": "core",
-  "os_supported": ["linux"],
+  "supported_os": ["linux"],
   "version": "0.1.0"
 }

--- a/cacti/manifest.json
+++ b/cacti/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "cacti",

--- a/cassandra/manifest.json
+++ b/cassandra/manifest.json
@@ -6,5 +6,6 @@
   "name": "cassandra",
   "short_description": "Apache Cassandra is an open source distributed database management system.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/cassandra/manifest.json
+++ b/cassandra/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "cassandra",

--- a/cassandra/manifest.json
+++ b/cassandra/manifest.json
@@ -6,6 +6,6 @@
   "name": "cassandra",
   "short_description": "Apache Cassandra is an open source distributed database management system.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/ceph/manifest.json
+++ b/ceph/manifest.json
@@ -6,6 +6,6 @@
   "name": "ceph",
   "short_description": "Ceph is a distributed filesystem that provides scalable and redundant data access across multiple servers.",
   "support": "core",
-  "os_supported": ["linux","apple"],
+  "supported_os": ["linux","mac_os"],
   "version": "0.1.0"
 }

--- a/ceph/manifest.json
+++ b/ceph/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "ceph",

--- a/ceph/manifest.json
+++ b/ceph/manifest.json
@@ -6,6 +6,6 @@
   "name": "ceph",
   "short_description": "Ceph is a distributed filesystem that provides scalable and redundant data access across multiple servers.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","apple"],
   "version": "0.1.0"
 }

--- a/ceph/manifest.json
+++ b/ceph/manifest.json
@@ -6,5 +6,6 @@
   "name": "ceph",
   "short_description": "Ceph is a distributed filesystem that provides scalable and redundant data access across multiple servers.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -6,6 +6,6 @@
   "name": "consul",
   "short_description": "Consul is a tool for service discovery and configuration. It is distributed, highly available, and scalable.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "consul",

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -6,5 +6,6 @@
   "name": "consul",
   "short_description": "Consul is a tool for service discovery and configuration. It is distributed, highly available, and scalable.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "couch",
   "version": "0.1",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",

--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -5,7 +5,7 @@
   "version": "0.1",
   "support": "core",
   "os_supported": ["linux","apple","windows"],
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
 

--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -4,6 +4,7 @@
   "display_name": "couch",
   "version": "0.1",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "manifest_version": "0.1.0",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",

--- a/couchbase/manifest.json
+++ b/couchbase/manifest.json
@@ -6,6 +6,6 @@
   "name": "couchbase",
   "short_description": "couchbase description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/couchbase/manifest.json
+++ b/couchbase/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "couchbase",

--- a/couchbase/manifest.json
+++ b/couchbase/manifest.json
@@ -6,5 +6,6 @@
   "name": "couchbase",
   "short_description": "couchbase description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/directory/manifest.json
+++ b/directory/manifest.json
@@ -6,6 +6,6 @@
   "name": "directory",
   "short_description": "The Directory integration helps monitoring and reporting metrics on files for a provided directory.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/directory/manifest.json
+++ b/directory/manifest.json
@@ -6,5 +6,6 @@
   "name": "directory",
   "short_description": "The Directory integration helps monitoring and reporting metrics on files for a provided directory.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/directory/manifest.json
+++ b/directory/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "directory",

--- a/disk/manifest.json
+++ b/disk/manifest.json
@@ -6,5 +6,6 @@
   "name": "disk",
   "short_description": "The disk check gathers metrics on mounted disks.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/disk/manifest.json
+++ b/disk/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "disk",

--- a/disk/manifest.json
+++ b/disk/manifest.json
@@ -6,6 +6,6 @@
   "name": "disk",
   "short_description": "The disk check gathers metrics on mounted disks.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/dns_check/manifest.json
+++ b/dns_check/manifest.json
@@ -6,6 +6,6 @@
   "name": "dns_check",
   "short_description": "dns_check description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/dns_check/manifest.json
+++ b/dns_check/manifest.json
@@ -6,5 +6,6 @@
   "name": "dns_check",
   "short_description": "dns_check description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/dns_check/manifest.json
+++ b/dns_check/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "dns_check",

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "elastic",

--- a/etcd/manifest.json
+++ b/etcd/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "etcd",

--- a/etcd/manifest.json
+++ b/etcd/manifest.json
@@ -6,5 +6,6 @@
   "name": "etcd",
   "short_description": "etcd is a distributed reliable key-value store.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/etcd/manifest.json
+++ b/etcd/manifest.json
@@ -6,6 +6,6 @@
   "name": "etcd",
   "short_description": "etcd is a distributed reliable key-value store.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/fluentd/manifest.json
+++ b/fluentd/manifest.json
@@ -6,6 +6,6 @@
   "name": "fluentd",
   "short_description": "Fluentd is an open source data collector, which lets you unify the data collection and consumption for a better use and understanding of data.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/fluentd/manifest.json
+++ b/fluentd/manifest.json
@@ -6,5 +6,6 @@
   "name": "fluentd",
   "short_description": "Fluentd is an open source data collector, which lets you unify the data collection and consumption for a better use and understanding of data.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/fluentd/manifest.json
+++ b/fluentd/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "fluentd",

--- a/gearmand/manifest.json
+++ b/gearmand/manifest.json
@@ -6,6 +6,6 @@
   "name": "gearmand",
   "short_description": "Visualize Gearman performance, know how many tasks are queued or running, correlate the performance of Gearman with the rest of your applications.",
   "support": "core",
-  "os_supported": ["linux","apple"],
+  "supported_os": ["linux","mac_os"],
   "version": "0.1.0"
 }

--- a/gearmand/manifest.json
+++ b/gearmand/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "gearmand",

--- a/gearmand/manifest.json
+++ b/gearmand/manifest.json
@@ -6,5 +6,6 @@
   "name": "gearmand",
   "short_description": "Visualize Gearman performance, know how many tasks are queued or running, correlate the performance of Gearman with the rest of your applications.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/gearmand/manifest.json
+++ b/gearmand/manifest.json
@@ -6,6 +6,6 @@
   "name": "gearmand",
   "short_description": "Visualize Gearman performance, know how many tasks are queued or running, correlate the performance of Gearman with the rest of your applications.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","apple"],
   "version": "0.1.0"
 }

--- a/go_expvar/manifest.json
+++ b/go_expvar/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "go_expvar",

--- a/go_expvar/manifest.json
+++ b/go_expvar/manifest.json
@@ -6,5 +6,6 @@
   "name": "go_expvar",
   "short_description": "Expvars is a golang package to expose variables via http.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/go_expvar/manifest.json
+++ b/go_expvar/manifest.json
@@ -6,6 +6,6 @@
   "name": "go_expvar",
   "short_description": "Expvars is a golang package to expose variables via http.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/gunicorn/manifest.json
+++ b/gunicorn/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "gunicorn",

--- a/gunicorn/manifest.json
+++ b/gunicorn/manifest.json
@@ -6,6 +6,6 @@
   "name": "gunicorn",
   "short_description": "Gunicorn is a Python WSGI HTTP Server for UNIX.",
   "support": "core",
-  "os_supported": ["linux","apple"],
+  "supported_os": ["linux","mac_os"],
   "version": "0.1.0"
 }

--- a/gunicorn/manifest.json
+++ b/gunicorn/manifest.json
@@ -6,5 +6,6 @@
   "name": "gunicorn",
   "short_description": "Gunicorn is a Python WSGI HTTP Server for UNIX.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/gunicorn/manifest.json
+++ b/gunicorn/manifest.json
@@ -6,6 +6,6 @@
   "name": "gunicorn",
   "short_description": "Gunicorn is a Python WSGI HTTP Server for UNIX.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","apple"],
   "version": "0.1.0"
 }

--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -5,7 +5,7 @@
   "version": "0.1",
   "support": "core",
   "os_supported": ["linux","apple","windows"],
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
 

--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "haproxy",
   "version": "0.1",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",

--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -4,6 +4,7 @@
   "display_name": "haproxy",
   "version": "0.1",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "manifest_version": "0.1.0",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",

--- a/hdfs_datanode/manifest.json
+++ b/hdfs_datanode/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "hdfs_datanode",

--- a/hdfs_datanode/manifest.json
+++ b/hdfs_datanode/manifest.json
@@ -6,6 +6,6 @@
   "name": "hdfs_datanode",
   "short_description": "hdfs_datanode description.",
   "support": "core",
-  "os_supported": ["linux","apple"],
+  "supported_os": ["linux","mac_os"],
   "version": "0.1.0"
 }

--- a/hdfs_datanode/manifest.json
+++ b/hdfs_datanode/manifest.json
@@ -6,6 +6,6 @@
   "name": "hdfs_datanode",
   "short_description": "hdfs_datanode description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","apple"],
   "version": "0.1.0"
 }

--- a/hdfs_datanode/manifest.json
+++ b/hdfs_datanode/manifest.json
@@ -6,5 +6,6 @@
   "name": "hdfs_datanode",
   "short_description": "hdfs_datanode description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/hdfs_namenode/manifest.json
+++ b/hdfs_namenode/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "hdfs_namenode",

--- a/hdfs_namenode/manifest.json
+++ b/hdfs_namenode/manifest.json
@@ -6,5 +6,6 @@
   "name": "hdfs_namenode",
   "short_description": "hdfs_namenode description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/hdfs_namenode/manifest.json
+++ b/hdfs_namenode/manifest.json
@@ -6,6 +6,6 @@
   "name": "hdfs_namenode",
   "short_description": "hdfs_namenode description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","apple"],
   "version": "0.1.0"
 }

--- a/hdfs_namenode/manifest.json
+++ b/hdfs_namenode/manifest.json
@@ -6,6 +6,6 @@
   "name": "hdfs_namenode",
   "short_description": "hdfs_namenode description.",
   "support": "core",
-  "os_supported": ["linux","apple"],
+  "supported_os": ["linux","mac_os"],
   "version": "0.1.0"
 }

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "http_check",

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -6,5 +6,6 @@
   "name": "http_check",
   "short_description": "http_check description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -6,6 +6,6 @@
   "name": "http_check",
   "short_description": "http_check description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/iis/manifest.json
+++ b/iis/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "iis",

--- a/iis/manifest.json
+++ b/iis/manifest.json
@@ -6,6 +6,6 @@
   "name": "iis",
   "short_description": "iis description.",
   "support": "core",
-  "os_supported": ["windows"],
+  "supported_os": ["windows"],
   "version": "0.1.0"
 }

--- a/iis/manifest.json
+++ b/iis/manifest.json
@@ -6,6 +6,6 @@
   "name": "iis",
   "short_description": "iis description.",
   "support": "core",
-  "os_supported": ["linux","windows"],
+  "os_supported": ["windows"],
   "version": "0.1.0"
 }

--- a/iis/manifest.json
+++ b/iis/manifest.json
@@ -5,6 +5,7 @@
   "min_agent_version": "5.6.3",
   "name": "iis",
   "short_description": "iis description.",
-  "support": "contrib",
+  "support": "core",
+  "os_supported": ["linux","windows"],
   "version": "0.1.0"
 }

--- a/kafka/manifest.json
+++ b/kafka/manifest.json
@@ -6,6 +6,6 @@
   "name": "kafka",
   "short_description": "Apache Kafka is publish-subscribe messaging rethought as a distributed commit log.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/kafka/manifest.json
+++ b/kafka/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "kafka",

--- a/kafka/manifest.json
+++ b/kafka/manifest.json
@@ -6,5 +6,6 @@
   "name": "kafka",
   "short_description": "Apache Kafka is publish-subscribe messaging rethought as a distributed commit log.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/kafka_consumer/manifest.json
+++ b/kafka_consumer/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "kafka_consumer",

--- a/kafka_consumer/manifest.json
+++ b/kafka_consumer/manifest.json
@@ -6,6 +6,6 @@
   "name": "kafka_consumer",
   "short_description": "Apache Kafka is publish-subscribe messaging rethought as a distributed commit log.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","apple"],
   "version": "0.1.0"
 }

--- a/kafka_consumer/manifest.json
+++ b/kafka_consumer/manifest.json
@@ -6,6 +6,6 @@
   "name": "kafka_consumer",
   "short_description": "Apache Kafka is publish-subscribe messaging rethought as a distributed commit log.",
   "support": "core",
-  "os_supported": ["linux","apple"],
+  "supported_os": ["linux","mac_os"],
   "version": "0.1.0"
 }

--- a/kafka_consumer/manifest.json
+++ b/kafka_consumer/manifest.json
@@ -6,5 +6,6 @@
   "name": "kafka_consumer",
   "short_description": "Apache Kafka is publish-subscribe messaging rethought as a distributed commit log.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/kong/manifest.json
+++ b/kong/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "kong",

--- a/kong/manifest.json
+++ b/kong/manifest.json
@@ -6,5 +6,6 @@
   "name": "kong",
   "short_description": "Kong is an open-source management layer for APIs, delivering high performance and reliability.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/kong/manifest.json
+++ b/kong/manifest.json
@@ -6,6 +6,6 @@
   "name": "kong",
   "short_description": "Kong is an open-source management layer for APIs, delivering high performance and reliability.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/kyototycoon/manifest.json
+++ b/kyototycoon/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "kyototycoon",

--- a/kyototycoon/manifest.json
+++ b/kyototycoon/manifest.json
@@ -6,6 +6,6 @@
   "name": "kyototycoon",
   "short_description": "Kyoto Tycoon is a lightweight database server with automatic expiration mechanism.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/kyototycoon/manifest.json
+++ b/kyototycoon/manifest.json
@@ -6,5 +6,6 @@
   "name": "kyototycoon",
   "short_description": "Kyoto Tycoon is a lightweight database server with automatic expiration mechanism.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/lighttpd/manifest.json
+++ b/lighttpd/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "lighttpd",

--- a/lighttpd/manifest.json
+++ b/lighttpd/manifest.json
@@ -6,5 +6,6 @@
   "name": "lighttpd",
   "short_description": "Lighttpd is a secure, fast, compliant, and very flexible web-server that has been optimized for high-performance environments.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/lighttpd/manifest.json
+++ b/lighttpd/manifest.json
@@ -6,6 +6,6 @@
   "name": "lighttpd",
   "short_description": "Lighttpd is a secure, fast, compliant, and very flexible web-server that has been optimized for high-performance environments.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/linux_proc_extras/manifest.json
+++ b/linux_proc_extras/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "linux_proc_extras",

--- a/linux_proc_extras/manifest.json
+++ b/linux_proc_extras/manifest.json
@@ -6,6 +6,6 @@
   "name": "linux_proc_extras",
   "short_description": "linux_proc_extras description.",
   "support": "core",
-  "os_supported": ["linux"],
+  "supported_os": ["linux"],
   "version": "0.1.0"
 }

--- a/linux_proc_extras/manifest.json
+++ b/linux_proc_extras/manifest.json
@@ -6,5 +6,6 @@
   "name": "linux_proc_extras",
   "short_description": "linux_proc_extras description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/linux_proc_extras/manifest.json
+++ b/linux_proc_extras/manifest.json
@@ -6,6 +6,6 @@
   "name": "linux_proc_extras",
   "short_description": "linux_proc_extras description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux"],
   "version": "0.1.0"
 }

--- a/mapreduce/manifest.json
+++ b/mapreduce/manifest.json
@@ -6,5 +6,6 @@
   "name": "mapreduce",
   "short_description": "mapreduce description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/mapreduce/manifest.json
+++ b/mapreduce/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "mapreduce",

--- a/mapreduce/manifest.json
+++ b/mapreduce/manifest.json
@@ -6,6 +6,6 @@
   "name": "mapreduce",
   "short_description": "mapreduce description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/marathon/manifest.json
+++ b/marathon/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "marathon",

--- a/marathon/manifest.json
+++ b/marathon/manifest.json
@@ -6,6 +6,6 @@
   "name": "marathon",
   "short_description": "marathon description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","apple"],
   "version": "0.1.0"
 }

--- a/marathon/manifest.json
+++ b/marathon/manifest.json
@@ -6,6 +6,6 @@
   "name": "marathon",
   "short_description": "marathon description.",
   "support": "core",
-  "os_supported": ["linux","apple"],
+  "supported_os": ["linux","mac_os"],
   "version": "0.1.0"
 }

--- a/marathon/manifest.json
+++ b/marathon/manifest.json
@@ -6,5 +6,6 @@
   "name": "marathon",
   "short_description": "marathon description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/mcache/manifest.json
+++ b/mcache/manifest.json
@@ -6,6 +6,6 @@
   "name": "mcache",
   "short_description": "Memcache is a general-purpose distributed memory caching system.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","apple"],
   "version": "0.1.0"
 }

--- a/mcache/manifest.json
+++ b/mcache/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "mcache",

--- a/mcache/manifest.json
+++ b/mcache/manifest.json
@@ -6,5 +6,6 @@
   "name": "mcache",
   "short_description": "Memcache is a general-purpose distributed memory caching system.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/mcache/manifest.json
+++ b/mcache/manifest.json
@@ -6,6 +6,6 @@
   "name": "mcache",
   "short_description": "Memcache is a general-purpose distributed memory caching system.",
   "support": "core",
-  "os_supported": ["linux","apple"],
+  "supported_os": ["linux","mac_os"],
   "version": "0.1.0"
 }

--- a/mesos_master/manifest.json
+++ b/mesos_master/manifest.json
@@ -6,6 +6,6 @@
   "name": "mesos_master",
   "short_description": "The Mesos master integration collects metrics from the Mesos master API.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","apple"],
   "version": "0.1.0"
 }

--- a/mesos_master/manifest.json
+++ b/mesos_master/manifest.json
@@ -6,6 +6,6 @@
   "name": "mesos_master",
   "short_description": "The Mesos master integration collects metrics from the Mesos master API.",
   "support": "core",
-  "os_supported": ["linux","apple"],
+  "supported_os": ["linux","mac_os"],
   "version": "0.1.0"
 }

--- a/mesos_master/manifest.json
+++ b/mesos_master/manifest.json
@@ -6,5 +6,6 @@
   "name": "mesos_master",
   "short_description": "The Mesos master integration collects metrics from the Mesos master API.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/mesos_master/manifest.json
+++ b/mesos_master/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "mesos_master",

--- a/mesos_slave/manifest.json
+++ b/mesos_slave/manifest.json
@@ -6,5 +6,6 @@
   "name": "mesos_master",
   "short_description": "The Mesos slave integration collects metrics from the Mesos slave APIs.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/mesos_slave/manifest.json
+++ b/mesos_slave/manifest.json
@@ -6,6 +6,6 @@
   "name": "mesos_master",
   "short_description": "The Mesos slave integration collects metrics from the Mesos slave APIs.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","apple"],
   "version": "0.1.0"
 }

--- a/mesos_slave/manifest.json
+++ b/mesos_slave/manifest.json
@@ -6,6 +6,6 @@
   "name": "mesos_master",
   "short_description": "The Mesos slave integration collects metrics from the Mesos slave APIs.",
   "support": "core",
-  "os_supported": ["linux","apple"],
+  "supported_os": ["linux","mac_os"],
   "version": "0.1.0"
 }

--- a/mesos_slave/manifest.json
+++ b/mesos_slave/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "mesos_master",

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -6,5 +6,6 @@
   "name": "mongo",
   "short_description": "MongoDB is an open-source, high-performance, schema-free, document-oriented database.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -6,6 +6,6 @@
   "name": "mongo",
   "short_description": "MongoDB is an open-source, high-performance, schema-free, document-oriented database.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "mongo",

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -5,7 +5,7 @@
   "version": "0.1.4",
   "support": "core",
   "os_supported": ["linux","apple","windows"],
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
 

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "MySQL",
   "version": "0.1.4",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -4,6 +4,7 @@
   "display_name": "MySQL",
   "version": "0.1.4",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "manifest_version": "0.1.0",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",

--- a/nagios/manifest.json
+++ b/nagios/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "nagios",

--- a/nagios/manifest.json
+++ b/nagios/manifest.json
@@ -6,5 +6,6 @@
   "name": "nagios",
   "short_description": "nagios description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/nagios/manifest.json
+++ b/nagios/manifest.json
@@ -6,6 +6,6 @@
   "name": "nagios",
   "short_description": "nagios description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/network/manifest.json
+++ b/network/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "network",

--- a/network/manifest.json
+++ b/network/manifest.json
@@ -6,5 +6,6 @@
   "name": "network",
   "short_description": "network description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/network/manifest.json
+++ b/network/manifest.json
@@ -6,6 +6,6 @@
   "name": "network",
   "short_description": "network description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/nginx/manifest.json
+++ b/nginx/manifest.json
@@ -6,6 +6,6 @@
   "name": "nginx",
   "short_description": "Nginx is a free, open-source, high-performance HTTP server and reverse proxy, as well as an IMAP/POP3 proxy server.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/nginx/manifest.json
+++ b/nginx/manifest.json
@@ -6,5 +6,6 @@
   "name": "nginx",
   "short_description": "Nginx is a free, open-source, high-performance HTTP server and reverse proxy, as well as an IMAP/POP3 proxy server.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/nginx/manifest.json
+++ b/nginx/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "nginx",

--- a/ntp/manifest.json
+++ b/ntp/manifest.json
@@ -6,5 +6,6 @@
   "name": "ntp",
   "short_description": "ntp description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/ntp/manifest.json
+++ b/ntp/manifest.json
@@ -6,6 +6,6 @@
   "name": "ntp",
   "short_description": "ntp description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/ntp/manifest.json
+++ b/ntp/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "ntp",

--- a/openstack/manifest.json
+++ b/openstack/manifest.json
@@ -6,6 +6,6 @@
   "name": "openstack",
   "short_description": "openstack description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/openstack/manifest.json
+++ b/openstack/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "openstack",

--- a/openstack/manifest.json
+++ b/openstack/manifest.json
@@ -6,5 +6,6 @@
   "name": "openstack",
   "short_description": "openstack description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/pgbouncer/manifest.json
+++ b/pgbouncer/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "pgbouncer",

--- a/pgbouncer/manifest.json
+++ b/pgbouncer/manifest.json
@@ -6,5 +6,6 @@
   "name": "pgbouncer",
   "short_description": "PGBouncer is an open-source, lightweight connection pooler for PostgreSQL.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/pgbouncer/manifest.json
+++ b/pgbouncer/manifest.json
@@ -6,6 +6,6 @@
   "name": "pgbouncer",
   "short_description": "PGBouncer is an open-source, lightweight connection pooler for PostgreSQL.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/php_fpm/manifest.json
+++ b/php_fpm/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "php_fpm",

--- a/php_fpm/manifest.json
+++ b/php_fpm/manifest.json
@@ -6,6 +6,6 @@
   "name": "php_fpm",
   "short_description": "PHP-FPM (FastCGI Process Manager) is an alternative PHP FastCGI implementation.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/php_fpm/manifest.json
+++ b/php_fpm/manifest.json
@@ -6,5 +6,6 @@
   "name": "php_fpm",
   "short_description": "PHP-FPM (FastCGI Process Manager) is an alternative PHP FastCGI implementation.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/postfix/manifest.json
+++ b/postfix/manifest.json
@@ -6,6 +6,6 @@
   "name": "postfix",
   "short_description": "Postfix is a free and open-source mail transfer agent that routes and delivers emails.",
   "support": "core",
-  "os_supported": ["linux","apple"],
+  "supported_os": ["linux","mac_os"],
   "version": "0.1.0"
 }

--- a/postfix/manifest.json
+++ b/postfix/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "postfix",

--- a/postfix/manifest.json
+++ b/postfix/manifest.json
@@ -6,6 +6,6 @@
   "name": "postfix",
   "short_description": "Postfix is a free and open-source mail transfer agent that routes and delivers emails.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","apple"],
   "version": "0.1.0"
 }

--- a/postfix/manifest.json
+++ b/postfix/manifest.json
@@ -6,5 +6,6 @@
   "name": "postfix",
   "short_description": "Postfix is a free and open-source mail transfer agent that routes and delivers emails.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -6,5 +6,6 @@
   "name": "postgres",
   "short_description": "PostgreSQL is an open-source, free object-relational database management system available on many platforms.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "postgres",

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -6,6 +6,6 @@
   "name": "postgres",
   "short_description": "PostgreSQL is an open-source, free object-relational database management system available on many platforms.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/powerdns_recursor/manifest.json
+++ b/powerdns_recursor/manifest.json
@@ -6,5 +6,6 @@
   "name": "powerdns_recursor",
   "short_description": "powerdns_recursor description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/powerdns_recursor/manifest.json
+++ b/powerdns_recursor/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "powerdns_recursor",

--- a/powerdns_recursor/manifest.json
+++ b/powerdns_recursor/manifest.json
@@ -6,6 +6,6 @@
   "name": "powerdns_recursor",
   "short_description": "powerdns_recursor description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/process/manifest.json
+++ b/process/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "process",

--- a/process/manifest.json
+++ b/process/manifest.json
@@ -6,6 +6,6 @@
   "name": "process",
   "short_description": "Capture metrics and monitor the status of running processes.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/process/manifest.json
+++ b/process/manifest.json
@@ -6,5 +6,6 @@
   "name": "process",
   "short_description": "Capture metrics and monitor the status of running processes.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -6,6 +6,6 @@
   "name": "rabbitmq",
   "short_description": "RabbitMQ is open source message broker software that implements the AMQP standard.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -6,5 +6,6 @@
   "name": "rabbitmq",
   "short_description": "RabbitMQ is open source message broker software that implements the AMQP standard.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "rabbitmq",

--- a/redisdb/manifest.json
+++ b/redisdb/manifest.json
@@ -5,5 +5,6 @@
   "name": "redisdb",
   "short_description": "Redis is an open-source, networked, in-memory, key-value data store with optional durability.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/redisdb/manifest.json
+++ b/redisdb/manifest.json
@@ -5,6 +5,6 @@
   "name": "redisdb",
   "short_description": "Redis is an open-source, networked, in-memory, key-value data store with optional durability.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/redisdb/manifest.json
+++ b/redisdb/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "min_agent_version": "5.6.3",
   "name": "redisdb",
   "short_description": "Redis is an open-source, networked, in-memory, key-value data store with optional durability.",

--- a/riak/manifest.json
+++ b/riak/manifest.json
@@ -6,6 +6,6 @@
   "name": "riak",
   "short_description": "Get metrics from riak service in real time.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/riak/manifest.json
+++ b/riak/manifest.json
@@ -6,5 +6,6 @@
   "name": "riak",
   "short_description": "Get metrics from riak service in real time.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/riak/manifest.json
+++ b/riak/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "riak",

--- a/riakcs/manifest.json
+++ b/riakcs/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "riakcs",

--- a/riakcs/manifest.json
+++ b/riakcs/manifest.json
@@ -6,5 +6,6 @@
   "name": "riakcs",
   "short_description": "Riak CS (Cloud Storage) is open source storage software built on top of Riak.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/riakcs/manifest.json
+++ b/riakcs/manifest.json
@@ -6,6 +6,6 @@
   "name": "riakcs",
   "short_description": "Riak CS (Cloud Storage) is open source storage software built on top of Riak.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/snmp/manifest.json
+++ b/snmp/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "snmp",

--- a/snmp/manifest.json
+++ b/snmp/manifest.json
@@ -6,5 +6,6 @@
   "name": "snmp",
   "short_description": "SNMP is a protocol for network management and monitoring.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/snmp/manifest.json
+++ b/snmp/manifest.json
@@ -6,6 +6,6 @@
   "name": "snmp",
   "short_description": "SNMP is a protocol for network management and monitoring.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/solr/manifest.json
+++ b/solr/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "solr",

--- a/solr/manifest.json
+++ b/solr/manifest.json
@@ -6,6 +6,6 @@
   "name": "solr",
   "short_description": "solr description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/solr/manifest.json
+++ b/solr/manifest.json
@@ -6,5 +6,6 @@
   "name": "solr",
   "short_description": "solr description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/spark/manifest.json
+++ b/spark/manifest.json
@@ -6,5 +6,6 @@
   "name": "spark",
   "short_description": "Apache Spark is an open source cluster computing framework.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/spark/manifest.json
+++ b/spark/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "spark",

--- a/spark/manifest.json
+++ b/spark/manifest.json
@@ -6,6 +6,6 @@
   "name": "spark",
   "short_description": "Apache Spark is an open source cluster computing framework.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -6,6 +6,6 @@
   "name": "sqlserver",
   "short_description": "sqlserver description.",
   "support": "core",
-  "os_supported": ["linux","windows"],
+  "supported_os": ["linux","windows"],
   "version": "0.1.0"
 }

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -6,5 +6,6 @@
   "name": "sqlserver",
   "short_description": "sqlserver description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "sqlserver",

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -6,6 +6,6 @@
   "name": "sqlserver",
   "short_description": "sqlserver description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","windows"],
   "version": "0.1.0"
 }

--- a/ssh_check/manifest.json
+++ b/ssh_check/manifest.json
@@ -6,5 +6,6 @@
   "name": "ssh_check",
   "short_description": "Secure Shell (SSH) is a cryptographic network protocol for secure data communication, remote command-line login and remote command execution.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/ssh_check/manifest.json
+++ b/ssh_check/manifest.json
@@ -6,6 +6,6 @@
   "name": "ssh_check",
   "short_description": "Secure Shell (SSH) is a cryptographic network protocol for secure data communication, remote command-line login and remote command execution.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/ssh_check/manifest.json
+++ b/ssh_check/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "ssh_check",

--- a/statsd/manifest.json
+++ b/statsd/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "statsd",

--- a/statsd/manifest.json
+++ b/statsd/manifest.json
@@ -6,5 +6,6 @@
   "name": "statsd",
   "short_description": "statsd description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/statsd/manifest.json
+++ b/statsd/manifest.json
@@ -6,6 +6,6 @@
   "name": "statsd",
   "short_description": "statsd description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/supervisord/manifest.json
+++ b/supervisord/manifest.json
@@ -6,5 +6,6 @@
   "name": "supervisord",
   "short_description": "Supervisor is a client/server system that allows its users to monitor and control a number of processes on UNIX-like operating systems.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/supervisord/manifest.json
+++ b/supervisord/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "supervisord",

--- a/supervisord/manifest.json
+++ b/supervisord/manifest.json
@@ -6,6 +6,6 @@
   "name": "supervisord",
   "short_description": "Supervisor is a client/server system that allows its users to monitor and control a number of processes on UNIX-like operating systems.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/system_core/manifest.json
+++ b/system_core/manifest.json
@@ -6,6 +6,6 @@
   "name": "system_core",
   "short_description": "system_core description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/system_core/manifest.json
+++ b/system_core/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "system_core",

--- a/system_core/manifest.json
+++ b/system_core/manifest.json
@@ -6,5 +6,6 @@
   "name": "system_core",
   "short_description": "system_core description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/system_swap/manifest.json
+++ b/system_swap/manifest.json
@@ -6,5 +6,6 @@
   "name": "system_swap",
   "short_description": "Adds some optional swap memory checks.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/system_swap/manifest.json
+++ b/system_swap/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "system_swap",

--- a/system_swap/manifest.json
+++ b/system_swap/manifest.json
@@ -6,6 +6,6 @@
   "name": "system_swap",
   "short_description": "Adds some optional swap memory checks.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/tcp_check/manifest.json
+++ b/tcp_check/manifest.json
@@ -6,5 +6,6 @@
   "name": "tcp_check",
   "short_description": "tcp_check description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/tcp_check/manifest.json
+++ b/tcp_check/manifest.json
@@ -6,6 +6,6 @@
   "name": "tcp_check",
   "short_description": "tcp_check description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/tcp_check/manifest.json
+++ b/tcp_check/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "tcp_check",

--- a/teamcity/manifest.json
+++ b/teamcity/manifest.json
@@ -6,6 +6,6 @@
   "name": "teamcity",
   "short_description": "Teamcity is a build management and continuous integration tool.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/teamcity/manifest.json
+++ b/teamcity/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "teamcity",

--- a/teamcity/manifest.json
+++ b/teamcity/manifest.json
@@ -6,5 +6,6 @@
   "name": "teamcity",
   "short_description": "Teamcity is a build management and continuous integration tool.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/tokumx/manifest.json
+++ b/tokumx/manifest.json
@@ -6,5 +6,6 @@
   "name": "tokumx",
   "short_description": "TokuMX is an open source, high-performance distribution of MongoDB",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/tokumx/manifest.json
+++ b/tokumx/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "tokumx",

--- a/tokumx/manifest.json
+++ b/tokumx/manifest.json
@@ -6,6 +6,6 @@
   "name": "tokumx",
   "short_description": "TokuMX is an open source, high-performance distribution of MongoDB",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -6,5 +6,6 @@
   "name": "tomcat",
   "short_description": "Visualize Tomcat performance and correlate with the rest of your applications",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "tomcat",

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -6,6 +6,6 @@
   "name": "tomcat",
   "short_description": "Visualize Tomcat performance and correlate with the rest of your applications",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/twemproxy/manifest.json
+++ b/twemproxy/manifest.json
@@ -1,10 +1,11 @@
 {
-  "manifest_version": "0.1.0",
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "0.1.1",
   "name": "twemproxy",
-  "version": "0.1.0",
   "min_agent_version": "5.6.3",
   "max_agent_version": "6.0.0",
   "short_description": "Visualize twemproxy performance and correlate with the rest of your applications",
-  "support": "core"
+  "support": "core",
   "os_supported": ["linux","apple","windows"],
+  "version": "0.1.0"
 }

--- a/twemproxy/manifest.json
+++ b/twemproxy/manifest.json
@@ -6,6 +6,6 @@
   "max_agent_version": "6.0.0",
   "short_description": "Visualize twemproxy performance and correlate with the rest of your applications",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/twemproxy/manifest.json
+++ b/twemproxy/manifest.json
@@ -6,4 +6,5 @@
   "max_agent_version": "6.0.0",
   "short_description": "Visualize twemproxy performance and correlate with the rest of your applications",
   "support": "core"
+  "os_supported": ["linux","apple","windows"],
 }

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "varnish",

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -6,5 +6,6 @@
   "name": "varnish",
   "short_description": "Visualize your cache performance in real-time and correlate the performance of Varnish with the rest of your applications",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -6,6 +6,6 @@
   "name": "varnish",
   "short_description": "Visualize your cache performance in real-time and correlate the performance of Varnish with the rest of your applications",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/vsphere/manifest.json
+++ b/vsphere/manifest.json
@@ -6,6 +6,6 @@
   "name": "vsphere",
   "short_description": "VMware vSphere is VMware's cloud computing virtualization operating system.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/vsphere/manifest.json
+++ b/vsphere/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "vsphere",

--- a/vsphere/manifest.json
+++ b/vsphere/manifest.json
@@ -6,5 +6,6 @@
   "name": "vsphere",
   "short_description": "VMware vSphere is VMware's cloud computing virtualization operating system.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/win32_event_log/manifest.json
+++ b/win32_event_log/manifest.json
@@ -6,6 +6,6 @@
   "name": "win32_event_log",
   "short_description": "win32_event_log description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","windows"],
   "version": "0.1.0"
 }

--- a/win32_event_log/manifest.json
+++ b/win32_event_log/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "win32_event_log",

--- a/win32_event_log/manifest.json
+++ b/win32_event_log/manifest.json
@@ -6,5 +6,6 @@
   "name": "win32_event_log",
   "short_description": "win32_event_log description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/win32_event_log/manifest.json
+++ b/win32_event_log/manifest.json
@@ -6,6 +6,6 @@
   "name": "win32_event_log",
   "short_description": "win32_event_log description.",
   "support": "core",
-  "os_supported": ["linux","windows"],
+  "os_supported": ["windows"],
   "version": "0.1.0"
 }

--- a/win32_event_log/manifest.json
+++ b/win32_event_log/manifest.json
@@ -6,6 +6,6 @@
   "name": "win32_event_log",
   "short_description": "win32_event_log description.",
   "support": "core",
-  "os_supported": ["windows"],
+  "supported_os": ["windows"],
   "version": "0.1.0"
 }

--- a/windows_service/manifest.json
+++ b/windows_service/manifest.json
@@ -6,6 +6,6 @@
   "name": "windows_service",
   "short_description": "windows_service description.",
   "support": "core",
-  "os_supported": ["windows"],
+  "supported_os": ["windows"],
   "version": "0.1.0"
 }

--- a/windows_service/manifest.json
+++ b/windows_service/manifest.json
@@ -6,6 +6,6 @@
   "name": "windows_service",
   "short_description": "windows_service description.",
   "support": "core",
-  "os_supported": ["linux","windows"],
+  "os_supported": ["windows"],
   "version": "0.1.0"
 }

--- a/windows_service/manifest.json
+++ b/windows_service/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "windows_service",

--- a/windows_service/manifest.json
+++ b/windows_service/manifest.json
@@ -6,6 +6,6 @@
   "name": "windows_service",
   "short_description": "windows_service description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","windows"],
   "version": "0.1.0"
 }

--- a/windows_service/manifest.json
+++ b/windows_service/manifest.json
@@ -6,5 +6,6 @@
   "name": "windows_service",
   "short_description": "windows_service description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/wmi_check/manifest.json
+++ b/wmi_check/manifest.json
@@ -6,6 +6,6 @@
   "name": "wmi_check",
   "short_description": "Get real time metrics from WMI queries.",
   "support": "core",
-  "os_supported": ["windows"],
+  "supported_os": ["windows"],
   "version": "0.1.0"
 }

--- a/wmi_check/manifest.json
+++ b/wmi_check/manifest.json
@@ -6,6 +6,6 @@
   "name": "wmi_check",
   "short_description": "Get real time metrics from WMI queries.",
   "support": "core",
-  "os_supported": ["linux","windows"],
+  "os_supported": ["windows"],
   "version": "0.1.0"
 }

--- a/wmi_check/manifest.json
+++ b/wmi_check/manifest.json
@@ -6,5 +6,6 @@
   "name": "wmi_check",
   "short_description": "Get real time metrics from WMI queries.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/wmi_check/manifest.json
+++ b/wmi_check/manifest.json
@@ -6,6 +6,6 @@
   "name": "wmi_check",
   "short_description": "Get real time metrics from WMI queries.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","windows"],
   "version": "0.1.0"
 }

--- a/wmi_check/manifest.json
+++ b/wmi_check/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "wmi_check",

--- a/yarn/manifest.json
+++ b/yarn/manifest.json
@@ -6,5 +6,6 @@
   "name": "yarn",
   "short_description": "yarn description.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }

--- a/yarn/manifest.json
+++ b/yarn/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "yarn",

--- a/yarn/manifest.json
+++ b/yarn/manifest.json
@@ -6,6 +6,6 @@
   "name": "yarn",
   "short_description": "yarn description.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "supported_os": ["linux","mac_os","windows"],
   "version": "0.1.0"
 }

--- a/zk/manifest.json
+++ b/zk/manifest.json
@@ -6,6 +6,6 @@
   "name": "zk",
   "short_description": "Collect zookeeper metrics.",
   "support": "core",
-  "os_supported": ["linux","apple"],
+  "supported_os": ["linux","mac_os"],
   "version": "0.1.0"
 }

--- a/zk/manifest.json
+++ b/zk/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "zk",

--- a/zk/manifest.json
+++ b/zk/manifest.json
@@ -6,6 +6,6 @@
   "name": "zk",
   "short_description": "Collect zookeeper metrics.",
   "support": "core",
-  "os_supported": ["linux","apple","windows"],
+  "os_supported": ["linux","apple"],
   "version": "0.1.0"
 }

--- a/zk/manifest.json
+++ b/zk/manifest.json
@@ -6,5 +6,6 @@
   "name": "zk",
   "short_description": "Collect zookeeper metrics.",
   "support": "core",
+  "os_supported": ["linux","apple","windows"],
   "version": "0.1.0"
 }


### PR DESCRIPTION
As per the [dd-agent](https://github.com/DataDog/dd-agent/blob/master/win32/gui.py#L113-L139):

EXCLUDED_WINDOWS_CHECKS = [
    'btrfs',
    'cacti',
    'ceph',
    'docker',
    'docker_daemon',
    'gearmand',
    'go-metro',
    'gunicorn',
    'hdfs',
    'kafka_consumer',
    'linux_proc_extras',
    'marathon',
    'mcache',
    'mesos',
    'postfix',
    'zk',
]

EXCLUDED_MAC_CHECKS = [
    'cacti',
    'iis',
    'sqlserver',
    'win32_event_log',
    'windows_service',
    'wmi_check',
]
