### PR TITLE
Remove commas from a few metadata descriptions

### DIFF
--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -1,6 +1,15 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 elasticsearch.active_primary_shards,gauge,,shard,,The number of active primary shards in the cluster.,0,elasticsearch,active primary shards
 elasticsearch.active_shards,gauge,,shard,,The number of active shards in the cluster.,0,elasticsearch,active shards
+elasticsearch.breakers.fielddata.estimated_size_in_bytes,gauge,,byte,,The estimated size in bytes of the field data circuit breaker.,0,elasticsearch,field data breaker size
+elasticsearch.breakers.fielddata.overhead,gauge,,,,The constant multiplier for byte estimations of the field data circuit breaker.,0,elasticsearch,field data breaker overhead
+elasticsearch.breakers.fielddata.tripped,gauge,,,,The number of times the field data circuit breaker has tripped.,0,elasticsearch,field data breaker tripped
+elasticsearch.breakers.parent.estimated_size_in_bytes,gauge,,byte,,The estimated size in bytes of the parent circuit breaker.,0,elasticsearch,parent breaker size
+elasticsearch.breakers.parent.overhead,gauge,,,,The constant multiplier for byte estimations of the parent circuit breaker.,0,elasticsearch,parent breaker overhead
+elasticsearch.breakers.parent.tripped,gauge,,,,The number of times the parent circuit breaker has tripped.,0,elasticsearch,parent breaker tripped
+elasticsearch.breakers.request.estimated_size_in_bytes,gauge,,byte,,The estimated size in bytes of the request circuit breaker.,0,elasticsearch,req breaker size
+elasticsearch.breakers.request.overhead,gauge,,,,The constant multiplier for byte estimations of the request circuit breaker.,0,elasticsearch,req breaker overhead
+elasticsearch.breakers.request.tripped,gauge,,,,The number of times the request circuit breaker has tripped.,0,elasticsearch,req breaker tripped
 elasticsearch.cache.field.evictions,gauge,,eviction,,The total number of evictions from the field data cache.,0,elasticsearch,field cache evictions
 elasticsearch.cache.field.size,gauge,,byte,,The size of the field cache.,0,elasticsearch,field cache size
 elasticsearch.cache.filter.count,gauge,,item,,The number of items in the filter cache.,0,elasticsearch,filter cache elements
@@ -38,11 +47,29 @@ elasticsearch.indexing.delete.total,gauge,,document,,The total number of documen
 elasticsearch.indexing.index.current,gauge,,document,,The number of documents currently being indexed to an index.,0,elasticsearch,current indexing
 elasticsearch.indexing.index.time,gauge,,second,,The total time spent indexing documents to an index.,0,elasticsearch,total indexing time
 elasticsearch.indexing.index.total,gauge,,document,,The total number of documents indexed to an index.,0,elasticsearch,total indexed
+elasticsearch.indices.indexing.index_failed,gauge,,,,The number of failed indexing operations.,-1,elasticsearch,index fails
+elasticsearch.indices.indexing.throttle_time,gauge,,millisecond,,The total time indexing waited due to throttling.,-1,elasticsearch,index fails
+elasticsearch.indices.query_cache.evictions,gauge,,eviction,,The number of query cache evictions.,0,elasticsearch,query cache evictions
+elasticsearch.indices.query_cache.hit_count,gauge,,hit,,The number of query cache hits.,0,elasticsearch,query cache hits
+elasticsearch.indices.query_cache.memory_size_in_bytes,gauge,,byte,,The memory used by the query cache.,0,elasticsearch,query cache mem
+elasticsearch.indices.query_cache.miss_count,gauge,,miss,,The number of query cache misses.,0,elasticsearch,query cache misses
+elasticsearch.indices.recovery.current_as_source,gauge,,,,The number of ongoing recoveries for which a shard serves as a source.,0,elasticsearch,index recoveries shard src
+elasticsearch.indices.recovery.current_as_target,gauge,,,,The number of ongoing recoveries for which a shard serves as a target.,0,elasticsearch,index recoveries shard tgt
+elasticsearch.indices.recovery.throttle_time,gauge,,millisecond,,The total time recoveries waited due to throttling.,-1,elasticsearch,index recoveries throttle
+elasticsearch.indices.request_cache.evictions,gauge,,eviction,,The number of request cache evictions.,0,elasticsearch,req cache evictions
+elasticsearch.indices.request_cache.hit_count,gauge,,hit,,The number of request cache hits.,0,elasticsearch,req cache hits
+elasticsearch.indices.request_cache.memory_size_in_bytes,gauge,,byte,,The memory used by the request cache.,0,elasticsearch,req cache mem
+elasticsearch.indices.request_cache.miss_count,gauge,,miss,,The number of request cache misses.,0,elasticsearch,req cache misses
 elasticsearch.indices.segments.count,gauge,,segment,,The number of segments in an index shard.,0,elasticsearch,shard segments count
