### PR TITLE
[kubernetes] Fix typo in reporting of exception when unable to collect metrics for a container

### DIFF
--- a/kubernetes/CHANGELOG.md
+++ b/kubernetes/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [IMPROVEMENT] query kubernetes service mapping every 5 minutes to reduce apiserver traffic (see service_tag_update_freq option) and add collect_service_tags option to disable it completely. See [#476][]
+* [IMPROVEMENT] Fix typo in exception reporting when unable to collect metrics for a container. See [#493][]
 
 1.1.0 / Unreleased
 ==================

--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -364,8 +364,8 @@ class Kubernetes(AgentCheck):
                 # also store tags for aliases
                 for alias in subcontainer.get('aliases', []):
                     container_tags[alias] = tags
-            except Exception, e:
-                self.log.error("Unable to collect metrics for container: {0} ({1}".format(c_id, e))
+            except Exception as e:
+                self.log.error("Unable to collect metrics for container: {0} ({1})".format(c_id, e))
 
         # container metrics from kubernetes API: limits and requests
         for pod in pods_list['items']:


### PR DESCRIPTION
### What does this PR do?

Fix a typo in the reporting of an exception and using the python 2.5+ format for exception (using as instead of comma)

### Motivation

Sanity cleanup


### Versioning

- [X] Updated `CHANGELOG.md`

