### PR TITLE
[docker] handle sha256: as image name in docker events

### DIFF
--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -827,7 +827,10 @@ class DockerDaemon(AgentCheck):
                 continue
             # from may be missing (for network events for example)
             if 'from' in event:
-                events[event['from']].appendleft(event)
+                image_name = event['from']
+                if image_name.startswith('sha256:'):
+                    image_name = self.docker_util.image_name_extractor({'Image': image_name})
+                events[image_name].appendleft(event)
         return events
 
     def _format_events(self, aggregated_events, containers_by_id):


### PR DESCRIPTION
Following up on https://github.com/DataDog/dd-agent/pull/3326, the sha256 move also affects docker events.

This PR reuses the same logic to resolve image name from checksums when one in encoutered
