### PR TITLE
Modified tag for tag_by_filesystem to include an additional tag with …

### DIFF
--- a/disk/check.py
+++ b/disk/check.py
@@ -115,7 +115,7 @@ class Disk(AgentCheck):
             self._valid_disks[part.device] = (part.fstype, part.mountpoint)
             self.log.debug('Passed: {0}'.format(part.device))
 
-            tags = [part.fstype] if self._tag_by_filesystem else []
+            tags = [part.fstype, 'filesystem:' + part.fstype] if self._tag_by_filesystem else []
             device_name = part.mountpoint if self._use_mount else part.device
 
             # legacy check names c: vs psutil name C:\\


### PR DESCRIPTION
### What does this PR do?

Modifies the tag generated by the `tag_by_filesystem` parameter in the disk integration to include a prefix of `filesystem`.
For example example: `filesystem:nfs`.
Old tags are still available for backwards compatibility. 

### Motivation

This PR was motivated by a feature request.