### PR TITLE
[kubernetes] Fix failures when the spec has "has_filesystem" entry but no stats entry for filesystem

### DIFF
--- a/kubernetes/CHANGELOG.md
+++ b/kubernetes/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [IMPROVEMENT] query kubernetes service mapping every 5 minutes to reduce apiserver traffic (see service_tag_update_freq option) and add collect_service_tags option to disable it completely. See [#476][]
 * [IMPROVEMENT] Fix typo in exception reporting when unable to collect metrics for a container. See [#493][]
+* [BUGFIX] fix failures when the spec has "has_filesystem" entry but no stats entry for filesystem. See [#494][]
 
 1.1.0 / Unreleased
 ==================

--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -321,7 +321,7 @@ class Kubernetes(AgentCheck):
         stats = subcontainer['stats'][-1]  # take the latest
         self._publish_raw_metrics(NAMESPACE, stats, tags)
 
-        if subcontainer.get("spec", {}).get("has_filesystem"):
+        if subcontainer.get("spec", {}).get("has_filesystem") and stats.get('filesystem', []) != []:
             fs = stats['filesystem'][-1]
             fs_utilization = float(fs['usage'])/float(fs['capacity'])
             self.publish_gauge(self, NAMESPACE + '.filesystem.usage_pct', fs_utilization, tags)


### PR DESCRIPTION
### What does this PR do?

Do not fail with an error message like the following when the spec contains a "has_filesystem" entry but no "filesystem" on stats.
```
2017-06-21 21:26:11 UTC | ERROR | dd.collector | checks.kubernetes(kubernetes.py:339) | Unable to collect metrics for container: f4463bab8651c821464306966aaaab7fadaaf438f04c2e246465c23e85bacd70 ('filesystem'
```

### Motivation

We are currently upgrading our storage driver from overlay1 to overlay2 on kubernetes 1.5.7 with the hosts on latest coreos alpha and the latest dd-agent (note we already tried a few months back and had the same issue but we didn't take the time to dig more).
Note: other elements that do have a real device show a filesystem property but those are just a mount of a directory from the host server. Using overlay1 their "has_filesystem" property is set to false now some are set to True wit overlay2.

Example (I really added a TON of debug on that so the line number don't match):
```
2017-06-22 00:38:07 UTC | DEBUG | dd.collector | checks.kubernetes(kubernetes.py:310) | _update_container_metrics - subcontainer.get('spec', ): {u'has_memory': True, u'has_filesystem': True, u'has_diskio': True, u'has_network': True, u'image': u'gcr.io/google_containers/pause-amd64:3.0', u'labels': {u'io.kubernetes.pod.namespace': u'kube-system', u'io.kubernetes.pod.name': u'myapp1-x65j2', u'io.kubernetes.container.terminationMessagePath': u'', u'io.kubernetes.container.restartCount': u'0', u'io.kubernetes.container.name': u'POD', u'io.kubernetes.pod.terminationGracePeriod': u'30', u'io.kubernetes.pod.uid': u'48743689-56d6-11e7-a253-0aaf59018e60', u'io.kubernetes.container.hash': u'd8dbe16c'}, u'creation_time': u'2017-06-21T23:06:46.354656044Z', u'has_cpu': True, u'memory': {u'reservation': 9223372036854771712, u'limit': 9223372036854771712, u'swap_limit': 9223372036854771712}, u'cpu': {u'mask': u'0-7', u'max_limit': 0, u'limit': 2, u'period': 100000}, u'has_custom_metrics': False}                                                                                                                             
2017-06-22 00:38:07 UTC | DEBUG | dd.collector | checks.kubernetes(kubernetes.py:312) | _update_container_metrics - subcontainer.get('spec',).get('has_filesystem'): True                                                                                                                
2017-06-22 00:38:07 UTC | DEBUG | dd.collector | checks.kubernetes(kubernetes.py:317) | _update_container_metrics - stats={u'network': {u'tx_dropped': 0, u'rx_packets': 1835250, u'name': u'eth0', u'rx_bytes': 2357507895, u'tx_errors': 0, u'interfaces': [{u'tx_dropped': 0, u'rx_packets': 1835250, u'name': u'eth0', u'rx_bytes': 2357507895, u'tx_errors': 0, u'rx_errors': 0, u'tx_bytes': 197221121, u'rx_dropped': 0, u'tx_packets': 399563}, {u'tx_dropped': 22, u'rx_packets': 14390, u'name': u'flannel.1', u'rx_bytes': 876327, u'tx_errors': 0, u'rx_errors': 0, u'tx_bytes': 798756, u'rx_dropped': 0, u'tx_packets': 12947}], u'tcp': {u'Established': 0, u'FinWait2': 0, u'TimeWait': 0, u'FinWait1': 0, u'LastAck': 0, u'CloseWait': 0, u'Close': 0, u'Closing': 0, u'Listen': 0, u'SynRecv': 0, u'SynSent': 0}, u'rx_errors': 0, u'tx_bytes': 197221121, u'rx_dropped': 0, u'tx_packets': 399563, u'tcp6': {u'Established': 0, u'FinWait2': 0, u'TimeWait': 0, u'FinWait1': 0, u'LastAck': 0, u'CloseWait': 0, u'Close': 0, u'Closing': 0, u'Listen': 0, u'SynRecv': 0, u'SynSent': 0}}, u'timestamp': u'2017-06-22T00:38:00.573700438Z', u'task_stats': {u'nr_stopped': 0, u'nr_sleeping': 0, u'nr_uninterruptible': 0, u'nr_running': 0, u'nr_io_wait': 0}, u'diskio': {}, u'memory': {u'cache': 0, u'working_set': 331776, u'failcnt': 0, u'hierarchical_data': {u'pgfault': 188, u'pgmajfault': 0}, u'swap': 0, u'usage': 331776, u'container_data': {u'pgfault': 188, u'pgmajfault': 0}, u'rss': 40960}, u'cpu': {u'usage': {u'system': 0, u'total': 13885455, u'user': 0, u'per_cpu_usage': [26105, 181819, 909043, 349613, 154247, 60259, 10934238, 1270131, 0, 0, 0, 0, 0, 0, 0]}, u'load_average': 0, u'cfs': {u'throttled_time
': 0, u'periods': 0, u'throttled_periods': 0}}}
```

### Versioning

- [ ] Bumped the version check in `manifest.json` => already unreleased
- [X] Updated `CHANGELOG.md`
