### PR TITLE
port kube_state to PrometheusCheck backend and add new 0.5 metrics

### DIFF
--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG - kubernetes_state
 
-1.1.0 Unreleased
+1.2.0 Unreleased
+==================
+
+### Changes
+
+* [FEATURE] Port to PrometheusCheck class and support for new 0.5.0 metrics
+
+1.1.0 06-05-2017
 ==================
 
 ### Changes

--- a/kubernetes_state/check.py
+++ b/kubernetes_state/check.py
@@ -1,52 +1,310 @@
-# (C) Datadog, Inc. 2016
+# (C) Datadog, Inc. 2016-2017
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-from checks import AgentCheck, CheckException
-from utils.prometheus import parse_metric_family
-from utils.kubernetes import KubeStateProcessor
 
-import requests
+from checks import CheckException
+from checks.prometheus_check import PrometheusCheck
+
+METRIC_TYPES = ['counter', 'gauge']
 
 
-class KubernetesState(AgentCheck):
+class KubernetesState(PrometheusCheck):
     """
-    Collect metrics from kube-state-metrics API [0].
-
-    [0] https://github.com/kubernetes/kube-state-metrics
+    Collect kube-state-metrics metrics in the Prometheus format
+    See https://github.com/kubernetes/kube-state-metrics
     """
     def __init__(self, name, init_config, agentConfig, instances=None):
         super(KubernetesState, self).__init__(name, init_config, agentConfig, instances)
