### PR TITLE
[http_check] doc refresh

### DIFF
--- a/http_check/README.md
+++ b/http_check/README.md
@@ -1,32 +1,102 @@
-# Http_check Integration
+# HTTP Integration
 
-## Overview
+# Overview
 
-Get metrics from http_check service in real time to:
+Monitor the up/down status of local or remote HTTP endpoints. The HTTP check can detect bad response codes (e.g. 404), identify soon-to-expire SSL certificates, search responses for specific text, and much more. The check also submits HTTP response times as a metric.
 
-* Visualize and monitor http_check states
-* Be notified about http_check failovers and events.
+# Installation
 
-## Installation
+The HTTP check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any host from which you want to probe your HTTP sites. Though many metrics-oriented checks are best run on the same host(s) as the monitored service, you may want to run this status-oriented check from hosts that do not run the monitored sites.
 
-Install the `dd-check-http_check` package manually or with your favorite configuration manager
+If you need the newest version of the HTTP check, install the `dd-check-http` package; this package's check will override the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
-## Configuration
+# Configuration
 
-Edit the `http_check.yaml` file to point to your server and port, set the masters to monitor
+Create a file `http_check.yaml` in the Agent's `conf.d` directory:
 
-## Validation
+```
+init_config:
 
-When you run `datadog-agent info` you should see something like the following:
+instances:
+  - name: Example website
+    url: https://example.com/
+    # disable_ssl_validation: false      # default is true, so set false to check SSL validation
+    # ca_certs: /path/to/ca/file         # e.g. /etc/ssl/certs/ca-certificates.crt
+    # check_certificate_expiration: true # default is true
+    # days_warning: 28                   # default 14
+    # days_critical: 14                  # default 7
+    # timeout: 3                         # in seconds. Default is 1.
+    skip_event: true # Default is false, i.e. emit events instead of service checks. Recommend to set to true.
+  - name: Example website (staging)
+    url: http://staging.example.com/
+    skip_event: true
+```
 
-    Checks
-    ======
+The HTTP check has more configuration options than many checks — many more than are shown above. Most options are opt-in, e.g. the Agent will not check SSL validation unless you configure the requisite options. Notably, the Agent _will_ check for soon-to-expire SSL certificates by default.
 
-        http_check
-        -----------
-          - instance #0 [OK]
-          - Collected 39 metrics, 0 events & 7 service checks
+See the [sample http_check.yaml](https://github.com/DataDog/integrations-core/blob/master/http_check/conf.yaml.example) for a full list and description of available options. There are options to send a POST (with data) instead of GET, set custom request headers, set desired response codes, and more.
 
-## Compatibility
+When you have finished configuring `http_check.yaml`, restart the Agent to begin sending HTTP service checks and response times to Datadog.
 
-The http_check check is compatible with all major platforms
+# Validation
+
+Run the Agent's `info` subcommand and look for `http_check` under the Checks section:
+
+```
+  Checks
+  ======
+    [...]
+
+    http_check
+    ----------
+      - instance #0 [WARNING]
+          Warning: Skipping SSL certificate validation for https://example.com based on configuration
+      - instance #1 [OK]
+      - Collected 2 metrics, 0 events & 4 service checks
+
+    [...]
+```
+
+# Troubleshooting
+
+# Compatibility
+
+The http_check check is compatible with all major platforms.
+
+# Metrics
+
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/http_check/metadata.csv) for a list of metrics provided by this integration.
+
+# Events
+
+Older versions of the HTTP check only emitted events to reflect site status, but now the check supports service checks, too. However, events are still the default behavior. Set `skip_event` to true for all configured instances to submit service checks instead of events. The Agent will soon deprecate `skip_event`, i.e. the HTTP check's default be will only support service checks.
+
+# Service Checks
+
+To create alert conditions on these service checks in Datadog, select 'Network' on the [Create Monitor](https://app.datadoghq.com/monitors#/create) page, not 'Integration'.
+
+**`http.can_connect`**:
+
+Returns `DOWN` when any of the following occur:
+
+* the request to `uri` times out
+* the response code is 4xx/5xx, or it doesn't match the pattern provided in the `http_response_status_code`
+* the response body does *not* contain the pattern in `content_match`
+* `reverse_content_match` is true and the response body *does* contain the pattern in `content_match`
+* `uri` contains `https` and `disable_ssl_validation` is false, and the SSL connection cannot be validated
+
+Otherwise, returns `UP`.
+
+**`http.ssl_cert`**:
+
+The check returns:
+
+* `DOWN` if the `uri`'s' certificate has already expired
+* `CRITICAL` if the `uri`'s' certificate expires in less than `days_critical` days
+* `WARNING` if the `uri`'s' certificate expires in less than `days_warning` days
+
+Otherwise, returns `UP`.
+
+To disable this check, set `check_certificate_expiration` to false.
+
+# Further Reading

--- a/http_check/metadata.csv
+++ b/http_check/metadata.csv
@@ -1,1 +1,2 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+network.http.response_time,gauge,,second,,"The response time of an HTTP request to a given url, tagged by url, e.g. 'url:http://example.com'.",-1,network,http resp time


### PR DESCRIPTION
Doc refresh for http_check. Please review especially the language around 'skip_event'; I want to make sure we send the right message. Will we be deprecating network-checks-as-events in Agent 6.0, anyway?