### PR TITLE
[ceph] Remove SOURCE_TYPE_NAME constant

### DIFF
--- a/ceph/check.py
+++ b/ceph/check.py
@@ -15,8 +15,6 @@ from checks import AgentCheck
 from utils.subprocess_output import get_subprocess_output
 from config import _is_affirmative
 
-EVENT_TYPE = SOURCE_TYPE_NAME = 'ceph'
-
 # third party
 import simplejson as json
 


### PR DESCRIPTION
It's only useful for checks which name is different from the source
type name used in the backend.

Makes the check consistent with dd-agent