### PR TITLE
[marathon] add queue gauge

### DIFF
--- a/marathon/CHANGELOG.md
+++ b/marathon/CHANGELOG.md
@@ -6,3 +6,4 @@
 ### Changes
 
 * [FEATURE] adds marathon integration.
+* [FEATURE] [#321](https://github.com/DataDog/integrations-core/pull/321): adds check for Marathon queue size

--- a/marathon/README.md
+++ b/marathon/README.md
@@ -6,6 +6,7 @@ Get metrics from marathon service in real time to:
 
 * Visualize and monitor marathon states
 * Be notified about marathon failovers and events.
+* Determine if your marathon tasks are not being scheduled as expected
 
 ## Installation
 

--- a/marathon/check.py
+++ b/marathon/check.py
@@ -74,6 +74,11 @@ class Marathon(AgentCheck):
         if response is not None:
             self.gauge('marathon.deployments', len(response), tags=instance_tags)
 
+        # Number of queued applications
+        response = self.get_json(urljoin(url, "v2/queue"), timeout, auth, acs_url, ssl_verify)
+        if response is not None:
+            self.gauge('marathon.queue.size', len(response['queue']), tags=instance_tags)
+
     def refresh_acs_token(self, auth, acs_url):
         try:
             auth_body = {

--- a/marathon/ci/fixtures/queue.json
+++ b/marathon/ci/fixtures/queue.json
@@ -1,0 +1,205 @@
+{
+  "queue": [
+    {
+      "count": 2,
+      "delay": {
+        "timeLeftSeconds": 0,
+        "overdue": true
+      },
+      "since": "2017-04-10T15:54:44.903Z",
+      "processedOffersSummary": {
+        "processedOffersCount": 718,
+        "unusedOffersCount": 718,
+        "lastUnusedOfferAt": "2017-04-10T16:46:21.803Z",
+        "rejectSummaryLastOffers": [
+          {
+            "reason": "UnfulfilledRole",
+            "declined": 0,
+            "processed": 5
+          },
+          {
+            "reason": "UnfulfilledConstraint",
+            "declined": 0,
+            "processed": 5
+          },
+          {
+            "reason": "NoCorrespondingReservationFound",
+            "declined": 0,
+            "processed": 5
+          },
+          {
+            "reason": "InsufficientCpus",
+            "declined": 5,
+            "processed": 5
+          },
+          {
+            "reason": "InsufficientMemory",
+            "declined": 0,
+            "processed": 0
+          },
+          {
+            "reason": "InsufficientDisk",
+            "declined": 0,
+            "processed": 0
+          },
+          {
+            "reason": "InsufficientGpus",
+            "declined": 0,
+            "processed": 0
+          },
+          {
+            "reason": "InsufficientPorts",
+            "declined": 0,
+            "processed": 0
+          }
+        ],
+        "rejectSummaryLaunchAttempt": [
+          {
+            "reason": "UnfulfilledRole",
+            "declined": 0,
+            "processed": 718
+          },
+          {
+            "reason": "UnfulfilledConstraint",
+            "declined": 0,
+            "processed": 718
+          },
+          {
+            "reason": "NoCorrespondingReservationFound",
+            "declined": 0,
+            "processed": 718
+          },
+          {
+            "reason": "InsufficientCpus",
+            "declined": 718,
+            "processed": 718
+          },
+          {
+            "reason": "InsufficientMemory",
+            "declined": 0,
+            "processed": 0
+          },
+          {
+            "reason": "InsufficientDisk",
+            "declined": 0,
+            "processed": 0
+          },
+          {
+            "reason": "InsufficientGpus",
+            "declined": 0,
+            "processed": 0
+          },
+          {
+            "reason": "InsufficientPorts",
+            "declined": 0,
+            "processed": 0
+          }
+        ]
+      },
+      "app": {
+        "id": "myapp",
+        "backoffFactor": 1.15,
+        "backoffSeconds": 1,
+        "constraints": [
+          [
+            "ec2_az",
+            "GROUP_BY"
+          ]
+        ],
+        "container": {
+          "type": "DOCKER",
+          "docker": {
+            "forcePullImage": true,
+            "image": "044418114861.dkr.ecr.us-east-1.amazonaws.com\/jetbridge-builds\/departures:bld-favicon-latest",
+            "network": "BRIDGE",
+            "parameters": [
+              {
+                "key": "label",
+                "value": "appName=myapp"
+              }
+            ],
+            "portMappings": [
+              {
+                "containerPort": 8080,
+                "hostPort": 0,
+                "labels": {
+
+                },
+                "protocol": "tcp",
+                "servicePort": 10069
+              }
+            ],
+            "privileged": false
+          },
+          "volumes": [
+            {
+              "containerPath": "\/logs",
+              "hostPath": "\/var\/log\/containers\/myapp",
+              "mode": "RW"
+            },
+            {
+              "containerPath": "\/cn\/mesos-tasks-configuration\/",
+              "hostPath": "\/cn\/mesos-tasks-configuration\/",
+              "mode": "RO"
+            }
+          ]
+        },
+        "cpus": 5050.51,
+        "disk": 0,
+        "env": {
+
+        },
+        "executor": "",
+        "fetch": [
+          {
+            "uri": "file:\/\/\/etc\/mesos\/docker.tar.gz",
+            "extract": true,
+            "executable": false,
+            "cache": false
+          }
+        ],
+        "healthChecks": [
+          {
+            "gracePeriodSeconds": 300,
+            "ignoreHttp1xx": false,
+            "intervalSeconds": 15,
+            "maxConsecutiveFailures": 3,
+            "path": "\/ping",
+            "portIndex": 0,
+            "protocol": "HTTP",
+            "timeoutSeconds": 10,
+            "delaySeconds": 15
+          }
+        ],
+        "instances": 2,
+        "labels": {
+          
+        },
+        "maxLaunchDelaySeconds": 3600,
+        "mem": 64646464,
+        "gpus": 0,
+        "portDefinitions": [
+          {
+            "port": 10069,
+            "protocol": "tcp"
+          }
+        ],
+        "requirePorts": false,
+        "upgradeStrategy": {
+          "maximumOverCapacity": 1,
+          "minimumHealthCapacity": 1
+        },
+        "version": "2017-04-10T15:22:31.683Z",
+        "versionInfo": {
+          "lastScalingAt": "2017-04-10T15:22:31.683Z",
+          "lastConfigChangeAt": "2017-04-10T15:22:31.683Z"
+        },
+        "killSelection": "YOUNGEST_FIRST",
+        "unreachableStrategy": {
+          "inactiveAfterSeconds": 300,
+          "expungeAfterSeconds": 600
+        }
+      }
+    }
+  ]
+}

--- a/marathon/manifest.json
+++ b/marathon/manifest.json
@@ -10,6 +10,6 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "guid": "6af353ff-ecca-420a-82c0-a0e84cf0a35e"
 }

--- a/marathon/metadata.csv
+++ b/marathon/metadata.csv
@@ -8,3 +8,4 @@ marathon.instances,gauge,,,,Number of instances of this application to start,0,m
 marathon.mem,gauge,,mebibyte,,Memory that is needed for the application per instance,0,marathon,mem
 marathon.tasksRunning,gauge,,task,,Number of tasks running,0,marathon,tasks running
 marathon.tasksStaged,gauge,,task,,Number of tasks staged to run,0,marathon,tasks staged
+marathon.queue.size,gauge,,,,Number of apps waiting for deployment,0,marathon,apps

--- a/marathon/test_marathon.py
+++ b/marathon/test_marathon.py
@@ -45,6 +45,8 @@ class MarathonCheckTest(AgentCheckTest):
                 return Fixtures.read_json_file("apps.json", sdk_dir=ci_dir)
             elif "v2/deployments" in url:
                 return Fixtures.read_json_file("deployments.json", sdk_dir=ci_dir)
+            elif "v2/queue" in url:
+                return Fixtures.read_json_file("queue.json", sdk_dir=ci_dir)
             else:
                 raise Exception("unknown url:" + url)
 
@@ -59,6 +61,8 @@ class MarathonCheckTest(AgentCheckTest):
                 return {"apps": []}
             elif "v2/deployments" in url:
                 return {"deployments": []}
+            elif "v2/queue" in url:
+                return {"queue": []}
             else:
                 raise Exception("unknown url:" + url)
 


### PR DESCRIPTION
### What does this PR do?

This PR aims to add a queue gauge for marathon integration. This is helpful to see as it indicates that potentially there is a resource ask that is currently unsolvable, thus requiring either of notification or scaling out of resource availability.

### Motivation

Our current mesos/marathon setup does not have great insight into when we are running up against our resource limits for new application deployments. The aim with this is to allow us to, in future, automate scaling out resources.

### Testing Guidelines

To test this, set up a mesos/marathon cluster with this updated check code, and attempt to schedule a task that asks for more memory than is available on any mesos worker.

### Additional Notes

It would be extremely beneficial to give instruction on running tests locally for developers, as the README.md seems to be aimed more at check consumers than developers. This is thus a best effort with regards to testing. The added code for the check itself is working as expected on some of our test infrastructure.