### PR TITLE
adds guids to all manifest.json files

### DIFF
--- a/activemq/manifest.json
+++ b/activemq/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "activemq",
   "short_description": "Get metrics from activemq service in real time.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "496df16d-5ad0-438c-aa2a-b8ba8ee3ae05"
 }

--- a/activemq_xml/manifest.json
+++ b/activemq_xml/manifest.json
@@ -1,10 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "activemq_xml",
   "short_description": "Get metrics from activemq service in real time.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "0433d687-68d3-42db-ad5c-6c232d881619"
+}

--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -1,16 +1,18 @@
 {
-  "manifest_version": 1,
+  "manifest_version": "0.1.2",
   "name": "Apache",
   "display_name": "Apache",
   "version": "0.1.0",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "manifest_version": "0.1.1",
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
-
   "maintainer": "help@datadoghq.com",
-
   "short_description": "Apache is a robust, commercial-grade, featureful, and freely-available source code implementation of an HTTP server.",
   "description": "Apache is a robust, commercial-grade, featureful, and freely-available source code implementation of an HTTP server.",
+  "guid": "cb2b4a06-4ede-465e-9478-a45f8b32058a"
 }

--- a/btrfs/manifest.json
+++ b/btrfs/manifest.json
@@ -1,11 +1,15 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "btrfs",
   "short_description": "btrfs description.",
   "support": "core",
-  "supported_os": ["linux","mac_os"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os"
+  ],
+  "version": "0.1.0",
+  "guid": "54f9329a-8270-4f5a-bd4b-cd169abfc791"
 }

--- a/cacti/manifest.json
+++ b/cacti/manifest.json
@@ -1,11 +1,14 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "cacti",
   "short_description": "Visualize Cacti metrics and correlate with the rest of your applications in Datadog.",
   "support": "core",
-  "supported_os": ["linux"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux"
+  ],
+  "version": "0.1.0",
+  "guid": "566466b0-1422-44ef-b14f-493a64e7b58a"
 }

--- a/cassandra/manifest.json
+++ b/cassandra/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "cassandra",
   "short_description": "Apache Cassandra is an open source distributed database management system.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "03ba454d-425c-4f61-9e9c-54682c3ebce5"
 }

--- a/ceph/manifest.json
+++ b/ceph/manifest.json
@@ -1,11 +1,15 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "ceph",
   "short_description": "Ceph is a distributed filesystem that provides scalable and redundant data access across multiple servers.",
   "support": "core",
-  "supported_os": ["linux","mac_os"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os"
+  ],
+  "version": "0.1.0",
+  "guid": "8a60c34f-ecde-4269-bcae-636e6cbce98f"
 }

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "consul",
   "short_description": "Consul is a tool for service discovery and configuration. It is distributed, highly available, and scalable.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "ec1e9fac-a339-49a3-b501-60656d2a5671"
 }

--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -1,14 +1,17 @@
 {
-  "manifest_version": 1,
+  "manifest_version": "0.1.2",
   "name": "couch",
   "display_name": "couch",
   "version": "0.1",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "manifest_version": "0.1.1",
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
-
   "short_description": "Apache CouchDB is a document-oriented database that can be queried and indexed using JavaScript in a MapReduce fashion.",
   "description": "Apache CouchDB is a document-oriented database that can be queried and indexed using JavaScript in a MapReduce fashion.",
+  "guid": "9e7ed68c-669a-40f0-8564-548d49aa8098"
 }

--- a/couchbase/manifest.json
+++ b/couchbase/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "couchbase",
   "short_description": "couchbase description.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "ba7ce7de-4fcb-4418-8c90-329baa6a5d59"
 }

--- a/directory/manifest.json
+++ b/directory/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "directory",
   "short_description": "The Directory integration helps monitoring and reporting metrics on files for a provided directory.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "0c38c4ef-5266-4667-9fb1-de8f2b73708a"
 }

--- a/disk/manifest.json
+++ b/disk/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "disk",
   "short_description": "The disk check gathers metrics on mounted disks.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "94588b23-111e-4ed2-a2af-fd6e4caeea04"
 }

--- a/dns_check/manifest.json
+++ b/dns_check/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "dns_check",
   "short_description": "dns_check description.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "31e4c84c-fc4b-4cd4-97ed-0331bf4e2023"
 }

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -1,10 +1,11 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "elastic",
   "short_description": "elastic description.",
   "support": "Elasticsearch is an Open Source, Distributed, Search Engine.",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "guid": "d91d91bd-4a8e-4489-bfb1-b119d4cc388a"
 }

