### PR TITLE
fix conf.yaml.example

### DIFF
--- a/yarn/conf.yaml.example
+++ b/yarn/conf.yaml.example
@@ -12,7 +12,7 @@ instances:
   # The ResourceManager port can be found in the yarn-site.xml conf file under
   # the property yarn.resourcemanager.webapp.address
   #
-  -  resourcemanager_uri: http://localhost:8088
+  - resourcemanager_uri: http://localhost:8088
 
     # A Required friendly name for the cluster.
     # cluster_name: MyYarnCluster


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Remove additional space before resourcemanager_uri:

### Motivation

Support Request

### Testing Guidelines

Installed/configured hadoop.  

Verified that the issue experienced by Bai was indeed occurring, see screenshot: https://cl.ly/1n0V2z3j3y45

Removed extra space before resourcemanager_uri: -  resourcemanager_uri: http://localhost:8088

Restarted agent and issue was resolved, see screenshot: https://cl.ly/1s1V451T2e04


### Additional Notes

N/A
