### PR TITLE
Cassandra dashboards fixes and improvements

### DIFF
--- a/cassandra/conf.yaml.example
+++ b/cassandra/conf.yaml.example
@@ -2,9 +2,17 @@ instances:
   - host: localhost
     port: 7199
     cassandra_aliasing: true
+    # Tags are used to be able to filter and aggregate metrics properly, in all the charts.
+    #
+    # The 'environment' tag depends on the <cluster_name> in Cassandra configuration:
+    #   - if the environment information (eg 'prod' or 'test') is included in the <cluster_name>, just use <cluster_name>.
+    #   - otherwise it's good to add the information to the 'environment' tag (eg 'prod-<cluster_name>').
+    # This will prevent aggregating metrics matchingly named clusters in distinct environments.
+    #
+    # The 'datacenter' tag should be the name of the Cassandra data center the node belongs to.
     tags:
-      environment: default_environment
-      datacenter: default_datacenter
+        environment: default_environment
+        datacenter: default_datacenter
   #   user: username
   #   password: password
   #   process_name_regex: .*process_name.* # Instead of specifying a host, and port. The agent can connect using the attach api.
@@ -125,13 +133,13 @@ init_config:
         attribute:
           - 75thPercentile
           - 95thPercentile
-      exclude:
-        keyspace:
-          - system
-          - system_auth
-          - system_distributed
-          - system_schema
-          - system_traces
+        exclude:
+          keyspace:
+            - system
+            - system_auth
+            - system_distributed
+            - system_schema
+            - system_traces
     - include:
         domain: org.apache.cassandra.metrics
         type: Table
@@ -227,44 +235,44 @@ init_config:
         name: Copy
         attribute:
           CollectionCount:
-              metric_type: counter
-              alias: jmx.gc.minor_collection_count
+            metric_type: counter
+            alias: jmx.gc.minor_collection_count
           CollectionTime:
-              metric_type: counter
-              alias: jmx.gc.minor_collection_time
+            metric_type: counter
+            alias: jmx.gc.minor_collection_time
     - include:
         domain: java.lang
         type: GarbageCollector
         name: PS Scavenge
         attribute:
           CollectionCount:
-              metric_type: counter
-              alias: jmx.gc.minor_collection_count
+            metric_type: counter
+            alias: jmx.gc.minor_collection_count
           CollectionTime:
-              metric_type: counter
-              alias: jmx.gc.minor_collection_time
+            metric_type: counter
+            alias: jmx.gc.minor_collection_time
     - include:
         domain: java.lang
         type: GarbageCollector
         name: ParNew
         attribute:
           CollectionCount:
-              metric_type: counter
-              alias: jmx.gc.minor_collection_count
+            metric_type: counter
+            alias: jmx.gc.minor_collection_count
           CollectionTime:
-              metric_type: counter
-              alias: jmx.gc.minor_collection_time
+            metric_type: counter
+            alias: jmx.gc.minor_collection_time
     - include:
         domain: java.lang
         type: GarbageCollector
         name: G1 Young Generation
         attribute:
           CollectionCount:
-              metric_type: counter
-              alias: jmx.gc.minor_collection_count
+            metric_type: counter
+            alias: jmx.gc.minor_collection_count
           CollectionTime:
-              metric_type: counter
-              alias: jmx.gc.minor_collection_time
+            metric_type: counter
+            alias: jmx.gc.minor_collection_time
     # Old Gen Collectors (Major collections)
     - include:
        domain: java.lang
@@ -272,44 +280,44 @@ init_config:
        name: MarkSweepCompact
        attribute:
           CollectionCount:
-              metric_type: counter
-              alias: jmx.gc.major_collection_count
+            metric_type: counter
+            alias: jmx.gc.major_collection_count
           CollectionTime:
-              metric_type: counter
-              alias: jmx.gc.major_collection_time
+            metric_type: counter
+            alias: jmx.gc.major_collection_time
     - include:
         domain: java.lang
         type: GarbageCollector
         name: PS MarkSweep
         attribute:
           CollectionCount:
-              metric_type: counter
-              alias: jmx.gc.major_collection_count
+            metric_type: counter
+            alias: jmx.gc.major_collection_count
           CollectionTime:
-              metric_type: counter
-              alias: jmx.gc.major_collection_time
+            metric_type: counter
+            alias: jmx.gc.major_collection_time
     - include:
         domain: java.lang
         type: GarbageCollector
         name: ConcurrentMarkSweep
         attribute:
           CollectionCount:
-              metric_type: counter
-              alias: jmx.gc.major_collection_count
+            metric_type: counter
+            alias: jmx.gc.major_collection_count
           CollectionTime:
-              metric_type: counter
-              alias: jmx.gc.major_collection_time
+            metric_type: counter
+            alias: jmx.gc.major_collection_time
     - include:
         domain: java.lang
         type: GarbageCollector
         name: G1 Mixed Generation
         attribute:
           CollectionCount:
-              metric_type: counter
-              alias: jmx.gc.major_collection_count
+            metric_type: counter
+            alias: jmx.gc.major_collection_count
           CollectionTime:
-              metric_type: counter
-              alias: jmx.gc.major_collection_time
+            metric_type: counter
+            alias: jmx.gc.major_collection_time
      # Deprecated metrics for pre Cassandra 3.0 versions compatibility.
      # If you are using cassandra 2, the metrics below will be used,
      # otherwise they will be ignored.
@@ -365,16 +373,16 @@ init_config:
           - SSTablesPerReadHistogram
           - TombstoneScannedHistogram
           - WaitingOnFreeMemtableSpace
-      attribute:
+        attribute:
           - 75thPercentile
           - 95thPercentile
-      exclude:
-        keyspace:
-          - system
-          - system_auth
-          - system_distributed
-          - system_schema
-          - system_traces
+        exclude:
+          keyspace:
+            - system
+            - system_auth
+            - system_distributed
+            - system_schema
+            - system_traces
     - include:
         domain: org.apache.cassandra.metrics
         type: ColumnFamily

--- a/cassandra/conf.yaml.example
+++ b/cassandra/conf.yaml.example
@@ -11,8 +11,8 @@ instances:
     #
     # The 'datacenter' tag should be the name of the Cassandra data center the node belongs to.
     tags:
-        environment: default_environment
-        datacenter: default_datacenter
+      environment: default_environment
+      datacenter: default_datacenter
   #   user: username
   #   password: password
   #   process_name_regex: .*process_name.* # Instead of specifying a host, and port. The agent can connect using the attach api.
@@ -133,13 +133,13 @@ init_config:
         attribute:
           - 75thPercentile
           - 95thPercentile
-        exclude:
-          keyspace:
-            - system
-            - system_auth
-            - system_distributed
-            - system_schema
-            - system_traces
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
     - include:
         domain: org.apache.cassandra.metrics
         type: Table
@@ -275,10 +275,10 @@ init_config:
             alias: jmx.gc.minor_collection_time
     # Old Gen Collectors (Major collections)
     - include:
-       domain: java.lang
-       type: GarbageCollector
-       name: MarkSweepCompact
-       attribute:
+        domain: java.lang
+        type: GarbageCollector
+        name: MarkSweepCompact
+        attribute:
           CollectionCount:
             metric_type: counter
             alias: jmx.gc.major_collection_count
@@ -376,13 +376,13 @@ init_config:
         attribute:
           - 75thPercentile
           - 95thPercentile
-        exclude:
-          keyspace:
-            - system
-            - system_auth
-            - system_distributed
-            - system_schema
-            - system_traces
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
     - include:
         domain: org.apache.cassandra.metrics
         type: ColumnFamily

--- a/cassandra/conf.yaml.example
+++ b/cassandra/conf.yaml.example
@@ -2,6 +2,9 @@ instances:
   - host: localhost
     port: 7199
     cassandra_aliasing: true
+    tags:
+      environment: default_environment
+      datacenter: default_datacenter
   #   user: username
   #   password: password
   #   process_name_regex: .*process_name.* # Instead of specifying a host, and port. The agent can connect using the attach api.
