### PR TITLE
[cassandra][skip_ci] Add missing metric for default dashboards

### DIFF
--- a/cassandra/conf.yaml.example
+++ b/cassandra/conf.yaml.example
@@ -58,6 +58,7 @@ init_config:
           - Value
           - Count
           - Mean
+          - 50thPercentile
           - 75thPercentile
           - 95thPercentile
           - 99thPercentile


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Add 50th percentile metric

### Motivation

Forgot one metric with #615 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`

### Additional Notes

Anything else we should know when reviewing?