### PR TITLE
Lewis/add count of binding on queues for rabbitmq

### DIFF
--- a/rabbitmq/CHANGELOG.md
+++ b/rabbitmq/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - rabbitmq
 
+1.2.2 / Unreleased
+==================
+
+### Changes
+
+* [FEATURE] Add a metric to get the number of bindings for a queue.
+
 1.2.1 / Unreleased
 ==================
 

--- a/rabbitmq/CHANGELOG.md
+++ b/rabbitmq/CHANGELOG.md
@@ -1,17 +1,12 @@
 # CHANGELOG - rabbitmq
 
-1.2.2 / Unreleased
+
+1.3.0 / Unreleased
 ==================
 
 ### Changes
 
 * [FEATURE] Add a metric to get the number of bindings for a queue.
-
-1.2.1 / Unreleased
-==================
-
-### Changes
-
 * [BUGFIX] Set aliveness service to CRITICAL if the rabbitmq server is down. See[#635][]
 
 1.2.0 / 2017-07-18

--- a/rabbitmq/check.py
+++ b/rabbitmq/check.py
@@ -326,18 +326,7 @@ class RabbitMQ(AgentCheck):
                 self.gauge('rabbitmq.queue.bindings.count', bindings_count, tags)
 
     def _get_metrics(self, data, object_type, custom_tags):
-        '''
-        tags = []
-        tag_list = TAGS_MAP[object_type]
-        for t in tag_list:
-            tag = data.get(t)
-            if tag:
-                # FIXME 6.x: remove this suffix or unify (sc doesn't have it)
-                tags.append('%s_%s:%s' % (TAG_PREFIX, tag_list[t], tag))
-        tags.extend(custom_tags)
-        '''
         tags = self._get_tags(data, object_type, custom_tags)
-        
         for attribute, metric_name, operation in ATTRIBUTES[object_type]:
             # Walk down through the data path, e.g. foo/bar => d['foo']['bar']
             root = data

--- a/rabbitmq/check.py
+++ b/rabbitmq/check.py
@@ -308,7 +308,8 @@ class RabbitMQ(AgentCheck):
         # get a list of the number of bindings on a given queue
         # /api/queues/vhost/name/bindings
         if object_type is QUEUE_TYPE:
-            self._get_queue_bindings_metrics(data, instance, object_type)
+            self._get_queue_bindings_metrics(base_url, custom_tags, data, instance_proxy,
+                                            instance, object_type, auth, ssl_verify)
 
     def _get_metrics(self, data, object_type, custom_tags):
         tags = self._get_tags(data, object_type, custom_tags)
@@ -328,15 +329,12 @@ class RabbitMQ(AgentCheck):
                     self.log.debug("Caught ValueError for %s %s = %s  with tags: %s" % (
                         METRIC_SUFFIX[object_type], attribute, value, tags))
 
-    def _get_queue_bindings_metrics(self, data, instance, object_type):
-        base_url, _, _, auth, ssl_verify, custom_tags = self._get_config(instance)
-        instance_proxy = self.get_instance_proxy(instance, base_url)
-
+    def _get_queue_bindings_metrics(self, base_url, custom_tags, data, instance_proxy,
+                                    instance, object_type, auth=None, ssl_verify=True):
         for item in data:
             vhost = item['vhost']
             tags = self._get_tags(item, object_type, custom_tags)
             url = '{}/{}/{}/bindings'.format(QUEUE_TYPE, urllib.quote_plus(vhost), item['name'])
-            self.log.info('url: {}'.format(urlparse.urljoin(base_url, url)))
             bindings_count = len(self._get_data(urlparse.urljoin(base_url, url), auth=auth,
                     ssl_verify=ssl_verify, proxies=instance_proxy))
 

--- a/rabbitmq/check.py
+++ b/rabbitmq/check.py
@@ -205,7 +205,7 @@ class RabbitMQ(AgentCheck):
         except ValueError as e:
             raise RabbitMQException('Cannot parse JSON response from API url: {} {}'.format(url, str(e)))
 
-    def _filter_list(self, data, explicit_filters, regex_filters, object_type):
+    def _filter_list(self, data, explicit_filters, regex_filters, object_type, tag_families):
         if explicit_filters or regex_filters:
             matching_lines = []
             for data_line in data:
@@ -219,7 +219,8 @@ class RabbitMQ(AgentCheck):
                 for p in regex_filters:
                     match = re.search(p, name)
                     if match:
-                        if _is_affirmative(instance.get("tag_families", False)) and match.groups():
+                        #if _is_affirmative(instance.get("tag_families", False)) and match.groups():
+                        if _is_affirmative(tag_families) and match.groups():
                             data_line["queue_family"] = match.groups()[0]
                         matching_lines.append(data_line)
                         match_found = True
@@ -240,7 +241,7 @@ class RabbitMQ(AgentCheck):
                 for p in regex_filters:
                     match = re.search(p, absolute_name)
                     if match:
-                        if _is_affirmative(instance.get("tag_families", False)) and match.groups():
+                        if _is_affirmative(tag_families) and match.groups():
                             data_line["queue_family"] = match.groups()[0]
                         matching_lines.append(data_line)
                         match_found = True
@@ -284,7 +285,7 @@ class RabbitMQ(AgentCheck):
                 "The maximum number of %s you can specify is %d." % (object_type, max_detailed))
 
         # a list of queues/nodes is specified. We process only those
