### PR TITLE
[vsphere] improved resiliency

### DIFF
--- a/vsphere/CHANGELOG.md
+++ b/vsphere/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - vsphere
 
+1.0.3 / Unreleased
+==================
+
+### Changes
+
+* [BUGFIX] Fix case where metrics metadata don't contain what we expect.
+
 1.0.2 / 2017-07-18
 ==================
 

--- a/vsphere/check.py
+++ b/vsphere/check.py
@@ -867,18 +867,23 @@ class VSphereCheck(AgentCheck):
                 if result.id.counterId not in self.metrics_metadata[i_key]:
                     self.log.debug("Skipping this metric value, because there is no metadata about it")
                     continue
-                if not result.value:
-                    self.log.debug("Skipping this metric value, because there are no samples available")
-                    continue
-                instance_name = result.id.instance or "none"
-                value = self._transform_value(instance, result.id.counterId, result.value[0])
 
                 # Metric types are absolute, delta, and rate
-                metric_name = self.metrics_metadata[i_key][result.id.counterId]['name']
+                try:
+                    metric_name = self.metrics_metadata[i_key][result.id.counterId]['name']
+                except KeyError:
+                    metric_name = None
 
                 if metric_name not in ALL_METRICS:
                     self.log.debug(u"Skipping unknown `%s` metric.", metric_name)
                     continue
+
+                if not result.value:
+                    self.log.debug(u"Skipping `%s` metric because the value is empty", metric_name)
+                    continue
+
+                instance_name = result.id.instance or "none"
+                value = self._transform_value(instance, result.id.counterId, result.value[0])
 
                 tags = ['instance:%s' % instance_name]
                 if not mor['hostname']: # no host tags available

--- a/vsphere/manifest.json
+++ b/vsphere/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.2",
+  "version": "1.0.3",
   "guid": "930b1839-cc1f-4e7a-b706-0e8cf3218464"
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Handle the error when we don't find the metric accessing metrics metadata.

### Motivation

From a customer, we might end with this in the collector logs otherwise:
```
Traceback (most recent call last):
  File "/opt/datadog-agent/agent/checks.d/vsphere.py", line 307, in wrapper
    method(*args, **kwargs)
  File "/opt/datadog-agent/agent/checks.d/vsphere.py", line 871, in _collect_metrics_atomic
    value = self._transform_value(instance, result.id.counterId, result.value[0])
IndexError: list index out of range
```

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`

