### PR TITLE
Moves the async function from tests to the Agent

### DIFF
--- a/dns_check/test_dns_check.py
+++ b/dns_check/test_dns_check.py
@@ -126,29 +126,12 @@ class DNSCheckTest(AgentCheckTest):
     def tearDown(self):
         self.check.stop()
 
-    def wait_for_async(self, method, attribute, count):
-        """
-        Loop on `self.check.method` until `self.check.attribute >= count`.
-
-        Raise after
-        """
-        i = 0
-        while i < RESULTS_TIMEOUT:
-            self.check._process_results()
-            if len(getattr(self.check, attribute)) >= count:
-                return getattr(self.check, method)()
-            time.sleep(1)
-            i += 1
-        raise Exception("Didn't get the right count of service checks in time, {0}/{1} in {2}s: {3}"
-                        .format(len(getattr(self.check, attribute)), count, i,
-                                getattr(self.check, attribute)))
-
     @mock.patch.object(Resolver, 'query', side_effect=success_query_mock)
     @mock.patch('time.time', side_effect=MockTime.time)
     def test_success(self, mocked_query, mocked_time):
         self.run_check(CONFIG_SUCCESS)
         # Overrides self.service_checks attribute when values are available
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 2)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 2, RESULTS_TIMEOUT)
         self.metrics = self.check.get_metrics()
 
         tags = ['instance:success', 'resolved_hostname:www.example.org', 'nameserver:127.0.0.1', 'record_type:A']

--- a/dns_check/test_dns_check.py
+++ b/dns_check/test_dns_check.py
@@ -3,7 +3,6 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 # stdlib
-import time
 import mock
 
 # 3p
@@ -148,7 +147,7 @@ class DNSCheckTest(AgentCheckTest):
     def test_success_nxdomain(self, mocked_query, mocked_time):
         self.run_check(CONFIG_SUCCESS_NXDOMAIN)
         # Overrides self.service_checks attribute when values are available
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
         self.metrics = self.check.get_metrics()
 
         tags = ['instance:nxdomain', 'nameserver:127.0.0.1', 'resolved_hostname:www.example.org', 'record_type:NXDOMAIN']
@@ -162,7 +161,7 @@ class DNSCheckTest(AgentCheckTest):
     def test_default_timeout(self, mocked_query, mocked_time):
         self.run_check(CONFIG_DEFAULT_TIMEOUT)
         # Overrides self.service_checks attribute when values are available
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
         self.metrics = self.check.get_metrics()
 
         tags = ['instance:default_timeout', 'resolved_hostname:www.example.org', 'nameserver:127.0.0.1', 'record_type:A']
@@ -175,7 +174,7 @@ class DNSCheckTest(AgentCheckTest):
     def test_instance_timeout(self, mocked_query, mocked_time):
         self.run_check(CONFIG_INSTANCE_TIMEOUT)
         # Overrides self.service_checks attribute when values are available
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
         self.metrics = self.check.get_metrics()
 
         tags = ['instance:instance_timeout', 'resolved_hostname:www.example.org', 'nameserver:127.0.0.1', 'record_type:A']
@@ -187,7 +186,7 @@ class DNSCheckTest(AgentCheckTest):
         for config, exception_class in CONFIG_INVALID:
             self.run_check(config)
             # Overrides self.service_checks attribute when values are available
-            self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+            self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
             self.metrics = self.check.get_metrics()
 
             self.assertRaises(exception_class)

--- a/http_check/test_http_check.py
+++ b/http_check/test_http_check.py
@@ -215,23 +215,6 @@ class HTTPCheckTest(AgentCheckTest):
         if self.check:
             self.check.stop()
 
