### PR TITLE
[mongo] Sanitize server URI correctly

### DIFF
--- a/mongo/check.py
+++ b/mongo/check.py
@@ -606,9 +606,9 @@ class MongoDb(AgentCheck):
         decoded_server = urllib.unquote_plus(server)
         clean_server_name = decoded_server.replace(password, "*" * 5) if password else decoded_server
 
-        if sanitize_username:
-            username_uri = u"{}@".format(username)
-            clean_server_name = clean_server_name.replace(username_uri, "")
+        if sanitize_username and username:
+            username_pattern = u"{}[@:]".format(re.escape(username))
+            clean_server_name = re.sub(username_pattern, "", clean_server_name)
 
         return username, password, db_name, nodelist, clean_server_name
 

--- a/mongo/test_mongo.py
+++ b/mongo/test_mongo.py
@@ -171,17 +171,20 @@ class TestMongoUnit(AgentCheckTest):
             ("mongodb://user:pass@localhost:27017/admin", "mongodb://user:*****@localhost:27017/admin"),
             ("mongodb://user:pass_%2@localhost:27017/admin", "mongodb://user:*****@localhost:27017/admin"), # pymongo parses the password as `pass_%2`
             ("mongodb://user:pass_%25@localhost:27017/admin", "mongodb://user:*****@localhost:27017/admin"), # pymongo parses the password as `pass_%` (`%25` is url-decoded to `%`)
+            ("mongodb://user%2@localhost:27017/admin", "mongodb://user%2@localhost:27017/admin"), # same thing here, parsed username: `user%2`
+            ("mongodb://user%25@localhost:27017/admin", "mongodb://user%@localhost:27017/admin"), # with the current sanitization approach, we expect the username to be decoded in the clean name
         )
 
         for server, expected_clean_name in server_names:
             _, _, _, _, clean_name = _parse_uri(server, sanitize_username=False)
             self.assertEquals(expected_clean_name, clean_name)
 
-
-        # Batch with `sanitize_username` set to True, with this option no password is expected in the mongo URI
+        # Batch with `sanitize_username` set to True
         server_names = (
             ("mongodb://localhost:27017/admin", "mongodb://localhost:27017/admin"),
-            ("mongodb://user@localhost:27017/admin", "mongodb://localhost:27017/admin"),
+            ("mongodb://user:pass@localhost:27017/admin", "mongodb://*****@localhost:27017/admin"),
+            ("mongodb://user:pass_%2@localhost:27017/admin", "mongodb://*****@localhost:27017/admin"),
+            ("mongodb://user:pass_%25@localhost:27017/admin", "mongodb://*****@localhost:27017/admin"),
             ("mongodb://user%2@localhost:27017/admin", "mongodb://localhost:27017/admin"),
             ("mongodb://user%25@localhost:27017/admin", "mongodb://localhost:27017/admin"),
         )

--- a/mongo/test_mongo.py
+++ b/mongo/test_mongo.py
@@ -23,7 +23,6 @@ MAX_WAIT = 150
 GAUGE = AgentCheck.gauge
 RATE = AgentCheck.rate
 
-@attr(requires='mongo')
 class TestMongoUnit(AgentCheckTest):
     """
     Unit tests for MongoDB AgentCheck.
@@ -156,6 +155,40 @@ class TestMongoUnit(AgentCheckTest):
         self.assertEquals('UNKNOWN', self.check.get_state_name(500))
         unknown_desc = self.check.get_state_description(500)
         self.assertTrue(unknown_desc.find('500') != -1)
+
+    def test_server_uri_sanitization(self):
+        # Initialize check
+        config = {
+            'instances': [self.MONGODB_CONFIG]
+        }
+        self.load_check(config)
+
+        _parse_uri = self.check._parse_uri
+
+        # Batch with `sanitize_username` set to False
+        server_names = (
+            ("mongodb://localhost:27017/admin", "mongodb://localhost:27017/admin"),
+            ("mongodb://user:pass@localhost:27017/admin", "mongodb://user:*****@localhost:27017/admin"),
+            ("mongodb://user:pass_%2@localhost:27017/admin", "mongodb://user:*****@localhost:27017/admin"), # pymongo parses the password as `pass_%2`
+            ("mongodb://user:pass_%25@localhost:27017/admin", "mongodb://user:*****@localhost:27017/admin"), # pymongo parses the password as `pass_%` (`%25` is url-decoded to `%`)
+        )
+
+        for server, expected_clean_name in server_names:
+            _, _, _, _, clean_name = _parse_uri(server, sanitize_username=False)
+            self.assertEquals(expected_clean_name, clean_name)
+
+
+        # Batch with `sanitize_username` set to True, with this option no password is expected in the mongo URI
+        server_names = (
+            ("mongodb://localhost:27017/admin", "mongodb://localhost:27017/admin"),
+            ("mongodb://user@localhost:27017/admin", "mongodb://localhost:27017/admin"),
+            ("mongodb://user%2@localhost:27017/admin", "mongodb://localhost:27017/admin"),
+            ("mongodb://user%25@localhost:27017/admin", "mongodb://localhost:27017/admin"),
+        )
+
+        for server, expected_clean_name in server_names:
+            _, _, _, _, clean_name = _parse_uri(server, sanitize_username=True)
+            self.assertEquals(expected_clean_name, clean_name)
 
 @attr(requires='mongo')
 class TestMongo(unittest.TestCase):


### PR DESCRIPTION
### What does this PR do?

Changes the approach to sanitize the server URI so that it works well whether the username and/or password are url-encoded or not in the raw server string.

Should fix the edge cases found in both https://github.com/DataDog/dd-agent/pull/2940 and #326 (#326 was silently causing a regression on what https://github.com/DataDog/dd-agent/pull/2940 fixed)

### Motivation

Trying to fix the sanitization of the mongo URI once and for all.

### Testing Guidelines

Added unit tests to take into account all known cases.

Also removed the `requires=mongo` attribute on the unit tests
of the integration.