### PR TITLE
[linux_proc_extras] fix proc path regression

### DIFF
--- a/linux_proc_extras/check.py
+++ b/linux_proc_extras/check.py
@@ -35,7 +35,7 @@ class MoreUnixCheck(AgentCheck):
         self.get_process_states()
 
     def set_paths(self):
-        proc_location = self.agentConfig.get('procfs_path', '/proc').rstrip('/').lstrip('/')
+        proc_location = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
 
         self.proc_path_map = {
             "inode_info": "sys/fs/inode-nr",

--- a/linux_proc_extras/test_linux_proc_extras.py
+++ b/linux_proc_extras/test_linux_proc_extras.py
@@ -40,13 +40,8 @@ class TestCheckLinuxProcExtras(AgentCheckTest):
     def test_check(self):
 
         self.load_check({'instances': []})
-
-        self.check.proc_path_map = {
-            "inode_info": "/proc/sys/fs/inode-nr",
-            "stat_info": "/proc/stat",
-            "entropy_info": "/proc/sys/kernel/random/entropy_avail",
-        }
         self.check.tags = []
+        self.check.set_paths()
 
         ci_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "ci")
         m = mock_open(read_data=Fixtures.read_file('entropy_avail', sdk_dir=ci_dir))
@@ -71,8 +66,6 @@ class TestCheckLinuxProcExtras(AgentCheckTest):
         self.service_checks = self.check.get_service_checks()
         self.service_metadata = []
         self.warnings = self.check.get_warnings()
-
-        self.check.log.info(self.metrics)
 
         # Assert metrics
         for metric in self.PROC_COUNTS + self.INODE_GAUGES + self.ENTROPY_GAUGES + self.PROCESS_STATS_GAUGES:


### PR DESCRIPTION
When moving the check, lstrip was added. It breaks the check (since
we're looking for absolute path), and I couldn't find a reason why it
was added. I removed them and also updated the tests.