### PR TITLE
[Postfix] fixes example file

### DIFF
--- a/postfix/conf.yaml.example
+++ b/postfix/conf.yaml.example
@@ -8,7 +8,7 @@
 #          Defaults:dd-agent !requiretty
 
 init_config:
-  - postfix_user: postfix
+  postfix_user: postfix
 
 instances:
   - directory: /var/spool/postfix


### PR DESCRIPTION
### What does this PR do?

The example file was broken, it should be a dict rather than a list. I found it during QA