### PR TITLE
Updating excluded_disks example

### DIFF
--- a/disk/README.md
+++ b/disk/README.md
@@ -33,7 +33,7 @@ Run the Agent's `info` subcommand and look for `disk` under the Checks section:
 ## Data Collected
 ### Metrics
 
-See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/disk/metadata.csv) for a list of metrics provided by this check.
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/disk/metadata.csv) for a list of metrics provided by this integration.
 
 ### Events
 The Disk check does not include any event at this time.

--- a/disk/conf.yaml.default
+++ b/disk/conf.yaml.default
@@ -16,9 +16,14 @@ instances:
 
     # The (optional) excluded_disks parameter will instruct the check to
     # ignore this list of disks.
+    # Linux example:
     # excluded_disks:
     #   - /dev/sda1
     #   - /dev/sda2
+    #
+    # Windows example:
+    # excluded_disks:
+    #  - F:\
     #
     # The (optional) excluded_disk_re parameter will instruct the check to
     # ignore all disks matching this regex.


### PR DESCRIPTION
The disk.yaml file provides no Windows example. However, the name of disks in Windows is not particularly obvious as it needs to include the backslash of the root directory. Because of this, users are often having to resort to complex regexes (set in excluded_disk_re) instead of the simple excluded_disks section