### PR TITLE
[powerdns_recursor] new docs

### DIFF
--- a/powerdns_recursor/README.md
+++ b/powerdns_recursor/README.md
@@ -1,32 +1,78 @@
-# Powerdns_recursor Integration
+# PowerDNS Recursor Integration
 
-## Overview
+# Overview
 
-Get metrics from powerdns_recursor service in real time to:
 
-* Visualize and monitor powerdns_recursor states
-* Be notified about powerdns_recursor failovers and events.
 
-## Installation
+# Installation
 
-Install the `dd-check-powerdns_recursor` package manually or with your favorite configuration manager
+The PowerDNS Recursor check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your recursors. If you need the newest version of the check, install the `dd-check-powerdns-recursor` package; this package's check will override the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
-## Configuration
+# Configuration
 
-Edit the `powerdns_recursor.yaml` file to point to your server and port, set the masters to monitor
+## Prepare PowerDNS
 
-## Validation
+This check collects performance statistics via pdns_recursor's statistics API. Versions of pdns_recursor before 4.1 do not enable the stats API by default. If you're running an older version, enable it by adding the following to your recursor config file (e.g. /etc/powerdns/recursor.conf):
 
-When you run `datadog-agent info` you should see something like the following:
+```
+webserver=yes
+api-key=changeme            # only available since ver 4.0
+webserver-readonly=yes    # default no
+# webserver-port=8081       # default 8082
+# webserver-address=0.0.0.0 # default 127.0.0.1
+```
 
-    Checks
-    ======
+If you're running pdns_recursor 3.x, prepend `experimental-` to these option names, e.g. `experimental-webserver=yes`.
 
-        powerdns_recursor
-        -----------
-          - instance #0 [OK]
-          - Collected 39 metrics, 0 events & 7 service checks
+If you're running pdns_recursor >= 4.1, simply set an `api-key` in the recursor config.
 
-## Compatibility
+Restart the recursor to enable the statistics API.
 
-The powerdns_recursor check is compatible with all major platforms
+## Connect the Agent
+
+Create a file `powerdns_recursor.yaml` in the Agent's `conf.d` directory:
+
+```
+init_config:
+
+instances:
+  - host: 127.0.0.1
+    port: 8082
+    api_key: changeme
+    version: 4 # omit this option if you're running pdns_recursor 3.x
+```
+
+Restart the Agent to begin sending PowerDNS metrics to Datadog.
+
+# Validation
+
+Run the Agent's `info` subcommand and look for `powerdns_recursor` under the Checks section:
+
+```
+  Checks
+  ======
+    [...]
+
+    powerdns_recursor
+    -------
+      - instance #0 [OK]
+      - Collected 8 metrics, 0 events & 1 service check
+
+    [...]
+```
+
+# Troubleshooting
+
+# Compatibility
+
+The PowerDNS Recursor check is compatible with all major platforms.
+
+# Metrics
+
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/powerdns_recursor/metadata.csv) for a list of metrics provided by this integration.
+
+# Service Checks
+
+**`powerdns.recursor.can_connect`**:
+
+Returns CRITICAL if the Agent is unable to connect to the recursor's statistics API, otherwise OK.

--- a/powerdns_recursor/README.md
+++ b/powerdns_recursor/README.md
@@ -2,7 +2,7 @@
 
 # Overview
 
-Track the performance of your PowerDNS recursors, and monitor strange or worrisome traffic. This Agent check collects a wealth of metrics from your recursors, including those for:
+Track the performance of your PowerDNS recursors and monitor strange or worrisome traffic. This Agent check collects a wealth of metrics from your recursors, including those for:
 
 * Query answer times — see how many responses take less than 1ms, 10ms, 100ms, 1s, and greater than 1s
 * Query timeouts
@@ -32,7 +32,7 @@ webserver-readonly=yes      # default no
 
 If you're running pdns_recursor 3.x, prepend `experimental-` to these option names, e.g. `experimental-webserver=yes`.
 
-If you're running pdns_recursor >= 4.1, only set `api-key` in the recursor config.
+If you're running pdns_recursor >= 4.1, just set `api-key`.
 
 Restart the recursor to enable the statistics API.
 
