### PR TITLE
Add check copying logic to the Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -69,6 +69,19 @@ def print_inconsistencies(display_name, inconsistencies)
   end
 end
 
+def os
+  case RUBY_PLATFORM
+  when /linux/
+    'linux'
+  when /darwin/
+    'mac_os'
+  when /x64-mingw32/
+    'windows'
+  else
+    raise 'Unsupported OS'
+  end
+end
+
 desc 'Outputs the checks/example configs of this repo that do not match the ones in `dd-agent` (temporary task)'
 task dd_agent_consistency: [:pull_latest_agent] do
   print_inconsistencies(
@@ -79,4 +92,68 @@ task dd_agent_consistency: [:pull_latest_agent] do
     'yaml example file',
     find_inconsistencies(find_yaml_confs, 'conf.d')
   )
+end
+
+desc 'Copy checks and configuration files over the given paths, optionally merging requirements files into one'
+task :copy_checks do
+  conf_dir = ENV['conf_dir']
+  raise "please specify 'conf_dir' param" if conf_dir.to_s.empty?
+  mkdir_p File.join(conf_dir, 'auto_conf')
+
+  checks_dir = ENV['checks_dir']
+  raise "please specify 'checks_dir' param" if checks_dir.to_s.empty?
+  mkdir_p checks_dir
+
+  all_reqs_file = nil
+
+  merge_to = ENV['merge_requirements_to']
+  unless merge_to.to_s.empty?
+    all_reqs_file = File.open(File.join(merge_to, 'check_requirements.txt'), 'w+')
+  end
+
+  Dir.glob('*/').each do |check|
+    check.slice! '/'
+
+    # Check the manifest to be sure that this check is enabled on this system
+    # or skip this iteration
+    manifest_file_path = "#{check}/manifest.json"
+
+    # If there is no manifest file, then we should assume the folder does not
+    # contain a working check and move onto the next
+    File.exist?(manifest_file_path) || next
+
+    manifest = JSON.parse(File.read(manifest_file_path))
+    manifest['supported_os'].include?(os) || next
+
+    # Copy the checks over
+    if File.exist? "#{check}/check.py"
+      copy "#{check}/check.py", "#{checks_dir}/#{check}.py"
+    end
+
+    # Copy the check config to the conf directories
+    if File.exist? "#{check}/conf.yaml.example"
+      copy "#{check}/conf.yaml.example", "#{conf_dir}/#{check}.yaml.example"
+    end
+
+    # Copy the default config, if it exists
+    if File.exist? "#{check}/conf.yaml.default"
+      copy "#{check}/conf.yaml.default", "#{conf_dir}/#{check}.yaml.default"
+    end
+
+    # We don't have auto_conf on windows yet
+    if os != 'windows'
+      if File.exist? "#{check}/auto_conf.yaml"
+        copy "#{check}/auto_conf.yaml", "#{conf_dir}/auto_conf/#{check}.yaml"
+      end
+    end
+
+    next unless all_reqs_file && File.exist?("#{check}/requirements.txt") && !manifest['use_omnibus_reqs']
+
+    reqs = File.open("#{check}/requirements.txt", 'r').read
+    reqs.each_line do |line|
+      all_reqs_file.puts line if line[0] != '#'
+    end
+  end
+
+  all_reqs_file.close if all_reqs_file
 end


### PR DESCRIPTION
### What does this PR do?

It adds a new rake task to be invoked like:
```
rake copy_checks conf_dir=/tmp/etc checks_dir=/tmp/checks.d
```
in order to copy all the checks and the relative configuration files to the specified paths.

Optionally, the command can be invoked to also merge all the `requirements.txt` files into one:
```
rake copy_checks conf_dir=/tmp/etc checks_dir=/tmp/checks.d merge_requirements_to=.
```

### Motivation

We have the same logic in the omnibus installer of the agent but this change would allow to write a more concise software definition for the integrations core, delegating the logic to the present Rakefile.

