### PR TITLE
[kafka_consumer] Switch ZK example from string to list

### DIFF
--- a/kafka_consumer/conf.yaml.example
+++ b/kafka_consumer/conf.yaml.example
@@ -33,4 +33,6 @@ instances:
   # - kafka_connect_str:
   #   - <kafka_host1:port>
   #   - <kafka_host2:port>
-  #   zk_connect_str: <zk_host1:port>,<zk_host2:port>
+  #   zk_connect_str:
+  #   - <zk_host1:port>
+  #   - <zk_host2:port>


### PR DESCRIPTION
`kazoo` 2.4 merged https://github.com/python-zk/kazoo/pull/424 which means `kazoo` now supports a list of multiple endpoints, not just a single string.

So updating the example conf file as a list is more readable than a string, and for most configuration management setups will require less munging of inputs when assembling variables into a template.

Note: Requires https://github.com/DataDog/integrations-core/pull/623 to be merged first