@@ -50,7 +50,7 @@ instances:
     version: 4 # omit this line if you're running pdns_recursor version 3.x
 ```
 
-Restart the Agent to begin sending PowerDNS metrics to Datadog.
+Restart the Agent to begin sending PowerDNS Recursor metrics to Datadog.
 
 # Validation
 

--- a/powerdns_recursor/README.md
+++ b/powerdns_recursor/README.md
@@ -2,11 +2,19 @@
 
 # Overview
 
+Track the performance of your PowerDNS recursors, and monitor strange or worrisome traffic. This Agent check collects a wealth of metrics from your recursors, including those for:
 
+* Query answer times — see how many responses take less than 1ms, 10ms, 100ms, 1s, and greater than 1s
+* Query timeouts
+* Cache hits and misses
+* Answer rates by type — SRVFAIL, NXDOMAIN, NOERROR
+* Ignored and dropped packets
+
+And many more.
 
 # Installation
 
-The PowerDNS Recursor check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your recursors. If you need the newest version of the check, install the `dd-check-powerdns-recursor` package; this package's check will override the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
+The PowerDNS Recursor check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your recursors.
 
 # Configuration
 
@@ -17,14 +25,14 @@ This check collects performance statistics via pdns_recursor's statistics API. V
 ```
 webserver=yes
 api-key=changeme            # only available since ver 4.0
-webserver-readonly=yes    # default no
+webserver-readonly=yes      # default no
 # webserver-port=8081       # default 8082
 # webserver-address=0.0.0.0 # default 127.0.0.1
 ```
 
 If you're running pdns_recursor 3.x, prepend `experimental-` to these option names, e.g. `experimental-webserver=yes`.
 
-If you're running pdns_recursor >= 4.1, simply set an `api-key` in the recursor config.
+If you're running pdns_recursor >= 4.1, only set `api-key` in the recursor config.
 
 Restart the recursor to enable the statistics API.
 
@@ -39,7 +47,7 @@ instances:
   - host: 127.0.0.1
     port: 8082
     api_key: changeme
-    version: 4 # omit this option if you're running pdns_recursor 3.x
+    version: 4 # omit this line if you're running pdns_recursor version 3.x
 ```
 
 Restart the Agent to begin sending PowerDNS metrics to Datadog.

--- a/powerdns_recursor/metadata.csv
+++ b/powerdns_recursor/metadata.csv
@@ -79,7 +79,7 @@ powerdns.recursor.policy_result_drop,gauge,,packet,second,The number of packets 
 powerdns.recursor.policy_result_nxdomain,gauge,,packet,second,The number of packets per second that were replied to with NXDOMAIN by the RPZ/filter engine; Available since pdns_recursor v4.x,0,powerdns_recursor,policy result nxdomain
 powerdns.recursor.policy_result_nodata,gauge,,packet,second,The number of packets per second that were replied to with NODATA by the RPZ/filter engine; Available since pdns_recursor v4.x,0,powerdns_recursor,policy result nodata
 powerdns.recursor.policy_result_truncate,gauge,,packet,second,The number of packets per second that were forced to TCP by the RPZ/filter engine; Available since pdns_recursor v4.x,0,powerdns_recursor,policy result truncate
-powerdns.recursor.real_memory_usage,gauge,,byte,,The amount of memory consumed by PowerDNS, in bytes; Available since pdns_recursor v4.x,0,powerdns_recursor,real memory usage
+powerdns.recursor.real_memory_usage,gauge,,byte,,The amount of memory consumed by PowerDNS in bytes; Available since pdns_recursor v4.x,0,powerdns_recursor,real memory usage
 powerdns.recursor.resource_limits,gauge,,query,second,The number of queries per second that could not be performed due to resource limits; Available since pdns_recursor v4.x,0,powerdns_recursor,resource limits
 powerdns.recursor.too_old_drops,gauge,,query,second,The number of questions per second that were dropped because they were too old; Available since pdns_recursor v4.x,0,powerdns_recursor,too old drops
 powerdns.recursor.udp_in_errors,gauge,,packet,second,The number of packets per second that were received faster than the OS could process them; Available since pdns_recursor v4.x,0,powerdns_recursor,udp in errors

--- a/powerdns_recursor/metadata.csv
+++ b/powerdns_recursor/metadata.csv
@@ -13,14 +13,36 @@ powerdns.recursor.answers10_100,gauge,,unit,second,Number of queries answered wi
 powerdns.recursor.answers100_1000,gauge,,unit,second,Number of queries answered within 1 second,0,powerdns_recursor,answers in 1000ms
 powerdns.recursor.cache_hits,gauge,,operation,second,The number of cache hits per second,0,powerdns_recursor,cache hits
 powerdns.recursor.cache_misses,gauge,,operation,second,The number of cache misses per second,0,powerdns_recursor,cache misses
