### PR TITLE
Layout update

### DIFF
--- a/activemq/README.md
+++ b/activemq/README.md
@@ -32,7 +32,7 @@ When you run `datadog-agent info` you should see something like the following:
 
 The activemq check is compatible with all major platforms
 
-##Data Collected
+## Data Collected
 ### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/activemq/metadata.csv) for a list of metrics provided by this integration.
 

--- a/activemq/README.md
+++ b/activemq/README.md
@@ -7,15 +7,16 @@ Get metrics from activemq service in real time to:
 * Visualize and monitor activemq states
 * Be notified about activemq failovers and events.
 
-## Installation
+## Setup
+### Installation
 
 Install the `dd-check-activemq` package manually or with your favorite configuration manager
 
-## Configuration
+### Configuration
 
 Edit the `activemq.yaml` file to point to your server and port, set the masters to monitor
 
-## Validation
+### Validation
 
 When you run `datadog-agent info` you should see something like the following:
 
@@ -31,5 +32,16 @@ When you run `datadog-agent info` you should see something like the following:
 
 The activemq check is compatible with all major platforms
 
+##Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/activemq/metadata.csv) for a list of metrics provided by this integration.
+
+### Events
+The Activemq check does not include any event at this time.
+
+### Service Checks
+The Activemq check does not include any service check at this time.
+
 ## Further Reading
+### Blog Article
 See our blog post [Monitor ActiveMQ metrics and performance](https://www.datadoghq.com/blog/monitor-activemq-metrics-performance/)

--- a/activemq_xml/README.md
+++ b/activemq_xml/README.md
@@ -32,7 +32,7 @@ When you run `datadog-agent info` you should see something like the following:
 
 The activemq_xml check is compatible with all major platforms
 
-##Data Collected
+## Data Collected
 ### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/activemq_xml/metadata.csv) for a list of metrics provided by this integration.
 

--- a/activemq_xml/README.md
+++ b/activemq_xml/README.md
@@ -7,15 +7,16 @@ Get metrics from activemq_xml service in real time to:
 * Visualize and monitor activemq_xml states
 * Be notified about activemq_xml failovers and events.
 
-## Installation
+## Setup
+### Installation
 
 Install the `dd-check-activemq_xml` package manually or with your favorite configuration manager
 
-## Configuration
+### Configuration
 
 Edit the `activemq_xml.yaml` file to point to your server and port, set the masters to monitor
 
-## Validation
+### Validation
 
 When you run `datadog-agent info` you should see something like the following:
 
@@ -30,3 +31,17 @@ When you run `datadog-agent info` you should see something like the following:
 ## Compatibility
 
 The activemq_xml check is compatible with all major platforms
+
+##Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/activemq_xml/metadata.csv) for a list of metrics provided by this integration.
+
+### Events
+The Activemq_xml check does not include any event at this time.
+
+### Service Checks
+The Activemq_xml check does not include any service check at this time.
+
+## Further Reading
+### Blog Article
+See our blog post [Monitor ActiveMQ metrics and performance](https://www.datadoghq.com/blog/monitor-activemq-metrics-performance/)

--- a/agent_metrics/README.md
+++ b/agent_metrics/README.md
@@ -32,7 +32,7 @@ When you run `datadog-agent info` you should see something like the following:
 
 The Agent_metrics check is compatible with all major platforms
 
-##Data Collected
+## Data Collected
 ### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/agent_metrics/metadata.csv) for a list of metrics provided by this integration.
 

--- a/agent_metrics/README.md
+++ b/agent_metrics/README.md
@@ -7,15 +7,16 @@ Get metrics from agent_metrics service in real time to:
 * Visualize and monitor agent_metrics states
 * Be notified about agent_metrics failovers and events.
 
-## Installation
+## Setup
+### Installation
 
 Install the `dd-check-agent_metrics` package manually or with your favorite configuration manager
 
-## Configuration
+### Configuration
 
 Edit the `agent_metrics.yaml` file to point to your server and port, set the masters to monitor
 
-## Validation
+### Validation
 
 When you run `datadog-agent info` you should see something like the following:
 
@@ -29,4 +30,14 @@ When you run `datadog-agent info` you should see something like the following:
 
 ## Compatibility
 
-The agent_metrics check is compatible with all major platforms
+The Agent_metrics check is compatible with all major platforms
+
+##Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/agent_metrics/metadata.csv) for a list of metrics provided by this integration.
+
+### Events
+The Agent_metrics check does not include any event at this time.
+
+### Service Checks
+The Agent_metrics check does not include any service check at this time.

--- a/apache/README.md
+++ b/apache/README.md
@@ -4,13 +4,14 @@
 
 The Apache check tracks requests per second, bytes served, number of worker threads, service uptime, and more.
 
-## Installation
+## Setup
+### Installation
 
 The Apache check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Apache servers.
 
 Install `mod_status` on your Apache servers and enable `ExtendedStatus`.
 
-## Configuration
+### Configuration
 
 Create a file `apache.yaml` in the Agent's `conf.d` directory:
 
@@ -26,7 +27,7 @@ instances:
 
 Restart the Agent to start sending Apache metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `apache` under the Checks section:
 
@@ -47,16 +48,20 @@ Run the Agent's `info` subcommand and look for `apache` under the Checks section
 
 The Apache check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/apache/metadata.csv) for a list of metrics provided by this check.
 
-## Service Checks
+### Events
+The Apache check does not include any event at this time.
+
+### Service Checks
 
 **apache.can_connect**:
 
 Returns CRITICAL if the Agent cannot connect to the configured `apache_status_url`, otherwise OK.
 
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to integrate your Apache web server with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/monitoring-apache-web-server-performance/).

--- a/btrfs/README.md
+++ b/btrfs/README.md
@@ -7,13 +7,14 @@ Get metrics from btrfs service in real time to:
 * Visualize and monitor btrfs states
 * Be notified about btrfs failovers and events.
 
-## Installation
+## Setup
+### Installation
 
 The Btrfs check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on every server that uses at least one Btrfs filesystem.
 
-## Configuration
+### Configuration
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `btrfs` under the Checks section:
 
@@ -30,14 +31,18 @@ Run the Agent's `info` subcommand and look for `btrfs` under the Checks section:
     [...]
 ```
 
-## Troubleshooting
-
 ## Compatibility
 
-The btrfs check is compatible with all major platforms.
+The Btrfs check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/btrfs/metadata.csv) for a list of metrics provided by this integration.
 
-## Events
+### Events
+The Btrfs check does not include any event at this time.
 
-## Service Checks
+### Service Checks
+The Btrfs check does not include any service check at this time.
+
+## Troubleshooting

--- a/cacti/README.md
+++ b/cacti/README.md
@@ -7,11 +7,12 @@ Get metrics from cacti service in real time to:
 * Visualize and monitor cacti states
 * Be notified about cacti failovers and events.
 
-## Installation
+## Setup
+### Installation
 
 The Cacti check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Cacti servers.
 
-## Configuration
+### Configuration
 
 Create a datadog user with read-only rights to the Cacti database
 
@@ -61,7 +62,7 @@ else echo -e "\033[0;31mdd-agent can not read the RRD files\033[0m";
 fi'
 ```
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `cacti` under the Checks section:
 
@@ -78,14 +79,18 @@ Run the Agent's `info` subcommand and look for `cacti` under the Checks section:
     [...]
 ```
 
-## Troubleshooting
-
 ## Compatibility
 
-The cacti check is compatible with all major platforms
+The Cacti check is compatible with all major platforms
 
-## Metrics
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/cacti/metadata.csv) for a list of metrics provided by this integration.
 
-## Events
+### Events
+The Cacti check does not include any event at this time.
 
-## Service Checks
+### Service Checks
+The Cacti check does not include any service check at this time.
+
+## Troubleshooting

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -7,13 +7,16 @@ Get metrics from cassandra service in real time to:
 * Visualize and monitor cassandra states
 * Be notified about cassandra failovers and events.
 
-## Installation
+## Setup
+### Installation
 
 The Cassandra check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Cassandra nodes.
 
-## Configuration
+### Configuration
 
-## Validation
+No configuration steps are required for the Cassandra check at this time
+
+### Validation
 
 Run the Agent's `info` subcommand and look for `cassandra` under the Checks section:
 
@@ -30,20 +33,22 @@ Run the Agent's `info` subcommand and look for `cassandra` under the Checks sect
     [...]
 ```
 
-## Troubleshooting
-
 ## Compatibility
 
 The cassandra check is compatible with all major platforms.
 
-## Metrics
-
+## Data Collected
+### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/cassandra/metadata.csv) for a list of metrics provided by this integration.
 
-## Events
+### Events
+The Cassandra check does not include any event at this time.
 
-## Service Checks
+### Service Checks
+The Cassandra check does not include any service check at this time.
+
+## Troubleshooting
 
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to integrate your Cassandra cluster with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/how-to-monitor-cassandra-performance-metrics) about it.

--- a/cassandra_nodetool/README.md
+++ b/cassandra_nodetool/README.md
@@ -1,16 +1,17 @@
 # Agent Check: Cassandra Nodetool
 
-# Overview
+## Overview
 
 This check collects metrics for your Cassandra cluster that are not available through [jmx integration](https://github.com/DataDog/integrations-core/tree/master/cassandra).
 It uses the `nodetool` utility to collect them.
 
-# Installation
+## Setup
+### Installation
 
 The varnish check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your cassandra nodes.
 If you need the newest version of the check, install the `dd-check-cassandra_nodetool` package.
 
-# Configuration
+### Configuration
 
 Create a file `cassandra_nodetool.yaml` in the Agent's `conf.d` directory:
 ```
@@ -39,7 +40,7 @@ instances:
   # tags: []
 ```
 
-# Validation
+### Validation
 
 When you run `datadog-agent info` you should see something like the following:
 
@@ -51,12 +52,22 @@ When you run `datadog-agent info` you should see something like the following:
           - instance #0 [OK]
           - Collected 39 metrics, 0 events & 7 service checks
 
-# Compatibility
+## Compatibility
 
 The `cassandra_nodetool` check is compatible with all major platforms
 
-# Service Checks
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/cassandra_nodetool/metadata.csv) for a list of metrics provided by this integration.
+
+### Events
+The Cassandra_nodetool check does not include any event at this time.
+
+### Service Checks
 
 **cassandra.nodetool.node_up**:
-
 The agent sends this service check for each node of the monitored cluster. Returns CRITICAL if the node is down, otherwise OK.
+
+## Further Reading
+### Blog Article
+To get a better idea of how (or why) to integrate your Cassandra cluster with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/how-to-monitor-cassandra-performance-metrics) about it.

--- a/ceph/README.md
+++ b/ceph/README.md
@@ -8,11 +8,12 @@ Enable the Datadog-Ceph integration to:
   * Receive service checks in case of issues
   * Monitor I/O performance metrics
 
-## Installation
+## Setup
+### Installation
 
 The Ceph check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Ceph servers.
 
-## Configuration
+### Configuration
 
 Create a file `ceph.yaml` in the Agent's `conf.d` directory:
 
@@ -30,7 +31,7 @@ If you enabled `use_sudo`, add a line like the following to your `sudoers` file:
 dd-agent ALL=(ALL) NOPASSWD:/path/to/your/ceph
 ```
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `ceph` under the Checks section:
 
@@ -47,16 +48,19 @@ Run the Agent's `info` subcommand and look for `ceph` under the Checks section:
     [...]
 ```
 
-## Troubleshooting
-
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/ceph/metadata.csv) for a list of metrics provided by this integration.
 
-## Events
+### Events
+The Ceph check does not include any event at this time.
 
-## Service Checks
+### Service Checks
+The Ceph check does not include any service check at this time.
+
+## Troubleshooting
 
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to integrate your Ceph cluster with Datadog, check out our [blog post](https://www.datadoghq.com/blog/monitor-ceph-datadog/) about it.

--- a/consul/README.md
+++ b/consul/README.md
@@ -19,13 +19,14 @@ And many more.
 
 Finally, in addition to metrics, the Datadog Agent also sends a service check for each of Consul's health checks, and an event after each new leader election.
 
-## Installation
+## Setup
+### Installation
 
 The Datadog Agent's Consul Check is included in the Agent package, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Consul nodes. If you need the newest version of the Consul check, install the `dd-check-consul` package; this package's check will override the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
-## Configuration
+### Configuration
 
-### Connect Datadog Agent to Consul Agent
+#### Connect Datadog Agent to Consul Agent
 
 Create a `consul.yaml` in the Datadog Agent's `conf.d` directory:
 
@@ -52,7 +53,7 @@ See the [sample consul.yaml](https://github.com/DataDog/integrations-core/blob/m
 
 Restart the Agent to start sending Consul metrics to Datadog.
 
-### Connect Consul Agent to DogStatsD
+#### Connect Consul Agent to DogStatsD
 
 In the main Consul configuration file, add your `dogstatsd_addr` nested under the top-level `telemetry` key:
 
@@ -68,9 +69,9 @@ In the main Consul configuration file, add your `dogstatsd_addr` nested under th
 
 Reload the Consul Agent to start sending more Consul metrics to DogStatsD.
 
-## Validation
+### Validation
 
-### Datadog Agent to Consul Agent
+#### Datadog Agent to Consul Agent
 
 Run the Agent's `info` subcommand and look for `consul` under the Checks section:
 
@@ -99,7 +100,7 @@ Also, if your Consul nodes have debug logging enabled, you'll see the Datadog Ag
     2017/03/27 21:38:12 [DEBUG] http: Request GET /v1/coordinate/nodes (84.95µs) from=127.0.0.1:53780
 ```
 
-### Consul Agent to DogStatsD
+#### Consul Agent to DogStatsD
 
 Use `netstat` to verify that Consul is sending its metrics, too:
 
@@ -112,7 +113,8 @@ udp        0      0 127.0.0.1:53874         127.0.0.1:8125          ESTABLISHED 
 
 The Consul check is compatible with all major platforms.
 
-#@ Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/consul/metadata.csv) for a list of metrics provided by the Datadog Agent's Consul check.
 
@@ -120,7 +122,13 @@ See [Consul's Telemetry doc](https://www.consul.io/docs/agent/telemetry.html) fo
 
 See [Consul's Network Coordinates doc](https://www.consul.io/docs/internals/coordinates.html) if you're curious about how the network latency metrics are calculated.
 
-## Service Checks
+### Events
+
+`consul.new_leader`:
+
+The Datadog Agent emits an event when the Consul cluster elects a new leader, tagging it with `prev_consul_leader`, `curr_consul_leader`, and `consul_datacenter`. 
+
+### Service Checks
 
 `consul.check`:
 
@@ -129,14 +137,8 @@ The Datadog Agent submits a service check for each of Consul's health checks, ta
 * `service:<name>`, if Consul reports a `ServiceName`
 * `consul_service_id:<id>`, if Consul reports a `ServiceID`
 
-## Events
-
-`consul.new_leader`:
-
-The Datadog Agent emits an event when the Consul cluster elects a new leader, tagging it with `prev_consul_leader`, `curr_consul_leader`, and `consul_datacenter`. 
-
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to integrate your Consul cluster with Datadog, check out our blog posts:
 
 * [Monitor Consul health and performance with Datadog](https://www.datadoghq.com/blog/monitor-consul-health-and-performance-with-datadog) - a more in-depth explanation of Datadog-Consul integration

--- a/couch/README.md
+++ b/couch/README.md
@@ -7,11 +7,12 @@ Capture CouchDB data in Datadog to:
 * Visualize key CouchDB metrics.
 * Correlate CouchDB performance with the rest of your applications.
 
-## Installation
+## Setup
+### Installation
 
 The CouchDB check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your CouchDB servers.
 
-## Configuration
+### Configuration
 
 Create a file `couch.yaml` in the Agent's `conf.d` directory:
 
@@ -28,7 +29,7 @@ Optionally, provide a `db_whitelist` and `db_blacklist` to control which databas
 
 Restart the Agent to begin sending CouchDB metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `couch` under the Checks section:
 
@@ -45,20 +46,23 @@ Run the Agent's `info` subcommand and look for `couch` under the Checks section:
     [...]
 ```
 
-## Troubleshooting
-
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/couch/metadata.csv) for a list of metrics provided by this integration.
 
-## Events
+### Events
 
-## Service Checks
+The Couch check does not include any event at this time.
+
+### Service Checks
 
 `couchdb.can_connect`:
 
 Returns `Critical` if the Agent cannot connect to CouchDB to collect metrics.
 
-## Further Reading
+## Troubleshooting
 
+## Further Reading
+### Blog Article
 To get a better idea of how (or why) to integrate your CouchDB cluster with Datadog, check out our [blog post](https://www.datadoghq.com/blog/monitoring-couchdb-with-datadog/) about it.

--- a/couchbase/README.md
+++ b/couchbase/README.md
@@ -12,11 +12,12 @@ Identify busy buckets, track cache miss ratios, and more. This Agent check colle
 
 And many more.
 
-## Installation
+## Setup
+### Installation
 
 The Couchbase check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Couchbase nodes.
 
-## Configuration
+### Configuration
 
 Create a file `couchbase.yaml` in the Agent's `conf.d` directory:
 
@@ -31,7 +32,7 @@ instances:
 
 Restart the Agent to begin sending Couchbase metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `couchbase` under the Checks section:
 
@@ -52,18 +53,20 @@ Run the Agent's `info` subcommand and look for `couchbase` under the Checks sect
 
 The couchbase check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/couchbase/metadata.csv) for a list of metrics provided by this integration.
 
-## Events
+### Events
+The Couchbase check does not include any event at this time.
 
-## Service Checks
+### Service Checks
 
 `couchbase.can_connect`:
 
 Returns `Critical` if the Agent cannot connect to Couchbase to collect metrics.
 
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to integrate your Couchbase cluster with Datadog, check out our [blog post](https://www.datadoghq.com/blog/monitoring-couchbase-performance-datadog/) about it.

--- a/directory/README.md
+++ b/directory/README.md
@@ -9,11 +9,12 @@ Capture metrics from directories and files of your choosing. The Agent will coll
   * age of the last modification
   * age of the creation
 
-## Installation
+## Setup
+### Installation
 
 The directory check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) anywhere you wish to use it.
 
-## Configuration
+### Configuration
 
 Create a file `directory.yaml` in the Agent's `conf.d` directory:
 
@@ -32,7 +33,7 @@ Ensure that the user running the Agent process (usually `dd-agent`) has read acc
 
 Restart the Agent to begin sending metrics on your chosen directories to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `directory` under the Checks section:
 
@@ -49,18 +50,21 @@ Run the Agent's `info` subcommand and look for `directory` under the Checks sect
     [...]
 ```
 
-## Troubleshooting
-
 ## Compatibility
 
 The directory check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/directory/metadata.csv) for a list of metrics provided by this integration.
 
-## Events
+### Events
+The Directory check does not include any event at this time.
 
-## Service Checks
+### Service Checks
+The Directory check does not include any service check at this time.
+
+## Troubleshooting
 
 ## Further Reading

--- a/disk/README.md
+++ b/disk/README.md
@@ -4,15 +4,16 @@
 
 Collect metrics related to disk usage and IO.
 
-## Installation
+## Setup
+### Installation
 
 The disk check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) anywhere you wish to use it.
 
-## Configuration
+### Configuration
 
 The disk check is enabled by default, and the Agent will collect metrics on all local partitions. If you want to configure the check with custom options, create a file `disk.yaml` in the Agent's `conf.d` directory. See the [sample disk.yaml](https://github.com/DataDog/integrations-core/blob/master/disk/conf.yaml.default) for all available configuration options.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `disk` under the Checks section:
 
@@ -29,8 +30,15 @@ Run the Agent's `info` subcommand and look for `disk` under the Checks section:
     [...]
 ```
 
-## Troubleshooting
-
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/disk/metadata.csv) for a list of metrics provided by this check.
+
+### Events
+The Disk check does not include any event at this time.
+
+### Service Checks
+The Disk check does not include any service check at this time.
+
+## Troubleshooting

