### PR TITLE
adding safe criterion to avoid password in clear

### DIFF
--- a/mongo/check.py
+++ b/mongo/check.py
@@ -636,7 +636,7 @@ class MongoDb(AgentCheck):
         # Therefore, the string replace (below) won't work, because it won't have an
         # exact match.  Convert the password *back* to URL encoded, so the string
         # replace works properly.
-        encoded_password = urllib.quote_plus(password, safe='%') if password else None
+        encoded_password = urllib.quote_plus(password, safe='%/:=&?~#+!$,;'@()*[]') if password else None
 
         clean_server_name = server.replace(encoded_password, "*" * 5) if encoded_password else server
 

--- a/mongo/check.py
+++ b/mongo/check.py
@@ -636,7 +636,7 @@ class MongoDb(AgentCheck):
         # Therefore, the string replace (below) won't work, because it won't have an
         # exact match.  Convert the password *back* to URL encoded, so the string
         # replace works properly.
-        encoded_password = urllib.quote_plus(password) if password else None
+        encoded_password = urllib.quote_plus(password, safe='%') if password else None
 
         clean_server_name = server.replace(encoded_password, "*" * 5) if encoded_password else server
 

--- a/mongo/check.py
+++ b/mongo/check.py
@@ -636,7 +636,7 @@ class MongoDb(AgentCheck):
         # Therefore, the string replace (below) won't work, because it won't have an
         # exact match.  Convert the password *back* to URL encoded, so the string
         # replace works properly.
-        encoded_password = urllib.quote_plus(password, safe='%/:=&?~#+!$,;'@()*[]') if password else None
+        encoded_password = urllib.quote_plus(password, safe="%/:=&?~#+!$,;'@()*[]") if password else None
 
         clean_server_name = server.replace(encoded_password, "*" * 5) if encoded_password else server
 


### PR DESCRIPTION
### What does this PR do?

The quote_plus function has a safe arg https://docs.python.org/2/library/urllib.html#urllib.quote_plus which is not used [here](https://github.com/DataDog/integrations-core/blob/master/mongo/check.py#L639). 
I added the case for the %/:=&?~#+!$,;'@()*[] characters as if present in the password it'd break the password encryption [here](https://github.com/DataDog/integrations-core/blob/master/mongo/check.py#L627-L641).
This seems to be a [known issue](http://svn.python.org/view/python/trunk/Lib/urllib.py?r1=71780&r2=71779&pathrev=71780)
Only `@` and `:` are leading to errors:
```
File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/pymongo/uri_parser.py", line 83, in parse_userinfo
            raise InvalidURI("':' or '@' characters in a username or password "
        InvalidURI: ':' or '@' characters in a username or password must be escaped according to RFC 2396.
```
I included them for consistency with the aforementioned issue.

### Motivation

From a customer case.

### Testing Guidelines

On my VM, I created different users for my mongodbs and set passwords to reproduce the error.

1/ The expected behavior. 
The mongo.yaml:
```
init_config:
instances:
  - server: mongodb://example-user:password9@localhost:27017/user-data
```
running `/opt/datadog-agent/agent/agent.py check mongo` we can see:
```
[...]
(u'mongodb.metrics.repl.buffer.count',
  1491959699,
  0L,
  {'hostname': 'vagrant-ubuntu-trusty-64',
   'tags': ['optional_tag3',
            'optional_tag4',
            'server:mongodb://example-user:*****@localhost:27017/user-data'],
   'type': 'gauge'}),
[...]
```
Which is expected.

2/ The issue 
However, modifying the password to include a `%`:
```
init_config:
instances:
  - server: mongodb://example-user-2:Password_%2@localhost:27017/user-data
```
The output is:
```
 (u'mongodb.globallock.currentqueue.total',
  1491960094,
  0,
  {'hostname': 'vagrant-ubuntu-trusty-64',
   'tags': ['optional_tag3',
            'optional_tag4',
            'server:mongodb://example-user-2:Password_%2@localhost:27017/user-data'],
   'type': 'gauge'})
```
The issue is that the server tag is appended and contains the password in clear which is then visible in the app: https://cl.ly/090G2R2O3c2Q.

Using the safe arg we then have:
```
(u'mongodb.globallock.currentqueue.total',
  1491960570,
  0,
  {'hostname': 'vagrant-ubuntu-trusty-64',
   'tags': ['optional_tag3',
            'optional_tag4',
            'server:mongodb://example-user-2:*****@localhost:27017/user-data'],
   'type': 'gauge'})
```

### Additionnal notes

The issue was originally brought up with the check from the agent 5.11. The customer was using a # in the password. 
If this is merged, users will need to upgrade the agent to have the SDK (5.12) so they can update the mongo check itself.