### PR TITLE
[ZK] Fix version parsing causing false positives with 3.4.10

### DIFF
--- a/zk/check.py
+++ b/zk/check.py
@@ -101,7 +101,9 @@ class ZookeeperCheck(AgentCheck):
 
     Parse content from `stat` and `mntr`(if available) commmands to retrieve health cluster metrics.
     """
-    version_pattern = re.compile(r'Zookeeper version: ([^.]+)\.([^.]+)\.([^-]+)', flags=re.I)
+    # example match:
+    # "Zookeeper version: 3.4.10-39d3a4f269333c922ed3db283be479f9deacaa0f, built on 03/23/2017 10:13 GMT"
+    version_pattern = re.compile(r'(\d+\.\d+\.\d+)')
 
     SOURCE_TYPE_NAME = 'zookeeper'
 
@@ -280,14 +282,13 @@ class ZookeeperCheck(AgentCheck):
         # body correctly. Particularly, the Connections val was added in
         # >= 3.4.4.
         start_line = buf.readline()
-        match = self.version_pattern.match(start_line)
+        match = self.version_pattern.search(start_line)
         if match is None:
             return (None, None, "inactive", None)
             raise Exception("Could not parse version from stat command output: %s" % start_line)
         else:
-            version_tuple = match.groups()
-        has_connections_val = version_tuple >= ('3', '4', '4')
-        version = "%s.%s.%s" % version_tuple
+            version = match.group()
+        has_connections_val = LooseVersion(version) > LooseVersion("3.4.4")
 
         # Clients:
         buf.readline()  # skip the Clients: header

--- a/zk/test_zk.py
+++ b/zk/test_zk.py
@@ -92,7 +92,7 @@ class ZooKeeperTestCase(AgentCheckTest):
         for mname in self.STAT_METRICS:
             self.assertMetric(mname, tags=["mode:standalone", "mytag"], count=1)
 
-        zk_version = os.environ.get("FLAVOR_VERSION") or "3.4.9"
+        zk_version = os.environ.get("FLAVOR_VERSION") or "3.4.10"
 
         if zk_version and LooseVersion(zk_version) > LooseVersion("3.4.0"):
             for mname in self.MNTR_METRICS:


### PR DESCRIPTION
### What does this PR do?

At some point in the code we parse the output of the `stat` command differently for different Zookeeper version. The version checking is performed like this:
```python
has_connections_val = version_tuple >= ('3', '4', '4')
```
the code relies on lexicographic order and this started to fail since ZK `3.4.10`.

The PR makes use of `LooseVersion` to address this problem.

### Testing Guidelines

The ZK version for tests was bumped to `3.4.10`