### PR TITLE
SqlServer integration extended to call custom proc to return metrics

### DIFF
--- a/sqlserver/check.py
+++ b/sqlserver/check.py
@@ -18,6 +18,8 @@ try:
 except ImportError:
     pyodbc = None
 
+from config import _is_affirmative
+
 # project
 from checks import AgentCheck
 

--- a/sqlserver/check.py
+++ b/sqlserver/check.py
@@ -52,6 +52,7 @@ VALUE_AND_BASE_QUERY = '''select cntr_value
                           and instance_name=?
                           order by cntr_type;'''
 
+DATABASE_EXISTS_QUERY = 'select name from sys.databases;'
 
 class SQLConnectionError(Exception):
     """
@@ -67,6 +68,8 @@ class SQLServer(AgentCheck):
     DEFAULT_COMMAND_TIMEOUT = 30
     DEFAULT_DATABASE = 'master'
     DEFAULT_DRIVER = 'SQL Server'
+    DEFAULT_DB_KEY = 'database'
+    PROC_GUARD_DB_KEY = 'proc_only_if_database'
 
     METRICS = [
         ('sqlserver.buffer.cache_hit_ratio', 'Buffer cache hit ratio', ''),  # RAW_LARGE_FRACTION
@@ -91,6 +94,14 @@ class SQLServer(AgentCheck):
         self.connections = {}
         self.failed_connections = {}
         self.instances_metrics = {}
+        self.existing_databases = None
+        self.do_check = {}
+        self.proc_type_mapping = {
+            'gauge': self.gauge,
+            'rate' : self.rate,
+            'histogram': self.histogram
+        }
+
         self.connector = init_config.get('connector', 'adodbapi')
         if not self.connector.lower() in self.valid_connectors:
             self.log.error("Invalid database connector %s, defaulting to adodbapi" % self.connector)
@@ -101,11 +112,56 @@ class SQLServer(AgentCheck):
         self.custom_metrics = init_config.get('custom_metrics', [])
         for instance in instances:
             try:
-                with self.open_managed_db_connections(instance):
-                    self._make_metric_list_to_collect(instance, self.custom_metrics)
+                # check to see if the database exists before we try any connections to it
+                with self.open_managed_db_connections(instance, None, db_name=self.DEFAULT_DATABASE):
+                    db_exists, context = self._check_db_exists(instance)
+                instance_key = self._conn_key(instance, self.DEFAULT_DB_KEY)
+                
+                if db_exists:
+                    self.do_check[instance_key] = True
+                    if instance.get('stored_procedure') is None:
+                        with self.open_managed_db_connections(instance, self.DEFAULT_DB_KEY):
+                            self._make_metric_list_to_collect(instance, self.custom_metrics)
+                else:
+                    # How much do we care that the DB doesn't exist?
+                    ignore = instance.get('ignore_missing_database')
+                    if ignore is not None and ignore:
+                        # not much : we expect it. Disable checks
+                        self.do_check[instance_key] = False
+                        self.log.info("Database %s does not exist. Disabling checks for this instance." % (context))
+                    else:
+                        # yes we do. Keep trying
+                        self.do_check[instance_key] = True
+                        self.log.exception("Database %s does not exist. Fix issue and restart agent" % (context))
+
             except SQLConnectionError:
                 self.log.exception("Skipping SQL Server instance")
                 continue
+
+    def _check_db_exists(self, instance):
+        """
+        Check if the database we're targeting actually exists
+        If not then we won't do any checks
+        This allows the same config to be installed on many servers but fail gracefully
+        """
+        
+        dsn, host, username, password, database, driver = self._get_access_info(instance, self.DEFAULT_DB_KEY)
+        context = "%s - %s" % (host, database)
+        if self.existing_databases is None:
+            cursor = self.get_cursor(instance, None, self.DEFAULT_DATABASE)
+        
+            try:
+                self.existing_databases = {}
+                cursor.execute(DATABASE_EXISTS_QUERY)
+                for row in cursor:
+                    self.existing_databases[row.name] = True
+
+                self.close_cursor(cursor)
+            except Exception, e:
+                self.log.error("Failed to check if database %s exists: %s" % (database, e))
+                return False, context
+        
+        return database in self.existing_databases, context
 
     def _make_metric_list_to_collect(self, instance, custom_metrics):
         """
@@ -152,7 +208,7 @@ class SQLServer(AgentCheck):
                                                         row.get('instance_name', ''),
                                                         row.get('tag_by', None)))
 
