### PR TITLE
[docker_daemon] catch IOError exception when container exits in the middle of a check run

### DIFF
--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -686,6 +686,8 @@ class DockerDaemon(AgentCheck):
                 cgroup_stat_file_failures += 1
                 if cgroup_stat_file_failures >= len(CGROUP_METRICS):
                     self.warning("Couldn't find the cgroup files. Skipping the CGROUP_METRICS for now.")
+            except IOError as e:
+                self.log.debug("Cannot read cgroup file, container likely raced to finish : %s", e)
             else:
                 stats = self._parse_cgroup_file(stat_file)
                 if stats:


### PR DESCRIPTION
### What does this PR do?

When parsing cgroup files, silently skip IOErrors as they mostly come from containers that exited in the middle of the check run

### Motivation

Although it didn't break metrics (next run would finish fine), it is log spam and confusing

