### PR TITLE
[dns_check] Sync with dd-agent

### DIFF
--- a/dns_check/check.py
+++ b/dns_check/check.py
@@ -67,8 +67,17 @@ class DNSCheck(NetworkCheck):
 
         try:
             self.log.debug('Querying "{0}" record for hostname "{1}"...'.format(record_type, hostname))
-            answer = resolver.query(hostname, rdtype=record_type)
-            assert(answer.rrset.items[0].to_text())
+            if record_type == "NXDOMAIN":
+                try:
+                    resolver.query(hostname)
+                except dns.resolver.NXDOMAIN:
+                    pass
+                else:
+                    raise AssertionError("Expected an NXDOMAIN, got a result.")
+            else:
+                answer = resolver.query(hostname, rdtype=record_type)
+                assert(answer.rrset.items[0].to_text())
+
             end_time = time.time()
 
         except dns.exception.Timeout:

--- a/dns_check/conf.yaml.example
+++ b/dns_check/conf.yaml.example
@@ -17,3 +17,16 @@ instances:
       # tags:
       #   - tag:one
       #   - tag:two
+
+    # If you use NXDOMAIN as the `record_type`, an NXDOMAIN result is expected from the query,
+    # and the check instance will report response time data.
+    # In many DNS systems, NXDOMAIN results are uncached. Further a query for a unqualified domain
+    # name that one expects to return an NXDOMAIN result can result in many dns queries, depending
+    # on the resolver's configured search domain.
+    # For these reasons, these queries are good candidates to monitor the worst-case performance of a DNS lookup.
+    # See https://github.com/DataDog/dd-agent/pull/2849 for more details.
+
+    # - name: nxdomain_example
+    #   hostname: nxdomain.example.org
+    #   nameserver: 127.0.0.1
+    #   record_type: NXDOMAIN

--- a/dns_check/test_dns_check.py
+++ b/dns_check/test_dns_check.py
@@ -135,11 +135,16 @@ class DNSCheckTest(AgentCheckTest):
     def test_success(self, mocked_query):
         self.run_check(CONFIG_SUCCESS)
         # Overrides self.service_checks attribute when values are available
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 2)
+        self.metrics = self.check.get_metrics()
+
         tags = ['instance:success', 'resolved_hostname:www.example.org', 'nameserver:127.0.0.1', 'record_type:A']
         self.assertServiceCheckOK(SERVICE_CHECK_NAME, tags=tags)
+        self.assertMetric('dns.response_time', count=1, tags=tags)
         tags = ['instance:cname', 'resolved_hostname:www.example.org', 'nameserver:127.0.0.1', 'record_type:CNAME']
         self.assertServiceCheckOK(SERVICE_CHECK_NAME, tags=tags)
+        self.assertMetric('dns.response_time', count=1, tags=tags)
+
         self.coverage_report()
 
     @mock.patch.object(Resolver, 'query', side_effect=nxdomain_query_mock)
@@ -160,8 +165,11 @@ class DNSCheckTest(AgentCheckTest):
         self.run_check(CONFIG_DEFAULT_TIMEOUT)
         # Overrides self.service_checks attribute when values are available
         self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.metrics = self.check.get_metrics()
+
         tags = ['instance:default_timeout', 'resolved_hostname:www.example.org', 'nameserver:127.0.0.1', 'record_type:A']
         self.assertServiceCheckCritical(SERVICE_CHECK_NAME, tags=tags)
+
         self.coverage_report()
 
     @mock.patch.object(Resolver, 'query', side_effect=Timeout())
@@ -169,8 +177,11 @@ class DNSCheckTest(AgentCheckTest):
         self.run_check(CONFIG_INSTANCE_TIMEOUT)
         # Overrides self.service_checks attribute when values are available
         self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.metrics = self.check.get_metrics()
+
         tags = ['instance:instance_timeout', 'resolved_hostname:www.example.org', 'nameserver:127.0.0.1', 'record_type:A']
         self.assertServiceCheckCritical(SERVICE_CHECK_NAME, tags=tags)
+
         self.coverage_report()
 
     def test_invalid_config(self):
@@ -178,6 +189,8 @@ class DNSCheckTest(AgentCheckTest):
             self.run_check(config)
             # Overrides self.service_checks attribute when values are available
             self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+            self.metrics = self.check.get_metrics()
+
             self.assertRaises(exception_class)
             self.assertServiceCheckCritical(SERVICE_CHECK_NAME)
             self.coverage_report()

--- a/dns_check/test_dns_check.py
+++ b/dns_check/test_dns_check.py
@@ -28,6 +28,15 @@ CONFIG_SUCCESS = {
     }]
 }
 
+CONFIG_SUCCESS_NXDOMAIN = {
+    'instances': [{
+        'name': 'nxdomain',
+        'hostname': 'www.example.org',
+        'nameserver': '127.0.0.1',
+        'record_type': 'NXDOMAIN'
+    }]
+}
+
 CONFIG_DEFAULT_TIMEOUT = {
     'init_config': {
         'default_timeout': 0.1
@@ -63,6 +72,11 @@ CONFIG_INVALID = [
         'name': 'invalid_rcrd_type',
         'hostname': 'www.example.org',
         'record_type': 'FOO'}]}, UnknownRdatatype),
+    # valid domain when NXDOMAIN is expected
+    ({'instances': [{
+        'name': 'valid_domain_for_nxdomain_type',
+        'hostname': 'example.com',
+        'record_type': 'NXDOMAIN'}]}, AssertionError),
 ]
 
 SERVICE_CHECK_NAME = 'dns.can_resolve'
@@ -89,6 +103,9 @@ def success_query_mock(d_name, rdtype):
         return MockDNSAnswer('127.0.0.1')
     elif rdtype == 'CNAME':
         return MockDNSAnswer('alias.example.org')
+
+def nxdomain_query_mock(d_name):
+    raise NXDOMAIN
 
 
 class DNSCheckTest(AgentCheckTest):
@@ -123,6 +140,19 @@ class DNSCheckTest(AgentCheckTest):
         self.assertServiceCheckOK(SERVICE_CHECK_NAME, tags=tags)
         tags = ['instance:cname', 'resolved_hostname:www.example.org', 'nameserver:127.0.0.1', 'record_type:CNAME']
         self.assertServiceCheckOK(SERVICE_CHECK_NAME, tags=tags)
+        self.coverage_report()
+
+    @mock.patch.object(Resolver, 'query', side_effect=nxdomain_query_mock)
+    def test_success_nxdomain(self, mocked_query):
+        self.run_check(CONFIG_SUCCESS_NXDOMAIN)
+        # Overrides self.service_checks attribute when values are available
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.metrics = self.check.get_metrics()
+
+        tags = ['instance:nxdomain', 'nameserver:127.0.0.1', 'resolved_hostname:www.example.org', 'record_type:NXDOMAIN']
+        self.assertServiceCheckOK(SERVICE_CHECK_NAME, tags=tags)
+        self.assertMetric('dns.response_time', count=1, tags=tags)
+
         self.coverage_report()
 
     @mock.patch.object(Resolver, 'query', side_effect=Timeout())


### PR DESCRIPTION
Manual sync (earlier than the sync we're going to do for all the other checks) because I merged a few changes in the tests on `dd-agent` and felt it'd be faster to port them here if I did it :)

The check is fully up-to-date now, and is not expecting any change in `dd-agent`