--- a/dns_check/README.md
+++ b/dns_check/README.md
@@ -4,13 +4,14 @@
 
 Monitor the resolvability of and lookup times for any DNS records using nameservers of your choosing.
 
-## Installation
+## Setup
+### Installation
 
 The DNS check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any host from which you want to probe your DNS servers. Though many metrics-oriented checks are best run on the same host(s) as the monitored service, you may want to run this status-oriented check from hosts that do not run the monitored DNS services.
 
 If you need the newest version of the DNS check, install the `dd-check-dns` package; this package's check will override the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
-## Configuration
+### Configuration
 
 Create a file `dns_check.yaml` in the Agent's `conf.d` directory:
 
@@ -30,7 +31,7 @@ If you omit the `nameserver` option, the check will use whichever nameserver is 
 
 Restart the Agent to begin sending DNS service checks and response times to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `dns_check` under the Checks section:
 
@@ -48,24 +49,26 @@ Run the Agent's `info` subcommand and look for `dns_check` under the Checks sect
     [...]
 ```
 
-## Troubleshooting
-
 ## Compatibility
 
 The DNS check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/dns_check/metadata.csv) for a list of metrics provided by this integration.
 
-## Events
+### Events
+The DNS check does not include any event at this time.
 
-## Service Checks
+### Service Checks
 
 `dns.can_resolve`:
 
 Returns CRITICAL if the Agent fails to resolve the request, otherwise returns UP.
 
 Tagged by `hostname` and `record_type`.
+
+## Troubleshooting
 
 ## Further Reading

--- a/docker_daemon/README.md
+++ b/docker_daemon/README.md
@@ -7,15 +7,16 @@ Get metrics from docker_daemon service in real time to:
 * Visualize and monitor docker_daemon states
 * Be notified about docker_daemon failovers and events.
 
-## Installation
+## Setup
+### Installation
 
 Install the `dd-check-docker_daemon` package manually or with your favorite configuration manager
 
-## Configuration
+### Configuration
 
 Edit the `docker_daemon.yaml` file to point to your server and port, set the masters to monitor
 
-## Validation
+### Validation
 
 When you run `datadog-agent info` you should see something like the following:
 
@@ -31,6 +32,16 @@ When you run `datadog-agent info` you should see something like the following:
 
 The docker_daemon check is compatible with all major platforms
 
-## Further Reading
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/docker_daemon/metadata.csv) for a list of metrics provided by this integration.
 
+### Events
+The Docker Daemon check does not include any event at this time.
+
+### Service Checks
+The Docker Daemon check does not include any service check at this time.
+
+## Further Reading
+### Blog Article
 To get a better idea of how (or why) to integrate your docker daemon with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/the-docker-monitoring-problem/) about it.

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -6,11 +6,12 @@ Stay up-to-date on the health of your Elasticsearch cluster, from its overall st
 
 The Datadog Agent's Elasticsearch check collects metrics for search and indexing performance, memory usage and garbage collection, node availability, shard statistics, disk space and performance, pending tasks, and many more. The Agent also sends events and service checks for the overall status of your cluster.
 
-## Installation
+## Setup
+### Installation
 
 The Elasticsearch check is packaged with the Datadog Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Elasticsearch nodes, or on some other server if you use a hosted Elasticsearch (e.g. Elastic Cloud).
 
-## Configuration
+### Configuration
 
 Create a file `elastic.yaml` in the Datadog Agent's `conf.d` directory:
 
@@ -30,7 +31,7 @@ See the [sample elastic.yaml](https://github.com/Datadog/integrations-core/blob/
 
 Restart the Agent to begin sending Elasticsearch metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's info subcommand and look for `elastic` under the Checks section:
 
@@ -47,6 +48,29 @@ Run the Agent's info subcommand and look for `elastic` under the Checks section:
     [...]
 ```
 
+## Compatibility
+
+The Elasticsearch check is compatible with all major platforms.
+
+## Data Collected
+### Metrics
+
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/elastic/metadata.csv) for a list of metrics provided by this integration.
+
+### Events
+
+The Elasticsearch check emits an event to Datadog each time the overall status of your Elasticsearch cluster changes — red, yellow, or green.
+
+### Service checks
+
+`elasticsearch.cluster_health`:
+
+Returns `OK` if the cluster status is green, `Warn` if yellow, and `Critical` otherwise.
+
+`elasticsearch.can_connect`:
+
+Returns `Critical` if the Agent cannot connect to Elasticsearch to collect metrics.
+
 ## Troubleshooting
 
 ### Agent cannot connect
@@ -59,28 +83,6 @@ Run the Agent's info subcommand and look for `elastic` under the Checks section:
 
 Check that the `url` in `elastic.yaml` is correct.
 
-## Compatibility
-
-The Elasticsearch check is compatible with all major platforms.
-
-## Metrics
-
-See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/elastic/metadata.csv) for a list of metrics provided by this integration.
-
-## Events
-
-The Elasticsearch check emits an event to Datadog each time the overall status of your Elasticsearch cluster changes — red, yellow, or green.
-
-## Service checks
-
-`elasticsearch.cluster_health`:
-
-Returns `OK` if the cluster status is green, `Warn` if yellow, and `Critical` otherwise.
-
-`elasticsearch.can_connect`:
-
-Returns `Critical` if the Agent cannot connect to Elasticsearch to collect metrics.
-
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to integrate your Elasticsearch cluster with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/monitor-elasticsearch-performance-metrics/) about it.

--- a/etcd/README.md
+++ b/etcd/README.md
@@ -8,11 +8,12 @@ Collect etcd metrics to:
 * Know when host configurations may be out of sync.
 * Correlate the performance of etcd with the rest of your applications.
 
-## Installation
+## Setup
+### Installation
 
 The etcd check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your etcd instance(s).
 
-## Configuration
+### Configuration
 
 Create a file `etcd.yaml` in the Agent's `conf.d` directory:
 
@@ -25,7 +26,7 @@ instances:
 
 Restart the Agent to begin sending etcd metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `etcd` under the Checks section:
 
@@ -42,24 +43,26 @@ Run the Agent's `info` subcommand and look for `etcd` under the Checks section:
     [...]
 ```
 
-## Troubleshooting
-
 ## Compatibility
 
 The etcd check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/etcd/metadata.csv) for a list of metrics provided by this integration.
 
-## Events
+### Events
+The Etcd check does not include any event at this time.
 
-## Service Checks
+### Service Checks
 
 `etcd.can_connect`:
 
 Returns 'Critical' if the Agent cannot collect metrics from your etcd API endpoint.
 
-## Further Reading
+## Troubleshooting
 
+## Further Reading
+### Blog Article
 To get a better idea of how (or why) to integrate etcd with Datadog, check out our [blog post](https://www.datadoghq.com/blog/monitor-etcd-performance/) about it.

--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -7,13 +7,13 @@ Get metrics from Fluentd to:
 * Visualize Fluentd performance.
 * Correlate the performance of Fluentd with the rest of your applications.
 
-## Installation
+## Setup
+### Installation
 
 The Fluentd check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Fluentd servers.
 
-## Configuration
-
-### Prepare Fluentd
+### Configuration
+#### Prepare Fluentd
 
 In your fluentd configuration, add a `monitor_agent` source:
 
@@ -25,7 +25,7 @@ In your fluentd configuration, add a `monitor_agent` source:
 </source>
 ```
 
-### Connect the Datadog Agent
+#### Connect the Datadog Agent
 
 Create a file `fluentd.yaml` in the Agent's `conf.d` directory:
 
@@ -42,7 +42,7 @@ instances:
 
 Restart the Agent to begin sending Fluentd metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `fluentd` under the Checks section:
 
@@ -59,18 +59,21 @@ Run the Agent's `info` subcommand and look for `fluentd` under the Checks sectio
     [...]
 ```
 
-## Metrics
+
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/fluentd/metadata.csv) for a list of metrics provided by this integration.
 
-## Events
+### Events
+The FluentD check does not include any event at this time.
 
-## Service Checks
+### Service Checks
 
 `fluentd.is_ok`:
 
 Returns 'Critical' if the Agent cannot connect to Fluentd to collect metrics. This is the check which most other integrations would call `can_connect`.
 
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to integrate your Fluentd servers with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/monitor-fluentd-datadog/) about it.

--- a/gearmand/README.md
+++ b/gearmand/README.md
@@ -8,11 +8,12 @@ Collect Gearman metrics to:
 * Know how many tasks are queued or running.
 * Correlate Gearman performance with the rest of your applications.
 
-## Installation
+## Setup
+### Installation
 
 The Gearman check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Gearman job servers.
 
-## Configuration
+### Configuration
 
 Create a file `gearmand.yaml` in the Agent's `conf.d` directory:
 
@@ -26,7 +27,7 @@ instances:
 
 Restart the Agent to begin sending Gearman metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `gearmand` under the Checks section:
 
@@ -43,22 +44,24 @@ Run the Agent's `info` subcommand and look for `gearmand` under the Checks secti
     [...]
 ```
 
-## Troubleshooting
-
 ## Compatibility
 
 The gearmand check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/gearmand/metadata.csv) for a list of metrics provided by this integration.
 
-## Events
+### Events
+The Gearmand check does not include any event at this time.
 
-## Service Checks
+### Service Checks
 
 `gearman.can_connect`:
 
 Returns `Critical` if the Agent cannot connect to Gearman to collect metrics.
+
+## Troubleshooting
 
 ## Further Reading

--- a/go-metro/README.md
+++ b/go-metro/README.md
@@ -6,7 +6,8 @@ The TCP RTT check reports on roundtrip times between the host the agent is runni
 
 This check is only shipped in the 64-bit DEB and RPM Datadog Agent packages.
 
