### PR TITLE
Remove threshold/window from tcp

### DIFF
--- a/tcp_check/README.md
+++ b/tcp_check/README.md
@@ -54,13 +54,10 @@ The TCP check is compatible with all major platforms.
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/tcp_check/metadata.csv) for a list of metrics provided by this integration.
 
-# Events
-
-Older versions of the TCP check only emitted events to reflect site status, but now the check supports service checks, too. However, events are still the default behavior. Set `skip_event` to true for all configured instances to submit service checks instead of events. The Agent will soon deprecate `skip_event`, i.e. the TCP check's default be will only support service checks.
 
 # Service Checks
 
-To create alert conditions on this service checks in Datadog, select 'Network' on the [Create Monitor](https://app.datadoghq.com/monitors#/create) page, not 'Integration'.
+Older versions of the TCP check only emitted events to reflect site status. This has now been deprecated in favor of Service Checks. The Agent will submit these by default.  To create alert conditions on this service checks in Datadog, select 'Network' on the [Create Monitor](https://app.datadoghq.com/monitors#/create) page, not 'Integration'.
 
 **`tcp.can_connect`**:
 

--- a/tcp_check/conf.yaml.example
+++ b/tcp_check/conf.yaml.example
@@ -6,13 +6,6 @@ instances:
     port: 8080
     timeout: 1
 
-    # The (optional) window and threshold parameters allow you to trigger
-    # alerts only if the check fails x times within the last y attempts
-    # where x is the threshold and y is the window.
-    #
-    # threshold: 3
-    # window: 5
-
     # The (optional) collect_response_time parameter will instruct the
     # check to create a metric 'network.tcp.response_time', tagged with
     # the url, reporting the response time in seconds.


### PR DESCRIPTION
Removes the window and threshold parameters as these are deprecated in favor of service checks

<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

This removes the Window and Threshold parameter options from the default TCP.yaml.example file and updates the README to reflect that Events to show site status is now deprecated.

### Motivation

These options are deprecated in favor of Service Checks and were already removed from the HTTP example Yaml file here - https://github.com/DataDog/dd-agent/pull/2400 This should be the last check that was using these options. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`

### Additional Notes

Anything else we should know when reviewing?
