### PR TITLE
[docker] add cpuacct.usage as docker.cpu.usage

### DIFF
--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -76,6 +76,13 @@ CGROUP_METRICS = [
         },
     },
     {
+        "cgroup": "cpuacct",
+        "file": "cpuacct.usage",
+        "metrics": {
+            "usage": ("docker.cpu.usage", RATE),
+        }
+    },
+    {
         "cgroup": "cpu",
         "file": "cpu.stat",
         "metrics": {
@@ -986,6 +993,8 @@ class DockerDaemon(AgentCheck):
             with open(stat_file, 'r') as fp:
                 if 'blkio' in stat_file:
                     return self._parse_blkio_metrics(fp.read().splitlines())
+                elif 'cpuacct.usage' in stat_file:
+                    return dict({'usage': str(int(fp.read())/10000000)})
                 else:
                     return dict(map(lambda x: x.split(' ', 1), fp.read().splitlines()))
         except IOError:

--- a/docker_daemon/metadata.csv
+++ b/docker_daemon/metadata.csv
@@ -11,6 +11,7 @@ docker.cpu.user.avg,gauge,,fraction,,Average value of docker.cpu.user,0,docker,c
 docker.cpu.user.count,rate,,sample,second,The rate that the value of docker.cpu.user was sampled,0,docker,cpu user count
 docker.cpu.user.max,gauge,,fraction,,Max value of docker.cpu.user,0,docker,cpu user max
 docker.cpu.user.median,gauge,,fraction,,Median value of docker.cpu.user,0,docker,cpu user median
+docker.cpu.usage,gauge,,fraction,,the fraction of CPU time obtained by this container,0,docker,docker.cpu.usage
 docker.cpu.throttled,gauge,,,,Number of times the cgroup has been throttled,-1,docker,cpu throttled
 docker.mem.cache,gauge,,byte,,The amount of memory that is being used to cache data from disk (e.g. memory contents that can be associated precisely with a block on a block device),0,docker,mem cache
 docker.mem.cache.95percentile,gauge,,byte,,95th percentile value of docker.mem.cache,0,docker,mem cache 95%


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Port the contrib from @ckiickA at https://github.com/DataDog/dd-agent/pull/2969 to the new repo + add metrics metadata for this metric.

### Motivation

This is indeed an interesting metric.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
