### PR TITLE
Introduce and clarify DogStatsD

### DIFF
--- a/gunicorn/README.md
+++ b/gunicorn/README.md
@@ -37,7 +37,7 @@ Restart the Agent to begin sending Gunicorn metrics to Datadog.
 
 ### Connect Gunicorn to DogStatsD
 
-Since version 19.1, Gunicorn [provides an option](http://docs.gunicorn.org/en/stable/settings.html#statsd-host) to send its metrics to a StatsD daemon. As with many Gunicorn options, you can either pass it to `gunicorn` on the CLI (`--statsd-host`) or set it in your app's configuration file (`statsd_host`). Configure your app to send metrics to DogStatsD at `"localhost:8125"`, and restart the app.
+Since version 19.1, Gunicorn [provides an option](http://docs.gunicorn.org/en/stable/settings.html#statsd-host) to send its metrics to a daemon that implements the StatsD protocol, such as [DogStatsD](https://docs.datadoghq.com/guides/dogstatsd). As with many Gunicorn options, you can either pass it to `gunicorn` on the CLI (`--statsd-host`) or set it in your app's configuration file (`statsd_host`). Configure your app to send metrics to DogStatsD at `"localhost:8125"`, and restart the app.
 
 ## Validation
 
@@ -116,4 +116,5 @@ Returns CRITICAL if the Agent cannot find a Gunicorn master process, or if canno
 
 ## Further Reading
 
-To get a better idea of how (or why) to integrate your Gunicorn apps with Datadog, check out our [blog post](https://www.datadoghq.com/blog/monitor-gunicorn-performance/).
+- To get a better idea of how (or why) to integrate your Gunicorn apps with Datadog, check out our [blog post](https://www.datadoghq.com/blog/monitor-gunicorn-performance/).
+- Learn about [StatsD, what it is and how it can help you](https://www.datadoghq.com/blog/statsd)

--- a/gunicorn/README.md
+++ b/gunicorn/README.md
@@ -117,4 +117,4 @@ Returns CRITICAL if the Agent cannot find a Gunicorn master process, or if canno
 ## Further Reading
 
 - To get a better idea of how (or why) to integrate your Gunicorn apps with Datadog, check out our [blog post](https://www.datadoghq.com/blog/monitor-gunicorn-performance/).
-- Learn about [StatsD, what it is and how it can help you](https://www.datadoghq.com/blog/statsd)
+- Learn about [StatsD, what it is and how it can help you](https://www.datadoghq.com/blog/statsd).


### PR DESCRIPTION
### What does this PR do?

This PR adds further information about DogStatsD by making it clear that it is a StatsD-compliant daemon and by adding external links to its documentation.

### Motivation

As I was reading the documentation to get the gunicorn integration working on my system, the first link in there took me out to the gunicorn upstream documentation, which discusses StatsD. That led me to think that the upstream StatsD daemon needed to be installed, as there was no info on what DogStatsD was and a confusing reference to StatsD instead.

In short, DogStatsD and StatsD were referenced in the documentation without introducing either of them first. In addition, the StatsD reference would have benefitted from clarifying that the reference was about the protocol, not the upstream daemon.

### Testing Guidelines

This is a minor edit to the documentation and requires no additional tests.

### Versioning

N/A

### Additional Notes

N/A