-
 powerdns.recursor.chain_resends,gauge,,operation,second,The number of queries chained to existing outstanding query per second,0,powerdns_recursor,chain resends
 powerdns.recursor.case_mismatches,gauge,,operation,second,The number of mismatches in character case per second,0,powerdns_recursor,case mismatches
 powerdns.recursor.client_parse_errors,gauge,,operation,second,The number of unparseable packets per second,0,powerdns_recursor,unparseable pkts
 powerdns.recursor.dont_outqueries,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,dont outqueries
+powerdns.recursor.ipv6_outqueries,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,ipv6 outqueries
+powerdns.recursor.ipv6_questions,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,ipv6 questions
+powerdns.recursor.nxdomain_answers,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,nxdomain answers
+powerdns.recursor.max_mthread_stack,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,max mthread stack
+powerdns.recursor.outgoing_timesouts,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,outgoing timeouts
+powerdns.recursor.over_capacity_drops,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,over capacity drops
+powerdns.recursor.packetcache_hits,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,packetcache hits
+powerdns.recursor.packetcache_misses,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,packetcache misses
+powerdns.recursor.policy_drops,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,policy drops
+powerdns.recursor.qa_latency,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,qa latency
+powerdns.recursor.server_parse_errors,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,server parse errors
+powerdns.recursor.servfail_answers,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,servfail answers
+powerdns.recursor.spoof_prevents,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,prevented spoofs
+powerdns.recursor.sys_msec,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,sys msec
+powerdns.recursor.tcp_client_overflow,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,tcp client overflow
+powerdns.recursor.tcp_clients,gauge,,operation,second,The number of active TCP/IP clients per second,0,powerdns_recursor,tcp clients
+powerdns.recursor.tcp_outqueries,gauge,,operation,second,The number of outgoing TCP queries per second,0,powerdns_recursor,tcp outqueries
+powerdns.recursor.throttled_out,gauge,,operation,second,The number of throttled outgoing UDP queries per second,0,powerdns_recursor,throttled out
+powerdns.recursor.unauthorized_tcp,gauge,,operation,second,The number of TCP questions denied per second because of allow-from restrictions,0,powerdns_recursor,unauth tcp
+powerdns.recursor.unauthorized_udp,gauge,,operation,second,The number of UDP questions denied per second because of allow-from restrictions,0,powerdns_recursor,unauth udp
+powerdns.recursor.unexpected_packets,gauge,,operation,second,The number of unexpected answers per second from remote servers,0,powerdns_recursor,unexpected pkts
+powerdns.recursor.unreachables,gauge,,operation,second,The number times nameservers were unreachable per second,0,powerdns_recursor,unreachables
 
 
-powerdns.recursor.noerror_answers,gauge,,operation,second,The number of times it answered NOERROR per second,0,powerdns_recursor,noerrors
+
+powerdns.recursor.noerror_answers,gauge,,operation,second,The number of NOERROR answers per second,0,powerdns_recursor,noerrors
 powerdns.recursor.outgoing_timeouts,gauge,,operation,second,The number of timeouts per second,0,powerdns_recursor,timeouts
 powerdns.recursor.questions,gauge,,operation,second,The number of user initiated udp queries per second,0,powerdns_recursor,questions
 powerdns.recursor.servfail_answers,gauge,,operation,second,The number of SERVFAIL answers per second,0,powerdns_recursor,fervfails

--- a/powerdns_recursor/metadata.csv
+++ b/powerdns_recursor/metadata.csv
@@ -1,6 +1,10 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 powerdns.recursor.cache_entries,gauge,,unit,,The number of entries in the cache,0,powerdns_recursor,cache entries
+powerdns.recursor.negcache_entries,gauge,,unit,,The number of entries in the negative answer cache,0,powerdns_recursor,negcache entries
+powerdns.recursor.packetcache_entries,gauge,,unit,,The number of entries in the packet cache,0,powerdns_recursor,pkt cache entries
+powerdns.recursor.failed_host_entries,gauge,,unit,,The number of servers that failed to resolve,0,powerdns_recursor,failed host entries
 powerdns.recursor.concurrent_queries,gauge,,unit,,The number of MThreads currently running,0,powerdns_recursor,concurrent queries
+powerdns.recursor.throttle_entries,gauge,,unit,,The number of entries in the throttle map,0,powerdns_recursor,throttle entries
 powerdns.recursor.all_outqueries,gauge,,operation,second,The number of outgoing udp queries per second,0,powerdns_recursor,all outqueries
 powerdns.recursor.answers_slow,gauge,,unit,second,Number of queries answered after 1 second,-1,powerdns_recursor, slow answers
 powerdns.recursor.answers0_1,gauge,,unit,second,Number of queries answered after 1 second,1,powerdns_recursor, answers in 1ms
