### PR TITLE
[kafka] adding troubleshooting info 

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -57,6 +57,43 @@ The Kafka check does not include any event at this time.
 ### Service Checks
 The Kafka check does not include any service check at this time.
 
+
+
+## Troubleshooting
+### Agent failed to retrieve RMIServer stub
+
+```
+instance #kafka-localhost-<PORT_NUM> [ERROR]: 'Cannot connect to instance localhost:<PORT_NUM>. java.io.IOException: Failed to retrieve RMIServer stub
+```
+
+The Datadog Agent is unable to connect to the Kafka instance to retrieve metrics from the exposed mBeans over the RMI protocol.
+
+Include the following JVM arguments when starting the Kafka instance to solve resolve this issue *(required for Producer, Consumer, and Broker as they are all separate Java instances)*
+```
+-Dcom.sun.management.jmxremote.port=<PORT_NUM> -Dcom.sun.management.jmxremote.rmi.port=<PORT_NUM>
+```
+
+### Producer and Consumer metrics don't appear in my Datadog application
+By default we only collect broker based metrics. 
+
+If you're running Java based Producers and Consumers, uncomment this section of the yaml file and point the Agent to the proper ports to start pulling in metrics, 
+```yaml
+# - host: remotehost
+    # port: 9998 # Producer
+    # tags:
+    # kafka: producer0
+    # env: stage
+    # newTag: test
+    # - host: remotehost
+    # port: 9997 # Consumer
+    # tags:
+    # kafka: consumer0
+    # env: stage
+    # newTag: test
+```
+
+If you are using custom Producer and Consumer clients that are not written in Java and/or not exposing mBeans, having this enabled would still collect zero metrics. To still submit your metrics from your code use dogstatsd.
+
 ## Further Reading
 ### Blog Article
 To get a better idea of how (or why) to monitor Kafka performance metrics with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/monitoring-kafka-performance-metrics/) about it.

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -92,7 +92,7 @@ If you're running Java based Producers and Consumers, uncomment this section of 
     # newTag: test
 ```
 
-If you are using custom Producer and Consumer clients that are not written in Java and/or not exposing mBeans, having this enabled would still collect zero metrics. To still submit your metrics from your code use dogstatsd.
+If you are using custom Producer and Consumer clients that are not written in Java and/or not exposing mBeans, having this enabled would still collect zero metrics. To still submit your metrics from your code use [dogstatsd](https://docs.datadoghq.com/guides/dogstatsd/).
 
 ## Further Reading
 ### Blog Article

--- a/kafka_consumer/README.md
+++ b/kafka_consumer/README.md
@@ -48,6 +48,18 @@ The Kafka-consumer check does not include any event at this time.
 ### Service Checks
 The Kafka-consumer check does not include any service check at this time.
 
+## Troubleshooting
+### Specifying a non existent partition in your kafka_Consumer.yaml file
+If you get this error in your info.log:
+```
+instance - #0 [Error]: ''
+```
+
+Specify the specific partition of your environment for your topic in your kafka_Consumer.yaml file:
+```
+#my_topic [0, 1, 4, 12]
+```
+
 ## Further Reading
 ### Blog Article
 To get a better idea of how (or why) to monitor Kafka consumer performance metrics with Datadog, check out our [series of blog posts](https://www.datadoghq.com/blog/monitoring-kafka-performance-metrics/) about it.


### PR DESCRIPTION
Merging kafka troubleshooting info from zendesk to this repo

https://help.datadoghq.com/hc/en-us/articles/115002655346-Troubleshooting-and-Deep-Dive-for-Kafka