-elasticsearch.indices.segments.fixed_bit_set_memory_in_bytes,gauge,,byte,,The size used by the in memory fixed bit set.,0,elasticsearch,fixed bit set memory
+elasticsearch.indices.segments.doc_values_memory_in_bytes,gauge,,byte,,The memory used by doc values.,0,elasticsearch,doc values memory
+elasticsearch.indices.segments.fixed_bit_set_memory_in_bytes,gauge,,byte,,The memory used by fixed bit set.,0,elasticsearch,fixed bit set memory
 elasticsearch.indices.segments.index_writer_max_memory_in_bytes,gauge,,byte,,The maximum memory used by the index writer.,0,elasticsearch,index writer max memory
 elasticsearch.indices.segments.index_writer_memory_in_bytes,gauge,,byte,,The memory used by the index writer.,0,elasticsearch,index writer memory
 elasticsearch.indices.segments.memory_in_bytes,gauge,,byte,,The memory used by index segments.,0,elasticsearch,index segments memory
+elasticsearch.indices.segments.norms_memory_in_bytes,gauge,,byte,,The memory used by norms.,0,elasticsearch,norms memory
+elasticsearch.indices.segments.stored_fields_memory_in_bytes,gauge,,byte,,The memory used by stored fields.,0,elasticsearch,stored fields memory
+elasticsearch.indices.segments.term_vectors_memory_in_bytes,gauge,,byte,,The memory used by term vectors.,0,elasticsearch,terms memory
+elasticsearch.indices.segments.terms_memory_in_bytes,gauge,,byte,,The memory used by terms.,0,elasticsearch,terms memory
 elasticsearch.indices.segments.version_map_memory_in_bytes,gauge,,byte,,The memory used by the segment version map.,0,elasticsearch,index segments version map memory
 elasticsearch.indices.translog.operations,gauge,,operation,,The number of operations in the transaction log.,0,elasticsearch,translog operations
 elasticsearch.indices.translog.size_in_bytes,gauge,,byte,,The size of the transaction log.,0,elasticsearch,translog size
@@ -108,36 +135,62 @@ elasticsearch.thread_pool.bulk.active,gauge,,thread,,The number of active thread
 elasticsearch.thread_pool.bulk.queue,gauge,,thread,,The number of queued threads in the bulk pool.,0,elasticsearch,queued bulk threads
 elasticsearch.thread_pool.bulk.threads,gauge,,thread,,The total number of threads in the bulk pool.,0,elasticsearch,total bulk threads
 elasticsearch.thread_pool.bulk.rejected,gauge,,thread,,The number of rejected threads in the bulk pool.,0,elasticsearch,rejected bulk threads
+elasticsearch.thread_pool.fetch_shard_started.active,gauge,,thread,,The number of active threads in the fetch shard started pool.,0,elasticsearch,active fetch shard started threads
+elasticsearch.thread_pool.fetch_shard_started.threads,gauge,,thread,,The total number of threads in the fetch shard started pool.,0,elasticsearch,total fetch shard started threads
+elasticsearch.thread_pool.fetch_shard_started.queue,gauge,,thread,,The number of queued threads in the fetch shard started pool.,0,elasticsearch,total fetch shard started threads
+elasticsearch.thread_pool.fetch_shard_started.rejected,gauge,,thread,,The number of rejected threads in the fetch shard started pool.,0,elasticsearch,total fetch shard started threads
+elasticsearch.thread_pool.fetch_shard_store.active,gauge,,thread,,The number of active threads in the fetch shard store pool.,0,elasticsearch,active fetch shard store threads
+elasticsearch.thread_pool.fetch_shard_store.threads,gauge,,thread,,The total number of threads in the fetch shard store pool.,0,elasticsearch,total fetch shard store threads
+elasticsearch.thread_pool.fetch_shard_store.queue,gauge,,thread,,The number of queued threads in the fetch shard store pool.,0,elasticsearch,total fetch shard store threads
+elasticsearch.thread_pool.fetch_shard_store.rejected,gauge,,thread,,The number of rejected threads in the fetch shard store pool.,0,elasticsearch,total fetch shard store threads
 elasticsearch.thread_pool.flush.active,gauge,,thread,,The number of active threads in the flush queue.,0,elasticsearch,active flush threads
 elasticsearch.thread_pool.flush.queue,gauge,,thread,,The number of queued threads in the flush pool.,0,elasticsearch,queued flush threads
 elasticsearch.thread_pool.flush.threads,gauge,,thread,,The total number of threads in the flush pool.,0,elasticsearch,total flush threads