@@ -12,9 +15,6 @@ instances:
   #   # java_options: "-Xmx200m -Xms50m" # Optional, Java JVM options
   #   # trust_store_path: /path/to/trustStore.jks # Optional, should be set if ssl is enabled
   #   # trust_store_password: password
-  #   tags:
-  #     env: stage
-  #     newTag: test
 
 init_config:
   # List of metrics to be collected by the integration
@@ -22,104 +22,16 @@ init_config:
   conf:
     - include:
         domain: org.apache.cassandra.metrics
-        # If you are using cassandra 2, you should replace 'type: Table' by 'type: ColumnFamily'
-        # type: ColumnFamily
-        type: Table 
-        bean_regex:
-          - .*keyspace=.*
-        name:
-            - KeyCacheHitRate
-            - RowCacheHitOutOfRange
-            - RowCacheHit
-            - RowCacheMiss
-            - MaxPartitionSize
-            - MeanPartitionSize
-            - MemtableOnHeapSize
-            - MemtableOffHeapSize
-            - PendingCompactions
-            - PendingFlushes
-            - SpeculativeRetries
-            - TotalDiskSpaceUsed
-            - BloomFilterDiskSpaceUsed
-            - BloomFilterFalsePositives
-            - BloomFilterFalseRatio
-            - CompressionRatio
-            - LiveDiskSpaceUsed
-            - LiveSSTableCount
-            - MemtableColumnsCount
-            - MemtableLiveDataSize
-            - MemtableSwitchCount
-            - ReadLatency
-            - WriteLatency
-            - SSTablesPerReadHistogram
-            - TombstoneScannedHistogram
-            - EstimatedPartitionSizeHistogram
-        attribute:
-          - Value
-          - Count
-          - Mean
-          - 50thPercentile
-          - 75thPercentile
-          - 95thPercentile
-          - 99thPercentile
-          - OneMinuteRate
-          - Max
-      exclude:
-        keyspace:
-          - OpsCenter
-          - system
-          - system_auth
-          - system_distributed
-          - system_schema
-          - system_traces
-    - include:
-        domain: org.apache.cassandra.metrics
         type: ClientRequest
-        scope:
-          - Read
-          - Write
-        name:
-          - Latency
-          - Timeouts
-          - Unavailables
-        attribute:
-          - Count
-          - OneMinuteRate
-    - include:
-        domain: org.apache.cassandra.metrics
-        type: ClientRequest
-        scope:
-          - Read
-          - Write
-        name:
-          - TotalLatency
-    - include:
-        domain: org.apache.cassandra.metrics
-        type: ClientRequest
-        scope:
-          - Read
-          - Write
         name:
           - Latency
         attribute:
-          - 50thPercentile
           - 75thPercentile
           - 95thPercentile
-          - 99thPercentile
           - OneMinuteRate
-    - include:
-        domain: org.apache.cassandra.metrics
-        type: Client
-        name:
-          - connectedNativeClients
     - include:
         domain: org.apache.cassandra.metrics
         type: DroppedMessage
-        scope:
-          - READ
-          - MUTATION
-          - BINARY
-          - REQUEST_RESPONSE
         name:
           - Dropped
         attribute:
@@ -129,12 +41,10 @@ init_config:
         type: ThreadPools
         scope:
           - MutationStage
+          - CounterMutationStage
           - ReadStage
-          - RequestResponseStage
-          - ReadRepairStage
+          - ViewMutationStage
         name:
-          - ActiveTasks
-          - TotalBlockedTasks
           - PendingTasks
           - CurrentlyBlockedTasks
         path:
@@ -144,9 +54,12 @@ init_config:
         type: ThreadPools
         scope:
           - MemtableFlushWriter
+          - HintsDispatcher
+          - MemtablePostFlush
+          - MigrationStage
+          - MiscStage
+          - SecondaryIndexManagement
         name:
-          - ActiveTasks
-          - TotalBlockedTasks
           - PendingTasks
           - CurrentlyBlockedTasks
         path:
@@ -157,26 +70,129 @@ init_config:
         name:
           - Load
           - Exceptions
-          - TotalHints
     - include:
         domain: org.apache.cassandra.metrics
-        type: 
-          - ColumnFamily
+        type: Table
         bean_regex:
           - .*keyspace=.*
         name:
-          - MaxRowSize
-          - MeanRowSize
-          - MinRowSize
+          - ReadLatency
+          - WriteLatency
         attribute:
-          - Value
-          - Count
-          - Mean
+          - 75thPercentile
+          - 95thPercentile
           - 99thPercentile
-          - Max
+          - OneMinuteRate
       exclude:
         keyspace:
-          - OpsCenter
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: Table
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - RangeLatency
+          - CasPrepareLatency
+          - CasProposeLatency
+          - CasCommitLatency
+          - ViewLockAcquireTime
+          - ViewReadTime
+        attribute:
+          - 75thPercentile
+          - 95thPercentile
+          - OneMinuteRate
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: Table
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - SSTablesPerReadHistogram
+          - TombstoneScannedHistogram
+          - WaitingOnFreeMemtableSpace
+        attribute:
+          - 75thPercentile
+          - 95thPercentile
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: Table
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - ColUpdateTimeDeltaHistogram
+        attribute:
+          - Min
+          - 75thPercentile
+          - 95thPercentile
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: Table
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - BloomFilterFalseRatio
+          - CompressionRatio
+          - KeyCacheHitRate
+          - LiveSSTableCount
+          - MaxPartitionSize
+          - MeanPartitionSize
+          - MeanRowSize
+          - MaxRowSize
+          - PendingCompactions
+          - SnapshotsSize
+        attribute:
+          - Value
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: Table
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - CompactionBytesWritten
+          - BytesFlushed
+          - PendingFlushes
+          - LiveDiskSpaceUsed
+          - TotalDiskSpaceUsed
+          - RowCacheHitOutOfRange
+          - RowCacheHit
+          - RowCacheMiss
+        attribute:
+          - Count
+      exclude:
+        keyspace:
           - system
           - system_auth
           - system_distributed
@@ -185,18 +201,8 @@ init_config:
     - include:
         domain: org.apache.cassandra.metrics
         type: Cache
-        name:
-          - Capacity
-          - Size
-        attribute:
-          - Value
-    - include:
-        domain: org.apache.cassandra.metrics
-        type: Cache
         scope: KeyCache
         name:
-          - Hits
-          - Requests
           - HitRate
         attribute:
           - Count
@@ -209,31 +215,11 @@ init_config:
         attribute:
           - Value
     - include:
-        domain: org.apache.cassandra.metrics
-        type: ThreadPools
-        path: request
-        name:
-          - ActiveTasks
-          - CompletedTasks
-          - PendingTasks
-          - CurrentlyBlockedTasks
-    - include:
         domain: org.apache.cassandra.db
+        type: Tables
         attribute:
-          - UpdateInterval
-    - include:
-        domain: org.apache.cassandra.metrics
-        type: Compaction
-        name:
-          - PendingTasks
-        attribute:
-          - Value
-    - include:
-        domain: org.apache.cassandra.net
-        type: FailureDetector
-        attribute:
-          DownEndpointCount:
-            alias: cassandra.db.downendpoints
+          DroppableTombstoneRatio:
+            alias: cassandra.db.droppable_tombstone_ratio
     # Young Gen Collectors (Minor Collections)
     - include:
         domain: java.lang
@@ -241,44 +227,44 @@ init_config:
         name: Copy
         attribute:
           CollectionCount:
-            metric_type: counter
-            alias: jmx.gc.minor_collection_count
+              metric_type: counter
+              alias: jmx.gc.minor_collection_count
           CollectionTime:
-            metric_type: counter
-            alias: jmx.gc.minor_collection_time
+              metric_type: counter
+              alias: jmx.gc.minor_collection_time
     - include:
         domain: java.lang
         type: GarbageCollector
         name: PS Scavenge
         attribute:
           CollectionCount:
-            metric_type: counter
-            alias: jmx.gc.minor_collection_count
+              metric_type: counter
+              alias: jmx.gc.minor_collection_count
           CollectionTime:
-            metric_type: counter
-            alias: jmx.gc.minor_collection_time
+              metric_type: counter
+              alias: jmx.gc.minor_collection_time
     - include:
         domain: java.lang
         type: GarbageCollector
         name: ParNew
         attribute:
           CollectionCount:
-            metric_type: counter
-            alias: jmx.gc.minor_collection_count
+              metric_type: counter
+              alias: jmx.gc.minor_collection_count
           CollectionTime:
-            metric_type: counter
-            alias: jmx.gc.minor_collection_time
+              metric_type: counter
+              alias: jmx.gc.minor_collection_time
     - include:
         domain: java.lang
         type: GarbageCollector
         name: G1 Young Generation
         attribute:
           CollectionCount:
-            metric_type: counter
-            alias: jmx.gc.minor_collection_count
+              metric_type: counter
+              alias: jmx.gc.minor_collection_count
           CollectionTime:
-            metric_type: counter
-            alias: jmx.gc.minor_collection_time
+              metric_type: counter
+              alias: jmx.gc.minor_collection_time
     # Old Gen Collectors (Major collections)
     - include:
        domain: java.lang
@@ -286,41 +272,175 @@ init_config:
        name: MarkSweepCompact
        attribute:
           CollectionCount:
-            metric_type: counter
-            alias: jmx.gc.major_collection_count
+              metric_type: counter
+              alias: jmx.gc.major_collection_count
           CollectionTime:
-            metric_type: counter
-            alias: jmx.gc.major_collection_time
+              metric_type: counter
+              alias: jmx.gc.major_collection_time
     - include:
         domain: java.lang
         type: GarbageCollector
         name: PS MarkSweep
         attribute:
           CollectionCount:
-            metric_type: counter
-            alias: jmx.gc.major_collection_count
+              metric_type: counter
+              alias: jmx.gc.major_collection_count
           CollectionTime:
-            metric_type: counter
-            alias: jmx.gc.major_collection_time
+              metric_type: counter
+              alias: jmx.gc.major_collection_time
     - include:
         domain: java.lang
         type: GarbageCollector
         name: ConcurrentMarkSweep
         attribute:
           CollectionCount:
-            metric_type: counter
-            alias: jmx.gc.major_collection_count
+              metric_type: counter
+              alias: jmx.gc.major_collection_count
           CollectionTime:
-            metric_type: counter
-            alias: jmx.gc.major_collection_time
+              metric_type: counter
+              alias: jmx.gc.major_collection_time
     - include:
         domain: java.lang
         type: GarbageCollector
         name: G1 Mixed Generation
         attribute:
           CollectionCount:
-            metric_type: counter
-            alias: jmx.gc.major_collection_count
+              metric_type: counter
+              alias: jmx.gc.major_collection_count
           CollectionTime:
-            metric_type: counter
-            alias: jmx.gc.major_collection_time
+              metric_type: counter
+              alias: jmx.gc.major_collection_time
+     # Deprecated metrics for pre Cassandra 3.0 versions compatibility.
+     # If you are using cassandra 2, the metrics below will be user, otherwise ignored.
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ColumnFamily
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - ReadLatency
+          - WriteLatency
+        attribute:
+          - 75thPercentile
+          - 95thPercentile
+          - 99thPercentile
+          - OneMinuteRate
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ColumnFamily
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - RangeLatency
+          - CasPrepareLatency
+          - CasProposeLatency
+          - CasCommitLatency
+          - ViewLockAcquireTime
+          - ViewReadTime
+        attribute:
+          - 75thPercentile
+          - 95thPercentile
+          - OneMinuteRate
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ColumnFamily
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - SSTablesPerReadHistogram
+          - TombstoneScannedHistogram
+          - WaitingOnFreeMemtableSpace
+      attribute:
+          - 75thPercentile
+          - 95thPercentile
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ColumnFamily
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - ColUpdateTimeDeltaHistogram
+        attribute:
+          - Min
+          - 75thPercentile
+          - 95thPercentile
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ColumnFamily
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - BloomFilterFalseRatio
+          - CompressionRatio
+          - KeyCacheHitRate
+          - LiveSSTableCount
+          - MaxPartitionSize
+          - MeanPartitionSize
+          - MeanRowSize
+          - MaxRowSize
+          - PendingCompactions
+          - SnapshotsSize
+        attribute:
+          - Value
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ColumnFamily
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - PendingFlushes
+          - LiveDiskSpaceUsed
+          - TotalDiskSpaceUsed
+          - RowCacheHitOutOfRange
+          - RowCacheHit
+          - RowCacheMiss
+        attribute:
+          - Count
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.db
+        type: ColumnFamilies
+        attribute:
+          DroppableTombstoneRatio:
+            alias: cassandra.db.droppable_tombstone_ratio

--- a/cassandra/conf.yaml.example
+++ b/cassandra/conf.yaml.example
@@ -311,7 +311,8 @@ init_config:
               metric_type: counter
               alias: jmx.gc.major_collection_time
      # Deprecated metrics for pre Cassandra 3.0 versions compatibility.
-     # If you are using cassandra 2, the metrics below will be user, otherwise ignored.
+     # If you are using cassandra 2, the metrics below will be used,
+     # otherwise they will be ignored.
     - include:
         domain: org.apache.cassandra.metrics
         type: ColumnFamily

--- a/cassandra/metadata.csv
+++ b/cassandra/metadata.csv
@@ -1,66 +1,65 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-cassandra.active_tasks,gauge,10,task,,The number of tasks that the thread pool is actively executing.,0,cassandra,actv tsks
-cassandra.bloom_filter_disk_space_used,gauge,10,byte,,Disk space used by the Bloom filters.,0,cassandra,blm fltr disk
-cassandra.bloom_filter_false_positives,gauge,10,event,,The number of Bloom filter false positives.,-1,cassandra,bloom false pos
 cassandra.bloom_filter_false_ratio,gauge,10,fraction,,The ratio of Bloom filter false positives to total checks.,-1,cassandra,bloom false ratio
