### PR TITLE
turn off preferred delimiters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,6 @@ Style/Documentation:
 
 Style/SingleLineBlockParams:
   Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Enabled: false


### PR DESCRIPTION
### What does this PR do?

This rubocop rule fails our template, it doesn't even match the [ruby style guide](https://github.com/bbatsov/rubocop/issues/4039).