### PR TITLE
[k8] resolve image sha for cadvisor metrics

### DIFF
--- a/kubernetes/CHANGELOG.md
+++ b/kubernetes/CHANGELOG.md
@@ -1,11 +1,11 @@
 # CHANGELOG - kubernetes
 
-
 1.4.0 / UNRELEASED
 ==================
 ### Changes
 
 * [FEATURE] Add an option to retry kubelet connection if it's not up at start time. See [#722][]
+* [BUGFIX] fix container_image names reported as sha checksums [#731][]
 
 1.3.0 / 2017-08-28
 ==================

--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -324,7 +324,7 @@ class Kubernetes(AgentCheck):
 
         tags.append('container_name:%s' % container_name)
 
-        container_image = subcontainer['spec'].get('image')
+        container_image = self.kubeutil.image_name_resolver(subcontainer['spec'].get('image'))
         if container_image:
             tags.append('container_image:%s' % container_image)
 

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -2,7 +2,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.0",
   "max_agent_version": "6.0.0",
-  "min_agent_version": "5.17.0",
+  "min_agent_version": "5.18.0",
   "name": "kubernetes",
   "short_description": "Capture Pod scheduling events, track the status of your Kubelets, and much more.",
   "guid": "eb31452b-d681-4823-87cc-2ef114559edf",


### PR DESCRIPTION
### What does this PR do?

Use new method from https://github.com/DataDog/dd-agent/pull/3505 to resove image sha to image name for cadvisor `container_image` tag

### Motivation

Consistency with docker check