### PR TITLE
[WIP] Remove more tags from docker & kube metrics when using histograms

### DIFF
--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -37,8 +37,8 @@ DISK_STATS_RE = re.compile('([0-9.]+)\s?([a-zA-Z]+)')
 
 GAUGE = AgentCheck.gauge
 RATE = AgentCheck.rate
-HISTORATE = AgentCheck.generate_historate_func(["container_name"])
-HISTO = AgentCheck.generate_histogram_func(["container_name"])
+HISTORATE = AgentCheck.generate_historate_func(["container_name", "pod_name", "kube_replica_set", "kube_replication_controller"])
+HISTO = AgentCheck.generate_histogram_func(["container_name", "pod_name", "kube_replica_set", "kube_replication_controller"])
 FUNC_MAP = {
     GAUGE: {True: HISTO, False: GAUGE},
     RATE: {True: HISTORATE, False: RATE}

--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -46,8 +46,8 @@ DEFAULT_ENABLED_GAUGES = [
 
 GAUGE = AgentCheck.gauge
 RATE = AgentCheck.rate
-HISTORATE = AgentCheck.generate_historate_func(["container_name"])
-HISTO = AgentCheck.generate_histogram_func(["container_name"])
+HISTORATE = AgentCheck.generate_historate_func(["container_name", "pod_name", "kube_replica_set", "kube_replication_controller"])
+HISTO = AgentCheck.generate_histogram_func(["container_name", "pod_name", "kube_replica_set", "kube_replication_controller"])
 FUNC_MAP = {
     GAUGE: {True: HISTO, False: GAUGE},
     RATE: {True: HISTORATE, False: RATE}


### PR DESCRIPTION
### What does this PR do?

The `use_histogram` option in the `docker_daemon` and `kubernetes` integrations is supposed to remove the high cardinality `container_name` tag and submit metrics as histograms/historates in order to move metrics to a deployment cardinality.

When we introduced new high-cardinality tags, we didn't keep the blacklist in sync and when using kubernetes, this feature does not work, as `pod_name` has a container cardinality.

This patch adds to the blacklist:
  - `pod_name`: container cardinality tag
  - `kube_replica_set`: each deployment version creates a new replicaset, so the cardinality is pretty high. They are [deprecated in favor of deployments](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/#when-to-use-a-replicaset) anyway
  - generic legacy `kube_replication_controller` (as we tag any creator found with this tag, including replicasets). They are [deprecated on favor of deployments](https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/) too.

### Motivation

With these tags gone, histograms go back to the intended deployment cardinality for both integrations. That should solve context explosion issues for some high-churn clusters.

### Testing Guidelines

Will need to update unit tests before merging.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`