--- a/etcd/manifest.json
+++ b/etcd/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "etcd",
   "short_description": "etcd is a distributed reliable key-value store.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "a1cfafdb-5d88-4ae1-acdc-6356df755b73"
 }

--- a/fluentd/manifest.json
+++ b/fluentd/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "fluentd",
   "short_description": "Fluentd is an open source data collector, which lets you unify the data collection and consumption for a better use and understanding of data.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "68100352-b993-43e6-9dc8-5ecd498e160b"
 }

--- a/gearmand/manifest.json
+++ b/gearmand/manifest.json
@@ -1,11 +1,15 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "gearmand",
   "short_description": "Visualize Gearman performance, know how many tasks are queued or running, correlate the performance of Gearman with the rest of your applications.",
   "support": "core",
-  "supported_os": ["linux","mac_os"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os"
+  ],
+  "version": "0.1.0",
+  "guid": "bdd65394-92ff-4d51-bbe3-ba732663fdb2"
 }

--- a/go_expvar/manifest.json
+++ b/go_expvar/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "go_expvar",
   "short_description": "Expvars is a golang package to expose variables via http.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "33557f7a-5f24-43f3-9551-78432894e539"
 }

--- a/gunicorn/manifest.json
+++ b/gunicorn/manifest.json
@@ -1,11 +1,15 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "gunicorn",
   "short_description": "Gunicorn is a Python WSGI HTTP Server for UNIX.",
   "support": "core",
-  "supported_os": ["linux","mac_os"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os"
+  ],
+  "version": "0.1.0",
+  "guid": "5347bfe1-2e9b-4c92-9410-48b8659ce10f"
 }

--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -1,15 +1,17 @@
 {
-  "manifest_version": 1,
+  "manifest_version": "0.1.2",
   "name": "haproxy",
   "display_name": "haproxy",
   "version": "0.1",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "manifest_version": "0.1.1",
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
-
   "short_description": "The HAProxy integration helps to collect performance and avaialbility metrics from HAProxy instances.",
   "description": "The HAProxy integration helps to collect performance and avaialbility metrics from HAProxy instances.",
-
+  "guid": "cd935030-131f-4545-8b6a-a4ca21b8565b"
 }

--- a/hdfs_datanode/manifest.json
+++ b/hdfs_datanode/manifest.json
@@ -1,11 +1,15 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "hdfs_datanode",
   "short_description": "hdfs_datanode description.",
   "support": "core",
-  "supported_os": ["linux","mac_os"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os"
+  ],
+  "version": "0.1.0",
+  "guid": "c1409bbd-ff4a-4616-9948-6dc7f4910942"
 }

--- a/hdfs_namenode/manifest.json
+++ b/hdfs_namenode/manifest.json
@@ -1,11 +1,15 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "hdfs_namenode",
   "short_description": "hdfs_namenode description.",
   "support": "core",
-  "supported_os": ["linux","mac_os"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os"
+  ],
+  "version": "0.1.0",
+  "guid": "41454590-0a25-4146-9c74-9d377db42764"
 }

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "http_check",
   "short_description": "http_check description.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "eb133a1f-697c-4143-bad3-10e72541fa9c"
 }

--- a/iis/manifest.json
+++ b/iis/manifest.json
@@ -1,11 +1,14 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "iis",
   "short_description": "iis description.",
   "support": "core",
-  "supported_os": ["windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "6ad932f0-8816-467a-8860-72af44d4f3ba"
 }

--- a/kafka/manifest.json
+++ b/kafka/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "kafka",
   "short_description": "Apache Kafka is publish-subscribe messaging rethought as a distributed commit log.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "f201c0b7-4b31-4528-9955-ae756a4580b8"
 }

--- a/kafka_consumer/manifest.json
+++ b/kafka_consumer/manifest.json
@@ -1,11 +1,15 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "kafka_consumer",
   "short_description": "Apache Kafka is publish-subscribe messaging rethought as a distributed commit log.",
   "support": "core",
-  "supported_os": ["linux","mac_os"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os"
+  ],
+  "version": "0.1.0",
+  "guid": "74e1ce9c-dee9-4ad5-9b6a-05eeee7f5259"
 }

--- a/kong/manifest.json
+++ b/kong/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "kong",
   "short_description": "Kong is an open-source management layer for APIs, delivering high performance and reliability.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "f1098d6f-b393-4374-81c0-47c0a142aeef"
 }

--- a/kyototycoon/manifest.json
+++ b/kyototycoon/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "kyototycoon",
   "short_description": "Kyoto Tycoon is a lightweight database server with automatic expiration mechanism.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "2661668b-d804-4c8d-96a7-8019525add8c"
 }

