### PR TITLE
[ssh_check] Fix thread leak

### DIFF
--- a/ssh_check/conf.yaml.example
+++ b/ssh_check/conf.yaml.example
@@ -8,5 +8,4 @@ instances:
     # sftp_check: True            # optional, leaving blank defaults to True
     # private_key_file:           # optional, file path to private key
     # private_key_type:           # optional, private key type rsa or ecdsa (defaults to rsa)
-                                  # warning: only ecdsa keys <= 256bits are supported
     # add_missing_keys: True      # optional, leaving blank defaults to False

--- a/ssh_check/test_ssh.py
+++ b/ssh_check/test_ssh.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 # stdlib
+import threading
 import unittest
 
 # 3p
@@ -47,7 +48,9 @@ class SshTestCase(unittest.TestCase):
         }
 
         agentConfig = {}
-        self.check = load_check('ssh', config, agentConfig)
+        self.check = load_check('ssh_check', config, agentConfig)
+
+        nb_threads = threading.active_count()
 
         # Testing that connection will work
         self.check.check(config['instances'][0])
@@ -64,3 +67,5 @@ class SshTestCase(unittest.TestCase):
         service_fail = self.check.get_service_checks()
         # Check failure status
         self.assertEqual(service_fail[0].get('status'), AgentCheck.CRITICAL)
+        # Check that we've closed all connections, if not we're leaking threads
+        self.assertEqual(nb_threads, threading.active_count())


### PR DESCRIPTION
### What does this PR do?

Since the upgrade to paramiko 2.x (see #426), it appears that a failure to close
connections leaks threads. To fix this, make sure we always close
connections.

We always close the client, even when the connection is unsuccessful
(paramiko handles this case gracefully).

Also, remove the mention of a limit on the size of `ecdsa` keys in
the example yaml file, since the limit applies only to paramiko 1.x.

### Testing

Add an assertion on the number of threads after the check has run.

### Versioning

I'll take care of both items while releasing the `5.14.0` agent:
- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`

### Additional notes

The diff on the check file is pretty big, but the only change I made was adding the `try`/`finally` block and changing a couple of comments.