### PR TITLE
Send CRITICAL service check for aliveness if the rabbitmq server goes down

### DIFF
--- a/rabbitmq/CHANGELOG.md
+++ b/rabbitmq/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - rabbitmq
 
+1.2.1 / Unreleased
+==================
+
+### Changes
+
+* [BUGFIX] Set aliveness service to CRITICAL if the rabbitmq server is down. See[#635][]
+
 1.2.0 / 2017-07-18
 ==================
 
@@ -28,4 +35,5 @@
 [#504]: https://github.com/DataDog/integrations-core/issues/504
 [#506]: https://github.com/DataDog/integrations-core/issues/506
 [#514]: https://github.com/DataDog/integrations-core/issues/514
+[#635]: https://github.com/DataDog/integrations-core/issues/635
 [@jamescarr]: https://github.com/jamescarr

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.2.0",
+  "version": "1.2.1",
   "guid": "a790a556-fbaa-4208-9d39-c42c3d57084b"
 }


### PR DESCRIPTION
### What does this PR do?

Since service_checks on the backend keep the latest value they received, we would still show a OK service_check for vhost aliveness even if the server is down. We now cache the latest list of vhosts we pulled from rabbitmq to send CRITICAL checks if the server don't respond anymore.

### Motivation

See #629 

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`
