### PR TITLE
[kafka_consumer] Bump kafka-python to 1.3.4

### DIFF
--- a/kafka_consumer/requirements.txt
+++ b/kafka_consumer/requirements.txt
@@ -1,3 +1,3 @@
 # integration pip requirements
-kafka-python==1.3.3
+kafka-python==1.3.4
 kazoo==2.4.0


### PR DESCRIPTION
Pickup some upstream bugfixes.

I'm one of the maintainers of `kafka-python`, so if there are any issues please file a bug and we'll try to get it fixed.

Sister PR: https://github.com/DataDog/omnibus-software/pull/155