### PR TITLE
[docker] kubernetes 1.6+ cgroup hierarchy support

### DIFF
--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -959,6 +959,8 @@ class DockerDaemon(AgentCheck):
             return True
         if line[2].startswith('/') and re.match(CONTAINER_ID_RE, line[2][1:]): # kubernetes
             return True
+        if line[2].startswith('/') and re.match(CONTAINER_ID_RE, line[2].split('/')[-1]): # kube 1.6+ qos hierarchy
+            return True
         return False
 
     # proc files


### PR DESCRIPTION
### What does this PR do?

Kubernetes 1.6 introduces a new cgroup hierarchy, that breaks our parsing routine on k8/coreos. This PR checks for this new format to restore cgroup metrics on the docker_daemon check

Tested on a coreOS dev node, testing on a full 1.6.1 cluster in progress