### PR TITLE
[Windows] updates for windows integrations builds.

### DIFF
--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1.0",
   "name": "couch",
   "display_name": "couch",
-  "version": "0.1",
+  "version": "0.1.0",
   "support": "core",
   "supported_os": [
     "linux",

--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1.0",
   "name": "haproxy",
   "display_name": "haproxy",
-  "version": "0.1",
+  "version": "0.1.0",
   "support": "core",
   "maintainer": "help@datadoghq.com",
   "supported_os": [

--- a/postgres/requirements.txt
+++ b/postgres/requirements.txt
@@ -3,4 +3,4 @@ pg8000==1.10.1
 
 # optional - SDK question here
 # Require libpq
-psycopg2==2.6
+psycopg2==2.6.2


### PR DESCRIPTION
Change version for psycopg2 to 2.6.2 (from 2.6)
Fix version fields for couch & haproxy