### PR TITLE
add Kubernetes Container name to tags

### DIFF
--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -446,6 +446,9 @@ class DockerDaemon(AgentCheck):
                                 tags.append("kube_replication_controller:%s" % replication_controller)
                                 tags.append("pod_name:%s" % pod_name)
 
+                        elif k == KubeUtil.CONTAINER_NAME_LABEL and Platform.is_k8s():
+                            if v:
+                                tags.append("kube_container_name:%s" % v)
                         elif k == SWARM_SVC_LABEL and Platform.is_swarm():
                             if v:
                                 tags.append("swarm_service:%s" % v)

--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -219,8 +219,12 @@ class Kubernetes(AgentCheck):
 
         pod_name = cont_labels[KubeUtil.POD_NAME_LABEL]
         pod_namespace = cont_labels[KubeUtil.NAMESPACE_LABEL]
+        # kube_container_name is the name of the Kubernetes container resource,
+        # not the name of the docker container (that's tagged as container_name)
+        kube_container_name = cont_labels[KubeUtil.CONTAINER_NAME_LABEL]
         tags.append(u"pod_name:{0}/{1}".format(pod_namespace, pod_name))
         tags.append(u"kube_namespace:{0}".format(pod_namespace))
+        tags.append(u"kube_container_name:{0}".format(kube_container_name))
 
         kube_labels_key = "{0}/{1}".format(pod_namespace, pod_name)
 

--- a/kubernetes/test_kubernetes.py
+++ b/kubernetes/test_kubernetes.py
@@ -240,7 +240,7 @@ class TestKubernetes(AgentCheckTest):
             (['container_name:k8s_POD.35220667_dd-agent-1rxlh_default_12c7be82-33ca-11e6-ac8f-42010af00003_f5cf585f',
               'container_image:gcr.io/google_containers/pause:2.0', 'image_name:gcr.io/google_containers/pause',
               'image_tag:2.0', 'pod_name:default/dd-agent-1rxlh', 'kube_namespace:default', 'kube_app:dd-agent',
-              'kube_foo:bar','kube_bar:baz', 'kube_replication_controller:dd-agent', 'kube_daemon_set:dd-agent'],
+              'kube_foo:bar','kube_bar:baz', 'kube_replication_controller:dd-agent', 'kube_daemon_set:dd-agent', 'kube_container_name:POD'],
             [MEM, CPU, FS, NET, NET_ERRORS]),
             (['container_name:/', 'pod_name:no_pod'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
             (['container_name:/system', 'pod_name:no_pod'], [MEM, CPU, NET, DISK]),
@@ -248,7 +248,7 @@ class TestKubernetes(AgentCheckTest):
               'container_image:datadog/docker-dd-agent:massi_ingest_k8s_events', 'image_name:datadog/docker-dd-agent',
               'image_tag:massi_ingest_k8s_events','pod_name:default/dd-agent-1rxlh',
               'kube_namespace:default', 'kube_app:dd-agent', 'kube_foo:bar',
-              'kube_bar:baz', 'kube_replication_controller:dd-agent', 'kube_daemon_set:dd-agent'], [LIM, REQ, MEM, CPU, NET, DISK, DISK_USAGE]),
+              'kube_bar:baz', 'kube_replication_controller:dd-agent', 'kube_daemon_set:dd-agent', 'kube_container_name:dd-agent'], [LIM, REQ, MEM, CPU, NET, DISK, DISK_USAGE]),
             (['kube_replication_controller:dd-agent', 'kube_namespace:default', 'kube_daemon_set:dd-agent'], [PODS]),
             ([], [LIM, REQ, CAP])  # container from kubernetes api doesn't have a corresponding entry in Cadvisor
         ]
@@ -296,11 +296,11 @@ class TestKubernetes(AgentCheckTest):
             (['container_image:datadog/docker-dd-agent:massi_ingest_k8s_events', 'image_name:datadog/docker-dd-agent',
               'image_tag:massi_ingest_k8s_events', 'pod_name:default/dd-agent-1rxlh',
               'kube_namespace:default', 'kube_app:dd-agent', 'kube_foo:bar','kube_bar:baz',
-              'kube_replication_controller:dd-agent', 'kube_daemon_set:dd-agent'], [MEM, CPU, NET, DISK, DISK_USAGE, LIM, REQ]),
+              'kube_replication_controller:dd-agent', 'kube_daemon_set:dd-agent', 'kube_container_name:dd-agent'], [MEM, CPU, NET, DISK, DISK_USAGE, LIM, REQ]),
             (['container_image:gcr.io/google_containers/pause:2.0', 'image_name:gcr.io/google_containers/pause',
               'image_tag:2.0', 'pod_name:default/dd-agent-1rxlh',
               'kube_namespace:default', 'kube_app:dd-agent', 'kube_foo:bar','kube_bar:baz',
-              'kube_replication_controller:dd-agent', 'kube_daemon_set:dd-agent'], [MEM, CPU, NET, NET_ERRORS, DISK_USAGE]),
+              'kube_replication_controller:dd-agent', 'kube_daemon_set:dd-agent', 'kube_container_name:POD'], [MEM, CPU, NET, NET_ERRORS, DISK_USAGE]),
             (['pod_name:no_pod'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
             (['kube_replication_controller:dd-agent', 'kube_namespace:default', 'kube_daemon_set:dd-agent'], [PODS]),
             ([], [LIM, REQ, CAP])  # container from kubernetes api doesn't have a corresponding entry in Cadvisor


### PR DESCRIPTION
### What does this PR do?

This PR adds a tag to `docker_daemon` and `kubernetes` metrics `pod_container_name` that takes the name of the Kubernetes Container resource corresponding to the container in question. This is kinda subtle (I'd love some feedback on naming / good ways to document something like this) - the *name* of a Container resource https://kubernetes.io/docs/api-reference/v1.6/#container-v1-core, not the actual Docker name of the container (which is already covered in `container_name`)

### Motivation

Because some stats are reported on a per-container basis, being able to easily select data using the same names that are in a Pod manifest is useful.

### Testing Guidelines

Notably, I haven't been able to get the `docker_daemon` check's tests working locally (on either OSX or Linux), so I'm hoping that the CI system tells me if I missed anything 😄 


This PR has a corresponding change to `dd-agent`'s `kubeutil.py` to have the `CONTAINER_NAME_LABEL` constant - submitting that separately.