### PR TITLE
[k8s/doc] recommend using hostIP instead of nodeName if avail

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -49,7 +49,7 @@ Yes, since Kubernetes 1.6, the concept of [Taints and tolerations](http://blog.k
 Add the following lines to your Deployment (or Daemonset if you are running a multi-master setup):
 ```
 spec:
- tolerations: 
+ tolerations:
  - key: node-role.kubernetes.io/master
    effect: NoSchedule
 ```
@@ -60,12 +60,14 @@ The agent assumes that the kubelet API is available at the default gateway of th
           - name: KUBERNETES_KUBELET_HOST
             valueFrom:
               fieldRef:
-                fieldPath: spec.nodeName
+                fieldPath: status.hostIP
+                # or if you run kubernetes < 1.7:
+                # fieldPath: spec.nodeName
 ```
 See [this PR](https://github.com/DataDog/dd-agent/pull/3051)
 
 ###  Why is there a container in each Kubernetes pod with 0% CPU and minimal disk/ram?
-These are pause containers (docker_image:gcr.io/google_containers/pause.*) that K8s injects into every pod to keep it populated even if the "real” container is restarting/stopped. 
+These are pause containers (docker_image:gcr.io/google_containers/pause.*) that K8s injects into every pod to keep it populated even if the "real” container is restarting/stopped.
 
 The docker_daemon check ignores them through a default exclusion list, but they will show up for K8s metrics like *kubernetes.cpu.usage.total* and *kubernetes.filesystem.usage*.
 
@@ -73,6 +75,6 @@ The docker_daemon check ignores them through a default exclusion list, but they 
 ### Datadog Blog
 To get a better idea of how (or why) to integrate your Kubernetes service, check out our [series of blog posts](https://www.datadoghq.com/blog/monitoring-kubernetes-era/) about it.
 
-### Knowledge Base 
+### Knowledge Base
 * [How to get more out of your Kubernetes integration?](https://help.datadoghq.com/hc/en-us/articles/115001293983-How-to-get-more-out-of-your-Kubernetes-integration)
 * [How to report host disk metrics when dd-agent runs in a docker container?](https://help.datadoghq.com/hc/en-us/articles/115001786703-How-to-report-host-disk-metrics-when-dd-agent-runs-in-a-docker-container-)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Recommend using hostIP instead of nodeName to reach kubelet as it's more reliable.

### Motivation

nodeName doesn't always resolve, and I've never seen hostIP fail.