### PR TITLE
remove psycopg2 as a test requirement

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,4 +3,3 @@ mock==2.0.0
 pep8==1.5.7
 pylint==1.6.4
 nose==1.3.4
-psycopg2==2.6.2 # required by postgres tests


### PR DESCRIPTION
It should be part of postgres dependency already.
[skip ci]

I know we removed it because it failed the Windows build, but his is failing locally on Mac.