### PR TITLE
add a custom tags  exaple to conf.yaml.example

### DIFF
--- a/tcp_check/conf.yaml.example
+++ b/tcp_check/conf.yaml.example
@@ -12,6 +12,11 @@ instances:
     #
     # collect_response_time: false
 
+    # Custom tags for this instance.
+    # tags:
+    #   - customtag1
+    #   - customtag2
+
     # The (optional) skip_event parameter will instruct the check to not
     # create any event to avoid duplicates with a server side service check.
     # This default to False.


### PR DESCRIPTION
### What does this PR do?

Will add a `tags:` example to `conf.yaml.example`.

### Motivation

Customer on support ticket `102260` was breaking the check  because he was adding tags like this:

```
tags: mytag1, mytag2
```
Currently, no examples in `conf.yaml.example`.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`

### Additional Notes

Anything else we should know when reviewing?