-        instance_key = self._conn_key(instance)
+        instance_key = self._conn_key(instance, self.DEFAULT_DB_KEY)
         self.instances_metrics[instance_key] = metrics_to_collect
 
     def typed_metric(self, instance, dd_name, sql_name, base_name, user_type, sql_type, instance_name, tag_by):
@@ -193,14 +249,14 @@ class SQLServer(AgentCheck):
                 self.log.debug("Overriding default connector for %s with %s", instance['host'], connector)
         return connector
 
-    def _get_access_info(self, instance):
+    def _get_access_info(self, instance, db_key, db_name=None):
         ''' Convenience method to extract info from instance
         '''
         dsn = instance.get('dsn')
         host = instance.get('host')
         username = instance.get('username')
         password = instance.get('password')
-        database = instance.get('database')
+        database = instance.get(db_key) if db_name is None else db_name
         driver = instance.get('driver')
         if not dsn:
             if not host:
@@ -211,17 +267,17 @@ class SQLServer(AgentCheck):
                 driver = self.DEFAULT_DRIVER
         return dsn, host, username, password, database, driver
 
-    def _conn_key(self, instance):
+    def _conn_key(self, instance, db_key, db_name=None):
         ''' Return a key to use for the connection cache
         '''
-        dsn, host, username, password, database, driver = self._get_access_info(instance)
+        dsn, host, username, password, database, driver = self._get_access_info(instance, db_key, db_name)
         return '%s:%s:%s:%s:%s:%s' % (dsn, host, username, password, database, driver)
 
-    def _conn_string_odbc(self, instance=None, conn_key=None):
+    def _conn_string_odbc(self, db_key, instance=None, conn_key=None, db_name=None):
         ''' Return a connection string to use with odbc
         '''
         if instance:
-            dsn, host, username, password, database, driver = self._get_access_info(instance)
+            dsn, host, username, password, database, driver = self._get_access_info(instance, db_key, db_name)
         elif conn_key:
             dsn, host, username, password, database, driver = conn_key.split(":")
 
@@ -244,11 +300,11 @@ class SQLServer(AgentCheck):
 
         return conn_str
 
-    def _conn_string_adodbapi(self, instance=None, conn_key=None):
+    def _conn_string_adodbapi(self, db_key, instance=None, conn_key=None, db_name=None):
         ''' Return a connection string to use with adodbapi
         '''
         if instance:
-            _, host, username, password, database, _ = self._get_access_info(instance)
+            _, host, username, password, database, _ = self._get_access_info(instance, db_key, db_name)
         elif conn_key:
             _, host, username, password, database, _ = conn_key.split(":")
         conn_str = 'Provider=SQLOLEDB;Data Source=%s;Initial Catalog=%s;' \
@@ -263,18 +319,18 @@ class SQLServer(AgentCheck):
 
 
     @contextmanager
-    def get_managed_cursor(self, instance):
-        cursor = self.get_cursor(instance)
+    def get_managed_cursor(self, instance, db_key, db_name=None):
+        cursor = self.get_cursor(instance, db_key, db_name)
         yield cursor
 
         self.close_cursor(cursor)
 
-    def get_cursor(self, instance):
+    def get_cursor(self, instance, db_key, db_name=None):
         '''
         Return a cursor to execute query against the db
         Cursor are cached in the self.connections dict
         '''
-        conn_key = self._conn_key(instance)
+        conn_key = self._conn_key(instance, db_key, db_name)
 
         conn = self.connections[conn_key]['conn']
         cursor = conn.cursor()
