### PR TITLE
[rabbitmq] disable proxy if so-desired

### DIFF
--- a/http_check/check.py
+++ b/http_check/check.py
@@ -155,7 +155,7 @@ class HTTPCheck(NetworkCheck):
         NetworkCheck.__init__(self, name, init_config, agentConfig, instances)
 
         self.ca_certs = init_config.get('ca_certs', get_ca_certs_path())
-`       self.proxies['no'] = get_no_proxy_from_env()
+        self.proxies['no'] = get_no_proxy_from_env()
 
 
     def _load_conf(self, instance):

--- a/http_check/check.py
+++ b/http_check/check.py
@@ -6,7 +6,6 @@
 from datetime import datetime
 import _strptime # noqa
 import os.path
-from os import environ
 import re
 import socket
 import ssl

--- a/http_check/check.py
+++ b/http_check/check.py
@@ -32,7 +32,6 @@ from requests.packages.urllib3.packages.ssl_match_hostname import \
 from checks.network_checks import EventType, NetworkCheck, Status
 from config import _is_affirmative
 from util import headers as agent_headers
-from utils.proxy import get_no_proxy_from_env, config_proxy_skip
 
 DEFAULT_EXPECTED_CODE = "(1|2|3)\d\d"
 CONTENT_LENGTH = 200
@@ -155,7 +154,6 @@ class HTTPCheck(NetworkCheck):
         NetworkCheck.__init__(self, name, init_config, agentConfig, instances)
 
         self.ca_certs = init_config.get('ca_certs', get_ca_certs_path())
-        self.proxies['no'] = get_no_proxy_from_env()
 
 
     def _load_conf(self, instance):
@@ -223,8 +221,7 @@ class HTTPCheck(NetworkCheck):
                 self.warning("Skipping SSL certificate validation for %s based on configuration"
                              % addr)
 
-            instance_proxy = config_proxy_skip(self.proxies.copy(), addr, skip_proxy=skip_proxy)
-
+            instance_proxy = self.get_instance_proxy(instance, addr)
             self.log.debug("Proxies used for %s - %s", addr, instance_proxy)
 
             auth = None

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -2,7 +2,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.0",
   "max_agent_version": "6.0.0",
-  "min_agent_version": "5.6.3",
+  "min_agent_version": "5.14.0",
   "name": "http_check",
   "short_description": "http_check description.",
   "support": "core",
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "guid": "eb133a1f-697c-4143-bad3-10e72541fa9c"
 }

--- a/rabbitmq/check.py
+++ b/rabbitmq/check.py
@@ -8,6 +8,7 @@ import re
 import time
 import urllib
 import urlparse
+from os import environ
 
 # 3p
 import requests
@@ -16,6 +17,7 @@ from requests.exceptions import RequestException
 # project
 from checks import AgentCheck
 from config import _is_affirmative
+from utils.proxy import get_no_proxy_from_env
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'rabbitmq'
 QUEUE_TYPE = 'queues'
@@ -103,6 +105,7 @@ class RabbitMQ(AgentCheck):
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
         self.already_alerted = []
+`       self.proxies['no'] = get_no_proxy_from_env()
 
     def _get_config(self, instance):
         # make sure 'rabbitmq_api_url' is present and get parameters
@@ -115,6 +118,7 @@ class RabbitMQ(AgentCheck):
         password = instance.get('rabbitmq_pass', 'guest')
         parsed_url = urlparse.urlparse(base_url)
         ssl_verify = _is_affirmative(instance.get('ssl_verify', True))
+        skip_proxy = _is_affirmative(instance.get('no_proxy', False))
         if not ssl_verify and parsed_url.scheme == 'https':
             self.log.warning('Skipping SSL cert validation for %s based on configuration.' % (base_url))
 
@@ -144,19 +148,21 @@ class RabbitMQ(AgentCheck):
 
         auth = (username, password)
 
-        return base_url, max_detailed, specified, auth, ssl_verify
+        return base_url, max_detailed, specified, auth, ssl_verify, skip_proxy
 
     def check(self, instance):
-        base_url, max_detailed, specified, auth, ssl_verify = self._get_config(instance)
+        base_url, max_detailed, specified, auth, ssl_verify, skip_proxy = self._get_config(instance)
         try:
             # Generate metrics from the status API.
