### PR TITLE
Comment out psycopg2 requirement

### DIFF
--- a/pgbouncer/requirements.txt
+++ b/pgbouncer/requirements.txt
@@ -1,2 +1,2 @@
 # integration pip requirements
-psycopg2==2.6.2
+# psycopg2==2.6.2 is satisfied in 'integration-deps'


### PR DESCRIPTION
<!--*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*-->

### What does this PR do?

Comment out the explicit requirement for `psycopg`, same as the `postgres` check.

### Motivation
1) Let's do the same things across different checks
2) Dependency should be handled in omnibus but right now `psycopg` is listed in the constraint file and the build fails if this and the version in omnibus don't match. This makes impossible to make experiments with updated packages omnibus side