-    def wait_for_async(self, method, attribute, count):
-        """
-        Loop on `self.check.method` until `self.check.attribute >= count`.
-
-        Raise after
-        """
-        i = 0
-        while i < RESULTS_TIMEOUT:
-            self.check._process_results()
-            if len(getattr(self.check, attribute)) >= count:
-                return getattr(self.check, method)()
-            time.sleep(1)
-            i += 1
-        raise Exception("Didn't get the right count of service checks in time, {0}/{1} in {2}s: {3}"
-                        .format(len(getattr(self.check, attribute)), count, i,
-                                getattr(self.check, attribute)))
-
     def test_http_headers(self):
         """
         Headers format.
@@ -251,7 +234,7 @@ class HTTPCheckTest(AgentCheckTest):
         self.run_check(CONFIG)
         # Overrides self.service_checks attribute when values are available\
         self.service_checks = self.wait_for_async(
-            'get_service_checks', 'service_checks', len(CONFIG['instances']))
+            'get_service_checks', 'service_checks', len(CONFIG['instances']), RESULTS_TIMEOUT)
 
         # HTTP connection error
         tags = ['url:https://thereisnosuchlink.com', 'instance:conn_error']

--- a/http_check/test_http_check.py
+++ b/http_check/test_http_check.py
@@ -4,9 +4,6 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-# stdlibb
-import time
-
 # 3p
 import mock
 from nose.plugins.attrib import attr
@@ -277,7 +274,7 @@ class HTTPCheckTest(AgentCheckTest):
     def test_check_ssl(self):
         self.run_check(CONFIG_SSL_ONLY)
         # Overrides self.service_checks attribute when values are available
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 6)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 6, RESULTS_TIMEOUT)
         tags = ['url:https://github.com:443', 'instance:good_cert']
         self.assertServiceCheckOK("http.can_connect", tags=tags)
         self.assertServiceCheckOK("http.ssl_cert", tags=tags)
@@ -300,7 +297,7 @@ class HTTPCheckTest(AgentCheckTest):
     def test_check_ssl_expire_error(self, getpeercert_func):
         self.run_check(CONFIG_EXPIRED_SSL)
 
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 2)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 2, RESULTS_TIMEOUT)
         tags = ['url:https://github.com', 'instance:expired_cert']
         self.assertServiceCheckOK("http.can_connect", tags=tags)
         self.assertServiceCheckCritical("http.ssl_cert", tags=tags)
@@ -310,7 +307,7 @@ class HTTPCheckTest(AgentCheckTest):
     def test_check_allow_redirects(self):
         self.run_check(CONFIG_HTTP_REDIRECTS)
         # Overrides self.service_checks attribute when values are available\
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
 
         tags = ['url:http://github.com', 'instance:redirect_service']
         self.assertServiceCheckOK("http.can_connect", tags=tags)
@@ -322,7 +319,7 @@ class HTTPCheckTest(AgentCheckTest):
         self.run_check(CONFIG_EXPIRED_SSL)
         # Overrides self.service_checks attribute when values are av
         # Needed for the HTTP headers
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 2)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 2, RESULTS_TIMEOUT)
         tags = ['url:https://github.com', 'instance:expired_cert']
         self.assertServiceCheckOK("http.can_connect", tags=tags)
         self.assertServiceCheckCritical("http.ssl_cert", tags=tags)
@@ -338,7 +335,7 @@ class HTTPCheckTest(AgentCheckTest):
         self.run_check(CONFIG_UNORMALIZED_INSTANCE_NAME)
 
         # Overrides self.service_checks attribute when values are available
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 2)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 2, RESULTS_TIMEOUT)
 
         # Assess instance name normalization
         tags = ['url:https://github.com', 'instance:need_to_be_normalized']
@@ -352,7 +349,7 @@ class HTTPCheckTest(AgentCheckTest):
         self.run_check(SIMPLE_CONFIG)
 
         # Overrides self.service_checks attribute when values are available\
-        self.warnings = self.wait_for_async('get_warnings', 'warnings', 1)
+        self.warnings = self.wait_for_async('get_warnings', 'warnings', 1, RESULTS_TIMEOUT)
 
         # Assess warnings
         self.assertWarning(

--- a/snmp/test_snmp.py
+++ b/snmp/test_snmp.py
@@ -249,7 +249,7 @@ class SNMPTestCase(AgentCheckTest):
 
         # Test service check
         self.assertServiceCheck("snmp.can_check", status=AgentCheck.OK,
-                                tags=self.CHECK_TAGS, count=1)
+                                tags=self.CHECK_TAGS, at_least=1)
 
         self.coverage_report()
 
@@ -265,12 +265,12 @@ class SNMPTestCase(AgentCheckTest):
         config = {
             'instances': [self.generate_instance_config(self.PLAY_WITH_GET_NEXT_METRICS)]
         }
-        self.run_check_twice(config)
+        self.run_check_n(config, repeat=3)
         self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
 
         # Test service check
         self.assertServiceCheck("snmp.can_check", status=AgentCheck.OK,
-                                tags=self.CHECK_TAGS, count=1)
+                                tags=self.CHECK_TAGS, at_least=1)
 
         self.run_check(config)
         self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
@@ -302,8 +302,7 @@ class SNMPTestCase(AgentCheckTest):
             self.assertMetric(metric_name, tags=self.CHECK_TAGS, count=1)
 
         # Test service check
-        self.assertServiceCheck("snmp.can_check", status=AgentCheck.OK,
-                                tags=self.CHECK_TAGS, count=1)
+        self.assertServiceCheck("snmp.can_check", status=AgentCheck.OK, tags=self.CHECK_TAGS, at_least=1)
 
         self.coverage_report()
 
@@ -329,7 +328,7 @@ class SNMPTestCase(AgentCheckTest):
 
         # Test service check
         self.assertServiceCheck("snmp.can_check", status=AgentCheck.OK,
-                                tags=self.CHECK_TAGS, count=1)
+                                tags=self.CHECK_TAGS, at_least=1)
 
         self.coverage_report()
 
@@ -374,7 +373,7 @@ class SNMPTestCase(AgentCheckTest):
 
         # Test service check
         self.assertServiceCheck("snmp.can_check", status=AgentCheck.OK,
-                                tags=self.CHECK_TAGS, count=1)
+                                tags=self.CHECK_TAGS, at_least=1)
 
         self.coverage_report()
 
@@ -419,7 +418,7 @@ class SNMPTestCase(AgentCheckTest):
 
         # Test service check
         self.assertServiceCheck("snmp.can_check", status=AgentCheck.OK,
-                                tags=self.CHECK_TAGS, count=1)
+                                tags=self.CHECK_TAGS, at_least=1)
 
         self.coverage_report()
 
@@ -464,7 +463,7 @@ class SNMPTestCase(AgentCheckTest):
 
         # Test service check
         self.assertServiceCheck("snmp.can_check", status=AgentCheck.OK,
-                                tags=self.CHECK_TAGS, count=1)
+                                tags=self.CHECK_TAGS, at_least=1)
 
         self.coverage_report()
 
@@ -509,7 +508,7 @@ class SNMPTestCase(AgentCheckTest):
 
         # Test service check
         self.assertServiceCheck("snmp.can_check", status=AgentCheck.OK,
-                                tags=self.CHECK_TAGS, count=1)
+                                tags=self.CHECK_TAGS, at_least=1)
 
         self.coverage_report()
 
@@ -555,7 +554,7 @@ class SNMPTestCase(AgentCheckTest):
 
         # # Test service check
         self.assertServiceCheck("snmp.can_check", status=AgentCheck.OK,
-                                tags=self.CHECK_TAGS, count=1)
+                                tags=self.CHECK_TAGS, at_least=1)
         self.coverage_report()
 
     def test_invalid_forcedtype_metric(self):
@@ -594,8 +593,7 @@ class SNMPTestCase(AgentCheckTest):
             tags = self.CHECK_TAGS + metric.get('metric_tags')
             self.assertMetric(metric_name, tags=tags, count=1)
         # Test service check
-        self.assertServiceCheck("snmp.can_check", status=AgentCheck.OK,
-                                tags=self.CHECK_TAGS, count=1)
+        self.assertServiceCheck("snmp.can_check", status=AgentCheck.OK, tags=self.CHECK_TAGS, at_least=1)
 
         self.coverage_report()
 

--- a/snmp/test_snmp.py
+++ b/snmp/test_snmp.py
@@ -209,24 +209,6 @@ class SNMPTestCase(AgentCheckTest):
 
         return instance_config
 
-    def wait_for_async(self, method, attribute, count):
-        """
-        Loop on `self.check.method` until `self.check.attribute >= count`.
-
-        Raise after
-        """
-        i = 0
-        while i < RESULTS_TIMEOUT:
-            self.check._process_results()
-            if len(getattr(self.check, attribute)) >= count:
-                return getattr(self.check, method)()
-            time.sleep(1)
-            i += 1
-        raise Exception("Didn't get the right count for {attribute} in time, {total}/{expected} in {seconds}s: {attr}"
-                        .format(attribute=attribute, total=len(getattr(self.check, attribute)), expected=count, seconds=i,
-                                attr=getattr(self.check, attribute)))
-
-
     def test_command_generator(self):
         """
         Command generator's parameters should match init_config
