### PR TITLE
[mysql][skip ci] Adds a comment that clarifies how to connect to using a socket

### DIFF
--- a/mysql/conf.yaml.example
+++ b/mysql/conf.yaml.example
@@ -1,6 +1,8 @@
 init_config:
 
 instances:
+    # NOTE: Even if the server name is "localhost", the agent will connect to MySQL using TCP/IP, unless you also
+    # provide a value for the sock key (below).
   - server: localhost
     # user: my_username
     # pass: my_password


### PR DESCRIPTION
MySQL clients will often use sockets if the hostname is "localhost" (https://serverfault.com/a/337844) [but our agent will not](https://github.com/DataDog/integrations-core/blob/5.15.0/mysql/check.py#L377). This PR clarifies our agent's behavior.