### PR TITLE
Mongo: correct condition for stripping out username

### DIFF
--- a/mongo/check.py
+++ b/mongo/check.py
@@ -640,7 +640,7 @@ class MongoDb(AgentCheck):
 
         clean_server_name = server.replace(encoded_password, "*" * 5) if encoded_password else server
 
-        if ssl_params:
+        if username:
             username_uri = u"{}@".format(urllib.quote(username))
             clean_server_name = clean_server_name.replace(username_uri, "")
 


### PR DESCRIPTION
Aplogies for the duplicate, I deleted my fork after issuing https://github.com/DataDog/integrations-core/pull/304 in the process of cleaning up my old forks.

### What does this PR do?

Currently, the code tries to strip out the username when SSL params are passed. This logic is partly valid, but assumes that a username is ALWAYS passed. This change first checks to make sure that the username is passed, then strips it out.

### Motivation

We are trying to get the mongo integration working in our production environment and this is the only blocker that is preventing us from doing so.