@@ -287,7 +343,7 @@ class SQLServer(AgentCheck):
         If the sql_type is one that needs a base (PERF_RAW_LARGE_FRACTION and
         PERF_AVERAGE_BULK), the name of the base counter will also be returned
         '''
-        with self.get_managed_cursor(instance) as cursor:
+        with self.get_managed_cursor(instance, self.DEFAULT_DB_KEY) as cursor:
             cursor.execute(COUNTER_TYPE_QUERY, (counter_name,))
             (sql_type,) = cursor.fetchone()
             if sql_type == PERF_LARGE_RAW_BASE:
@@ -313,24 +369,85 @@ class SQLServer(AgentCheck):
         return sql_type, base_name
 
     def check(self, instance):
+        if self.do_check[self._conn_key(instance, self.DEFAULT_DB_KEY)]:
+            proc = instance.get('stored_procedure')
+            if proc is None:
+                self.do_perf_counter_check(instance)
+            else:
+                self.do_stored_procedure_check(instance, proc)
+        else:
+            self.log.debug("Skipping check")
+            
+    def do_perf_counter_check(self, instance):
         """
         Fetch the metrics from the sys.dm_os_performance_counters table
         """
         custom_tags = instance.get('tags', [])
-        instance_key = self._conn_key(instance)
+        instance_key = self._conn_key(instance, self.DEFAULT_DB_KEY)
 
-        with self.open_managed_db_connections(instance):
+        with self.open_managed_db_connections(instance, self.DEFAULT_DB_KEY):
             # if the server was down at check __init__ key could be missing.
             if instance_key not in self.instances_metrics:
                 self._make_metric_list_to_collect(instance, self.custom_metrics)
             metrics_to_collect = self.instances_metrics[instance_key]
 
-            with self.get_managed_cursor(instance) as cursor:
+            with self.get_managed_cursor(instance, self.DEFAULT_DB_KEY) as cursor:
                 for metric in metrics_to_collect:
                     try:
                         metric.fetch_metric(cursor, custom_tags)
                     except Exception as e:
                         self.log.warning("Could not fetch metric %s: %s" % (metric.datadog_name, e))
+
+    def do_stored_procedure_check(self, instance, proc):
+        """
+        Fetch the metrics from the stored proc
+        """
+
+        guardSql = instance.get('proc_only_if')
+
+        if (guardSql and self.proc_check_guard(instance, guardSql)) or not guardSql:
+            self.open_db_connections(instance, self.DEFAULT_DB_KEY)
+            cursor = self.get_cursor(instance, self.DEFAULT_DB_KEY)
+
+            try:
+                cursor.callproc(proc)
+                rows = cursor.fetchall()
+                for row in rows:
+                    tags = [] if row.tags is None or row.tags == '' else row.tags.split(',')
+
+                    if row.type in self.proc_type_mapping:
+                        self.proc_type_mapping[row.type](row.metric, row.value, tags)
+                    else:
+                        self.log.warning('%s is not a recognised type from procedure %s, metric %s'
+                                         % (row.type, proc, row.metric))
+                        
+            except Exception, e:
+                self.log.warning("Could not call procedure %s: %s" % (proc, e))
+                
+            self.close_cursor(cursor)
+            self.close_db_connections(instance, self.DEFAULT_DB_KEY)
+        else:
+            self.log.info("Skipping call to %s due to only_if" % (proc))
+
+    def proc_check_guard(self, instance, sql):
+        """
+        check to see if the guard SQL returns a single column containing 0 or 1
+        We return true if 1, else False
+        """
+        self.open_db_connections(instance, self.PROC_GUARD_DB_KEY)
+        cursor = self.get_cursor(instance, self.PROC_GUARD_DB_KEY)
+
+        should_run = False
+        try:
+            cursor.execute(sql, ())
+            result = cursor.fetchone()
+            should_run = result[0] == 1
+        except Exception, e:
+            self.log.error("Failed to run proc_only_if sql %s : %s" % (sql, e))
+        
+        self.close_cursor(cursor)
+        self.close_db_connections(instance, self.PROC_GUARD_DB_KEY)
+        return should_run
 
     def close_cursor(self, cursor):
         """
@@ -343,13 +460,13 @@ class SQLServer(AgentCheck):
         except Exception as e:
             self.log.warning("Could not close adodbapi cursor\n{0}".format(e))
 
-    def close_db_connections(self, instance):
+    def close_db_connections(self, instance, db_key, db_name=None):
         """
         We close the db connections explicitly b/c when we don't they keep
         locks on the db. This presents as issues such as the SQL Server Agent
         being unable to stop.
         """
-        conn_key = self._conn_key(instance)
+        conn_key = self._conn_key(instance, db_key, db_name)
         if conn_key not in self.connections:
             return
 
@@ -360,13 +477,13 @@ class SQLServer(AgentCheck):
             self.log.warning("Could not close adodbapi db connection\n{0}".format(e))
 
     @contextmanager
-    def open_managed_db_connections(self, instance):
-        self.open_db_connections(instance)
+    def open_managed_db_connections(self, instance, db_key, db_name=None):
+        self.open_db_connections(instance, db_key, db_name)
         yield
 
-        self.close_db_connections(instance)
+        self.close_db_connections(instance, db_key, db_name)
 
-    def open_db_connections(self, instance):
+    def open_db_connections(self, instance, db_key, db_name=None):
         """
         We open the db connections explicitly, so we can ensure they are open
         before we use them, and are closable, once we are finished. Open db
@@ -374,12 +491,12 @@ class SQLServer(AgentCheck):
         Server Agent being unable to stop.
         """
 
-        conn_key = self._conn_key(instance)
+        conn_key = self._conn_key(instance, db_key, db_name)
         timeout = int(instance.get('command_timeout',
                                    self.DEFAULT_COMMAND_TIMEOUT))
 
-        host = instance.get('host')
-        database = instance.get('database', self.DEFAULT_DATABASE)
+        dsn, host, username, password, database, driver = self._get_access_info(
+            instance, db_key, db_name)
         service_check_tags = [
             'host:%s' % host,
             'db:%s' % database
@@ -387,10 +504,11 @@ class SQLServer(AgentCheck):
 
         try:
             if self._get_connector(instance) == 'adodbapi':
-                cs = self._conn_string_adodbapi(instance=instance)
-                rawconn = adodbapi.connect(cs,  timeout=timeout)
+                cs = self._conn_string_adodbapi(db_key, instance=instance, db_name=db_name)
+                # autocommit: true disables implicit transaction
+                rawconn = adodbapi.connect(cs, {'timeout':timeout, 'autocommit':True})
             else:
-                cs = self._conn_string_odbc(instance=instance)
+                cs = self._conn_string_odbc(db_key, instance=instance, db_name=db_name)
                 rawconn = pyodbc.connect(cs, timeout=timeout)
 
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
@@ -408,6 +526,7 @@ class SQLServer(AgentCheck):
         except Exception as e:
             cx = "%s - %s" % (host, database)
             message = "Unable to connect to SQL Server for instance %s." % cx
+            self.log.warning("%s Exception: %s", message, e)
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
                                tags=service_check_tags, message=message)
 

--- a/sqlserver/check.py
+++ b/sqlserver/check.py
@@ -118,7 +118,7 @@ class SQLServer(AgentCheck):
                 # check to see if the database exists before we try any connections to it
                 with self.open_managed_db_connections(instance, None, db_name=self.DEFAULT_DATABASE):
                     db_exists, context = self._check_db_exists(instance)
-                
+
                 if db_exists:
                     self.do_check[instance_key] = True
                     if instance.get('stored_procedure') is None:
@@ -145,12 +145,12 @@ class SQLServer(AgentCheck):
         If not then we won't do any checks
         This allows the same config to be installed on many servers but fail gracefully
         """
-        
+
         dsn, host, username, password, database, driver = self._get_access_info(instance, self.DEFAULT_DB_KEY)
         context = "%s - %s" % (host, database)
         if self.existing_databases is None:
             cursor = self.get_cursor(instance, None, self.DEFAULT_DATABASE)
-        
+
             try:
                 self.existing_databases = {}
                 cursor.execute(DATABASE_EXISTS_QUERY)
@@ -161,7 +161,7 @@ class SQLServer(AgentCheck):
             except Exception, e:
                 self.log.error("Failed to check if database %s exists: %s" % (database, e))
                 return False, context
-        
+
         return database in self.existing_databases, context
 
     def _make_metric_list_to_collect(self, instance, custom_metrics):
@@ -378,7 +378,7 @@ class SQLServer(AgentCheck):
                 self.do_stored_procedure_check(instance, proc)
         else:
             self.log.debug("Skipping check")
-            
+
     def do_perf_counter_check(self, instance):
         """
         Fetch the metrics from the sys.dm_os_performance_counters table
@@ -421,10 +421,10 @@ class SQLServer(AgentCheck):
                     else:
                         self.log.warning('%s is not a recognised type from procedure %s, metric %s'
                                          % (row.type, proc, row.metric))
-                        
+
             except Exception, e:
                 self.log.warning("Could not call procedure %s: %s" % (proc, e))
-                
+
             self.close_cursor(cursor)
             self.close_db_connections(instance, self.DEFAULT_DB_KEY)
         else:
@@ -445,7 +445,7 @@ class SQLServer(AgentCheck):
             should_run = result[0] == 1
         except Exception, e:
             self.log.error("Failed to run proc_only_if sql %s : %s" % (sql, e))
-        
+
         self.close_cursor(cursor)
         self.close_db_connections(instance, self.PROC_GUARD_DB_KEY)
         return should_run

--- a/sqlserver/check.py
+++ b/sqlserver/check.py
@@ -126,7 +126,7 @@ class SQLServer(AgentCheck):
                             self._make_metric_list_to_collect(instance, self.custom_metrics)
                 else:
                     # How much do we care that the DB doesn't exist?
-                    ignore = instance.get('ignore_missing_database')
+                    ignore = _is_affirmative(instance.get("ignore_missing_database", False))
                     if ignore is not None and ignore:
                         # not much : we expect it. leave checks disabled
                         self.log.info("Database %s does not exist. Disabling checks for this instance." % (context))

--- a/sqlserver/conf.yaml.example
+++ b/sqlserver/conf.yaml.example
@@ -34,6 +34,8 @@ init_config:
     #   tag_by: db
 
     # As well as capturing from the DMV you can also capture from a custom proc
+    # Please note this feature will produce a number of custom metrics that might affect your billing
+    #
     # The proc should return this table
     # CREATE TABLE #Datadog
     # (
@@ -44,7 +46,7 @@ init_config:
     # )
     # 
     # You can also specify:
-    # ignore_missing_database : if DB doesn't exist on the server then don't do the check
+    # ignore_missing_database : if DB doesn't exist on the server then don't do the check. Default False
     # proc_only_if : run this SQL before each call to stored_procedure. Only if it returns 1 then call the proc
     # proc_only_if_database : the database to run the proc_only_if SQL in. Optional. 
     #                         Defaults to database attribute

--- a/sqlserver/conf.yaml.example
+++ b/sqlserver/conf.yaml.example
@@ -33,10 +33,28 @@ init_config:
     #   instance_name: ALL
     #   tag_by: db
 
+    # As well as capturing from the DMV you can also capture from a custom proc
+    # The proc should return this table
+    # CREATE TABLE #Datadog
+    # (
+    # 	[metric] varchar(255) not null,
+    # 	[type] varchar(50) not null,
+    # 	[value] float not null,
+    # 	[tags] varchar(255)
+    # )
+    # 
+    # You can also specify:
+    # ignore_missing_database : if DB doesn't exist on the server then don't do the check
+    # proc_only_if : run this SQL before each call to stored_procedure. Only if it returns 1 then call the proc
+    # proc_only_if_database : the database to run the proc_only_if SQL in. Optional. 
+    #                         Defaults to database attribute
+    #
+    # The proc_only_if guard condition is useful for HA scenarios where a database can move between servers.
+
 instances:
    # All '%' characters must be escaped as '%%'.
 
-    - host: HOST,PORT
+  - host: HOST,PORT
     # Optional, change the connection method from adodbapi (the default) to
     # odbc (valid connector names are 'odbc' and 'adodbapi')
     # odbc is only available on Windows
@@ -56,3 +74,11 @@ instances:
     # database: my_database # Optional, defaults to "master"
     tags:
       - optional_tag
+
+  # get metrics from custom proc in MyDB but only if the database is writeable (i.e. it's the master in an availability group)
+  - host: HOST,PORT
+    database: MyDB
+    stored_procedure: GetDatadogMetrics
+    proc_only_if: SELECT CASE CONVERT(sysname,DatabasePropertyEx('MyDB','Updateability')) WHEN 'READ_WRITE' THEN 1 ELSE 0 END
+    proc_only_if_database: master
+    ignore_missing_database: True 

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -10,6 +10,6 @@
     "linux",
     "windows"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "guid": "635cb962-ee9f-4788-aa55-a7ffb9661498"
 }

--- a/sqlserver/requirements.txt
+++ b/sqlserver/requirements.txt
@@ -1,7 +1,7 @@
 # integration pip requirements
 adodbapi==2.6.0.7
 pyro4==4.36
-testfixtures=4.14.3
+testfixtures==4.14.3
 
 # Requires unixodbc on Linux, so only build on windows for now
 pyodbc==4.0.13; sys_platform == 'win32'

--- a/sqlserver/requirements.txt
+++ b/sqlserver/requirements.txt
@@ -1,6 +1,7 @@
 # integration pip requirements
 adodbapi==2.6.0.7
 pyro4==4.36
+testfixtures=4.14.3
 
 # Requires unixodbc on Linux, so only build on windows for now
 pyodbc==4.0.13; sys_platform == 'win32'

--- a/sqlserver/test_proc.sql
+++ b/sqlserver/test_proc.sql
@@ -1,0 +1,44 @@
+
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[GetDatadogMetricsTest]') AND type in (N'P', N'PC'))
+DROP PROCEDURE [dbo].[GetDatadogMetricsTest]
+GO
+
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+-- =======================================================================================
+-- Description:	Gets metrics for Datadog
+-- =======================================================================================
+CREATE PROCEDURE [dbo].[GetDatadogMetricsTest]
+AS
+BEGIN
+	set transaction isolation level read uncommitted
+	set nocount on
+
+	-- if the DB is read only then we must be a secondary so don't report any data
+	IF (SELECT CONVERT(sysname,DatabasePropertyEx(DB_NAME(),'Updateability'))) = 'READ_ONLY'
+		RETURN
+
+	CREATE TABLE #Datadog
+	(
+		[metric] varchar(255) not null,
+		[type] varchar(50) not null,
+		[value] float not null,
+		[tags] varchar(255)
+	)
+
+	INSERT INTO #Datadog (metric, type, value, tags)
+	VALUES ('sql.test.gauge', 'gauge', 5, 'tag:test')
+		,('sql.test.rate', 'rate', 500, null)
+		,('sql.test.histogram', 'histogram', FLOOR(RAND()*20), null)
+
+	SELECT * FROM #Datadog
+END
+GO
+
+GRANT EXECUTE ON [dbo].[GetDatadogMetricsTest] To Public
+GO

--- a/sqlserver/test_sqlserver.py
+++ b/sqlserver/test_sqlserver.py
@@ -148,10 +148,10 @@ class TestSqlserver(AgentCheckTest):
 
         with LogCapture() as l:
             self.run_check(config, force_reload=True)
-            l.check(
-                ('checks.sqlserver', 'ERROR', 'Skipping SQL Server instance'),
-                ('checks.sqlserver', 'DEBUG', 'Skipping check'),
-            )
+            assert l.records[0].message == 'Skipping SQL Server instance'
+            assert l.records[0].levelname == 'ERROR'
+            assert l.records[1].message == 'Skipping check'
+            assert l.records[1].levelname == 'DEBUG'
 
         self.assertServiceCheckCritical('sqlserver.can_connect',
                                         tags=['host:(local)\SQL2012SP1', 'db:master'])

--- a/sqlserver/test_sqlserver.py
+++ b/sqlserver/test_sqlserver.py
@@ -7,7 +7,6 @@ import copy
 from nose.plugins.attrib import attr
 
 # 3p
-import logging
 from testfixtures import LogCapture
 
 # project

--- a/sqlserver/test_sqlserver.py
+++ b/sqlserver/test_sqlserver.py
@@ -148,9 +148,9 @@ class TestSqlserver(AgentCheckTest):
 
         with LogCapture() as l:
             self.run_check(config, force_reload=True)
-            assert l.records[0].message == 'Skipping SQL Server instance'
+            assert l.records[0].msg == 'Skipping SQL Server instance'
             assert l.records[0].levelname == 'ERROR'
-            assert l.records[1].message == 'Skipping check'
+            assert l.records[1].msg == 'Skipping check'
             assert l.records[1].levelname == 'DEBUG'
 
         self.assertServiceCheckCritical('sqlserver.can_connect',

--- a/sqlserver/test_sqlserver.py
+++ b/sqlserver/test_sqlserver.py
@@ -7,6 +7,8 @@ import copy
 from nose.plugins.attrib import attr
 
 # 3p
+import logging
+from testfixtures import LogCapture
 
 # project
 from tests.checks.common import AgentCheckTest
@@ -144,8 +146,12 @@ class TestSqlserver(AgentCheckTest):
             'timeout': 1,
         }]
 
-        with self.assertRaisesRegexp(Exception, 'Unable to connect to SQL Server'):
+        with LogCapture() as l:
             self.run_check(config, force_reload=True)
+            l.check(
+                ('checks.sqlserver', 'ERROR', 'Skipping SQL Server instance'),
+                ('checks.sqlserver', 'DEBUG', 'Skipping check'),
+            )
 
         self.assertServiceCheckCritical('sqlserver.can_connect',
                                         tags=['host:(local)\SQL2012SP1', 'db:master'])


### PR DESCRIPTION
This PR is a transfer of http://github.com/DataDog/dd-agent/pull/2445 and also includes a fix for http://github.com/DataDog/dd-agent/issues/2555. It allows Datadog to capture metrics from a custom stored procedure. This allows the user to surface their own data as a metric.

It also supports a guard proc so that the metrics aren't collected from secondary servers in an availability group, but will automatically be collected if the database fails over.

@masci Can you review/merge please.

I've included an example proc and tested with agent 5.12.2 on Windows 10/SQL 2014 and the ADODB driver.
