### PR TITLE
[ci][windows] Remove 32bit python CI on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,17 +10,11 @@ environment:
   SKIP_LINT: true
   DD_AGENT_BRANCH: master
   SDK_TESTING: true
-  matrix:
-  - PYTHON: C:\\Python27
-    PYTHON_VERSION: 2.7.11
-    PYTHON_ARCH: 32
-    PYWIN32_URL: https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20219/pywin32-219.win32-py2.7.exe
-    PYWIN32_INSTALL_DIR: pywin32-219-py2.7-win32.egg
-  - PYTHON: C:\\Python27-x64
-    PYTHON_VERSION: 2.7.9
-    PYTHON_ARCH: 64
-    PYWIN32_URL: http://sourceforge.net/projects/pywin32/files/pywin32/Build%20219/pywin32-219.win-amd64-py2.7.exe/download
-    PYWIN32_INSTALL_DIR: pywin32-219-py2.7-win-amd64.egg
+  PYTHON: C:\\Python27-x64
+  PYTHON_VERSION: 2.7.13
+  PYTHON_ARCH: 64
+  PYWIN32_URL: http://sourceforge.net/projects/pywin32/files/pywin32/Build%20219/pywin32-219.win-amd64-py2.7.exe/download
+  PYWIN32_INSTALL_DIR: pywin32-219-py2.7-win-amd64.egg
 cache:
   - C:\projects\integrations-core\.cache
   - C:\projects\integrations-core\vendor\cache

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
   PYTHON: C:\\Python27-x64
   PYTHON_VERSION: 2.7.13
   PYTHON_ARCH: 64
-  PYWIN32_URL: http://sourceforge.net/projects/pywin32/files/pywin32/Build%20219/pywin32-219.win-amd64-py2.7.exe/download
+  PYWIN32_URL: https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20219/pywin32-219.win-amd64-py2.7.exe
   PYWIN32_INSTALL_DIR: pywin32-219-py2.7-win-amd64.egg
 cache:
   - C:\projects\integrations-core\.cache


### PR DESCRIPTION
We only ship the windows agent with 64bit python nowadays (starting from the upcoming `5.12.0` actually), so it's not worth it to test python 32bit on appveyor.

Also, upgrades python to 2.7.13 on AppVeyor.