### PR TITLE
Don't run win32_event_log tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,6 @@ env:
     - TRAVIS_FLAVOR=twemproxy FLAVOR_VERSION=latest
     - TRAVIS_FLAVOR=varnish FLAVOR_VERSION=4.1.4
     - TRAVIS_FLAVOR=varnish FLAVOR_VERSION=5.0.0
-    - TRAVIS_FLAVOR=win32_event_log
     # END OF TRAVIS MATRIX
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,4 +48,3 @@ test_script:
   - bundle exec rake ci:run[iis]
   - bundle exec rake ci:run[windows_service]
   - bundle exec rake ci:run[wmi_check]
-  - bundle exec rake ci:run[win32_event_log]

--- a/win32_event_log/test_win32_event_log.py
+++ b/win32_event_log/test_win32_event_log.py
@@ -5,9 +5,6 @@
 # stdlib
 from mock import patch
 
-# 3p
-from nose.plugins.attrib import attr
-
 # project
 from tests.core.test_wmi import TestCommonWMI
 from tests.checks.common import AgentCheckTest
@@ -17,12 +14,13 @@ def to_time(wmi_ts):
     "Just return any time struct"
     return (2100, 12, 24, 11, 30, 47, 0, 0)
 
+
 def from_time(year=0, month=0, day=0, hours=0, minutes=0,
             seconds=0, microseconds=0, timezone=0):
     "Just return any WMI date"
     return "20151224113047.000000-480"
 
-@attr(requires='win32_event_log')
+
 class TestWin32_event_log(AgentCheckTest, TestCommonWMI):
     """Basic Test for win32_event_log integration."""
     CHECK_NAME = 'win32_event_log'


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Remove `win32_event_log` from the travis matrix.

### Motivation

~~We spend 1 minute of a runner to skip tests every time.~~
