### PR TITLE
Adding support for authSource parameter from mongodb URL

### DIFF
--- a/mongo/CHANGELOG.md
+++ b/mongo/CHANGELOG.md
@@ -1,9 +1,10 @@
 # CHANGELOG - mongo
 
-1.2.1 / UNRELEASED
+1.3.0 / UNRELEASED
 ==================
 ### Changes
 
+* [FEATURE] Add support for `authSource` parameter in mongo URL. See [#691][]
 * [IMPROVEMENT] Simplify "system.namespaces" usage. See [#625][]
 * [BUGFIX] Don't overwrite the higher-level `cli`/`db` for replset stats. See [#627][]
 
@@ -39,3 +40,4 @@
 [#491]: https://github.com/DataDog/integrations-core/issues/491
 [#625]: https://github.com/DataDog/integrations-core/pull/625
 [#627]: https://github.com/DataDog/integrations-core/pull/627
+[#691]: https://github.com/DataDog/integrations-core/pull/691

--- a/mongo/check.py
+++ b/mongo/check.py
@@ -556,7 +556,7 @@ class MongoDb(AgentCheck):
             metric_prefix=metric_prefix, metric_suffix=metric_suffix
         )
 
-    def _authenticate(self, database, username, password, use_x509):
+    def _authenticate(self, database, username, password, use_x509, server_name, service_check_tags):
         """
         Authenticate to the database.
 
@@ -586,6 +586,15 @@ class MongoDb(AgentCheck):
                 u"Authentication failed due to invalid credentials or configuration issues. %s", e
             )
 
+        if not authenticated:
+            message = ("Mongo: cannot connect with config %s" % server_name)
+            self.service_check(
+                self.SERVICE_CHECK_NAME,
+                AgentCheck.CRITICAL,
+                tags=service_check_tags,
+                message=message)
+            raise Exception(message)
+
         return authenticated
 
     def _parse_uri(self, server, sanitize_username=False):
@@ -599,6 +608,7 @@ class MongoDb(AgentCheck):
         password = parsed.get('password')
         db_name = parsed.get('database')
         nodelist = parsed.get('nodelist')
+        auth_source = parsed.get('options', {}).get('authsource')
 
         # Remove password (and optionally username) from sanitized server URI.
         # To ensure that the `replace` works well, we first need to url-decode the raw server string
@@ -610,7 +620,7 @@ class MongoDb(AgentCheck):
             username_pattern = u"{}[@:]".format(re.escape(username))
             clean_server_name = re.sub(username_pattern, "", clean_server_name)
 
-        return username, password, db_name, nodelist, clean_server_name
+        return username, password, db_name, nodelist, clean_server_name, auth_source
 
     def check(self, instance):
         """
@@ -648,7 +658,7 @@ class MongoDb(AgentCheck):
                 del ssl_params[key]
 
         server = instance['server']
-        username, password, db_name, nodelist, clean_server_name = self._parse_uri(server, sanitize_username=bool(ssl_params))
+        username, password, db_name, nodelist, clean_server_name, auth_source = self._parse_uri(server, sanitize_username=bool(ssl_params))
         additional_metrics = instance.get('additional_metrics', [])
 
         # Get the list of metrics to collect
@@ -713,14 +723,12 @@ class MongoDb(AgentCheck):
             )
             do_auth = False
 
-        if do_auth and not self._authenticate(db, username, password, use_x509):
-            message = u"Mongo: cannot connect with config `%s`" % clean_server_name
-            self.service_check(
-                self.SERVICE_CHECK_NAME,
-                AgentCheck.CRITICAL,
-                tags=service_check_tags,
-                message=message)
-            raise Exception(message)
+        if do_auth:
+            if auth_source:
+                self.log.info("authSource was specified in the the server URL: using '%s' as the authentication database", auth_source)
+                self._authenticate(cli[auth_source], username, password, use_x509, clean_server_name, service_check_tags)
+            else:
+                self._authenticate(db, username, password, use_x509, clean_server_name, service_check_tags)
 
         try:
             status = db.command('serverStatus', tcmalloc=collect_tcmalloc_metrics)
@@ -768,16 +776,12 @@ class MongoDb(AgentCheck):
                     replicaset=setname,
                     read_preference=pymongo.ReadPreference.NEAREST,
                     **ssl_params)
-                db_rs = cli_rs[db_name]
 
-                if do_auth and not self._authenticate(db_rs, username, password, use_x509):
-                    message = ("Mongo: cannot connect with config %s" % server)
-                    self.service_check(
-                        self.SERVICE_CHECK_NAME,
-                        AgentCheck.CRITICAL,
-                        tags=service_check_tags,
-                        message=message)
-                    raise Exception(message)
+                if do_auth:
+                    if auth_source:
+                        self._authenticate(cli_rs[auth_source], username, password, use_x509, server, service_check_tags)
+                    else:
+                        self._authenticate(cli_rs[db_name], username, password, use_x509, server, service_check_tags)
 
                 # Replication set information
                 replset_name = replSet['set']

--- a/mongo/ci/start-docker.sh
+++ b/mongo/ci/start-docker.sh
@@ -76,3 +76,9 @@ echo "The shards have been initialized"
 echo 'docker exec -it $NAME mongo --eval cfg = rs.conf(); cfg.members[0].host = "localhost:$PORT"; rs.reconfig(cfg); printjson(rs.conf()); localhost:$PORT'
 echo "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());"
 docker exec -it $NAME mongo --eval "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());" localhost:$PORT
+
+echo "Setting test user"
+docker exec -it $NAME mongo --eval 'db.createUser({ user: "testUser", pwd: "testPass", roles: [ { role: "read", db: "test" } ] })' localhost:$PORT/authDB
+
+echo "Setting test user"
+docker exec -it $NAME mongo --eval 'db.createUser({ user: "testUser2", pwd: "testPass2", roles: [ { role: "read", db: "test" } ] })' localhost:$PORT/test

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.2.1",
+  "version": "1.3.0",
   "guid": "d51c342e-7a02-4611-a47f-1e8eade5735c"
 }

--- a/mongo/test_mongo.py
+++ b/mongo/test_mongo.py
@@ -176,7 +176,7 @@ class TestMongoUnit(AgentCheckTest):
         )
 
         for server, expected_clean_name in server_names:
-            _, _, _, _, clean_name = _parse_uri(server, sanitize_username=False)
+            _, _, _, _, clean_name, _ = _parse_uri(server, sanitize_username=False)
             self.assertEquals(expected_clean_name, clean_name)
 
         # Batch with `sanitize_username` set to True
@@ -190,7 +190,7 @@ class TestMongoUnit(AgentCheckTest):
         )
 
         for server, expected_clean_name in server_names:
-            _, _, _, _, clean_name = _parse_uri(server, sanitize_username=True)
+            _, _, _, _, clean_name, _ = _parse_uri(server, sanitize_username=True)
             self.assertEquals(expected_clean_name, clean_name)
 
 @attr(requires='mongo')
@@ -235,9 +235,9 @@ class TestMongo(unittest.TestCase):
         }
         self.config = {
             'instances': [{
-                'server': "mongodb://localhost:%s/test" % PORT1
+                'server': "mongodb://testUser:testPass@localhost:%s/test?authSource=authDB" % PORT1
             }, {
-                'server': "mongodb://localhost:%s/test" % PORT2
+                'server': "mongodb://testUser2:testPass2@localhost:%s/test" % PORT2
             }]
         }
 


### PR DESCRIPTION
### What does this PR do?

We do not support the [authSource](https://docs.mongodb.com/manual/reference/connection-string/#authentication-options) parameter from mongo forcing users to store their user in the same database that the one being monitored.

This was raised here: #676 

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`