-## Installation
+## Setup
+### Installation
 
 The TCP RTT check—also known as [go-metro](https://github.com/DataDog/go-metro)—is packaged with the Agent, but requires additional system libraries. The check uses timestamps provided by the PCAP library to compute the time between any outgoing packet and the corresponding TCP acknowledgement. As such, PCAP must be installed and configured.
 
@@ -30,7 +31,7 @@ Finally, configure PCAP:
 $ sudo setcap cap_net_raw+ep /opt/datadog-agent/bin/go-metro
 ```
 
-## Configuration
+### Configuration
 
 Edit the ```go-metro.yaml``` file in your agent's ```conf.d``` directory. The following is an example file that will show the TCP RTT times for app.datadoghq.com and 192.168.0.22:
 
@@ -52,7 +53,7 @@ Edit the ```go-metro.yaml``` file in your agent's ```conf.d``` directory. The fo
         hosts:
           - app.datadoghq.com
 
-## Validation
+### Validation
 
 To validate that the check is running correctly, you should see `system.net.tcp.rtt` metrics showing in the Datadog interface. Also, if you run `sudo /etc/init.d/datadog-agent status`, you should see something similar to the following:
 
@@ -77,6 +78,13 @@ This is a passive check, so unless there are packets actively being sent to the 
 
 The TCP RTT check is compatible with Linux platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/go-metro/metadata.csv) for a list of metrics provided by this check.
+
+### Events
+The Go-metro check does not include any event at this time.
+
+### Service Checks
+The Go-metro check does not include any service check at this time.

--- a/go_expvar/README.md
+++ b/go_expvar/README.md
@@ -6,19 +6,20 @@ Track the memory usage of your Go services and collect metrics instrumented from
 
 If you prefer to instrument your Go code using only [dogstats-go](https://github.com/DataDog/datadog-go), you can still use this integration to collect memory-related metrics.
 
-## Installation
+## Setup
+### Installation
 
 The Go Expvar check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) anywhere you run Go services whose metrics you want to collect.
 
-## Configuration
+### Configuration
 
-### Prepare your Go service
+#### Prepare your Go service
 
 If your Go service doesn't use the [expvar package](https://golang.org/pkg/expvar/) already, you'll need to import it (`import "expvar"`). If you don't want to instrument your own metrics with expvar — i.e. you only want to collect your service's memory metrics — import the package using the blank identifier (`import _ "expvar"`).
 
 If your service doesn't already listen for HTTP requests (via the http package), [make it listen](https://golang.org/pkg/net/http/#ListenAndServe) locally, just for the Datadog Agent.
 
-### Connect the Agent
+#### Connect the Agent
 
 Create a file `go_expvar.yaml` in the Agent's `conf.d` directory:
 
@@ -43,7 +44,7 @@ If you don't configure a `metrics` list, the Agent will still collect memstat me
 
 Restart the Agent to begin sending memstat and expvar metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `go_expvar` under the Checks section:
 
@@ -64,14 +65,17 @@ Run the Agent's `info` subcommand and look for `go_expvar` under the Checks sect
 
 The go_expvar check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/go_expvar/metadata.csv) for a list of metrics provided by this integration.
 
-## Service Checks
+### Events
+The Go-Expvar check does not include any event at this time.
 
-## Events
+### Service Checks
+The Go-Expvar check does not include any service check at this time.
 
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to instrument your Go apps with Expvar and Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/instrument-go-apps-expvar-datadog/) about it.

--- a/gunicorn/README.md
+++ b/gunicorn/README.md
@@ -11,15 +11,15 @@ Gunicorn itself can provide further metrics via DogStatsD, including those for:
 * Request duration (average, median, max, 95th percentile, etc)
 * Log message rate by log level (critical, error, warning, exception)
 
-## Installation
+## Setup
+### Installation
 
 The Datadog Agent's Gunicorn check is included in the Agent package, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Gunicorn servers. If you need the newest version of the Gunicorn check, install the `dd-check-gunicorn` package; this package's check will override the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 The Gunicorn check requires your Gunicorn app's Python environment to have the [`setproctitle`](https://pypi.python.org/pypi/setproctitle) package; without it, the Datadog Agent will always report that it cannot find a `gunicorn` master process (and hence, cannot find workers, either). Install the `setproctitle` package in your app's Python environment if you want to collect the `gunicorn.workers` metric.
 
-## Configuration
-
-### Configure the Datadog Agent
+### Configuration
+#### Configure the Datadog Agent
 
 Create a `gunicorn.yaml` in the Datadog Agent's `conf.d` directory:
 
@@ -35,11 +35,11 @@ instances:
 
 Restart the Agent to begin sending Gunicorn metrics to Datadog.
 
-### Connect Gunicorn to DogStatsD
+#### Connect Gunicorn to DogStatsD
 
 Since version 19.1, Gunicorn [provides an option](http://docs.gunicorn.org/en/stable/settings.html#statsd-host) to send its metrics to a StatsD daemon. As with many Gunicorn options, you can either pass it to `gunicorn` on the CLI (`--statsd-host`) or set it in your app's configuration file (`statsd_host`). Configure your app to send metrics to DogStatsD at `"localhost:8125"`, and restart the app.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `gunicorn` under the Checks section:
 
@@ -65,8 +65,26 @@ $ sudo netstat -nup | grep "127.0.0.1:8125.*ESTABLISHED"
 udp        0      0 127.0.0.1:38374         127.0.0.1:8125          ESTABLISHED 15500/gunicorn: mas
 ```
 
-## Troubleshooting
+## Compatibility
 
+The gunicorn check is compatible with all major platforms.
+
+## Data Collected
+### Metrics
+
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/gunicorn/metadata.csv) for a list of metrics provided by this integration - those from the Agent _and_ those sent by Gunicorn to DogStatsD.
+
+### Events
+The Gunicorn check does not include any event at this time.
+
+### Service Checks
+
+`gunicorn.is_running`:
+
+Returns CRITICAL if the Agent cannot find a Gunicorn master process, or if cannot find any working or idle worker processes.
+
+
+## Troubleshooting
 ### Agent cannot find Gunicorn process
 ```
   Checks
@@ -100,20 +118,6 @@ ubuntu   18462 18457  0 20:26 pts/0    00:00:00 gunicorn: worker [my_app]
 ubuntu   18463 18457  0 20:26 pts/0    00:00:00 gunicorn: worker [my_app]
 ```
 
-## Compatibility
-
-The gunicorn check is compatible with all major platforms.
-
-## Metrics
-
-See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/gunicorn/metadata.csv) for a list of metrics provided by this integration - those from the Agent _and_ those sent by Gunicorn to DogStatsD.
-
-## Service Checks
-
-`gunicorn.is_running`:
-
-Returns CRITICAL if the Agent cannot find a Gunicorn master process, or if cannot find any working or idle worker processes.
-
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to integrate your Gunicorn apps with Datadog, check out our [blog post](https://www.datadoghq.com/blog/monitor-gunicorn-performance/).

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -8,13 +8,13 @@ Capture HAProxy activity in Datadog to:
 * Know when a server goes down.
 * Correlate the performance of HAProxy with the rest of your applications.
 
-## Installation
+## Setup
+### Installation
 
 The HAProxy check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your HAProxy servers.
 
-## Configuration
-
-### Prepare HAProxy
+### Configuration
+#### Prepare HAProxy
 
 The Agent collects metrics via a stats endpoint. Configure one in your `haproxy.conf`:
 
@@ -45,7 +45,7 @@ instances:
 
 Restart the Agent to begin sending HAProxy metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `haproxy` under the Checks section:
 
@@ -62,20 +62,20 @@ Run the Agent's `info` subcommand and look for `haproxy` under the Checks sectio
     [...]
 ```
 
-## Troubleshooting
-
 ## Compatibility
-
 The haproxy check is compatible with all major platforms.
 
 ## Metrics
-
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/haproxy/metadata.csv) for a list of metrics provided by this integration.
 
 ## Events
+The Haproxy check does not include any event at this time.
 
 ## Service Checks
+The Haproxy check does not include any service check at this time.
+
+## Troubleshooting
 
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to integrate your HAProxy servers with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/monitoring-haproxy-performance-metrics/) about it.

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -65,13 +65,14 @@ Run the Agent's `info` subcommand and look for `haproxy` under the Checks sectio
 ## Compatibility
 The haproxy check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/haproxy/metadata.csv) for a list of metrics provided by this integration.
 
-## Events
+### Events
 The Haproxy check does not include any event at this time.
 
-## Service Checks
+### Service Checks
 The Haproxy check does not include any service check at this time.
 
 ## Troubleshooting

--- a/hdfs_datanode/README.md
+++ b/hdfs_datanode/README.md
@@ -6,13 +6,13 @@ Track disk utilization and failed volumes on each of your HDFS DataNodes. This A
 
 Use this check (hdfs_datanode) and its counterpart check (hdfs_namenode), not the older two-in-one check (hdfs); that check is deprecated.
 
-## Installation
+## Setup
+### Installation
 
 The HDFS DataNode check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your DataNodes.
 
-## Configuration
-
-### Prepare the DataNode
+### Configuration
+#### Prepare the DataNode
 
 The Agent collects metrics from the DataNode's JMX remote interface. The interface is disabled by default, so enable it by setting the following option in `hadoop-env.sh` (usually found in $HADOOP_HOME/conf):
 
@@ -25,7 +25,7 @@ export HADOOP_DATANODE_OPTS="-Dcom.sun.management.jmxremote
 
 Restart the DataNode process to enable the JMX interface.
 
-### Connect the Agent
+#### Connect the Agent
 
 Create a file `hdfs_datanode.yaml` in the Agent's `conf.d` directory:
 
@@ -38,7 +38,7 @@ instances:
 
 Restart the Agent to begin sending DataNode metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `hdfs_datanode` under the Checks section:
 
@@ -55,24 +55,25 @@ Run the Agent's `info` subcommand and look for `hdfs_datanode` under the Checks 
     [...]
 ```
 
-## Troubleshooting
-
 ## Compatibility
 
 The hdfs_datanode check is compatible with all major platforms.
 
-## Metrics
-
+## Data Collected
+### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/hdfs_datanode/metadata.csv) for a list of metrics provided by this integration.
 
-## Events
+### Events
+The HDFS-datanode check does not include any event at this time.
 
-## Service Checks
+### Service Checks
 
 `hdfs.datanode.jmx.can_connect`:
 
 Returns `Critical` if the Agent cannot connect to the DataNode's JMX interface for any reason (e.g. wrong port provided, timeout, un-parseable JSON response).
 
-## Further Reading
+## Troubleshooting
 
+## Further Reading
+### Blog Article
 To get a better idea of how (or why) to integrate your HDFS DataNodes with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/hadoop-architecture-overview/) about monitoring Hadoop. In particular, [Part 2](https://www.datadoghq.com/blog/monitor-hadoop-metrics/) provides a useful walkthrough of key metrics.

--- a/hdfs_namenode/README.md
+++ b/hdfs_namenode/README.md
@@ -6,13 +6,13 @@ Monitor your primary _and_ standby HDFS NameNodes to know when your cluster fall
 
 Use this check (hdfs_namenode) and its counterpart check (hdfs_datanode), not the older two-in-one check (hdfs); that check is deprecated.
 
-## Installation
+## Setup
+### Installation
 
 The HDFS NameNode check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your NameNodes.
 
-## Configuration
-
-### Prepare the NameNode
+### Configuration
+#### Prepare the NameNode
 
 The Agent collects metrics from the NameNode's JMX remote interface. The interface is disabled by default, so enable it by setting the following option in `hadoop-env.sh` (usually found in $HADOOP_HOME/conf):
 
@@ -25,7 +25,7 @@ export HADOOP_NAMENODE_OPTS="-Dcom.sun.management.jmxremote
 
 Restart the NameNode process to enable the JMX interface.
 
-### Connect the Agent
+#### Connect the Agent
 
 Create a file `hdfs_namenode.yaml` in the Agent's `conf.d` directory:
 
@@ -38,7 +38,7 @@ instances:
 
 Restart the Agent to begin sending NameNode metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `hdfs_namenode` under the Checks section:
 
@@ -55,24 +55,26 @@ Run the Agent's `info` subcommand and look for `hdfs_namenode` under the Checks 
     [...]
 ```
 
-## Troubleshooting
-
 ## Compatibility
 
 The hdfs_namenode check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/hdfs_namenode/metadata.csv) for a list of metrics provided by this integration.
 
-## Events
+### Events
+The HDFS-namenode check does not include any event at this time.
 
-## Service Checks
+### Service Checks
 
 `hdfs.namenode.jmx.can_connect`:
 
 Returns `Critical` if the Agent cannot connect to the NameNode's JMX interface for any reason (e.g. wrong port provided, timeout, un-parseable JSON response).
 
-## Further Reading
+## Troubleshooting
 
+## Further Reading
+### Blog Article
 To get a better idea of how (or why) to integrate your HDFS NameNodes with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/hadoop-architecture-overview/) about monitoring Hadoop. In particular, [Part 2](https://www.datadoghq.com/blog/monitor-hadoop-metrics/) provides a useful walkthrough of key metrics.

--- a/http_check/README.md
+++ b/http_check/README.md
@@ -4,13 +4,14 @@
 
 Monitor the up/down status of local or remote HTTP endpoints. The HTTP check can detect bad response codes (e.g. 404), identify soon-to-expire SSL certificates, search responses for specific text, and much more. The check also submits HTTP response times as a metric.
 
-## Installation
+## Setup
+### Installation
 
 The HTTP check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any host from which you want to probe your HTTP sites. Though many metrics-oriented checks are best run on the same host(s) as the monitored service, you may want to run this status-oriented check from hosts that do not run the monitored sites.
 
 If you need the newest version of the HTTP check, install the `dd-check-http` package; this package's check will override the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
-## Configuration
+### Configuration
 
 Create a file `http_check.yaml` in the Agent's `conf.d` directory:
 
@@ -38,7 +39,7 @@ See the [sample http_check.yaml](https://github.com/DataDog/integrations-core/bl
 
 When you have finished configuring `http_check.yaml`, restart the Agent to begin sending HTTP service checks and response times to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `http_check` under the Checks section:
 
@@ -57,23 +58,22 @@ Run the Agent's `info` subcommand and look for `http_check` under the Checks sec
     [...]
 ```
 
-## Troubleshooting
-
 ## Compatibility
 
 The http_check check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/http_check/metadata.csv) for a list of metrics provided by this integration.
 
-## Events
+### Events
 
 Older versions of the HTTP check only emitted events to reflect site status, but now the check supports service checks, too. However, emitting events is still the default behavior. Set `skip_event` to true for all configured instances to submit service checks instead of events.
 
 The Agent will soon deprecate `skip_event`, i.e. the HTTP check will only support service checks.
 
-## Service Checks
+### Service Checks
 
 To create alert conditions on these service checks in Datadog, select 'Network' on the [Create Monitor](https://app.datadoghq.com/monitors#/create) page, not 'Integration'.
 
@@ -100,5 +100,7 @@ The check returns:
 Otherwise, returns `UP`.
 
 To disable this check, set `check_certificate_expiration` to false.
+
+## Troubleshooting
 
 ## Further Reading

--- a/iis/README.md
+++ b/iis/README.md
@@ -4,15 +4,15 @@
 
 Collect IIS metrics aggregated across all of your sites, or on a per-site basis. The IIS Agent check collects metrics for active connections, bytes sent and received, request count by HTTP method, and more. It also sends a service check for each site, letting you know whether it's up or down.
 
-## Installation
+## Setup
+### Installation
 
 The IIS check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your IIS servers.
 
 Also, your IIS servers must have the `Win32_PerfFormattedData_W3SVC_WebService` WMI class installed. 
 
-## Configuration
-
-### Prepare IIS
+### Configuration
+#### Prepare IIS
 
 On your IIS servers, first resync the WMI counters.
 
@@ -29,7 +29,7 @@ On Windows >= 2008 (or equivalent), instead run:
 C:/> winmgmt /resyncperf
 ```
 
-### Connect the Agent \
+#### Connect the Agent \
 
 Create a file `iis.yaml` in the Agent's `conf.d` directory:
 
@@ -51,7 +51,7 @@ You can also monitor sites on remote IIS servers. See the [sample iis.conf](http
 
 Restart the Agent to begin sending IIS metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `iis` under the Checks section:
 
@@ -68,13 +68,15 @@ Run the Agent's `info` subcommand and look for `iis` under the Checks section:
     [...]
 ```
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/iis/metadata.csv) for a list of metrics provided by this integration.
 
-## Events
+### Events
+The IIS check does not include any event at this time.
 
-## Service Checks
+### Service Checks
 
 `iis.site_up`:
 

