### PR TITLE
[tcp_check] sleep 0.1 longer to lower flakiness

### DIFF
--- a/tcp_check/test_tcp_check.py
+++ b/tcp_check/test_tcp_check.py
@@ -56,7 +56,7 @@ class TCPCheckTest(AgentCheckTest):
             self.check._process_results()
             if len(getattr(self.check, attribute)) >= count:
                 return getattr(self.check, method)()
-            time.sleep(1)
+            time.sleep(1.1)
             i += 1
         raise Exception("Didn't get the right count of service checks in time, {0}/{1} in {2}s: {3}"
                         .format(len(getattr(self.check, attribute)), count, i,


### PR DESCRIPTION
This test often raises false positives, it might be because of a sleep a
bit too short.