### PR TITLE
[supervisord] Fix test on service checks

### DIFF
--- a/supervisord/test_supervisord.py
+++ b/supervisord/test_supervisord.py
@@ -454,7 +454,7 @@ Stop time: \nExit Status: 0"""
     def norm_service_check(service_check):
         '''Removes timestamp, host_name, message and id'''
         for field in ['timestamp', 'host_name', 'message', 'id']:
-            service_check.pop(field)
+            service_check.pop(field, None)
         return service_check
 
 


### PR DESCRIPTION
### What does this PR do?

Fixes test on service checks of the supervisor check.

Some service check fields are not necessarily in the dict anymore, so
stop assuming they are.

### Motivation

Test was broken since https://github.com/DataDog/dd-agent/pull/3487

### Versioning

Just a test update, no need to bump version.
~- [ ] Bumped the version check in `manifest.json`~
~- [ ] Updated `CHANGELOG.md`~
