### PR TITLE
[mysql] exclude slave count and binlog_running from slave_running jud…

### DIFF
--- a/mysql/check.py
+++ b/mysql/check.py
@@ -561,12 +561,7 @@ class MySql(AgentCheck):
 
             # if we don't yet have a status - inspect
             if slave_running_status == AgentCheck.UNKNOWN:
-                if self._is_master(slaves, binlog_running):  # master
-                    if slaves > 0 and binlog_running:
-                        slave_running_status = AgentCheck.OK
-                    else:
-                        slave_running_status = AgentCheck.WARNING
-                elif slave_running:  # slave (or standalone)
+                if slave_running:
                     if slave_running.lower().strip() == 'on':
                         slave_running_status = AgentCheck.OK
                     else:


### PR DESCRIPTION
### What does this PR do?
This pull request removes the split in master/slave judgement for the mysql.replication.slave_running metric.

### Motivation
My view on this:
-  I think the current logic doesn't cover the situation where a mysql server is configured as a slave and creates binlogs.
- I would say that mysql.replication.slave_running should, no matter if it's a master or slave, only be based on the mysql 'slave_running' variable.