### PR TITLE
Properly parse backend.list -p output for new versions of varnish

### DIFF
--- a/varnish/CHANGELOG.md
+++ b/varnish/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - varnish
 
+1.0.5 Unreleased
+==================
+
+### Changes
+
+* [BUGFIX] Fix `varnishadm backend.list -p` parsing for newer versions of Varnish.
+
 1.0.4 2017-08-28
 ==================
 

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.4",
+  "version": "1.0.5",
   "guid": "d2052eae-89b8-4cb1-b631-f373010da4b8"
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

The current service check is broken in newer versions of Varnish since the output of `varnishadm backend.list -p` has changed.

### Motivation

The current `varnish.backend_healthy` service check doesn't work on newer versions of Varnish.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [X] Bumped the version check in `manifest.json`
- [X] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

Anything else we should know when reviewing?
