### PR TITLE
[testing] [kubernetes] [jenkins] Fixes broken tests

### DIFF
--- a/jenkins/check.py
+++ b/jenkins/check.py
@@ -25,8 +25,8 @@ class Skip(Exception):
 class Jenkins(AgentCheck):
     datetime_format = '%Y-%m-%d_%H-%M-%S'
 
-    def __init__(self, name, init_config, agentConfig):
-        AgentCheck.__init__(self, name, init_config, agentConfig)
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
         self.high_watermarks = {}
 
     def _timestamp_from_build_file(self, dir_name, tree):

--- a/kubernetes/test_kubernetes.py
+++ b/kubernetes/test_kubernetes.py
@@ -541,7 +541,7 @@ class TestKubeutil(unittest.TestCase):
     def test_get_auth_token(self):
         KubeUtil.AUTH_TOKEN_PATH = '/foo/bar'
         self.assertIsNone(KubeUtil.get_auth_token())
-        KubeUtil.AUTH_TOKEN_PATH = Fixtures.file('events.json')  # any file could do the trick
+        KubeUtil.AUTH_TOKEN_PATH = Fixtures.file('events.json', sdk_dir=FIXTURE_DIR,)  # any file could do the trick
         self.assertIsNotNone(KubeUtil.get_auth_token())
 
     def test_is_k8s(self):


### PR DESCRIPTION
One of the Kubernetes fixtures was broken, this fixes it so the tests keep passing.

The Jenkins test also assumed an old agent structure that was broken after the dd-agent stuff was removed, it is now also fixed.