### PR TITLE
[supervisor] bump to 3.3.3

### DIFF
--- a/supervisord/CHANGELOG.md
+++ b/supervisord/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - supervisord
 
+1.1.0 / Unreleased
+==================
+
+### Changes
+
+* [SECURITY] bumping supervisor dep to 3.3.3 to address [CVE-2017-11610](https://nvd.nist.gov/vuln/detail/CVE-2017-11610).
+
 1.0.0 / 2017-03-22
 ==================
 

--- a/supervisord/manifest.json
+++ b/supervisord/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "guid": "2b81259b-723e-47be-8612-87e1f64152e9"
 }

--- a/supervisord/requirements.txt
+++ b/supervisord/requirements.txt
@@ -1,2 +1,2 @@
 # integration pip requirements
-supervisor==3.3.0
+supervisor==3.3.3


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?
Bumps supervisor to version `3.3.3`

### Motivation
3.3.0 is vulnerable to remote code execution.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
