### PR TITLE
[directory] Make dirtagname option explanation more clear

### DIFF
--- a/directory/conf.yaml.example
+++ b/directory/conf.yaml.example
@@ -15,8 +15,8 @@ instances:
   # Instances take the following parameters:
   # "directory" - string, the directory to monitor. Required
   # "name" - string, tag metrics with specified name. defaults to the "directory"
-  # "dirtagname" - string, the name of the tag used for the directory. defaults to "name"
-  # "filetagname" - string, the name of the tag used for each file. defaults to "filename"
+  # "dirtagname" - string, the name of the key for the tag used for the directory, the value will be the value of "name" (see above). The resulting tag will be "<dirtagname>:<name>". defaults to "name"
+  # "filetagname" - string, the name of the key for the tag used for each file, the value will be the filename. The resulting tag will be "<filetagname>:<filename>". defaults to "filename"
   # "filegauges" - boolean, when true stats will be an individual gauge per file (max. 20 files!) and not a histogram of the whole directory. default False
   # "pattern" - string, the `fnmatch` pattern to use when reading the "directory"'s files. The pattern will be matched against the files' absolute paths and relative paths in "directory". default "*"
   # "recursive" - boolean, when true the stats will recurse into directories. default False


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Make dirtagname option explanation more clear

### Motivation

The explanation was not clear

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`

### Additional Notes

Should we also modify the check so that the default for `dirtagname` is `dirname`, and keep sending the tag with key `name` for backward compatibility ? This would be to avoid this where we have two tags `name`: 
![image_202016-04-18_20at_201 50 32_20pm](https://user-images.githubusercontent.com/19330189/27802600-c185e7a4-5ff2-11e7-80c0-d7a2e601d2b9.png)
