### PR TITLE
[kubernets] collect_events true should disable all other checks

### DIFF
--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -149,18 +149,19 @@ class Kubernetes(AgentCheck):
 
         pods_list = self.kubeutil.retrieve_pods_list()
 
-        # kubelet health checks
-        self._perform_kubelet_checks(self.kubeutil.kube_health_url)
-
-        # kubelet metrics
-        self._update_metrics(instance, pods_list)
-
         # kubelet events
         if _is_affirmative(instance.get('collect_events', DEFAULT_COLLECT_EVENTS)):
             try:
                 self._process_events(instance, pods_list)
             except Exception as ex:
                 self.log.error("Event collection failed: %s" % str(ex))
+        else:
+            # kubelet health checks
+            self._perform_kubelet_checks(self.kubeutil.kube_health_url)
+
+            # kubelet metrics
+            self._update_metrics(instance, pods_list)
+
 
     def _publish_raw_metrics(self, metric, dat, tags, depth=0):
         if depth >= self.max_depth:

--- a/kubernetes/conf.yaml.example
+++ b/kubernetes/conf.yaml.example
@@ -43,6 +43,7 @@ instances:
   # collect_events controls whether the agent should fetch events from the kubernetes API and
   # ingest them in Datadog. To avoid duplicates, only one agent at a time across the entire
   # cluster should have this feature enabled. To enable the feature, set the parameter to `true`.
+  # Setting this to true disables all other checks.
   #
   # collect_events: false
   #


### PR DESCRIPTION
The suggested deployment strategy is to use a daemon set for the agent with collect_events=false. And then to have a single deployment with collect_events=true. This leads to double metrics collected on the host that has the single deployment. By disabling all non-event metrics when collect_events=true we stop double collecting.  
