### PR TITLE
kube_{creator} and kube_service for more metrics

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -77,6 +77,7 @@ test:
         - rake ci:run[kafka_consumer]
         - rake ci:run[kafka]
         - rake ci:run[docker_daemon]
+        - rake ci:run[kubernetes]
         - bundle exec rake requirements
     post:
         - if [[ $(docker ps -a -q) ]]; then docker stop $(docker ps -a -q); fi

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -206,7 +206,7 @@ class DockerDaemon(AgentCheck):
             # Set tagging options
             self.custom_tags = instance.get("tags", [])
             self.collect_labels_as_tags = instance.get("collect_labels_as_tags", DEFAULT_LABELS_AS_TAGS)
-            self.kube_labels = {}
+            self.kube_pod_tags = {}
 
             self.use_histogram = _is_affirmative(instance.get('use_histogram', False))
             performance_tags = instance.get("performance_tags", DEFAULT_PERFORMANCE_TAGS)
@@ -276,10 +276,10 @@ class DockerDaemon(AgentCheck):
                 self._count_and_weigh_images()
 
             if Platform.is_k8s():
-                self.kube_labels = {}
+                self.kube_pod_tags = {}
                 if self.kubeutil:
                     try:
-                        self.kube_labels = self.kubeutil.get_kube_labels()
+                        self.kube_pod_tags = self.kubeutil.get_kube_pod_tags()
                     except Exception as e:
                         self.log.warning('Could not retrieve kubernetes labels: %s' % str(e))
 
@@ -485,9 +485,9 @@ class DockerDaemon(AgentCheck):
                 ecs_tags = self.ecsutil.extract_container_tags(entity)
                 tags.extend(ecs_tags)
 
-            # Add kube labels
+            # Add kube labels and creator/service tags
             if Platform.is_k8s():
-                kube_tags = self.kube_labels.get(pod_name)
+                kube_tags = self.kube_pod_tags.get(pod_name)
                 if kube_tags:
                     tags.extend(list(kube_tags))
 

--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -343,7 +343,7 @@ class Kubernetes(AgentCheck):
         metrics = self.kubeutil.retrieve_metrics()
 
         excluded_labels = instance.get('excluded_labels')
-        kube_labels = self.kubeutil.extract_kube_labels(pods_list, excluded_keys=excluded_labels)
+        kube_labels = self.kubeutil.extract_kube_pod_tags(pods_list, excluded_keys=excluded_labels)
 
         if not metrics:
             raise Exception('No metrics retrieved cmd=%s' % self.metrics_cmd)

--- a/kubernetes/conf.yaml.example
+++ b/kubernetes/conf.yaml.example
@@ -113,6 +113,8 @@ instances:
   # enabled_gauges:
   #   - filesystem.*
   #
+  # Prefix to use when converting pod labels to metric tags, can be made empty with ""
+  # label_to_tag_prefix: "kube_"
   #
   # Custom tags that should be applied to kubernetes metrics
   # tags:


### PR DESCRIPTION
Sister PR for https://github.com/DataDog/dd-agent/pull/3348

Added documentation for https://github.com/DataDog/dd-agent/pull/3345 as the three PRs are joined by the hip