### PR TITLE
Remove quotes from vm_include_only_regex

### DIFF
--- a/vsphere/conf.yaml.example
+++ b/vsphere/conf.yaml.example
@@ -32,7 +32,7 @@ instances:
     # to fetch metrics for these ESXi hosts and the VMs
     # running on it
     # optional
-    # host_include_only_regex: ".*\.prod.datadoghq.com"
+    # host_include_only_regex: .*\.prod.datadoghq.com
 
     # Use a regex to include only the VMs that are
     # matching this pattern.

--- a/vsphere/conf.yaml.example
+++ b/vsphere/conf.yaml.example
@@ -37,7 +37,7 @@ instances:
     # Use a regex to include only the VMs that are
     # matching this pattern.
     # optional
-    # vm_include_only_regex: ".*\.sql\.datadoghq\.com"
+    # vm_include_only_regex: .*\.sql\.datadoghq\.com
 
     # Set to true if you'd like to only collect metrics on vSphere VMs which
     # are marked by a custom field with the value 'DatadogMonitored'


### PR DESCRIPTION
Removes the quotes around the vm_include_only_regex parameter as this doesn't appear to be valid YAML

<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

This PR removes the quotes surrounding the vm_include_only_regex as this doesn't appear to be valid YAML syntax. Brought up by a user who confirmed removing these resolved the problem. Additionally, confirmed with an Online Yaml Parser

### Motivation

User reached out that this example was incorrect.

Looked at some YAML documentation - http://yaml.org/spec/1.1/#id872840 It looks like the `\` character is used as an escape method only when its inside quotes. However, if its not in quotes, it will not be treated as an escape character. Any examples with `\` in them for a regex seemingly shouldn't include quotes. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`

### Additional Notes

Anything else we should know when reviewing?
