### PR TITLE
[varnish] Support for Varnish 4.1 backend.list format

### DIFF
--- a/varnish/check.py
+++ b/varnish/check.py
@@ -313,7 +313,7 @@ reload_2017-08-25T14:33:03.test2 probe      Healthy 5/5
         backend, status, message = None, None, None
         for line in output.split("\n"):
             tokens = line.strip().split()
-            if len(tokens) > 0:
+            if len(tokens) > 2:
                 if tokens[0] != 'Backend':
                     backend_split = tokens[0].split('.')
                     if len(backend_split) > 1:

--- a/varnish/check.py
+++ b/varnish/check.py
@@ -321,13 +321,13 @@ reload_2017-08-25T14:33:03.test2 probe      Healthy 5/5
                     status = tokens[1].lower()
                     if (status == 'probe'):
                         probestatus = tokens[2].lower()
-                        if backend != None:
+                        if backend is not None:
                             backends_by_status[probestatus].append((backend, ''))
                     elif (status == 'healthy'):
-                        if backend != None:
+                        if backend is not None:
                             backends_by_status[status].append((backend, ''))
                     elif (status == 'sick'):
-                        if backend != None:
+                        if backend is not None:
                             backends_by_status['forcesick'].append((backend, ''))
 
         for status, backends in backends_by_status.iteritems():

--- a/varnish/test_varnish.py
+++ b/varnish/test_varnish.py
@@ -161,7 +161,7 @@ class VarnishCheckTest(AgentCheckTest):
 
         self.run_check(config)
         args, _ = mock_subprocess.call_args
-        self.assertEquals(args[0], ['sudo', VARNISHADM_PATH, '-S', SECRETFILE_PATH, 'backend.list', '-p'])
+        self.assertEquals(args[0], ['sudo', VARNISHADM_PATH, '-S', SECRETFILE_PATH, 'backend.list'])
 
     # This the docker image is in a different repository, we check that the
     # verison requested in the FLAVOR_VERSION is the on running inside the


### PR DESCRIPTION
### What does this PR do?

The current Varnish check assumes that the format of 3.0 `debug.health` and 4.1 `backend.list -p`  formats are the same. They are not.
This PR changes to use `backend.list` and adds code for parsing the format.

### Motivation

With the current code backend checks doesn't work for Varnish 4.1.
I needed this code myself to make it work on our Varnishes.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`

### Additional Notes

If you force a sick backend status, you will get a warning instead of an error in Datadog.
