### PR TITLE
Mongo: only replace username if it is passed

### DIFF
--- a/mongo/check.py
+++ b/mongo/check.py
@@ -642,7 +642,9 @@ class MongoDb(AgentCheck):
 
         if ssl_params:
             username_uri = u"{}@".format(urllib.quote(username))
-            clean_server_name = clean_server_name.replace(username_uri, "")
+
+            if username_uri:
+                clean_server_name = clean_server_name.replace(username_uri, "")
 
         # Get the list of metrics to collect
         collect_tcmalloc_metrics = 'tcmalloc' in additional_metrics


### PR DESCRIPTION
### What does this PR do?

Currently, the code tries to strip out the username when SSL params are passed. This logic is partly valid, but assumes that a username is ALWAYS passed. This change first checks to make sure that the username is passed, then strips it out.

### Motivation

We are trying to get the mongo integration working in our production environment and this is the only blocker that is preventing us from doing so.