### PR TITLE
[mysql] we need to allow for configurable (non)blocking collection of replicas statuses

### DIFF
--- a/mysql/check.py
+++ b/mysql/check.py
@@ -529,7 +529,7 @@ class MySql(AgentCheck):
         if _is_affirmative(options.get('replication', False)):
             # Get replica stats
             results.update(self._get_replica_stats(db))
-            nonblocking = _is_affirmative(options.get('replication_non_blocking_status', True))
+            nonblocking = _is_affirmative(options.get('replication_non_blocking_status', False))
             results.update(self._get_slave_status(db, above_560, nonblocking))
             metrics.update(REPLICA_VARS)
 

--- a/mysql/conf.yaml.example
+++ b/mysql/conf.yaml.example
@@ -13,6 +13,7 @@ instances:
     #   - optional_tag2
     # options:               # Optional
     #   replication: false
+    #   replication_non_blocking_status: true  # attempt to grab slave status in a non-blocking manner
     #   galera_cluster: false
     #   extra_status_metrics: true
     #   extra_innodb_metrics: true

--- a/mysql/conf.yaml.example
+++ b/mysql/conf.yaml.example
@@ -13,7 +13,7 @@ instances:
     #   - optional_tag2
     # options:               # Optional
     #   replication: false
-    #   replication_non_blocking_status: true  # attempt to grab slave status in a non-blocking manner
+    #   replication_non_blocking_status: false  # grab slave count in non-blocking manner (req. performance_schema)
     #   galera_cluster: false
     #   extra_status_metrics: true
     #   extra_innodb_metrics: true


### PR DESCRIPTION
### What does this PR do?

Allows configuration of the non-blocking method we use to collect replica statuses.

### Motivation

Some customers don't have the `performance_schema table` populated and have to fallback to the blocking query. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

I'm thinking we should maybe just get rid of the non-blocking alternative as it should be a quick query. My only concern here would be having users with 5.6.0+ that have the non-blocking query populated in performance schema, but maybe something unexpected with in the information schema processlist.... We've seen all sorts of weirdness in the past across versions and MySQL compatible distributions. 