### PR TITLE
[mesos] collect mesos.registrar.log.recovered metric

### DIFF
--- a/mesos_master/check.py
+++ b/mesos_master/check.py
@@ -110,6 +110,7 @@ class MesosMaster(AgentCheck):
         'system/mem_total_bytes'                            : ('mesos.stats.system.mem_total_bytes', GAUGE),
         'master/elected'                                    : ('mesos.stats.elected', GAUGE),
         'master/uptime_secs'                                : ('mesos.stats.uptime_secs', GAUGE),
+        'registrar/log/recovered'                           : ('mesos.registrar.log.recovered', GAUGE),
     }
 
     # These metrics are aggregated only on the elected master

--- a/mesos_master/ci/fixtures/stats.json
+++ b/mesos_master/ci/fixtures/stats.json
@@ -10,6 +10,7 @@
   "system/cpus_total": 1,
   "started_tasks": 0,
   "staged_tasks": 0,
+  "registrar/log/recovered": 1.0,
   "registrar/state_store_ms/p9999": 9.90120192,
   "registrar/state_store_ms/p999": 9.8956032,
   "registrar/state_store_ms/p99": 9.839616,

--- a/mesos_master/metadata.csv
+++ b/mesos_master/metadata.csv
@@ -44,6 +44,7 @@ mesos.registrar.state_store_ms.p95,gauge,,millisecond,,95th percentile registry 
 mesos.registrar.state_store_ms.p99,gauge,,millisecond,,99th percentile registry write latency,-1,mesos,latency p99
 mesos.registrar.state_store_ms.p999,gauge,,millisecond,,99.9th percentile registry write latency,-1,mesos,latency p999
 mesos.registrar.state_store_ms.p9999,gauge,,millisecond,,99.99th percentile registry write latency,-1,mesos,latency p9999
+mesos.registrar.log.recovered,gauge,,,,Registrar log recovered,1,mesos,registrar log recovered
 mesos.cluster.frameworks_active,gauge,,,,Number of active frameworks,0,mesos,active frameworks
 mesos.cluster.frameworks_connected,gauge,,,,Number of connected frameworks,0,mesos,connected frameworks
 mesos.cluster.frameworks_disconnected,gauge,,,,Number of disconnected frameworks,0,mesos,disconnected frameworks


### PR DESCRIPTION
This collects the `mesos.registrar.log.recovered` metric, as defined at https://mesos.apache.org/documentation/latest/monitoring/.  The metric was added to Mesos 1.0.0 as per [MESOS-5618](https://issues.apache.org/jira/browse/MESOS-5618).

I have been successfully monitoring Mesos masters (1.1.0) with this change deployed on them.

Sidenote: Running`rake ci:run[mesos_master]` locally displays "Ran 0 tests in 0.000s" (even before making changes), despite the test defined in`test_mesos_master.py`.  I encountered this on both Mac and Debian Linux.