### PR TITLE
[go_expvar] docs sync

### DIFF
--- a/go_expvar/README.md
+++ b/go_expvar/README.md
@@ -4,7 +4,7 @@
 
 Track the memory usage of your Go services and collect metrics instrumented from Go's expvar package.
 
-If you prefer to instrument your Go code with [dogstats-go](https://github.com/DataDog/datadog-go) instead, you can still use this integration to collect memory-related metrics.
+If you prefer to instrument your Go code using only [dogstats-go](https://github.com/DataDog/datadog-go), you can still use this integration to collect memory-related metrics.
 
 # Installation
 

--- a/go_expvar/README.md
+++ b/go_expvar/README.md
@@ -1,4 +1,4 @@
-# Go expvar Integration
+# Go Expvar Integration
 
 # Overview
 
@@ -26,7 +26,6 @@ Create a file `go_expvar.yaml` in the Agent's `conf.d` directory:
 init_config:
 
 instances:
-  # where <your_apps_port> is the HTTP port of your Go service
   - expvar_url: http://localhost:<your_apps_port>/debug/vars
     # optionally change the top-level namespace for metrics, e.g. my_go_app.memstats.alloc
     namespace: my_go_app # defaults to go_expvar, e.g. go_expvar.memstats.alloc

--- a/go_expvar/README.md
+++ b/go_expvar/README.md
@@ -30,7 +30,7 @@ instances:
   - expvar_url: http://localhost:<your_apps_port>/debug/vars
     # optionally change the top-level namespace for metrics, e.g. my_go_app.memstats.alloc
     namespace: my_go_app # defaults to go_expvar, e.g. go_expvar.memstats.alloc
-    # define the metrics to collect, e.g. a counter var your service exposes with expvar.NewInt("my_func_counter")
+    # optionally define the metrics to collect, e.g. a counter var your service exposes with expvar.NewInt("my_func_counter")
     metrics:
       - path: my_func_counter
         # if you don't want it named my_go_app.my_func_counter
@@ -40,9 +40,9 @@ instances:
         #  - "tag_name1:tag_value1"
 ```
 
-If you don't configure a `metrics` list, the Agent will still collect most memstat metrics. Use `metrics` to tell the Agent which extra memstat metrics and which expvar vars to collect.
+If you don't configure a `metrics` list, the Agent will still collect memstat metrics. Use `metrics` to tell the Agent which expvar vars to collect.
 
-Restart the Agent to begin sending expvar metrics to Datadog.
+Restart the Agent to begin sending memstat and expvar metrics to Datadog.
 
 # Validation
 

--- a/go_expvar/README.md
+++ b/go_expvar/README.md
@@ -1,10 +1,10 @@
-# Go Expvar Integration
+# Go expvar Integration
 
 # Overview
 
-Track the memory usage of your Go services and collect custom metrics you've instrumented with Go's expvar package.
+Track the memory usage of your Go services and collect metrics instrumented from Go's expvar package.
 
-If you already instrument your Go code with [dogstats-go](https://github.com/DataDog/datadog-go), you can still use this check to collect memory-related metrics.
+If you prefer to instrument your Go code with [dogstats-go](https://github.com/DataDog/datadog-go) instead, you can still use this integration to collect memory-related metrics.
 
 # Installation
 

--- a/go_expvar/README.md
+++ b/go_expvar/README.md
@@ -40,7 +40,7 @@ instances:
         #  - "tag_name1:tag_value1"
 ```
 
-If you don't configure a `metrics` list, the Agent will still collect most memstat metrics. Use `metrics` to tell the Agent which extra memstat metrics to collect, and which expvar vars you want to collect.
+If you don't configure a `metrics` list, the Agent will still collect most memstat metrics. Use `metrics` to tell the Agent which extra memstat metrics and which expvar vars to collect.
 
 Restart the Agent to begin sending expvar metrics to Datadog.
 


### PR DESCRIPTION
Adds content to the Go Expvar docs and otherwise polishes them into the newer docs format.