### PR TITLE
Adding wiredTiger page read/write data to metrics

### DIFF
--- a/mongo/CHANGELOG.md
+++ b/mongo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - mongo
 
+1.4.0 / Unreleased
+==================
+### Changes
+
+* [IMPROVEMENT] Started monitoring the wiredTiger cache page read/write statistics. See [#769][]
+
 1.3.0 / 2017-08-28
 ==================
 ### Changes

--- a/mongo/check.py
+++ b/mongo/check.py
@@ -300,6 +300,8 @@ class MongoDb(AgentCheck):
         "wiredTiger.cache.maximum bytes configured": GAUGE,
         "wiredTiger.cache.maximum page size at eviction": GAUGE,
         "wiredTiger.cache.modified pages evicted": GAUGE,
+        "wiredTiger.cache.pages read into cache": GAUGE, # noqa
+        "wiredTiger.cache.pages written from cache": GAUGE, # noqa
         "wiredTiger.cache.pages currently held in the cache": (GAUGE, "wiredTiger.cache.pages_currently_held_in_cache"),  # noqa
         "wiredTiger.cache.pages evicted because they exceeded the in-memory maximum": (RATE, "wiredTiger.cache.pages_evicted_exceeding_the_in-memory_maximum"),  # noqa
         "wiredTiger.cache.pages evicted by application threads": RATE,

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.3.0",
+  "version": "1.4.0",
   "guid": "d51c342e-7a02-4611-a47f-1e8eade5735c"
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Adds wiredTiger page read/write as collected mongodb metrics

### Motivation

I think wiredTiger page read and write data is critical data, useful for performance tuning. Without it, we can't know what's the disk io used by mongodb.

### Testing Guidelines

No tests have been altered. This should pass the tests automatically as it doesn't change any of the fuctionality.

### Versioning
I didn't bump the version. Should I? There was nothing about this in CONTRIBUTING.md .

### Additional Notes
Maybe we should also add bytes/read and bytes/written to the monitored metrics?

I added the #noqa comment to indicate that the collection of this metric doesn't have an integration/unit test. Was I correct in doing so?
