### PR TITLE
move tcp_check testing to its own travis flavor for faster re-runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,7 @@ env:
     - TRAVIS_FLAVOR=sqlserver FLAVOR_VERSION=latest
     - TRAVIS_FLAVOR=statsd
     - TRAVIS_FLAVOR=supervisord FLAVOR_VERSION=3.3.0
+    - TRAVIS_FLAVOR=tcp_check    
     - TRAVIS_FLAVOR=tokumx
     - TRAVIS_FLAVOR=tomcat FLAVOR_VERSION=latest
     - TRAVIS_FLAVOR=twemproxy FLAVOR_VERSION=latest

--- a/tcp_check/test_tcp_check.py
+++ b/tcp_check/test_tcp_check.py
@@ -5,6 +5,9 @@
 # stdlibb
 import time
 
+# 3p
+from nose.plugins.attrib import attr
+
 # project
 from tests.checks.common import AgentCheckTest
 
@@ -39,6 +42,8 @@ CONFIG = {
     }]
 }
 
+
+@attr(requires='tcp_check')
 class TCPCheckTest(AgentCheckTest):
     CHECK_NAME = 'tcp_check'
 


### PR DESCRIPTION
### What does this PR do?

Create a separate CI suite and travis flavor for the flaky tcp_check

### Motivation

Will allow to diagnose more easily than this is the faulty check without reading the `default` flavor output, and allow to re-run this separately for faster time-to-green.