-        data = self._filter_list(data, explicit_filters, regex_filters, object_type)
+        data = self._filter_list(data, explicit_filters, regex_filters, object_type, instance.get("tag_families", False))
 
         # if no filters are specified, check everything according to the limits
         if len(data) > ALERT_THRESHOLD * max_detailed:

--- a/rabbitmq/check.py
+++ b/rabbitmq/check.py
@@ -219,7 +219,6 @@ class RabbitMQ(AgentCheck):
                 for p in regex_filters:
                     match = re.search(p, name)
                     if match:
-                        #if _is_affirmative(instance.get("tag_families", False)) and match.groups():
                         if _is_affirmative(tag_families) and match.groups():
                             data_line["queue_family"] = match.groups()[0]
                         matching_lines.append(data_line)
@@ -246,13 +245,9 @@ class RabbitMQ(AgentCheck):
                         matching_lines.append(data_line)
                         match_found = True
                         break
-
                 if match_found:
                     continue
-
-            self.log.debug('matching_lines : {}'.format(matching_lines))
             return matching_lines
-        self.log.debug('data : {}'.format(data))
         return data
 
     def _get_tags(self, data, object_type, custom_tags):
@@ -316,7 +311,6 @@ class RabbitMQ(AgentCheck):
         if object_type is QUEUE_TYPE:
             for item in data:
                 vhost = item['vhost']
-                #tags = ['queue:{}'.format(item['name'])]
                 tags = self._get_tags(item, object_type, custom_tags)
                 if vhost == '/':
                     vhost = '%2f'

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.2.2",
+  "version": "1.3.0",
   "guid": "a790a556-fbaa-4208-9d39-c42c3d57084b"
 }

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.2.1",
+  "version": "1.2.2",
   "guid": "a790a556-fbaa-4208-9d39-c42c3d57084b"
 }

--- a/rabbitmq/metadata.csv
+++ b/rabbitmq/metadata.csv
@@ -5,6 +5,7 @@ rabbitmq.node.run_queue,gauge,,process,,Average number of Erlang processes waiti
 rabbitmq.node.sockets_used,gauge,,,,Number of file descriptors used as sockets,0,rabbitmq,skts used
 rabbitmq.node.partitions,gauge,,,,Number of network partitions this node is seeing,0,rabbitmq,partitions
 rabbitmq.queue.active_consumers,gauge,,,,"Number of active consumers, consumers that can immediately receive any messages sent to the queue",0,rabbitmq,act cons
+rabbitmq.queue.bindings.count,gauge,,,,"Number of bindings for a specific queue",0,rabbitmq,queue bind
 rabbitmq.queue.consumers,gauge,,,,Number of consumers,0,rabbitmq,cons
 rabbitmq.queue.consumer_utilisation,gauge,,fraction,,The ratio of time that a queue's consumers can take new messages,0,rabbitmq,cons util
 rabbitmq.queue.memory,gauge,,byte,,"Bytes of memory consumed by the Erlang process associated with the queue, including stack, heap and internal structures",0,rabbitmq,mem

--- a/rabbitmq/test_rabbitmq.py
+++ b/rabbitmq/test_rabbitmq.py
@@ -88,6 +88,7 @@ COMMON_METRICS = [
 
 Q_METRICS = [
     'consumers',
+    'bindings.count',
     'memory',
     'messages',
     'messages.rate',


### PR DESCRIPTION
### What does this PR do?

Will add metric `rabbitmq.queue.bindings.count` to get the number of bindings for a specific queue.

### Motivation

Requested here: https://trello.com/c/RPdlM0yB/303-rabbitmq-integration-add-the-metric-count-of-binding-on-queues

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`

### Additional Notes
