### PR TITLE
Add labels_mapper option to kubernetes_state to allow tag renaming

### DIFF
--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ### Changes
 
-* [FEATURE] Support for StatefulSet metrics
+* [FEATURE] Support for StatefulSet metrics. See [#561][]
+* [FEATURE] Support tag renaming via the labels_mapper option. See [#651][]
 
 1.2.0 / 2017-07-18
 ==================

--- a/kubernetes_state/auto_conf.yaml
+++ b/kubernetes_state/auto_conf.yaml
@@ -2,6 +2,10 @@ docker_images:
   - kube-state-metrics
 
 init_config:
+  # Tags are reported as set by kube-state-metrics. If you want to translate
+  # them to other tags, you can use the labels_mapper dictionary
+  #  labels_mapper:
+  #    namespace: kube_namespace
 instances:
   # To enable Kube State metrics you must specify the url exposing the API
   - kube_state_url: http://%%host%%:%%port%%/metrics

--- a/kubernetes_state/auto_conf.yaml
+++ b/kubernetes_state/auto_conf.yaml
@@ -2,10 +2,11 @@ docker_images:
   - kube-state-metrics
 
 init_config:
-  # Tags are reported as set by kube-state-metrics. If you want to translate
-  # them to other tags, you can use the labels_mapper dictionary
-  #  labels_mapper:
-  #    namespace: kube_namespace
+
 instances:
   # To enable Kube State metrics you must specify the url exposing the API
   - kube_state_url: http://%%host%%:%%port%%/metrics
+    # Tags are reported as set by kube-state-metrics. If you want to translate
+    # them to other tags, you can use the labels_mapper dictionary
+    # labels_mapper:
+    #   namespace: kube_namespace

--- a/kubernetes_state/check.py
+++ b/kubernetes_state/check.py
@@ -17,12 +17,6 @@ class KubernetesState(PrometheusCheck):
         super(KubernetesState, self).__init__(name, init_config, agentConfig, instances)
         self.NAMESPACE = 'kubernetes_state'
 
-        if 'labels_mapper' in init_config:
-            if isinstance(init_config['labels_mapper'], dict):
-                self.labels_mapper = init_config['labels_mapper']
-            else:
-                self.log.warning("labels_mapper should be a dictionnary")
-
         self.pod_phase_to_status = {
             'pending':   self.WARNING,
             'running':   self.OK,
@@ -129,6 +123,12 @@ class KubernetesState(PrometheusCheck):
         endpoint = instance.get('kube_state_url')
         if endpoint is None:
             raise CheckException("Unable to find kube_state_url in config file.")
+
+        if 'labels_mapper' in instance:
+            if isinstance(instance['labels_mapper'], dict):
+                self.labels_mapper = instance['labels_mapper']
+            else:
+                self.log.warning("labels_mapper should be a dictionnary")
 
         send_buckets = instance.get('send_histograms_buckets', True)
         # By default we send the buckets.

--- a/kubernetes_state/conf.yaml.example
+++ b/kubernetes_state/conf.yaml.example
@@ -1,4 +1,10 @@
 init_config:
+  # Tags are reported as set by kube-state-metrics. If you want to translate
+  # them to other tags, you can use the labels_mapper dictionary
+  #  labels_mapper:
+  #    namespace: kube_namespace
+
+  # Custom tags can be added to all metrics reported by this integration
   #    tags:
   #      - optional_tag1
   #      - optional_tag2

--- a/kubernetes_state/conf.yaml.example
+++ b/kubernetes_state/conf.yaml.example
@@ -1,9 +1,4 @@
 init_config:
-  # Tags are reported as set by kube-state-metrics. If you want to translate
-  # them to other tags, you can use the labels_mapper dictionary
-  #  labels_mapper:
-  #    namespace: kube_namespace
-
   # Custom tags can be added to all metrics reported by this integration
   #    tags:
   #      - optional_tag1
@@ -16,3 +11,7 @@ instances:
   # the CPP extension to process Protocol buffer messages coming from the api. Depending
   # on the metrics volume, the check may run very slowly.
   - kube_state_url: http://example.com:8080/metrics
+    # Tags are reported as set by kube-state-metrics. If you want to translate
+    # them to other tags, you can use the labels_mapper dictionary
+    # labels_mapper:
+    #   namespace: kube_namespace


### PR DESCRIPTION
### What does this PR do?

Allows user to set a `labels_mapper` option in `init_config` to rename tags from their original prometheus label name to better values. This is based on the existing mechanism in `PrometheusCheck`, so changes are minimal.

### Motivation

User request to have metrics tagged with `kube_namespace` instead of `namespace` for consistency with the kubernetes check.

### Versioning

- ~~[ ] Bumped the version check in `manifest.json`~~
- [x] Updated `CHANGELOG.md`
