### PR TITLE
[redisdb] Added `maxmemory` to redis memory info

### DIFF
--- a/redisdb/CHANGELOG.md
+++ b/redisdb/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Changes
 
 * [IMPROVEMENT] adds "redis.net.commands.instantaneous" metric [#672][].
-
+* [IMPROVEMENT] adds "redis.mem.maxmemory" metric
 
 1.1.0 / 2017-07-18
 ==================

--- a/redisdb/check.py
+++ b/redisdb/check.py
@@ -73,6 +73,7 @@ class Redis(AgentCheck):
         'used_memory_lua':              'redis.mem.lua',
         'used_memory_peak':             'redis.mem.peak',
         'used_memory_rss':              'redis.mem.rss',
+        'maxmemory':                    'redis.mem.maxmemory',
 
         # replication
         'master_last_io_seconds_ago':   'redis.replication.last_io_seconds_ago',

--- a/redisdb/metadata.csv
+++ b/redisdb/metadata.csv
@@ -19,6 +19,7 @@ redis.keys.evicted,gauge,,key,,The total number of keys evicted due to the maxme
 redis.keys.expired,gauge,,key,,The total number of keys expired from the db.,0,redis,keys expired
 redis.mem.fragmentation_ratio,gauge,,fraction,,Ratio between used_memory_rss and used_memory.,-1,redis,frag ratio
 redis.mem.lua,gauge,,byte,,Amount of memory used by the Lua engine.,-1,redis,mem lua
+redis.mem.maxmemory,,byte,,Maximum amount of memory alloted to the Redisdb system.,-1,redis,mem maxmemory
 redis.mem.peak,gauge,,byte,,The peak amount of memory used by Redis.,-1,redis,mem peak
 redis.mem.rss,gauge,,byte,,Amount of memory that Redis allocated as seen by the os.,-1,redis,mem rss
 redis.mem.used,gauge,,byte,,Amount of memory allocated by Redis.,-1,redis,mem used


### PR DESCRIPTION
This will enable users to produce % memory used and thus create monitors and alerts on approaching max memory.

### What does this PR do?

Adds one more metric to help enable more preventative actions for operators.

### Motivation

The need internally to determine redis health or alert of approaching doom.

### Testing Guidelines

Ran tests locally, didn't seem to affect them.

### Versioning

- [ ] Bumped the version check in `manifest.json` (already bumped and not released)
- [x] Updated `CHANGELOG.md`

### Additional Notes

n/a
