### PR TITLE
[directory] patterns will now match relative paths of files within th…

### DIFF
--- a/directory/CHANGELOG.md
+++ b/directory/CHANGELOG.md
@@ -1,8 +1,17 @@
 # CHANGELOG - directory
 
+1.1.0 / Unreleased
+==================
+
+### Changes
+
+* [FEATURE] adds pattern matching against files' relative paths. See [#429][]
+
 1.0.003-22-2017
 ==================
 
 ### Changes
 
 * [FEATURE] adds directory integration.
+
+[#429]: https://github.com/DataDog/integrations-core/pull/429

--- a/directory/check.py
+++ b/directory/check.py
@@ -7,7 +7,7 @@
 # stdlib
 from fnmatch import fnmatch
 from os import stat
-from os.path import abspath, exists, join
+from os.path import abspath, exists, join, relpath
 import time
 
 # 3p
@@ -61,8 +61,12 @@ class DirectoryCheck(AgentCheck):
         for root, dirs, files in walk(directory):
             for filename in files:
                 filename = join(root, filename)
-                # check if it passes our filter
-                if not fnmatch(filename, pattern):
+                rel_filename = relpath(filename, directory)
+                # Check if the path of the file relative to the directory
+                # matches the pattern. Also check if the absolute path of the
+                # filename matches the pattern, for compatibility with previous
+                # agent verions.
+                if not (fnmatch(filename, pattern) or fnmatch(rel_filename, pattern)):
                     continue
 
                 directory_files += 1

--- a/directory/conf.yaml.example
+++ b/directory/conf.yaml.example
@@ -18,7 +18,7 @@ instances:
   # "dirtagname" - string, the name of the tag used for the directory. defaults to "name"
   # "filetagname" - string, the name of the tag used for each file. defaults to "filename"
   # "filegauges" - boolean, when true stats will be an individual gauge per file (max. 20 files!) and not a histogram of the whole directory. default False
-  # "pattern" - string, the `fnmatch` pattern to use when reading the "directory"'s files. The pattern will be matched against the files' absolute paths. default "*"
+  # "pattern" - string, the `fnmatch` pattern to use when reading the "directory"'s files. The pattern will be matched against the files' absolute paths and relative paths in "directory". default "*"
   # "recursive" - boolean, when true the stats will recurse into directories. default False
   # "countonly" - boolean, when true the stats will only count the number of files matching the pattern. Useful for very large directories.
 

--- a/directory/manifest.json
+++ b/directory/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "guid": "0c38c4ef-5266-4667-9fb1-de8f2b73708a"
 }


### PR DESCRIPTION
…e instance directory

Previously, patterns were compared to the absolute pathnames of files using fnmatch. For example, a pattern foo would not match a file named foo in directory bar. Instead you would have to specify the absolute pathname of foo as the pattern. This commit changes the directory check so that a pattern foo will match a file named foo in a directory bar (but it must match the relative path. A pattern foo will not match a file named foo in a subdirectory of bar called baz. The pattern would need to be baz/foo to match this file).

### Motivation

It is unintuitive (and tedious) to specify the absolute path of a file as a pattern to match that file. The alternative of prepending a * to all file names wouldn't work in all cases (e.g. in a directory with files named bar and foobar, it isn't possible to write a pattern that will only match bar).

### Testing Guidelines

The directory integration's tests were updated to test this feature.

### Additional Notes