-cassandra.capacity,gauge,10,byte,,"The capacity of the caches, such as the key cache and row cache.",0,cassandra,cache cap
-cassandra.completed_tasks,gauge,10,task,,The number of tasks that the thread pool has completed.,0,cassandra,compl tsks
-cassandra.compression_ratio,gauge,10,fraction,,The compression ratio for all SSTables in a column family.,0,cassandra,compress ratio
-cassandra.currently_blocked_tasks.count,gauge,10,task,,The number of currently blocked tasks for the thread pool.,-1,cassandra,blkd tsks
-cassandra.exceptions.count,gauge,10,error,,The number of exceptions thrown.,-1,cassandra,excptns
-cassandra.hits.count,gauge,10,hit,,The number of hits to a cache.,1,cassandra,hits
-cassandra.latency.count,gauge,10,request,,The number of client requests.,0,cassandra,req
-cassandra.latency.one_minute_rate,gauge,10,request,second,"Recent rate of client requests, as an exponentially weighted moving average over a one-minute interval.",0,cassandra,req/s
-cassandra.live_disk_space_used.count,gauge,10,byte,,"Disk space used by ""live"" SSTables (only counts non-obsolete files).",0,cassandra,live disk used
-cassandra.live_ss_table_count,gauge,10,file,,"Number of ""live"" (non-obsolete) SSTables.",0,cassandra,live sstables
-cassandra.load.count,gauge,10,byte,,Disk space used on a node.,0,cassandra,load
-cassandra.max_row_size,gauge,10,byte,,Size of the largest compacted row.,0,cassandra,max row
-cassandra.mean_row_size,gauge,10,byte,,Average size of compacted rows.,0,cassandra,mean row
-cassandra.memtable_columns_count,gauge,10,column,,Number of columns in memtable.,0,cassandra,memtable col
-cassandra.memtable_live_data_size,gauge,10,byte,,Size of data stored in memtable.,0,cassandra,memtable size
-cassandra.memtable_switch_count.count,gauge,10,event,,Number of times a full memtable has been switched out for an empty one due to flushing.,0,cassandra,memtable switch
-cassandra.min_row_size,gauge,10,byte,,Size of the smallest compacted row.,0,cassandra,min row
-cassandra.pending_tasks,gauge,10,task,,The number of pending tasks for the thread pool.,-1,cassandra,pend tsks
-cassandra.requests.count,gauge,10,request,,The number of requests to a cache.,0,cassandra,cache req
-cassandra.size,gauge,10,byte,,Size of cache.,0,cassandra,cache size
-cassandra.timeouts.count,gauge,10,timeout,,Count of requests not acknowledged within configurable timeout window.,-1,cassandra,timeout
-cassandra.timeouts.one_minute_rate,gauge,10,timeout,second,"Recent timeout rate, as an exponentially weighted moving average over a one-minute interval.",-1,cassandra,timeout/s
-cassandra.total_disk_space_used.count,gauge,10,byte,,Disk space used by a column family.,0,cassandra,cf disk space
-cassandra.total_latency.count,gauge,10,microsecond,,Total latency for all client requests.,-1,cassandra,tot latency
-cassandra.unavailables.count,gauge,10,error,,Count of requests for which the required number of nodes was unavailable.,-1,cassandra,unavail
-cassandra.unavailables.one_minute_rate,gauge,10,error,second,"Recent rate of unavailable exceptions, as an exponentially weighted moving average over a one-minute interval. ",-1,cassandra,unavail/s
-cassandra.db.update_interval,gauge,10,millisecond,,"The configurable update interval for the dynamic snitch, which monitors read latency to route requests away from slow nodes. ",0,cassandra,dyn sntch intvl
-cassandra.db.write_count,gauge,10,write,,The number of local write requests for a column family. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.latency.count instead),0,cassandra,writes
-cassandra.db.read_count,gauge,10,read,,The number of local read requests for a column family. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.latency.count instead),0,cassandra,reads
-cassandra.db.live_ss_table_count,gauge,10,file,,"Number of ""live"" (non-obsolete) SSTables. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.live_ss_table_count instead)",0,cassandra,live sstables
-cassandra.db.total_disk_space_used,gauge,10,byte,,Disk space used by a column family. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.total_disk_space_used.count instead),0,cassandra,cf disk space
-cassandra.db.memtable_data_size,gauge,10,byte,,Size of data stored in memtable. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.memtable_live_data_size instead),0,cassandra,memtable size
-cassandra.internal.currently_blocked_tasks,gauge,10,task,,The number of currently blocked tasks for the thread pool. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.currently_blocked_tasks.count instead),-1,cassandra,blkd tsks
-cassandra.db.max_row_size,gauge,10,byte,,Size of the largest compacted row. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.max_row_size instead),0,cassandra,max row
-cassandra.db.live_disk_space_used,gauge,10,byte,,"Disk space used by ""live"" SSTables (only counts non-obsolete files). (Metric may not be available for Cassandra versions > 2.2. Use cassandra.live_disk_space_used.count instead)",0,cassandra,live disk used
-cassandra.internal.active_count,gauge,10,task,,The number of tasks that the thread pool is actively executing. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.active_tasks instead),0,cassandra,actv tsks
-cassandra.internal.completed_tasks,gauge,10,task,,The number of tasks that the thread pool has completed. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.completed_tasks instead),0,cassandra,compl tsks
-cassandra.db.total_write_latency_micros,gauge,10,microsecond,,Total latency for all write requests. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.total_latency.count instead),-1,cassandra,tot write lat
-cassandra.db.total_read_latency_micros,gauge,10,microsecond,,Total latency for all read requests. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.total_latency.count instead),-1,cassandra,tot read lat
-cassandra.internal.total_blocked_tasks,gauge,10,task,,The cumulative total of currently blocked tasks for the thread pool. (Metric may not be available for Cassandra versions > 2.2.),-1,cassandra,blkd tsks
-cassandra.db.mean_row_size,gauge,10,byte,,Average size of compacted rows. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.mean_row_size instead),0,cassandra,mean row
-cassandra.db.compression_ratio,gauge,10,fraction,,The compression ratio for all SSTables in a column family. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.compression_ratio instead),0,cassandra,compress ratio
-cassandra.db.memtable_switch_count,gauge,10,event,,Number of times a full memtable has been switched out for an empty one due to flushing. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.memtable_switch_count.count instead),0,cassandra,memtable switch
-cassandra.db.memtable_columns_count,gauge,10,column,,Number of columns in memtable. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.memtable_columns_count instead),0,cassandra,memtable col
-cassandra.db.min_row_size,gauge,10,byte,,Size of the smallest compacted row. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.min_row_size instead),0,cassandra,min row
-cassandra.db.bloom_filter_false_positives,gauge,10,event,,The number of Bloom filter false positives. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.bloom_filter_false_positives instead),-1,cassandra,bloom false pos
-cassandra.db.bloom_filter_disk_space_used,gauge,10,byte,,Disk space used by the Bloom filters. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.bloom_filter_disk_space_used instead),0,cassandra,blm fltr disk
-cassandra.db.bloom_filter_false_ratio,gauge,10,fraction,,The ratio of Bloom filter false positives to total checks. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.bloom_filter_false_ratio instead),-1,cassandra,bloom false ratio
-cassandra.net.total_timeouts,gauge,10,timeout,,Count of requests not acknowledged within configurable timeout window. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.timeouts.count instead),-1,cassandra,timeout
-cassandra.db.completed_tasks,gauge,10,task,,Completed compaction or commitlog tasks. (Metric may not be available for Cassandra versions > 2.2.),0,cassandra,compl db tasks
-cassandra.db.pending_tasks,gauge,10,task,,"Pending compaction, commitlog, or column family tasks. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.pending_tasks instead)",-1,cassandra,pend tsks
-cassandra.db.load,gauge,10,byte,,Disk space used on a node. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.load.count instead),0,cassandra,load
-cassandra.db.exception_count,gauge,10,error,,The number of exceptions thrown. (Metric may not be available for Cassandra versions > 2.2. Use cassandra.exceptions.count instead),-1,cassandra,excptns
-cassandra.db.recent_read_latency_micros,gauge,10,microsecond,,The latency of reads since the last time this attribute was read. (Metric may not be available for Cassandra versions > 2.2.),-1,cassandra,recent read lat
-cassandra.db.recent_write_latency_micros,gauge,10,microsecond,,The latency of writes since the last time this attribute was read. (Metric may not be available for Cassandra versions > 2.2.),-1,cassandra,recent wrt lat
-cassandra.db.key_cache_recent_hit_rate,gauge,10,fraction,,Ratio of key cache hits to key cache requests since the last time this attribute was read. (Metric may not be available for Cassandra versions > 2.2.),1,cassandra,key cache hit
-cassandra.db.recent_range_latency_micros,gauge,10,microsecond,,The latency of range scans since the last time this attribute was read. (Metric may not be available for Cassandra versions > 2.2.),-1,cassandra,recent range lat
-cassandra.db.total_range_latency_micros,gauge,10,microsecond,,Total latency for all range scans. (Metric may not be available for Cassandra versions > 2.2.),-1,cassandra,tot range lat
-cassandra.db.write_operations,gauge,10,operation,,Count of write operations. (Metric may not be available for Cassandra versions > 2.2.),0,cassandra,write ops
-cassandra.db.read_operations,gauge,10,operation,,Count of read operations. (Metric may not be available for Cassandra versions > 2.2.),0,cassandra,read ops
-cassandra.db.range_operations,gauge,10,operation,,Count of range scan operations. (Metric may not be available for Cassandra versions > 2.2.),0,cassandra,range ops
+cassandra.bytes_flushed.count,gauge,10,byte,,The amount of data that was flushed since (re)start.,,cassandra,bytes flushed
+cassandra.cas_commit_latency.75th_percentile,gauge,10,microsecond,,The latency of paxos commit round - p75.,,cassandra,cas commit latency p75
+cassandra.cas_commit_latency.95th_percentile,gauge,10,microsecond,,The latency of paxos commit round - p95.,,cassandra,cas commit latency p95
+cassandra.cas_commit_latency.one_minute_rate,gauge,10,operation,second,The number of paxos commit round per second.,,cassandra,cas commit commit count
+cassandra.cas_prepare_latency.75th_percentile,gauge,10,microsecond,,The latency of paxos prepare round - p75.,,cassandra,cas prepare latency p75
+cassandra.cas_prepare_latency.95th_percentile,gauge,10,microsecond,,The latency of paxos prepare round - p95.,,cassandra,cas prepare latency p95
+cassandra.cas_prepare_latency.one_minute_rate,gauge,10,operation,second,The number of paxos prepare round per second.,,cassandra,cas prepare commit count
+cassandra.cas_propose_latency.75th_percentile,gauge,10,microsecond,,The latency of paxos propose round - p75.,,cassandra,cas propose latency p75
+cassandra.cas_propose_latency.95th_percentile,gauge,10,microsecond,,The latency of paxos propose round - p95.,,cassandra,cas propose latency p95
+cassandra.cas_propose_latency.one_minute_rate,gauge,10,operation,second,The number of paxos propose round per second.,,cassandra,cas propose commit count
+cassandra.col_update_time_delta_histogram.75th_percentile,gauge,10,microsecond,,The column update time delta - p75.,,cassandra,update time delta p75
+cassandra.col_update_time_delta_histogram.95th_percentile,gauge,10,microsecond,,The column update time delta - p95.,,cassandra,update time delta p95
+cassandra.col_update_time_delta_histogram.min,gauge,10,microsecond,,The column update time delta - min.,,cassandra,update time delta Min
+cassandra.compaction_bytes_written.count,gauge,10,byte,,The amount of data that was compacted since (re)start.,,cassandra,bytes compacted
+cassandra.compression_ratio,gauge,10,fraction,,"The compression ratio for all SSTables. /!\ A low value means a high compression contrary to what the name suggests. Formula used is: 'size of the compressed SSTable / size of original'",0,cassandra,compress ratio
+cassandra.currently_blocked_tasks,gauge,10,task,,The number of currently blocked tasks for the thread pool.,-1,cassandra,blocked tasks
+cassandra.currently_blocked_tasks.count,gauge,10,task,,The number of currently blocked tasks for the thread pool.,-1,cassandra,blocked tasks
+cassandra.db.droppable_tombstone_ratio,gauge,10,fraction,,The estimate of the droppable tombstone ratio.,,cassandra,droppable data
+cassandra.dropped.one_minute_rate,gauge,10,thread,,The tasks dropped during execution for the thread pool.,,cassandra,dropped
+cassandra.exceptions.count,gauge,10,error,,The number of exceptions thrown from ‘Storage’ metrics.,-1,cassandra,exceptions
+cassandra.key_cache_hit_rate,gauge,10,fraction,,The key cache hit rate.,,cassandra,hit
+cassandra.latency.75th_percentile,gauge,10,microsecond,,The client request latency - p75.,,cassandra,request latency p75
+cassandra.latency.95th_percentile,gauge,10,microsecond,,The client request latency - p95.,,cassandra,request latency p95
+cassandra.latency.one_minute_rate,gauge,10,request,second,The number of client requests.,,cassandra,request cout
+cassandra.live_disk_space_used.count,gauge,10,byte,,"The disk space used by ""live"" SSTables (only counts in use files).",0,cassandra,live disk used
+cassandra.live_ss_table_count,gauge,10,file,,"Number of ""live"" (in use) SSTables.",0,cassandra,live sstables
+cassandra.load.count,gauge,10,byte,,The disk space used by live data on a node.,0,cassandra,load
+cassandra.max_partition_size,gauge,10,byte,,The size of the largest compacted partition.,0,cassandra,max partition
+cassandra.max_row_size,gauge,10,byte,,The size of the largest compacted row.,0,cassandra,max row
+cassandra.mean_partition_size,gauge,10,byte,,The average size of compacted partition.,0,cassandra,mean partition
+cassandra.mean_row_size,gauge,10,byte,,The average size of compacted rows.,0,cassandra,mean row
+cassandra.pending_compactions,gauge,10,task,,The number of pending compactions.,,cassandra,pending compactions
+cassandra.pending_flushes.count,gauge,10,flush,,The number of pending flushes.,,cassandra,pending flushes
+cassandra.pending_tasks,gauge,10,task,,The number of pending tasks for the thread pool.,-1,cassandra,pending tasks
+cassandra.range_latency.75th_percentile,gauge,10,microsecond,,The local range request latency - p75.,,cassandra,local range req latency p75
+cassandra.range_latency.95th_percentile,gauge,10,microsecond,,The local range request latency - p95.,,cassandra,local range req latency p95
+cassandra.range_latency.one_minute_rate,gauge,10,request,second,The number of local range requests.,,cassandra,local range req count
+cassandra.read_latency.75th_percentile,gauge,10,microsecond,,The local read latency - p75.,,cassandra,local read latency p75
+cassandra.read_latency.95th_percentile,gauge,10,microsecond,,The local read latency - p95.,,cassandra,local read latency p95
+cassandra.read_latency.99th_percentile,gauge,10,microsecond,,The local read latency - p99.,,cassandra,local read latency p99
+cassandra.read_latency.one_minute_rate,gauge,10,read,second,The number of local read requests.,,cassandra,local read count
+cassandra.row_cache_hit_out_of_range.count,gauge,10,hit,,The number of row cache hits that do not satisfy the query filter and went to disk.,0,cassandra,out of row cache hits
+cassandra.row_cache_hit.count,gauge,10,hit,,The number of row cache hits.,,cassandra,row cache hits
+cassandra.row_cache_miss.count,gauge,10,miss,,The number of table row cache misses.,,cassandra,row cache misses
+cassandra.snapshots_size,gauge,10,byte,,The disk space truly used by snapshots.,,cassandra,snapshot size
+cassandra.ss_tables_per_read_histogram.75th_percentile,gauge,10,file,read,The number of SSTable data files accessed per read - p75.,,cassandra,sstables per read p75
+cassandra.ss_tables_per_read_histogram.95th_percentile,gauge,10,file,read,The number of SSTable data files accessed per read - p95.,,cassandra,sstables per read p95
+cassandra.tombstone_scanned_histogram.75th_percentile,gauge,10,record,read,Number of tombstones scanned per read - p75.,,cassandra,tombstones per read
+cassandra.tombstone_scanned_histogram.95th_percentile,gauge,10,record,read,Number of tombstones scanned per read - p95.,,cassandra,tombstones per read
+cassandra.total_commit_log_size,gauge,10,byte,,The size used on disk by commit logs.,,cassandra,commit logs size
+cassandra.total_disk_space_used.count,gauge,10,byte,,Total disk space used by SSTables including obsolete ones waiting to be GC’d.,,cassandra,total sstable
+cassandra.view_lock_acquire_time.75th_percentile,gauge,10,microsecond,,The time taken acquiring a partition lock for materialized view updates - p75.,,cassandra,MV lock acquire time p75
+cassandra.view_lock_acquire_time.95th_percentile,gauge,10,microsecond,,The time taken acquiring a partition lock for materialized view updates - p95.,,cassandra,MV lock acquire time p95
+cassandra.view_lock_acquire_time.one_minute_rate,gauge,10,request,second,The number of requests to acquire a partition lock for materialized view updates.,,cassandra,MV lock acquire count
+cassandra.view_read_time.75th_percentile,gauge,10,microsecond,,The time taken during the local read of a materialized view update - p75.,,cassandra,MV update read time p75
+cassandra.view_read_time.95th_percentile,gauge,10,microsecond,,The time taken during the local read of a materialized view update - p95.,,cassandra,MV update read time p95
+cassandra.view_read_time.one_minute_rate,gauge,10,request,second,The number of local reads for materialized view updates.,,cassandra,MV update read count
+cassandra.waiting_on_free_memtable_space.75th_percentile,gauge,10,microsecond,,The time spent waiting for free memtable space either on- or off-heap - p75.,,cassandra,waiting memtable p75
+cassandra.waiting_on_free_memtable_space.95th_percentile,gauge,10,microsecond,,The time spent waiting for free memtable space either on- or off-heap - p95.,,cassandra,waiting memtable p95
+cassandra.write_latency.75th_percentile,gauge,10,microsecond,,The local read latency - p75.,,cassandra,local write latency p75
+cassandra.write_latency.95th_percentile,gauge,10,microsecond,,The local read latency - p95.,,cassandra,local write latency p95
+cassandra.write_latency.99th_percentile,gauge,10,microsecond,,The local read latency - p99.,,cassandra,local write latency p99
+cassandra.write_latency.one_minute_rate,gauge,10,write,second,The number of local write requets.,,cassandra,local write count