@@ -256,7 +238,7 @@ class SNMPTestCase(AgentCheckTest):
                 self.SUPPORTED_METRIC_TYPES + self.UNSUPPORTED_METRICS)]
         }
         self.run_check_n(config, repeat=3)
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
 
         # Test metrics
         for metric in self.SUPPORTED_METRIC_TYPES:

--- a/snmp/test_snmp.py
+++ b/snmp/test_snmp.py
@@ -4,7 +4,6 @@
 
 # stdlib
 import copy
-import time
 
 # 3rd party
 from nose.plugins.attrib import attr
@@ -267,14 +266,14 @@ class SNMPTestCase(AgentCheckTest):
             'instances': [self.generate_instance_config(self.PLAY_WITH_GET_NEXT_METRICS)]
         }
         self.run_check_twice(config)
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
 
         # Test service check
         self.assertServiceCheck("snmp.can_check", status=AgentCheck.OK,
                                 tags=self.CHECK_TAGS, count=1)
 
         self.run_check(config)
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
 
         # Test metrics
         for metric in self.PLAY_WITH_GET_NEXT_METRICS:
@@ -295,7 +294,7 @@ class SNMPTestCase(AgentCheckTest):
             'instances': [self.generate_instance_config(self.SCALAR_OBJECTS)]
         }
         self.run_check_n(config, repeat=3)
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
 
         # Test metrics
         for metric in self.SCALAR_OBJECTS:
@@ -316,7 +315,7 @@ class SNMPTestCase(AgentCheckTest):
             'instances': [self.generate_instance_config(self.TABULAR_OBJECTS)]
         }
         self.run_check_n(config, repeat=3, sleep=2)
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
 
         # Test metrics
         for symbol in self.TABULAR_OBJECTS[0]['symbols']:
@@ -361,7 +360,7 @@ class SNMPTestCase(AgentCheckTest):
 
 
         self.run_check_n(config, repeat=3, sleep=2)
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
 
         # Test metrics
         for symbol in self.TABULAR_OBJECTS[0]['symbols']:
@@ -406,7 +405,7 @@ class SNMPTestCase(AgentCheckTest):
 
 
         self.run_check_n(config, repeat=3, sleep=2)
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
 
         # Test metrics
         for symbol in self.TABULAR_OBJECTS[0]['symbols']:
@@ -451,7 +450,7 @@ class SNMPTestCase(AgentCheckTest):
 
 
         self.run_check_n(config, repeat=3, sleep=2)
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
 
         # Test metrics
         for symbol in self.TABULAR_OBJECTS[0]['symbols']:
@@ -496,7 +495,7 @@ class SNMPTestCase(AgentCheckTest):
 
 
         self.run_check_n(config, repeat=3, sleep=2)
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
 
         # Test metrics
         for symbol in self.TABULAR_OBJECTS[0]['symbols']:
@@ -524,12 +523,12 @@ class SNMPTestCase(AgentCheckTest):
         }
         self.run_check(config)
 
-        self.warnings = self.wait_for_async('get_warnings', 'warnings', 1)
+        self.warnings = self.wait_for_async('get_warnings', 'warnings', 1, RESULTS_TIMEOUT)
         self.assertWarning("Fail to collect some metrics: No symbol IF-MIB::noIdeaWhatIAmDoingHere",
                            count=1, exact_match=False)
 
         # # Test service check
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
         self.assertServiceCheck("snmp.can_check", status=AgentCheck.CRITICAL,
                                 tags=self.CHECK_TAGS, count=1)
         self.coverage_report()
@@ -542,7 +541,7 @@ class SNMPTestCase(AgentCheckTest):
             'instances': [self.generate_instance_config(self.FORCED_METRICS)]
         }
         self.run_check_twice(config)
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
 
         for metric in self.FORCED_METRICS:
             metric_name = "snmp." + (metric.get('name') or metric.get('symbol'))
@@ -570,11 +569,11 @@ class SNMPTestCase(AgentCheckTest):
 
         self.run_check(config)
 
-        self.warnings = self.wait_for_async('get_warnings', 'warnings', 1)
+        self.warnings = self.wait_for_async('get_warnings', 'warnings', 1, RESULTS_TIMEOUT)
         self.assertWarning("Invalid forced-type specified:", count=1, exact_match=False)
 
         # # Test service check
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
         self.assertServiceCheck("snmp.can_check", status=AgentCheck.CRITICAL,
                                 tags=self.CHECK_TAGS, count=1)
         self.coverage_report()
