### PR TITLE
Clean & freeze ruby test deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ var/
 .installed.cfg
 *.egg
 *.zip
-Gemfile.lock
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
@@ -70,9 +69,9 @@ target/
 
 #sdk collateral
 venv/
+vendor/
 embedded/
 .bundle/
-Gemfile.lock
 .ropeproject/
 setuptools-*.zip
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'addressable'
-gem 'public_suffix', '~> 1.4.0', platform: [:ruby_19, :jruby]
-gem 'colorize'
-gem 'httparty'
-gem 'rake', '~>11.3.0'
-gem 'bundler'
 gem 'datadog-sdk-testing'
-gem 'rubocop', '~>0.38.0'
-gem 'rainbow', '~>2.0.0'
+gem 'rake', '~> 11.3.0'
+gem 'rubocop', '~> 0.38.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,37 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.3.0)
+    colorize (0.8.1)
+    datadog-sdk-testing (0.6.0)
+      colorize (~> 0.8)
+      httparty (~> 0.14)
+      rake (~> 11.0)
+      rubocop (~> 0.38)
+    httparty (0.14.0)
+      multi_xml (>= 0.5.2)
+    multi_xml (0.6.0)
+    parser (2.4.0.0)
+      ast (~> 2.2)
+    powerpack (0.1.1)
+    rainbow (2.2.1)
+    rake (11.3.0)
+    rubocop (0.38.0)
+      parser (>= 2.3.0.6, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
+    unicode-display_width (1.1.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  datadog-sdk-testing
+  rake (~> 11.3.0)
+  rubocop (~> 0.38.0)
+
+BUNDLED WITH
+   1.14.6


### PR DESCRIPTION
To avoid breaking everything on datadog-sdk-gem releases (even though it never
happened yet).