--- a/cassandra/metadata.csv
+++ b/cassandra/metadata.csv
@@ -1,29 +1,29 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 cassandra.bloom_filter_false_ratio,gauge,10,fraction,,The ratio of Bloom filter false positives to total checks.,-1,cassandra,bloom false ratio
-cassandra.bytes_flushed.count,gauge,10,byte,,The amount of data that was flushed since (re)start.,,cassandra,bytes flushed
-cassandra.cas_commit_latency.75th_percentile,gauge,10,microsecond,,The latency of paxos commit round - p75.,,cassandra,cas commit latency p75
-cassandra.cas_commit_latency.95th_percentile,gauge,10,microsecond,,The latency of paxos commit round - p95.,,cassandra,cas commit latency p95
-cassandra.cas_commit_latency.one_minute_rate,gauge,10,operation,second,The number of paxos commit round per second.,,cassandra,cas commit commit count
-cassandra.cas_prepare_latency.75th_percentile,gauge,10,microsecond,,The latency of paxos prepare round - p75.,,cassandra,cas prepare latency p75
-cassandra.cas_prepare_latency.95th_percentile,gauge,10,microsecond,,The latency of paxos prepare round - p95.,,cassandra,cas prepare latency p95
-cassandra.cas_prepare_latency.one_minute_rate,gauge,10,operation,second,The number of paxos prepare round per second.,,cassandra,cas prepare commit count
-cassandra.cas_propose_latency.75th_percentile,gauge,10,microsecond,,The latency of paxos propose round - p75.,,cassandra,cas propose latency p75
-cassandra.cas_propose_latency.95th_percentile,gauge,10,microsecond,,The latency of paxos propose round - p95.,,cassandra,cas propose latency p95
-cassandra.cas_propose_latency.one_minute_rate,gauge,10,operation,second,The number of paxos propose round per second.,,cassandra,cas propose commit count
-cassandra.col_update_time_delta_histogram.75th_percentile,gauge,10,microsecond,,The column update time delta - p75.,,cassandra,update time delta p75
-cassandra.col_update_time_delta_histogram.95th_percentile,gauge,10,microsecond,,The column update time delta - p95.,,cassandra,update time delta p95
-cassandra.col_update_time_delta_histogram.min,gauge,10,microsecond,,The column update time delta - min.,,cassandra,update time delta Min
-cassandra.compaction_bytes_written.count,gauge,10,byte,,The amount of data that was compacted since (re)start.,,cassandra,bytes compacted
-cassandra.compression_ratio,gauge,10,fraction,,"The compression ratio for all SSTables. /!\ A low value means a high compression contrary to what the name suggests. Formula used is: 'size of the compressed SSTable / size of original'",0,cassandra,compress ratio
+cassandra.bytes_flushed.count,gauge,10,byte,,The amount of data that was flushed since (re)start.,0,cassandra,bytes flushed
+cassandra.cas_commit_latency.75th_percentile,gauge,10,microsecond,,The latency of paxos commit round - p75.,-1,cassandra,cas commit latency p75
+cassandra.cas_commit_latency.95th_percentile,gauge,10,microsecond,,The latency of paxos commit round - p95.,-1,cassandra,cas commit latency p95
+cassandra.cas_commit_latency.one_minute_rate,gauge,10,operation,second,The number of paxos commit round per second.,0,cassandra,cas commit commit count
+cassandra.cas_prepare_latency.75th_percentile,gauge,10,microsecond,,The latency of paxos prepare round - p75.,-1,cassandra,cas prepare latency p75
+cassandra.cas_prepare_latency.95th_percentile,gauge,10,microsecond,,The latency of paxos prepare round - p95.,-1,cassandra,cas prepare latency p95
+cassandra.cas_prepare_latency.one_minute_rate,gauge,10,operation,second,The number of paxos prepare round per second.,0,cassandra,cas prepare commit count
+cassandra.cas_propose_latency.75th_percentile,gauge,10,microsecond,,The latency of paxos propose round - p75.,-1,cassandra,cas propose latency p75
+cassandra.cas_propose_latency.95th_percentile,gauge,10,microsecond,,The latency of paxos propose round - p95.,-1,cassandra,cas propose latency p95
+cassandra.cas_propose_latency.one_minute_rate,gauge,10,operation,second,The number of paxos propose round per second.,0,cassandra,cas propose commit count
+cassandra.col_update_time_delta_histogram.75th_percentile,gauge,10,microsecond,,The column update time delta - p75.,0,cassandra,update time delta p75
+cassandra.col_update_time_delta_histogram.95th_percentile,gauge,10,microsecond,,The column update time delta - p95.,0,cassandra,update time delta p95
+cassandra.col_update_time_delta_histogram.min,gauge,10,microsecond,,The column update time delta - min.,0,cassandra,update time delta Min
+cassandra.compaction_bytes_written.count,gauge,10,byte,,The amount of data that was compacted since (re)start.,0,cassandra,bytes compacted
+cassandra.compression_ratio,gauge,10,fraction,,The compression ratio for all SSTables. /!\ A low value means a high compression contrary to what the name suggests. Formula used is: 'size of the compressed SSTable / size of original',-1,cassandra,compress ratio
 cassandra.currently_blocked_tasks,gauge,10,task,,The number of currently blocked tasks for the thread pool.,-1,cassandra,blocked tasks
 cassandra.currently_blocked_tasks.count,gauge,10,task,,The number of currently blocked tasks for the thread pool.,-1,cassandra,blocked tasks
