### PR TITLE
[http_check] client side certificate support

### DIFF
--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - http_check
 
+1.2.0 / Unreleased
+==================
+
+### Changes
+
+* [FEATURE] Add support for client side certificate. See[#688][].
+
 1.1.2 / 2017-08-28
 ==================
 
@@ -34,3 +41,4 @@
 [#328]: https://github.com/DataDog/integrations-core/issues/328
 [#461]: https://github.com/DataDog/integrations-core/issues/461
 [#652]: https://github.com/DataDog/integrations-core/issues/652
+[#688]: https://github.com/DataDog/integrations-core/pull/688

--- a/http_check/check.py
+++ b/http_check/check.py
@@ -162,6 +162,8 @@ class HTTPCheck(NetworkCheck):
         tags = instance.get('tags', [])
         username = instance.get('username')
         password = instance.get('password')
+        client_cert = instance.get('client_cert')
+        client_key = instance.get('client_key')
         http_response_status_code = str(instance.get('http_response_status_code', DEFAULT_EXPECTED_CODE))
         timeout = int(instance.get('timeout', 10))
         config_headers = instance.get('headers', {})
@@ -186,12 +188,12 @@ class HTTPCheck(NetworkCheck):
         skip_proxy = _is_affirmative(instance.get('no_proxy', False))
         allow_redirects = _is_affirmative(instance.get('allow_redirects', True))
 
-        return url, username, password, method, data, http_response_status_code, timeout, include_content,\
+        return url, username, password, client_cert, client_key, method, data, http_response_status_code, timeout, include_content,\
             headers, response_time, content_match, reverse_content_match, tags, ssl, ssl_expire, instance_ca_certs,\
             weakcipher, ignore_ssl_warning, skip_proxy, allow_redirects
 
     def _check(self, instance):
-        addr, username, password, method, data, http_response_status_code, timeout, include_content, headers,\
+        addr, username, password, client_cert, client_key, method, data, http_response_status_code, timeout, include_content, headers,\
             response_time, content_match, reverse_content_match, tags, disable_ssl_validation,\
             ssl_expire, instance_ca_certs, weakcipher, ignore_ssl_warning, skip_proxy, allow_redirects = self._load_conf(instance)
         start = time.time()
@@ -239,7 +241,8 @@ class HTTPCheck(NetworkCheck):
                              proxies = instance_proxy, allow_redirects=allow_redirects,
                              verify=False if disable_ssl_validation else instance_ca_certs,
                              json = data if method == 'post' and isinstance(data, dict) else None,
-                             data = data if method == 'post' and isinstance(data, basestring) else None)
+                             data = data if method == 'post' and isinstance(data, basestring) else None,
+                             cert = (client_cert, client_key) if client_cert and client_key else None)
 
         except (socket.timeout, requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
             length = int((time.time() - start) * 1000)

--- a/http_check/conf.yaml.example
+++ b/http_check/conf.yaml.example
@@ -41,6 +41,13 @@ instances:
     # username: user
     # password: pass
 
+    # If your service uses client side certificates, you can optionally
+    # specify a client certificate and key files that will be used in the check.
+    # The private key to your local certificate must be unencrypted.
+    #
+    # client_cert: /opt/client.crt
+    # client_key: /opt/client.key
+
     # The (optional) http_response_status_code parameter will instruct the check
     # to look for a particular HTTP response status code or a Regex identifying
     # a set of possible status codes.

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.1.2",
+  "version": "1.2.0",
   "guid": "eb133a1f-697c-4143-bad3-10e72541fa9c"
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds support of client side certificates to http_check.

### Motivation

Some http services use client side certificates for authentication instead of basic user/password.

### Versioning

- [v] Bumped the version check in `manifest.json`
- [v] Updated `CHANGELOG.md`

### Additional Notes

requests docs: http://docs.python-requests.org/en/master/user/advanced/#client-side-certificates
