### PR TITLE
[Kubernetes] Adding custom tags to service checks

### DIFF
--- a/kubernetes/CHANGELOG.md
+++ b/kubernetes/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Changes
 
 * [FEATURE] add an option to collect node labels as host tags
-* [IMPROVEMENT] add custom tags to service checks
+* [IMPROVEMENT] add custom tags to service checks [#642][]
 
 1.2.0 / 2017-07-18
 ==================

--- a/kubernetes/CHANGELOG.md
+++ b/kubernetes/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changes
 
 * [FEATURE] add an option to collect node labels as host tags
+* [IMPROVEMENT] add custom tags to service checks
 
 1.2.0 / 2017-07-18
 ==================


### PR DESCRIPTION
### What does this PR do?

This PR adds the custom tags setup in kubernetes.yaml to the service checks sent to the integration

### Motivation

Customer request: it should solve issue [636](https://github.com/DataDog/integrations-core/issues/636)

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`
