### PR TITLE
collect kube_container_name by default in docker_daemon check

### DIFF
--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -412,6 +412,7 @@ class DockerDaemon(AgentCheck):
         # Collect pod names as tags on kubernetes
         if Platform.is_k8s() and KubeUtil.POD_NAME_LABEL not in self.collect_labels_as_tags:
             self.collect_labels_as_tags.append(KubeUtil.POD_NAME_LABEL)
+            self.collect_labels_as_tags.append(KubeUtil.CONTAINER_NAME_LABEL)
 
         # Collect container names as tags on rancher
         if Platform.is_rancher():


### PR DESCRIPTION
collect `kube_container_name` by default in docker_daemon check, like the kubernetes check does
