### PR TITLE
Tag MySQL replication metrics with the source replication channel

### DIFF
--- a/activemq/CHANGELOG.md
+++ b/activemq/CHANGELOG.md
@@ -1,12 +1,3 @@
-# CHANGELOG - mysql
-
-1.0.1
-==================
-
-### Changes
-
-* [FEATURE] tag `mysql.replication.*` metrics with the replication channel name
-
 # CHANGELOG - activemq
 
 1.0.1 / 2017-11-21

--- a/activemq/CHANGELOG.md
+++ b/activemq/CHANGELOG.md
@@ -1,3 +1,12 @@
+# CHANGELOG - mysql
+
+1.0.1
+==================
+
+### Changes
+
+* [FEATURE] tag `mysql.replication.*` metrics with the replication channel name
+
 # CHANGELOG - activemq
 
 1.0.1 / 2017-11-21

--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG - mysql
 
+1.1.0 / Unreleased
+==================
+
+### Changes
+
+* [FEATURE] tag `mysql.replication.*` metrics with the replication channel name
+
+
 1.0.5 / 2017-11-21
 ==================
 

--- a/mysql/check.py
+++ b/mysql/check.py
@@ -865,7 +865,7 @@ class MySql(AgentCheck):
                             if key not in replica_results:
                                 replica_results[key] = {}
 
-                            if slave_result[key]:
+                            if slave_result[key] is not None:
                                 replica_results[key]["channel:{0}".format(channel)] = slave_result[key]
 
                 cursor.execute("SHOW MASTER STATUS;")

--- a/mysql/check.py
+++ b/mysql/check.py
@@ -859,10 +859,9 @@ class MySql(AgentCheck):
                         # MySQL <5.7 does not have Channel_Name
                         channel = slave_result.get('Channel_Name', 'default')
                         for key in slave_result:
-                            if key not in replica_results:
-                                replica_results[key] = {}
-
                             if slave_result[key] is not None:
+                                if key not in replica_results:
+                                    replica_results[key] = {}
                                 replica_results[key]["channel:{0}".format(channel)] = slave_result[key]
 
                 cursor.execute("SHOW MASTER STATUS;")

--- a/mysql/check.py
+++ b/mysql/check.py
@@ -857,10 +857,7 @@ class MySql(AgentCheck):
                 if len(slave_results) > 0:
                     for slave_result in slave_results:
                         # MySQL <5.7 does not have Channel_Name
-                        if 'Channel_Name' in slave_result:
-                            channel = slave_result['Channel_Name'] or 'default'
-                        else:
-                            channel = 'default'
+                        channel = slave_result.get('Channel_Name', 'default')
                         for key in slave_result:
                             if key not in replica_results:
                                 replica_results[key] = {}

--- a/mysql/check.py
+++ b/mysql/check.py
@@ -543,12 +543,12 @@ class MySql(AgentCheck):
             # MySQL 5.7.x might not have 'Slave_running'. See: https://bugs.mysql.com/bug.php?id=78544
             # look at replica vars collected at the top of if-block
             if self._version_compatible(db, host, (5, 7, 0)):
-                slave_io_running = self._collect_string('Slave_IO_Running', results)
-                slave_sql_running = self._collect_string('Slave_SQL_Running', results)
+                slave_io_running = self._collect_type('Slave_IO_Running', results, dict)
+                slave_sql_running = self._collect_type('Slave_SQL_Running', results, dict)
                 if slave_io_running:
-                    slave_io_running = (slave_io_running.lower().strip() == "yes")
+                    slave_io_running = any(v.lower().strip() == 'yes' for v in slave_io_running.itervalues())
                 if slave_sql_running:
-                    slave_sql_running = (slave_sql_running.lower().strip() == "yes")
+                    slave_sql_running = any(v.lower().strip() == 'yes' for v in slave_sql_running.itervalues())
 
                 if not (slave_io_running is None and slave_sql_running is None):
                     if slave_io_running and slave_sql_running:
@@ -851,10 +851,17 @@ class MySql(AgentCheck):
         try:
             with closing(db.cursor(pymysql.cursors.DictCursor)) as cursor:
                 replica_results = {}
+
                 cursor.execute("SHOW SLAVE STATUS;")
-                slave_results = cursor.fetchone()
-                if slave_results:
-                    replica_results.update(slave_results)
+                slave_results = cursor.fetchall()
+                if len(slave_results) > 0:
+                    for slave_result in slave_results:
+                        channel = slave_result['Channel_Name'] or 'default'
+                        for key in slave_result:
+                            if key not in replica_results:
+                                replica_results[key] = {}
+                            replica_results[key]["channel:{0}".format(channel)] = slave_result[key]
+
                 cursor.execute("SHOW MASTER STATUS;")
                 binlog_results = cursor.fetchone()
                 if binlog_results:

--- a/mysql/check.py
+++ b/mysql/check.py
@@ -864,7 +864,9 @@ class MySql(AgentCheck):
                         for key in slave_result:
                             if key not in replica_results:
                                 replica_results[key] = {}
-                            replica_results[key]["channel:{0}".format(channel)] = slave_result[key]
+
+                            if slave_result[key]:
+                                replica_results[key]["channel:{0}".format(channel)] = slave_result[key]
 
                 cursor.execute("SHOW MASTER STATUS;")
                 binlog_results = cursor.fetchone()

--- a/mysql/check.py
+++ b/mysql/check.py
@@ -856,7 +856,11 @@ class MySql(AgentCheck):
                 slave_results = cursor.fetchall()
                 if len(slave_results) > 0:
                     for slave_result in slave_results:
-                        channel = slave_result['Channel_Name'] or 'default'
+                        # MySQL <5.7 does not have Channel_Name
+                        if 'Channel_Name' in slave_result:
+                            channel = slave_result['Channel_Name'] or 'default'
+                        else:
+                            channel = 'default'
                         for key in slave_result:
                             if key not in replica_results:
                                 replica_results[key] = {}

--- a/mysql/check.py
+++ b/mysql/check.py
@@ -856,8 +856,9 @@ class MySql(AgentCheck):
                 slave_results = cursor.fetchall()
                 if len(slave_results) > 0:
                     for slave_result in slave_results:
-                        # MySQL <5.7 does not have Channel_Name
-                        channel = slave_result.get('Channel_Name', 'default')
+                        # MySQL <5.7 does not have Channel_Name.
+                        # For MySQL >=5.7 'Channel_Name' is set to an empty string by default
+                        channel = slave_result.get('Channel_Name') or 'default'
                         for key in slave_result:
                             if slave_result[key] is not None:
                                 if key not in replica_results:

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1.1",
   "name": "MySQL",
   "display_name": "MySQL",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "support": "core",
   "supported_os": [
     "linux",

--- a/mysql/test_mysql.py
+++ b/mysql/test_mysql.py
@@ -400,6 +400,8 @@ class TestMySql(AgentCheckTest):
         config['instances'][0]['port'] = 13307
         self.run_check_twice(config)
 
+        self.assertMetricTag('mysql.replication.seconds_behind_master', 'channel:default')
+
         # Test service check
         self.assertServiceCheck('mysql.can_connect', status=AgentCheck.OK,
                                 tags=self.SC_TAGS_REPLICA, count=1)


### PR DESCRIPTION
Fixes #500

### What does this PR do?

MySQL 5.7 introduces "replication channels", which means a slave can replicate from multiple masters ("sources") at any given time.

This PR tags the mysql.replication.seconds_behind_master metric with `channel:<CHANNEL_NAME>`. That way users could get an average across the channels, or have monitors alert when one of the channels falls behind.

### Motivation

Inability to monitor  if all replication channels are actually caught up to `master`.

### Testing Guidelines

I've added an assertion to the `test_complex_config_replica` test to make sure that the channel name is tagged.

### Versioning

- [X] Bumped the version check in `manifest.json`
- [X] Updated `CHANGELOG.md`