--- a/lighttpd/manifest.json
+++ b/lighttpd/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "lighttpd",
   "short_description": "Lighttpd is a secure, fast, compliant, and very flexible web-server that has been optimized for high-performance environments.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "01dcfe7a-7a56-4388-a388-799ee6daaaab"
 }

--- a/linux_proc_extras/manifest.json
+++ b/linux_proc_extras/manifest.json
@@ -1,11 +1,14 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "linux_proc_extras",
   "short_description": "linux_proc_extras description.",
   "support": "core",
-  "supported_os": ["linux"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux"
+  ],
+  "version": "0.1.0",
+  "guid": "47f243d7-5df4-47b5-9f1a-923b4f7cefe7"
 }

--- a/mapreduce/manifest.json
+++ b/mapreduce/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "mapreduce",
   "short_description": "mapreduce description.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "1c143492-84ac-42d2-89d5-a45c718092b0"
 }

--- a/marathon/manifest.json
+++ b/marathon/manifest.json
@@ -1,11 +1,15 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "marathon",
   "short_description": "marathon description.",
   "support": "core",
-  "supported_os": ["linux","mac_os"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os"
+  ],
+  "version": "0.1.0",
+  "guid": "6af353ff-ecca-420a-82c0-a0e84cf0a35e"
 }

--- a/mcache/manifest.json
+++ b/mcache/manifest.json
@@ -1,11 +1,15 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "mcache",
   "short_description": "Memcache is a general-purpose distributed memory caching system.",
   "support": "core",
-  "supported_os": ["linux","mac_os"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os"
+  ],
+  "version": "0.1.0",
+  "guid": "b1c4033c-bf96-4456-be63-e74ff171f991"
 }

--- a/mesos_master/manifest.json
+++ b/mesos_master/manifest.json
@@ -1,11 +1,15 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "mesos_master",
   "short_description": "The Mesos master integration collects metrics from the Mesos master API.",
   "support": "core",
-  "supported_os": ["linux","mac_os"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os"
+  ],
+  "version": "0.1.0",
+  "guid": "f807f479-33f6-4c45-9c11-04ee2473acdc"
 }

--- a/mesos_slave/manifest.json
+++ b/mesos_slave/manifest.json
@@ -1,11 +1,15 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "mesos_master",
   "short_description": "The Mesos slave integration collects metrics from the Mesos slave APIs.",
   "support": "core",
-  "supported_os": ["linux","mac_os"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os"
+  ],
+  "version": "0.1.0",
+  "guid": "14d0267e-9989-4d09-8362-9319958e858e"
 }

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "mongo",
   "short_description": "MongoDB is an open-source, high-performance, schema-free, document-oriented database.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "d51c342e-7a02-4611-a47f-1e8eade5735c"
 }

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -1,24 +1,24 @@
 {
-  "manifest_version": 1,
+  "manifest_version": "0.1.2",
   "name": "MySQL",
   "display_name": "MySQL",
   "version": "0.1.4",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "manifest_version": "0.1.1",
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
-
   "maintainer": "help@datadoghq.com",
-
   "short_description": "The MySQL integration helps to collect performance and avaialbility metrics from MySQL server instances.",
   "description": "The MySQL integration helps to collect performance and avaialbility metrics from MySQL server instances.",
-
   "resources": {
     "small": "resources/small_mysql.png",
     "bot": "resources/bot_mysql.png",
     "monitor_editor": "resources/monitor_mysql.png",
     "my_image": "resources/mysql.png"
-  }
-
+  },
+  "guid": "056bfc7f-4775-4581-9442-502078593d10"
 }

--- a/nagios/manifest.json
+++ b/nagios/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "nagios",
   "short_description": "nagios description.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "f7629918-751c-4a05-87e7-0e3de34e51e7"
 }

--- a/network/manifest.json
+++ b/network/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "network",
   "short_description": "network description.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "43631795-8a1f-404d-83ae-397639a84050"
 }

--- a/nginx/manifest.json
+++ b/nginx/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "nginx",
   "short_description": "Nginx is a free, open-source, high-performance HTTP server and reverse proxy, as well as an IMAP/POP3 proxy server.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "88620208-3919-457c-ba51-d844d09ac97f"
 }

--- a/ntp/manifest.json
+++ b/ntp/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "ntp",
   "short_description": "ntp description.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "9d105f8c-7fd3-48d7-a5d1-1cc386ec0367"
 }