--- a/iis/README.md
+++ b/iis/README.md
@@ -29,7 +29,7 @@ On Windows >= 2008 (or equivalent), instead run:
 C:/> winmgmt /resyncperf
 ```
 
-#### Connect the Agent \
+#### Connect the Agent
 
 Create a file `iis.yaml` in the Agent's `conf.d` directory:
 

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -11,13 +11,14 @@ This check has a limit of 350 metrics per instance. The number of returned metri
 
 To collect Kafka consumer metrics, see the kafka_consumer check.
 
-## Installation
+## Setup
+### Installation
 
 The Agent's Kafka check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Kafka nodes.
 
 The check collects metrics via JMX, so you'll need a JVM on each kafka node so the Agent can fork [jmxfetch](https://github.com/DataDog/jmxfetch). You can use the same JVM that Kafka uses.
 
-## Configuration
+### Configuration
 
 **The following instructions are for the Datadog agent >= 5.0. For agents before that, refer to the [older documentation](https://github.com/DataDog/dd-agent/wiki/Deprecated-instructions-to-install-python-dependencies-for-the-Datadog-Agent).**
 
@@ -25,7 +26,7 @@ Configure a `kafka.yaml` in the Datadog Agent's `conf.d` directory. Kafka bean n
 
 After you've configured `kafka.yaml`, restart the Agent to begin sending Kafka metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `kafka` under the Checks section:
 
@@ -46,10 +47,16 @@ Run the Agent's `info` subcommand and look for `kafka` under the Checks section:
 
 The kafka check is compatible with all major platforms.
 
-## Metrics
-
+## Data Collected
+### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/kafka/metadata.csv) for a list of metrics provided by this check.
 
-## Further Reading
+### Events
+The Kafka check does not include any event at this time.
 
+### Service Checks
+The Kafka check does not include any service check at this time.
+
+## Further Reading
+### Blog Article
 To get a better idea of how (or why) to monitor Kafka performance metrics with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/monitoring-kafka-performance-metrics/) about it.

--- a/kafka_consumer/README.md
+++ b/kafka_consumer/README.md
@@ -1,6 +1,6 @@
 # Agent Check: Kafka Consumer
 
-# Overview
+## Overview
 
 This Agent check only collects metrics for message offsets. If you want to collect metrics about the Kafka brokers themselves, see the kafka check.
 
@@ -8,15 +8,16 @@ This check fetches the highwater offsets from the Kafka brokers, consumer offset
 
 This check does NOT support Kafka versions > 0.8—it can't collect consumer offsets for new-style consumer groups which store their offsets in Kafka. If run such a version of Kafka, track [this issue on GitHub](https://github.com/DataDog/integrations-core/issues/457).
 
-# Installation
+## Setup
+### Installation
 
 The Agent's Kafka consumer check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Kafka nodes. If you need the newest version of the check, install the `dd-check-kafka-consumer` package.
 
-# Configuration
+### Configuration
 
 Create a `kafka_consumer.yaml` file using [this sample conf file](https://github.com/DataDog/integrations-core/blob/master/kafka_consumer/conf.yaml.example) as an example. Then restart the Datadog Agent to start sending metrics to Datadog.
 
-# Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `kafka_consumer` under the Checks section:
 
@@ -37,10 +38,16 @@ Run the Agent's `info` subcommand and look for `kafka_consumer` under the Checks
 
 The kafka_consumer check is compatible with all major platforms.
 
-# Metrics
-
+## Data collected
+### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/kafka_consumer/metadata.csv) for a list of metrics provided by this check.
 
-## Further Reading
+### Events
+The Kafka-consumer check does not include any event at this time.
 
+### Service Checks
+The Kafka-consumer check does not include any service check at this time.
+
+## Further Reading
+### Blog Article
 To get a better idea of how (or why) to monitor Kafka consumer performance metrics with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/monitoring-kafka-performance-metrics/) about it.

--- a/kong/README.md
+++ b/kong/README.md
@@ -4,11 +4,12 @@
 
 The Agent's Kong check tracks total requests, response codes, client connections, and more.
 
-## Installation
+## Setup
+### Installation
 
 The Kong check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Kong servers. If you need the newest version of the check, install the `dd-check-kong` package.
 
-## Configuration
+### Configuration
 
 Create a `kong.yaml` in the Datadog Agent's `conf.d` directory:
 
@@ -27,7 +28,7 @@ instances:
 
 Restart the Agent to begin sending Kong metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for kong` under the Checks section:
 
@@ -48,16 +49,20 @@ Run the Agent's `info` subcommand and look for kong` under the Checks section:
 
 The kong check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/kong/metadata.csv) for a list of metrics provided by this check.
 
-## Service Checks
+### Events
+The Kong check does not include any event at this time.
+
+### Service Checks
 
 `kong.can_connect`:
 
 Returns CRITICAL if the Agent cannot connect to Kong to collect metrics, otherwise OK.
 
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to monitor Kong with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/monitor-kong-datadog/) about it.

--- a/kube_dns/README.md
+++ b/kube_dns/README.md
@@ -10,15 +10,16 @@ Get metrics from kube-dns service in real time to:
 See https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns for
 more informations about kube-dns
 
-## Installation
+## Setup
+### Installation
 
 Install the `dd-check-kube_dns` package manually or with your favorite configuration manager
 
-## Configuration
+### Configuration
 
 Edit the `kube_dns.yaml` file to point to your server and port, set the masters to monitor
 
-### Using with service discovery
+#### Using with service discovery
 
 If you are using 1 dd-agent pod per kubernetes worker nodes, you could use the
 following annotations on your kube-dns pod to get the data retrieve
@@ -43,7 +44,7 @@ metadata:
    add the annotations to the metadata of the template's spec.
 
 
-## Validation
+### Validation
 
 When you run `datadog-agent info` you should see something like the following:
 
@@ -58,3 +59,13 @@ When you run `datadog-agent info` you should see something like the following:
 ## Compatibility
 
 The kube_dns check is compatible with all major platforms
+
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/kube_dns/metadata.csv) for a list of metrics provided by this integration.
+
+### Events
+The Kube-DNS check does not include any event at this time.
+
+### Service Checks
+The Kube-DNS check does not include any service check at this time.

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -7,15 +7,16 @@ Get metrics from kubernetes service in real time to:
 * Visualize and monitor kubernetes states
 * Be notified about kubernetes failovers and events.
 
-## Installation
+## Setup
+### Installation
 
 Install the `dd-check-kubernetes` package manually or with your favorite configuration manager
 
-## Configuration
+### Configuration
 
 Edit the `kubernetes.yaml` file to point to your server and port, set the masters to monitor
 
-## Validation
+### Validation
 
 When you run `datadog-agent info` you should see something like the following:
 
@@ -31,6 +32,16 @@ When you run `datadog-agent info` you should see something like the following:
 
 The kubernetes check is compatible with all major platforms
 
-## Further Reading
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/kubernetes/metadata.csv) for a list of metrics provided by this integration.
 
+### Events
+The Kubernetes check does not include any event at this time.
+
+### Service Checks
+The Kubernetes check does not include any service check at this time.
+
+## Further Reading
+### Blog Article
 To get a better idea of how (or why) to integrate your Kubernetes service, check out our [series of blog posts](https://www.datadoghq.com/blog/monitoring-kubernetes-era/) about it.

--- a/kubernetes_state/README.md
+++ b/kubernetes_state/README.md
@@ -7,15 +7,16 @@ Get metrics from kubernetes_state service in real time to:
 * Visualize and monitor kubernetes_state states
 * Be notified about kubernetes_state failovers and events.
 
-## Installation
+## Setup
+### Installation
 
 Install the `dd-check-kubernetes_state` package manually or with your favorite configuration manager
 
-## Configuration
+### Configuration
 
 Edit the `kubernetes_state.yaml` file to point to your server and port, set the masters to monitor
 
-## Validation
+### Validation
 
 When you run `datadog-agent info` you should see something like the following:
 
@@ -30,3 +31,13 @@ When you run `datadog-agent info` you should see something like the following:
 ## Compatibility
 
 The kubernetes_state check is compatible with all major platforms
+
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/kubernetes_state/metadata.csv) for a list of metrics provided by this integration.
+
+### Events
+The Kubernetes-state check does not include any event at this time.
+
+### Service Checks
+The Kubernetes-state check does not include any service check at this time.

--- a/kyototycoon/README.md
+++ b/kyototycoon/README.md
@@ -4,11 +4,12 @@
 
 The Agent's Kyototycoon check tracks get, set, and delete operations, and lets you monitor replication lag.
 
-## Installation
+## Setup
+### Installation
 
 The Kyototycoon check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Kyototycoon servers. If you need the newest version of the check, install the `dd-check-kyototycoon` package.
 
-## Configuration
+### Configuration
 
 Create a file `kyototycoon.yaml` in the Agent's `conf.d` directory:
 
@@ -29,7 +30,7 @@ instances:
 #     baz: bat
 ```
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `kyototycoon` under the Checks section:
 
@@ -50,11 +51,15 @@ Run the Agent's `info` subcommand and look for `kyototycoon` under the Checks se
 
 The kyototycoon check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/kyototycoon/metadata.csv) for a list of metrics provided by this check.
 
-## Service Checks
+### Events
+The Kyototycoon check does not include any event at this time.
+
+### Service Checks
 
 `kyototycoon.can_connect`:
 

--- a/lighttpd/README.md
+++ b/lighttpd/README.md
@@ -4,13 +4,14 @@
 
 The Agent's lighttpd check tracks uptime, bytes served, requests per second, response codes, and more.
 
-## Installation
+## Setup
+### Installation
 
 The lighttpd check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your lighttpd servers. If you need the newest version of the check, install the `dd-check-lighttpd` package.
 
 You'll also need to install `mod_status` on your Lighttpd servers.
 
-## Configuration
+### Configuration
 
 Create a file `lighttpd.yaml` in the Agent's `conf.d` directory:
 
@@ -26,7 +27,7 @@ instances:
 
 Restart the Agent to begin sending lighttpd metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `lighttpd` under the Checks section:
 
@@ -47,7 +48,8 @@ Run the Agent's `info` subcommand and look for `lighttpd` under the Checks secti
 
 The lighttpd check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 The check collects different metrics depending on the major version of lighttpd.
 
@@ -90,13 +92,15 @@ It collects these metrics for lighttpd 2:
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/lighttpd/metadata.csv) for a description of metrics provided by this check.
 
-## Service Checks
+### Events
+The Lighttpd check does not include any event at this time.
+
+### Service Checks
 
 `- lighttpd.can_connect`:
 
 Returns CRITICAL if the Agent cannot connect to lighttpd to collect metrics, otherwise OK.
 
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to monitor Lighttpd web server metrics with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/monitor-lighttpd-web-server-metrics/) about it.
-

--- a/linux_proc_extras/README.md
+++ b/linux_proc_extras/README.md
@@ -1,21 +1,21 @@
 # Linux_proc_extras Integration
 
 ## Overview
-
 Get metrics from linux_proc_extras service in real time to:
 
 * Visualize and monitor linux_proc_extras states
 * Be notified about linux_proc_extras failovers and events.
 
-## Installation
+## Setup
+### Installation
 
 Install the `dd-check-linux_proc_extras` package manually or with your favorite configuration manager
 
-## Configuration
+### Configuration
 
 Edit the `linux_proc_extras.yaml` file to point to your server and port, set the masters to monitor
 
-## Validation
+### Validation
 
 When you run `datadog-agent info` you should see something like the following:
 
@@ -30,3 +30,13 @@ When you run `datadog-agent info` you should see something like the following:
 ## Compatibility
 
 The linux_proc_extras check is compatible with all major platforms
+
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/linux_proc_extras/metadata.csv) for a list of metrics provided by this integration.
+
+### Events
+The Linux proc extras check does not include any event at this time.
+
+### Service Checks
+The Linux proc extras check does not include any service check at this time.

--- a/mapreduce/README.md
+++ b/mapreduce/README.md
@@ -7,15 +7,16 @@ Get metrics from mapreduce service in real time to:
 * Visualize and monitor mapreduce states
 * Be notified about mapreduce failovers and events.
 
-## Installation
+## Setup
+### Installation
 
 Install the `dd-check-mapreduce` package manually or with your favorite configuration manager
 
-## Configuration
+### Configuration
 
 Edit the `mapreduce.yaml` file to point to your server and port, set the masters to monitor
 
-## Validation
+### Validation
 
 When you run `datadog-agent info` you should see something like the following:
 
@@ -31,6 +32,16 @@ When you run `datadog-agent info` you should see something like the following:
 
 The mapreduce check is compatible with all major platforms
 
-## Further Reading
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/mapreduce/metadata.csv) for a list of metrics provided by this integration.
 
+### Events
+The Mapreduce check does not include any event at this time.
+
+### Service Checks
+The Mapreduce check does not include any service check at this time.
+
+## Further Reading
+### Blog Article
 To get a better idea of how (or why) to monitor Hadoop health and performance with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/hadoop-architecture-overview/) about it.

--- a/marathon/README.md
+++ b/marathon/README.md
@@ -7,11 +7,12 @@ The Agent's Marathon check lets you:
 * Track the state and health of every application: see configured memory, disk, cpu, and instances; monitor the number of healthy and unhealthy tasks
 * Monitor the number of queued applications and the number of deployments
 
-## Installation
+## Setup
+### Installation
 
 The Marathon check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Marathon master. If you need the newest version of the check, install the `dd-check-marathon` package.
 
-## Configuration
+### Configuration
 
 Create a file `marathon.yaml` in the Agent's `conf.d` directory:
 
@@ -30,7 +31,7 @@ The function of `user` and `password` depends on whether or not you configure `a
 
 Restart the Agent to begin sending Marathon metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `marathon` under the Checks section:
 
@@ -51,11 +52,14 @@ Run the Agent's `info` subcommand and look for `marathon` under the Checks secti
 
 The marathon check is compatible with all major platforms.
 
-## Metrics
-
+## Data Collected
+### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/marathon/metadata.csv) for a list of metrics provided by this check.
 
-## Service Checks
+### Events
+The Marathon check does not include any event at this time.
+
+### Service Checks
 
 `marathon.can_connect`:
 

--- a/mcache/README.md
+++ b/mcache/README.md
@@ -4,11 +4,12 @@
 
 The Agent's memcache check lets you track memcache's memory use, hits, misses, evictions, fill percent, and much more.
 
-## Installation
+## Setup
+### Installation
 
 The memcache check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your memcache servers. If you need the newest version of the check, install the `dd-check-mcache` package.
 
-## Configuration
+### Configuration
 
 Create a file `mcache.yaml` in the Agent's `conf.d` directory:
 
@@ -28,7 +29,7 @@ instances:
 
 Restart the Agent to begin sending memcache metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `mcache` under the Checks section:
 
@@ -49,20 +50,25 @@ Run the Agent's `info` subcommand and look for `mcache` under the Checks section
 
 The memcache check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/mcache/metadata.csv) for a list of metrics provided by this check.
 
 The check only collects `memcache.slabs.*` metrics if you set `options.slabs: true` in `mcache.yaml`. Likewise, it only collects `memcache.items.*` metrics if you set `options.items: true`.
 
-## Service Checks
+
+### Events
+The Mcache check does not include any event at this time.
+
+### Service Checks
 
 `memcache.can_connect`:
 
 Returns CRITICAL if the Agent cannot connect to memcache to collect metrics, otherwise OK.
 
 ## Further Reading
