### PR TITLE
[couch] escaped the database names (fixes #214)

### DIFF
--- a/couch/check.py
+++ b/couch/check.py
@@ -4,6 +4,7 @@
 
 # stdlib
 from urlparse import urljoin
+import urllib
 
 # 3rd party
 import requests
@@ -119,7 +120,7 @@ class CouchDb(AgentCheck):
             databases = list(databases)[:self.MAX_DB]
 
         for dbName in databases:
-            url = urljoin(server, dbName)
+            url = urljoin(server, urllib.quote(dbName, safe = ''))
             try:
                 db_stats = self._get_stats(url, instance)
             except requests.exceptions.HTTPError as e:

--- a/couch/check.py
+++ b/couch/check.py
@@ -4,7 +4,7 @@
 
 # stdlib
 from urlparse import urljoin
-import urllib
+from urllib import quote
 
 # 3rd party
 import requests
@@ -120,7 +120,7 @@ class CouchDb(AgentCheck):
             databases = list(databases)[:self.MAX_DB]
 
         for dbName in databases:
-            url = urljoin(server, urllib.quote(dbName, safe = ''))
+            url = urljoin(server, quote(dbName, safe = ''))
             try:
                 db_stats = self._get_stats(url, instance)
             except requests.exceptions.HTTPError as e:


### PR DESCRIPTION
### What does this PR do?

To support forward slashes in db names, the names have to be URI encoded. This fixes the root cause of #214.

### Motivation

The integration doesn't work at all (throws errors) when the couchdb has databases with slashes (e.g. `users/datadog`).

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

There will still be an error when the try/except block throws. `db_stats` is referenced before assignment.
