### PR TITLE
[docker] remove uninitialised self.ecsutil & .nomadutil references

### DIFF
--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [BUGFIX] safely check volume list before accessing. See [#544][]
+* [BUGFIX] fix event collection on ecs and nomad. See [#616][]
 
 1.3.0 / 2017-07-18
 ==================
@@ -75,4 +76,5 @@
 [#509]: https://github.com/DataDog/integrations-core/issues/509
 [#544]: https://github.com/DataDog/integrations-core/issues/544
 [#553]: https://github.com/DataDog/integrations-core/issues/553
+[#616]: https://github.com/DataDog/integrations-core/issues/616
 [@sophaskins]: https://github.com/sophaskins

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -760,10 +760,6 @@ class DockerDaemon(AgentCheck):
             get_sd_backend(self.agentConfig).update_checks(changed_container_ids)
         if changed_container_ids:
             self.metadata_collector.invalidate_cache(events)
-            if Platform.is_nomad():
-                self.nomadutil.invalidate_cache(events)
-            elif Platform.is_ecs_instance():
-                self.ecsutil.invalidate_cache(events)
         return events
 
     def _pre_aggregate_events(self, api_events, containers_by_id):


### PR DESCRIPTION
Remove uninitialised self.ecsutil & .nomadutil references in the _get_events method.
They are now abstracted through metadata_collector and not direcly imported anymore. This leads to runtime error during event collection in ecs and nomad since https://github.com/DataDog/integrations-core/pull/486

### Versioning

- [ ] ~~Bumped the version check in `manifest.json`~~
- [x] Updated `CHANGELOG.md`
