### PR TITLE
[ceph] Add option to define the cluster name

### DIFF
--- a/ceph/CHANGELOG.md
+++ b/ceph/CHANGELOG.md
@@ -1,7 +1,13 @@
 # CHANGELOG - ceph
 
-1.0.003-22-2017
-==================
+## 1.1.0 / Unreleased
+
+### Changes
+
+* [FEATURE] Add option to define the cluster name. See #438.
+
+
+## 1.0.0 / 03-22-2017
 
 ### Changes
 

--- a/ceph/check.py
+++ b/ceph/check.py
@@ -23,9 +23,10 @@ class Ceph(AgentCheck):
     """ Collect metrics and events from ceph """
 
     DEFAULT_CEPH_CMD = '/usr/bin/ceph'
-    NAMESPACE = "ceph"
+    DEFAULT_CEPH_CLUSTER = 'ceph'
+    NAMESPACE = 'ceph'
 
-    def _collect_raw(self, ceph_cmd, instance):
+    def _collect_raw(self, ceph_cmd, ceph_cluster, instance):
         use_sudo = _is_affirmative(instance.get('use_sudo', False))
         ceph_args = []
         if use_sudo:
@@ -35,6 +36,8 @@ class Ceph(AgentCheck):
             ceph_args = ['sudo', ceph_cmd]
         else:
             ceph_args = [ceph_cmd]
+
+        ceph_args += ['--cluster', ceph_cluster]
 
         args = ceph_args + ['version']
         try:
@@ -221,7 +224,8 @@ class Ceph(AgentCheck):
 
     def check(self, instance):
         ceph_cmd = instance.get('ceph_cmd') or self.DEFAULT_CEPH_CMD
-        raw = self._collect_raw(ceph_cmd, instance)
+        ceph_cluster = instance.get('ceph_cluster') or self.DEFAULT_CEPH_CLUSTER
+        raw = self._collect_raw(ceph_cmd, ceph_cluster, instance)
         tags = self._extract_tags(raw, instance)
         self._extract_metrics(raw, tags)
         self._perform_service_checks(raw, tags)

--- a/ceph/conf.yaml.example
+++ b/ceph/conf.yaml.example
@@ -5,6 +5,7 @@ instances:
 #    - name:mars_cluster
 #
 #    ceph_cmd: /usr/bin/ceph
+#    ceph_cluster: ceph
 #
 # If your environment requires sudo, please add a line like:
 #          dd-agent ALL=(ALL) NOPASSWD:/usr/bin/ceph

--- a/ceph/manifest.json
+++ b/ceph/manifest.json
@@ -10,6 +10,6 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "guid": "8a60c34f-ecde-4269-bcae-636e6cbce98f"
 }

--- a/ceph/test_ceph.py
+++ b/ceph/test_ceph.py
@@ -19,7 +19,7 @@ class TestCeph(AgentCheckTest):
 
     def test_simple_metrics(self):
         mocks = {
-            '_collect_raw': lambda x,y: json.loads(Fixtures.read_file('raw.json', sdk_dir=self.FIXTURE_DIR)),
+            '_collect_raw': lambda x,y,z: json.loads(Fixtures.read_file('raw.json', sdk_dir=self.FIXTURE_DIR)),
         }
         config = {
             'instances': [{'host': 'foo'}]
@@ -37,7 +37,7 @@ class TestCeph(AgentCheckTest):
 
     def test_warn_health(self):
         mocks = {
-            '_collect_raw': lambda x,y: json.loads(
+            '_collect_raw': lambda x,y,z: json.loads(
                 Fixtures.read_file('warn.json', sdk_dir=self.FIXTURE_DIR)),
         }
         config = {
@@ -56,7 +56,7 @@ class TestCeph(AgentCheckTest):
 
     def test_tagged_metrics(self):
         mocks = {
-            '_collect_raw': lambda x,y: json.loads(
+            '_collect_raw': lambda x,y,z: json.loads(
                 Fixtures.read_file('raw.json', sdk_dir=self.FIXTURE_DIR)),
         }
         config = {
@@ -81,7 +81,7 @@ class TestCeph(AgentCheckTest):
 
     def test_osd_status_metrics(self):
         mocks = {
-            '_collect_raw': lambda x,y: json.loads(
+            '_collect_raw': lambda x,y,z: json.loads(
                 Fixtures.read_file('ceph_10.2.2.json', sdk_dir=self.FIXTURE_DIR)),
         }
         config = {
@@ -115,7 +115,7 @@ class TestCeph(AgentCheckTest):
         shouldn't make the check fail
         """
         mocks = {
-            '_collect_raw': lambda x,y: json.loads(
+            '_collect_raw': lambda x,y,z: json.loads(
                 Fixtures.read_file('ceph_10.2.2_mon_health.json', sdk_dir=self.FIXTURE_DIR)),
         }
         config = {


### PR DESCRIPTION
### What does this PR do?
It adds the option to define the cluster name in the yaml config.

### Motivation
We have a single administration node which commandeers multiple Ceph clusters. This feature gives us the ability to define a cluster, and collect metrics for it. If it's not configured, the default cluster name "ceph" will be used.