-
+### Blog Article
 Read more about monitoring memcache with Datadog in [this blog post](https://www.datadoghq.com/blog/speed-up-web-applications-memcached/), and how you can instrument Memcached performance metrics with DogStatsD [in this blog post](https://www.datadoghq.com/blog/instrument-memcached-performance-metrics-dogstatsd/)
 
 Learn how to monitor ElastiCache performance metrics with Redis or Memcached in [this blog post](https://www.datadoghq.com/blog/monitoring-elasticache-performance-metrics-with-redis-or-memcached/)

--- a/mesos_master/README.md
+++ b/mesos_master/README.md
@@ -10,8 +10,8 @@ This check collects metrics from Mesos masters for:
 * Number of frameworks active, inactive, connected, and disconnected
 
 And many more.
-
-## Installation
+## Setup
+### Installation
 
 Run the docker-dd-agent container on each of your Mesos master nodes:
 
@@ -29,13 +29,13 @@ docker run -d --name dd-agent \
 
 Substitute your Datadog API key and Mesos Master's API URL into the command above.
 
-## Configuration
+### Configuration
 
 If you passed the correct Master URL when starting docker-dd-agent, the Agent is already using a default `mesos_master.yaml` to collect metrics from your masters; you don't need to configure anything else.
 
 Unless your masters' API uses a self-signed certificate. In that case, set `disable_ssl_validation: true` in `mesos_master.yaml`.
 
-## Validation
+### Validation
 
 In the Datadog app, search for `mesos.cluster` in the Metrics Explorer.
 
@@ -43,16 +43,20 @@ In the Datadog app, search for `mesos.cluster` in the Metrics Explorer.
 
 The mesos_master check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/mesos_master/metadata.csv) for a list of metrics provided by this check.
 
-## Service Checks
+### Events
+The Mesos-master check does not include any event at this time.
+
+### Service Checks
 
 `mesos_master.can_connect`:
 
 Returns CRITICAL if the Agent cannot connect to the Mesos Master API to collect metrics, otherwise OK.
 
 ## Further Reading
-
+### Blog Article
 See our blog post [Installing Datadog on Mesos with DC/OS](https://www.datadoghq.com/blog/deploy-datadog-dcos/).

--- a/mesos_slave/README.md
+++ b/mesos_slave/README.md
@@ -12,15 +12,16 @@ And many more.
 
 This check also creates a service check for every executor task.
 
-## Installation
+## Setup
+### Installation
 
 Follow the instructions in our [blog post](https://www.datadoghq.com/blog/deploy-datadog-dcos/) to install the Datadog Agent on each Mesos agent node via the DC/OS web UI.
 
-## Configuration
+### Configuration
 
 Unless you want to configure a custom `mesos_slave.yaml`—perhaps you need to set `disable_ssl_validation: true`—you don't need to do anything after installing the Agent.
 
-## Validation
+### Validation
 
 In the Datadog app, search for `mesos.slave` in the Metrics Explorer.
 
@@ -28,11 +29,15 @@ In the Datadog app, search for `mesos.slave` in the Metrics Explorer.
 
 The mesos_slave check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/mesos_slave/metadata.csv) for a list of metrics provided by this check.
 
-## Service Check
+### Events
+The Mesos-slave check does not include any event at this time.
+
+### Service Check
 
 `mesos_slave.can_connect`:
 
@@ -55,5 +60,5 @@ The mesos_slave check creates a service check for each executor task, giving it 
 |TASK_ERROR|AgentCheck.CRITICAL
 
 ## Further Reading
-
+### Blog Article
 See our blog post [Installing Datadog on Mesos with DC/OS](https://www.datadoghq.com/blog/deploy-datadog-dcos/).

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -7,13 +7,13 @@ Connect MongoDB to Datadog in order to:
 * Visualize key MongoDB metrics.
 * Correlate MongoDB performance with the rest of your applications.
 
-## Installation
+## Setup
+### Installation
 
 The MongoDB check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your MongoDB masters. If you need the newest version of the check, install the `dd-check-mongo` package.
 
-## Configuration
-
-### Prepare MongoDB
+### Configuration
+#### Prepare MongoDB
 
 In a Mongo shell, create a read-only user for the Datadog Agent in the `admin` database:
 
@@ -37,7 +37,7 @@ db.createUser({
 })
 ```
 
-### Connect the Agent
+#### Connect the Agent
 
 Create a file `mongodb.yaml` in the Agent's `conf.d` directory:
 
@@ -57,7 +57,7 @@ instances:
 
 Restart the Agent to start sending MongoDB metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `mongo` under the Checks section:
 
@@ -78,7 +78,8 @@ Run the Agent's `info` subcommand and look for `mongo` under the Checks section:
 
 The mongo check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/mongo/metadata.csv) for a list of metrics provided by this check.
 
@@ -103,20 +104,20 @@ See the [MongoDB 3.0 Manual](https://docs.mongodb.org/manual/reference/command/d
 |mongodb.tcmalloc|tcmalloc|
 |mongodb.metrics.commands|metrics.commands|
 
-## Events
+### Events
 
 **Replication state changes**:
 
 This check emits an event each time a Mongo node has a change in its replication state.
 
-## Service Checks
+### Service Checks
 
 `mongodb.can_connect`:
 
 Returns CRITICAL if the Agent cannot connect to MongoDB to collect metrics, otherwise OK.
 
 ## Further Reading
-
+### Blog Article
 Read our series of blog posts about collecting metrics from MongoDB with Datadog:
 
 * [Start here](https://www.datadoghq.com/blog/monitoring-mongodb-performance-metrics-wiredtiger/) if you're using the WiredTiger storage engine.

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -11,13 +11,13 @@ The Datadog Agent can collect many metrics from MySQL databases, including:
 
 And many more. You can also invent your own metrics using custom SQL queries.
 
-## Installation
+## Setup
+### Installation
 
 The MySQL check is included in the Datadog Agent package, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your MySQL servers. If you need the newest version of the check, install the `dd-check-mysql` package.
 
-## Configuration
-
-### Prepare MySQL
+### Configuration
+#### Prepare MySQL
 
 On each MySQL server, create a database user for the Datadog Agent:
 
@@ -51,7 +51,7 @@ mysql> GRANT SELECT ON performance_schema.* TO 'datadog'@'localhost';
 Query OK, 0 rows affected (0.00 sec)
 ```
 
-### Connect the Agent
+#### Connect the Agent
 
 Create a basic `mysql.yaml` in the Agent's `conf.d` directory to connect it to the MySQL server:
 
@@ -79,7 +79,7 @@ See our [sample mysql.yaml](https://github.com/Datadog/integrations-core/blob/ma
 
 Restart the Agent to start sending MySQL metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `mysql` under the Checks section:
 
@@ -99,48 +99,12 @@ Run the Agent's `info` subcommand and look for `mysql` under the Checks section:
 
 If the status is not OK, see the Troubleshooting section.
 
-## Troubleshooting
-
-You may observe one of these common problems in the output of the Datadog Agent's `info` subcommand.
-
-### Agent cannot authenticate
-```
-    mysql
-    -----
-      - instance #0 [ERROR]: '(1045, u"Access denied for user \'datadog\'@\'localhost\' (using password: YES)")'
-      - Collected 0 metrics, 0 events & 1 service check
-```
-
-Either the `'datadog'@'localhost'` user doesn't exist or the Agent is not configured with correct credentials. Review the Configuration section to add a user, and review the Agent's `mysql.yaml`.
-
-### Database user lacks privileges
-```
-    mysql
-    -----
-      - instance #0 [WARNING]
-          Warning: Privilege error or engine unavailable accessing the INNODB status                          tables (must grant PROCESS): (1227, u'Access denied; you need (at least one of) the PROCESS privilege(s) for this operation')
-      - Collected 21 metrics, 0 events & 1 service check
-```
-
-The Agent can authenticate, but it lacks privileges for one or more metrics it wants to collect. In this case, it lacks the PROCESS privilege:
-
-```
-mysql> select user,host,process_priv from mysql.user where user='datadog';
-+---------+-----------+--------------+
-| user    | host      | process_priv |
-+---------+-----------+--------------+
-| datadog | localhost | N            |
-+---------+-----------+--------------+
-1 row in set (0.00 sec)
-```
-
-Review the Configuration section and grant the datadog user all necessary privileges. Do NOT grant all privileges on all databases to this user.
-
 ## Compatibility
 
 The MySQL integration is supported on versions x.x+
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/mysql/metadata.csv) for a list of metrics provided by this check.
 
@@ -287,7 +251,10 @@ The check does not collect all metrics by default. Set the following boolean con
 |----------|--------|
 | mysql.info.schema.size | GAUGE |
 
-## Service Checks
+### Events
+The MySQL check does not include any event at this time.
+
+### Service Checks
 
 `mysql.replication.slave_running`:
 
@@ -297,6 +264,43 @@ Returns CRITICAL for a slave that's not running, otherwise OK.
 
 Returns CRITICAL if the Agent cannot connect to MySQL to collect metrics, otherwise OK.
 
-## Further Reading
+## Troubleshooting
 
+You may observe one of these common problems in the output of the Datadog Agent's `info` subcommand.
+
+### Agent cannot authenticate
+```
+    mysql
+    -----
+      - instance #0 [ERROR]: '(1045, u"Access denied for user \'datadog\'@\'localhost\' (using password: YES)")'
+      - Collected 0 metrics, 0 events & 1 service check
+```
+
+Either the `'datadog'@'localhost'` user doesn't exist or the Agent is not configured with correct credentials. Review the Configuration section to add a user, and review the Agent's `mysql.yaml`.
+
+### Database user lacks privileges
+```
+    mysql
+    -----
+      - instance #0 [WARNING]
+          Warning: Privilege error or engine unavailable accessing the INNODB status                          tables (must grant PROCESS): (1227, u'Access denied; you need (at least one of) the PROCESS privilege(s) for this operation')
+      - Collected 21 metrics, 0 events & 1 service check
+```
+
+The Agent can authenticate, but it lacks privileges for one or more metrics it wants to collect. In this case, it lacks the PROCESS privilege:
+
+```
+mysql> select user,host,process_priv from mysql.user where user='datadog';
++---------+-----------+--------------+
+| user    | host      | process_priv |
++---------+-----------+--------------+
+| datadog | localhost | N            |
++---------+-----------+--------------+
+1 row in set (0.00 sec)
+```
+
+Review the Configuration section and grant the datadog user all necessary privileges. Do NOT grant all privileges on all databases to this user.
+
+## Further Reading
+### Blog Article
 Read our [series of blog posts](https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics/) about monitoring MySQL with Datadog.

--- a/nagios/README.md
+++ b/nagios/README.md
@@ -10,11 +10,12 @@ This check watches your Nagios server's logs and sends events to your Datadog ev
 
 The check emits events for service flaps, host state changes, passive service checks, host and service downtimes, and more. It can also send Nagios Perfdata to Datadog as metrics.
 
-## Installation
+## Setup
+### Installation
 
 The Nagios check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Nagios servers. If you need the newest version of the check, install the `dd-check-nagios` package.
 
-## Configuration
+### Configuration
 
 Create a file `nagios.yaml` in the Agent's `conf.d` directory:
 
@@ -36,7 +37,7 @@ This check also works with Icinga, the popular fork of Nagios. If you use Icinga
 
 Restart the Agent to start sending Nagios events and (optionally) perfdata metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `nagios` under the Checks section:
 
@@ -57,11 +58,12 @@ Run the Agent's `info` subcommand and look for `nagios` under the Checks section
 
 The nagios check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 With a default configuration, the Nagios check doesn't collect any metrics. But if you set `collect_host_performance_data` and/or `collect_service_performance_data` to `True`, the check watches for perfdata and sumbits it as gauge metrics to Datadog.
 
-## Events
+### Events
 
 The check watches the Nagios events log for log lines containing these string, emitting an event for each such line:
 
@@ -78,6 +80,9 @@ The check watches the Nagios events log for log lines containing these string, e
 - PROCESS_SERVICE_CHECK_RESULT
 - SERVICE DOWNTIME ALERT
 
-## Further Reading
+### Service Checks
+The Nagios check does not include any service check at this time.
 
+## Further Reading
+### Blog Article
 To get a better idea of how to understand your Nagios alerts with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/nagios-monitoring/) about it.

--- a/network/README.md
+++ b/network/README.md
@@ -4,11 +4,12 @@
 
 The network check collects TCP/IP stats from the host operating system.
 
-## Installation
+## Setup
+### Installation
 
 The network check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any host. If you need the newest version of the check, install the `dd-check-network` package.
 
-## Configuration
+### Configuration
 
 The Agent enables the network check by default, but if you want to configure the check yourself, create a file `network.yaml` in the Agent's `conf.d` directory:
 
@@ -27,7 +28,7 @@ instances:
 
 Restart the Agent to effect any configuration changes.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `network` under the Checks section:
 
@@ -48,6 +49,12 @@ Run the Agent's `info` subcommand and look for `network` under the Checks sectio
 
 The network check is compatible with all major platforms.
 
-## Metrics
-
+## Data Collected
+### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/network/metadata.csv) for a list of metrics provided by this check.
+
+### Events
+The Network check does not include any event at this time.
+
+### Service Checks
+The Network check does not include any service check at this time.

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -15,12 +15,12 @@ For users of NGINX Plus, the commercial version of NGINX, the Agent can collect 
 * SSL (handshakes, failed handshakes, etc)
 
 And many more.
-
-## Installation
+## Setup
+### Installation
 
 The NGINX check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your NGINX servers. If you need the newest version of the check, install the `dd-check-nginx` package.
 
-### NGINX status module
+#### NGINX status module
 
 The NGINX check pulls metrics from a local NGINX status endpoint, so your `nginx` binaries need to have been compiled with one of two NGINX status modules:
 
@@ -38,9 +38,8 @@ http_stub_status_module
 
 If the command output does not include `http_stub_status_module`, you must install an NGINX package that includes the module. You _can_ compile your own NGINX—enabling the module as you compile it—but most modern Linux distributions provide alternative NGINX packages with various combinations of extra modules built in. Check your operating system's NGINX packages to find one that includes the stub status module.
 
-## Configuration
-
-### Prepare NGINX
+### Configuration
+#### Prepare NGINX
 
 On each NGINX server, create a `status.conf` in the directory that contains your other NGINX configuration files (e.g. `/etc/nginx/conf.d/`):
 
@@ -71,7 +70,7 @@ You may optionally configure HTTP basic authentication in the server block, but 
 
 Reload NGINX to enable the status endpoint. (There's no need for a full restart)
 
-### Connect the Agent
+#### Connect the Agent
 
 Create an `nginx.yaml` in the Agent's `conf.d` directory:
 
@@ -87,7 +86,7 @@ instances:
 
 Restart the Agent to start sending NGINX metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `nginx` under the Checks section:
 
@@ -106,42 +105,12 @@ Run the Agent's `info` subcommand and look for `nginx` under the Checks section:
 
 See the Troubleshooting section if the status is not OK.
 
-## Troubleshooting
-
-You may observe one of these common problems in the output of the Datadog Agent's info subcommand.
-
-### Agent cannot connect
-```
-  Checks
-  ======
-  
-    nginx
-    -----
-      - instance #0 [ERROR]: "('Connection aborted.', error(111, 'Connection refused'))"
-      - Collected 0 metrics, 0 events & 1 service check
-```
-
-Either NGINX's local status endpoint is not running, or the Agent is not configured with correct connection information for it.
-
-Check that the main `nginx.conf` includes a line like the following:
-
-```
-http{
-	
-	...
-
-	include <directory_that_contains_status.conf>/*.conf;
-	# e.g.: include /etc/nginx/conf.d/*.conf;
-}
-```
-
-Otherwise, review the **Configuration** section.
-
 ## Compatibility
 
 The NGINX check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/nginx/metadata.csv) for a full list of provided metrics.
 
@@ -169,12 +138,45 @@ Finally, these metrics have no good equivalent:
 | nginx.net.reading | The current number of connections where nginx is reading the request header. |
 | nginx.net.writing | The current number of connections where nginx is writing the response back to the client. |
 
-## Service Checks
+### Events
+The Nginx check does not include any event at this time.
+
+### Service Checks
 
 `nginx.can_connect`:
 
 Returns CRITICAL if the Agent cannot connect to NGINX to collect metrics, otherwise OK.
 
-## Further Reading
+## Troubleshooting
+You may observe one of these common problems in the output of the Datadog Agent's info subcommand.
 
+### Agent cannot connect
+```
+  Checks
+  ======
+  
+    nginx
+    -----
+      - instance #0 [ERROR]: "('Connection aborted.', error(111, 'Connection refused'))"
+      - Collected 0 metrics, 0 events & 1 service check
+```
+
+Either NGINX's local status endpoint is not running, or the Agent is not configured with correct connection information for it.
+
+Check that the main `nginx.conf` includes a line like the following:
+
+```
+http{
+  
+  ...
+
+  include <directory_that_contains_status.conf>/*.conf;
+  # e.g.: include /etc/nginx/conf.d/*.conf;
+}
+```
+
+Otherwise, review the **Configuration** section.
+
+## Further Reading
+### Blog Article
 Read our [series of blog posts](https://www.datadoghq.com/blog/how-to-monitor-nginx/) about how to monitor NGINX with Datadog.

--- a/ntp/README.md
+++ b/ntp/README.md
@@ -4,11 +4,12 @@
 
 Get alerts when your hosts drift out of sync with your chosen NTP server.
 
-## Installation
+## Setup
+### Installation
 
 The NTP check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) wherever you'd like to run the check. If you need the newest version of the check, install the `dd-check-ntp` package.
 
-## Configuration
+### Configuration
 
 The Agent enables the NTP check by default, but if you want to configure the check yourself, create a file `ntp.yaml` in the Agent's `conf.d` directory:
 
@@ -25,7 +26,7 @@ instances:
 
 Restart the Agent to effect any configuration changes.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `ntp` under the Checks section:
 
@@ -42,15 +43,18 @@ Run the Agent's `info` subcommand and look for `ntp` under the Checks section:
     [...]
 ```
 
-## Compatibility
+### Compatibility
 
 The NTP check is compatible with all major platforms.
 
-## Metrics
-
+## Data Collected
+### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/ntp/metadata.csv) for a list of metrics provided by this check.
 
-## Service Checks
+### Events
+The NTP check does not include any event at this time.
+
+### Service Checks
 
 `ntp.in_sync`:
 

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -7,15 +7,16 @@ Get metrics from openstack service in real time to:
 * Visualize and monitor openstack states
 * Be notified about openstack failovers and events.
 
-## Installation
+## Setup
+### Installation
 
 Install the `dd-check-openstack` package manually or with your favorite configuration manager
 
-## Configuration
+### Configuration
 
 Edit the `openstack.yaml` file to point to your server and port, set the masters to monitor
 
-## Validation
+### Validation
 
 When you run `datadog-agent info` you should see something like the following:
 
@@ -31,8 +32,18 @@ When you run `datadog-agent info` you should see something like the following:
 
 The openstack check is compatible with all major platforms
 
-## Further Reading
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/openstack/metadata.csv) for a list of metrics provided by this integration.
 
+### Events
+The Openstack check does not include any event at this time.
+
+### Service Checks
+The Openstack check does not include any service check at this time.
+
+## Further Reading
+### Blog Article
 To get a better idea of how (or why) to integrate your Nova OpenStack compute module with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/openstack-monitoring-nova/) about it.
 
 See also our blog posts: 

--- a/pgbouncer/README.md
+++ b/pgbouncer/README.md
@@ -4,11 +4,12 @@
 
 The PgBouncer check tracks connection pool metrics and lets you monitor traffic to and from your application.
 
-## Installation
+## Setup
+### Installation
 
 The PgBouncer check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your PgBouncer nodes. If you need the newest version of the check, install the `dd-check-pgbouncer` package.
 
-## Configuration
+### Configuration
 
 Create a file `pgbouncer.yaml` in the Agent's `conf.d` directory:
 
@@ -29,7 +30,7 @@ instances:
 
 Restart the Agent to start sending PgBouncer metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `pgbouncer` under the Checks section:
 
@@ -50,11 +51,14 @@ Run the Agent's `info` subcommand and look for `pgbouncer` under the Checks sect
 
 The PgBouncer check is compatible with all major platforms.
 
-## Metrics
-
+## Data Collected
+### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/pgbouncer/metadata.csv) for a list of metrics provided by this check.
 
-## Service Checks
+### Events
+The PGboucer check does not include any event at this time.
+
+### Service Checks
 
 `pgbouncer.can_connect`:
 

--- a/php_fpm/README.md
+++ b/php_fpm/README.md
@@ -4,11 +4,12 @@
 
 The PHP-FPM check monitors the state of your FPM pool and tracks request performance.
 
-## Installation
+## Setup
+### Installation
 
 The PHP-FPM check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any servers that use PHP-FPM. If you need the newest version of the check, install the `dd-check-php-fpm` package.
 
-## Configuration
+### Configuration
 
 Create a file `php_fpm.yaml` in the Agent's `conf.d` directory:
 
@@ -28,7 +29,7 @@ instances:
 
 Restart the Agent to start sending PHP-FPM metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `php_fpm` under the Checks section:
 
@@ -49,12 +50,20 @@ Run the Agent's `info` subcommand and look for `php_fpm` under the Checks sectio
 
 The php_fpm check is compatible with all major platforms.
 
-## Metrics 
+## Data Collected
+### Metrics 
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/php_fpm/metadata.csv) for a list of metrics provided by this check.
 
-## Service Checks
+### Events
+The php-fpm check does not include any event at this time.
+
+### Service Checks
 
 `php_fpm.can_ping`:
 
 Returns CRITICAL if the Agent cannot ping PHP-FPM at the configured `ping_url`, otherwise OK.
+
+## Further Reading
+### Blog Article
+

--- a/postfix/README.md
+++ b/postfix/README.md
@@ -4,11 +4,12 @@
 
 This check monitors the size of all your Postfix queues.
 
-## Installation
+## Setup
+### Installation
 
 The Postfix check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Postfix servers. If you need the newest version of the check, install the `dd-check-postfix` package.
 
-## Configuration
+### Configuration
 
 Create a file `postfix.yaml` in the Agent's `conf.d` directory:
 
@@ -40,7 +41,7 @@ dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/deferred -type 
 
 Restart the Agent to start sending Postfix metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for postfix` under the Checks section:
 
@@ -61,10 +62,16 @@ Run the Agent's `info` subcommand and look for postfix` under the Checks section
 
 The postfix check is compatible with all major platforms.
 
-## Metrics
-
+## Data Collected
+### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/postfix/metadata.csv) for a list of metrics provided by this check.
 
-## Further Reading
+### Events
+The Postfix check does not include any event at this time.
 
+### Service Checks
+The Postfix check does not include any service check at this time.
+
+## Further Reading
+### Blog Article 
 To get a better idea of how (or why) to monitor Postfix queue performance with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/monitor-postfix-queues/) about it.

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -7,15 +7,16 @@ Get metrics from postgres service in real time to:
 * Visualize and monitor postgres states
 * Be notified about postgres failovers and events.
 
-## Installation
+## Setup
+### Installation
 
 Install the `dd-check-postgres` package manually or with your favorite configuration manager
 
-## Configuration
+### Configuration
 
 Edit the `postgres.yaml` file to point to your server and port, set the masters to monitor
 
-## Validation
+### Validation
 
 When you run `datadog-agent info` you should see something like the following:
 
@@ -31,6 +32,16 @@ When you run `datadog-agent info` you should see something like the following:
 
 The postgres check is compatible with all major platforms
 
-## Further Reading
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/postgres/metadata.csv) for a list of metrics provided by this integration.
 
