### PR TITLE
[http_check] Make tornado optional

### DIFF
--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changes
 
 * [FEATURE] Add support for client side certificate. See[#688][].
+* [IMPROVEMENT] Make tornado optional. See [#758][].
 
 1.1.2 / 2017-08-28
 ==================
@@ -41,4 +42,5 @@
 [#328]: https://github.com/DataDog/integrations-core/issues/328
 [#461]: https://github.com/DataDog/integrations-core/issues/461
 [#652]: https://github.com/DataDog/integrations-core/issues/652
-[#688]: https://github.com/DataDog/integrations-core/pull/688
+[#688]: https://github.com/DataDog/integrations-core/issues/688
+[#758]: https://github.com/DataDog/integrations-core/issues/758

--- a/http_check/check.py
+++ b/http_check/check.py
@@ -15,7 +15,6 @@ from urlparse import urlparse
 
 # 3rd party
 import requests
-import tornado
 
 from requests.adapters import HTTPAdapter
 from requests.packages import urllib3
@@ -132,13 +131,19 @@ def get_ca_certs_path():
     """
     Get a path to the trusted certificates of the system
     """
-    CA_CERTS = [
-        '/opt/datadog-agent/embedded/ssl/certs/cacert.pem',
-        os.path.join(os.path.dirname(tornado.__file__), 'ca-certificates.crt'),
-        '/etc/ssl/certs/ca-certificates.crt',
-    ]
+    ca_certs = ['/opt/datadog-agent/embedded/ssl/certs/cacert.pem']
 
-    for f in CA_CERTS:
+    try:
+        import tornado
+    except ImportError:
+        # if `tornado` is not present, simply ignore its certificates
+        pass
+    else:
+        ca_certs.append(os.path.join(os.path.dirname(tornado.__file__), 'ca-certificates.crt'))
+
+    ca_certs.append('/etc/ssl/certs/ca-certificates.crt')
+
+    for f in ca_certs:
         if os.path.exists(f):
             return f
     return None

--- a/http_check/requirements.txt
+++ b/http_check/requirements.txt
@@ -1,1 +1,4 @@
 # integration pip requirements
+# note: requests is also used in many checks
+# upgrade with caution
+requests==2.11.1


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

* Makes `tornado` optional for the check to work
* Explicits the dependency on `requests`

### Motivation

We only use tornado to add its ca_certs to the list of default
ca_certs.

The core agent may not be providing tornado (for instance, the agent6
doesn't provide it now), so let's make the import optional.

### Versioning

~~- [ ] Bumped the version check in `manifest.json`~~ (current version is unreleased)
- [x] Updated `CHANGELOG.md`
