### PR TITLE
[ssh_check] use version 1.0 of winrandom-ctypes

### DIFF
--- a/ssh_check/requirements.txt
+++ b/ssh_check/requirements.txt
@@ -1,3 +1,3 @@
 # integration pip requirements
 paramiko==1.15.2
-winrandom-ctypes==1.0.3; sys_platform == 'win32'
+winrandom-ctypes==1.0; sys_platform == 'win32'


### PR DESCRIPTION
As 1.0.3 doesn't exist.