### PR TITLE
[process] handle the case pid file doesn't exist

### DIFF
--- a/process/check.py
+++ b/process/check.py
@@ -342,9 +342,13 @@ class ProcessCheck(AgentCheck):
             # psutil.NoSuchProcess is raised.
             pids = self._get_pid_set(pid)
         elif pid_file is not None:
-            with open(pid_file, 'r') as file_pid:
-                pid_line = file_pid.readline().strip()
-                pids = self._get_pid_set(int(pid_line))
+            try:
+                with open(pid_file, 'r') as file_pid:
+                    pid_line = file_pid.readline().strip()
+                    pids = self._get_pid_set(int(pid_line))
+            except IOError:
+                # pid file doesn't exist, assuming the process is not running
+                pids = set()
         else:
             raise ValueError('The "search_string" or "pid" options are required for process identification')
 

--- a/process/check.py
+++ b/process/check.py
@@ -346,8 +346,9 @@ class ProcessCheck(AgentCheck):
                 with open(pid_file, 'r') as file_pid:
                     pid_line = file_pid.readline().strip()
                     pids = self._get_pid_set(int(pid_line))
-            except IOError:
+            except IOError as e:
                 # pid file doesn't exist, assuming the process is not running
+                self.log.debug('Unable to find pid file: %s', e)
                 pids = set()
         else:
             raise ValueError('The "search_string" or "pid" options are required for process identification')

--- a/process/test_process.py
+++ b/process/test_process.py
@@ -356,6 +356,17 @@ class ProcessCheckTest(AgentCheckTest):
 
             self.assertMetric('system.processes.cpu.pct', count=1, tags=expected_tags)
 
+    def test_check_missing_pid(self):
+        config = {
+            'instances': [{
+                'name': 'foo',
+                'pid_file': '/foo/bar/baz',
+            }]
+        }
+
+        self.run_check(config, mocks={'get_pagefault_stats': noop_get_pagefault_stats})
+        self.assertServiceCheckCritical('process.up', count=1)
+
     def test_check_real_process(self):
         "Check that we detect python running (at least this process)"
         from utils.platform import Platform


### PR DESCRIPTION
### What does this PR do?

When configuring the check to monitor a pid file, if the file doesn't exist should mean the process is not running and the agent should send a CRIT service check.

### Motivation

Currently when using the pid file, when the file is not there the check gets into an error state:
```
process 
------- 
- instance #0 [ERROR]: "[Errno 2] No such file or directory: '/path/to/process.pid'" 
```