### PR TITLE
[disk] be resilient when dealing with NFS secure mounts

### DIFF
--- a/disk/CHANGELOG.md
+++ b/disk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - disk
 
+1.0.2 / Unreleased
+==================
+
+### Changes
+
+* [BUG] Skip now works with NFS secure mounts too. See #484.
+
 1.0.1 / 2017-07-18
 ==================
 

--- a/disk/check.py
+++ b/disk/check.py
@@ -130,14 +130,21 @@ class Disk(AgentCheck):
         # ENOENT, pop-up a Windows GUI error for a non-ready
         # partition or just hang;
         # and all the other excluded disks
-        return ((Platform.is_win32() and ('cdrom' in part.opts or
-                                          part.fstype == '')) or
-                self._exclude_disk(part.device, part.fstype, part.mountpoint))
+        skip_win = Platform.is_win32() and ('cdrom' in part.opts or part.fstype == '')
+        return skip_win or self._exclude_disk(part.device, part.fstype, part.mountpoint)
 
     def _exclude_disk(self, name, filesystem, mountpoint):
         """
         Return True for disks we don't want or that match regex in the config file
         """
+        self.log.debug('_exclude_disk: {}, {}, {}'.format(name, filesystem, mountpoint))
+
+        # Hack for NFS secure mounts
+        # Secure mounts might look like this: '/mypath (deleted)', we should
+        # ignore all the bits not part of the mountpoint name. Take also into
+        # account a space might be in the mountpoint.
+        mountpoint = mountpoint.rsplit(' ', 1)[0]
+
         name_empty = not name or name == 'none'
 
         # allow empty names if `all_partitions` is `yes` so we can evaluate mountpoints

--- a/disk/manifest.json
+++ b/disk/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "guid": "94588b23-111e-4ed2-a2af-fd6e4caeea04"
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

When dealing with secure NFS mounts, in the collector log you can see:
```
Unable to get disk metrics for /mypath (deleted): [Errno 2] No such file or directory: '/mypath (deleted)'
```

Since the string is composed like this, in the check:
`self.log.warn("Unable to get disk metrics for %s: %s", part.mountpoint, e)`
this means that `(deleted)` ​is part of the mountpoint name returned by psutils and this fools any attempt to exclude a filesystem.

This PR contains a hack to strip the unwanted part of the mountpoint string before evaluating the skip clauses, looking for feedback whether this is an acceptable workaround to the problem.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`
