### PR TITLE
[changelog] Set release date on integration changelogs

### DIFF
--- a/cassandra/CHANGELOG.md
+++ b/cassandra/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - cassandra
 
-1.1.0 / Unreleased
+1.1.0 / 2017-08-28
 ==================
 
 ### Changes

--- a/cassandra_nodetool/CHANGELOG.md
+++ b/cassandra_nodetool/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - Cassandra Nodetool Check
 
-0.1.0/ Unreleased
+0.1.0/ 2017-08-28
 ==================
 
 ### Changes

--- a/couchbase/CHANGELOG.md
+++ b/couchbase/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - couchbase
 
-1.1.1 / Unreleased
+1.1.1 / 2017-08-28
 ==================
 
 ### Changes

--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - docker_daemon
 
-1.3.2 / Unreleased
+1.3.2 / 2017-08-28
 ==================
 ### Changes
 

--- a/elastic/CHANGELOG.md
+++ b/elastic/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - elastic
 
-1.0.1 / Unreleased
+1.0.1 / 2017-08-28
 ==================
 
 ### Changes

--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - http_check
 
-1.1.2 / Unreleased
+1.1.2 / 2017-08-28
 ==================
 
 ### Changes

--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -8,7 +8,7 @@
 * [FEATURE] discovery of groups, topics and partitions. See [#633][] (Thanks [@jeffwidman][])
 
 
-1.0.2 / Unreleased
+1.0.2 / 2017-08-28
 ==================
 
 ### Changes

--- a/kubernetes/CHANGELOG.md
+++ b/kubernetes/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG - kubernetes
 
 
-1.3.0 / Unreleased
+1.3.0 / 2017-08-28
 ==================
 ### Changes
 

--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - kubernetes_state
 
-1.3.0 / Unreleased
+1.3.0 / 2017-08-28
 ==================
 
 ### Changes

--- a/marathon/CHANGELOG.md
+++ b/marathon/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - marathon
 
-1.2.0 / Unreleased
+1.2.0 / 2017-08-28
 ==================
 
 ### Changes

--- a/mongo/CHANGELOG.md
+++ b/mongo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - mongo
 
-1.3.0 / UNRELEASED
+1.3.0 / 2017-08-28
 ==================
 ### Changes
 

--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - mysql
 
-1.0.4 / Unreleased
+1.0.4 / 2017-08-28
 ==================
 
 ### Changes

--- a/network/CHANGELOG.md
+++ b/network/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - network
 
-1.2.2 / Unreleased
+1.2.2 / 2017-08-28
 ==================
 
 ### Changes

--- a/openstack/CHANGELOG.md
+++ b/openstack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - openstack
 
-1.0.1 / Unreleased
+1.0.1 / 2017-08-28
 ==================
 
 ### Changes

--- a/postfix/CHANGELOG.md
+++ b/postfix/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - postfix
 
-1.1.0 / Unreleased
+1.1.0 / 2017-08-28
 ==================
 
 ### Changes

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - postgres
 
-1.1.0 / Unreleased
+1.1.0 / 2017-08-28
 ==================
 
 ### Changes

--- a/process/CHANGELOG.md
+++ b/process/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - process
 
-1.1.2 / Unreleased
+1.1.2 / 2017-08-28
 ==================
 
  * [IMPROVEMENT] Better logging when a process was not found. See [#609][]

--- a/rabbitmq/CHANGELOG.md
+++ b/rabbitmq/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG - rabbitmq
 
 
-1.3.0 / Unreleased
+1.3.0 / 2017-08-28
 ==================
 
 ### Changes

--- a/redisdb/CHANGELOG.md
+++ b/redisdb/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - redisdb
 
-1.2.0 / Unreleased
+1.2.0 / 2017-08-28
 ==================
 
 ### Changes

--- a/ssh_check/CHANGELOG.md
+++ b/ssh_check/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - ssh_check
 
-1.1.1 / Unreleased
+1.1.1 / 2017-08-28
 ==================
 
 ### Changes

--- a/varnish/CHANGELOG.md
+++ b/varnish/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - varnish
 
-1.0.4 Unreleased
+1.0.4 2017-08-28
 ==================
 
 ### Changes

--- a/vsphere/CHANGELOG.md
+++ b/vsphere/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - vsphere
 
-1.0.3 / Unreleased
+1.0.3 / 2017-08-28
 ==================
 
 ### Changes


### PR DESCRIPTION
[skip ci]

### What does this PR do?

Set release dates on integration changelogs, for the integrations that were released
with 5.17.0 (they've all been released as individual packages too)