### PR TITLE
[docker] add option to cap rate values and filter them out

### DIFF
--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -1114,7 +1114,7 @@ class DockerDaemon(AgentCheck):
     def filter_capped_metrics(self):
         metrics = self.aggregator.metrics.values()
         for metric in metrics:
-            if metric.name in self.capped_metrics:
+            if metric.name in self.capped_metrics and len(metric.samples) >= 2:
                 cap = self.capped_metrics[metric.name]
                 val = metric._rate(metric.samples[-2], metric.samples[-1])
                 if val > cap:

--- a/docker_daemon/conf.yaml.example
+++ b/docker_daemon/conf.yaml.example
@@ -164,3 +164,12 @@ instances:
     # Default to None
     # Example:
     # collect_labels_as_tags: ["com.docker.compose.service", "com.docker.compose.project"]
+
+    ## Rate Filtering
+    ##
+
+    # Allows ad-hoc spike filtering if the system reports incorrect metrics.
+    # This will drop points if the computed rate is higher than the cap value
+    # capped_metrics:
+    #   docker.cpu.user: 1000
+    #   docker.cpu.system: 1000


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Add cap logic to filter out erroneous points in Docker rates.

### Motivation

`docker.cpu.user` and `docker.cpu.system` show abnormal spikes. We know the issue is in the system exposing the metric because the file we read it from has the wrong value (it's not a computation issue), but until we find where it stems from and report/fix it we need to drop those erroneous points to make graphs usable.

### Testing Guidelines

Tested it on a local cluster, it did the job.