### PR TITLE
Update the postfix README and change the sudoers example to be more restrictive.

### DIFF
--- a/postfix/README.md
+++ b/postfix/README.md
@@ -13,7 +13,22 @@ Install the `dd-check-postfix` package manually or with your favorite configurat
 
 ## Configuration
 
-Edit the `postfix.yaml` file to point to your server and port, set the masters to monitor
+* Edit the `postfix.yaml` file to point to your postfix spool/queues directory (e.g. `/var/spool/postfix)..
+* Add a few mail queues to monitor (e.g. `incoming`, `active`, and `deferred`).
+* Update `/etc/sudoers` to allow `dd-agent` to run `find /path/to/postfix/spool/* -type f`.
+
+Example:
+
+```yaml
+init_config:
+
+instances:
+  - directory: /var/spool/postfix
+    queues:
+      - incoming
+      - active
+      - deferred
+```
 
 ## Validation
 

--- a/postfix/README.md
+++ b/postfix/README.md
@@ -13,10 +13,9 @@ Install the `dd-check-postfix` package manually or with your favorite configurat
 
 ## Configuration
 
-* Edit the `postfix.yaml` file to point to your postfix spool/queues directory (e.g. `/var/spool/postfix)..
+* Edit the `postfix.yaml` file to point to your postfix spool/queues directory (e.g. `/var/spool/postfix`).
 * Add a few mail queues to monitor (e.g. `incoming`, `active`, and `deferred`).
-* Update `/etc/sudoers` to allow `dd-agent` to run `find /path/to/postfix/spool/* -type f`.
-
+* Update `/etc/sudoers` to allow the user `dd-agent` to run `find /path/to/postfix/spool/* -type f` (e.g. `dd-agent ALL=(ALL) NOPASSWD:/usr/bin/find /var/spool/postfix* -type f`).  
 Example:
 
 ```yaml

--- a/postfix/check.py
+++ b/postfix/check.py
@@ -17,7 +17,7 @@ class PostfixCheck(AgentCheck):
              sudo access is not required when running dd-agent as root (not recommended)
 
     example /etc/sudoers entry:
-             dd-agent ALL=(ALL) NOPASSWD:/usr/bin/find
+             dd-agent ALL=(ALL) NOPASSWD:/usr/bin/find /var/spool/postfix* -type f
 
     YAML config options:
         "directory" - the value of 'postconf -h queue_directory'


### PR DESCRIPTION
### What does this PR do?

* Updates the README to be more descriptive, including an example.
* Changes the example `/etc/sudoers` example to be more restrictive than previously.

### Motivation

We didn't want to give `dd-agent` full access to `find` given the command can be quite destructive in the wrong hands (e.g. `-delete`). After a bit of fiddling around, we got a working example that scopes it specifically to the command the check file runs.

### Testing Guidelines

1. Modify `/etc/sudoers` per the updated comment.
2. `su - dd-agent`
3. Try running different variations of the find command (e.g. change `-type f` to `-type d`).

You should see something like this:

```
$ sudo /usr/bin/find /var/spool/postfix/active -type d
[sudo] password for dd-agent: 
$ sudo /usr/bin/find /var/spool/postfix/active -type f
/var/spool/postfix/active/7AA621B40BEC
/var/spool/postfix/active/6108B1B403AA
/var/spool/postfix/active/649161B40468
/var/spool/postfix/active/889441B408A4
/var/spool/postfix/active/98E7F1B40821
```

Any variation that's not an exact match will prompt for a password.

### Additional Notes

n/a