### PR TITLE
[kafka_consumer] set an upper bound to the number of contexts.

### DIFF
--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changes
 
+* [SANITY] set upper bound on number of contexts. Submit "broker available" metrics. See [#753][]
 * [FEATURE] discovery of groups, topics and partitions. See [#633][] (Thanks [@jeffwidman][])
 * [SANITY] Remove usage of `AgentCheck.read_config` (deprecated method). See [#733][]
 
@@ -39,4 +40,5 @@
 [#633]: https://github.com/DataDog/integrations-core/issues/633
 [#684]: https://github.com/DataDog/integrations-core/issues/684
 [#733]: https://github.com/DataDog/integrations-core/issues/733
+[#753]: https://github.com/DataDog/integrations-core/issues/753
 [@jeffwidman]: https://github.com/jeffwidman

--- a/kafka_consumer/conf.yaml.example
+++ b/kafka_consumer/conf.yaml.example
@@ -10,6 +10,11 @@ init_config:
   # to increase this value to avoid hitting zookeeper too hard.
   # https://help.datadoghq.com/hc/en-us/articles/203557899-How-do-I-change-the-frequency-of-an-agent-check-
   # min_collection_interval: 600
+  #
+  # Please note that to avoid blindly collecting offsets and lag for an
+  # unbounded number of partitions (as could be the case after introducing
+  # the self discovery of consumer groups, topics and partitions) the check
+  # will collect at metrics for at most 100 partitions.
 
 instances:
   # In a production environment, it's often useful to specify multiple


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Tackles two issue:
- Since the auto collection of consumer groups, topics and partitions was introduced we're under risk of creating way too many contexts. This PR will set an upper bound to the number of contexts the check may collect. If the value of potential contexts is exceeded the check will not submit any metrics.
- We will not submit consumer offsets if the offsets are not available in the broker. Although the metrics are available, it changed behavior and could affect existing monitors and dashboards. 

Currently I'm just computing the context leaves, which is equal to the total number of partitions across all topics. The actual number of contexts generated would exceed that, by virtue of the different valid permutations. The rationale was basically setting a reasonable upper bound on the number of different partitions collected in a `production` cluster. We could always be more strict regarding the precise number of contexts.

### Motivation

Collateral spotted during QA.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

