### PR TITLE
Add generic install instructions which each integration's README can …

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 This repository contains the Agent Integrations that Datadog officially develops and supports. To add a new integration, please see the [Integrations Extras](https://github.com/DataDog/integrations-extras) repository and the [accompanying documentation](http://docs.datadoghq.com/guides/integration_sdk/).
 
+# Installing the Integrations
+
+The [Datadog Agent](https://github.com/DataDog/dd-agent) contains all core integrations from this repository, so to get started using them, simply install the `datadog-agent` package for your operating system.
+
+Additionally, you may install any individual core integration via its own `dd-check-<integration_name>` package, e.g. `dd-check-nginx`. These packages are built from this repository and always have the latest code for the checks, while `datadog-agent` - which we may release less often - can contain older versions of the integrations or may be missing brand new integrations. The individual check packages allow us to get you the latest updates and newest checks during the time between releases of `datadog-agent`.
+
+In other words: on the day of a new `datadog-agent` release, you'll likely get the same version of the nginx check from the agent package as you would from `dd-check-nginx`. But if the agent hasn't been released in 6 weeks and this repository contains a bugfix for the nginx check, install the latest `dd-check-nginx` to override the older check code included in `datadog-agent`.
+
 # Reporting Issues
 
 For more information on integrations, please reference our [documentation](http://docs.datadoghq.com) and [knowledge base](https://help.datadoghq.com/hc/en-us). You can also visit our [help page](http://docs.datadoghq.com/help/) to connect with us.


### PR DESCRIPTION
I think it would be nice to make the release and packaging policy clear to end users (not sure if we're doing this elsewhere). @gmmeyer please review this and let me know if I'm understanding things correctly.