-        self.kube_state_processor = KubeStateProcessor(self)
+        self.NAMESPACE = 'kubernetes_state'
+
+        self.pod_phase_to_status = {
+            'pending':   self.WARNING,
+            'running':   self.OK,
+            'succeeded': self.OK,
+            'failed':    self.CRITICAL,
+            'unknown':   self.UNKNOWN
+        }
+
+        self.condition_to_status_positive = {
+            'true':      self.OK,
+            'false':     self.CRITICAL,
+            'unknown':   self.UNKNOWN
+        }
+
+        self.condition_to_status_negative = {
+            'true':      self.CRITICAL,
+            'false':     self.OK,
+            'unknown':   self.UNKNOWN
+        }
+
+        self.metrics_mapper = {
+            'kube_daemonset_status_current_number_scheduled': 'daemonset.scheduled',
+            'kube_daemonset_status_desired_number_scheduled': 'daemonset.desired',
+            'kube_daemonset_status_number_misscheduled': 'daemonset.misscheduled',
+            'kube_daemonset_status_number_ready': 'daemonset.ready',
+            'kube_deployment_spec_paused': 'deployment.paused',
+            'kube_deployment_spec_replicas': 'deployment.replicas_desired',
+            'kube_deployment_spec_strategy_rollingupdate_max_unavailable': 'deployment.rollingupdate.max_unavailable',
+            'kube_deployment_status_replicas': 'deployment.replicas',
+            'kube_deployment_status_replicas_available': 'deployment.replicas_available',
+            'kube_deployment_status_replicas_unavailable': 'deployment.replicas_unavailable',
+            'kube_deployment_status_replicas_updated': 'deployment.replicas_updated',
+            'kube_node_status_allocatable_cpu_cores': 'node.cpu_allocatable',
+            'kube_node_status_allocatable_memory_bytes': 'node.memory_allocatable',
+            'kube_node_status_allocatable_pods': 'node.pods_allocatable',
+            'kube_node_status_capacity_cpu_cores': 'node.cpu_capacity',
+            'kube_node_status_capacity_memory_bytes': 'node.memory_capacity',
+            'kube_node_status_capacity_pods': 'node.pods_capacity',
+            'kube_pod_container_resource_limits_cpu_cores': 'container.cpu_limit',
+            'kube_pod_container_resource_limits_memory_bytes': 'container.memory_limit',
+            'kube_pod_container_resource_requests_cpu_cores': 'container.cpu_requested',
+            'kube_pod_container_resource_requests_memory_bytes': 'container.memory_requested',
+            'kube_pod_container_status_ready': 'container.ready',
+            'kube_pod_container_status_restarts': 'container.restarts',
+            'kube_pod_container_status_running': 'container.running',
+            'kube_pod_container_status_terminated': 'container.terminated',
+            'kube_pod_container_status_waiting': 'container.waiting',
+            'kube_pod_status_ready': 'pod.ready',
+            'kube_pod_status_scheduled': 'pod.scheduled',
+            'kube_replicaset_spec_replicas': 'replicaset.replicas_desired',
+            'kube_replicaset_status_fully_labeled_replicas': 'replicaset.fully_labeled_replicas',
+            'kube_replicaset_status_ready_replicas': 'replicaset.replicas_ready',
+            'kube_replicaset_status_replicas': 'replicaset.replicas',
+            'kube_replicationcontroller_spec_replicas': 'replicationcontroller.replicas_desired',
+            'kube_replicationcontroller_status_available_replicas': 'replicationcontroller.replicas_available',
+            'kube_replicationcontroller_status_fully_labeled_replicas': 'replicationcontroller.fully_labeled_replicas',
+            'kube_replicationcontroller_status_ready_replicas': 'replicationcontroller.replicas_ready',
+            'kube_replicationcontroller_status_replicas': 'replicationcontroller.replicas',
+        }
+
+        self.ignore_metrics = [
+            # _info and _labels don't convey any metric
+            'kube_cronjob_info',
+            'kube_job_info',
+            'kube_node_info',
+            'kube_node_labels',
+            'kube_pod_container_info',
+            'kube_pod_info',
+            'kube_pod_labels',
+            'kube_service_info',
+            'kube_service_labels',
+            # _generation metrics are more metadata than metrics, no real use case for now
+            'kube_daemonset_metadata_generation',
+            'kube_daemonset_metadata_generation',
+            'kube_deployment_metadata_generation',
+            'kube_deployment_status_observed_generation',
+            'kube_replicaset_metadata_generation',
+            'kube_replicaset_status_observed_generation',
+            'kube_replicationcontroller_metadata_generation',
+            'kube_replicationcontroller_status_observed_generation',
+            # kube_node_status_phase has no use case as a service check
+            'kube_node_status_phase',
+            # These CronJob and Job metrics need use cases to determine how do implement
+            'kube_cronjob_status_active',
+            'kube_cronjob_status_last_schedule_time',
+            'kube_cronjob_spec_suspend',
+            'kube_cronjob_spec_starting_deadline_seconds',
+            'kube_job_spec_active_dealine_seconds',
+            'kube_job_spec_completions',
+            'kube_job_spec_parallelism',
+            'kube_job_status_active',
+            'kube_job_status_completion_time',  # We could compute the duration=completion-start as a gauge
+            'kube_job_status_failed',     # Container number gauge, redundant with job-global kube_job_failed
+            'kube_job_status_start_time',
+            'kube_job_status_succeeded',  # Container number gauge, redundant with job-global kube_job_complete
+
+        ]
 
     def check(self, instance):
-        self._update_kube_state_metrics(instance)
-
-    def _update_kube_state_metrics(self, instance):
-        """
-        Retrieve the binary payload and process Prometheus metrics into
-        Datadog metrics.
-        """
-        kube_state_url = instance.get('kube_state_url')
-        if kube_state_url is None:
+        endpoint = instance.get('kube_state_url')
+        if endpoint is None:
             raise CheckException("Unable to find kube_state_url in config file.")
 
