### PR TITLE
[mysql] slaves connected should be a gauge.

### DIFF
--- a/mysql/check.py
+++ b/mysql/check.py
@@ -265,7 +265,7 @@ SCHEMA_VARS = {
 
 REPLICA_VARS = {
     'Seconds_Behind_Master': ('mysql.replication.seconds_behind_master', GAUGE),
-    'Slaves_connected': ('mysql.replication.slaves_connected', COUNT),
+    'Slaves_connected': ('mysql.replication.slaves_connected', GAUGE),
 }
 
 SYNTHETIC_VARS = {

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -39,4 +39,5 @@ mysql.performance.threads_running,gauge,,thread,,The number of threads that are 
 mysql.performance.user_time,gauge,,percent,,Percentage of CPU time spent in user space by MySQL.,-1,mysql,cpu user
 mysql.replication.seconds_behind_master,gauge,,second,,The lag in seconds between the master and the slave.,-1,mysql,replication lag
 mysql.replication.slave_running,gauge,,,,A boolean showing if this server is a replication slave that is connected to a replication master.,0,mysql,slave running
+mysql.replication.slaves_connected,gauge,,,,Number of slaves connected to a replication master.,0,mysql,slaves connected
 mysql.performance.queries,gauge,,query,second,The rate of queries.,0,mysql,queries


### PR DESCRIPTION
### What does this PR do?

Sending slaves connected as a count is not correct and misleading. It should be a gauge.

### Motivation

Found the issue while testing a change. The metric will be summed up when looking at it in different timescales when submitted as a count, which is totally misleading. It should definitely be a gauge.