-cassandra.db.droppable_tombstone_ratio,gauge,10,fraction,,The estimate of the droppable tombstone ratio.,,cassandra,droppable data
-cassandra.dropped.one_minute_rate,gauge,10,thread,,The tasks dropped during execution for the thread pool.,,cassandra,dropped
+cassandra.db.droppable_tombstone_ratio,gauge,10,fraction,,The estimate of the droppable tombstone ratio.,-1,cassandra,droppable data
+cassandra.dropped.one_minute_rate,gauge,10,thread,,The tasks dropped during execution for the thread pool.,-1,cassandra,dropped
 cassandra.exceptions.count,gauge,10,error,,The number of exceptions thrown from ‘Storage’ metrics.,-1,cassandra,exceptions
-cassandra.key_cache_hit_rate,gauge,10,fraction,,The key cache hit rate.,,cassandra,hit
-cassandra.latency.75th_percentile,gauge,10,microsecond,,The client request latency - p75.,,cassandra,request latency p75
-cassandra.latency.95th_percentile,gauge,10,microsecond,,The client request latency - p95.,,cassandra,request latency p95
-cassandra.latency.one_minute_rate,gauge,10,request,second,The number of client requests.,,cassandra,request cout
+cassandra.key_cache_hit_rate,gauge,10,fraction,,The key cache hit rate.,1,cassandra,hit
+cassandra.latency.75th_percentile,gauge,10,microsecond,,The client request latency - p75.,-1,cassandra,request latency p75
+cassandra.latency.95th_percentile,gauge,10,microsecond,,The client request latency - p95.,-1,cassandra,request latency p95
+cassandra.latency.one_minute_rate,gauge,10,request,second,The number of client requests.,0,cassandra,request cout
 cassandra.live_disk_space_used.count,gauge,10,byte,,"The disk space used by ""live"" SSTables (only counts in use files).",0,cassandra,live disk used
 cassandra.live_ss_table_count,gauge,10,file,,"Number of ""live"" (in use) SSTables.",0,cassandra,live sstables
 cassandra.load.count,gauge,10,byte,,The disk space used by live data on a node.,0,cassandra,load