+### Events
+The Postgres check does not include any event at this time.
+
+### Service Checks
+The Postgres check does not include any service check at this time.
+
+## Further Reading
+## Blog Article
 To get a better idea of how (or why) to have 100x faster Postgres performance by changing 1 line with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/100x-faster-postgres-performance-by-changing-1-line/) about it.

--- a/powerdns_recursor/README.md
+++ b/powerdns_recursor/README.md
@@ -12,13 +12,13 @@ Track the performance of your PowerDNS recursors and monitor strange or worrisom
 
 And many more.
 
-## Installation
+## Setup
+### Installation
 
 The PowerDNS Recursor check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your recursors.
 
-## Configuration
-
-### Prepare PowerDNS
+### Configuration
+#### Prepare PowerDNS
 
 This check collects performance statistics via pdns_recursor's statistics API. Versions of pdns_recursor before 4.1 do not enable the stats API by default. If you're running an older version, enable it by adding the following to your recursor config file (e.g. /etc/powerdns/recursor.conf):
 
@@ -36,7 +36,7 @@ If you're running pdns_recursor >= 4.1, just set `api-key`.
 
 Restart the recursor to enable the statistics API.
 
-### Connect the Agent
+#### Connect the Agent
 
 Create a file `powerdns_recursor.yaml` in the Agent's `conf.d` directory:
 
@@ -52,8 +52,7 @@ instances:
 
 Restart the Agent to begin sending PowerDNS Recursor metrics to Datadog.
 
-## Validation
-
+### Validation
 Run the Agent's `info` subcommand and look for `powerdns_recursor` under the Checks section:
 
 ```
@@ -69,19 +68,20 @@ Run the Agent's `info` subcommand and look for `powerdns_recursor` under the Che
     [...]
 ```
 
-## Troubleshooting
-
 ## Compatibility
 
 The PowerDNS Recursor check is compatible with all major platforms.
 
-## Metrics
-
+## Data Collected
+### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/powerdns_recursor/metadata.csv) for a list of metrics provided by this integration.
 
-## Service Checks
+### Events
+The PowerDns check does not include any event at this time.### Service Checks
 
+### Service Checks
 **`powerdns.recursor.can_connect`**:
 
 Returns CRITICAL if the Agent is unable to connect to the recursor's statistics API, otherwise OK.
 
+## Troubleshooting

--- a/process/README.md
+++ b/process/README.md
@@ -1,17 +1,18 @@
 # Process Check
 
-# Overview
+## Overview
 
 The process check lets you:
 
 * Collect resource usage metrics for specific running processes on any host: CPU, memory, I/O, number of threads, etc
 * Use [Process Monitors](http://docs.datadoghq.com/monitoring/#process): configure thresholds for how many instances of a specific process ought to be running and get alerts when the thresholds aren't met (see **Service Checks** below).
 
-# Installation
+## Setup
+### Installation
 
 The process check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) anywhere you want to use the check. If you need the newest version of the check, install the `dd-check-process` package.
 
-# Configuration
+### Configuration
 
 Unlike many checks, the process check doesn't monitor anything useful by default; you must tell it which processes you want to monitor, and how.
 
@@ -38,7 +39,7 @@ See the [example configuration](https://github.com/DataDog/integrations-core/blo
 
 Restart the Agent to start sending process metrics and service checks to Datadog.
 
-# Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for process` under the Checks section:
 
@@ -58,18 +59,20 @@ Run the Agent's `info` subcommand and look for process` under the Checks section
 
 Each instance configured in `process.yaml` should have one `instance #<num> [OK]` line in the output, regardless of how many search_strings it might be configured with.
 
-# Compatibility
+## Compatibility
 
 The process check is compatible with all major platforms.
 
-# Metrics
-
+## Data Collected
+### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/process/metadata.csv) for a list of metrics provided by this check.
 
 All metrics are per `instance` configured in process.yaml, and are tagged `process_name:<instance_name>`.
 
-# Service Checks
+### Events
+The Process check does not include any event at this time.
 
+### Service Checks
 **process.up**:
 
 The Agent submits this service check for each instance in `process.yaml`, tagging each with `process:<name>`.
@@ -94,5 +97,5 @@ The Agent submits a `process.up` tagged `process:my_worker_process` whose status
 - OK when there are 3, 4 or 5 worker processes
 
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to monitor process resource consumption with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/process-check-monitoring/) about it.

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -9,18 +9,17 @@ The RabbitMQ check lets you:
 * Monitor vhosts for aliveness and number of connections
 
 And more.
-
-## Installation
+## Setup
+### Installation
 
 The RabbitMQ check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your RabbitMQ servers. If you need the newest version of the check, install the `dd-check-rabbitmq` package.
 
-## Configuration
-
-### Prepare RabbitMQ
+### Configuration
+#### Prepare RabbitMQ
 
 You must enable the RabbitMQ management plugin. See [RabbitMQ's documentation](https://www.rabbitmq.com/management.html) to enable it.
 
-### Connect the Agent
+#### Connect the Agent
 
 Create a file `rabbitmq.yaml` in the Agent's `conf.d` directory:
 
@@ -47,7 +46,7 @@ There are options for `queues` and `nodes` that work similarly—the Agent check
 
 Restart the Agent to begin sending RabbitMQ metrics, events, and service checks to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `rabbitmq` under the Checks section:
 
@@ -68,19 +67,20 @@ Run the Agent's `info` subcommand and look for `rabbitmq` under the Checks secti
 
 The rabbitmq check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/rabbitmq/metadata.csv) for a list of metrics provided by this check.
 
 The Agent tags `rabbitmq.queue.*` metrics by queue name, and `rabbitmq.node.*` metrics by node name.
 
-## Events
+### Events
 
 For performance reasons, the RabbitMQ check self-limits the number of queues and nodes it will collect metrics for. If and when the check nears this limit, it emits a warning-level event to your event stream.
 
 See the [example check configuration](https://github.com/DataDog/integrations-core/blob/master/rabbitmq/conf.yaml.example) for details about these limits.
 
-## Service Checks
+### Service Checks
 
 **rabbitmq.aliveness**:
 

--- a/redisdb/README.md
+++ b/redisdb/README.md
@@ -4,11 +4,12 @@
 
 Whether you use Redis as a database, cache, or message queue, this integration helps you track problems with your Redis servers and the parts of your infrastructure that they serve. The Datadog Agent's Redis check collects a wealth of metrics related to performance, memory usage, blocked clients, slave connections, disk persistence, expired and evicted keys, and many more.
 
-## Installation
+## Setup
+### Installation
 
 The Redis check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Redis servers. If you need the newest version of the check, install the `dd-check-redis` package.
 
-## Configuration
+### Configuration
 
 Create a `redisdb.yaml` in the Datadog Agent's `conf.d` directory:
 
@@ -26,7 +27,7 @@ See [this sample redisdb.yaml](https://github.com/Datadog/integrations-core/blob
 
 Restart the Agent to begin sending Redis metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `redis` under the Checks section:
 
@@ -43,8 +44,25 @@ Run the Agent's `info` subcommand and look for `redis` under the Checks section:
     [...]
 ```
 
-## Troubleshooting
+## Compatibility
 
+The redis check is compatible with all major platforms.
+
+## Data Collected
+### Metrics
+
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/redisdb/metadata.csv) for a list of metrics provided by this integration.
+
+### Events
+The RedisDB check does not include any event at this time.
+
+### Service Checks
+
+`redis.can_connect`:
+
+Returns CRITICAL if the Agent cannot connect to Redis to collect metrics, otherwise OK.
+
+## Troubleshooting
 ### Agent cannot connect
 ```
     redisdb
@@ -65,20 +83,6 @@ Check that the connection info in `redisdb.yaml` is correct.
 
 Configure a `password` in `redisdb.yaml`.
 
-## Compatibility
-
-The redis check is compatible with all major platforms.
-
-## Metrics
-
-See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/redisdb/metadata.csv) for a list of metrics provided by this integration.
-
-## Service Checks
-
-`redis.can_connect`:
-
-Returns CRITICAL if the Agent cannot connect to Redis to collect metrics, otherwise OK.
-
 ## Further Reading
-
+### Blog Article
 Read our [series of blog posts](https://www.datadoghq.com/blog/how-to-monitor-redis-performance-metrics/) about how to monitor your Redis servers with Datadog.

--- a/riak/README.md
+++ b/riak/README.md
@@ -4,11 +4,12 @@
 
 This check lets you track node, vnode and ring performance metrics from RiakKV or RiakTS.
 
-## Installation
+## Setup
+### Installation
 
 The Riak check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Riak servers. If you need the newest version of the check, install the `dd-check-riak` package.
 
-## Configuration
+### Configuration
 
 Create a file `riak.yaml` in the Agent's `conf.d` directory:
 
@@ -21,7 +22,7 @@ instances:
 
 Restart the Agent to start sending Riak metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `riak` under the Checks section:
 
@@ -42,11 +43,15 @@ Run the Agent's `info` subcommand and look for `riak` under the Checks section:
 
 The riak check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/riak/metadata.csv) for a list of metrics provided by this check.
 
-## Service Checks
+### Events
+The Riak check does not include any event at this time.
+
+### Service Checks
 
 **riak.can_connect**:
 

--- a/riakcs/README.md
+++ b/riakcs/README.md
@@ -7,11 +7,12 @@ Capture RiakCS metrics in Datadog to:
 * Visualize key RiakCS metrics.
 * Correlate RiakCS performance with the rest of your applications.
 
-## Installation
+## Setup
+### Installation
 
 The RiakCS check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your RiakCS nodes. If you need the newest version of the check, install the `dd-check-riakcs` package.
 
-## Configuration
+### Configuration
 
 Create a file `riakcs.yaml` in the Agent's `conf.d` directory:
 
@@ -29,7 +30,7 @@ instances:
 
 Restart the Agent to start sending RiakCS metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `riakcs` under the Checks section:
 
@@ -50,16 +51,20 @@ Run the Agent's `info` subcommand and look for `riakcs` under the Checks section
 
 The riakcs check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/riakcs/metadata.csv) for a list of metrics provided by this check.
 
-## Service Checks
+### Events
+The RiackCS check does not include any event at this time.
+
+### Service Checks
 
 **riakcs.can_connect**:
 
 Returns CRITICAL if the Agent cannot connect to the RiakCS endpoint to collect metrics, otherwise OK.
 
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to monitor Riak CS performance and availability with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/monitor-riak-cs-performance-and-availability/) about it.