@@ -9,9 +13,16 @@ powerdns.recursor.answers10_100,gauge,,unit,second,Number of queries answered wi
 powerdns.recursor.answers100_1000,gauge,,unit,second,Number of queries answered within 1 second,0,powerdns_recursor,answers in 1000ms
 powerdns.recursor.cache_hits,gauge,,operation,second,The number of cache hits per second,0,powerdns_recursor,cache hits
 powerdns.recursor.cache_misses,gauge,,operation,second,The number of cache misses per second,0,powerdns_recursor,cache misses
+
+powerdns.recursor.chain_resends,gauge,,operation,second,The number of queries chained to existing outstanding query per second,0,powerdns_recursor,chain resends
+powerdns.recursor.case_mismatches,gauge,,operation,second,The number of mismatches in character case per second,0,powerdns_recursor,case mismatches
+powerdns.recursor.client_parse_errors,gauge,,operation,second,The number of unparseable packets per second,0,powerdns_recursor,unparseable pkts
+powerdns.recursor.dont_outqueries,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,dont outqueries
+
+
 powerdns.recursor.noerror_answers,gauge,,operation,second,The number of times it answered NOERROR per second,0,powerdns_recursor,noerrors
 powerdns.recursor.outgoing_timeouts,gauge,,operation,second,The number of timeouts per second,0,powerdns_recursor,timeouts
 powerdns.recursor.questions,gauge,,operation,second,The number of user initiated udp queries per second,0,powerdns_recursor,questions
-powerdns.recursor.servfail_answers,gauge,,operation,second,The number of times it answered SERVFAIL per second,0,powerdns_recursor,fervfails
+powerdns.recursor.servfail_answers,gauge,,operation,second,The number of SERVFAIL answers per second,0,powerdns_recursor,fervfails
 powerdns.recursor.tcp_outqueries,gauge,,operation,second,The number of outgoing tcp queries per second,0,powerdns_recursor,tcp outqueries
 powerdns.recursor.tcp_questions,gauge,,operation,second,The number of incoming tcp queries per second,0,powerdns_recursor,tcp questions