@@ -31,35 +31,35 @@ cassandra.max_partition_size,gauge,10,byte,,The size of the largest compacted pa
 cassandra.max_row_size,gauge,10,byte,,The size of the largest compacted row.,0,cassandra,max row
 cassandra.mean_partition_size,gauge,10,byte,,The average size of compacted partition.,0,cassandra,mean partition
 cassandra.mean_row_size,gauge,10,byte,,The average size of compacted rows.,0,cassandra,mean row
-cassandra.pending_compactions,gauge,10,task,,The number of pending compactions.,,cassandra,pending compactions
-cassandra.pending_flushes.count,gauge,10,flush,,The number of pending flushes.,,cassandra,pending flushes
+cassandra.pending_compactions,gauge,10,task,,The number of pending compactions.,-1,cassandra,pending compactions
+cassandra.pending_flushes.count,gauge,10,flush,,The number of pending flushes.,-1,cassandra,pending flushes
 cassandra.pending_tasks,gauge,10,task,,The number of pending tasks for the thread pool.,-1,cassandra,pending tasks
-cassandra.range_latency.75th_percentile,gauge,10,microsecond,,The local range request latency - p75.,,cassandra,local range req latency p75
-cassandra.range_latency.95th_percentile,gauge,10,microsecond,,The local range request latency - p95.,,cassandra,local range req latency p95
-cassandra.range_latency.one_minute_rate,gauge,10,request,second,The number of local range requests.,,cassandra,local range req count
-cassandra.read_latency.75th_percentile,gauge,10,microsecond,,The local read latency - p75.,,cassandra,local read latency p75
-cassandra.read_latency.95th_percentile,gauge,10,microsecond,,The local read latency - p95.,,cassandra,local read latency p95
-cassandra.read_latency.99th_percentile,gauge,10,microsecond,,The local read latency - p99.,,cassandra,local read latency p99
-cassandra.read_latency.one_minute_rate,gauge,10,read,second,The number of local read requests.,,cassandra,local read count
-cassandra.row_cache_hit_out_of_range.count,gauge,10,hit,,The number of row cache hits that do not satisfy the query filter and went to disk.,0,cassandra,out of row cache hits
-cassandra.row_cache_hit.count,gauge,10,hit,,The number of row cache hits.,,cassandra,row cache hits
-cassandra.row_cache_miss.count,gauge,10,miss,,The number of table row cache misses.,,cassandra,row cache misses
-cassandra.snapshots_size,gauge,10,byte,,The disk space truly used by snapshots.,,cassandra,snapshot size
-cassandra.ss_tables_per_read_histogram.75th_percentile,gauge,10,file,read,The number of SSTable data files accessed per read - p75.,,cassandra,sstables per read p75
-cassandra.ss_tables_per_read_histogram.95th_percentile,gauge,10,file,read,The number of SSTable data files accessed per read - p95.,,cassandra,sstables per read p95
-cassandra.tombstone_scanned_histogram.75th_percentile,gauge,10,record,read,Number of tombstones scanned per read - p75.,,cassandra,tombstones per read
-cassandra.tombstone_scanned_histogram.95th_percentile,gauge,10,record,read,Number of tombstones scanned per read - p95.,,cassandra,tombstones per read
-cassandra.total_commit_log_size,gauge,10,byte,,The size used on disk by commit logs.,,cassandra,commit logs size
-cassandra.total_disk_space_used.count,gauge,10,byte,,Total disk space used by SSTables including obsolete ones waiting to be GC’d.,,cassandra,total sstable
-cassandra.view_lock_acquire_time.75th_percentile,gauge,10,microsecond,,The time taken acquiring a partition lock for materialized view updates - p75.,,cassandra,MV lock acquire time p75
-cassandra.view_lock_acquire_time.95th_percentile,gauge,10,microsecond,,The time taken acquiring a partition lock for materialized view updates - p95.,,cassandra,MV lock acquire time p95
-cassandra.view_lock_acquire_time.one_minute_rate,gauge,10,request,second,The number of requests to acquire a partition lock for materialized view updates.,,cassandra,MV lock acquire count
-cassandra.view_read_time.75th_percentile,gauge,10,microsecond,,The time taken during the local read of a materialized view update - p75.,,cassandra,MV update read time p75
-cassandra.view_read_time.95th_percentile,gauge,10,microsecond,,The time taken during the local read of a materialized view update - p95.,,cassandra,MV update read time p95
-cassandra.view_read_time.one_minute_rate,gauge,10,request,second,The number of local reads for materialized view updates.,,cassandra,MV update read count
-cassandra.waiting_on_free_memtable_space.75th_percentile,gauge,10,microsecond,,The time spent waiting for free memtable space either on- or off-heap - p75.,,cassandra,waiting memtable p75
-cassandra.waiting_on_free_memtable_space.95th_percentile,gauge,10,microsecond,,The time spent waiting for free memtable space either on- or off-heap - p95.,,cassandra,waiting memtable p95
-cassandra.write_latency.75th_percentile,gauge,10,microsecond,,The local read latency - p75.,,cassandra,local write latency p75
-cassandra.write_latency.95th_percentile,gauge,10,microsecond,,The local read latency - p95.,,cassandra,local write latency p95
-cassandra.write_latency.99th_percentile,gauge,10,microsecond,,The local read latency - p99.,,cassandra,local write latency p99
-cassandra.write_latency.one_minute_rate,gauge,10,write,second,The number of local write requets.,,cassandra,local write count
+cassandra.range_latency.75th_percentile,gauge,10,microsecond,,The local range request latency - p75.,-1,cassandra,local range req latency p75
+cassandra.range_latency.95th_percentile,gauge,10,microsecond,,The local range request latency - p95.,-1,cassandra,local range req latency p95
+cassandra.range_latency.one_minute_rate,gauge,10,request,second,The number of local range requests.,0,cassandra,local range req count
+cassandra.read_latency.75th_percentile,gauge,10,microsecond,,The local read latency - p75.,-1,cassandra,local read latency p75
+cassandra.read_latency.95th_percentile,gauge,10,microsecond,,The local read latency - p95.,-1,cassandra,local read latency p95
+cassandra.read_latency.99th_percentile,gauge,10,microsecond,,The local read latency - p99.,-1,cassandra,local read latency p99
+cassandra.read_latency.one_minute_rate,gauge,10,read,second,The number of local read requests.,0,cassandra,local read count
+cassandra.row_cache_hit_out_of_range.count,gauge,10,hit,,The number of row cache hits that do not satisfy the query filter and went to disk.,-1,cassandra,out of row cache hits
+cassandra.row_cache_hit.count,gauge,10,hit,,The number of row cache hits.,1,cassandra,row cache hits
+cassandra.row_cache_miss.count,gauge,10,miss,,The number of table row cache misses.,-1,cassandra,row cache misses
+cassandra.snapshots_size,gauge,10,byte,,The disk space truly used by snapshots.,0,cassandra,snapshot size
+cassandra.ss_tables_per_read_histogram.75th_percentile,gauge,10,file,read,The number of SSTable data files accessed per read - p75.,-1,cassandra,sstables per read p75
+cassandra.ss_tables_per_read_histogram.95th_percentile,gauge,10,file,read,The number of SSTable data files accessed per read - p95.,-1,cassandra,sstables per read p95
+cassandra.tombstone_scanned_histogram.75th_percentile,gauge,10,record,read,Number of tombstones scanned per read - p75.,-1,cassandra,tombstones per read p75
+cassandra.tombstone_scanned_histogram.95th_percentile,gauge,10,record,read,Number of tombstones scanned per read - p95.,-1,cassandra,tombstones per read p95
+cassandra.total_commit_log_size,gauge,10,byte,,The size used on disk by commit logs.,0,cassandra,commit logs size
+cassandra.total_disk_space_used.count,gauge,10,byte,,Total disk space used by SSTables including obsolete ones waiting to be GC’d.,0,cassandra,total sstable
+cassandra.view_lock_acquire_time.75th_percentile,gauge,10,microsecond,,The time taken acquiring a partition lock for materialized view updates - p75.,-1,cassandra,MV lock acquire time p75
+cassandra.view_lock_acquire_time.95th_percentile,gauge,10,microsecond,,The time taken acquiring a partition lock for materialized view updates - p95.,-1,cassandra,MV lock acquire time p95
+cassandra.view_lock_acquire_time.one_minute_rate,gauge,10,request,second,The number of requests to acquire a partition lock for materialized view updates.,0,cassandra,MV lock acquire count
+cassandra.view_read_time.75th_percentile,gauge,10,microsecond,,The time taken during the local read of a materialized view update - p75.,-1,cassandra,MV update read time p75
+cassandra.view_read_time.95th_percentile,gauge,10,microsecond,,The time taken during the local read of a materialized view update - p95.,-1,cassandra,MV update read time p95
+cassandra.view_read_time.one_minute_rate,gauge,10,request,second,The number of local reads for materialized view updates.,0,cassandra,MV update read count
+cassandra.waiting_on_free_memtable_space.75th_percentile,gauge,10,microsecond,,The time spent waiting for free memtable space either on- or off-heap - p75.,-1,cassandra,waiting memtable p75
+cassandra.waiting_on_free_memtable_space.95th_percentile,gauge,10,microsecond,,The time spent waiting for free memtable space either on- or off-heap - p95.,-1,cassandra,waiting memtable p95
+cassandra.write_latency.75th_percentile,gauge,10,microsecond,,The local write latency - p75.,-1,cassandra,local write latency p75
+cassandra.write_latency.95th_percentile,gauge,10,microsecond,,The local write latency - p95.,-1,cassandra,local write latency p95
+cassandra.write_latency.99th_percentile,gauge,10,microsecond,,The local write latency - p99.,-1,cassandra,local write latency p99
+cassandra.write_latency.one_minute_rate,gauge,10,write,second,The number of local write requests.,0,cassandra,local write count


