### PR TITLE
[docker] more resilient diskmapper stats parser

### DIFF
--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -33,6 +33,8 @@ EXIT_SERVICE_CHECK_NAME = 'docker.exit'
 SIZE_REFRESH_RATE = 5  # Collect container sizes every 5 iterations of the check
 CONTAINER_ID_RE = re.compile('[0-9a-f]{64}')
 
+DISK_STATS_RE = re.compile('([0-9.]+)\s?([a-zA-Z]+)')
+
 GAUGE = AgentCheck.gauge
 RATE = AgentCheck.rate
 HISTORATE = AgentCheck.generate_historate_func(["container_name"])
@@ -958,7 +960,11 @@ class DockerDaemon(AgentCheck):
         """Cast the disk stats to float and convert them to bytes"""
         for name, raw_val in metrics.iteritems():
             if raw_val:
-                val, unit = raw_val.split(' ')
+                match = DISK_STATS_RE.search(raw_val)
+                if match is None or len(match.groups()) != 2:
+                    self.log.warning('Can\'t parse value %s for disk metric %s. Dropping it.' % (raw_val, name))
+                    metrics[name] = None
+                val, unit = match.groups()
                 # by default some are uppercased others lowercased. That's error prone.
                 unit = unit.lower()
                 try:


### PR DESCRIPTION
### What does this PR do?

Some setups of docker transmit devicemapper disk stats in a new format (value and unit are not separated by a space anymore), which make the docker_daemon fail with uncaught exception.

This PR uses a regexp to parse the disk stats and includes a fallback (skipping the stat) on parsing error.

### Testing Guidelines

Unit test test_devicemapper_no_spaces added to suite