--- a/openstack/manifest.json
+++ b/openstack/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "openstack",
   "short_description": "openstack description.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "944452d0-208e-4d1c-8adb-495f517ce2c2"
 }

--- a/pgbouncer/manifest.json
+++ b/pgbouncer/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "pgbouncer",
   "short_description": "PGBouncer is an open-source, lightweight connection pooler for PostgreSQL.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "51386802-4502-4991-b592-27eff1ca111c"
 }

--- a/php_fpm/manifest.json
+++ b/php_fpm/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "php_fpm",
   "short_description": "PHP-FPM (FastCGI Process Manager) is an alternative PHP FastCGI implementation.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "47f2c337-83ac-4767-b460-1927d8343764"
 }

--- a/postfix/manifest.json
+++ b/postfix/manifest.json
@@ -1,11 +1,15 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "postfix",
   "short_description": "Postfix is a free and open-source mail transfer agent that routes and delivers emails.",
   "support": "core",
-  "supported_os": ["linux","mac_os"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os"
+  ],
+  "version": "0.1.0",
+  "guid": "7f03c5b7-ee54-466e-8854-5896d62c82b4"
 }

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "postgres",
   "short_description": "PostgreSQL is an open-source, free object-relational database management system available on many platforms.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "e9ca29d5-5b4f-4478-8989-20d89afda0c9"
 }

--- a/powerdns_recursor/manifest.json
+++ b/powerdns_recursor/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "powerdns_recursor",
   "short_description": "powerdns_recursor description.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "ae533b67-a2af-45ce-8e23-235acb3a3893"
 }

--- a/process/manifest.json
+++ b/process/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "process",
   "short_description": "Capture metrics and monitor the status of running processes.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "1675eced-b435-464a-8f84-f65e438f838e"
 }

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "rabbitmq",
   "short_description": "RabbitMQ is open source message broker software that implements the AMQP standard.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "a790a556-fbaa-4208-9d39-c42c3d57084b"
 }

--- a/redisdb/manifest.json
+++ b/redisdb/manifest.json
@@ -1,10 +1,15 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "min_agent_version": "5.6.3",
   "name": "redisdb",
   "short_description": "Redis is an open-source, networked, in-memory, key-value data store with optional durability.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "0e2f3ed1-d36b-47a4-b69c-fedb50adf240"
 }

--- a/riak/manifest.json
+++ b/riak/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "riak",
   "short_description": "Get metrics from riak service in real time.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "e1ed642c-8a15-420c-954b-6fb894905956"
 }

--- a/riakcs/manifest.json
+++ b/riakcs/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "riakcs",
   "short_description": "Riak CS (Cloud Storage) is open source storage software built on top of Riak.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "55ba6b94-8eeb-486b-aa94-6366a044fdf0"
 }

--- a/snmp/manifest.json
+++ b/snmp/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "snmp",
   "short_description": "SNMP is a protocol for network management and monitoring.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "080bb566-d1c8-428c-9d85-71cc2cdf393c"
 }

--- a/solr/manifest.json
+++ b/solr/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "solr",
   "short_description": "solr description.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "0235124a-0207-44dd-aede-f578a6d46b26"
 }

--- a/spark/manifest.json
+++ b/spark/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "spark",
   "short_description": "Apache Spark is an open source cluster computing framework.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "f7a5a40f-f73c-465a-be8f-b2b371c706a2"
 }

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -1,11 +1,15 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "sqlserver",
   "short_description": "sqlserver description.",
   "support": "core",
-  "supported_os": ["linux","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "635cb962-ee9f-4788-aa55-a7ffb9661498"
 }

--- a/ssh_check/manifest.json
+++ b/ssh_check/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "ssh_check",
   "short_description": "Secure Shell (SSH) is a cryptographic network protocol for secure data communication, remote command-line login and remote command execution.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "4eb195ef-554f-4cc2-80af-8f286c631fa8"
 }

--- a/statsd/manifest.json
+++ b/statsd/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "statsd",
   "short_description": "statsd description.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "4830acf3-626b-42ff-a1db-3f37babd0ae6"
 }

--- a/supervisord/manifest.json
+++ b/supervisord/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "supervisord",
   "short_description": "Supervisor is a client/server system that allows its users to monitor and control a number of processes on UNIX-like operating systems.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "2b81259b-723e-47be-8612-87e1f64152e9"
 }

--- a/system_core/manifest.json
+++ b/system_core/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "system_core",
   "short_description": "system_core description.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "e123ef26-81bb-4c1b-b079-4dd4cc7d7ae7"
 }

