### PR TITLE
Add link to kubernetes_state integration in kubernetes.yaml file

### DIFF
--- a/kubernetes/conf.yaml.example
+++ b/kubernetes/conf.yaml.example
@@ -12,7 +12,7 @@ instances:
   # KUBERNETES_KUBELET_HOST is found (if your node names can be resolved by pods, we recommend you set this variable to spec.nodeName through the downward API).
   #
   # To enable Kube State metrics, please refer to kubernetes_states integration. For more information,
-  # please consult https://github.com/DataDog/integrations-core/tree/master/kubernetes_state
+  # please consult http://docs.datadoghq.com/integrations/kubernetes/#kubernetes-state-metrics
   #
   # If the read-only endpoint is disabled, the check will query kubelet over HTTPS
   #

--- a/kubernetes/conf.yaml.example
+++ b/kubernetes/conf.yaml.example
@@ -11,8 +11,10 @@ instances:
   # reach the kubelet and cadvisor APIs unless the environment variable
   # KUBERNETES_KUBELET_HOST is found (if your node names can be resolved by pods, we recommend you set this variable to spec.nodeName through the downward API).
   #
-  # To enable Kube State metrics, please refer to kubernetes_states integration. For more information,
+  # To enable Kubernetes State Metrics, please refer to kubernetes_states integration.
+  # For more information,
   # please consult http://docs.datadoghq.com/integrations/kubernetes/#kubernetes-state-metrics
+  # and https://github.com/DataDog/integrations-core/ on the kubernetes_state directory.
   #
   # If the read-only endpoint is disabled, the check will query kubelet over HTTPS
   #

--- a/kubernetes/conf.yaml.example
+++ b/kubernetes/conf.yaml.example
@@ -11,6 +11,9 @@ instances:
   # reach the kubelet and cadvisor APIs unless the environment variable
   # KUBERNETES_KUBELET_HOST is found (if your node names can be resolved by pods, we recommend you set this variable to spec.nodeName through the downward API).
   #
+  # To enable Kube State metrics, please refer to kubernetes_states integration. For more information,
+  # please consult https://github.com/DataDog/integrations-core/tree/master/kubernetes_state
+  #
   # If the read-only endpoint is disabled, the check will query kubelet over HTTPS
   #
   # To override this behavior, e.g. in the case of a standalone cadvisor instance, use the following:


### PR DESCRIPTION
### What does this PR do?

Links the Kubernetes integration configuration file to the kubernetes_state integration for more context. 

### Motivation

Confusion among customers

### Testing Guidelines

Lines added are comments and are therefore transparent to the code 

### Additional Notes

N/A