### PR TITLE
[docker] fix missing net metrics in k8s

### DIFF
--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -752,6 +752,8 @@ class DockerDaemon(AgentCheck):
                 networks = self.network_mappings[container['Id']]
             else:
                 networks = self.docker_util.get_container_network_mapping(container)
+                if not networks:
+                    networks = {'eth0': 'bridge'}
                 self.network_mappings[container['Id']] = networks
         except Exception as e:
             # Revert to previous behaviour if the method is missing or failing


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

In Kubernetes there is no network in docker inspect. For this reason the docker check never enters [this code branch](https://github.com/DataDog/integrations-core/blob/5.13.2/docker_daemon/check.py#L729-L734).

In the background though, there is a network interface in containers: eth0 is a bridge and packet routing is handled by k8s itself (well, its network driver).

This PR adds a default network even if none was found so that we at least collect basic (if not precise) stats (and tags) about containers network activity in Kubernetes.

**Note**: it doesn't impact containers with no network (started with `--net=none`) because they don't have a matching interface (eth0) in `/proc/net/dev`, so the check will keep not entering the code branch linked above.

### Motivation

Users reported this behavior.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
