### PR TITLE
tag all the metrics by app name

### DIFF
--- a/gunicorn/check.py
+++ b/gunicorn/check.py
@@ -52,13 +52,14 @@ class GUnicornCheck(AgentCheck):
         # if no workers are running, alert CRITICAL, otherwise OK
         msg = "%s working and %s idle workers for %s" % (working, idle, proc_name)
         status = AgentCheck.CRITICAL if working == 0 and idle == 0 else AgentCheck.OK
+        tags = ['app:' + proc_name]
 
-        self.service_check(self.SVC_NAME, status, tags=['app:' + proc_name], message=msg)
+        self.service_check(self.SVC_NAME, status, tags=tags, message=msg)
 
         # Submit the data.
         self.log.debug("instance %s procs - working:%s idle:%s" % (proc_name, working, idle))
-        self.gauge("gunicorn.workers", working, self.WORKING_TAGS)
-        self.gauge("gunicorn.workers", idle, self.IDLE_TAGS)
+        self.gauge("gunicorn.workers", working, tags + self.WORKING_TAGS)
+        self.gauge("gunicorn.workers", idle, tags + self.IDLE_TAGS)
 
     def _count_workers(self, worker_procs):
         working = 0

--- a/gunicorn/manifest.json
+++ b/gunicorn/manifest.json
@@ -10,6 +10,6 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "guid": "5347bfe1-2e9b-4c92-9410-48b8659ce10f"
 }

--- a/gunicorn/test_gunicorn.py
+++ b/gunicorn/test_gunicorn.py
@@ -31,8 +31,8 @@ class TestGunicorn(AgentCheckTest):
         """
         self.run_check({'instances': [{'proc_name': 'dd-test-gunicorn'}]})
 
-        self.assertMetric("gunicorn.workers", tags=['state:idle'], at_least=0)
-        self.assertMetric("gunicorn.workers", tags=['state:working'], at_least=0)
+        self.assertMetric("gunicorn.workers", tags=['app:dd-test-gunicorn', 'state:idle'], at_least=0)
+        self.assertMetric("gunicorn.workers", tags=['app:dd-test-gunicorn', 'state:working'], at_least=0)
 
         self.assertServiceCheck("gunicorn.is_running", count=1)
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Tags with `app:app_name` the `gunicorn.workers` metric, as it already was the case for the `gunicorn.is_running` service check.

### Motivation

As per customer request.
