### PR TITLE
Set connectTimeout & serverSelectionTimeout to timeout in config

### DIFF
--- a/mongo/CHANGELOG.md
+++ b/mongo/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changes
 
+* [BUGFIX] Also set serverSelectionTimeout and connectTimeout to the value in yaml file.
 * [BUGFIX] Redact username/password in logs, etc. See #326 and #347
 
 1.0.003-22-2017

--- a/mongo/check.py
+++ b/mongo/check.py
@@ -689,6 +689,8 @@ class MongoDb(AgentCheck):
             cli = pymongo.mongo_client.MongoClient(
                 server,
                 socketTimeoutMS=timeout,
+                connectTimeoutMS=timeout,
+                serverSelectionTimeoutMS=timeout,
                 read_preference=pymongo.ReadPreference.PRIMARY_PREFERRED,
                 **ssl_params)
             # some commands can only go against the admin DB
@@ -761,6 +763,8 @@ class MongoDb(AgentCheck):
                 cli = pymongo.mongo_client.MongoClient(
                     server,
                     socketTimeoutMS=timeout,
+                    connectTimeoutMS=timeout,
+                    serverSelectionTimeoutMS=timeout,
                     replicaset=setname,
                     read_preference=pymongo.ReadPreference.NEAREST,
                     **ssl_params)

--- a/mongo/conf.yaml.example
+++ b/mongo/conf.yaml.example
@@ -4,7 +4,8 @@ instances:
   # Specify the MongoDB URI, with database to use for reporting (defaults to "admin")
   # E.g. mongodb://datadog:LnCbkX4uhpuLHSUrcayEoAZA@localhost:27016/my-db
   - server: mongodb://user:pass@host:port/db-name
-    # Time to wait on creating a MongoDB connection
+    # Controls connectTimeoutMS, serverSelectionTimeoutMS and socketTimeoutMS (see http://api.mongodb.com/python/3.4.0/api/pymongo/mongo_client.html)
+    # Defaults to 30 seconds
     # timeout: 30
 
     # tags:


### PR DESCRIPTION
### What does this PR do?

Set `connectTimeout` & `serverSelectionTimeout` to timeout specified in config `mongo.yaml`

### Motivation

Support case https://trello.com/c/NSmmQoDA/35-collector-interval-slows-when-services-are-reset
When the mongo server is stopped, it is the serverSelectionTimeout that happens. That's why changing timeout in the config didn't have any impact.
See http://api.mongodb.com/python/current/api/pymongo/mongo_client.html
