### PR TITLE
[docker] client-side event filtering on event type

### DIFF
--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changes
 
 * [FEATURE] Add an option to wait for docker if it's not ready at start time. See [#722][]
+* [FEATURE] Add client-side event filtering by event type. See [#744][]
 
 1.3.2 / 2017-08-28
 ==================

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -139,6 +139,11 @@ EXCLUDED_ATTRIBUTES = [
     'name',
     'container',
 ]
+DEFAULT_FILTERED_EVENT_TYPES = [
+    'top',
+    'exec_create',
+    'exec_start',
+]
 
 CONTAINER = "container"
 PERFORMANCE = "performance"
@@ -240,6 +245,8 @@ class DockerDaemon(AgentCheck):
             self.collect_disk_stats = _is_affirmative(instance.get('collect_disk_stats', False))
             self.collect_exit_codes = _is_affirmative(instance.get('collect_exit_codes', False))
             self.collect_ecs_tags = _is_affirmative(instance.get('ecs_tags', True)) and Platform.is_ecs_instance()
+
+            self.filtered_event_types = tuple(instance.get("filtered_event_types", DEFAULT_FILTERED_EVENT_TYPES))
 
             self.capped_metrics = instance.get('capped_metrics')
 
@@ -788,10 +795,14 @@ class DockerDaemon(AgentCheck):
         events = []
         for image_name, event_group in aggregated_events.iteritems():
             container_tags = set()
-            low_prio_events = []
+            filtered_events_count = 0
             normal_prio_events = []
 
             for event in event_group:
+                # Only keep events that are not configured to be filtered out
+                if event['status'].startswith(self.filtered_event_types):
+                    filtered_events_count += 1
+                    continue
                 container_name = event['id'][:11]
 
                 if event['id'] in containers_by_id:
@@ -804,15 +815,9 @@ class DockerDaemon(AgentCheck):
                         if attr in event['Actor']['Attributes'] and attr not in EXCLUDED_ATTRIBUTES:
                             container_tags.add('%s:%s' % (attr, event['Actor']['Attributes'][attr]))
 
-                # health checks generate tons of these so we treat them separately and lower their priority
-                if event['status'].startswith('exec_create:') or event['status'].startswith('exec_start:'):
-                    low_prio_events.append((event, container_name))
-                else:
-                    normal_prio_events.append((event, container_name))
+                normal_prio_events.append((event, container_name))
+            self.log.debug('%d events were filtered out' % filtered_events_count)
 
-            exec_event = self._create_dd_event(low_prio_events, image_name, container_tags, priority='Low')
-            if exec_event:
-                events.append(exec_event)
 
             normal_event = self._create_dd_event(normal_prio_events, image_name, container_tags, priority='Normal')
             if normal_event:

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -816,7 +816,8 @@ class DockerDaemon(AgentCheck):
                             container_tags.add('%s:%s' % (attr, event['Actor']['Attributes'][attr]))
 
                 normal_prio_events.append((event, container_name))
-            self.log.debug('%d events were filtered out' % filtered_events_count)
+            if filtered_events_count:
+                self.log.debug('%d events were filtered out because of ignored event type' % filtered_events_count)
 
 
             normal_event = self._create_dd_event(normal_prio_events, image_name, container_tags, priority='Normal')

--- a/docker_daemon/conf.yaml.example
+++ b/docker_daemon/conf.yaml.example
@@ -53,6 +53,14 @@ instances:
     #
     # collect_events: false
 
+    # By default we do not collect events with a status ['top', 'exec_start', 'exec_create'].
+    # Here can be added additional statuses to be filtered. 
+    # List of available statuses can be found here https://docs.docker.com/engine/reference/commandline/events/#object-types
+    # filtered_event_types:
+    #    - 'top'
+    #    - 'exec_start'
+    #    - 'exec_create'
+
     # Collect disk usage per container with docker.container.size_rw and
     # docker.container.size_rootfs metrics.
     # Warning: This might take time for Docker daemon to generate,


### PR DESCRIPTION
### What does this PR do?

Simplifying the process to filter out events by types.

### Motivation

By default the check used to collect all events, the filter available was not specific enough leading to a collection of all events or nothing on a status basis.

### Testing Guidelines

See unit tests

### Versioning

1.4.0 still unreleased
Modified Changelog
