### PR TITLE
make use_histogram configurable

### DIFF
--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [IMPROVEMENT] Add custom tags to all service checks. See [#782][]
 * [IMPROVEMENT] Add docker memory soft limit metric. See [#760][]
+* [IMPROVEMENT] Honor docker_histo_striptags option in datadog.conf for histograms [#725][]
 
 1.5.1 / 2017-11-08
 ==================
@@ -115,6 +116,9 @@
 [#722]: https://github.com/DataDog/integrations-core/issues/722
 [#744]: https://github.com/DataDog/integrations-core/issues/744
 [#770]: https://github.com/DataDog/integrations-core/issues/770
+<<<<<<< HEAD
 [#782]: https://github.com/DataDog/integrations-core/issues/782
 [#817]: https://github.com/DataDog/integrations-core/issues/817
+=======
+>>>>>>> make tags stripped by use_histogram configurable
 [@sophaskins]: https://github.com/sophaskins

--- a/docker_daemon/conf.yaml.example
+++ b/docker_daemon/conf.yaml.example
@@ -149,7 +149,13 @@ instances:
     # To customize this default behavior, override exclude.
     # If you do so, default exclusion patterns won't apply anymore and will need to be added explicitly.
 
-
+    # use_histogram controls whether we send detailed metrics, i.e. one per container.
+    # When false, we send detailed metrics corresponding to individual containers, tagging by container id
+    # to keep them unique.
+    # When true, we aggregate data based on container image / deployment.
+    # Tag exclusion list is configurable via the docker_histo_striptags option in datadog.conf
+    #
+    # use_histogram: false
 
     ## Tagging
     ##

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -2,7 +2,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.0",
   "max_agent_version": "6.0.0",
-  "min_agent_version": "5.15.0",
+  "min_agent_version": "5.18.0",
   "name": "docker_daemon",
   "short_description": "Correlate container performance with that of the services running inside them.",
   "guid": "08ee2733-0441-4438-8af8-e2f6fb926772",

--- a/kubernetes/CHANGELOG.md
+++ b/kubernetes/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - kubernetes
 
+1.6.0 / Unreleased
+==================
+### Changes
+
+* [IMPROVEMENT] Honor docker_histo_striptags option in datadog.conf for histograms [#725][]
+
 1.5.0 / 2017-10-10
 ==================
 ### Changes

--- a/kubernetes/conf.yaml.example
+++ b/kubernetes/conf.yaml.example
@@ -148,7 +148,8 @@ instances:
   # use_histogram controls whether we send detailed metrics, i.e. one per container.
   # When false, we send detailed metrics corresponding to individual containers, tagging by container id
   # to keep them unique.
-  # When true, we aggregate data based on container image.
+  # When true, we aggregate data based on container image / deployment.
+  # Tag exclusion list is configurable via the docker_histo_striptags option in datadog.conf
   #
   # use_histogram: false
   #

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -11,7 +11,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.5.0",
+  "version": "1.6.0",
   "public_title": "Datadog-Kubernetes Integration",
   "categories":["orchestration", "containers"],
   "doc_link": "https://docs.datadoghq.com/integrations/kubernetes/",

--- a/kubernetes/metadata.csv
+++ b/kubernetes/metadata.csv
@@ -1,8 +1,7 @@
-metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 kubernetes.cpu.capacity,gauge,,,,The number of cores in this machine.,0,kubernetes,k8s.cpu.capacity
-kubernetes.cpu.usage.total,gauge,,percent_nano,,The percentage of CPU time used,-1,kubernetes,k8s.cpu
 kubernetes.cpu.limits,gauge,,cpu,,The limit of cpu cores set,0,kubernetes,k8s.cpu.limits
 kubernetes.cpu.requests,gauge,,cpu,,The requested cpu cores,0,kubernetes,k8s.cpu.requests
+kubernetes.cpu.usage.total,gauge,,percent_nano,,The percentage of CPU time used,-1,kubernetes,k8s.cpu
 kubernetes.filesystem.usage,gauge,,byte,,The amount of disk used,-1,kubernetes,k8s.disk.usage
 kubernetes.filesystem.usage_pct,gauge,,fraction,,The percentage of disk used,-1,kubernetes,k8s.disk.used_pct
 kubernetes.memory.capacity,gauge,,byte,,The amount of memory (in bytes) in this machine,0,kubernetes,k8s.mem.capacity
@@ -12,3 +11,5 @@ kubernetes.memory.usage,gauge,,byte,,The amount of memory used,-1,kubernetes,k8s
 kubernetes.network.rx_bytes,gauge,,byte,second,The amount of bytes per second received,0,kubernetes,k8s.net.rx
 kubernetes.network.tx_bytes,gauge,,byte,second,The amount of bytes per second transmitted,0,kubernetes,k8s.net.tx
 kubernetes.network_errors,gauge,,error,second,The amount of network errors per second,-1,kubernetes,k8s.net.errors
+kubernetes.pods.running,gauge,,,,The number of pods running on this host per creator,0,kubernetes,k8s.cpu.capacity
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name

--- a/kubernetes/test_kubernetes.py
+++ b/kubernetes/test_kubernetes.py
@@ -181,20 +181,22 @@ class TestKubernetes(AgentCheckTest):
             ]
         }
         # Can't use run_check_twice due to specific metrics
-        self.run_check_twice(config, mocks=mocks, force_reload=True)
+        self.run_check_twice(config, mocks=mocks, force_reload=True,
+                             agent_config={'docker_histo_striptags': 'container_name,pod_name,kube_replica_set'})
+
 
         metric_suffix = ["count", "avg", "median", "max", "95percentile"]
 
         expected_tags = [
-            (['pod_name:no_pod'], [MEM, CPU, NET, DISK, DISK_USAGE, NET_ERRORS]),
-            (['kube_replication_controller:propjoe', 'kube_namespace:default', 'pod_name:default/propjoe-dhdzk'], [MEM, CPU, FS, NET, NET_ERRORS]),
-            (['kube_replication_controller:kube-dns-v8', 'kube_namespace:kube-system', 'pod_name:kube-system/kube-dns-v8-smhcb'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
-            (['kube_replication_controller:fluentd-cloud-logging-kubernetes-minion', 'kube_namespace:kube-system', 'pod_name:kube-system/fluentd-cloud-logging-kubernetes-minion-mu4w'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
-            (['kube_replication_controller:kube-dns-v8', 'kube_namespace:kube-system', 'pod_name:kube-system/kube-dns-v8-smhcb'], [MEM, CPU, FS, NET, NET_ERRORS]),
-            (['kube_replication_controller:propjoe', 'kube_namespace:default', 'pod_name:default/propjoe-dhdzk'], [MEM, CPU, FS, NET, NET_ERRORS]),
-            (['kube_replication_controller:kube-ui-v1','kube_namespace:kube-system', 'pod_name:kube-system/kube-ui-v1-sv2sq'], [MEM, CPU, FS, NET, NET_ERRORS]),
-            (['kube_replication_controller:propjoe', 'kube_namespace:default', 'pod_name:default/propjoe-lkc3l'], [MEM, CPU, FS, NET, NET_ERRORS]),
-            (['kube_replication_controller:haproxy-6db79c7bbcac01601ac35bcdb18868b3', 'kube_namespace:default', 'pod_name:default/haproxy-6db79c7bbcac01601ac35bcdb18868b3-rr7la'], [MEM, CPU, FS, NET, NET_ERRORS]),
+            ([], [MEM, CPU, NET, DISK, DISK_USAGE, NET_ERRORS]),
+            (['kube_replication_controller:propjoe', 'kube_namespace:default'], [MEM, CPU, FS, NET, NET_ERRORS]),
+            (['kube_replication_controller:kube-dns-v8', 'kube_namespace:kube-system'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
+            (['kube_replication_controller:fluentd-cloud-logging-kubernetes-minion', 'kube_namespace:kube-system'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
+            (['kube_replication_controller:kube-dns-v8', 'kube_namespace:kube-system'], [MEM, CPU, FS, NET, NET_ERRORS]),
+            (['kube_replication_controller:propjoe', 'kube_namespace:default'], [MEM, CPU, FS, NET, NET_ERRORS]),
+            (['kube_replication_controller:kube-ui-v1','kube_namespace:kube-system'], [MEM, CPU, FS, NET, NET_ERRORS]),
+            (['kube_replication_controller:propjoe', 'kube_namespace:default'], [MEM, CPU, FS, NET, NET_ERRORS]),
+            (['kube_replication_controller:haproxy-6db79c7bbcac01601ac35bcdb18868b3', 'kube_namespace:default'], [MEM, CPU, FS, NET, NET_ERRORS]),
             (['kube_replication_controller:l7-lb-controller', 'kube_namespace:kube-system'], [PODS]),
             (['kube_replication_controller:redis-slave', 'kube_namespace:default'], [PODS]),
             (['kube_replication_controller:frontend', 'kube_namespace:default'], [PODS]),
@@ -302,20 +304,21 @@ class TestKubernetes(AgentCheckTest):
         }
 
         # Can't use run_check_twice due to specific metrics
-        self.run_check_twice(config, mocks=mocks, force_reload=True)
+        self.run_check_twice(config, mocks=mocks, force_reload=True,
+                             agent_config={'docker_histo_striptags': 'container_name,pod_name,kube_replica_set,kube_replication_controller'})
 
         metric_suffix = ["count", "avg", "median", "max", "95percentile"]
 
         expected_tags = [
             (['container_image:datadog/docker-dd-agent:massi_ingest_k8s_events', 'image_name:datadog/docker-dd-agent',
-              'image_tag:massi_ingest_k8s_events', 'pod_name:dd-agent-1rxlh',
+              'image_tag:massi_ingest_k8s_events',
               'kube_namespace:default', 'kube_app:dd-agent', 'kube_foo:bar','kube_bar:baz',
-              'kube_replication_controller:dd-agent', 'kube_daemon_set:dd-agent', 'kube_container_name:dd-agent'], [MEM, CPU, NET, DISK, DISK_USAGE, LIM, REQ]),
+              'kube_daemon_set:dd-agent', 'kube_container_name:dd-agent'], [MEM, CPU, NET, DISK, DISK_USAGE, LIM, REQ]),
             (['container_image:gcr.io/google_containers/pause:2.0', 'image_name:gcr.io/google_containers/pause',
-              'image_tag:2.0', 'pod_name:dd-agent-1rxlh',
-              'kube_namespace:default', 'kube_app:dd-agent', 'kube_foo:bar','kube_bar:baz',
-              'kube_replication_controller:dd-agent', 'kube_daemon_set:dd-agent', 'kube_container_name:POD'], [MEM, CPU, NET, NET_ERRORS, DISK_USAGE]),
-            (['kube_replication_controller:dd-agent', 'kube_namespace:default', 'kube_daemon_set:dd-agent'], [PODS]),
+              'image_tag:2.0', 'kube_namespace:default', 'kube_app:dd-agent', 'kube_foo:bar','kube_bar:baz',
+              'kube_daemon_set:dd-agent', 'kube_container_name:POD'], [MEM, CPU, NET, NET_ERRORS, DISK_USAGE]),
+            ([], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
+            (['kube_namespace:default', 'kube_daemon_set:dd-agent'], [PODS]),
             ([], [LIM, REQ, CAP])  # container from kubernetes api doesn't have a corresponding entry in Cadvisor
         ]
 


### PR DESCRIPTION
### What does this PR do?

Allows to configure the high cardinality tags to be stripped when using `use_histogram` in the docker & kubernetes checks. Use common logic in the `config` module for consistency. Some node-wide metrics have been moved to explicit gauges, no need to histogram them.

Superseedes https://github.com/DataDog/integrations-core/pull/711

Sister PR: https://github.com/DataDog/dd-agent/pull/3503

### Testing Guidelines

The kube integration tests `test_historate_1_1` and `test_historate_1_2` use different `docker_histo_striptags` settings and should cover this feature for regressions.

Testing fails because master out of sync, passes locally

Docker image: `datadog/dev-dd-agent:xvello_histogram`

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`
- [ ] Update metadata with the relevant series
- [x] Change node-card metrics to directly submit gauge instead of histogram
