### PR TITLE
[http_check] add support for SOAP requests

### DIFF
--- a/http_check/check.py
+++ b/http_check/check.py
@@ -253,7 +253,8 @@ class HTTPCheck(NetworkCheck):
             r = sess.request(method.upper(), addr, auth=auth, timeout=timeout, headers=headers,
                              proxies = instance_proxy, allow_redirects=allow_redirects,
                              verify=False if disable_ssl_validation else instance_ca_certs,
-                             json = data if method == 'post' else None)
+                             json = data if method == 'post' and isinstance(data, dict) else None,
+                             data = data if method == 'post' and isinstance(data, basestring) else None)
 
         except (socket.timeout, requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
             length = int((time.time() - start) * 1000)

--- a/http_check/conf.yaml.example
+++ b/http_check/conf.yaml.example
@@ -11,6 +11,7 @@ instances:
     # HTTP method to POST.
     # If using the POST method, you can then specify the data to send in the body of the request
     # with the data parameter.
+    # SOAP requests are supported if you use the POST method and supply an XML string as the data parameter.
     #
     # method: get
     # data:

--- a/http_check/test_http_check.py
+++ b/http_check/test_http_check.py
@@ -197,6 +197,16 @@ CONFIG_POST_METHOD = {
     }]
 }
 
+CONFIG_POST_SOAP = {
+    'instances': [{
+        'name': 'post_soap',
+        'url': 'http://httpbin.org/post',
+        'timeout': 1,
+        'method': 'post',
+        'data': '<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:m="http://www.example.org/stocks"><soap:Header></soap:Header><soap:Body><m:GetStockPrice><m:StockName>EXAMPLE</m:StockName></m:GetStockPrice></soap:Body></soap:Envelope>'
+    }]
+}
+
 @attr(requires='skip')
 class HTTPCheckTest(AgentCheckTest):
     CHECK_NAME = 'http_check'
@@ -361,3 +371,4 @@ class HTTPCheckTest(AgentCheckTest):
     def test_post_method(self):
         # Run the check
         self.run_check(CONFIG_POST_METHOD)
+        self.run_check(CONFIG_POST_SOAP)


### PR DESCRIPTION
### What does this PR do?

This PR implements SOAP endpoint monitoring in the http_check module.

It is related to the support chat request 87991.

I was trying to setup an HTTP check in the agent, sending a SOAP request. Unfortunately, I was not sure how to supply the SOAP data. The data: config parameter only accepted key-value pairs. I tried putting my SOAP request (XML text) plain in the data: field, but I received Error 500 from the server.

So I contacted support via the chat and they told me:

> Our agent expects the data key to be a dictionary, because it passes it to the requests library to be converted to JSON:
https://github.com/DataDog/integrations-core/blob/5.12.3/http_check/check.py#L253
http://docs.python-requests.org/en/master/user/quickstart/#more-complicated-post-requests

> I can submit a feature request to modify our HTTP check to support sending SOAP requests. What priority is this for your team: high, medium, or low/nice to have?

> In the meantime, you could apply a small patch to the http check to submit the data key using the data parameter on the request call if data isn't a dictionary, which should allow you to submit XML content. Let me know if you'd like our help developing that patch.

So instead of waiting for upstream I implemented this. You may edit or reimplement it any way that is more appropriate, of course.