### PR TITLE
collects mesos tags during docker_daemon check

### DIFF
--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -436,11 +436,14 @@ class DockerDaemon(AgentCheck):
             if self.collect_mesos_tags and (tag_type is CONTAINER or tag_type is PERFORMANCE):
                 cont_id = entity.get("Id")
                 if cont_id is not None:
-                    cont_inspected = self.docker_client.inspect_container(cont_id)
-                    for env_var in cont_inspected['Config']['Env']:
-                        arr = env_var.split("=")
-                        if arr[0].upper() in MESOS_TAG_ENVS:
-                            tags.append("{}:{}".format(arr[0].lower(), arr[1]))
+                    try:
+                        cont_inspected = self.docker_client.inspect_container(cont_id)
+                        for env_var in cont_inspected['Config']['Env']:
+                            arr = env_var.split("=")
+                            if arr[0].upper() in MESOS_TAG_ENVS:
+                                tags.append("{}:{}".format(arr[0].lower(), arr[1]))
+                    except Exception as e:
+                        self.log.debug("Unable to inspect Docker container: %s", e)
 
             # Add kube labels
             if Platform.is_k8s():

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -120,6 +120,12 @@ TAG_EXTRACTORS = {
     "container_id": lambda c: [c["Id"]],
 }
 
+MESOS_TAG_ENVS = [
+    "MARATHON_APP_ID",
+    "CHRONOS_JOB_NAME",
+    "MESOS_TASK_ID",
+]
+
 CONTAINER = "container"
 PERFORMANCE = "performance"
 FILTERED = "filtered"
@@ -211,6 +217,7 @@ class DockerDaemon(AgentCheck):
             self.collect_image_size = _is_affirmative(instance.get('collect_image_size', False))
             self.collect_disk_stats = _is_affirmative(instance.get('collect_disk_stats', False))
             self.collect_ecs_tags = _is_affirmative(instance.get('ecs_tags', True)) and Platform.is_ecs_instance()
+            self.collect_mesos_tags = _is_affirmative(instance.get('mesos_tags', False))
 
             self.ecs_tags = {}
 
@@ -424,6 +431,16 @@ class DockerDaemon(AgentCheck):
                 if entity_id in self.ecs_tags:
                     ecs_tags = self.ecs_tags[entity_id]
                     tags.extend(ecs_tags)
+
+            # Add Mesos tags
+            if self.collect_mesos_tags and (tag_type is CONTAINER or tag_type is PERFORMANCE):
+                cont_id = entity.get("Id")
+                if cont_id is not None:
+                    cont_inspected = self.docker_client.inspect_container(cont_id)
+                    for env_var in cont_inspected['Config']['Env']:
+                        arr = env_var.split("=")
+                        if arr[0].upper() in MESOS_TAG_ENVS:
+                            tags.append("{}:{}".format(arr[0].lower(), arr[1]))
 
             # Add kube labels
             if Platform.is_k8s():

--- a/docker_daemon/conf.yaml.example
+++ b/docker_daemon/conf.yaml.example
@@ -135,6 +135,12 @@ instances:
     #
     # ecs_tags: false
 
+    # Collect the  mesos tags from containers.
+    # By default collects mesos_task_id and marathon_app_id or chronos_job_name
+    # Default: false
+    #
+    # mesos_tags: true
+
     # Custom metrics tagging
     # Define which Docker tags to apply on metrics.
     # Since it impacts the aggregation, modify it carefully (only if you really need it).


### PR DESCRIPTION
### What does this PR do?
It adds `mesos_task_id` and `marathon_app_id` or `chronos_job_name` to docker daemon check tags.

Its based on https://github.com/DataDog/dd-agent/pull/2870 but adds the other 2 tags.

It does it by inspecting container and extracting environment variables set by mesos.

### Motivation
With mesos the `container_name` is useless.  


### Testing Guidelines

No tests yet.