+elasticsearch.thread_pool.flush.rejected,gauge,,thread,,The number of rejected threads in the flush pool.,0,elasticsearch,rejected flush threads
+elasticsearch.thread_pool.force_merge.active,gauge,,thread,,The number of active threads for force merge operations.,0,elasticsearch,active force merge threads
+elasticsearch.thread_pool.force_merge.threads,gauge,,thread,,The total number of threads for force merge operations.,0,elasticsearch,total force merge threads
+elasticsearch.thread_pool.force_merge.queue,gauge,,thread,,The number of queued threads for force merge operations.,0,elasticsearch,rejected force merge threads
+elasticsearch.thread_pool.force_merge.rejected,gauge,,thread,,The number of rejected threads for force merge operations.,0,elasticsearch,rejected force merge threads
 elasticsearch.thread_pool.generic.active,gauge,,thread,,The number of active threads in the generic pool.,0,elasticsearch,active generic threads
 elasticsearch.thread_pool.generic.queue,gauge,,thread,,The number of queued threads in the generic pool.,0,elasticsearch,queued generic threads
 elasticsearch.thread_pool.generic.threads,gauge,,thread,,The total number of threads in the generic pool.,0,elasticsearch,total generic threads
+elasticsearch.thread_pool.generic.rejected,gauge,,thread,,The number of rejected threads in the generic pool.,0,elasticsearch,rejected generic threads
 elasticsearch.thread_pool.get.active,gauge,,thread,,The number of active threads in the get pool.,0,elasticsearch,active get threads
 elasticsearch.thread_pool.get.queue,gauge,,thread,,The number of queued threads in the get pool.,0,elasticsearch,queued get threads
 elasticsearch.thread_pool.get.threads,gauge,,thread,,The total number of threads in the get pool.,0,elasticsearch,total get threads
+elasticsearch.thread_pool.get.rejected,gauge,,thread,,The number of rejected threads in the get pool.,0,elasticsearch,rejected get threads
 elasticsearch.thread_pool.index.active,gauge,,thread,,The number of active threads in the index pool.,0,elasticsearch,active index threads
 elasticsearch.thread_pool.index.queue,gauge,,thread,,The number of queued threads in the index pool.,0,elasticsearch,queued index threads
 elasticsearch.thread_pool.index.threads,gauge,,thread,,The total number of threads in the index pool.,0,elasticsearch,total index threads
+elasticsearch.thread_pool.index.rejected,gauge,,thread,,The number of rejected threads in the index pool.,0,elasticsearch,rejected index threads
+elasticsearch.thread_pool.listener.active,gauge,,thread,,The number of active threads in the listener pool.,0,elasticsearch,active listener threads
+elasticsearch.thread_pool.listener.queue,gauge,,thread,,The number of queued threads in the listener pool.,0,elasticsearch,queued listener threads
+elasticsearch.thread_pool.listener.threads,gauge,,thread,,The total number of threads in the listener pool.,0,elasticsearch,total listener threads
+elasticsearch.thread_pool.listener.rejected,gauge,,thread,,The number of rejected threads in the listener pool.,0,elasticsearch,rejected listener threads
 elasticsearch.thread_pool.management.active,gauge,,thread,,The number of active threads in the management pool.,0,elasticsearch,active management threads
 elasticsearch.thread_pool.management.queue,gauge,,thread,,The number of queued threads in the management pool.,0,elasticsearch,queued management threads
 elasticsearch.thread_pool.management.threads,gauge,,thread,,The total number of threads in the management pool.,0,elasticsearch,total management threads
+elasticsearch.thread_pool.management.rejected,gauge,,thread,,The number of rejected threads in the management pool.,0,elasticsearch,rejected management threads
 elasticsearch.thread_pool.merge.active,gauge,,thread,,The number of active threads in the merge pool.,0,elasticsearch,active merge threads
 elasticsearch.thread_pool.merge.queue,gauge,,thread,,The number of queued threads in the merge pool.,0,elasticsearch,queued merge threads
 elasticsearch.thread_pool.merge.threads,gauge,,thread,,The total number of threads in the merge pool.,0,elasticsearch,total merge threads
+elasticsearch.thread_pool.merge.rejected,gauge,,thread,,The number of rejected threads in the merge pool.,0,elasticsearch,rejected merge threads
 elasticsearch.thread_pool.percolate.active,gauge,,thread,,The number of active threads in the percolate pool.,0,elasticsearch,active percolate threads
 elasticsearch.thread_pool.percolate.queue,gauge,,thread,,The number of queued threads in the percolate pool.,0,elasticsearch,queued percolate threads
 elasticsearch.thread_pool.percolate.threads,gauge,,thread,,The total number of threads in the percolate pool.,0,elasticsearch,total percolate threads
