### PR TITLE
[yarn] fix tagging for app metrics

### DIFF
--- a/yarn/check.py
+++ b/yarn/check.py
@@ -222,9 +222,11 @@ class YarnCheck(AgentCheck):
                 tags = []
                 for dd_tag, yarn_key in app_tags.iteritems():
                     try:
-                        tags.append("{tag}:{value}".format(
-                            tag=dd_tag, value=app_json[yarn_key]
-                        ))
+                        val = app_json[yarn_key]
+                        if val:
+                            tags.append("{tag}:{value}".format(
+                                tag=dd_tag, value=val
+                            ))
                     except KeyError:
                         self.log.error("Invalid value %s for application_tag", yarn_key)
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Skip tags if their value in app_json is empty.

### Motivation

Discovered during QA.

### Testing Guidelines

- deploy yarn cluster
- schedule a job on it
- look at the app_json payload, some fields can be empty
- before the fix it reported an `app_tags:` tag for example
- now the tag is simply not sent

### Additional Notes

example payload: 
```json
{u'runningContainers': 7, u'allocatedVCores': 7, u'clusterId': 1489066795611, u'amContainerLogs': u'http://namenode:8042/node/containerlogs/container_1489066795611_0003_01_000001/root', u'id': u'application_1489066795611_0003', u'resourceRequests': [{u'priority': {u'priority': 0}, u'numContainers': 0, u'nodeLabelExpression': u'', u'relaxLocality': True, u'capability': {u'virtualCores': 1, u'memory': 2048}, u'resourceName': u'*'}, {u'priority': {u'priority': 20}, u'numContainers': 24, u'nodeLabelExpression': u'', u'relaxLocality': True, u'capability': {u'virtualCores': 1, u'memory': 1024}, u'resourceName': u'/default-rack'}, {u'priority': {u'priority': 20}, u'numContainers': 24, u'nodeLabelExpression': u'', u'relaxLocality': True, u'capability': {u'virtualCores': 1, u'memory': 1024}, u'resourceName': u'*'}, {u'priority': {u'priority': 20}, u'numContainers': 24, u'nodeLabelExpression': u'', u'relaxLocality': True, u'capability': {u'virtualCores': 1, u'memory': 1024}, u'resourceName': u'namenode'}], u'preemptedResourceMB': 0, u'finishedTime': 0, u'numAMContainerPreempted': 0, u'user': u'root', u'preemptedResourceVCores': 0, u'startedTime': 1489068373813, u'elapsedTime': 10832, u'state': u'RUNNING', u'numNonAMContainerPreempted': 0, u'progress': 5.0, u'trackingUI': u'ApplicationMaster', u'trackingUrl': u'http://namenode:8088/proxy/application_1489066795611_0003/', u'allocatedMB': 8192, u'amHostHttpAddress': u'namenode:8042', u'memorySeconds': 46704, u'applicationTags': u'', u'name': u'grep-search', u'queue': u'default', u'vcoreSeconds': 34, u'applicationType': u'MAPREDUCE', u'diagnostics': u'', u'finalStatus': u'UNDEFINED'}
```