### PR TITLE
Increase timeout of the tcp_check since it fail pretty often on travis

### DIFF
--- a/tcp_check/test_tcp_check.py
+++ b/tcp_check/test_tcp_check.py
@@ -11,7 +11,7 @@ from nose.plugins.attrib import attr
 # project
 from tests.checks.common import AgentCheckTest
 
-RESULTS_TIMEOUT = 20
+RESULTS_TIMEOUT = 40
 
 CONFIG = {
     'init_config': {},


### PR DESCRIPTION
### What does this PR do?

TCP tests are very flaky on the CI right now. Let experience with the timeout to see if travis speed might be one of the problems.