### PR TITLE
Updating the check to be compatible with the next major version of the agent.

### DIFF
--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 * [FEATURE] Add an option to wait for docker if it's not ready at start time. See [#722][]
 * [FEATURE] Add client-side event filtering by event type. See [#744][]
+* [FEATURE] Update the check to be Agent6 ready. See [#750][]
 
 1.3.2 / 2017-08-28
 ==================
@@ -94,4 +95,5 @@
 [#616]: https://github.com/DataDog/integrations-core/issues/616
 [#641]: https://github.com/DataDog/integrations-core/issues/641
 [#701]: https://github.com/DataDog/integrations-core/issues/701
+[#750]: https://github.com/DataDog/integrations-core/issues/750
 [@sophaskins]: https://github.com/sophaskins


### PR DESCRIPTION
### What does this PR do?

`generate_historate_func` and  `generate_histogram_func` have been
deprecated. Also `DockerUtil` might not have been initialized yet, so we
 give `init_config` and `instance` as parameters to avoid parsing again the configuration file.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.