### PR TITLE
[kafka_consumer] Remove usage of `AgentCheck.read_config`

### DIFF
--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Changes
 
 * [FEATURE] discovery of groups, topics and partitions. See [#633][] (Thanks [@jeffwidman][])
-
+* [SANITY] Remove usage of `AgentCheck.read_config` (deprecated method). See [#733][]
 
 1.0.2 / 2017-08-28
 ==================
@@ -38,4 +38,5 @@
 [#624]: https://github.com/DataDog/integrations-core/issues/624
 [#633]: https://github.com/DataDog/integrations-core/issues/633
 [#684]: https://github.com/DataDog/integrations-core/issues/684
+[#733]: https://github.com/DataDog/integrations-core/issues/733
 [@jeffwidman]: https://github.com/jeffwidman


### PR DESCRIPTION
### What does this PR do?

Remove usage of `AgentCheck.read_config`. `kafka_consumer` is the only integration using it.

### Motivation

This method is deprecated and won't be provided in the next major version of the agent, stop using it.

### Testing Guidelines

The existing test should cover this change.

### Versioning

~~- [ ] Bumped the version check in `manifest.json`~~ (`1.1.0` is still unreleased)
- [x] Updated `CHANGELOG.md`.

