### PR TITLE
[sqlserver] mark pyodbc as a windows dependency

### DIFF
--- a/sqlserver/requirements.txt
+++ b/sqlserver/requirements.txt
@@ -2,7 +2,5 @@
 adodbapi==2.6.0.7
 pyro4==4.36
 
-
-# optional - SDK question here
-# Requires unixodbc on Linux
-# pyodbc==4.0.13 is satisfied in 'integration-deps'
+# Requires unixodbc on Linux, so only build on windows for now
+pyodbc==4.0.13; sys_platform == 'win32'


### PR DESCRIPTION
We're going to stop using Omnibus for these pip dependencies, so they
all have to be listed in the requirements files.
Let's do this for the SQLServer check dependencies.