-            self.get_stats(instance, base_url, QUEUE_TYPE, max_detailed[QUEUE_TYPE], specified[QUEUE_TYPE], auth=auth, ssl_verify=ssl_verify)
-            self.get_stats(instance, base_url, NODE_TYPE, max_detailed[NODE_TYPE], specified[NODE_TYPE], auth=auth, ssl_verify=ssl_verify)
+            self.get_stats(instance, base_url, QUEUE_TYPE, max_detailed[QUEUE_TYPE], specified[QUEUE_TYPE],
+                           auth=auth, ssl_verify=ssl_verify, skip_proxy=skip_proxy)
+            self.get_stats(instance, base_url, NODE_TYPE, max_detailed[NODE_TYPE], specified[NODE_TYPE],
+                           auth=auth, ssl_verify=ssl_verify, skip_proxy=skip_proxy)
 
             # Generate a service check from the aliveness API. In the case of an invalid response
             # code or unparseable JSON this check will send no data.
             vhosts = instance.get('vhosts')
-            self._check_aliveness(base_url, vhosts, auth=auth, ssl_verify=ssl_verify)
+            self._check_aliveness(base_url, vhosts, auth=auth, ssl_verify=ssl_verify, skip_proxy=skip_proxy)
 
             # Generate a service check for the service status.
             self.service_check('rabbitmq.status', AgentCheck.OK)
@@ -166,9 +172,9 @@ class RabbitMQ(AgentCheck):
             self.service_check('rabbitmq.status', AgentCheck.CRITICAL, message=msg)
             self.log.error(msg)
 
-    def _get_data(self, url, auth=None, ssl_verify=True):
+    def _get_data(self, url, auth=None, ssl_verify=True, proxies={}):
         try:
-            r = requests.get(url, auth=auth, timeout=self.default_integration_http_timeout, verify=ssl_verify)
+            r = requests.get(url, auth=auth, proxies=proxies, timeout=self.default_integration_http_timeout, verify=ssl_verify)
             r.raise_for_status()
             return r.json()
         except RequestException as e:
@@ -176,7 +182,7 @@ class RabbitMQ(AgentCheck):
         except ValueError as e:
             raise RabbitMQException('Cannot parse JSON response from API url: {} {}'.format(url, str(e)))
 
-    def get_stats(self, instance, base_url, object_type, max_detailed, filters, auth=None, ssl_verify=True):
+    def get_stats(self, instance, base_url, object_type, max_detailed, filters, auth=None, ssl_verify=True, skip_proxy=False):
         """
         instance: the check instance
         base_url: the url of the rabbitmq management api (e.g. http://localhost:15672/api)
@@ -184,7 +190,9 @@ class RabbitMQ(AgentCheck):
         max_detailed: the limit of objects to collect for this type
         filters: explicit or regexes filters of specified queues or nodes (specified in the yaml file)
         """
-        data = self._get_data(urlparse.urljoin(base_url, object_type), auth=auth, ssl_verify=ssl_verify)
+        instance_proxy = config_proxy_skip(self.proxies.copy(), base_url, skip_proxy=skip_proxy)
+        data = self._get_data(urlparse.urljoin(base_url, object_type), auth=auth,
+                              ssl_verify=ssl_verify, proxies=instance_proxy)
 
         # Make a copy of this list as we will remove items from it at each
         # iteration
@@ -315,24 +323,27 @@ class RabbitMQ(AgentCheck):
 
         self.event(event)
 
-    def _check_aliveness(self, base_url, vhosts=None, auth=None, ssl_verify=True):
+    def _check_aliveness(self, base_url, vhosts=None, auth=None, ssl_verify=True, skip_proxy=False):
         """
         Check the aliveness API against all or a subset of vhosts. The API
         will return {"status": "ok"} and a 200 response code in the case
         that the check passes.
         """
+
+        vhost_proxy = config_proxy_skip(self.proxies.copy(), vhosts_url, skip_proxy=skip_proxy)
         if not vhosts:
             # Fetch a list of _all_ vhosts from the API.
             vhosts_url = urlparse.urljoin(base_url, 'vhosts')
-            vhosts_response = self._get_data(vhosts_url, auth=auth, ssl_verify=ssl_verify)
+            vhosts_response = self._get_data(vhosts_url, auth=auth, ssl_verify=ssl_verify, proxies=vhost_proxy)
             vhosts = [v['name'] for v in vhosts_response]
 