### PR DESCRIPTION
### What does this PR do?

- Update the filtering of metrics in cassandra integration to fit with latest version of dashboards we are proposing in from the dev environments, @irabinovitch is the person we are in contact with and he knows were to take the dashboards from so it can go through datadog QA.
- Add by default tags we need to use as template variables in distinct dashboards.
- Makes the default configuration compatible with C*2.0
- Makes the default configuration compatible with C*2.1
- Makes the default configuration compatible with C*2.2
- Still compatible with C*3+
- Made filtering more exhaustive to use exactly the metrics we display
- Update the corresponding metadata CSV so we have units everywhere and a small description.

### Motivation

This request is part of the work TLP is doing to have a nice set of dashboards out of the box for Cassandra / Datadog users.

### Testing 

This code needs to be tested with Cassandra (2+) and TLP - * Dashboards from TLP datadog account. On our end, filtering was working, we found no way to test metadata.csv file though.

### Additional Notes

**conf.yaml.example**

For some reason, this filtering is not working correctly and we are accepting more measurement (histogram parts) than we actually need for these 3 attributes. I am not sure why. It also happen with "column family" in older versions of Cassandra.

```
- include:
        domain: org.apache.cassandra.metrics
        type: Table
        bean_regex:
          - .*keyspace=.*
        name:
          - SSTablesPerReadHistogram
          - TombstoneScannedHistogram
          - WaitingOnFreeMemtableSpace
        attribute:
          - 75thPercentile
          - 95thPercentile
      exclude:
        keyspace:
          - system
          - system_auth
          - system_distributed
          - system_schema
          - system_traces
```

**metadata.csv**: I am not sure about the column "orientation" and I let it empty for all the metrics that were added. Also could you make sure the format / syntax is valid there. I am not sure if percentiles need to be detailed etc. 

#### About dashboards

The changes mentioned above are made to support a specific version of the Cassandra dashboards, for completeness' sake, please find dashboards "change log" below.

@irabinovitch here are all the comments of most what was done lately, it's been hard for me to keep tracks of everything, but I was willing to at least explain why I changed some stuff added by Datadog teams. happy to discuss the design and adjust files in this PR accordingly. I recommend QA teams to take as it is now (I merged their past work in there) and see if that suits the needs.

**Important / Design:**

- Could we force displaying those dashboards with 3 charts per rows (at least by default?). I was designed to be displayed that way and we believe it makes things way more clear for the user. If not it might be worth it to mention that somewhere alongside with the tag configuration.
- Also, all the charts where built with filters using template variables (that you can see in TLP datadog account).

**Possible improvements**:

- Top list: It would be nice to make top list that can be broken down by multiple variables, not just one. JSON allows it, a save from the UI breaks it as the UI only accepts one variable there (for example Top list of disk space used broken down by host AND device would be awesome).
	
**Hand over**:
	
- A lot of charts changed (using better metric, specified when available on C*3+ only, added metrics and charts for C*2.1 and C*2.2 compatibility 
- Added marker as guidelines to new Cassandra operators.
- Some charts were added to improve existing chart tracking new informations
- Changes listed below were also made when merging your (datadog teams) work with what we did in the meantime. We tried to detail them so you can have the big picture of the design we used to create dashboards. We hope you will like the changes but we are happy to discuss anything.
- For all those reason it might be easier to take dashboards as they are now in our development environment and check if that version would work for you or make the changes as you see fit from there
 - We provide this pull request for metrics in use for those dashboards, compatible with C*2.1+ (maybe C*2.0, not tested) and the corresponding metadata so it should be easy to plug this new version hopefully on your side

**List of dashboard changes**:

**Overview Dashboard**: 

- **We need to use the information about the node being up or down itself, disregarding other nodes status. As of now a down node will not be shown**. I recommend you to simulate a node down and see this chart in a 3+ node cluster if I am unclear.
- We removed Live space growth: This information is important we agree. Yet the overview dashboard is made to exclusively. The on disk data growth is not likely to be helpful to detect or prevent an anomaly from happening, but it’s a good information to have indeed and we placed it in the new “SSTable Management” dashboard that gather information about SSTable, flushes, compactions, and disk.
- We split Read / write counts and added “other operation” counts and latencies. We believe that when the workload between reads and writes is unbalanced, the smallest one would look “flat” in the chart even though it would drop 50 % of the load. So it is good to split them as we want to detect anomaly and ratio between reads and write would still be trivial for the operator as both charts seat next to each other.
- We put  ‘dropped messages’ to the top as it is a key factor in anomaly detection. Also a database is suppose to store and deliver messages successfully, if it doesn’t we want to know about it. We also removed the filtering here so ANY dropped messages, so no kind of issue slips through the cracks.
- Memtable count, Memtable data size: We believe the same way this is too “low level” to be in this dashboard that has to remain simple and just monitor minimal things to never miss that “something happened” or to say the cluster is healthy. Those charts would fit in a dashboard “Hardware and JVM usage” that is not yet designed but that we aim to build for a V2 of those dashboards. For now we dropped these 2 charts from overview.
- Max partition size became a top list, to change and because it fits. We do not mind much the evolution of the biggest partition at this point but see clearly how big are the partitions.
- System memory: we missed that one, thanks for adding it. Now using avg instead of sum though, to be more consistent with CPU and for readability.
- I/O wait (%): this is definitely a good fit as many of the Cassandra issues are related to disk one way or another. We broke it per host / device though, so we know what disk precisely is having troubles.
- We also removed non-working charts called ‘Read and write rate’, ‘Write latency (ms)’ and ‘Key/Row cache hit rate’. They are trying to use metrics that are currently not available here https://github.com/DataDog/integrations-core/blob/master/cassandra/conf.yaml.example. Mostly these charts exist in “TLP - Read path” and use metrics from org.apache.cassandra.metrics and not org.apache.cassandra.db).

**Read Path / Write Path Dashboards**

We reworked the 2 dashboards to add a few charts and improving some exiting charts and the layout as well.

We saw no changes from what we offered in the first version of the dashboards so no merge from Datadog default chart is needed there. Taking the new dashboard from our TLP account is probably the easiest way to go. Then check it to see if it still suits you :-).

**SSTable management dashboard**

This dashboard being new, we should have no merge issues there.