### PR TITLE
[process] Add option to collect metrics for child processes

### DIFF
--- a/process/CHANGELOG.md
+++ b/process/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - process
 
+1.1.0 / Unreleased
+==================
+
+### Changes
+
+* [IMPROVEMENT] Add option to collect metrics for children of matched processes
+
 1.0.1 / 2017-05-11
 ==================
 

--- a/process/check.py
+++ b/process/check.py
@@ -305,6 +305,7 @@ class ProcessCheck(AgentCheck):
         for pid in pids:
             try:
                 children = psutil.Process(pid).children(recursive=True)
+                self.log.debug('%s children were collected for process %s', len(children), pid)
                 for child in children:
                     children_pids.add(child.pid)
             except psutil.NoSuchProcess:

--- a/process/check.py
+++ b/process/check.py
@@ -300,6 +300,18 @@ class ProcessCheck(AgentCheck):
 
         return map(lambda i: int(i), data.split()[9:13])
 
+    def _get_child_processes(self, pids):
+        children_pids = set()
+        for pid in pids:
+            try:
+                children = psutil.Process(pid).children(recursive=True)
+                for child in children:
+                    children_pids.add(child.pid)
+            except psutil.NoSuchProcess:
+                pass
+
+        return children_pids
+
     def check(self, instance):
         name = instance.get('name', None)
         tags = instance.get('tags', [])
@@ -308,6 +320,7 @@ class ProcessCheck(AgentCheck):
         ignore_ad = _is_affirmative(instance.get('ignore_denied_access', True))
         pid = instance.get('pid')
         pid_file = instance.get('pid_file')
+        collect_children = _is_affirmative(instance.get('collect_children', False))
 
         if self._conflicting_procfs:
             self.warning('The `procfs_path` defined in `process.yaml` is different from the one defined in '
@@ -352,6 +365,9 @@ class ProcessCheck(AgentCheck):
                 pids = set()
         else:
             raise ValueError('The "search_string" or "pid" options are required for process identification')
+
+        if collect_children:
+            pids.update(self._get_child_processes(pids))
 
         proc_state = self.get_process_state(name, pids)
 

--- a/process/conf.yaml.example
+++ b/process/conf.yaml.example
@@ -29,6 +29,7 @@ instances:
 #                   above the second one, the process check will return CRITICAL.
 #     In this example, process check will return OK for 3 to 5 process. WARNING for 1, 2, 6, 7 processes and Critical below 1 or above 7.
 #     CRITICAL is always dominant in case of overlapping.
+#    collect_children: BOOLEAN. If true, the check will also collect metrics from all child processes of a matched process. Default to false.
 #
 # Examples:
 #

--- a/process/conf.yaml.example
+++ b/process/conf.yaml.example
@@ -29,7 +29,8 @@ instances:
 #                   above the second one, the process check will return CRITICAL.
 #     In this example, process check will return OK for 3 to 5 process. WARNING for 1, 2, 6, 7 processes and Critical below 1 or above 7.
 #     CRITICAL is always dominant in case of overlapping.
-#    collect_children: BOOLEAN. If true, the check will also collect metrics from all child processes of a matched process. Default to false.
+#    collect_children: BOOLEAN. If true, the check will also collect metrics from all child processes of a matched process. Default to false. 
+#                      Please be aware that the collection is recursive, and might take some time depending on the use case.
 #
 # Examples:
 #

--- a/process/test_process.py
+++ b/process/test_process.py
@@ -38,6 +38,9 @@ class MockProcess(object):
     def is_running(self):
         return True
 
+    def children(self, recursive=False):
+        return []
+
 def noop_get_pagefault_stats(pid):
     return None
 
@@ -355,6 +358,26 @@ class ProcessCheckTest(AgentCheckTest):
                 continue
 
             self.assertMetric('system.processes.cpu.pct', count=1, tags=expected_tags)
+
+    def mock_get_child_processes(self, pids):
+        return [2, 3, 4]
+
+    @attr(requires='process')
+    @patch('psutil.Process', return_value=MockProcess())
+    def test_check_collect_children(self, mock_process):
+
+
+        config = {
+            'instances': [{
+                'name': 'foo',
+                'pid': 1,
+                'collect_children': True
+            }]
+        }
+
+        self.run_check(config, mocks={'_get_child_processes': self.mock_get_child_processes})
+
+        self.assertMetric('system.processes.number', 4, tags=self.generate_expected_tags(config['instances'][0]))
 
     def test_check_missing_pid(self):
         config = {

--- a/process/test_process.py
+++ b/process/test_process.py
@@ -362,7 +362,6 @@ class ProcessCheckTest(AgentCheckTest):
     def mock_get_child_processes(self, pids):
         return [2, 3, 4]
 
-    @attr(requires='process')
     @patch('psutil.Process', return_value=MockProcess())
     def test_check_collect_children(self, mock_process):
 


### PR DESCRIPTION
### What does this PR do?

Add an option to collect the metrics from the children of matched processes

### Motivation

[Customer request](https://datadog.zendesk.com/agent/tickets/41895)