--- a/snmp/README.md
+++ b/snmp/README.md
@@ -4,11 +4,12 @@
 
 This check lets you collect SNMP metrics from your network devices.
 
-## Installation
+## Setup
+### Installation
 
 The SNMP check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any host where you want to run the check. If you need the newest version of the check, install the `dd-check-snmp` package.
 
-## Configuration
+### Configuration
 
 The SNMP check doesn't collect anything by default; you have to tell it specifically what to collect.
 
@@ -43,7 +44,7 @@ instances:
 
 List each SNMP device as a distinct instance, and for each instance, list any SNMP counters and gauges you like in the `metrics` option. There are a few ways to specify what metrics to collect.
 
-### MIB and symbol
+#### MIB and symbol
 
 ```
     metrics:
@@ -51,7 +52,7 @@ List each SNMP device as a distinct instance, and for each instance, list any SN
         symbol: udpInDatagrams
 ```
 
-### OID and name
+#### OID and name
 
 ```
     metrics:
@@ -59,7 +60,7 @@ List each SNMP device as a distinct instance, and for each instance, list any SN
         name: tcpActiveOpens # what to use in the metric name; can be anything
 ```
 
-### MIB and table
+#### MIB and table
 
 ```
     metrics:
@@ -75,7 +76,7 @@ List each SNMP device as a distinct instance, and for each instance, list any SN
 
 This lets you collect metrics on all rows in a table (`symbols`) and specify how to tag each metric (`metric_tags`).
 
-### Use your own MIB
+#### Use your own MIB
 
 The SNMP check can collect MIB data that is formatted via [pysnmp](https://pypi.python.org/pypi/pysnmp). You can use the `build-pysnmp-mibs` script that ships with pysnmp to generate such data.
 
@@ -85,7 +86,7 @@ Put all your pysnmp MIBs into any directory and point the SNMP check to this dir
 
 Restart the Agent to start sending SNMP metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `snmp` under the Checks section:
 
@@ -106,13 +107,17 @@ Run the Agent's `info` subcommand and look for `snmp` under the Checks section:
 
 The snmp check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 The SNMP check doesn't generate any standard metrics, so [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/snmp/metadata.csv) is empty. 
 
 The check submits collects and submits the metrics you specify under the `snmp.*` namespace.
 
-## Service Checks
+### Events
+The SNMP check does not include any event at this time.
+
+### Service Checks
 
 **snmp.can_check**:
 

--- a/solr/README.md
+++ b/solr/README.md
@@ -4,13 +4,14 @@
 
 The Solr check tracks the state and performance of a Solr cluster. It collects metrics like number of documents indexed, cache hits and evictions, average request times, average requests per second, and more.
 
-## Installation
+## Setup
+### Installation
 
 The Solr check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Solr nodes.
 
 This check is JMX-based, so you'll need to enable JMX Remote on your Tomcat servers. Read the [JMX Check documentation](http://docs.datadoghq.com/integrations/java/) for more information on that.
 
-## Configuration
+### Configuration
 
 Create a file `solr.yaml` in the Agent's `conf.d` directory:
 
@@ -95,7 +96,7 @@ Again, see the [JMX Check documentation](http://docs.datadoghq.com/integrations/
 
 Restart the Agent to start sending Solr metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `solr` under the Checks section:
 
@@ -116,6 +117,13 @@ Run the Agent's `info` subcommand and look for `solr` under the Checks section:
 
 The solr check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/solr/metadata.csv) for a list of metrics provided by this check.
+
+### Events
+The Solr check does not include any event at this time.
+
+### Service Checks
+The Solr check does not include any service check at this time.

--- a/spark/README.md
+++ b/spark/README.md
@@ -1,6 +1,6 @@
 # Spark Check
 
-# Overview
+## Overview
 
 The Spark check collects metrics for:
 
@@ -9,7 +9,8 @@ The Spark check collects metrics for:
 - Tasks: number of tasks active, skipped, failed, total
 - Job state: number of jobs active, completed, skipped, failed
 
-# Installation
+## Setup
+### Installation
 
 The Spark check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your:
 
@@ -19,7 +20,7 @@ The Spark check is packaged with the Agent, so simply [install the Agent](https:
 
 If you need the newest version of the check, install the `dd-check-spark` package.
 
-# Configuration
+### Configuration
 
 Create a file `spark.yaml` in the Agent's `conf.d` directory:
 
@@ -45,7 +46,7 @@ Set `spark_url` and `spark_cluster_mode` according to how you're running Spark.
 
 Restart the Agent to start sending Spark metrics to Datadog.
 
-# Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `spark` under the Checks section:
 
@@ -62,16 +63,18 @@ Run the Agent's `info` subcommand and look for `spark` under the Checks section:
     [...]
 ```
 
-# Compatibility
+## Compatibility
 
 The spark check is compatible with all major platforms.
 
-# Metrics
-
+## Data Collected
+### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/spark/metadata.csv) for a list of metrics provided by this check.
 
-# Service Checks
+### Events
+The Spark check does not include any event at this time.
 
+### Service Checks
 The Agent submits one of the following service checks, depending on how you're running Spark:
 
 - **spark.standalone_master.can_connect**
@@ -81,5 +84,5 @@ The Agent submits one of the following service checks, depending on how you're r
 The checks return CRITICAL if the Agent cannot collect Spark metrics, otherwise OK.
 
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to monitor Hadoop & Spark with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/monitoring-spark/) about it.

--- a/sqlserver/README.md
+++ b/sqlserver/README.md
@@ -6,11 +6,12 @@ This check lets you track the performance of your SQL Server instances. It colle
 
 You can also create your own metrics by having the check run custom queries.
 
-## Installation
+## Setup
+### Installation
 
 The SQL Server check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your SQL Server instances. If you need the newest version of the check, install the `dd-check-sqlserver` package.
 
-## Configuration
+### Configuration
 
 Create a file `sqlserver.yaml` in the Agent's `conf.d` directory:
 
@@ -29,7 +30,7 @@ See the [example check configuration](https://github.com/DataDog/integrations-co
 
 Restart the Agent to start sending SQL Server metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `sqlserver` under the Checks section:
 
@@ -50,18 +51,22 @@ Run the Agent's `info` subcommand and look for `sqlserver` under the Checks sect
 
 The sqlserver check is compatible with all Windows and Linux platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/sqlserver/metadata.csv) for a list of metrics provided by this check.
 
 Most of these metrics come from your SQL Server's `sys.dm_os_performance_counters` table.
 
-## Service Checks
+### Events
+The SQL server check does not include any event at this time.
+
+### Service Checks
 
 **sqlserver.can_connect**:
 
 Returns CRITICAL if the Agent cannot connect to SQL Server to collect metrics, otherwise OK.
 
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to monitor your Azure SQL Databases with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/monitor-azure-sql-databases-datadog/) about it.

--- a/ssh_check/README.md
+++ b/ssh_check/README.md
@@ -4,11 +4,12 @@
 
 This check lets you monitor SSH connectivity to remote hosts and SFTP response times.
 
-## Installation
+## Setup
+### Installation
 
 The SSH/SFTP check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) anywhere from which you'd like to test SSH connectivity. If you need the newest version of the check, install the `dd-check-ssh-check` package.
 
-## Configuration
+### Configuration
 
 Create a file `ssh_check.yaml` in the Agent's `conf.d` directory:
 
@@ -28,7 +29,7 @@ instances:
 
 Restart the Agent to start sending SSH/SFTP metrics and service checks to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `ssh_check` under the Checks section:
 
@@ -49,11 +50,15 @@ Run the Agent's `info` subcommand and look for `ssh_check` under the Checks sect
 
 The ssh check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/ssh_check/metadata.csv) for a list of metrics provided by this check.
 
-## Service Checks
+### Events
+The SSH Check check does not include any event at this time.
+
+### Service Checks
 
 **ssh.can_connect**:
 

--- a/statsd/README.md
+++ b/statsd/README.md
@@ -1,16 +1,17 @@
 # Agent Check: StatsD
 
-# Overview
+## Overview
 
 This check monitors the availability and uptime of non-Datadog StatsD servers. It also tracks the number of metrics, by metric type, received by StatsD.
 
 This check does NOT forward application metrics from StatsD servers to Datadog. It collects metrics about StatsD itself.
 
-# Installation
+## Setup
+### Installation
 
 The StatsD check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any servers that run StatsD. If you need the newest version of the check, install the `dd-check-statsd` package.
 
-# Configuration
+### Configuration
 
 Create a file `statsd.yaml` in the Agent's `conf.d` directory:
 
@@ -24,7 +25,7 @@ instances:
 
 Restart the Agent to start sending StatsD metrics and service checks to Datadog.
 
-# Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `statsd` under the Checks section:
 
@@ -45,9 +46,14 @@ Run the Agent's `info` subcommand and look for `statsd` under the Checks section
 
 The statsd check is compatible with all major platforms.
 
-# Metrics
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/statsd/metadata.csv) for a list of metrics provided by this integration.
 
-# Service Checks
+### Events
+The StatsD check does not include any event at this time.
+
+## Service Checks
 
 **statsd.is_up**:
 
@@ -58,7 +64,7 @@ Returns CRITICAL if the StatsD server does not respond to the Agent's health sta
 Returns CRITICAL if the Agent cannot collect metrics about StatsD, otherwise OK.
 
 ## Further Reading
-
+### Blog Article
 If you don't know what StatsD is and how does it work, check out [our blog post about it](https://www.datadoghq.com/blog/statsd/)
 
 To get a better idea of how (or why) to visualize StatsD metrics with Counts Graphing with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/visualize-statsd-metrics-counts-graphing/) about it.

--- a/statsd/README.md
+++ b/statsd/README.md
@@ -42,7 +42,7 @@ Run the Agent's `info` subcommand and look for `statsd` under the Checks section
     [...]
 ```
 
-# Compatibility
+## Compatibility
 
 The statsd check is compatible with all major platforms.
 
@@ -53,7 +53,7 @@ See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/stat
 ### Events
 The StatsD check does not include any event at this time.
 
-## Service Checks
+### Service Checks
 
 **statsd.is_up**:
 

--- a/supervisord/README.md
+++ b/supervisord/README.md
@@ -4,17 +4,16 @@
 
 This check monitors the uptime, status, and number of processes running under supervisord.
 
-## Installation
+## Setup
+### Installation
 
 The Supervisor check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any servers that use Supervisor to manage processes. If you need the newest version of the check, install the `dd-check-supervisord` package.
 
-## Configuration
-
-### Prepare supervisord
+### Configuration
+#### Prepare supervisord
 
 The Agent can collect data from Supervisor via HTTP server or UNIX socket. The Agent collects the same data no matter which collection method you configure.
-
-#### HTTP server
+##### HTTP server
 
 Add a block like this to supervisor's main configuration file (e.g. `/etc/supervisor.conf`):
 
@@ -25,7 +24,7 @@ username=user  # optional
 password=pass  # optional
 ```
 
-#### UNIX socket 
+##### UNIX socket 
 
 Add blocks like these to `/etc/supervisor.conf` (if they're not already there):
 
@@ -44,7 +43,7 @@ If supervisor is running as root, make sure `chmod` is set so that non-root user
 
 Reload supervisord.
 
-### Connect the Agent
+#### Connect the Agent
 
 Create a file `supervisord.yaml` in the Agent's `conf.d` directory:
 
@@ -68,7 +67,7 @@ See the [example check configuration](https://github.com/DataDog/integrations-co
 
 Restart the Agent to start sending Supervisor metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `supervisord` under the Checks section:
 
@@ -89,11 +88,15 @@ Run the Agent's `info` subcommand and look for `supervisord` under the Checks se
 
 The supervisord check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/supervisord/metadata.csv) for a list of metrics provided by this check.
 
-## Service Checks
+### Events
+The Supervisord check does not include any event at this time.
+
+### Service Checks
 
 **supervisord.can_connect**:
 
@@ -116,6 +119,6 @@ This table shows the `supervisord.process.status` that results from each supervi
 |FATAL|CRITICAL|
 |UNKNOWN|UNKNOWN|
 
-# Further Reading
-
+## Further Reading
+### Blog Article
 See our [blog post](https://www.datadoghq.com/blog/supervisor-monitors-your-processes-datadog-monitors-supervisor/) about monitoring Supervisor with Datadog.

--- a/system_core/README.md
+++ b/system_core/README.md
@@ -4,11 +4,12 @@
 
 This check collects the number of CPU cores on a host and CPU times (i.e. system, user, idle, etc).
 
-## Installation
+## Setup
+### Installation
 
 The system_core check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any host.
 
-## Configuration
+### Configuration
 
 Create a file `system_core.yaml` in the Agent's `conf.d` directory:
 
@@ -23,7 +24,7 @@ The Agent just needs one item in `instances` in order to enable the check. The c
 
 Restart the Agent to enable the check.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `system_core` under the Checks section:
 
@@ -44,8 +45,15 @@ Run the Agent's `info` subcommand and look for `system_core` under the Checks se
 
 The system_core check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/system_core/metadata.csv) for a list of metrics provided by this check.
 
 Depending on the platform, the check may collect other CPU time metrics, e.g. `system.core.interrupt` on Windows, `system.core.iowait` on Linux, etc.
+
+### Events
+The System Core check does not include any event at this time.
+
+### Service Checks
+The System Core check does not include any service check at this time.

--- a/system_swap/README.md
+++ b/system_swap/README.md
@@ -4,11 +4,12 @@
 
 This check monitors the number of bytes a host has swapped in and swapped out.
 
-## Installation
+## Setup
+### Installation
 
 The system swap check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any host.
 
-## Configuration
+### Configuration
 
 Create a blank Agent check configuration file called `system_swap.yaml` in the Agent's `conf.d` directory:
 
@@ -21,7 +22,7 @@ instances: [{}]
 
 Restart the Agent to start collecting swap metrics.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `system_swap` under the Checks section:
 
@@ -42,6 +43,13 @@ Run the Agent's `info` subcommand and look for `system_swap` under the Checks se
 
 The system_swap check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/system_swap/metadata.csv) for a list of metrics provided by this check.
+
+### Events
+The System Swap check does not include any event at this time.
+
+### Service Checks
+The System Swap check does not include any service check at this time.

--- a/tcp_check/README.md
+++ b/tcp_check/README.md
@@ -4,13 +4,14 @@
 
 Monitor TCP connectivity and response time for any host and port.
 
-## Installation
+## Setup
+### Installation
 
 The TCP check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any host from which you want to probe TCP ports. Though many metrics-oriented checks are best run on the same host(s) as the monitored service, you'll probably want to run this check from hosts that do not run the monitored TCP services, i.e. to test remote connectivity.
 
 If you need the newest version of the TCP check, install the `dd-check-tcp` package.
 
-## Configuration
+### Configuration
 
 Create a file `tcp_check.yaml` in the Agent's `conf.d` directory:
 
@@ -27,7 +28,7 @@ instances:
 
 Restart the Agent to start sending TCP service checks and response times to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `tcp_check` under the Checks section:
 
@@ -48,11 +49,15 @@ Run the Agent's `info` subcommand and look for `tcp_check` under the Checks sect
 
 The TCP check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/tcp_check/metadata.csv) for a list of metrics provided by this check.
 
-## Service Checks
+### Events
+The TCP check does not include any event at this time.
+
+### Service Checks
 
 **`tcp.can_connect`**:
 

--- a/teamcity/README.md
+++ b/teamcity/README.md
@@ -6,13 +6,13 @@ This check watches for build-related events and sends them to Datadog.
 
 Unlike most Agent checks, this one doesn't collect any metrics—just events.
 
-## Installation
+## Setup
+### Installation
 
 The Teamcity check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Teamcity servers. If you need the newest version of the check, install the `dd-check-teamcity` package.
 
