### PR TITLE
add alternative image name to kube-dns autoconf

### DIFF
--- a/kube_dns/auto_conf.yaml
+++ b/kube_dns/auto_conf.yaml
@@ -1,5 +1,6 @@
 docker_images:
   - kubedns-amd64
+  - k8s-dns-kube-dns-amd64
 
 init_config:
 


### PR DESCRIPTION
### What does this PR do?

Add the GCE image name for kube-dns autoconf 

### Motivation

Allow out-of-the-box detection for GCE clusters
