### PR TITLE
[rabbitmq] once a connection state is discovered - remember it.

### DIFF
--- a/rabbitmq/check.py
+++ b/rabbitmq/check.py
@@ -106,6 +106,7 @@ class RabbitMQ(AgentCheck):
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
         self.already_alerted = []
+        self.connection_states = {}
 
     def _get_config(self, instance):
         # make sure 'rabbitmq_api_url' is present and get parameters
@@ -321,7 +322,14 @@ class RabbitMQ(AgentCheck):
                               ssl_verify=ssl_verify, proxies=instance_proxy)
 
         stats = {vhost: 0 for vhost in vhosts}
-        connection_states = defaultdict(int)
+        if base_url not in self.connection_states:
+            self.connection_states[base_url] = defaultdict(int)
+
+        # let's keep the dict around to "discover" states.
+        connection_states = self.connection_states[base_url]
+        for conn_state in connection_states.iterkeys():
+            connection_states[conn_state] = 0
+
         for conn in data:
             if conn['vhost'] in vhosts:
                 stats[conn['vhost']] += 1


### PR DESCRIPTION
### What does this PR do?

Once a RabbitMQ connection state is discovered (documentation for rabbitmq I found was pretty bad, so although I wanted to hardcode all possible states, and get them their key, I wasn't certain of all available states, so this was the next best alternative) store it and always report it, with the calculated value, or a zero. 
  
### Motivation

The previous approach would not report the metric if the value was zero, I'm not sure that would be the intended behavior. I guess that would depend on the way we use the reported metric - let's discuss if we want to merge or close this.

This is still suboptimal, as a restart of the agent would take us back to square one, and we would stop reporting a certain metric context, until the connection state was re-discovered.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.
