### PR TITLE
[k8s] add deployment and service tags to metrics

### DIFF
--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -97,6 +97,15 @@ class Kubernetes(AgentCheck):
         else:
             self._sd_backend = None
 
+        self.k8s_namespace_regexp = None
+        if inst:
+            regexp = inst.get('namespace_name_regexp', None)
+            if regexp:
+                try:
+                    self.k8s_namespace_regexp = re.compile(regexp)
+                except re.error as e:
+                    self.log.warning('Invalid regexp for "namespace_name_regexp" in configuration (ignoring regexp): %s' % str(e))
+
         # Delay init to first check (need the instance options)
         self._collect_events = None
         self.event_retriever = None

--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -74,7 +74,6 @@ FACTORS = {
 
 QUANTITY_EXP = re.compile(r'[-+]?\d+[\.]?\d*[numkMGTPE]?i?')
 
-TAG_SEPARATOR = "|"
 
 class Kubernetes(AgentCheck):
     """ Collect metrics and events from kubelet """
@@ -445,12 +444,11 @@ class Kubernetes(AgentCheck):
             if 'namespace' in pod_meta:
                 pod_tags.append('kube_namespace:%s' % pod_meta['namespace'])
 
-            pod_tags.sort()
-            tags_map[TAG_SEPARATOR.join(pod_tags)] += 1
+            tags_map[frozenset(pod_tags)] += 1
 
         commmon_tags = instance.get('tags', [])
         for pod_tags, pod_count in tags_map.iteritems():
-            tags = pod_tags.split(TAG_SEPARATOR)
+            tags = list(pod_tags)
             tags.extend(commmon_tags)
             self.publish_gauge(self, NAMESPACE + '.pods.running', pod_count, tags)
 

--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -13,9 +13,6 @@ import re
 import time
 import calendar
 
-# 3rd party
-import simplejson as json
-
 # project
 from checks import AgentCheck
 from config import _is_affirmative

--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -502,15 +502,6 @@ class Kubernetes(AgentCheck):
                              '''from 5.13. Please use 'namespaces' and/or 'namespace_name_regexp' instead.''')
             k8s_namespaces.append(instance.get('namespace'))
 
-        self.k8s_namespace_regexp = None
-        if instance:
-            regexp = inst.get('namespace_name_regexp', None)
-            if regexp:
-                try:
-                    self.k8s_namespace_regexp = re.compile(regexp)
-                except re.error as e:
-                    self.log.warning('Invalid regexp for "namespace_name_regexp" in configuration (ignoring regexp): %s' % str(e))
-
         if self.k8s_namespace_regexp:
             namespaces_endpoint = '{}/namespaces'.format(self.kubeutil.kubernetes_api_url)
             self.log.debug('Kubernetes API endpoint to query namespaces: %s' % namespaces_endpoint)

--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -103,7 +103,6 @@ class Kubernetes(AgentCheck):
                 except re.error as e:
                     self.log.warning('Invalid regexp for "namespace_name_regexp" in configuration (ignoring regexp): %s' % str(e))
 
-        if inst:
             self._collect_events = _is_affirmative(inst.get('collect_events', DEFAULT_COLLECT_EVENTS))
             if self._collect_events:
                 self.event_retriever = self.kubeutil.get_event_retriever()

--- a/kubernetes/ci/fixtures/pods_list_1.2.json
+++ b/kubernetes/ci/fixtures/pods_list_1.2.json
@@ -15,6 +15,7 @@
         "resourceVersion": "1522",
         "creationTimestamp": "2016-06-03T19:03:00Z",
         "annotations": {
+          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"dd-agent\",\"uid\":\"12c56a58-33ca-11e6-ac8f-42010af00003\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"456736\"}}\n",
           "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container dd-agent"
         }
       },

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -2,7 +2,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.0",
   "max_agent_version": "6.0.0",
-  "min_agent_version": "5.13.0",
+  "min_agent_version": "5.14.0",
   "name": "kubernetes",
   "short_description": "Capture Pod scheduling events, track the status of your Kubelets, and much more.",
   "guid": "eb31452b-d681-4823-87cc-2ef114559edf",

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -2,7 +2,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.0",
   "max_agent_version": "6.0.0",
