### PR TITLE
[docker_daemon] Collect rancher label container name as tag

### DIFF
--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -17,7 +17,8 @@ from config import _is_affirmative
 from utils.dockerutil import (DockerUtil,
                               MountException,
                               BogusPIDException,
-                              SWARM_SVC_LABEL)
+                              SWARM_SVC_LABEL,
+                              RANCHER_CONTAINER_NAME)
 from utils.kubernetes import KubeUtil
 from utils.platform import Platform
 from utils.service_discovery.sd_backend import get_sd_backend
@@ -26,7 +27,6 @@ from utils.service_discovery.sd_backend import get_sd_backend
 EVENT_TYPE = 'docker'
 SERVICE_CHECK_NAME = 'docker.service_up'
 HEALTHCHECK_SERVICE_CHECK_NAME = 'docker.container_health'
-RANCHER_CONTAINER_NAME = 'io.rancher.container.name'
 SIZE_REFRESH_RATE = 5  # Collect container sizes every 5 iterations of the check
 CONTAINER_ID_RE = re.compile('[0-9a-f]{64}')
 

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -18,7 +18,9 @@ from utils.dockerutil import (DockerUtil,
                               MountException,
                               BogusPIDException,
                               SWARM_SVC_LABEL,
-                              RANCHER_CONTAINER_NAME)
+                              RANCHER_CONTAINER_NAME,
+                              RANCHER_SVC_NAME,
+                              RANCHER_STACK_NAME)
 from utils.kubernetes import KubeUtil
 from utils.platform import Platform
 from utils.service_discovery.sd_backend import get_sd_backend
@@ -373,8 +375,13 @@ class DockerDaemon(AgentCheck):
             self.collect_labels_as_tags.append(KubeUtil.POD_NAME_LABEL)
 
         # Collect container names as tags on rancher
-        if Platform.is_rancher() and RANCHER_CONTAINER_NAME not in self.collect_labels_as_tags:
-            self.collect_labels_as_tags.append(RANCHER_CONTAINER_NAME)
+        if Platform.is_rancher():
+            if RANCHER_CONTAINER_NAME not in self.collect_labels_as_tags:
+                self.collect_labels_as_tags.append(RANCHER_CONTAINER_NAME)
+            if RANCHER_SVC_NAME not in self.collect_labels_as_tags:
+                self.collect_labels_as_tags.append(RANCHER_SVC_NAME)
+            if RANCHER_STACK_NAME not in self.collect_labels_as_tags:
+                self.collect_labels_as_tags.append(RANCHER_STACK_NAME)
 
         if entity is not None:
             pod_name = None
@@ -405,7 +412,13 @@ class DockerDaemon(AgentCheck):
                                 tags.append("swarm_service:%s" % v)
                         elif k == RANCHER_CONTAINER_NAME and Platform.is_rancher():
                             if v:
+                                tags.append('rancher_container:%s' % v)
+                        elif k == RANCHER_SVC_NAME and Platform.is_rancher():
+                            if v:
                                 tags.append('rancher_service:%s' % v)
+                        elif k == RANCHER_STACK_NAME and Platform.is_rancher():
+                            if v:
+                                tags.append('rancher_stack:%s' % v)
 
                         elif not v:
                             tags.append(k)


### PR DESCRIPTION
Collects the rancher label for the container name and send it as a tag.
This way users will be able to graph their metrics based on rancher resources.