### PR TITLE
Use sudo for privileged process checks on filedescriptors

### DIFF
--- a/process/README.md
+++ b/process/README.md
@@ -35,6 +35,15 @@ You can also configure the check to find any process by exact PID (`pid`) or pid
 
 To have the check search for processes in a path other than `/proc`, set `procfs_path: <your_proc_path>` in `datadog.conf`, NOT in `process.yaml` (its use has been deprecated there). Set this to `/host/proc` if you're running the Agent from a Docker container (i.e. [docker-dd-agent](https://github.com/DataDog/docker-dd-agent)) and want to monitor processes running on the server hosting your containers. You DON'T need to set this to monitor processes running _in_ your containers; the [Docker check](https://github.com/DataDog/integrations-core/tree/master/docker_daemon) monitors those.
 
+Some process metrics require either running the datadog collector as the same user as the monitored process or privileged access to be retrieved.
+Where the former option is not desired, and to avoid running the datadog collector as `root`, the `try_sudo` option lets the process check try using `sudo` to collect this metric.
+As of now, only the `open_fd` metric on Unix platforms is taking advantage of this setting.
+Note: the appropriate sudoers rules have to be configured for this to work, e.g. if packaged with the datadog agent:
+```
+dd-agent ALL=NOPASSWD: /opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/checks.d/process.py num_fds *
+dd-agent ALL=NOPASSWD: /opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/checks.d/process.pyc num_fds *
+```
+
 See the [example configuration](https://github.com/DataDog/integrations-core/blob/master/process/conf.yaml.example) for more details on configuration options.
 
 [Restart the Agent](https://docs.datadoghq.com/agent/faq/start-stop-restart-the-datadog-agent) to start sending process metrics and service checks to Datadog.

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -173,7 +173,7 @@ class ProcessCheck(AgentCheck):
             self.last_ad_cache_ts[name] = time.time()
         return matching_pids
 
-    def psutil_wrapper(self, process, method, accessors, *args, **kwargs):
+    def psutil_wrapper(self, process, method, accessors, try_sudo, *args, **kwargs):
         """
         A psutil wrapper that is calling
         * psutil.method(*args, **kwargs) and returns the result
@@ -210,7 +210,7 @@ class ProcessCheck(AgentCheck):
             self.log.debug("psutil method %s not implemented", method)
         except psutil.AccessDenied:
             self.log.debug("psutil was denied acccess for method %s", method)
-            if method == 'num_fds' and Platform.is_unix():
+            if method == 'num_fds' and Platform.is_unix() and try_sudo:
                 try:
                     # It is up the agent's packager to grant corresponding sudo policy on unix platforms
                     result = int(subprocess.check_output(['sudo', sys.executable, __file__, method, str(process.pid)]))
@@ -223,7 +223,7 @@ class ProcessCheck(AgentCheck):
 
         return result
 
-    def get_process_state(self, name, pids):
+    def get_process_state(self, name, pids, try_sudo):
         st = defaultdict(list)
 
         # Remove from cache the processes that are not in `pids`
@@ -251,36 +251,36 @@ class ProcessCheck(AgentCheck):
 
             p = self.process_cache[name][pid]
 
-            meminfo = self.psutil_wrapper(p, 'memory_info', ['rss', 'vms'])
+            meminfo = self.psutil_wrapper(p, 'memory_info', ['rss', 'vms'], try_sudo)
             st['rss'].append(meminfo.get('rss'))
             st['vms'].append(meminfo.get('vms'))
 
-            mem_percent = self.psutil_wrapper(p, 'memory_percent', None)
+            mem_percent = self.psutil_wrapper(p, 'memory_percent', None, try_sudo)
             st['mem_pct'].append(mem_percent)
 
             # will fail on win32 and solaris
-            shared_mem = self.psutil_wrapper(p, 'memory_info_ex', ['shared']).get('shared')
+            shared_mem = self.psutil_wrapper(p, 'memory_info_ex', ['shared'], try_sudo).get('shared')
             if shared_mem is not None and meminfo.get('rss') is not None:
                 st['real'].append(meminfo['rss'] - shared_mem)
             else:
                 st['real'].append(None)
 
-            ctxinfo = self.psutil_wrapper(p, 'num_ctx_switches', ['voluntary', 'involuntary'])
+            ctxinfo = self.psutil_wrapper(p, 'num_ctx_switches', ['voluntary', 'involuntary'], try_sudo)
             st['ctx_swtch_vol'].append(ctxinfo.get('voluntary'))
             st['ctx_swtch_invol'].append(ctxinfo.get('involuntary'))
 
-            st['thr'].append(self.psutil_wrapper(p, 'num_threads', None))
+            st['thr'].append(self.psutil_wrapper(p, 'num_threads', None, try_sudo))
 
-            cpu_percent = self.psutil_wrapper(p, 'cpu_percent', None)
+            cpu_percent = self.psutil_wrapper(p, 'cpu_percent', None, try_sudo)
             if not new_process:
                 # psutil returns `0.` for `cpu_percent` the first time it's sampled on a process,
                 # so save the value only on non-new processes
                 st['cpu'].append(cpu_percent)
 
-            st['open_fd'].append(self.psutil_wrapper(p, 'num_fds', None))
-            st['open_handle'].append(self.psutil_wrapper(p, 'num_handles', None))
+            st['open_fd'].append(self.psutil_wrapper(p, 'num_fds', None, try_sudo))
+            st['open_handle'].append(self.psutil_wrapper(p, 'num_handles', None, try_sudo))
 
-            ioinfo = self.psutil_wrapper(p, 'io_counters', ['read_count', 'write_count', 'read_bytes', 'write_bytes'])
+            ioinfo = self.psutil_wrapper(p, 'io_counters', ['read_count', 'write_count', 'read_bytes', 'write_bytes'], try_sudo)
             st['r_count'].append(ioinfo.get('read_count'))
             st['w_count'].append(ioinfo.get('write_count'))
             st['r_bytes'].append(ioinfo.get('read_bytes'))
@@ -300,7 +300,7 @@ class ProcessCheck(AgentCheck):
                 st['cmajflt'].append(None)
 
             #calculate process run time
-            create_time = self.psutil_wrapper(p, 'create_time', None)
+            create_time = self.psutil_wrapper(p, 'create_time', None, try_sudo)
             if create_time is not None:
                 now = time.time()
                 run_time = now - create_time
@@ -350,6 +350,7 @@ class ProcessCheck(AgentCheck):
         pid_file = instance.get('pid_file')
         collect_children = _is_affirmative(instance.get('collect_children', False))
         user = instance.get('user', False)
+        try_sudo = instance.get('try_sudo', False)
 
         if self._conflicting_procfs:
             self.warning('The `procfs_path` defined in `process.yaml` is different from the one defined in '
@@ -401,7 +402,7 @@ class ProcessCheck(AgentCheck):
         if user:
             pids = self._filter_by_user(user, pids)
 
-        proc_state = self.get_process_state(name, pids)
+        proc_state = self.get_process_state(name, pids, try_sudo)
 
         # FIXME 6.x remove the `name` tag
         tags.extend(['process_name:%s' % name, name])

--- a/process/test/test_process.py
+++ b/process/test/test_process.py
@@ -188,7 +188,8 @@ class ProcessCheckTest(AgentCheckTest):
         name = self.check.psutil_wrapper(
             self.get_psutil_proc(),
             'name',
-            None
+            None,
+            False
         )
 
         self.assertNotEquals(name, None)
@@ -199,7 +200,8 @@ class ProcessCheckTest(AgentCheckTest):
         name = self.check.psutil_wrapper(
             self.get_psutil_proc(),
             'blah',
-            None
+            None,
+            False
         )
 
         self.assertEquals(name, None)
@@ -210,7 +212,8 @@ class ProcessCheckTest(AgentCheckTest):
         meminfo = self.check.psutil_wrapper(
             self.get_psutil_proc(),
             'memory_info',
-            ['rss', 'vms', 'foo']
+            ['rss', 'vms', 'foo'],
+            False
         )
 
         self.assertIn('rss', meminfo)
@@ -223,7 +226,8 @@ class ProcessCheckTest(AgentCheckTest):
         meminfo = self.check.psutil_wrapper(
             self.get_psutil_proc(),
             'memory_infoo',
-            ['rss', 'vms']
+            ['rss', 'vms'],
+            False
         )
 
         self.assertNotIn('rss', meminfo)
@@ -263,7 +267,7 @@ class ProcessCheckTest(AgentCheckTest):
             idx = search_string[0].split('_')[1]
         return self.CONFIG_STUBS[int(idx)]['mocked_processes']
 
-    def mock_psutil_wrapper(self, process, method, accessors, *args, **kwargs):
+    def mock_psutil_wrapper(self, process, method, accessors, try_sudo, *args, **kwargs):
         if method == 'num_handles':  # remove num_handles as it's win32 only
             return None
 


### PR DESCRIPTION
### What does this PR do?

Repackaged the patch I suggested at https://github.com/DataDog/dd-agent/issues/2033#issuecomment-325657568 in a dd-agent-omnibus compatible way (no additional python file, only `process/check.py` is modified).

### Motivation

Datadog does not provide out of box support for monitoring file descriptors used by processes not running under the same user (`dd-agent` by default).

The suggested work-around of running the datadog agent as root is explicitly not recommended which is probably reasonable: https://help.datadoghq.com/hc/en-us/articles/115000066506-Why-don-t-I-see-the-system-processes-open-file-descriptors-metric-

### Additional Notes

This requires the addition of the following sudo policies in the deb and rpm packages:

```
dd-agent ALL=NOPASSWD: /opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/checks.d/process.py num_fds *
dd-agent ALL=NOPASSWD: /opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/checks.d/process.pyc num_fds *
```

Usage of sudo generates frequent logging in `/var/log/auth.log`. That may be silenced with additional PAM rules in `/etc/pam.d/sudo` if desired.

Resolves DataDog/dd-agent/issues#2033

The same may be done for the `io_counters` method.