### PR TITLE
[AD] Improve docker, k8s checks to wait on docker & kubelet

### DIFF
--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - docker_daemon
 
+
+1.4.0 / Unreleased
+==================
+### Changes
+
+* [FEATURE] Add an option to wait for docker if it's not ready at start time. See [#722][]
+
 1.3.2 / 2017-08-28
 ==================
 ### Changes

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -256,10 +256,15 @@ class DockerDaemon(AgentCheck):
             # https://github.com/DataDog/dd-agent/issues/1896
             self.init()
 
-            if self.docker_util.client is None:
-                message = "Unable to connect to Docker daemon"
+            try:
+                if self.docker_util.client is None:
+                    message = "Unable to connect to Docker daemon"
+                    self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
+                                       message=message)
+                    return
+            except Exception as ex:
                 self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-                                   message=message)
+                                   message=str(ex))
                 return
 
             if not self.init_success:

--- a/docker_daemon/conf.yaml.example
+++ b/docker_daemon/conf.yaml.example
@@ -20,6 +20,22 @@ init_config:
   # tls_cacert: /path/to/ca.pem
   # tls_verify: True
 
+  # Initialization retries
+  #
+  # if the agent is expected to start before Docker,
+  # use these settings to configure the retry policy.
+  #
+  # init_retry_interval defines how long (in seconds) the docker client
+  # will wait before retrying initialization.
+  # Defaults to 0.
+  #
+  # init_retry_interval: 20
+  #
+  # init_retries configures how many retries are made before failing permanently.
+  # Defaults to 0.
+  #
+  # init_retries: 5
+
 instances:
   - ## Daemon and system configuration
     ##
@@ -166,9 +182,9 @@ instances:
     # collect_labels_as_tags: ["com.docker.compose.service", "com.docker.compose.project"]
     # List of docker event attributes to add as tags of the datadog events
     # Defaults to None.
-    # 
+    #
     # event_attributes_as_tags: ["signal"]
-    
+
     ## Rate Filtering
     ##
 

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -11,5 +11,5 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.3.2"
+  "version": "1.4.0"
 }

--- a/kubernetes/CHANGELOG.md
+++ b/kubernetes/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG - kubernetes
 
 
+1.4.0 / UNRELEASED
+==================
+### Changes
+
+* [FEATURE] Add an option to retry kubelet connection if it's not up at start time. See [#722][]
+
 1.3.0 / 2017-08-28
 ==================
 ### Changes

--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -174,9 +174,6 @@ class Kubernetes(AgentCheck):
             self.event_retriever = None
 
     def check(self, instance):
-        # Leader election
-        self.refresh_leader_status(instance)
-
         if not self.kubeutil.init_success:
             if self.kubeutil.left_init_retries > 0:
                 self.kubeutil.init_kubelet(instance)
@@ -184,6 +181,9 @@ class Kubernetes(AgentCheck):
                 return
             else:
                 raise Exception("Unable to initialize Kubelet client. Try setting the host parameter. The Kubernetes check failed permanently.")
+
+        # Leader election
+        self.refresh_leader_status(instance)
 
         self.max_depth = instance.get('max_depth', DEFAULT_MAX_DEPTH)
         enabled_gauges = instance.get('enabled_gauges', DEFAULT_ENABLED_GAUGES)

--- a/kubernetes/conf.yaml.example
+++ b/kubernetes/conf.yaml.example
@@ -1,4 +1,19 @@
 init_config:
+  # Initialization retries
+  #
+  # if the agent is expected to start before Kubelet,
+  # use these settings to configure the retry policy.
+  #
+  # init_retry_interval defines how long (in seconds) the kubelet client
+  # will wait before retrying initialization.
+  # Defaults to 0.
+  #
+  # init_retry_interval: 20
+  #
+  # init_retries configures how many retries are made before failing permanently.
+  # Defaults to 0.
+  #
+  # init_retries: 5
 
 instances:
   # The kubernetes check retrieves metrics from cadvisor running under kubelet on each node.

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -11,5 +11,5 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.3.0"
+  "version": "1.4.0"
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Make docker, kubernetes checks handle DockerUtil and KubeUtil not being initialized at start up time.
To do so we introduce retry settings in their respective conf.yaml.

### Motivation

It can be useful to start the agent as soon as possible to gain observability over the system initialization. If we want this to work, we need core integrations and auto discovery to wait on their underlying service to start.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`

### Additional Notes

linked PR: https://github.com/DataDog/dd-agent/pull/3497