--- a/powerdns_recursor/metadata.csv
+++ b/powerdns_recursor/metadata.csv
@@ -1,50 +1,89 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-powerdns.recursor.cache_entries,gauge,,unit,,The number of entries in the cache,0,powerdns_recursor,cache entries
-powerdns.recursor.negcache_entries,gauge,,unit,,The number of entries in the negative answer cache,0,powerdns_recursor,negcache entries
-powerdns.recursor.packetcache_entries,gauge,,unit,,The number of entries in the packet cache,0,powerdns_recursor,pkt cache entries
-powerdns.recursor.failed_host_entries,gauge,,unit,,The number of servers that failed to resolve,0,powerdns_recursor,failed host entries
-powerdns.recursor.concurrent_queries,gauge,,unit,,The number of MThreads currently running,0,powerdns_recursor,concurrent queries
-powerdns.recursor.throttle_entries,gauge,,unit,,The number of entries in the throttle map,0,powerdns_recursor,throttle entries
-powerdns.recursor.all_outqueries,gauge,,operation,second,The number of outgoing udp queries per second,0,powerdns_recursor,all outqueries
-powerdns.recursor.answers_slow,gauge,,unit,second,Number of queries answered after 1 second,-1,powerdns_recursor, slow answers
-powerdns.recursor.answers0_1,gauge,,unit,second,Number of queries answered after 1 second,1,powerdns_recursor, answers in 1ms
-powerdns.recursor.answers1_10,gauge,,unit,second,Number of queries answered within 10 milliseconds,0,powerdns_recursor, answers in 10ms
-powerdns.recursor.answers10_100,gauge,,unit,second,Number of queries answered within 100 milliseconds,0,powerdns_recursor,answers in 100ms
-powerdns.recursor.answers100_1000,gauge,,unit,second,Number of queries answered within 1 second,0,powerdns_recursor,answers in 1000ms
-powerdns.recursor.cache_hits,gauge,,operation,second,The number of cache hits per second,0,powerdns_recursor,cache hits
-powerdns.recursor.cache_misses,gauge,,operation,second,The number of cache misses per second,0,powerdns_recursor,cache misses
-powerdns.recursor.chain_resends,gauge,,operation,second,The number of queries chained to existing outstanding query per second,0,powerdns_recursor,chain resends
-powerdns.recursor.case_mismatches,gauge,,operation,second,The number of mismatches in character case per second,0,powerdns_recursor,case mismatches
-powerdns.recursor.client_parse_errors,gauge,,operation,second,The number of unparseable packets per second,0,powerdns_recursor,unparseable pkts
-powerdns.recursor.dont_outqueries,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,dont outqueries
-powerdns.recursor.ipv6_outqueries,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,ipv6 outqueries
-powerdns.recursor.ipv6_questions,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,ipv6 questions
-powerdns.recursor.nxdomain_answers,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,nxdomain answers
-powerdns.recursor.max_mthread_stack,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,max mthread stack
-powerdns.recursor.outgoing_timesouts,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,outgoing timeouts
-powerdns.recursor.over_capacity_drops,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,over capacity drops
-powerdns.recursor.packetcache_hits,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,packetcache hits
-powerdns.recursor.packetcache_misses,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,packetcache misses
-powerdns.recursor.policy_drops,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,policy drops
-powerdns.recursor.qa_latency,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,qa latency
-powerdns.recursor.server_parse_errors,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,server parse errors
-powerdns.recursor.servfail_answers,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,servfail answers
-powerdns.recursor.spoof_prevents,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,prevented spoofs
-powerdns.recursor.sys_msec,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,sys msec
-powerdns.recursor.tcp_client_overflow,gauge,,operation,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,tcp client overflow
-powerdns.recursor.tcp_clients,gauge,,operation,second,The number of active TCP/IP clients per second,0,powerdns_recursor,tcp clients
+powerdns.recursor.cache_entries,gauge,,entry,,The number of entries in the cache,0,powerdns_recursor,cache entries
+powerdns.recursor.negcache_entries,gauge,,entry,,The number of entries in the negative answer cache,0,powerdns_recursor,negcache entries
+powerdns.recursor.packetcache_entries,gauge,,entry,,The number of entries in the packet cache,0,powerdns_recursor,pkt cache entries
+powerdns.recursor.failed_host_entries,gauge,,server,,The number of servers that failed to resolve,0,powerdns_recursor,failed host entries
+powerdns.recursor.concurrent_queries,gauge,,query,,The number of MThreads currently running,0,powerdns_recursor,concurrent queries
+powerdns.recursor.throttle_entries,gauge,,entry,,The number of entries in the throttle map,0,powerdns_recursor,throttle entries
+powerdns.recursor.all_outqueries,gauge,,query,second,The number of outgoing udp queries per second,0,powerdns_recursor,all outqueries
+powerdns.recursor.answers_slow,gauge,,query,second,Number of queries per second NOT answered within 1 second,-1,powerdns_recursor,answers/sec > 1s
+powerdns.recursor.answers0_1,gauge,,query,second,Number of queries per second answered within 1 millisecond,1,powerdns_recursor,answers/sec < 1ms
+powerdns.recursor.answers1_10,gauge,,query,second,Number of queries per second answered within 10 milliseconds,0,powerdns_recursor,answers/sec < 10ms
+powerdns.recursor.answers10_100,gauge,,query,second,Number of queries per second answered within 100 milliseconds,0,powerdns_recursor,answers/sec < 100ms
+powerdns.recursor.answers100_1000,gauge,,query,second,Number of queries per second answered within 1 second,0,powerdns_recursor,answers/sec < 1s
+powerdns.recursor.cache_hits,gauge,,hit,second,The number of cache hits per second,0,powerdns_recursor,cache hits
+powerdns.recursor.cache_misses,gauge,,miss,second,The number of cache misses per second,0,powerdns_recursor,cache misses
+powerdns.recursor.chain_resends,gauge,,query,second,The number of queries per second chained to existing outstanding query,0,powerdns_recursor,chain resends
+powerdns.recursor.case_mismatches,gauge,,error,second,The number of mismatches in character case per second,0,powerdns_recursor,case mismatches
+powerdns.recursor.client_parse_errors,gauge,,error,second,The number of unparseable packets per second,0,powerdns_recursor,unparseable pkts
+powerdns.recursor.dont_outqueries,gauge,,query,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,dont outqueries
+powerdns.recursor.ipv6_outqueries,gauge,,,second,The number of outgoing queries per second over IPv6,0,powerdns_recursor,ipv6 outqueries
+powerdns.recursor.ipv6_questions,gauge,,query,second,The number of end-user-initiated IPv6 UDP queries with the RD bit set,0,powerdns_recursor,ipv6 questions
+powerdns.recursor.nxdomain_answers,gauge,,response,second,The number of NXDOMAIN answers per second,0,powerdns_recursor,nxdomain answers
+powerdns.recursor.max_mthread_stack,gauge,,,,The maximum amount of thread stack ever used,0,powerdns_recursor,max mthread stack
+powerdns.recursor.outgoing_timeouts,gauge,,timeout,second,The number of outgoing UDP query timeouts per second,0,powerdns_recursor,outgoing timeouts
+powerdns.recursor.over_capacity_drops,gauge,,query,second,The number of questions per second dropped due to having reached concurrent query limit,-1,powerdns_recursor,over capacity drops
+powerdns.recursor.packetcache_hits,gauge,,hit,second,The number of packet cache hits per second,0,powerdns_recursor,packetcache hits
+powerdns.recursor.packetcache_misses,gauge,,miss,second,The number of packet cache misses per second,0,powerdns_recursor,packetcache misses
+powerdns.recursor.policy_drops,gauge,,packet,second,The number of packets dropped per second because of Lua policy decision,0,powerdns_recursor,policy drops
+powerdns.recursor.qa_latency,gauge,,microsecond,,The average latency in microseconds exponentially weighted over past 'latency-statistic-size' packets,0,powerdns_recursor,qa latency
+powerdns.recursor.server_parse_errors,gauge,,error,second,The number of server replied packets per second that could not be parsed,0,powerdns_recursor,server parse errors
+powerdns.recursor.servfail_answers,gauge,,response,second,The number of SERVFAIL answers per second,0,powerdns_recursor,servfail answers
+powerdns.recursor.spoof_prevents,gauge,,,,The number of times per second PowerDNS considers itself spoofed and drops data,0,powerdns_recursor,prevented spoofs
+powerdns.recursor.sys_msec,gauge,,millisecond,,The number of CPU milliseconds spent in 'system' mode,0,powerdns_recursor,sys msec
+powerdns.recursor.tcp_client_overflow,gauge,,query,second,The number of outgoing queries dropped per second because of 'dont query' setting,0,powerdns_recursor,tcp client overflow
+powerdns.recursor.tcp_clients,gauge,,,,The number of active TCP/IP clients per second,0,powerdns_recursor,tcp clients
 powerdns.recursor.tcp_outqueries,gauge,,operation,second,The number of outgoing TCP queries per second,0,powerdns_recursor,tcp outqueries
 powerdns.recursor.throttled_out,gauge,,operation,second,The number of throttled outgoing UDP queries per second,0,powerdns_recursor,throttled out
 powerdns.recursor.unauthorized_tcp,gauge,,operation,second,The number of TCP questions denied per second because of allow-from restrictions,0,powerdns_recursor,unauth tcp
 powerdns.recursor.unauthorized_udp,gauge,,operation,second,The number of UDP questions denied per second because of allow-from restrictions,0,powerdns_recursor,unauth udp
 powerdns.recursor.unexpected_packets,gauge,,operation,second,The number of unexpected answers per second from remote servers,0,powerdns_recursor,unexpected pkts