-  "min_agent_version": "5.6.3",
+  "min_agent_version": "5.13.0",
   "name": "kubernetes",
   "short_description": "Capture Pod scheduling events, track the status of your Kubelets, and much more.",
   "guid": "eb31452b-d681-4823-87cc-2ef114559edf",

--- a/kubernetes/test_kubernetes.py
+++ b/kubernetes/test_kubernetes.py
@@ -58,6 +58,7 @@ def KubeUtil_fake_retrieve_json_auth(url, timeout=10):
         return json.loads(Fixtures.read_file("events.json", sdk_dir=FIXTURE_DIR, string_escape=False))
     return {}
 
+
 class TestKubernetes(AgentCheckTest):
 
     CHECK_NAME = 'kubernetes'
@@ -244,7 +245,7 @@ class TestKubernetes(AgentCheckTest):
               'image_tag:massi_ingest_k8s_events','pod_name:default/dd-agent-1rxlh',
               'kube_namespace:default', 'kube_app:dd-agent', 'kube_foo:bar',
               'kube_bar:baz', 'kube_replication_controller:dd-agent'], [LIM, REQ, MEM, CPU, NET, DISK, DISK_USAGE]),
-            (['kube_replication_controller:dd-agent', 'kube_namespace:default'], [PODS]),
+            (['kube_replication_controller:dd-agent', 'kube_namespace:default', 'kube_daemon_set:dd-agent'], [PODS]),
             ([], [LIM, REQ, CAP])  # container from kubernetes api doesn't have a corresponding entry in Cadvisor
         ]
 
@@ -297,7 +298,7 @@ class TestKubernetes(AgentCheckTest):
               'kube_namespace:default', 'kube_app:dd-agent', 'kube_foo:bar','kube_bar:baz',
               'kube_replication_controller:dd-agent'], [MEM, CPU, NET, NET_ERRORS, DISK_USAGE]),
             (['pod_name:no_pod'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
-            (['kube_replication_controller:dd-agent', 'kube_namespace:default'], [PODS]),
+            (['kube_replication_controller:dd-agent', 'kube_namespace:default', 'kube_daemon_set:dd-agent'], [PODS]),
             ([], [LIM, REQ, CAP])  # container from kubernetes api doesn't have a corresponding entry in Cadvisor
         ]
 
@@ -398,6 +399,7 @@ class TestKubernetes(AgentCheckTest):
         # Can't use run_check_twice due to specific metrics
         self.run_check(config, force_reload=True)
         self.assertServiceCheck("kubernetes.kubelet.check", status=AgentCheck.CRITICAL, tags=None, count=1)
+
 
 class TestKubeutil(unittest.TestCase):
     @mock.patch('utils.kubernetes.KubeUtil._locate_kubelet', return_value='http://172.17.0.1:10255')

--- a/kubernetes/test_kubernetes.py
+++ b/kubernetes/test_kubernetes.py
@@ -1,4 +1,4 @@
-    # (C) Datadog, Inc. 2010-2016
+# (C) Datadog, Inc. 2010-2016
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
@@ -613,7 +613,7 @@ class TestKubeutil(unittest.TestCase):
             (
                 {},
                 {'verify': False, 'timeout': 10, 'params': None, 'headers': None, 'cert': None}
-            ), (   
+            ), (
                 {'bearer_token': 'foo_tok'},
                 {'verify': False, 'timeout': 10, 'params': None, 'headers': {'Authorization': 'Bearer foo_tok'}, 'cert': None}
             ), (


### PR DESCRIPTION
### What does this PR do?

Linked to https://github.com/DataDog/dd-agent/pull/3300

- add kube_deployment/kube_replica_set/kube_deamon_set/kube_job tags to the .pods.running metric
- rewrite the _update_pods_metrics (source of .pods.running) logic to handle more tags and count pods with no creator (some system pods)

### Motivation

Better filtering for users' dashboards and monitors
