### PR TITLE
Fix namespace of postgres metric 'replication_delay_bytes'

### DIFF
--- a/postgres/check.py
+++ b/postgres/check.py
@@ -223,7 +223,7 @@ SELECT schemaname, count(*) FROM
     }
 
     REPLICATION_METRICS_9_2 = {
-        'abs(pg_xlog_location_diff(pg_last_xlog_receive_location(), pg_last_xlog_replay_location())) AS replication_delay_bytes': ('postgres.replication_delay_bytes', GAUGE)
+        'abs(pg_xlog_location_diff(pg_last_xlog_receive_location(), pg_last_xlog_replay_location())) AS replication_delay_bytes': ('postgresql.replication_delay_bytes', GAUGE)
     }
 
     REPLICATION_METRICS = {


### PR DESCRIPTION
### What does this PR do?

Fixes a (presumable) typo in one metric name.

### Motivation

A customer noticed it while pointing out that the metric is also missing from metadata.

### Additional Notes

I am about to add `replication_delay` and `replication_delay_bytes` to Postgres metrics metadata. I suppose I should add both `postgres.replication_delay_bytes` _and_ `postgresql.replication_delay_bytes` in anticipation of this being merged?