### PR TITLE
[docker][ecs] handle NetworkMode: host

### DIFF
--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -218,6 +218,7 @@ class DockerDaemon(AgentCheck):
             self.collect_ecs_tags = _is_affirmative(instance.get('ecs_tags', True)) and Platform.is_ecs_instance()
 
             self.ecs_tags = {}
+            self.ecs_agent_local = None
 
         except Exception as e:
             self.log.critical(e)
@@ -472,13 +473,22 @@ class DockerDaemon(AgentCheck):
 
         return entity["_tag_values"][tag_name]
 
-    def _localhost_ecs_agent(self):
+    def _is_ecs_agent_local(self):
+        """Return True if we can reach the ecs-agent over localhost, False otherwise.
+        This is needed because if the ecs-agent is started with --net=host it won't have an IP address attached.
+        """
+        if self.ecs_agent_local is not None:
+            return self.ecs_agent_local
         result = ""
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(5)
-        result = sock.connect_ex(('localhost', ECS_INTROSPECT_DEFAULT_PORT))
+        try:
+            result = sock.connect_ex(('localhost', ECS_INTROSPECT_DEFAULT_PORT))
+        except Exception as e:
+            self.log.debug("Unable to connect to ecs-agent. Exception: {0}".format(e))
         sock.close()
-        return True if result == 0 else False
+        self.ecs_agent_local = True if result == 0 else False
+        return self.ecs_agent_local
 
     def refresh_ecs_tags(self):
         ecs_config = self.docker_client.inspect_container('ecs-agent')
@@ -487,7 +497,7 @@ class DockerDaemon(AgentCheck):
         port = ports.keys()[0].split('/')[0] if ports else None
         if not ip:
             port = ECS_INTROSPECT_DEFAULT_PORT
-            if self._localhost_ecs_agent():
+            if self._is_ecs_agent_local():
                 ip = "localhost"
             elif Platform.is_containerized() and self.docker_gateway:
                 ip = self.docker_gateway

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -487,7 +487,12 @@ class DockerDaemon(AgentCheck):
         except Exception as e:
             self.log.debug("Unable to connect to ecs-agent. Exception: {0}".format(e))
         sock.close()
-        self.ecs_agent_local = True if result == 0 else False
+        if result == 0:
+            self.ecs_agent_local = True
+        else:
+            self.ecs_agent_local = False
+            self.log.debug("ecs-agent is not avaiable locally, encountered error: {0}".format(result))
+
         return self.ecs_agent_local
 
     def refresh_ecs_tags(self):

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -479,20 +479,20 @@ class DockerDaemon(AgentCheck):
         """
         if self.ecs_agent_local is not None:
             return self.ecs_agent_local
-        result = ""
+
+        self.ecs_agent_local = False
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(5)
         try:
             result = sock.connect_ex(('localhost', ECS_INTROSPECT_DEFAULT_PORT))
         except Exception as e:
             self.log.debug("Unable to connect to ecs-agent. Exception: {0}".format(e))
-        sock.close()
-        if result == 0:
-            self.ecs_agent_local = True
         else:
-            self.ecs_agent_local = False
-            self.log.debug("ecs-agent is not avaiable locally, encountered error: {0}".format(result))
-
+            if result == 0:
+                self.ecs_agent_local = True
+            else:
+                self.log.debug("ecs-agent is not available locally, encountered error code: {0}".format(result))
+        sock.close()
         return self.ecs_agent_local
 
     def refresh_ecs_tags(self):


### PR DESCRIPTION
### What does this PR do?

When the dd-agent task is configured with `"NetworkMode": "host"` we would use the `docker_gateway` IP when we should use `localhost`. This PR handles this case.

### Motivation

Came up in a support case.