### PR TITLE
[kubernetes] if kubelet is down the integration should report a healthcheck still

### DIFF
--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -147,20 +147,24 @@ class Kubernetes(AgentCheck):
         # initialized by _filter_containers
         self._filtered_containers = set()
 
-        pods_list = self.kubeutil.retrieve_pods_list()
+        try:
+            pods_list = self.kubeutil.retrieve_pods_list()
+        except:
+            pods_list = None
 
         # kubelet health checks
         self._perform_kubelet_checks(self.kubeutil.kube_health_url)
 
-        # kubelet metrics
-        self._update_metrics(instance, pods_list)
+        if pods_list is not None:
+            # kubelet metrics
+            self._update_metrics(instance, pods_list)
 
-        # kubelet events
-        if _is_affirmative(instance.get('collect_events', DEFAULT_COLLECT_EVENTS)):
-            try:
-                self._process_events(instance, pods_list)
-            except Exception as ex:
-                self.log.error("Event collection failed: %s" % str(ex))
+            # kubelet events
+            if _is_affirmative(instance.get('collect_events', DEFAULT_COLLECT_EVENTS)):
+                try:
+                    self._process_events(instance, pods_list)
+                except Exception as ex:
+                    self.log.error("Event collection failed: %s" % str(ex))
 
     def _publish_raw_metrics(self, metric, dat, tags, depth=0):
         if depth >= self.max_depth:


### PR DESCRIPTION
### What does this PR do?

It intercepts connection error at `retrieve_pods_list` and skip all further checks except health checks if kubelet is down

### Motivation

We want to use this integration to monitor dead kubelet processes
