### PR TITLE
[network] capture TCPRetransFail, fix #697

### DIFF
--- a/network/CHANGELOG.md
+++ b/network/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - network
 
+1.3.0 / 2017-09-01
+==================
+
+### Changes
+
+* [FEATURE] Collects TCPRetransFail metric from /proc/net/netstat, See [#697][]
+
 1.2.2 / 2017-08-28
 ==================
 

--- a/network/check.py
+++ b/network/check.py
@@ -363,6 +363,7 @@ class Network(AgentCheck):
                 'ListenOverflows': 'system.net.tcp.listen_overflows',
                 'ListenDrops': 'system.net.tcp.listen_drops',
                 'TCPBacklogDrop': 'system.net.tcp.backlog_drops',
+                'TCPRetransFail': 'system.net.tcp.failed_retransmits',
             },
             'Udp': {
                 'InDatagrams': 'system.net.udp.in_datagrams',

--- a/network/manifest.json
+++ b/network/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.2.2",
+  "version": "1.3.0",
   "guid": "43631795-8a1f-404d-83ae-397639a84050",
   "public_title": "Datadog-Network Integration",
   "categories":["web", "network"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Collects `TCPRetransFail` metric from `/proc/net/netstat`. 

### Motivation

Addresses #697, which describes a useful additional metric to gather regarding network health: 

> We had a host that was hitting a high number of these that was causing some network instability. The closest metric we had was system.net.tcp.retrans_segs but this just indicates that a segment was retransmitted, which is normal TCP behaviors. The problem is when they fail to retransmit, but this metric isn't tracked by dd-agent today.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`

### Additional Notes

Anything else we should know when reviewing?
