### PR TITLE
[manifest][skip ci] bump version manifests for 5.13.2 release.

### DIFF
--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -11,5 +11,5 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1.0",
   "name": "haproxy",
   "display_name": "haproxy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "support": "core",
   "maintainer": "help@datadoghq.com",
   "supported_os": [

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1.0",
   "name": "MySQL",
   "display_name": "MySQL",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "support": "core",
   "supported_os": [
     "linux",

--- a/process/manifest.json
+++ b/process/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "guid": "1675eced-b435-464a-8f84-f65e438f838e"
 }


### PR DESCRIPTION
### What does this PR do?

Bumps relevant manifests ahead of release 5.13.2.

### Motivation

Changes in PR's #394 #393 #379 and #349 are targeted to make the release, these changes should be reflected in their manifest's versioning.