### PR TITLE
[docker] fix volume counting

### DIFF
--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [BUGFIX] safely check volume list before accessing. See [#544][]
+* [BUGFIX] make it a bit safer. See [#701][]
 
 1.3.1 / 2017-07-26 
 ==================

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -597,8 +597,8 @@ class DockerDaemon(AgentCheck):
 
         attached_volumes = self.docker_client.volumes(filters={'dangling': False})
         dangling_volumes = self.docker_client.volumes(filters={'dangling': True})
-        attached_count = len(attached_volumes.get('Volumes', []))
-        dangling_count = len(dangling_volumes.get('Volumes', []))
+        attached_count = len(attached_volumes.get('Volumes', []) or [])
+        dangling_count = len(dangling_volumes.get('Volumes', []) or [])
         m_func(self, 'docker.volume.count', attached_count, tags=['volume_state:attached'])
         m_func(self, 'docker.volume.count', dangling_count, tags=['volume_state:dangling'])
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

the `Volumes` key can exist but its value is `None`, in which case the `.get` will fail as well. Set it to an empty list instead of None.

### Motivation

Found it during QA.

### Testing Guidelines

Remove all docker volumes (`docker volume rm $(docker volume ls -q)`) and run the check, it shouldn't except on `TypeError: object of type 'NoneType' has no len()` anymore.

### Versioning

- [ ] Bumped the version check in `manifest.json`  - **don't need to, this changed wasn't released yet**
- [x] Updated `CHANGELOG.md`

### Additional Notes

Creating a card to write solid tests for this check...
