### PR TITLE
[network] Fix incorrect `log.error` call in BSD check.

### DIFF
--- a/network/CHANGELOG.md
+++ b/network/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Changes
 
-* [BUGFIX] Fix incorrect `log.error` call in BSD check.
+* [BUGFIX] Fix incorrect `log.error` call in BSD check. See [#698][]
 
 1.2.1 / 2017-07-18
 ==================
@@ -40,4 +40,5 @@
 [#299]: https://github.com/DataDog/integrations-core/issues/299
 [#452]: https://github.com/DataDog/integrations-core/issues/452
 [#501]: https://github.com/DataDog/integrations-core/issues/501
+[#698]: https://github.com/DataDog/integrations-core/issues/698
 [@cory-stripe]: https://github.com/cory-stripe

--- a/network/CHANGELOG.md
+++ b/network/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - network
 
+1.2.2 / Unreleased
+==================
+
+### Changes
+
+* [BUGFIX] Fix incorrect `log.error` call in BSD check.
+
 1.2.1 / 2017-07-18
 ==================
 

--- a/network/check.py
+++ b/network/check.py
@@ -435,7 +435,7 @@ class Network(AgentCheck):
             #          -7       -6       -5        -4       -3       -2        -1
             for h in ("Ipkts", "Ierrs", "Ibytes", "Opkts", "Oerrs", "Obytes", "Coll"):
                 if h not in headers:
-                    self.logger.error("%s not found in %s; cannot parse" % (h, headers))
+                    self.log.error("%s not found in %s; cannot parse" % (h, headers))
                     return False
 
             current = None

--- a/network/manifest.json
+++ b/network/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.2.1",
+  "version": "1.2.2",
   "guid": "43631795-8a1f-404d-83ae-397639a84050"
 }


### PR DESCRIPTION
### What does this PR do?

Fix incorrect `log.error` call in BSD check.

### Motivation

Fixes #656

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`

