### PR TITLE
Bump kafka-python to 1.3.3

### DIFF
--- a/kafka_consumer/requirements.txt
+++ b/kafka_consumer/requirements.txt
@@ -1,3 +1,3 @@
 # integration pip requirements
-kafka-python==1.3.1
+kafka-python==1.3.3
 kazoo==2.2.1


### PR DESCRIPTION
1.3.3 fixes a number of bugs and also adds support for several API calls that will come in handy when adding support for offsets stored in kafka.
