### PR TITLE
[docker_daemon] Add ability to report exit codes of containers in case of DIE event

### DIFF
--- a/docker_daemon/conf.yaml.example
+++ b/docker_daemon/conf.yaml.example
@@ -96,6 +96,12 @@ instances:
     #
     # collect_disk_stats: true
 
+    # Collect containers exit codes
+    # This is useful to monitor if ephemeral containers exit with an error or not.
+    # Defaults to false.
+    #
+    # collect_exit_codes: true
+
 
     # Exclude containers based on their tags
     # An excluded container will not get any individual container metric reported for it.


### PR DESCRIPTION
### What does this PR do?

It adds the ability to report the exit codes of containers as a sparse metric.

### Motivation

A customer launches ephemeral containers at regular intervals and would like to be able to alert on non-zero exit codes.