+elasticsearch.thread_pool.percolate.rejected,gauge,,thread,,The number of rejected threads in the percolate pool.,0,elasticsearch,rejected percolate threads
 elasticsearch.thread_pool.refresh.active,gauge,,thread,,The number of active threads in the refresh pool.,0,elasticsearch,active refresh threads
 elasticsearch.thread_pool.refresh.queue,gauge,,thread,,The number of queued threads in the refresh pool.,0,elasticsearch,queued refresh threads
 elasticsearch.thread_pool.refresh.threads,gauge,,thread,,The total number of threads in the refresh pool.,0,elasticsearch,total refresh threads
+elasticsearch.thread_pool.refresh.rejected,gauge,,thread,,The number of rejected threads in the refresh pool.,0,elasticsearch,rejected refresh threads
 elasticsearch.thread_pool.search.active,gauge,,thread,,The number of active threads in the search pool.,0,elasticsearch,active search threads
 elasticsearch.thread_pool.search.queue,gauge,,thread,,The number of queued threads in the search pool.,0,elasticsearch,queued search threads
 elasticsearch.thread_pool.search.threads,gauge,,thread,,The total number of threads in the search pool.,0,elasticsearch,total search threads
+elasticsearch.thread_pool.search.rejected,gauge,,thread,,The number of rejected threads in the search pool.,0,elasticsearch,rejected search threads
 elasticsearch.thread_pool.snapshot.active,gauge,,thread,,The number of active threads in the snapshot pool.,0,elasticsearch,active snapshot threads
 elasticsearch.thread_pool.snapshot.queue,gauge,,thread,,The number of queued threads in the snapshot pool.,0,elasticsearch,queued snapshot threads
 elasticsearch.thread_pool.snapshot.threads,gauge,,thread,,The total number of threads in the snapshot pool.,0,elasticsearch,total snapshot threads
+elasticsearch.thread_pool.snapshot.rejected,gauge,,thread,,The number of rejected threads in the snapshot pool.,0,elasticsearch,rejected snapshot threads
 elasticsearch.transport.rx_count,gauge,,packet,,The total number of packets received in cluster communication.,0,elasticsearch,transport packets received
 elasticsearch.transport.rx_size,gauge,,byte,,The total size of data received in cluster communication.,0,elasticsearch,transport bytes received
 elasticsearch.transport.server_open,gauge,,connection,,The number of connections opened for cluster communication.,0,elasticsearch,transport open connections

--- a/redisdb/metadata.csv
+++ b/redisdb/metadata.csv
@@ -13,7 +13,7 @@ redis.cpu.user_children,gauge,,second,,User CPU consumed by the background proce
 redis.expires,gauge,,key,,The number of keys that have expired.,0,redis,expires
 redis.expires.percent,gauge,,percent,,Percentage of total keys that have been expired.,0,redis,expires pct
 redis.info.latency_ms,gauge,,millisecond,,The latency of the redis info command.,0,redis,info latency
-redis.key.length,gauge,,,,The number of elements in a given key, tagged by key, e.g. 'key:mykeyname'. Enable in Agent config via the keys option.,0,redis,key length
+redis.key.length,gauge,,,,The number of elements in a given key tagged by key e.g. 'key:mykeyname'. Enable in Agent config via the keys option.,0,redis,key length
 redis.keys,gauge,,key,,The total number of keys.,0,redis,keys
 redis.keys.evicted,gauge,,key,,The total number of keys evicted due to the maxmemory limit.,0,redis,keys evicted
 redis.keys.expired,gauge,,key,,The total number of keys expired from the db.,0,redis,keys expired
@@ -49,5 +49,5 @@ redis.slowlog.micros.max,gauge,,microsecond,,The maximum duration of queries rep
 redis.slowlog.micros.median,gauge,,microsecond,,The median duration of queries reported in the slow log.,0,redis,slowlog median
 redis.stats.keyspace_hits,gauge,,key,,The total number of successful lookups in the db.,0,redis,keyspace hits
 redis.stats.keyspace_misses,gauge,,key,,The total number of missed lookups in the db.,0,redis,keyspace misses
-redis.command.calls,gauge,,,,The number of times a redis command has been called, tagged by 'command', e.g. 'command:append'. Enable in Agent config via the command_stats option.,0,redis,cmd calls
-redis.command.usec_per_call,gauge,,,,The CPU time consumed per redis command call, tagged by 'command', e.g. 'command:append'. Enable in Agent config via the command_stats option.,0,redis,usec per cmd
+redis.command.calls,gauge,,,,The number of times a redis command has been called tagged by 'command' e.g. 'command:append'. Enable in Agent config via the command_stats option.,0,redis,cmd calls
+redis.command.usec_per_call,gauge,,,,The CPU time consumed per redis command call tagged by 'command' e.g. 'command:append'. Enable in Agent config via the command_stats option.,0,redis,usec per cmd


### PR DESCRIPTION
In a CSV, commas within a field are a no go.