### PR TITLE
move headers to utils folder

### DIFF
--- a/apache/CHANGELOG.md
+++ b/apache/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - apache
 
+1.1.0 / Unreleased
+==================
+
+### Changes
+
+* [DEPRECATION] Removes the deprecated headers function. See [#743][]
+
 1.0.0 / 2017-03-22
 ==================
 

--- a/apache/check.py
+++ b/apache/check.py
@@ -10,7 +10,7 @@ import requests
 
 # project
 from checks import AgentCheck
-from util import headers
+from utils.headers import headers
 from config import _is_affirmative
 
 

--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1.0",
   "name": "Apache",
   "display_name": "Apache",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "support": "core",
   "supported_os": [
     "linux",

--- a/couch/CHANGELOG.md
+++ b/couch/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - couch
 
+1.1.0 / Unreleased
+==================
+
+### Changes
+
+* [DEPRECATION] Removes the deprecated headers function. See [#743][]
+
 1.0.1 / 2017-04-24
 ==================
 

--- a/couch/check.py
+++ b/couch/check.py
@@ -11,7 +11,7 @@ import requests
 
 # project
 from checks import AgentCheck
-from util import headers
+from utils.headers import headers
 
 
 class CouchDb(AgentCheck):

--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1.0",
   "name": "couch",
   "display_name": "couch",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "support": "core",
   "supported_os": [
     "linux",

--- a/couchbase/CHANGELOG.md
+++ b/couchbase/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - couchbase
 
-1.1.1 / Unreleased
+1.2.0 / Unreleased
 ==================
 
 ### Changes

--- a/couchbase/CHANGELOG.md
+++ b/couchbase/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changes
 
 * [BUGFIX] Fix the conversion of request_time* metrics. See [#705][]
+* [DEPRECATION] Removes the deprecated headers function. See [#743][]
 
 1.1.0 / 2017-07-18
 ==================

--- a/couchbase/check.py
+++ b/couchbase/check.py
@@ -11,7 +11,7 @@ import requests
 
 # project
 from checks import AgentCheck
-from util import headers
+from utils.headers import headers
 
 # Constants
 COUCHBASE_STATS_PATH = '/pools/default'

--- a/couchbase/manifest.json
+++ b/couchbase/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.1.1",
+  "version": "1.2.0",
   "guid": "ba7ce7de-4fcb-4418-8c90-329baa6a5d59"
 }

--- a/elastic/CHANGELOG.md
+++ b/elastic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - elastic
 
+1.1.0 / Unreleased
+==================
+
+### Changes
+
+* [DEPRECATION] Removes the deprecated headers function. See [#743][]
+
 1.0.1 / 2017-08-28
 ==================
 

--- a/elastic/check.py
+++ b/elastic/check.py
@@ -13,7 +13,7 @@ import requests
 # project
 from checks import AgentCheck
 from config import _is_affirmative
-from util import headers
+from utils.headers import headers
 
 
 class NodeNotFound(Exception):

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.1",
+  "version": "1.1.0",
   "guid": "d91d91bd-4a8e-4489-bfb1-b119d4cc388a"
 }

--- a/etcd/CHANGELOG.md
+++ b/etcd/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changes
 
 * [FEATURE] Updates the Service Check tag to only use the base URL
+* [DEPRECATION] Removes the deprecated headers function. See [#743][]
 
 1.0.0 / 2017-03-22
 ==================

--- a/etcd/check.py
+++ b/etcd/check.py
@@ -9,7 +9,7 @@ import requests
 # project
 from checks import AgentCheck
 from config import _is_affirmative
-from util import headers
+from utils.headers import headers
 
 
 class Etcd(AgentCheck):

--- a/fluentd/CHANGELOG.md
+++ b/fluentd/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - fluentd
 
+1.1.0 / Unreleased
+==================
+
+### Changes
+
+* [DEPRECATION] Removes the deprecated headers function. See [#743][]
+
 1.0.0 / 2017-03-22
 ==================
 

--- a/fluentd/check.py
+++ b/fluentd/check.py
@@ -12,7 +12,7 @@ import requests
 
 # project
 from checks import AgentCheck
-from util import headers
+from utils.headers import headers
 
 
 class Fluentd(AgentCheck):

--- a/fluentd/manifest.json
+++ b/fluentd/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "guid": "68100352-b993-43e6-9dc8-5ecd498e160b"
 }

--- a/haproxy/CHANGELOG.md
+++ b/haproxy/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - haproxy
 
+1.1.0 / Unreleased
+==================
+
+### Changes
+
+* [DEPRECATION] Removes the deprecated headers function. See [#743][]
+
 1.0.2 / 2017-05-11
 ==================
 

--- a/haproxy/check.py
+++ b/haproxy/check.py
@@ -16,7 +16,7 @@ import requests
 # project
 from checks import AgentCheck
 from config import _is_affirmative
-from util import headers
+from utils.headers import headers
 
 STATS_URL = "/;csv;norefresh"
 EVENT_TYPE = SOURCE_TYPE_NAME = 'haproxy'

--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1.0",
   "name": "haproxy",
   "display_name": "haproxy",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "support": "core",
   "maintainer": "help@datadoghq.com",
   "supported_os": [

--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changes
 
 * [FEATURE] Add support for client side certificate. See[#688][].
+* [DEPRECATION] Removes the deprecated headers function. See [#743][]
 
 1.1.2 / 2017-08-28
 ==================

--- a/http_check/check.py
+++ b/http_check/check.py
@@ -30,7 +30,7 @@ from requests.packages.urllib3.packages.ssl_match_hostname import \
 # project
 from checks.network_checks import EventType, NetworkCheck, Status
 from config import _is_affirmative
-from util import headers as agent_headers
+from utils.headers import headers as agent_headers
 
 DEFAULT_EXPECTED_CODE = "(1|2|3)\d\d"
 CONTENT_LENGTH = 200

--- a/http_check/test_http_check.py
+++ b/http_check/test_http_check.py
@@ -14,7 +14,7 @@ from nose.plugins.attrib import attr
 # project
 from config import AGENT_VERSION
 from tests.checks.common import AgentCheckTest
-from util import headers as agent_headers
+from utils.headers import headers as agent_headers
 
 RESULTS_TIMEOUT = 20
 

--- a/kong/CHANGELOG.md
+++ b/kong/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - kong
 
+1.1.0 / Unreleased
+==================
+
+### Changes
+
+* [DEPRECATION] Removes the deprecated headers function. See [#743][]
+
 1.0.0 / 2017-03-22
 ==================
 

--- a/kong/check.py
+++ b/kong/check.py
@@ -11,7 +11,7 @@ import simplejson as json
 
 # project
 from checks import AgentCheck
-from util import headers
+from utils.headers import headers
 
 
 class Kong(AgentCheck):

--- a/kong/manifest.json
+++ b/kong/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "guid": "f1098d6f-b393-4374-81c0-47c0a142aeef"
 }

--- a/kubernetes/CHANGELOG.md
+++ b/kubernetes/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - kubernetes
 
-1.4.0 / UNRELEASED
+1.4.0 / Unreleased
 ==================
 ### Changes
 

--- a/lighttpd/CHANGELOG.md
+++ b/lighttpd/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - lighttpd
 
+1.1.0 / Unreleased
+==================
+
+### Changes
+
+* [DEPRECATION] Removes the deprecated headers function. See [#743][]
+
 1.0.0 / 2017-03-22
 ==================
 

--- a/lighttpd/check.py
+++ b/lighttpd/check.py
@@ -11,7 +11,7 @@ import requests
 
 # project
 from checks import AgentCheck
-from util import headers
+from utils.headers import headers
 
 VERSION_REGEX = re.compile(r".*/(\d)")
 

--- a/lighttpd/manifest.json
+++ b/lighttpd/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "guid": "01dcfe7a-7a56-4388-a388-799ee6daaaab"
 }

--- a/nginx/CHANGELOG.md
+++ b/nginx/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - nginx
 
+1.2.0 / Unreleased
+==================
+
+### Changes
+
+* [DEPRECATION] Removes the deprecated headers function. See [#743][]
+
 1.1.0 / 2017-07-18
 ==================
 

--- a/nginx/check.py
+++ b/nginx/check.py
@@ -12,7 +12,7 @@ import simplejson as json
 
 # project
 from checks import AgentCheck
-from util import headers
+from utils.headers import headers
 
 
 UPSTREAM_RESPONSE_CODES_SEND_AS_COUNT = [

--- a/nginx/manifest.json
+++ b/nginx/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.1.0",
+  "version": "1.2.0",
   "guid": "88620208-3919-457c-ba51-d844d09ac97f"
 }

--- a/php_fpm/CHANGELOG.md
+++ b/php_fpm/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - php_fpm
 
+1.1.0 / Unreleased
+==================
+
+### Changes
+
+* [DEPRECATION] Removes the deprecated headers function. See [#743][]
+
 1.0.0 / 2017-03-22
 ==================
 

--- a/php_fpm/check.py
+++ b/php_fpm/check.py
@@ -7,7 +7,7 @@ import requests
 
 # project
 from checks import AgentCheck
-from util import headers
+from utils.headers import headers
 
 
 class PHPFPMCheck(AgentCheck):

--- a/php_fpm/manifest.json
+++ b/php_fpm/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "guid": "47f2c337-83ac-4767-b460-1927d8343764"
 }


### PR DESCRIPTION
### What does this PR do?

`util.py` is deprecated and we're removing it in Agent 6. The headers function is still there and is used by 12 checks and one test. This moves them all over to a replacement in the utils folder.

Related PRs:
https://github.com/DataDog/datadog-agent/pull/552
https://github.com/DataDog/dd-agent/pull/3514