### PR TITLE
[docker] collect mesos tags

### DIFF
--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -23,7 +23,7 @@ from utils.dockerutil import (DockerUtil,
 from utils.kubernetes import KubeUtil
 from utils.platform import Platform
 from utils.service_discovery.sd_backend import get_sd_backend
-from utils.orchestrator import NomadUtil, ECSUtil
+from utils.orchestrator import NomadUtil, ECSUtil, Tagger
 
 
 EVENT_TYPE = 'docker'
@@ -182,6 +182,8 @@ class DockerDaemon(AgentCheck):
 
             self.docker_client = self.docker_util.client
             self.docker_gateway = DockerUtil.get_gateway()
+
+            self.orchestrator_tagger = Tagger()
 
             if Platform.is_k8s():
                 try:
@@ -496,6 +498,10 @@ class DockerDaemon(AgentCheck):
                 nomad_tags = self.nomadutil.extract_container_tags(entity)
                 if nomad_tags:
                     tags.extend(nomad_tags)
+
+            if self.orchestrator_tagger.has_detected():
+                orch_tags = self.orchestrator_tagger.get_container_tags(co=entity)
+                tags.extend(orch_tags)
 
         return tags
 

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -23,7 +23,7 @@ from utils.dockerutil import (DockerUtil,
 from utils.kubernetes import KubeUtil
 from utils.platform import Platform
 from utils.service_discovery.sd_backend import get_sd_backend
-from utils.orchestrator import NomadUtil, ECSUtil, Tagger
+from utils.orchestrator import NomadUtil, ECSUtil, MetadataCollector
 
 
 EVENT_TYPE = 'docker'
@@ -183,7 +183,7 @@ class DockerDaemon(AgentCheck):
             self.docker_client = self.docker_util.client
             self.docker_gateway = DockerUtil.get_gateway()
 
-            self.orchestrator_tagger = Tagger()
+            self.metadata_collector = MetadataCollector()
 
             if Platform.is_k8s():
                 try:
@@ -499,8 +499,8 @@ class DockerDaemon(AgentCheck):
                 if nomad_tags:
                     tags.extend(nomad_tags)
 
-            if self.orchestrator_tagger.has_detected():
-                orch_tags = self.orchestrator_tagger.get_container_tags(co=entity)
+            if self.metadata_collector.has_detected():
+                orch_tags = self.metadata_collector.get_container_tags(co=entity)
                 tags.extend(orch_tags)
 
         return tags
@@ -771,6 +771,7 @@ class DockerDaemon(AgentCheck):
         if changed_container_ids and self._service_discovery:
             get_sd_backend(self.agentConfig).update_checks(changed_container_ids)
         if changed_container_ids:
+            self.metadata_collector.invalidate_cache(events)
             if Platform.is_nomad():
                 self.nomadutil.invalidate_cache(events)
             elif Platform.is_ecs_instance():

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -2,7 +2,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.0",
   "max_agent_version": "6.0.0",
-  "min_agent_version": "5.14.0",
+  "min_agent_version": "5.15.0",
   "name": "docker_daemon",
   "short_description": "Correlate container performance with that of the services running inside them.",
   "guid": "08ee2733-0441-4438-8af8-e2f6fb926772",
@@ -11,5 +11,5 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.2.0"
+  "version": "1.3.0"
 }


### PR DESCRIPTION
### What does this PR do?

As a sister PR for https://github.com/DataDog/dd-agent/pull/3375, this uses the new orchestrator.Tagger class to retrieve the Mesos tags for docker metrics

As usual, tests will turn green when sister PR is merged in dd-agent:master