--- a/system_swap/manifest.json
+++ b/system_swap/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "system_swap",
   "short_description": "Adds some optional swap memory checks.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "4b3dcc12-7bc9-474a-960f-14680eb587a3"
 }

--- a/tcp_check/manifest.json
+++ b/tcp_check/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "tcp_check",
   "short_description": "tcp_check description.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "c514029e-0ed8-4c9f-abe5-2fd4096726ba"
 }

--- a/teamcity/manifest.json
+++ b/teamcity/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "teamcity",
   "short_description": "Teamcity is a build management and continuous integration tool.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "b390dd3f-47d5-4555-976a-36722833f000"
 }

--- a/tokumx/manifest.json
+++ b/tokumx/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "tokumx",
   "short_description": "TokuMX is an open source, high-performance distribution of MongoDB",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "7785939b-bfb6-4d3e-acc2-94c1f5fb33e7"
 }

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "tomcat",
   "short_description": "Visualize Tomcat performance and correlate with the rest of your applications",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "60f37d34-3bb7-43c9-9b52-2659b8898997"
 }

--- a/twemproxy/manifest.json
+++ b/twemproxy/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "name": "twemproxy",
   "min_agent_version": "5.6.3",
   "max_agent_version": "6.0.0",
   "short_description": "Visualize twemproxy performance and correlate with the rest of your applications",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "a5cca58a-9984-4226-ad1c-8dff73c9d6ac"
 }

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "varnish",
   "short_description": "Visualize your cache performance in real-time and correlate the performance of Varnish with the rest of your applications",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "d2052eae-89b8-4cb1-b631-f373010da4b8"
 }

--- a/vsphere/manifest.json
+++ b/vsphere/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "vsphere",
   "short_description": "VMware vSphere is VMware's cloud computing virtualization operating system.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "930b1839-cc1f-4e7a-b706-0e8cf3218464"
 }

--- a/win32_event_log/manifest.json
+++ b/win32_event_log/manifest.json
@@ -1,11 +1,14 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "win32_event_log",
   "short_description": "win32_event_log description.",
   "support": "core",
-  "supported_os": ["windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "b04d6f04-947c-4068-b73d-f861adc39959"
 }

--- a/windows_service/manifest.json
+++ b/windows_service/manifest.json
@@ -1,11 +1,14 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "windows_service",
   "short_description": "windows_service description.",
   "support": "core",
-  "supported_os": ["windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "2289acf0-e413-4384-83f7-88157b430805"
 }

--- a/wmi_check/manifest.json
+++ b/wmi_check/manifest.json
@@ -1,11 +1,14 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "wmi_check",
   "short_description": "Get real time metrics from WMI queries.",
   "support": "core",
-  "supported_os": ["windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "d70f5c68-873d-436e-bddb-dbb3e107e3b5"
 }

--- a/yarn/manifest.json
+++ b/yarn/manifest.json
@@ -1,11 +1,16 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "yarn",
   "short_description": "yarn description.",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "3223c2e3-29dd-4cfb-82a2-51b951c648eb"
 }

--- a/zk/manifest.json
+++ b/zk/manifest.json
@@ -1,11 +1,15 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "zk",
   "short_description": "Collect zookeeper metrics.",
   "support": "core",
-  "supported_os": ["linux","mac_os"],
-  "version": "0.1.0"
+  "supported_os": [
+    "linux",
+    "mac_os"
+  ],
+  "version": "0.1.0",
+  "guid": "5519c110-5183-438e-85ad-63678c072ac7"
 }


### PR DESCRIPTION
This adds a guid to each `manifest.json` file. I used a script to do this and, afterwards, check that each was unique. In the course of doing so, I found that some of our `manifest.json` files were invalid. We should check that they're valid from now on. We need to add a pre-commit hook to this. 

I used the following script:

```ruby
require 'json'
require 'securerandom'
require 'pp'

Dir.glob("./**/manifest.json") do |f|
  manifest = JSON.parse(File.read(f))
  guid = SecureRandom.uuid
  manifest['guid'] = guid
  manifest['manifest_version'] = "0.1.2"
  File.open(f, "w") do |manifestFile|
    manifestFile.write(JSON.pretty_generate(manifest))
  end
end

Dir.glob("./**/manifest.json") do |f1|
  manifest1 = JSON.parse(File.read(f1))
  guid1 = manifest1['guid']
  Dir.glob("./**/manifest.json") do |f2|
    manifest2 = JSON.parse(File.read(f2))
    guid2 = manifest2['guid']
    if guid1 == guid2 && f1 != f2
      raise "#{f1} guid is equal to #{f2} guid"
    end
  end
end

```