### PR TITLE
[docker_daemon] report service down when docker daemon does not repont

### DIFF
--- a/docker_daemon/test_docker_daemon.py
+++ b/docker_daemon/test_docker_daemon.py
@@ -37,6 +37,16 @@ def reset_docker_settings():
     """Populate docker settings with default, dummy settings"""
     DockerUtil().set_docker_settings({}, {})
 
+@attr(requires='docker_daemon')
+class TestCheckDockerDaemonDown(AgentCheckTest):
+    """Tests for docker_daemon integration when docker is down."""
+    CHECK_NAME = 'docker_daemon'
+
+    @mock.patch('docker.client.Client._retrieve_server_version',
+                side_effect=Exception("Connection timeout"))
+    def test_docker_down(self, *args):
+        self.run_check(MOCK_CONFIG, force_reload=True)
+        self.assertServiceCheck("docker.service_up", status=AgentCheck.CRITICAL, tags=None, count=1)
 
 @attr(requires='docker_daemon')
 class TestCheckDockerDaemon(AgentCheckTest):


### PR DESCRIPTION
### What does this PR do?

This PR reports docker daemon out if it can't connect to the daemon

### Motivation

We want to use the integration be be alerted when the daemon is down but instead it reports Initialization failure in logs and skip the run
