### PR TITLE
Adds extra check for service checks

### DIFF
--- a/tcp_check/test_tcp_check.py
+++ b/tcp_check/test_tcp_check.py
@@ -52,7 +52,7 @@ class TCPCheckTest(AgentCheckTest):
         Raise after
         """
 
-        # Check the initial values to see if we already have a results before waiting for the async
+        # Check the initial values to see if we already have results before waiting for the async
         # instances to finish
         initial_values = getattr(self, attribute)
 

--- a/tcp_check/test_tcp_check.py
+++ b/tcp_check/test_tcp_check.py
@@ -51,12 +51,13 @@ class TCPCheckTest(AgentCheckTest):
 
         Raise after
         """
-        num_service_checks = len(self.getattr(self.check, attribute))
+        service_checks = getattr(self, attribute)
+
         i = 0
         while i < RESULTS_TIMEOUT:
             self.check._process_results()
-            if len(getattr(self.check, attribute)) + num_service_checks >= count:
-                return getattr(self.check, method)()
+            if len(getattr(self.check, attribute)) + len(service_checks) >= count:
+                return getattr(self.check, method)() + service_checks
             time.sleep(1.1)
             i += 1
         raise Exception("Didn't get the right count of service checks in time, {0}/{1} in {2}s: {3}"

--- a/tcp_check/test_tcp_check.py
+++ b/tcp_check/test_tcp_check.py
@@ -51,10 +51,11 @@ class TCPCheckTest(AgentCheckTest):
 
         Raise after
         """
+        num_service_checks = len(self.getattr(self.check, attribute))
         i = 0
         while i < RESULTS_TIMEOUT:
             self.check._process_results()
-            if len(getattr(self.check, attribute)) >= count:
+            if len(getattr(self.check, attribute)) + num_service_checks >= count:
                 return getattr(self.check, method)()
             time.sleep(1.1)
             i += 1

--- a/tcp_check/test_tcp_check.py
+++ b/tcp_check/test_tcp_check.py
@@ -51,13 +51,16 @@ class TCPCheckTest(AgentCheckTest):
 
         Raise after
         """
-        service_checks = getattr(self, attribute)
+
+        # Check the initial values to see if we already have a results before waiting for the async
+        # instances to finish
+        initial_values = getattr(self, attribute)
 
         i = 0
         while i < RESULTS_TIMEOUT:
             self.check._process_results()
-            if len(getattr(self.check, attribute)) + len(service_checks) >= count:
-                return getattr(self.check, method)() + service_checks
+            if len(getattr(self.check, attribute)) + len(initial_values) >= count:
+                return getattr(self.check, method)() + initial_values
             time.sleep(1.1)
             i += 1
         raise Exception("Didn't get the right count of service checks in time, {0}/{1} in {2}s: {3}"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Checks to see if we already have a service check before processing results. 

### Motivation

The TCP check seemed to be flaky due to how quickly the localhost check was returning. From the logs, it appears that this was sending a DOWN service check after about 0ms, so depending on how long this took, the test could fail because we may not see this service check. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`

### Additional Notes

Anything else we should know when reviewing?
