### PR TITLE
disable cadvisor metrics if port == 0, to avoid integration warning

### DIFF
--- a/kubernetes/CHANGELOG.md
+++ b/kubernetes/CHANGELOG.md
@@ -5,8 +5,9 @@
 ==================
 ### Changes
 
-* [FEATURE] add an option to collect node labels as host tags
+* [FEATURE] add an option to collect node labels as host tags. See [#614][]
 * [IMPROVEMENT] add custom tags to service checks [#642][]
+* [FEATURE] skip cAdvisor metrics if port is set to 0. See [#655][]
 
 1.2.0 / 2017-07-18
 ==================

--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -182,11 +182,13 @@ class Kubernetes(AgentCheck):
             self._update_pods_metrics(instance, pods_list)
             # cAdvisor & kubelet metrics, will fail if port 4194 is not open
             try:
-                self._update_metrics(instance, pods_list)
+                if int(instance.get('port', KubeUtil.DEFAULT_CADVISOR_PORT)) > 0:
+                    self._update_metrics(instance, pods_list)
             except ConnectionError:
                 self.warning('''Can't access the cAdvisor metrics, performance metrics and'''
                              ''' limits/requests will not be collected. Please setup'''
-                             ''' your kubelet with the --cadvisor-port=4194 option''')
+                             ''' your kubelet with the --cadvisor-port=4194 option, or set port to 0'''
+                             ''' in this check's configuration to disable cAdvisor lookup.''')
             except Exception as err:
                 self.log.warning("Error while getting performance metrics: %s" % str(err))
 

--- a/kubernetes/conf.yaml.example
+++ b/kubernetes/conf.yaml.example
@@ -27,7 +27,7 @@ instances:
   # port: 4194
   # method: http
 
-  # cAdvisor port
+  # cAdvisor port, set it to 0 if cAdvisor is unavailable
  - port: 4194
   #
   # cAdvisor host


### PR DESCRIPTION
### What does this PR do?

Disable the cAdvisor check from `kubernetes` if port is 0. Currently, connection errors are gracefully caught but result in an integration warning. If the choice not to use cadvisor is deliberate, remove the warning altogether.

### Motivation

Current integration warning could be misinterpreted.