-powerdns.recursor.unreachables,gauge,,operation,second,The number times nameservers were unreachable per second,0,powerdns_recursor,unreachables
-
-
-
+powerdns.recursor.unreachables,gauge,,,,The number times per second nameservers were unreachable,0,powerdns_recursor,unreachables
+powerdns.recursor.uptime,gauge,,second,,The number of seconds PowerDNS has been running,0,powerdns_recursor,uptime
+powerdns.recursor.user_msec,gauge,,millisecond,,The number of CPU milliseconds spent in 'user' mode,0,powerdns_recursor,user msec
 powerdns.recursor.noerror_answers,gauge,,operation,second,The number of NOERROR answers per second,0,powerdns_recursor,noerrors
-powerdns.recursor.outgoing_timeouts,gauge,,operation,second,The number of timeouts per second,0,powerdns_recursor,timeouts
 powerdns.recursor.questions,gauge,,operation,second,The number of user initiated udp queries per second,0,powerdns_recursor,questions
-powerdns.recursor.servfail_answers,gauge,,operation,second,The number of SERVFAIL answers per second,0,powerdns_recursor,fervfails
-powerdns.recursor.tcp_outqueries,gauge,,operation,second,The number of outgoing tcp queries per second,0,powerdns_recursor,tcp outqueries
 powerdns.recursor.tcp_questions,gauge,,operation,second,The number of incoming tcp queries per second,0,powerdns_recursor,tcp questions
