### PR TITLE
Sync some metadata from dogweb before deleting it from there

### DIFF
--- a/consul/metadata.csv
+++ b/consul/metadata.csv
@@ -7,3 +7,42 @@ consul.catalog.services_critical,gauge,,service,,Total critical services on node
 consul.catalog.services_passing,gauge,,service,,Total passing services on nodes,1,consul,svc pass
 consul.catalog.services_up,gauge,,service,,Total services registered on nodes,0,consul,svc up
 consul.catalog.services_warning,gauge,,service,,Total warning services on nodes,-1,consul,svc warn
+consul.net.node.latency.min,gauge,,millisecond,,minimum latency from this node to all others,-1,consul,min latency
+consul.net.node.latency.p25,gauge,,millisecond,,p25 latency from this node to all others,-1,consul,p25 latency
+consul.net.node.latency.median,gauge,,millisecond,,median latency from this node to all others,-1,consul,median latency
+consul.net.node.latency.p75,gauge,,millisecond,,p75 latency from this node to all others,-1,consul,p75 latency
+consul.net.node.latency.p90,gauge,,millisecond,,p90 latency from this node to all others,-1,consul,p90 latency
+consul.net.node.latency.p95,gauge,,millisecond,,p95 latency from this node to all others,-1,consul,p95 latency
+consul.net.node.latency.p99,gauge,,millisecond,,p99 latency from this node to all others,-1,consul,p99 latency
+consul.net.node.latency.max,gauge,,millisecond,,maximum latency from this node to all others,-1,consul,max latency
+consul.runtime.num_goroutines,gauge,10,,,Number of running goroutines,0,consul,num goroutines
+consul.runtime.alloc_bytes,gauge,10,byte,,Current bytes allocated by the Consul process,0,consul,bytes alloc
+consul.runtime.heap_objects,gauge,10,object,,Number of objects allocated on the heap,0,consul,heap objs
+consul.runtime.sys_bytes,gauge,10,byte,,Total size of the virtual address space reserved by the Go runtime,0,consul,
+consul.runtime.malloc_count,gauge,10,object,,Cumulative count of heap objects allocated,0,consul,
+consul.runtime.free_count,gauge,10,object,,Cumulative count of heap objects freed,0,consul,
+consul.runtime.heap_objects,gauge,10,byte,,Bytes of allocated heap objects,0,consul,heap alloc
+consul.runtime.total_gc_pause_ns,gauge,10,nanosecond,,Cumulative nanoseconds in GC stop-the-world pauses since Consul started,0,consul,
+consul.runtime.total_gc_runs,gauge,10,,,Number of completed GC cycles,0,consul,
+consul.raft.state.leader,rate,10,event,,Number of completed leader elections,-1,consul,leader elecs
+consul.raft.state.candidate,rate,10,event,,Number of initiated leader elections,-1,consul,leader elecs init
+consul.raft.apply,rate,10,transaction,,Number of raft transactions occurring,0,consul,raft trans
+consul.raft.commitTime.avg,gauge,10,millisecond,,The average time it takes to commit a new entry to the raft log on the leader,-1,consul,raft cmt avg
+consul.raft.commitTime.count,rate,10,,,The number of samples of raft.commitTime,0,consul,raft cmt cnt
+consul.raft.commitTime.max,gauge,10,millisecond,,The max time it takes to commit a new entry to the raft log on the leader,-1,consul,raft cmt max
+consul.raft.commitTime.median,gauge,10,millisecond,,The median time it takes to commit a new entry to the raft log on the leader,-1,consul,raft cmt med
+consul.raft.commitTime.95percentile,gauge,10,millisecond,,The p95 time it takes to commit a new entry to the raft log on the leader,-1,consul,raft cmt p95
+consul.raft.leader.dispatchLog.avg,gauge,10,millisecond,,The average time it takes for the leader to write log entries to disk,-1,consul,dispatch log avg
+consul.raft.leader.dispatchLog.count,rate,10,,,The number of samples of raft.leader.dispatchLog,0,consul,dispatch log cnt
+consul.raft.leader.dispatchLog.max,gauge,10,millisecond,,The max time it takes for the leader to write log entries to disk,-1,consul,dispatch log max
+consul.raft.leader.dispatchLog.median,gauge,10,millisecond,,The median time it takes for the leader to write log entries to disk,-1,consul,dispatch log med
+consul.raft.leader.dispatchLog.95percentile,gauge,10,millisecond,,The p95 time it takes for the leader to write log entries to disk,-1,consul,dispatch log p95
+consul.raft.leader.lastContact.avg,gauge,10,millisecond,,Average time elapsed since the leader was last able to check its lease with followers,-1,consul,
+consul.raft.leader.lastContact.count,rate,10,,,The number of samples of raft.leader.lastContact,0,consul,
+consul.raft.leader.lastContact.max,gauge,10,millisecond,,Max time elapsed since the leader was last able to check its lease with followers,-1,consul,
+consul.raft.leader.lastContact.median,gauge,10,millisecond,,Median time elapsed since the leader was last able to check its lease with followers,-1,consul,
+consul.raft.leader.lastContact.95percentile,gauge,10,millisecond,,P95 time elapsed since the leader was last able to check its lease with followers,-1,consul,
+consul.memberlist.msg.suspect,rate,10,,,Number of times an agent suspects another as failed while probing during gossip protocol,-1,consul,
+consul.serf.member.flap,rate,10,,,Number of times an agent is marked dead and then quickly recovers,-1,consul,
+consul.serf.events,rate,10,event,,Incremented when an agent processes a serf event,0,consul,num events
+consul.serf.member.join,rate,10,event,,Incremented when an agent processes a join event,0,consul,num joins

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -2,7 +2,7 @@ metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation
 kafka.net.bytes_out,gauge,10,byte,second,Outgoing byte rate.,0,kafka,bytes out
 kafka.net.bytes_in,gauge,10,byte,second,Incoming byte rate.,0,kafka,bytes in
 kafka.net.bytes_rejected,gauge,10,byte,second,Rejected byte rate.,-1,kafka,bytes rejected
-kafka.messages_in,gauge,10 ,message,,Incoming message rate.,0,kafka,messages in
+kafka.messages_in,gauge,10,message,,Incoming message rate.,0,kafka,messages in
 kafka.request.fetch.failed,gauge,10,request,,Number of client fetch request failures.,-1,kafka,req fetch fail
 kafka.request.fetch.failed_per_second,gauge,10,request,second,Rate of client fetch request failures per second.,-1,kafka,req fetch fail rate
 kafka.request.produce.time.avg,gauge,10,request,second,Average time for a produce request.,0,kafka,req prod time avg


### PR DESCRIPTION
The added consul metadata is telemetry data consul pushes via dogstatsd. I know we're not in the habit of curating metadata we don't control, but we already have it in this case; I pushed it to dogweb some time ago.