### PR TITLE
[windows] only include psycopg2 on non-windows

### DIFF
--- a/postgres/requirements.txt
+++ b/postgres/requirements.txt
@@ -1,3 +1,3 @@
 # integration pip requirements
 pg8000==1.10.1
-psycopg2==2.7.1
+psycopg2==2.7.1; sys_platform != 'win32'


### PR DESCRIPTION
re-change the requirement to not pull psycopg2 on windows.  Fixes multiple build breakages.