### PR TITLE
Updating metric list

### DIFF
--- a/apache/metadata.csv
+++ b/apache/metadata.csv
@@ -1,4 +1,8 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+apache.conns_total,gauge,,connection,,The total number of connections performed.,0,apache,ConnsTotal
+apache.conns_async_writing,gauge,,connection,,The number of asynchronous writes connections.,0,apache,ConnsAsyncWriting
+apache.conns_async_keep_alive,gauge,,connection,,The number of asynchronous keep alive connections.,0,apache,ConnsAsyncKeepAlive
+apache.conns_async_closing,gauge,,connection,,The number of asynchronous closing connections.,0,apache,ConnsAsyncClosing
 apache.net.bytes,gauge,,byte,,The total number of bytes served.,0,apache,B served
 apache.net.bytes_per_s,gauge,,byte,second,The number of bytes served per second.,0,apache,B per sec
 apache.net.hits,gauge,,request,,The total number of requests performed.,0,apache,requests


### PR DESCRIPTION
Metrics like apache.conns_total are not listed in the Metrics list but they can be captured by our code, see code here: https://github.com/DataDog/integrations-core/blob/master/apache/check.py#L22-L37

Updating metadata.csv to take care of this