### PR TITLE
[snmp] Add individual metric tagging to OID and MIB Non-tabular values

### DIFF
--- a/snmp/check.py
+++ b/snmp/check.py
@@ -395,7 +395,10 @@ class SnmpCheck(NetworkCheck):
                                          queried_oid)
                         continue
                 name = metric.get('name', 'unnamed_metric')
-                self.submit_metric(name, value, forced_type, tags)
+                metric_tags = tags
+                if metric.get('metric_tags'):
+                    metric_tags = metric_tags + metric.get('metric_tags')
+                self.submit_metric(name, value, forced_type, metric_tags)
 
     def report_table_metrics(self, metrics, results, tags):
         '''
@@ -433,7 +436,10 @@ class SnmpCheck(NetworkCheck):
                     self.log.warning("Several rows corresponding while the metric is supposed to be a scalar")
                     continue
                 val = result[0][1]
-                self.submit_metric(name, val, forced_type, tags)
+                metric_tags = tags
+                if metric.get('metric_tags'):
+                    metric_tags = metric_tags + metric.get('metric_tags')
+                self.submit_metric(name, val, forced_type, metric_tags)
             elif 'OID' in metric:
                 pass # This one is already handled by the other batch of requests
             else:

--- a/snmp/conf.yaml.example
+++ b/snmp/conf.yaml.example
@@ -29,6 +29,12 @@ instances:
   #     # If it's just a scalar, you can specify by OID and name it
   #     - OID: 1.3.6.1.2.1.6.5
   #       name: tcpPassiveOpens
+  #     
+  #     # You can also specify a specific tag for these with the metric_tags field
+  #     - OID: 1.3.6.1.2.1.6.5
+  #       name: tcpPassiveOpens
+  #       metric_tags:
+  #         - TCP
   #
   #     # This monitor auto-detects OID data types from the remote agent's response.
   #     # If you're dealing with a buggy agent that returns incorrect data types for OIDs,

--- a/snmp/test_snmp.py
+++ b/snmp/test_snmp.py
@@ -106,6 +106,22 @@ class SNMPTestCase(AgentCheckTest):
         }
     ]
 
+    SCALAR_OBJECTS_WITH_TAGS = [
+        {
+            'OID': "1.3.6.1.2.1.7.1.0",
+            'name': "udpDatagrams",
+            'metric_tags': ['udpdgrams', 'UDP']
+        }, {
+            'OID': "1.3.6.1.2.1.6.10.0",
+            'name': "tcpInSegs",
+            'metric_tags': ['tcpinsegs', 'TCP']
+        }, {
+            'MIB': "TCP-MIB",
+            'symbol': "tcpCurrEstab",
+            'metric_tags': ['MIB', 'TCP', 'estab']
+        }
+    ]
+
     TABULAR_OBJECTS = [{
         'MIB': "IF-MIB",
         'table': "ifTable",
@@ -360,6 +376,27 @@ class SNMPTestCase(AgentCheckTest):
         self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
         self.assertServiceCheck("snmp.can_check", status=AgentCheck.CRITICAL,
                                 tags=self.CHECK_TAGS, count=1)
+        self.coverage_report()
+
+    def test_scalar_with_tags(self):
+        """
+        Support SNMP scalar objects with tags
+        """
+        config = {
+            'instances': [self.generate_instance_config(self.SCALAR_OBJECTS_WITH_TAGS)]
+        }
+        self.run_check_n(config, repeat=3)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+
+        # Test metrics
+        for metric in self.SCALAR_OBJECTS_WITH_TAGS:
+            metric_name = "snmp." + (metric.get('name') or metric.get('symbol'))
+            tags = self.CHECK_TAGS + metric.get('metric_tags')
+            self.assertMetric(metric_name, tags=tags, count=1)
+        # Test service check
+        self.assertServiceCheck("snmp.can_check", status=AgentCheck.OK,
+                                tags=self.CHECK_TAGS, count=1)
+
         self.coverage_report()
 
     def test_network_failure(self):


### PR DESCRIPTION
This PR updates the snmp check to allow for a new yaml-specified tag under metrics defined like so:
```
- MIB: TCP-MIB
   symbol: tcpActiveOpens
   metric_tags:
       - TCP
  
- OID: 1.3.6.1.2.1.6.5
   name: tcpPassiveOpens
   metric_tags:
      - TCP
```
The metric will then be submitted with these individual tags in addition to the overarching tags for the specific instance.