### PR TITLE
Maxime/cassandra nodetool fix

### DIFF
--- a/cassandra_nodetool/check.py
+++ b/cassandra_nodetool/check.py
@@ -20,13 +20,20 @@ TO_BYTES = {
     'MB': 1e6,
     'GB': 1e9,
     'TB': 1e12,
+
+    # only available in cassandra 3.11 or later
+    'iB': 1,
+    'KiB': 1e3,
+    'MiB': 1e6,
+    'GiB': 1e9,
+    'TiB': 1e12,
 }
 
 class CassandraNodetoolCheck(AgentCheck):
 
     datacenter_name_re = re.compile('^Datacenter: (.*)')
     node_status_re = re.compile('^(?P<status>[UD])[NLJM] +(?P<address>\d+\.\d+\.\d+\.\d+) +'
-                                '(?P<load>\d+\.\d*) (?P<load_unit>(K|M|G|T)?B) +\d+ +'
+                                '(?P<load>\d+\.\d*) (?P<load_unit>(K|M|G|T)?i?B) +\d+ +'
                                 '(?P<owns>(\d+\.\d+)|\?)%? +(?P<id>[a-fA-F0-9-]*) +(?P<rack>.*)')
 
     def __init__(self, name, init_config, agentConfig, instances=None):

--- a/cassandra_nodetool/check.py
+++ b/cassandra_nodetool/check.py
@@ -53,6 +53,9 @@ class CassandraNodetoolCheck(AgentCheck):
         # Flag to send service checks only once and not for every keyspace
         send_service_checks = True
 
+        if not keyspaces:
+            self.log.info("No keyspaces set in the configuration: no metrics will be sent")
+
         for keyspace in keyspaces:
             # Build the nodetool command
             cmd = nodetool_cmd + ['-h', host, '-p', port]

--- a/cassandra_nodetool/conf.yaml.example
+++ b/cassandra_nodetool/conf.yaml.example
@@ -8,16 +8,16 @@ instances:
   # the list of keyspaces to monitor, an empty list will result in no metrics being sent
   - keyspaces: []
 
-  # host that nodetool will connect to.
-  # host: localhost
+    # host that nodetool will connect to.
+    # host: localhost
 
-  # the port JMX is listening to for connections.
-  # port: 7199
+    # the port JMX is listening to for connections.
+    # port: 7199
 
-  # a set of credentials to connect to the host. These are the credentials for the JMX server.
-  # For the check to work, this user must have a read/write access so that nodetool can execute the `status` command
-  # username:
-  # password:
+    # a set of credentials to connect to the host. These are the credentials for the JMX server.
+    # For the check to work, this user must have a read/write access so that nodetool can execute the `status` command
+    # username:
+    # password:
 
-  # a list of additionnal tags to be sent with the metrics
-  # tags: []
+    # a list of additionnal tags to be sent with the metrics
+    # tags: []

--- a/cassandra_nodetool/conf.yaml.example
+++ b/cassandra_nodetool/conf.yaml.example
@@ -5,7 +5,7 @@ init_config:
 
 instances:
 
-  # the list of keyspaces to monitor
+  # the list of keyspaces to monitor, an empty list will result in no metrics being sent
   - keyspaces: []
 
   # host that nodetool will connect to.


### PR DESCRIPTION
### What does this PR do?

Fix integration to be compatible with the latest version of cassandra (3.11+).
Add more log to warn user about the default configuration producing no metrics.
Update the defautl configuration to produce a valid yaml if lines are commented out.