### PR TITLE
[ssh_check] only install Windows reqs on Windows

### DIFF
--- a/ssh_check/requirements.txt
+++ b/ssh_check/requirements.txt
@@ -1,3 +1,3 @@
 # integration pip requirements
 paramiko==1.15.2
-winrandom-ctypes==1.0.3
+winrandom-ctypes==1.0.3; sys_platform == 'win32'


### PR DESCRIPTION
See http://legacy.python.org/dev/peps/pep-0496/ for the explanation on how it works, and https://docs.python.org/2/library/sys.html#sys.platform for the possible values.