### PR TITLE
[kubernetes] enable event collection by default for leader agent

### DIFF
--- a/kubernetes/CHANGELOG.md
+++ b/kubernetes/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [FEATURE] add an option to collect node labels as host tags. See [#614][]
 * [IMPROVEMENT] add custom tags to service checks [#642][]
 * [FEATURE] skip cAdvisor metrics if port is set to 0. See [#655][]
+* [FEATURE] enable event collection according to agent leader status. See [#687][]
 
 1.2.0 / 2017-07-18
 ==================

--- a/kubernetes/conf.yaml.example
+++ b/kubernetes/conf.yaml.example
@@ -71,12 +71,37 @@ instances:
   #
   # kubelet_tls_verify: True
 
-  # collect_events controls whether the agent should fetch events from the kubernetes API and
-  # ingest them in Datadog. To avoid duplicates, only one agent at a time across the entire
-  # cluster should have this feature enabled. To enable the feature, set the parameter to `true`.
+  # collect_events controls whether the agent should fetch events from
+  # the kubernetes API and ingest them in Datadog.
+  # To avoid duplicates, only one agent at a time across the entire
+  # cluster should have this feature enabled.
+  # If this is difficult to achieve in your deployment, see the following
+  # Leader election section.
+  # To enable the feature, set the parameter to `true`.
   #
   # collect_events: false
+
+  # Leader election
   #
+  # Agents can perform leader election among themselves.
+  # The leader agent will collect events from the apiserver
+  # even if collect_events is false.
+  # To perform the election it needs get, list, delete, create, and update
+  # rights on ConfigMaps (this can be configured with a Cluster Role).
+  # This makes sure we don't overload the apiserver with redundant
+  # queries coming from every agent.
+  # Default is false.
+  #
+  # leader_candidate: true
+  #
+  # lease duration is the duration for which a leader is elected.
+  # It should be at least twice the check run period (15s by default)
+  # When modifying this setting, keep in mind that the shorter
+  # the lease duration, the more often agents will query the apiserver
+  # Default is 5 minutes.
+  #
+  # leader_lease_duration: 600
+
   # Matching the pods to Kubernetes services requires to retrieve events regularly.
   # To reduce the traffic to the apiserver, we only query them every 5 minutes, adding a delay
   # in pod -> service matching. You can configure it below (in seconds) or disable kube_service

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -2,7 +2,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.0",
   "max_agent_version": "6.0.0",
-  "min_agent_version": "5.15.0",
+  "min_agent_version": "5.17.0",
   "name": "kubernetes",
   "short_description": "Capture Pod scheduling events, track the status of your Kubelets, and much more.",
   "guid": "eb31452b-d681-4823-87cc-2ef114559edf",

--- a/kubernetes/test_kubernetes.py
+++ b/kubernetes/test_kubernetes.py
@@ -50,6 +50,19 @@ METRICS = [
     ('kubernetes.memory.capacity', CAP),
 ]
 
+
+class MockResponse:
+    """
+    Helper class to mock a json response from requests
+    """
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self.json_data
+
+
 class MockIterLinesResponse:
     """
     Helper class to mock a text response from requests
@@ -64,9 +77,9 @@ class MockIterLinesResponse:
 
 def KubeUtil_fake_retrieve_json_auth(url, timeout=10, params=None):
     if url.endswith("/namespaces"):
-        return json.loads(Fixtures.read_file("namespaces.json", sdk_dir=FIXTURE_DIR, string_escape=False))
+        return MockResponse(json.loads(Fixtures.read_file("namespaces.json", sdk_dir=FIXTURE_DIR, string_escape=False)), 200)
     if url.endswith("/events"):
-        return json.loads(Fixtures.read_file("events.json", sdk_dir=FIXTURE_DIR, string_escape=False))
+        return MockResponse(json.loads(Fixtures.read_file("events.json", sdk_dir=FIXTURE_DIR, string_escape=False)), 200)
     return {}
 
 
@@ -622,7 +635,7 @@ class TestKubeutil(unittest.TestCase):
         ]
 
         for node_list, expected_result in node_lists:
-            with mock.patch('utils.kubernetes.kubeutil.KubeUtil.retrieve_json_auth', return_value=node_list):
+            with mock.patch('utils.kubernetes.kubeutil.KubeUtil.retrieve_json_auth', return_value=MockResponse(node_list, 200)):
                 self.assertEqual(self.kubeutil.get_node_hostname('ip-10-0-0-179'), expected_result)
 
     def test_extract_kube_pod_tags(self):

--- a/kubernetes/test_kubernetes.py
+++ b/kubernetes/test_kubernetes.py
@@ -706,13 +706,13 @@ class TestKubeutil(unittest.TestCase):
             # tls_settings, expected_params
             (
                 {},
-                {'verify': False, 'timeout': 10, 'params': None, 'headers': None, 'cert': None}
+                {'verify': False, 'timeout': 3, 'params': None, 'headers': {'content-type': 'application/json'}, 'cert': None}
             ), (
                 {'bearer_token': 'foo_tok'},
-                {'verify': False, 'timeout': 10, 'params': None, 'headers': {'Authorization': 'Bearer foo_tok'}, 'cert': None}
+                {'verify': False, 'timeout': 3, 'params': None, 'headers': {'Authorization': 'Bearer foo_tok', 'content-type': 'application/json'}, 'cert': None}
             ), (
                 {'bearer_token': 'foo_tok','apiserver_client_cert': ('foo.crt', 'foo.key')},
-                {'verify': False, 'timeout': 10, 'params': None, 'headers': None, 'cert': ('foo.crt', 'foo.key')}
+                {'verify': False, 'timeout': 3, 'params': None, 'headers': {'content-type': 'application/json'}, 'cert': ('foo.crt', 'foo.key')}
             ),
         ]
 
@@ -726,7 +726,7 @@ class TestKubeutil(unittest.TestCase):
         self.kubeutil.tls_settings = {'bearer_token': 'foo_tok'}
         self.kubeutil.CA_CRT_PATH = __file__
         self.kubeutil.retrieve_json_auth('url')
-        r.get.assert_called_with('url', verify=__file__, timeout=10, params=None, headers={'Authorization': 'Bearer foo_tok'}, cert=None)
+        r.get.assert_called_with('url', verify=__file__, timeout=3, params=None, headers={'Authorization': 'Bearer foo_tok', 'content-type': 'application/json'}, cert=None)
 
     def test_get_node_info(self):
         with mock.patch('utils.kubernetes.KubeUtil._fetch_host_data') as f:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Update the Kubernetes check to account for the leader election.

### Motivation

https://github.com/DataDog/dd-agent/pull/3476 implements leader election among agents on Kubernetes. Event collection needs to check leader status.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`

### Additional Notes

Linked to https://github.com/DataDog/dd-agent/pull/3476