### PR TITLE
[elastic] Update elastic URL parsing logic

### DIFF
--- a/elastic/CHANGELOG.md
+++ b/elastic/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changes
 
 * [FEATURE] Add metric for index count.
+* [BUGFIX] Add logic for if elastic URL contains a path 
 
 1.0.0 / 2017-03-22
 ==================

--- a/elastic/check.py
+++ b/elastic/check.py
@@ -356,8 +356,11 @@ class ESCheck(AgentCheck):
         # Support URLs that have a path in them from the config, for
         # backwards-compatibility.
         parsed = urlparse.urlparse(url)
-        if parsed[2] != "":
+        if parsed[2] != "" and parsed[2] == '/':
             url = "%s://%s" % (parsed[0], parsed[1])
+        else:
+            url = "%s://%s/%s" % (parsed[0], parsed[1], parsed[2])
+
         port = parsed.port
         host = parsed.hostname
 


### PR DESCRIPTION
### What does this PR do?
Updates the parsing logic of the URL grabbed from the config. 

### Motivation
Currently, if the URL is structured with a path after the domain, the check will fail, as the path will get stripped out. 

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`