### PR TITLE
[postfix] Run the check as postfix user, not root

### DIFF
--- a/postfix/CHANGELOG.md
+++ b/postfix/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG - postfix
 
+1.1.0 / Unreleased
+==================
+
+### Changes
+
+* [IMPROVEMENT] run the check as the postfix user, not root
+
+
 1.0.0 / 2017-03-22
 ==================
 

--- a/postfix/README.md
+++ b/postfix/README.md
@@ -14,6 +14,7 @@ Create a file `postfix.yaml` in the Agent's `conf.d` directory:
 
 ```
 init_config:
+  - postfix_user: postfix
 
 instances:
   # add one instance for each postfix service you want to track
@@ -27,8 +28,10 @@ instances:
 #     - optional_tag2
 ```
 
-For each mail queue in `queues`, the Agent forks a `find` on its directory. It uses `sudo`to do this, so you must add the following lines to `/etc/sudoers` for the Agent's user, `dd-agent`:
-
+For each mail queue in `queues`, the Agent forks a `find` on its directory.
+It uses `sudo` to do this with the privileges of the postfix user, so you must
+add the following lines to `/etc/sudoers` for the Agent's user, `dd-agent`,
+assuming postfix runs as `postfix`:
 ```
 dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/incoming -type f
 dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/active -type f

--- a/postfix/README.md
+++ b/postfix/README.md
@@ -30,9 +30,9 @@ instances:
 For each mail queue in `queues`, the Agent forks a `find` on its directory. It uses `sudo`to do this, so you must add the following lines to `/etc/sudoers` for the Agent's user, `dd-agent`:
 
 ```
-dd-agent ALL=(ALL) NOPASSWD:/usr/bin/find /var/spool/postfix/incoming -type f
-dd-agent ALL=(ALL) NOPASSWD:/usr/bin/find /var/spool/postfix/active -type f
-dd-agent ALL=(ALL) NOPASSWD:/usr/bin/find /var/spool/postfix/deferred -type f
+dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/incoming -type f
+dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/active -type f
+dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/deferred -type f
 ```
 
 Restart the Agent to start sending Postfix metrics to Datadog.

--- a/postfix/check.py
+++ b/postfix/check.py
@@ -63,7 +63,8 @@ class PostfixCheck(AgentCheck):
                 # can dd-agent user run sudo?
                 test_sudo = os.system('setsid sudo -l < /dev/null')
                 if test_sudo == 0:
-                    postfix_user = self.init_config.get('postfix_user')
+                    # default to `root` for backward compatibility
+                    postfix_user = self.init_config.get('postfix_user', 'root')
                     output, _, _ = get_subprocess_output(['sudo', '-u', postfix_user, 'find', queue_path, '-type', 'f'], self.log, False)
                     count = len(output.splitlines())
                 else:

--- a/postfix/check.py
+++ b/postfix/check.py
@@ -17,7 +17,9 @@ class PostfixCheck(AgentCheck):
              sudo access is not required when running dd-agent as root (not recommended)
 
     example /etc/sudoers entry:
-             dd-agent ALL=(ALL) NOPASSWD:/usr/bin/find /var/spool/postfix* -type f
+        dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/incoming -type f
+        dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/active -type f
+        dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/deferred -type f
 
     YAML config options:
         "directory" - the value of 'postconf -h queue_directory'
@@ -61,7 +63,8 @@ class PostfixCheck(AgentCheck):
                 # can dd-agent user run sudo?
                 test_sudo = os.system('setsid sudo -l < /dev/null')
                 if test_sudo == 0:
-                    output, _, _ = get_subprocess_output(['sudo', 'find', queue_path, '-type', 'f'], self.log, False)
+                    postfix_user = self.init_config.get('postfix_user')
+                    output, _, _ = get_subprocess_output(['sudo', '-u', postfix_user, 'find', queue_path, '-type', 'f'], self.log, False)
                     count = len(output.splitlines())
                 else:
                     raise Exception('The dd-agent user does not have sudo access')

--- a/postfix/conf.yaml.example
+++ b/postfix/conf.yaml.example
@@ -8,6 +8,7 @@
 #          Defaults:dd-agent !requiretty
 
 init_config:
+  - postfix_user: postfix
 
 instances:
   - directory: /var/spool/postfix

--- a/postfix/conf.yaml.example
+++ b/postfix/conf.yaml.example
@@ -2,7 +2,7 @@
 # command to run the postfix check.  Here's an example:
 #
 # example /etc/sudoers entry:
-#          dd-agent ALL=(ALL) NOPASSWD:/usr/bin/find
+#          dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/incoming -type f
 #
 # Redhat/CentOS/Amazon Linux flavours will need to add:
 #          Defaults:dd-agent !requiretty

--- a/postfix/manifest.json
+++ b/postfix/manifest.json
@@ -10,6 +10,6 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "guid": "7f03c5b7-ee54-466e-8854-5896d62c82b4"
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

No need to run `find` as `root`, let's `sudo -u postfix` instead.
The actual user name for the postfix user is configurable to avoid to hardcode it.

### Motivation

Improve the check security wise

### Versioning

- [x ] Bumped the version check in `manifest.json`
- [x ] Updated `CHANGELOG.md`
