### PR TITLE
[snmp] Add individual metric tagging to OID and MIB Non-tabular values

### DIFF
--- a/snmp/check.py
+++ b/snmp/check.py
@@ -395,7 +395,10 @@ class SnmpCheck(NetworkCheck):
                                          queried_oid)
                         continue
                 name = metric.get('name', 'unnamed_metric')
-                self.submit_metric(name, value, forced_type, tags)
+                metric_tags = tags
+                if metric.get('metric_tags'):
+                    metric_tags = metric_tags + metric.get('metric_tags')
+                self.submit_metric(name, value, forced_type, metric_tags)
 
     def report_table_metrics(self, metrics, results, tags):
         '''
@@ -433,7 +436,10 @@ class SnmpCheck(NetworkCheck):
                     self.log.warning("Several rows corresponding while the metric is supposed to be a scalar")
                     continue
                 val = result[0][1]
-                self.submit_metric(name, val, forced_type, tags)
+                metric_tags = tags
+                if metric.get('metric_tags'):
+                    metric_tags = metric_tags + metric.get('metric_tags')
+                self.submit_metric(name, val, forced_type, metric_tags)
             elif 'OID' in metric:
                 pass # This one is already handled by the other batch of requests
             else:


### PR DESCRIPTION
This PR updates the snmp check to allow for a new yaml-specified tag under metrics defined like so:

```
- MIB: TCP-MIB
   symbol: tcpActiveOpens
   metric_tags:
       - TCP
  
- OID: 1.3.6.1.2.1.6.5
   name: tcpPassiveOpens
   metric_tags:
      - TCP
```

The metric will then be submitted with these individual tags in addition to the overarching tags for the specific instance. 