### PR TITLE
[redisdb] add support for redis patterns

### DIFF
--- a/redisdb/check.py
+++ b/redisdb/check.py
@@ -233,24 +233,30 @@ class Redis(AgentCheck):
                 self.warning("keys in redis configuration is either not a list or empty")
             else:
                 l_tags = list(tags)
-                for key in key_list:
-                    key_type = conn.type(key)
-                    key_tags = l_tags + ['key:' + key]
-
-                    if key_type == 'list':
-                        self.gauge('redis.key.length', conn.llen(key), tags=key_tags)
-                    elif key_type == 'set':
-                        self.gauge('redis.key.length', conn.scard(key), tags=key_tags)
-                    elif key_type == 'zset':
-                        self.gauge('redis.key.length', conn.zcard(key), tags=key_tags)
-                    elif key_type == 'hash':
-                        self.gauge('redis.key.length', conn.hlen(key), tags=key_tags)
+                for key_pattern in key_list:
+                    if re.search(r"(?<!\\)[*?[]", key_pattern):
+                        keys = conn.scan_iter(match=key_pattern)
                     else:
-                        # If the type is unknown, it might be because the key doesn't exist,
-                        # which can be because the list is empty. So always send 0 in that case.
-                        if instance.get("warn_on_missing_keys", True):
-                            self.warning("{0} key not found in redis".format(key))
-                        self.gauge('redis.key.length', 0, tags=key_tags)
+                        keys = [key_pattern, ]
+
+                    for key in keys:
+                        key_type = conn.type(key)
+                        key_tags = l_tags + ['key:' + key]
+
+                        if key_type == 'list':
+                            self.gauge('redis.key.length', conn.llen(key), tags=key_tags)
+                        elif key_type == 'set':
+                            self.gauge('redis.key.length', conn.scard(key), tags=key_tags)
+                        elif key_type == 'zset':
+                            self.gauge('redis.key.length', conn.zcard(key), tags=key_tags)
+                        elif key_type == 'hash':
+                            self.gauge('redis.key.length', conn.hlen(key), tags=key_tags)
+                        else:
+                            # If the type is unknown, it might be because the key doesn't exist,
+                            # which can be because the list is empty. So always send 0 in that case.
+                            if instance.get("warn_on_missing_keys", True):
+                                self.warning("{0} key not found in redis".format(key))
+                            self.gauge('redis.key.length', 0, tags=key_tags)
 
         self._check_replication(info, tags)
         if instance.get("command_stats", False):


### PR DESCRIPTION
### What does this PR do?

this pr adds support for patterns in redis watched keys, you can add keys like this:

keys:
  - hello
  - h*llo
  - h?llo
  - h[ae]llo

[link](https://redis.io/commands/keys)

### Motivation

wanted to watch a long list of keys (name of keys are a random number, prefixed with keyname, example: `prefix_10`, with this PR I can watch all my keys with `prefix_*` in redisdb.yml