-        try:
-            payload = self._get_kube_state(kube_state_url)
-            msg = "Got a payload of size {} from Kube State API at url:{}".format(len(payload), kube_state_url)
-            self.log.debug(msg)
-            for metric in parse_metric_family(payload):
-                self.kube_state_processor.process(metric, instance=instance)
-        except Exception as e:
-            self.log.error("Unable to retrieve metrics from Kube State API: {}".format(e))
+        send_buckets = instance.get('send_histograms_buckets', True)
+        # By default we send the buckets.
+        if send_buckets is not None and str(send_buckets).lower() == 'false':
+            send_buckets = False
+        else:
+            send_buckets = True
 
-    def _get_kube_state(self, endpoint):
+        self.process(endpoint, send_histograms_buckets=send_buckets, instance=instance)
+
+    def _condition_to_service_check(self, metric, sc_name, mapping, tags=None):
         """
-        Get metrics from the Kube State API using the protobuf format.
-        """
-        headers = {
-            'accept': 'application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited',
-            'accept-encoding': 'gzip',
+        Some metrics contains conditions, labels that have "condition" as name and "true", "false", or "unknown"
+        as value. The metric value is expected to be a gauge equal to 0 or 1 in this case.
+        For example:
+
+        metric {
+          label { name: "condition", value: "true"
+          }
+          # other labels here
+          gauge { value: 1.0 }
         }
-        req = requests.get(endpoint, headers=headers)
-        req.raise_for_status()
-        return req.content
+
+        This function evaluates metrics containing conditions and sends a service check
+        based on a provided condition->check mapping dict
+        """
+        if bool(metric.gauge.value) is False:
+            return  # Ignore if gauge is not 1
+        for label in metric.label:
+            if label.name == 'condition':
+                if label.value in mapping:
+                    self.service_check(sc_name, mapping[label.value], tags=tags)
+                else:
+                    self.log.debug("Unable to handle %s - unknown condition %s" % (sc_name, label.value))
+
+    def _extract_label_value(self, name, labels):
+        """
+        Search for `name` in labels name and returns
+        corresponding value.
+        Returns None if name was not found.
+        """
+        for label in labels:
+            if label.name == name:
+                return label.value
+        return None
+
+    def _label_to_tag(self, name, labels, tag_name=None):
+        """
+        Search for `name` in labels name and returns corresponding tag string.
+        Tag name is label name if not specified.
+        Returns None if name was not found.
+        """
+        value = self._extract_label_value(name, labels)
+        if value:
+            return '%s:%s' % (tag_name or name, value)
+        else:
+            return None
+
+    # Labels attached: namespace, pod, phase=Pending|Running|Succeeded|Failed|Unknown
+    # The phase gets not passed through; rather, it becomes the service check suffix.
+    def kube_pod_status_phase(self, message, **kwargs):
+        """ Phase a pod is in. """
+        check_basename = self.NAMESPACE + '.pod.phase.'
+        for metric in message.metric:
+            # The gauge value is always 1, no point in fetching it.
+            phase = ''
+            tags = []
+            for label in metric.label:
+                if label.name == 'phase':
+                    phase = label.value.lower()
+                else:
+                    tags.append('{}:{}'.format(label.name, label.value))
+            #TODO: add deployment/replicaset?
+            status = self.pod_phase_to_status.get(phase, self.UNKNOWN)
+            self.service_check(check_basename + phase, status, tags=tags)
+
+    def kube_job_complete(self, message, **kwargs):
+        service_check_name = self.NAMESPACE + '.job.complete'
+        for metric in message.metric:
+            tags = []
+            for label in metric.label:
+                tags.append('{}:{}'.format(label.name, label.value))
+            self.service_check(service_check_name, self.OK, tags=tags)
+
+    def kube_job_failed(self, message, **kwargs):
+        service_check_name = self.NAMESPACE + '.job.complete'
+        for metric in message.metric:
+            tags = []
+            for label in metric.label:
+                tags.append('{}:{}'.format(label.name, label.value))
+            self.service_check(service_check_name, self.CRITICAL, tags=tags)
+
+    def kube_node_status_ready(self, message, **kwargs):
+        """ The ready status of a cluster node. """
+        service_check_name = self.NAMESPACE + '.node.ready'
+        for metric in message.metric:
+            self._condition_to_service_check(metric, service_check_name, self.condition_to_status_positive,
+                                             tags=[self._label_to_tag("node", metric.label)])
+
+    def kube_node_status_out_of_disk(self, message, **kwargs):
+        """ Whether the node is out of disk space. """
+        service_check_name = self.NAMESPACE + '.node.out_of_disk'
+        for metric in message.metric:
+            self._condition_to_service_check(metric, service_check_name, self.condition_to_status_negative,
+                                             tags=[self._label_to_tag("node", metric.label)])
+
+    def kube_node_status_memory_pressure(self, message, **kwargs):
+        """ Whether the node is in a memory pressure state. """
+        service_check_name = self.NAMESPACE + '.node.memory_pressure'
+        for metric in message.metric:
+            self._condition_to_service_check(metric, service_check_name, self.condition_to_status_negative,
+                                             tags=[self._label_to_tag("node", metric.label)])
+
+    def kube_node_status_disk_pressure(self, message, **kwargs):
+        """ Whether the node is in a disk pressure state. """
+        service_check_name = self.NAMESPACE + '.node.disk_pressure'
+        for metric in message.metric:
+            self._condition_to_service_check(metric, service_check_name, self.condition_to_status_negative,
+                                             tags=[self._label_to_tag("node", metric.label)])
+
+    def kube_node_status_network_unavailable(self, message, **kwargs):
+        """ Whether the node is in a network unavailable state. """
+        service_check_name = self.NAMESPACE + '.node.network_unavailable'
+        for metric in message.metric:
+            self._condition_to_service_check(metric, service_check_name, self.condition_to_status_negative,
+                                             tags=[self._label_to_tag("node", metric.label)])
+
+    def kube_node_spec_unschedulable(self, message, **kwargs):
+        """ Whether a node can schedule new pods. """
+        metric_name = self.NAMESPACE + '.node.status'
+        statuses = ('schedulable', 'unschedulable')
+        if message.type < len(METRIC_TYPES):
+            for metric in message.metric:
+                tags = ['{}:{}'.format(label.name, label.value) for label in metric.label]
+                status = statuses[int(getattr(metric, METRIC_TYPES[message.type]).value)]  # value can be 0 or 1
+                tags.append('status:{}'.format(status))
+                self.gauge(metric_name, 1, tags)  # metric value is always one, value is on the tags
+        else:
+            self.log.error("Metric type %s unsupported for metric %s" % (message.type, message.name))
+
+    def kube_resourcequota(self, message, **kwargs):
+        """ Quota and current usage by resource type. """
+        metric_base_name = self.NAMESPACE + '.resourcequota.{}.{}'
+        suffixes = {'used': 'used', 'hard': 'limit'}
+        if message.type < len(METRIC_TYPES):
+            for metric in message.metric:
+                mtype = self._extract_label_value("type", metric.label)
+                resource = self._extract_label_value("resource", metric.label)
+                tags = [
+                    self._label_to_tag("namespace", metric.label),
+                    self._label_to_tag("resourcequota", metric.label)
+                ]
+                val = getattr(metric, METRIC_TYPES[message.type]).value
+                self.gauge(metric_base_name.format(resource, suffixes[mtype]), val, tags)
+        else:
+            self.log.error("Metric type %s unsupported for metric %s" % (message.type, message.name))
+
+    def kube_limitrange(self, message, **kwargs):
+        """ Resource limits by consumer type. """
+        # type's cardinality is low: https://github.com/kubernetes/kubernetes/blob/v1.6.1/pkg/api/v1/types.go#L3872-L3879
+        # idem for resource: https://github.com/kubernetes/kubernetes/blob/v1.6.1/pkg/api/v1/types.go#L3342-L3352
+        # idem for constraint: https://github.com/kubernetes/kubernetes/blob/v1.6.1/pkg/api/v1/types.go#L3882-L3901
+        metric_base_name = self.NAMESPACE + '.limitrange.{}.{}'
+        constraints = {
+            'min': 'min',
+            'max': 'max',
+            'default': 'default',
+            'defaultRequest': 'default_request',
+            'maxLimitRequestRatio': 'max_limit_request_ratio',
+        }
+
+        if message.type < len(METRIC_TYPES):
+            for metric in message.metric:
+                constraint = self._extract_label_value("constraint", metric.label)
+                if constraint in constraints:
+                    constraint = constraints[constraint]
+                else:
+                    self.error("Constraint %s unsupported for metric %s" % (constraint, message.name))
+                    continue
+                resource = self._extract_label_value("resource", metric.label)
+                tags = [
+                    self._label_to_tag("namespace", metric.label),
+                    self._label_to_tag("limitrange", metric.label),
+                    self._label_to_tag("type", metric.label, tag_name="consumer_type")
+                ]
+                val = getattr(metric, METRIC_TYPES[message.type]).value
+                self.gauge(metric_base_name.format(resource, constraint), val, tags)
+        else:
+            self.log.error("Metric type %s unsupported for metric %s" % (message.type, message.name))

--- a/kubernetes_state/manifest.json
+++ b/kubernetes_state/manifest.json
@@ -2,7 +2,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.0",
   "max_agent_version": "6.0.0",
-  "min_agent_version": "5.6.3",
+  "min_agent_version": "5.15.0",
   "name": "kubernetes_state",
   "short_description": "kubernetes_state description.",
   "guid": "fa0e4395-3eae-4df8-88f2-9d7075c21a2d",
@@ -11,6 +11,6 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.1.0",
+  "version": "1.2.0",
   "use_omnibus_reqs": true
 }

--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -5,6 +5,7 @@ kubernetes_state.node.pods_capacity,gauge,,,,The total pod resources of the node
 kubernetes_state.node.cpu_allocatable,gauge,,cpu,,The CPU resources of a node that are available for scheduling,0,kubernetes,k8s_state.node.cpu_allocatable
 kubernetes_state.node.memory_allocatable,gauge,,byte,,The memory resources of a node that are available for scheduling,0,kubernetes,k8s_state.node.memory_allocatable
 kubernetes_state.node.pods_allocatable,gauge,,,,The pod resources of a node that are available for scheduling,0,kubernetes,k8s_state.node.pods_allocatable
+kubernetes_state.node.status,gauge,,,,The number of nodes in a given status, per tag,0,kubernetes,k8s_state.node.status
 kubernetes_state.deployment.replicas,gauge,,,,The number of replicas per deployment,0,kubernetes,k8s_state.deployment.replicas
 kubernetes_state.deployment.replicas_available,gauge,,,,The number of available replicas per deployment,0,kubernetes,k8s_state.deployment.replicas_available
 kubernetes_state.deployment.replicas_unavailable,gauge,,,,The number of unavailable replicas per deployment,0,kubernetes,k8s_state.deployment.replicas_unavailable
@@ -15,6 +16,7 @@ kubernetes_state.deployment.rollingupdate.max_unavailable,gauge,,,,Maximum numbe
 kubernetes_state.daemonset.scheduled,gauge,,,,The number of nodes running at least one daemon pod and that are supposed to,0,kubernetes,k8s_state.ds.scheduled
 kubernetes_state.daemonset.misscheduled,gauge,,,,The number of nodes running a daemon pod but are not supposed to,-1,kubernetes,k8s_state.ds.misscheduled
 kubernetes_state.daemonset.desired,gauge,,,,The number of nodes that should be running the daemon pod,0,kubernetes,k8s_state.ds.desired
+kubernetes_state.daemonset.ready,gauge,,,,The number of nodes that should be running the daemon pod and have one or more running and ready,0,kubernetes,k8s_state.ds.ready
 kubernetes_state.pod.ready,gauge,,,,Whether the pod is ready to serve requests,1,kubernetes,k8s_state.pod.ready
 kubernetes_state.pod.scheduled,gauge,,,,Reports the status of the scheduling process for the pod with its tags,0,kubernetes,k8s_state.pod.scheduled
 kubernetes_state.container.ready,gauge,,,,Whether the containers readiness check succeeded,0,kubernetes,k8s_state.container.rdy
@@ -30,6 +32,11 @@ kubernetes_state.replicaset.replicas,gauge,,,,The number of replicas per Replica
 kubernetes_state.replicaset.fully_labeled_replicas,gauge,,,,The number of fully labeled replicas per ReplicaSet,0,kubernetes,k8s_state.rs.fully_labeled
 kubernetes_state.replicaset.replicas_ready,gauge,,,,The number of ready replicas per ReplicaSet,0,kubernetes,k8s_state.rs.replicas_rdy
 kubernetes_state.replicaset.replicas_desired,gauge,,,,Number of desired pods for a ReplicaSet,0,kubernetes,k8s_state.rs.replicas_desired
+kubernetes_state.replicationcontroller.replicas,gauge,,,,The number of replicas per ReplicationController,0,kubernetes,k8s_state.rc.replicas
+kubernetes_state.replicationcontroller.fully_labeled_replicas,gauge,,,,The number of fully labeled replicas per ReplicationController,0,kubernetes,k8s_state.rc.fully_labeled
+kubernetes_state.replicationcontroller.replicas_ready,gauge,,,,The number of ready replicas per ReplicationController,0,kubernetes,k8s_state.rc.replicas_rdy
+kubernetes_state.replicationcontroller.replicas_desired,gauge,,,,Number of desired replicas for a ReplicationController,0,kubernetes,k8s_state.rc.replicas_desired
+kubernetes_state.replicationcontroller.replicas_available,gauge,,,,The number of available replicas per ReplicationController,0,kubernetes,k8s_state.rc.replicas_available
 kubernetes_state.resourcequota.pods.used,gauge,,,,Observed number of pods used for a resource quota,0,kubernetes,k8s_state.resourcequota.pods.used
 kubernetes_state.resourcequota.services.used,gauge,,,,Observed number of services used for a resource quota,0,kubernetes,k8s_state.resourcequota.svc.used
 kubernetes_state.resourcequota.persistentvolumeclaims.used,gauge,,,,Observed number of persistent volume claims used for a resource quota,0,kubernetes,k8s_state.resourcequota.pvc.used
@@ -50,3 +57,13 @@ kubernetes_state.resourcequota.requests.memory.limit,gauge,,byte,,Hard limit on 
 kubernetes_state.resourcequota.requests.storage.limit,gauge,,byte,,Hard limit on the total of storage bytes requested for a resource quota,0,kubernetes,k8s_state.resourcequota.requests.storage.limit
 kubernetes_state.resourcequota.limits.cpu.limit,gauge,,cpu,,Hard limit on the sum of CPU core limits for a resource quota,0,kubernetes,k8s_state.resourcequota.limits.cpu.limit
 kubernetes_state.resourcequota.limits.memory.limit,gauge,,byte,,Hard limit on the sum of memory bytes limits for a resource quota,0,kubernetes,k8s_state.resourcequota.limits.mem.limit
+kubernetes_state.limitrange.cpu.min,,,,Minimum CPU request for this type,0,kubernetes,k8s_state.cpu.min
+kubernetes_state.limitrange.cpu.max,,,,Maximum CPU limit for this type,0,kubernetes,k8s_state.cpu.max
+kubernetes_state.limitrange.cpu.default,,,,Default CPU limit if not specified,0,kubernetes,k8s_state.cpu.default
+kubernetes_state.limitrange.cpu.default_request,,,,Default CPU request if not specified,0,kubernetes,k8s_state.cpu.default_request
+kubernetes_state.limitrange.cpu.max_limit_request_ratio,,,,Maximum CPU limit / request ratio,0,kubernetes,k8s_state.cpu.max_ratio
+kubernetes_state.limitrange.memory.min,,,,Minimum memory request for this type,0,kubernetes,k8s_state.mem.min
+kubernetes_state.limitrange.memory.max,,,,Maximum memory limit for this type,0,kubernetes,k8s_state.mem.max
+kubernetes_state.limitrange.memory.default,,,,Default memory limit if not specified,0,kubernetes,k8s_state.mem.default
+kubernetes_state.limitrange.memory.default_request,,,,Default memory request if not specified,0,kubernetes,k8s_state.mem.default_request
+kubernetes_state.limitrange.memory.max_limit_request_ratio,,,,Maximum memory limit / request ratio,0,kubernetes,k8s_state.mem.max_ratio

--- a/kubernetes_state/test_kubernetes_state.py
+++ b/kubernetes_state/test_kubernetes_state.py
@@ -63,29 +63,6 @@ class TestKubernetesState(AgentCheckTest):
         NAMESPACE + '.container.waiting',
     ]
 
-    def test__get_kube_state(self):
-        headers = {
-            'accept': 'application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited',
-            'accept-encoding': 'gzip',
-        }
-        url = 'https://example.com'
-
-        self.load_check({'instances': [{'host': 'foo'}]})
-        with mock.patch('{}.requests'.format(self.check.__module__)) as r:
-            self.check._get_kube_state(url)
-            r.get.assert_called_once_with(url, headers=headers)
-
-    def test_kube_state(self):
-        mocked = mock.MagicMock()
-        mocks = {
-            '_perform_kubelet_checks': mock.MagicMock(),
-            '_update_metrics': mock.MagicMock(),
-            '_update_kube_state_metrics': mocked,
-        }
-        config = {'instances': [{'host': 'foo', 'kube_state_url': 'https://example.com:12345'}]}
-        self.run_check(config, force_reload=True, mocks=mocks)
-        mocked.assert_called_once()
-
     def assertMetricNotAllZeros(self, metric_name):
         for mname, ts, val, mdata in self.metrics:
             if mname == metric_name:
@@ -93,18 +70,11 @@ class TestKubernetesState(AgentCheckTest):
                     return True
         raise AssertionError("All metrics named %s have 0 value." % metric_name)
 
-    def test__update_kube_state_metrics(self):
+    @mock.patch('checks.prometheus_check.PrometheusCheck.poll')
+    def test__update_kube_state_metrics(self, mock_poll):
         f_name = os.path.join(os.path.dirname(__file__), 'ci', 'fixtures', 'prometheus', 'protobuf.bin')
-        mocked = mock.MagicMock()
         with open(f_name, 'rb') as f:
-            mocked.return_value = f.read()
-
-        mocks = {
-            '_perform_kubelet_checks': mock.MagicMock(),
-            '_update_metrics': mock.MagicMock(),
-            'kubeutil': mock.MagicMock(),
-            '_get_kube_state': mocked,
-        }
+            mock_poll.return_value = ('application/vnd.google.protobuf', f.read())
 
         config = {
             'instances': [{
@@ -113,7 +83,7 @@ class TestKubernetesState(AgentCheckTest):
             }]
         }
 
-        self.run_check(config, mocks=mocks)
+        self.run_check(config)
 
         self.assertServiceCheck(NAMESPACE + '.node.ready', self.check.OK)
         self.assertServiceCheck(NAMESPACE + '.node.out_of_disk', self.check.OK)


### PR DESCRIPTION
### What does this PR do?

- [x] Port the kubernetes_state check to PrometheusCheck
- [x] update metrics for 0.5.0
- [x] update tests
- [x] update metadata

Ignored metrics are documented in the self.ignored_metrics array, this needs https://github.com/DataDog/dd-agent/pull/3394 to be actually taken into account.
