### PR TITLE
[openstack] Adds human friendly "project_name" tag in all cases.

### DIFF
--- a/openstack/check.py
+++ b/openstack/check.py
@@ -851,41 +851,38 @@ class OpenStackCheck(AgentCheck):
         Returns the project that this instance of the check is scoped to
         """
         project_auth_scope = self.get_scope_for_instance(instance)
-        if project_auth_scope.tenant_id:
-            scope = {"id": project_auth_scope.tenant_id}
-            if project_auth_scope.project_name:
-                scope["name"] = project_auth_scope.project_name
-            else:
-                # Try to get the project name from the keystone API so that it may be added as a tag
-                url = "{0}/{1}/{2}/{3}".format(self.keystone_server_url, DEFAULT_KEYSTONE_API_VERSION, "projects", project_auth_scope.tenant_id)
-                headers = {'X-Auth-Token': self.get_auth_token(instance)}
-                try:
-                    project_details = self._make_request_with_auth_fallback(url, headers)
-                    # Set the project name so we won't have to fetch it next time
-                    project_auth_scope.project_name = project_details["project"]["name"]
-                    scope["name"] = project_auth_scope.project_name
-                except Exception as e:
-                    self.warning('Unable to get project name for project id {0}: {1}'.format(project_auth_scope.tenant_id, str(e)))
-            return scope
-
-        filter_params = {
-            "name": project_auth_scope.project_name,
-            "domain_id": project_auth_scope.domain_id
-        }
-
+        filter_params = {}
         url = "{0}/{1}/{2}".format(self.keystone_server_url, DEFAULT_KEYSTONE_API_VERSION, "projects")
+        if project_auth_scope.tenant_id:
+            if project_auth_scope.project_name:
+                return {
+                    "id": project_auth_scope.tenant_id,
+                    "name": project_auth_scope.project_name
+                }
+
+            url = "{}/{}".format(url, project_auth_scope.tenant_id)
+        else:
+            filter_params = {
+                "name": project_auth_scope.project_name,
+                "domain_id": project_auth_scope.domain_id
+            }
+
         headers = {'X-Auth-Token': self.get_auth_token(instance)}
 
         try:
             project_details = self._make_request_with_auth_fallback(url, headers, params=filter_params)
-            assert len(project_details["projects"]) == 1, "Non-unique project credentials"
+            if filter_params:
+                assert len(project_details["projects"]) == 1, "Non-unique project credentials"
 
-            # Set the tenant_id so we won't have to fetch it next time
-            project_auth_scope.tenant_id = project_details["projects"][0].get("id")
+                # Set the tenant_id so we won't have to fetch it next time
+                project_auth_scope.tenant_id = project_details["projects"][0].get("id")
+                return project_details["projects"][0]
+            else:
+                project_auth_scope.project_name = project_details["project"]["name"]
+                return project_details["project"]
 
-            return project_details["projects"][0]
         except Exception as e:
-            self.warning('Unable to get the list of all project ids: {0}'.format(str(e)))
+            self.warning('Unable to get the project details: {0}'.format(str(e)))
 
         return None
 


### PR DESCRIPTION
If the project is specified in the check config using the tenant id (rather than using the domain id and the project name), the check will now attempt to fetch the project name from the keystone API, so that it may be added to project and server metrics as the "project_name" tag. Previously, if the project was specified using the tenant id, the only tag that could be used to differentiate projects was the tenant_id tag, which isn't easy for humans to understand.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`

### Additional Notes

Anything else we should know when reviewing?
