### PR TITLE
[docker] Prepare removal of the docker check

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,12 +1,17 @@
 # CHANGELOG - Docker
 
-1.0.003-22-2017
-==================
+## Deprecated
+
+The "docker" check is deprecated and will be removed in a future version of the agent. Please use the "docker_daemon" one instead
+
+## 1.0.1 / Unreleased
 
 ### Changes
 
-#### Deprecated
+ * Update the deprecation warning with the EOL date.
 
-The "docker" check is deprecated and will be removed in a future version of the agent. Please use the "docker_daemon" one instead
+## 1.0.0 / 03-22-2017
+
+### Changes
 
 * [FEATURE] adds docker integration.

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,35 +2,4 @@
 
 ## Deprecated
 
-The "docker" check is deprecated and will be removed in a future version of the agent. Please use the "docker_daemon" one instead
-
-## Overview
-
-Get metrics from docker service in real time to:
-
-* Visualize and monitor docker states
-* Be notified about docker failovers and events.
-
-## Installation
-
-Install the `dd-check-docker` package manually or with your favorite configuration manager
-
-## Configuration
-
-Edit the `docker.yaml` file to point to your server and port, set the masters to monitor
-
-## Validation
-
-When you run `datadog-agent info` you should see something like the following:
-
-    Checks
-    ======
-
-        docker
-        -----------
-          - instance #0 [OK]
-          - Collected 39 metrics, 0 events & 7 service checks
-
-## Compatibility
-
-The docker check is compatible with all major platforms
+The "docker" check will be removed with the next Agent release, 5.15. Please use the "docker_daemon" one instead

--- a/docker/check.py
+++ b/docker/check.py
@@ -139,7 +139,7 @@ class Docker(AgentCheck):
     def check(self, instance):
         # Report image metrics
         self.warning('Using the "docker" check is deprecated and will be removed'
-        ' in a future version of the agent. Please use the "docker_daemon" one instead')
+        ' in the next version of the agent, 5.15. Please use the "docker_daemon" one instead')
         if _is_affirmative(instance.get('collect_images_stats', True)):
             self._count_images(instance)
 

--- a/docker/manifest.json
+++ b/docker/manifest.json
@@ -1,7 +1,7 @@
 {
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.0",
-  "max_agent_version": "6.0.0",
+  "max_agent_version": "5.14",
   "min_agent_version": "5.6.3",
   "name": "docker",
   "short_description": "docker description.",
@@ -11,5 +11,5 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/docker/manifest.json
+++ b/docker/manifest.json
@@ -1,7 +1,7 @@
 {
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.0",
-  "max_agent_version": "5.14",
+  "max_agent_version": "5.14.1",
   "min_agent_version": "5.6.3",
   "name": "docker",
   "short_description": "docker description.",


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

The EOL of the docker check will be along with the 5.15 release, let's update docs and code before the final removal.

### Motivation

The docker check has been deprecated since a long time now, it's causing a lot of confusion among the agent users, it's time to clean up.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`

