### PR TITLE
[kubernetes] bugfix for correct hostname in k8s events 

### DIFF
--- a/kubernetes/CHANGELOG.md
+++ b/kubernetes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - kubernetes
 
+1.1.2 / Unreleased
+==================
+### Changes
+[BUGFIX] Use correct Node hostname in event collection
+
 1.1.1 / Unreleased
 ==================
 ### Changes

--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -496,11 +496,13 @@ class Kubernetes(AgentCheck):
             tags = self.kubeutil.extract_event_tags(event)
             tags.extend(instance.get('tags', []))
 
-            title = '{} {} on {}'.format(involved_obj.get('name'), event.get('reason'), node_name)
+            title = '{} {}'.format(involved_obj.get('name'), event.get('reason'))
             message = event.get('message')
             source = event.get('source')
             if source:
+                title += ' on {}'.format(source.get('host', ''))
                 message += '\nSource: {} {}\n'.format(source.get('component', ''), source.get('host', ''))
+                
             msg_body = "%%%\n{}\n```\n{}\n```\n%%%".format(title, message)
             dd_event = {
                 'timestamp': event_ts,

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -11,5 +11,5 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.1.1"
+  "version": "1.1.2"
 }


### PR DESCRIPTION
Use the associated hostname from the k8s Events API when posting a Datadog Event, rather than `node_name` where the check is being run.