### PR TITLE
[kubernetes] add option for node labels --> host tags

### DIFF
--- a/kubernetes/CHANGELOG.md
+++ b/kubernetes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - kubernetes
 
+
+1.3.0 / Unreleased
+==================
+### Changes
+
+* [FEATURE] add an option to collect node labels as host tags
+
 1.2.0 / 2017-07-18
 ==================
 ### Changes

--- a/kubernetes/conf.yaml.example
+++ b/kubernetes/conf.yaml.example
@@ -97,6 +97,13 @@ instances:
   #
   # namespace_name_regexp:
 
+  # Node labels that should be collected and their name in host tags. Off by default, but some of them are redundant
+  # with metadata collected by cloud provider crawlers (AWS, GCE, Azure)
+  #
+  # node_labels_to_host_tags:
+  #   kubernetes.io/hostname: nodename
+  #   beta.kubernetes.io/os: os
+
   # use_histogram controls whether we send detailed metrics, i.e. one per container.
   # When false, we send detailed metrics corresponding to individual containers, tagging by container id
   # to keep them unique.

--- a/kubernetes/conf.yaml.example
+++ b/kubernetes/conf.yaml.example
@@ -97,8 +97,9 @@ instances:
   #
   # namespace_name_regexp:
 
-  # Node labels that should be collected and their name in host tags. Off by default, but some of them are redundant
-  # with metadata collected by cloud provider crawlers (AWS, GCE, Azure)
+  # Node labels that should be collected and their name in host tags. Off by default.
+  # Some of these labels are redundant with metadata collected by
+  # cloud provider crawlers (AWS, GCE, Azure)
   #
   # node_labels_to_host_tags:
   #   kubernetes.io/hostname: nodename

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -11,5 +11,5 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.2.0"
+  "version": "1.3.0"
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Add an option to import k8s node labels as host tags

### Motivation

Why not?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`

### Additional Notes

Linked to https://github.com/DataDog/dd-agent/pull/3445