-## Configuration
-
-### Prepare Teamcity
+### Configuration
+#### Prepare Teamcity
 
 Follow [Teamcity's documentation](https://confluence.jetbrains.com/display/TCD9/Enabling+Guest+Login) to enable Guest Login. 
 
@@ -38,7 +38,7 @@ Add an item like the above to `instances` for each build configuration you want 
 
 Restart the Agent to start collecting and sending Teamcity events to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `teamcity` under the Checks section:
 
@@ -59,6 +59,16 @@ Run the Agent's `info` subcommand and look for `teamcity` under the Checks secti
 
 The teamcity check is compatible with all major platforms.
 
-## Further Reading
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/teamcity/metadata.csv) for a list of metrics provided by this integration.
 
+### Events
+The Teamcity check does not include any event at this time.
+
+### Service Checks
+The Teamcity check does not include any service check at this time.
+
+## Further Reading
+### Blog Article
 To get a better idea of how (or why) to track performance impact of code changes with TeamCity and Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/track-performance-impact-of-code-changes-with-teamcity-and-datadog/) about it.

--- a/tokumx/README.md
+++ b/tokumx/README.md
@@ -10,13 +10,13 @@ This check collects TokuMX metrics like:
 
 And more.
 
-## Installation
+## Setup
+### Installation
 
 The TokuMX check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your TokuMX servers. If you need the newest version of the check, install the `dd-check-tokumx` package.
 
-## Configuration
-
-### Prepare TokuMX
+### Configuration
+#### Prepare TokuMX
 
 In a Mongo shell, create a read-only user for the Datadog Agent in the `admin` database:
 
@@ -28,7 +28,7 @@ db.auth("admin", "<YOUR_TOKUMX_ADMIN_PASSWORD>")
 db.addUser("datadog", "<UNIQUEPASSWORD>", true)
 ```
 
-### Connect the Agent
+#### Connect the Agent
 
 Create a file `tokumx.yaml` in the Agent's `conf.d` directory:
 
@@ -41,7 +41,7 @@ instances:
 
 Restart the Agent to start sending TokuMX metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `tokuxmx` under the Checks section:
 
@@ -62,22 +62,21 @@ Run the Agent's `info` subcommand and look for `tokuxmx` under the Checks sectio
 
 The tokumx check is compatible with all major platforms.
 
-## Metrics
-
+## Data Collected
+### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/tokumx/metadata.csv) for a list of metrics provided by this check.
 
-## Events
-
+### Events
 **Replication state changes**:
 
 This check emits an event each time a TokuMX node has a change in its replication state.
 
-## Service Checks
+### Service Checks
 
 `tokumx.can_connect`:
 
 Returns CRITICAL if the Agent cannot connect to TokuMX to collect metrics, otherwise OK.
 
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to monitor TokuMX databases with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/monitor-key-tokumx-metrics-mongodb-applications/) about it.

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -10,13 +10,14 @@ This check collects Tomcat metrics like:
 
 And more.
 
-## Installation
+## Setup
+### Installation
 
 The Tomcat check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Tomcat servers.
 
 This check is JMX-based, so you'll need to enable JMX Remote on your Tomcat servers. Follow the instructions in the [Tomcat documentation](http://tomcat.apache.org/tomcat-6.0-doc/monitoring.html) to do that.
 
-## Configuration
+### Configuration
 
 Create a file `tomcat.yaml` in the Agent's `conf.d` directory:
 
@@ -97,7 +98,7 @@ See the [JMX Check documentation](http://docs.datadoghq.com/integrations/java/) 
 
 Restart the Agent to start sending Tomcat metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `tomcat` under the Checks section:
 
@@ -118,10 +119,16 @@ Run the Agent's `info` subcommand and look for `tomcat` under the Checks section
 
 The tomcat check is compatible with all major platforms.
 
-## Metrics
-
+## Data Collected
+### Metrics
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/tomcat/metadata.csv) for a list of metrics provided by this check.
 
-## Further Reading
+### Events
+The Tomcat check does not include any event at this time.
 
+### Service Checks
+The Tomcat check does not include any service check at this time.
+
+## Further Reading
+### Blog Article
 See our [blog post](https://www.datadoghq.com/blog/monitor-tomcat-metrics/) about monitoring Tomcat with Datadog.

--- a/twemproxy/README.md
+++ b/twemproxy/README.md
@@ -4,11 +4,12 @@
 
 Track overall and per-pool stats on each of your twemproxy servers. This Agent check collects metrics for client and server connections and errors, request and response rates, bytes in and out of the proxy, and more.
 
-## Installation
+## Setup
+### Installation
 
 The Agent's twemproxy check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on each of your Twemproxy servers.
 
-## Configuration
+### Configuration
 
 Create a file `twemproxy.yaml` in the Agent's `conf.d` directory:
 
@@ -22,7 +23,7 @@ instances:
 
 Restart the Agent to begin sending twemproxy metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `twemproxy` under the Checks section:
 
@@ -43,11 +44,15 @@ Run the Agent's `info` subcommand and look for `twemproxy` under the Checks sect
 
 The twemproxy check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/twemproxy/metadata.csv) for a list of metrics provided by this check.
 
-## Service Checks
+### Events
+The Twemproxy check does not include any event at this time.
+
+### Service Checks
 
 `twemproxy.can_connect`:
 

--- a/varnish/README.md
+++ b/varnish/README.md
@@ -1,6 +1,6 @@
 # Agent Check: Varnish
 
-# Overview
+## Overview
 
 This check collects varnish metrics regarding:
 
@@ -11,11 +11,12 @@ This check collects varnish metrics regarding:
 
 It also submits service checks for the health of each backend.
 
-# Installation
+## Setup
+### Installation
 
 The varnish check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your varnish servers. If you need the newest version of the check, install the `dd-check-varnish` package.
 
-# Configuration
+### Configuration
 
 If you're running Varnish 4.1+, add the dd-agent system user to the varnish group (e.g. `sudo usermod -G varnish -a dd-agent`).
 
@@ -40,7 +41,7 @@ dd-agent ALL=(ALL) NOPASSWD:/usr/bin/varnishadm
 
 Restart the Agent to start sending varnish metrics and service checks to Datadog.
 
-# Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `varnish` under the Checks section:
 
@@ -56,20 +57,22 @@ Run the Agent's `info` subcommand and look for `varnish` under the Checks sectio
 
     [...]
 ```
-# Compatibility
+## Compatibility
 
 The Varnish check is compatible with all major platforms.
 
-# Service Checks
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/varnish/metadata.csv) for a list of metrics provided by this check.
 
+### Events
+The Varnish check does not include any event at this time.
+
+### Service Checks
 **varnish.backend_healthy**:
 
 The Agent submits this service check if you configure `varnishadm`. It submits a service check for each varnish backend, tagging each with `backend:<backend_name>`.
 
-# Further Reading
-
+## Further Reading
+### Blog Article
 See our [series of blog posts](https://www.datadoghq.com/blog/top-varnish-performance-metrics/) about monitoring varnish with Datadog.
-
-# Metrics
-
-See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/varnish/metadata.csv) for a list of metrics provided by this check.

--- a/vsphere/README.md
+++ b/vsphere/README.md
@@ -4,11 +4,12 @@
 
 This check collects resource usage metrics from your vSphere cluster—CPU, disk, memory, and network usage. It also watches your vCenter server for events and emits them to Datadog.
 
-## Installation
+## Setup
+### Installation
 
 The vSphere check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your vCenter server. If you need the newest version of the check, install the `dd-check-mcache` package.
 
-## Configuration
+### Configuration
 
 In the Administration section of vCenter, add a read-only user called datadog-readonly.
 
@@ -26,7 +27,7 @@ instances:
 
 Restart the Agent to start sending vSphere metrics and events to Datadog.
 
-## Configuration Options
+#### Configuration Options
 
 * `ssl_verify` (Optional) - Set to false to disable SSL verification, when connecting to vCenter
 * `ssl_capath` (Optional) - Set to the absolute file path of a directory containing CA certificates in PEM format
@@ -36,7 +37,7 @@ Restart the Agent to start sending vSphere metrics and events to Datadog.
 * `all_metrics` (Optional) - When set to true, this will collect EVERY metric from vCenter, which means a LOT of metrics you probably do not care about. We have selected a set of metrics that are interesting to monitor for you if false.
 * `event_config` (Optional) - Event config is a dictionary. For now the only switch you can flip is collect_vcenter_alarms which will send as events the alarms set in vCenter.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `vsphere` under the Checks section:
 
@@ -57,11 +58,12 @@ Run the Agent's `info` subcommand and look for `vsphere` under the Checks sectio
 
 The vsphere check is compatible with all Windows platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/vsphere/metadata.csv) for a list of metrics provided by this check.
 
-## Events
+### Events
 
 This check watches vCenter's Event Manager for events and emits them to Datadog. It does NOT emit the following event types:
 
@@ -82,12 +84,12 @@ VmMessageEvent
 VmSuspendedEvent
 VmPoweredOffEvent
 
-## Service Checks
+### Service Checks
 
 `vcenter.can_connect`:
 
 Returns CRITICAL if the Agent cannot connect to vCenter to collect metrics, otherwise OK.
 
 ## Further Reading
-
+### Blog Article
 See our [blog post](https://www.datadoghq.com/blog/unified-vsphere-app-monitoring-datadog/#auto-discovery-across-vm-and-app-layers) on monitoring vSphere environments with Datadog.

--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -4,11 +4,12 @@
 
 This check watches for events in the Windows Event Log and forwards them to Datadog.
 
-## Installation
+## Setup
+### Installation
 
 The Windows Event Log check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Windows hosts.
 
-## Configuration
+### Configuration
 
 Create a file `win32_event_log.yaml` in the Agent's `conf.d` directory:
 
@@ -23,7 +24,7 @@ This minimal file will capture all events from localhost, but you can configure 
 
 Restart the Agent to start sending Windows events to Datadog.
 
-## Validation
+### Validation
 
 See the info page in the Agent Manager and look for `win32_event_log` under the Checks section:
 
@@ -44,6 +45,16 @@ See the info page in the Agent Manager and look for `win32_event_log` under the 
 
 The win32_event_log check is compatible with all Windows platforms.
 
-## Further Reading
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/win32_event_log/metadata.csv) for a list of metrics provided by this integration.
 
+### Events
+All Windows Event are forwarded to your Datadog application
+
+### Service Checks
+The Win32 Event log check does not include any service check at this time.
+
+## Further Reading
+### Blog Article
 See our [series of blog posts](https://www.datadoghq.com/blog/monitoring-windows-server-2012) about monitoring Windows Server 2012 with Datadog.

--- a/windows_service/README.md
+++ b/windows_service/README.md
@@ -4,11 +4,12 @@
 
 This check monitors the state of any Windows Service and submits a service check to Datadog.
 
-## Installation
+## Setup
+### Installation
 
 The Windows Service check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Windows hosts.
 
-## Configuration
+### Configuration
 
 Create a file `windows_service.yaml` in the Agent's `conf.d` directory:
 
@@ -29,7 +30,7 @@ You must provide service names as they appear in services.msc's properties field
 
 Restart the Agent to start monitoring the services and sending service checks to Datadog.
 
-## Validation
+### Validation
 
 See the info page in the Agent Manager and look for `windows_service` under the Checks section:
 
@@ -50,8 +51,14 @@ See the info page in the Agent Manager and look for `windows_service` under the 
 
 The Windows Service check is compatible with all Windows platforms.
 
-## Service Checks
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/windows_service/metadata.csv) for a list of metrics provided by this integration.
 
+### Events
+The Windows Service check does not include any event at this time.
+
+### Service Checks
 **windows_service.state**:
 
 The Agent submits this service check for each Windows service configured in `services`, tagging the service check with 'service:<service_name>'. The service check takes on the following statuses depending on Windows status:
@@ -68,5 +75,5 @@ The Agent submits this service check for each Windows service configured in `ser
 |Unknown|UNKNOWN|
 
 ## Further Reading
-
+### Blog Article
 See our [series of blog posts](https://www.datadoghq.com/blog/monitoring-windows-server-2012) about monitoring Windows Server 2012 with Datadog.

--- a/wmi_check/README.md
+++ b/wmi_check/README.md
@@ -7,15 +7,16 @@ Get metrics from wmi_check service in real time to:
 * Visualize and monitor wmi_check states
 * Be notified about wmi_check failovers and events.
 
-## Installation
+## Setup
+### Installation
 
 Install the `dd-check-wmi_check` package manually or with your favorite configuration manager
 
-## Configuration
+### Configuration
 
 Edit the `wmi_check.yaml` file to point to your server and port, set the masters to monitor
 
-## Validation
+### Validation
 
 When you run `datadog-agent info` you should see something like the following:
 
@@ -30,3 +31,13 @@ When you run `datadog-agent info` you should see something like the following:
 ## Compatibility
 
 The wmi_check check is compatible with all major platforms
+
+## Data Collected
+### Metrics
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/wmi_check/metadata.csv) for a list of metrics provided by this integration.
+
+### Events
+The WMI check does not include any event at this time.
+
+### Service Checks
+The WMI check does not include any service check at this time.

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -9,12 +9,12 @@ This check collects metrics from your YARN ResourceManager, including:
 * Node metrics: available vCores, time of last health update, etc
 
 And more.
-
-## Installation
+## Setup
+### Installation
 
 The YARN check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your YARN ResourceManager. If you need the newest version of the check, install the `dd-check-yarn` package.
 
-## Configuration
+### Configuration
 
 Create a file `yarn.yaml` in the Agent's `conf.d` directory:
 
@@ -31,7 +31,7 @@ See the [example check configuration](https://github.com/DataDog/integrations-co
 
 Restart the Agent to start sending YARN metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `yarn` under the Checks section:
 
@@ -52,16 +52,19 @@ Run the Agent's `info` subcommand and look for `yarn` under the Checks section:
 
 The yarn check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/yarn/metadata.csv) for a list of metrics provided by this check.
 
-## Service Checks
+### Events
+The Yarn check does not include any event at this time.
 
+### Service Checks
 **yarn.can_connect**:
 
 Returns CRITICAL if the Agent cannot connect to the ResourceManager URI to collect metrics, otherwise OK.
 
 ## Further Reading
-
+### Blog Article
 To get a better idea of how (or why) to monitor a hadoop architecture with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/hadoop-architecture-overview/) about it.

--- a/zk/README.md
+++ b/zk/README.md
@@ -4,11 +4,12 @@
 
 The Zookeeper check tracks client connections and latencies, monitors the number of unprocessed requests, and more.
 
-## Installation
+## Setup
+### Installation
 
 The Zookeeper check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Zookeeper servers. If you need the newest version of the check, install the `dd-check-zk` package.
 
-## Configuration
+### Configuration
 
 Create a file `zk.yaml` in the Agent's `conf.d` directory:
 
@@ -23,7 +24,7 @@ instances:
 
 Restart the Agent to start sending Zookeeper metrics to Datadog.
 
-## Validation
+### Validation
 
 Run the Agent's `info` subcommand and look for `zk` under the Checks section:
 
@@ -44,11 +45,15 @@ Run the Agent's `info` subcommand and look for `zk` under the Checks section:
 
 The Zookeeper check is compatible with all major platforms.
 
-## Metrics
+## Data Collected
+### Metrics
 
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/zookeeper/metadata.csv) for a list of metrics provided by this check.
 
-## Service Checks
+### Events
+The Zookeeper check does not include any event at this time.
+
+### Service Checks
 
 **zookeeper.ruok**:
 


### PR DESCRIPTION
### What does this PR do?

The idea is to unify integrations readme files layout between our doc and the integrations core repo.

The unified layout is: 
(|--- is a h2 title, |---|--- is a h3 title..... since h1 should be used only for integration name on the top ==> better SEO)

|----Overview
| --- Setup
| --- | --- Installation
| --- | --- Configuration
| --- | --- Validation

| --- Data Collected
| --- | --- Service checks
| --- | --- Events
| --- | --- Metrics

| --- Troubleshooting
| --- | --- faq_1 ?
| --- | --- faq_2 ?

| --- Further Reading
| --- | --- KB
| --- | --- Blog Article

This will also allow us to scrap content from those readme files in order to create content for ou doc always up to date (as we do for metrics right now)

https://github.com/DataDog/documentation/pull/1575 <== Documentation equivalent