### PR TITLE
[php_fpm] Add timeout options

### DIFF
--- a/php_fpm/check.py
+++ b/php_fpm/check.py
@@ -44,6 +44,8 @@ class PHPFPMCheck(AgentCheck):
         tags = instance.get('tags', [])
         http_host = instance.get('http_host')
 
+        timeout = instance.get('timeout')
+
         if user and password:
             auth = (user, password)
 
@@ -54,24 +56,24 @@ class PHPFPMCheck(AgentCheck):
         status_exception = None
         if status_url is not None:
             try:
-                pool = self._process_status(status_url, auth, tags, http_host)
+                pool = self._process_status(status_url, auth, tags, http_host, timeout)
             except Exception as e:
                 status_exception = e
                 pass
 
         if ping_url is not None:
-            self._process_ping(ping_url, ping_reply, auth, tags, pool, http_host)
+            self._process_ping(ping_url, ping_reply, auth, tags, pool, http_host, timeout)
 
         # pylint doesn't understand that we are raising this only if it's here
         if status_exception is not None:
             raise status_exception  # pylint: disable=E0702
 
-    def _process_status(self, status_url, auth, tags, http_host):
+    def _process_status(self, status_url, auth, tags, http_host, timeout):
         data = {}
         try:
             # TODO: adding the 'full' parameter gets you per-process detailed
             # informations, which could be nice to parse and output as metrics
-            resp = requests.get(status_url, auth=auth,
+            resp = requests.get(status_url, auth=auth, timeout=timeout,
                                 headers=headers(self.agentConfig, http_host=http_host),
                                 params={'json': True})
             resp.raise_for_status()
@@ -101,7 +103,7 @@ class PHPFPMCheck(AgentCheck):
         # return pool, to tag the service check with it if we have one
         return pool_name
 
-    def _process_ping(self, ping_url, ping_reply, auth, tags, pool_name, http_host):
+    def _process_ping(self, ping_url, ping_reply, auth, tags, pool_name, http_host, timeout):
         if ping_reply is None:
             ping_reply = 'pong'
 
@@ -112,7 +114,7 @@ class PHPFPMCheck(AgentCheck):
         try:
             # TODO: adding the 'full' parameter gets you per-process detailed
             # informations, which could be nice to parse and output as metrics
-            resp = requests.get(ping_url, auth=auth,
+            resp = requests.get(ping_url, auth=auth, timeout=timeout,
                                 headers=headers(self.agentConfig, http_host=http_host))
             resp.raise_for_status()
 

--- a/php_fpm/check.py
+++ b/php_fpm/check.py
@@ -45,6 +45,8 @@ class PHPFPMCheck(AgentCheck):
         http_host = instance.get('http_host')
 
         timeout = instance.get('timeout')
+        if timeout is None:
+            timeout = 20
 
         if user and password:
             auth = (user, password)

--- a/php_fpm/conf.yaml.example
+++ b/php_fpm/conf.yaml.example
@@ -24,7 +24,7 @@ instances:
     # pass in a custom Host header like so
     # http_host: such.production.host
     #
-    # If you need to specify a custom timeout in seconds:
+    # If you need to specify a custom timeout in seconds (default is 20):
     # timeout: 5
     #
     # Array of custom tags

--- a/php_fpm/conf.yaml.example
+++ b/php_fpm/conf.yaml.example
@@ -24,6 +24,9 @@ instances:
     # pass in a custom Host header like so
     # http_host: such.production.host
     #
+    # If you need to specify a custom timeout in seconds:
+    # timeout: 5
+    #
     # Array of custom tags
     # By default metrics and service check will be tagged by pool and host
     # tags:


### PR DESCRIPTION
## Summary
This PR does two things:
 - Adds a timeout parameter to the php_fpm check
 - Sets the default timeout to 20 seconds

## Rationale

The packaged FPM check uses an unspecified [timeout](http://docs.python-requests.org/en/master/user/quickstart/#timeouts) for requests it makes, which can potentially lead to failing pools taking forever to return a response (or as long as intermediary
services/proxies/etc allow).

The effect is that should a pool fail to return a response, the affected check iteration can hang, blocking execution of _all_ further checks and subsequent metric submission.  DataDog/dd-agent#2854 is a useful reference point for a similar issue.

The unlimited timeout behaviour can cause the agent [watchdog](https://github.com/DataDog/dd-agent/wiki/FAQ#why-is-my-agent-process-dying) thread to kick in and terminate the agent before any data is returned.

Ultimately, this means one failing pool can block the return of _any_ data at all.  This is sub-optimal for an operator responding to an incident; the best data they are able to get without further investigation is that there isn't any data at all for the host.

A 20 second timeout seems a reasonable compromise for an ill performing pool to prevent this scenario.  Should the operator require, they can specify a custom timeout.