### PR TITLE
[docker_daemon] no premature log formatting

### DIFF
--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -979,7 +979,6 @@ class DockerDaemon(AgentCheck):
         self._disable_net_metrics = False
 
         for folder in pid_dirs:
-
             try:
                 path = os.path.join(proc_path, folder, 'cgroup')
                 with open(path, 'r') as f:
@@ -992,9 +991,7 @@ class DockerDaemon(AgentCheck):
                         selinux_policy = f.readlines()[0]
             except IOError, e:
                 #  Issue #2074
-                self.log.debug("Cannot read %s, "
-                               "process likely raced to finish : %s" %
-                               (path, str(e)))
+                self.log.debug("Cannot read %s, process likely raced to finish : %s", path, e)
             except Exception as e:
                 self.warning("Cannot read %s : %s" % (path, str(e)))
                 continue
@@ -1011,11 +1008,13 @@ class DockerDaemon(AgentCheck):
                 if matches:
                     container_id = matches[-1]
                     if container_id not in container_dict:
-                        self.log.debug("Container %s not in container_dict, it's likely excluded", container_id)
+                        self.log.debug(
+                            "Container %s not in container_dict, it's likely excluded", container_id
+                        )
                         continue
                     container_dict[container_id]['_pid'] = folder
                     container_dict[container_id]['_proc_root'] = os.path.join(proc_path, folder)
-                elif custom_cgroups: # if we match by pid that should be enough (?) - O(n) ugh!
+                elif custom_cgroups:  # if we match by pid that should be enough (?) - O(n) ugh!
                     for _, container in container_dict.iteritems():
                         if container.get('_pid') == int(folder):
                             container['_proc_root'] = os.path.join(proc_path, folder)


### PR DESCRIPTION
### What does this PR do?

Avoid log DEBUG premature formatting.

### Motivation

CPU profiling on the `docker_daemon` check shows that a lot of time is spent processing the DEBUG logs in the `_crawl_container_pids` method.
```
2017-03-30 10:54:21,148 | INFO | dd.collector | collector(profile.py:80) |          2262860 function calls (2262674 primitive calls) in 6.642 seconds

   Ordered by: cumulative time
   List reduced from 530 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    6.642    6.642 /opt/datadog-agent/agent/checks/__init__.py:741(run)
        1    0.000    0.000    6.640    6.640 /opt/datadog-agent/agent/checks.d/docker_daemon.py:194(check)
        1    1.018    1.018    6.184    6.184 /opt/datadog-agent/agent/checks.d/docker_daemon.py:811(_crawl_container_pids)
    20533    0.116    0.000    3.375    0.000 /opt/datadog-agent/embedded/lib/python2.7/logging/__init__.py:1145(debug)
    20487    0.096    0.000    3.188    0.000 /opt/datadog-agent/embedded/lib/python2.7/logging/__init__.py:1267(_log)
    20487    0.050    0.000    1.982    0.000 /opt/datadog-agent/embedded/lib/python2.7/logging/__init__.py:1288(handle)
    20487    0.099    0.000    1.903    0.000 /opt/datadog-agent/embedded/lib/python2.7/logging/__init__.py:1320(callHandlers)
    20487    0.080    0.000    1.804    0.000 /opt/datadog-agent/embedded/lib/python2.7/logging/__init__.py:746(handle)
    20487    0.132    0.000    1.433    0.000 /opt/datadog-agent/embedded/lib/python2.7/logging/__init__.py:849(emit)
    20487    0.073    0.000    0.928    0.000 /opt/datadog-agent/embedded/lib/python2.7/logging/__init__.py:1254(makeRecord)
    20487    0.431    0.000    0.855    0.000 /opt/datadog-agent/embedded/lib/python2.7/logging/__init__.py:237(__init__)
    20487    0.038    0.000    0.727    0.000 /opt/datadog-agent/embedded/lib/python2.7/logging/__init__.py:723(format)
    20487    0.179    0.000    0.689    0.000 /opt/datadog-agent/embedded/lib/python2.7/logging/__init__.py:452(format)
    20487    0.153    0.000    0.396    0.000 /opt/datadog-agent/embedded/lib/python2.7/logging/__init__.py:405(formatTime)
    32454    0.375    0.000    0.375    0.000 {method 'readlines' of 'file' objects}
    32798    0.360    0.000    0.360    0.000 {open}
    20487    0.086    0.000    0.340    0.000 /opt/datadog-agent/embedded/lib/python2.7/logging/__init__.py:838(flush)
   137561    0.135    0.000    0.334    0.000 /opt/datadog-agent/agent/checks.d/docker_daemon.py:799(_is_container_cgroup)
        1    0.002    0.002    0.300    0.300 /opt/datadog-agent/agent/checks.d/docker_daemon.py:255(_get_and_count_containers)
    33298    0.193    0.000    0.297    0.000 /opt/datadog-agent/embedded/lib/python2.7/posixpath.py:61(join)
```

This can be avoided when the log level is set to > DEBUG, if the logs are not prematurely formatted.
