### PR TITLE
removes things that are deprecated in agent6

### DIFF
--- a/supervisord/test_supervisord.py
+++ b/supervisord/test_supervisord.py
@@ -346,7 +346,7 @@ instances:
         }
 
         for tc in self.TEST_CASES:
-            check = load_check('supervisord', tc['yaml'], agentConfig)
+            check = load_check('supervisord', {'init_config': {}, 'instances': tc['instances']}, agentConfig)
             self.assertTrue(check is not None, msg=check)
             for instance in tc['instances']:
                 name = instance['name']
@@ -405,7 +405,7 @@ Stop time: \nExit Status: 0"""
             'version': '0.1',
             'api_key': 'tota'
         }
-        check = load_check('supervisord', self.TEST_CASES[0]['yaml'], agentConfig)
+        check = load_check('supervisord', {'init_config': {}, 'instances': self.TEST_CASES[0]['instances']}, agentConfig)
         self.assertEquals(expected_message, check._build_message(process))
 
     # Helper Methods #######################################################

--- a/supervisord/test_supervisord.py
+++ b/supervisord/test_supervisord.py
@@ -16,7 +16,7 @@ from mock import patch
 
 # project
 from checks import AgentCheck
-from tests.checks.common import AgentCheckTest, get_check_class, load_check
+from tests.checks.common import AgentCheckTest, load_check
 
 PROCESSES = ["program_0", "program_1", "program_2"]
 STATUSES = ["down", "up", "unknown"]
@@ -298,11 +298,11 @@ instances:
       - '^mysq.$'
       - invalid_process""",
         'instances': [{
-                       'name': 'server0',
-                       'host': 'localhost',
-                       'port': 9001,
-                       'proc_regex': ['^mysq.$', 'invalid_process']
-                      }],
+            'name': 'server0',
+            'host': 'localhost',
+            'port': 9001,
+            'proc_regex': ['^mysq.$', 'invalid_process']
+        }],
         'expected_metrics': {
             'server0': [
                 ('supervisord.process.count', 1,

--- a/supervisord/test_supervisord.py
+++ b/supervisord/test_supervisord.py
@@ -16,7 +16,7 @@ from mock import patch
 
 # project
 from checks import AgentCheck
-from tests.checks.common import AgentCheckTest, get_check_class
+from tests.checks.common import AgentCheckTest, get_check_class, load_check
 
 PROCESSES = ["program_0", "program_1", "program_2"]
 STATUSES = ["down", "up", "unknown"]
@@ -119,7 +119,7 @@ instances:
     - name: server1
       host: localhost
       port: 9001""",
-        'expected_instances': [{
+        'instances': [{
             'host': 'localhost',
             'name': 'server1',
             'port': 9001
@@ -168,7 +168,7 @@ instances:
       - webapp
   - name: server1
     host: 10.60.130.82""",
-        'expected_instances': [{
+        'instances': [{
             'name': 'server0',
             'host': 'localhost',
             'port': 9001,
@@ -226,7 +226,7 @@ instances:
   - name: server0
     host: invalid_host
     port: 9009""",
-        'expected_instances': [{
+        'instances': [{
             'name': 'server0',
             'host': 'invalid_host',
             'port': 9009
@@ -242,7 +242,7 @@ instances:
     port: 9010
     user: invalid_user
     pass: invalid_pass""",
-        'expected_instances': [{
+        'instances': [{
             'name': 'server0',
             'host': 'localhost',
             'port': 9010,
@@ -261,7 +261,7 @@ instances:
     proc_names:
       - mysql
       - invalid_process""",
-        'expected_instances': [{
+        'instances': [{
             'name': 'server0',
             'host': 'localhost',
             'port': 9001,
@@ -297,7 +297,7 @@ instances:
     proc_regex:
       - '^mysq.$'
       - invalid_process""",
-        'expected_instances': [{
+        'instances': [{
                                'name': 'server0',
                                'host': 'localhost',
                                'port': 9001,
@@ -347,13 +347,9 @@ instances:
         }
 
         for tc in self.TEST_CASES:
-            check, instances = check_class.from_yaml(yaml_text=tc['yaml'],
-                                                     check_name='supervisord',
-                                                     agentConfig=agentConfig)
-
+            check = load_check('supervisord', tc['yaml'], agentConfig)
             self.assertTrue(check is not None, msg=check)
-            self.assertEquals(tc['expected_instances'], instances)
-            for instance in instances:
+            for instance in tc['instances']:
                 name = instance['name']
 
                 try:

--- a/supervisord/test_supervisord.py
+++ b/supervisord/test_supervisord.py
@@ -298,11 +298,11 @@ instances:
       - '^mysq.$'
       - invalid_process""",
         'instances': [{
-                               'name': 'server0',
-                               'host': 'localhost',
-                               'port': 9001,
-                               'proc_regex': ['^mysq.$', 'invalid_process']
-                               }],
+                       'name': 'server0',
+                       'host': 'localhost',
+                       'port': 9001,
+                       'proc_regex': ['^mysq.$', 'invalid_process']
+                      }],
         'expected_metrics': {
             'server0': [
                 ('supervisord.process.count', 1,
@@ -340,7 +340,6 @@ instances:
 
     def test_check(self):
         """Integration test for supervisord check. Using a mocked supervisord."""
-        check_class = get_check_class('supervisord')
         agentConfig = {
             'version': '0.1',
             'api_key': 'tota'
@@ -402,14 +401,11 @@ State: RUNNING
 Start time: 2014-11-01 04:16:28
 Stop time: \nExit Status: 0"""
 
-        check_class = get_check_class('supervisord')
         agentConfig = {
             'version': '0.1',
             'api_key': 'tota'
         }
-        check, _ = check_class.from_yaml(yaml_text=self.TEST_CASES[0]['yaml'],
-                                         check_name='supervisord',
-                                         agentConfig=agentConfig)
+        check = load_check('supervisord', self.TEST_CASES[0]['yaml'], agentConfig)
         self.assertEquals(expected_message, check._build_message(process))
 
     # Helper Methods #######################################################

--- a/vsphere/check.py
+++ b/vsphere/check.py
@@ -964,19 +964,3 @@ class VSphereCheck(AgentCheck):
         ### <TEST-INSTRUMENTATION>
         self.gauge('datadog.agent.vsphere.queue_size', self.pool._workq.qsize(), tags=['instant:final'])
         ### </TEST-INSTRUMENTATION>
-
-if __name__ == '__main__':
-    check, _instances = VSphereCheck.from_yaml('conf.d/vsphere.yaml')
-    try:
-        for i in xrange(200):
-            print "Loop %d" % i
-            for instance in check.instances:
-                check.check(instance)
-                if check.has_events():
-                    print 'Events: %s' % (check.get_events())
-                print 'Metrics: %d' % (len(check.get_metrics()))
-            time.sleep(10)
-    except Exception as e:
-        print "Whoops something happened {0}".format(traceback.format_exc())
-    finally:
-        check.stop()


### PR DESCRIPTION
### What does this PR do?

Agent 6 is deprecating a lot of methods. This removes most of them that were still called here (with the exception of the `get_metrics` method and it's siblings. 

They cannot be removed because they are used in every test, and there is no way to remove them without breaking every test. We will need to rewrite the test parent class to fix them. However, it's not possible to do that while the tests are still running on the Agent5 base. 