### PR TITLE
[windows] Remove windows support for docker_daemon and mesos checks

### DIFF
--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -9,8 +9,7 @@
   "support": "contrib",
   "supported_os": [
     "linux",
-    "mac_os",
-    "windows"
+    "mac_os"
   ],
   "version": "1.0.0"
 }

--- a/mesos/manifest.json
+++ b/mesos/manifest.json
@@ -9,8 +9,7 @@
   "support": "contrib",
   "supported_os": [
     "linux",
-    "mac_os",
-    "windows"
+    "mac_os"
   ],
   "version": "0.1.0"
 }


### PR DESCRIPTION
These 2 checks have never supported windows, let's remove windows
from their manifests