@@ -587,7 +586,7 @@ class SNMPTestCase(AgentCheckTest):
             'instances': [self.generate_instance_config(self.SCALAR_OBJECTS_WITH_TAGS)]
         }
         self.run_check_n(config, repeat=3)
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
 
         # Test metrics
         for metric in self.SCALAR_OBJECTS_WITH_TAGS:
@@ -613,12 +612,12 @@ class SNMPTestCase(AgentCheckTest):
             'instances': [instance]
         }
         self.run_check(config)
-        self.warnings = self.wait_for_async('get_warnings', 'warnings', 1)
+        self.warnings = self.wait_for_async('get_warnings', 'warnings', 1, RESULTS_TIMEOUT)
 
         self.assertWarning("No SNMP response received before timeout for instance localhost", count=1)
 
         # Test service check
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1, RESULTS_TIMEOUT)
         self.assertServiceCheck("snmp.can_check", status=AgentCheck.CRITICAL,
                                 tags=self.CHECK_TAGS, count=1)
 

--- a/tcp_check/test_tcp_check.py
+++ b/tcp_check/test_tcp_check.py
@@ -11,7 +11,7 @@ from nose.plugins.attrib import attr
 # project
 from tests.checks.common import AgentCheckTest
 
-RESULTS_TIMEOUT = 40
+RESULTS_TIMEOUT = 20
 
 CONFIG = {
     'init_config': {},
@@ -65,28 +65,6 @@ class TCPCheckTest(AgentCheckTest):
     def tearDown(self):
         self.check.stop()
 
-    def wait_for_async(self, method, attribute, count):
-        """
-        Loop on `self.check.method` until `self.check.attribute >= count`.
-
-        Raise after
-        """
-
-        # Check the initial values to see if we already have results before waiting for the async
-        # instances to finish
-        initial_values = getattr(self, attribute)
-
-        i = 0
-        while i < RESULTS_TIMEOUT:
-            self.check._process_results()
-            if len(getattr(self.check, attribute)) + len(initial_values) >= count:
-                return getattr(self.check, method)() + initial_values
-            time.sleep(1.1)
-            i += 1
-        raise Exception("Didn't get the right count of service checks in time, {0}/{1} in {2}s: {3}"
-                        .format(len(getattr(self.check, attribute)), count, i,
-                                getattr(self.check, attribute)))
-
     def test_event_deprecation(self):
         """
         Deprecate events usage for service checks.
@@ -95,7 +73,7 @@ class TCPCheckTest(AgentCheckTest):
         self.run_check(CONFIG_EVENTS)
 
         # Overrides self.service_checks attribute when values are available
-        self.warnings = self.wait_for_async('get_warnings', 'warnings', len(CONFIG_EVENTS['instances']))
+        self.warnings = self.wait_for_async('get_warnings', 'warnings', len(CONFIG_EVENTS['instances']), RESULTS_TIMEOUT)
 
         # Assess warnings
         self.assertWarning(

--- a/tcp_check/test_tcp_check.py
+++ b/tcp_check/test_tcp_check.py
@@ -2,9 +2,6 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-# stdlibb
-import time
-
 # 3p
 from nose.plugins.attrib import attr
 
@@ -91,7 +88,7 @@ class TCPCheckTest(AgentCheckTest):
         self.run_check(CONFIG)
 
         # Overrides self.service_checks attribute when values are available
-        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', len(CONFIG['instances']))
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', len(CONFIG['instances']), RESULTS_TIMEOUT)
         self.metrics = self.check.get_metrics()
 
         expected_tags = ["instance:DownService", "target_host:127.0.0.1", "port:65530"]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Moves the async function from the network based Integration tests out to the Agent. 

### Motivation

There are about 4-5 integrations that use this same function for testing purposes. There is another PR that adds this function to the Agent. Initially the Network checks were flaky due to the quick return of a service check for localhost. This would impact all network checks. Instead of keeping this updated on all integrations, its easier to do this once from the Agent. 

Agent PR - https://github.com/DataDog/dd-agent/pull/3408

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`

### Additional Notes

Anything else we should know when reviewing?
