### PR TITLE
[ssh] fix misplaced parentheses in config validation

### DIFF
--- a/ssh_check/check.py
+++ b/ssh_check/check.py
@@ -41,7 +41,7 @@ class CheckSSH(AgentCheck):
         params = []
         for option, required, default, expected_type in self.OPTIONS:
             value = instance.get(option)
-            if required and (not value or type(value)) != expected_type:
+            if required and (not value or type(value) != expected_type):
                 raise Exception("Please specify a valid {0}".format(option))
 
             if value is None or type(value) != expected_type:


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### Motivation

This really looks like a typo, since comparing a boolean value to `expected_type` doesn't make much sense.

### Testing Guidelines

Untested by author.