### PR TITLE
[sqlserver] Fix check not failing when connection error in init

### DIFF
--- a/sqlserver/check.py
+++ b/sqlserver/check.py
@@ -131,7 +131,7 @@ class SQLServer(AgentCheck):
                     if ignore is not None and ignore:
                         # not much : we expect it. leave checks disabled
                         self.do_check[instance_key] = False
-                        self.warning("Database %s does not exist. Disabling checks for this instance." % (context))
+                        self.log.warning("Database %s does not exist. Disabling checks for this instance." % (context))
                     else:
                         # yes we do. Keep trying
                         self.log.error("Database %s does not exist. Fix issue and restart agent" % (context))

--- a/sqlserver/check.py
+++ b/sqlserver/check.py
@@ -115,14 +115,13 @@ class SQLServer(AgentCheck):
         for instance in instances:
             try:
                 instance_key = self._conn_key(instance, self.DEFAULT_DB_KEY)
-                self.do_check[instance_key] = False
+                self.do_check[instance_key] = True
 
                 # check to see if the database exists before we try any connections to it
                 with self.open_managed_db_connections(instance, None, db_name=self.DEFAULT_DATABASE):
                     db_exists, context = self._check_db_exists(instance)
 
                 if db_exists:
-                    self.do_check[instance_key] = True
                     if instance.get('stored_procedure') is None:
                         with self.open_managed_db_connections(instance, self.DEFAULT_DB_KEY):
                             self._make_metric_list_to_collect(instance, self.custom_metrics)
@@ -131,11 +130,11 @@ class SQLServer(AgentCheck):
                     ignore = _is_affirmative(instance.get("ignore_missing_database", False))
                     if ignore is not None and ignore:
                         # not much : we expect it. leave checks disabled
-                        self.log.info("Database %s does not exist. Disabling checks for this instance." % (context))
+                        self.do_check[instance_key] = False
+                        self.warning("Database %s does not exist. Disabling checks for this instance." % (context))
                     else:
                         # yes we do. Keep trying
-                        self.do_check[instance_key] = True
-                        self.log.exception("Database %s does not exist. Fix issue and restart agent" % (context))
+                        self.log.error("Database %s does not exist. Fix issue and restart agent" % (context))
 
             except SQLConnectionError:
                 self.log.exception("Skipping SQL Server instance")
@@ -159,10 +158,11 @@ class SQLServer(AgentCheck):
                 for row in cursor:
                     self.existing_databases[row.name] = True
 
-                self.close_cursor(cursor)
             except Exception, e:
                 self.log.error("Failed to check if database %s exists: %s" % (database, e))
                 return False, context
+            finally:
+                self.close_cursor(cursor)
 
         return database in self.existing_databases, context
 

--- a/sqlserver/conf.yaml.example
+++ b/sqlserver/conf.yaml.example
@@ -35,6 +35,8 @@ init_config:
 
     # As well as capturing from the DMV you can also capture from a custom proc
     # Please note this feature will produce a number of custom metrics that might affect your billing
+    # To use this feature, specify in your instance the procedure to execute : 
+    # stored_procedure: ProcedureToExecute
     #
     # The proc should return this table
     # CREATE TABLE #Datadog
@@ -78,9 +80,11 @@ instances:
       - optional_tag
 
   # get metrics from custom proc in MyDB but only if the database is writeable (i.e. it's the master in an availability group)
-  - host: HOST,PORT
-    database: MyDB
-    stored_procedure: GetDatadogMetrics
-    proc_only_if: SELECT CASE CONVERT(sysname,DatabasePropertyEx('MyDB','Updateability')) WHEN 'READ_WRITE' THEN 1 ELSE 0 END
-    proc_only_if_database: master
-    ignore_missing_database: True 
+  # - host: HOST,PORT
+  #   database: MyDB
+  #   username: my_username
+  #   password: my_password
+  #   stored_procedure: GetDatadogMetrics
+  #   proc_only_if: SELECT CASE CONVERT(sysname,DatabasePropertyEx('MyDB','Updateability')) WHEN 'READ_WRITE' THEN 1 ELSE 0 END
+  #   proc_only_if_database: master
+  #   ignore_missing_database: True 

--- a/sqlserver/test_sqlserver.py
+++ b/sqlserver/test_sqlserver.py
@@ -6,9 +6,6 @@
 import copy
 from nose.plugins.attrib import attr
 
-# 3p
-from testfixtures import LogCapture
-
 # project
 from tests.checks.common import AgentCheckTest
 

--- a/sqlserver/test_sqlserver.py
+++ b/sqlserver/test_sqlserver.py
@@ -145,12 +145,8 @@ class TestSqlserver(AgentCheckTest):
             'timeout': 1,
         }]
 
-        with LogCapture() as l:
+        with self.assertRaisesRegexp(Exception, 'Unable to connect to SQL Server'):
             self.run_check(config, force_reload=True)
-            assert l.records[0].msg == 'Skipping SQL Server instance'
-            assert l.records[0].levelname == 'ERROR'
-            assert l.records[1].msg == 'Skipping check'
-            assert l.records[1].levelname == 'DEBUG'
 
         self.assertServiceCheckCritical('sqlserver.can_connect',
                                         tags=['host:(local)\SQL2012SP1', 'db:master'])


### PR DESCRIPTION
Fix check not failing when connection error in init
Also prevent a case where a cursor would not be closed