+        aliveness_proxy = config_proxy_skip(self.proxies.copy(), aliveness_url, skip_proxy=skip_proxy)
         for vhost in vhosts:
             tags = ['vhost:%s' % vhost]
             # We need to urlencode the vhost because it can be '/'.
             path = u'aliveness-test/%s' % (urllib.quote_plus(vhost))
             aliveness_url = urlparse.urljoin(base_url, path)
-            aliveness_response = self._get_data(aliveness_url, auth=auth, ssl_verify=ssl_verify)
+            aliveness_response = self._get_data(aliveness_url, auth=auth, ssl_verify=ssl_verify, proxies=aliveness_proxy)
             message = u"Response from aliveness API: %s" % aliveness_response
 
             if aliveness_response.get('status') == 'ok':

--- a/rabbitmq/check.py
+++ b/rabbitmq/check.py
@@ -17,7 +17,7 @@ from requests.exceptions import RequestException
 # project
 from checks import AgentCheck
 from config import _is_affirmative
-from utils.proxy import get_no_proxy_from_env
+from utils.proxy import get_no_proxy_from_env, config_proxy_skip
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'rabbitmq'
 QUEUE_TYPE = 'queues'

--- a/rabbitmq/check.py
+++ b/rabbitmq/check.py
@@ -8,7 +8,6 @@ import re
 import time
 import urllib
 import urlparse
-from os import environ
 
 # 3p
 import requests

--- a/rabbitmq/conf.yaml.example
+++ b/rabbitmq/conf.yaml.example
@@ -20,6 +20,13 @@ instances:
     #
     # ssl_verify: false
 
+    # The (optional) no_proxy parameter would bypass any proxy settings enabled
+    # and attempt to reach the the URL directly.
+    # If no proxy is defined at any level, this flag bears no effect.
+    # Defaults to False.
+    #
+    # no_proxy: false
+
     # tag_families: true
     # Use the `nodes` or `nodes_regexes` parameters to specify the nodes you'd like to
     # collect metrics on (up to 100 nodes).

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -2,7 +2,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.0",
   "max_agent_version": "6.0.0",
-  "min_agent_version": "5.6.3",
+  "min_agent_version": "5.14.0",
   "name": "rabbitmq",
   "short_description": "Track queue size, consumer count, unacknowledged messages, and more.",
   "support": "core",
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "guid": "a790a556-fbaa-4208-9d39-c42c3d57084b"
 }

--- a/rabbitmq/test_rabbitmq.py
+++ b/rabbitmq/test_rabbitmq.py
@@ -170,12 +170,13 @@ class TestRabbitMQ(AgentCheckTest):
         self.assertEqual(sc['status'], AgentCheck.OK)
 
     def test__check_aliveness(self):
-        self.load_check({"instances": [{"rabbitmq_api_url": "http://example.com"}]})
+        instances = {"instances": [{"rabbitmq_api_url": "http://example.com"}]}
+        self.load_check(instances)
         self.check._get_data = mock.MagicMock()
 
         # only one vhost should be OK
         self.check._get_data.side_effect = [{"status": "ok"}, {}]
-        self.check._check_aliveness('', vhosts=['foo', 'bar'])
+        self.check._check_aliveness(instances['instances'][0], '', vhosts=['foo', 'bar'])
         sc = self.check.get_service_checks()
 
         self.assertEqual(len(sc), 2)
@@ -187,4 +188,4 @@ class TestRabbitMQ(AgentCheckTest):
         # in case of connection errors, this check should stay silent
         from check import RabbitMQException  # pylint: disable=import-error,no-name-in-module
         self.check._get_data.side_effect = RabbitMQException
-        self.assertRaises(RabbitMQException, self.check._check_aliveness, '')
+        self.assertRaises(RabbitMQException, self.check._check_aliveness, instances['instances'][0], '')


### PR DESCRIPTION
### What does this PR do?

This PR allows the user to skip the proxy configuration for the rabbitmq if specified in the check configuration. It mimics the behavior already implemented in the HTTP check. Also, because of the similarities, common code has been dropped into `dd-agent` with a small refactor. 

### Motivation

Customer request.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes
Only merge after the sister PR [here](https://github.com/DataDog/dd-agent/pull/3331) is merged.

The CI will continue to fail until we merge that code too.