+powerdns.recursor.auth4_answers_slow,gauge,,query,second,Number of queries per second NOT answered by auth4s within 1 second; Available since pdns_recursor v4.x,-1,powerdns_recursor,auth4s answers/sec > 1s
+powerdns.recursor.auth4_answers0_1,gauge,,query,second,Number of queries per second answered by auth4s within 1 millisecond; Available since pdns_recursor v4.x,1,powerdns_recursor,auth4s answers/sec < 1ms
+powerdns.recursor.auth4_answers1_10,gauge,,query,second,Number of queries per second answered by auth4s within 10 milliseconds; Available since pdns_recursor v4.x,0,powerdns_recursor,auth4s answers/sec < 10ms
+powerdns.recursor.auth4_answers10_100,gauge,,query,second,Number of queries per second answered by auth4s within 100 milliseconds; Available since pdns_recursor v4.x,0,powerdns_recursor,auth4s answers/sec < 100ms
+powerdns.recursor.auth4_answers100_1000,gauge,,query,second,Number of queries per second answered by auth4s within 1 second; Available since pdns_recursor v4.x,0,powerdns_recursor,auth4s answers/sec < 1s
+powerdns.recursor.auth6_answers_slow,gauge,,query,second,Number of queries per second NOT answered by auth6s within 1 second; Available since pdns_recursor v4.x,-1,powerdns_recursor,auth6s answers/sec > 1s
+powerdns.recursor.auth6_answers0_1,gauge,,query,second,Number of queries per second answered by auth6s within 1 millisecond; Available since pdns_recursor v4.x,1,powerdns_recursor,auth6s answers/sec < 1ms
+powerdns.recursor.auth6_answers1_10,gauge,,query,second,Number of queries per second answered by auth6s within 10 milliseconds; Available since pdns_recursor v4.x,0,powerdns_recursor,auth6s answers/sec < 10ms
+powerdns.recursor.auth6_answers10_100,gauge,,query,second,Number of queries per second answered by auth6s within 100 milliseconds; Available since pdns_recursor v4.x,0,powerdns_recursor,auth6s answers/sec < 100ms
+powerdns.recursor.auth6_answers100_1000,gauge,,query,second,Number of queries per second answered by auth6s within 1 second; Available since pdns_recursor v4.x,0,powerdns_recursor,auth6s answers/sec < 1s
+powerdns.recursor.dlg_only_drops,gauge,,record,second,The number of records dropped per second because of 'delegation only' setting; Available since pdns_recursor v4.x,0,powerdns_recursor,dlg only drops
+powerdns.recursor.dlg_only_drops,gauge,,record,second,The number of records dropped per second because of 'delegation only' setting; Available since pdns_recursor v4.x,0,powerdns_recursor,dlg only drops
+powerdns.recursor.dnssec_queries,gauge,,record,second,The number of queries received per second with the DO bit set; Available since pdns_recursor v4.x,0,powerdns_recursor,dnssec queries
+powerdns.recursor.dnssec_result_bogus,gauge,,,,The number of DNSSEC validations per second that had the Bogus state; Available since pdns_recursor v4.x,0,powerdns_recursor,dnssec bogus
+powerdns.recursor.dnssec_result_indeterminate,gauge,,,,The number of DNSSEC validations per second that had the Indeterminate state; Available since pdns_recursor v4.x,0,powerdns_recursor,dnssec indeterminate
+powerdns.recursor.dnssec_result_insecure,gauge,,,,The number of DNSSEC validations per second that had the Insecure state; Available since pdns_recursor v4.x,0,powerdns_recursor,dnssec insecure
+powerdns.recursor.dnssec_result_nta,gauge,,,,The number of DNSSEC validations per second that had the NTA (negative trust anchor) state; Available since pdns_recursor v4.x,0,powerdns_recursor,dnssec nta
+powerdns.recursor.dnssec_result_secure,gauge,,,,The number of DNSSEC validations per second that had the Secure state; Available since pdns_recursor v4.x,0,powerdns_recursor,dnssec secure
+powerdns.recursor.dnssec_validations,gauge,,,,The number of DNSSEC validations performed per second; Available since pdns_recursor v4.x,0,powerdns_recursor,dnssec validations
+powerdns.recursor.edns_ping_matches,gauge,,server,second,The number of servers per second that sent a valid EDNS PING response; Available since pdns_recursor v4.x,0,powerdns_recursor,edns match
+powerdns.recursor.edns_ping_mismatches,gauge,,server,second,The number of servers per second that sent an invalid EDNS PING response; Available since pdns_recursor v4.x,0,powerdns_recursor,edns mismatch
+powerdns.recursor.ignored_packets,gauge,,packet,second,The number of non-query packets received per second on server sockets that should only get queries; Available since pdns_recursor v4.x,0,powerdns_recursor,ignored pkts
+powerdns.recursor.no_error_packets,gauge,,packet,second,The number of erroneous packets received per second; Available since pdns_recursor v4.x,0,powerdns_recursor,error packets
+powerdns.recursor.noedns_outqueries,gauge,,query,second,The number of queries per second sent without EDNS; Available since pdns_recursor v4.x,0,powerdns_recursor,non edns queries
+powerdns.recursor.noping_outqueries,gauge,,query,second,The number of queries per second sent without EDNS PING; Available since pdns_recursor v4.x,0,powerdns_recursor,non edns queries
+powerdns.recursor.nsset_invalidations,gauge,,,,The number of times per second an nsset was dropped because it no longer worked; Available since pdns_recursor v4.x,0,powerdns_recursor,nsset invalidations
+powerdns.recursor.nsspeeds_entries,gauge,,entry,,The number of entries in the NS speeds map; Available since pdns_recursor v4.x,0,powerdns_recursor,nsspeeds entries
+powerdns.recursor.outgoing4_timeouts,gauge,,timeout,second,The number of timeouts per second for outgoing UDP IPv4 queries; Available since pdns_recursor v4.x,0,powerdns_recursor,outgoing4 timeouts
+powerdns.recursor.outgoing6_timeouts,gauge,,timeout,second,The number of timeouts per second for outgoing UDP IPv6 queries; Available since pdns_recursor v4.x,0,powerdns_recursor,outgoing6 timeouts
+powerdns.recursor.policy_result_custom,gauge,,packet,second,The number of packets per second that were sent a custom answer by the RPZ/filter engine; Available since pdns_recursor v4.x,0,powerdns_recursor,policy result custom
+powerdns.recursor.policy_result_noaction,gauge,,packet,second,The number of packets per second that were not actioned upon by the RPZ/filter engine; Available since pdns_recursor v4.x,0,powerdns_recursor,policy result noaction
+powerdns.recursor.policy_result_drop,gauge,,packet,second,The number of packets per second dropped by the RPZ/filter engine; Available since pdns_recursor v4.x,0,powerdns_recursor,policy result drop
+powerdns.recursor.policy_result_nxdomain,gauge,,packet,second,The number of packets per second that were replied to with NXDOMAIN by the RPZ/filter engine; Available since pdns_recursor v4.x,0,powerdns_recursor,policy result nxdomain
+powerdns.recursor.policy_result_nodata,gauge,,packet,second,The number of packets per second that were replied to with NODATA by the RPZ/filter engine; Available since pdns_recursor v4.x,0,powerdns_recursor,policy result nodata
+powerdns.recursor.policy_result_truncate,gauge,,packet,second,The number of packets per second that were forced to TCP by the RPZ/filter engine; Available since pdns_recursor v4.x,0,powerdns_recursor,policy result truncate
+powerdns.recursor.real_memory_usage,gauge,,byte,,The amount of memory consumed by PowerDNS, in bytes; Available since pdns_recursor v4.x,0,powerdns_recursor,real memory usage
+powerdns.recursor.resource_limits,gauge,,query,second,The number of queries per second that could not be performed due to resource limits; Available since pdns_recursor v4.x,0,powerdns_recursor,resource limits
+powerdns.recursor.too_old_drops,gauge,,query,second,The number of questions per second that were dropped because they were too old; Available since pdns_recursor v4.x,0,powerdns_recursor,too old drops
+powerdns.recursor.udp_in_errors,gauge,,packet,second,The number of packets per second that were received faster than the OS could process them; Available since pdns_recursor v4.x,0,powerdns_recursor,udp in errors
+powerdns.recursor.udp_noport_errors,gauge,,packet,second,The number of UDP packets per second where an ICMP response was received saying the remote port was not listening; Available since pdns_recursor v4.x,0,powerdns_recursor,udp noport errors
+powerdns.recursor.udp_in_errors,gauge,,packet,second,The number of packets per second that were received faster than the OS could process them; Available since pdns_recursor v4.x,0,powerdns_recursor,udp in errors
+powerdns.recursor.udp_recvbuf_errors,gauge,,error,second,The number of errors per second caused in the UDP receive buffer; Available since pdns_recursor v4.x,0,powerdns_recursor,udp recvbuf errors
+powerdns.recursor.udp_sndbuf_errors,gauge,,error,second,The number of errors per second caused in the UDP send buffer; Available since pdns_recursor v4.x,0,powerdns_recursor,udp sndbuf errors


### PR DESCRIPTION
Still needs a *lot* of new metadata, and we need to clarify which metrics are available in pdns_recursor v4 only.