### PR TITLE
Fix container name lookup & pod_name

### DIFF
--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -1,11 +1,11 @@
 # CHANGELOG - docker_daemon
 
 
-1.4.1 / Unreleased
+1.5.0 / Unreleased
 ==================
 ### Changes
 
-* [BUGFIX] Remove namespace from pod_name tag. See [#770][]
+* [IMPROVEMENT] Remove namespace from pod_name tag. See [#770][]
 
 1.4.0 / 2017-09-12
 ==================

--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG - docker_daemon
 
 
+1.4.1 / Unreleased
+==================
+### Changes
+
+* [BUGFIX] Remove namespace from pod_name tag. See [#770][]
+
 1.4.0 / 2017-09-12
 ==================
 ### Changes

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -64,8 +64,8 @@ CGROUP_METRICS = [
             # We only get these metrics if they are properly set, i.e. they are a "reasonable" value
             "docker.mem.limit": (["hierarchical_memory_limit"], lambda x: float(x) if float(x) < 2 ** 60 else None, GAUGE),
             "docker.mem.sw_limit": (["hierarchical_memsw_limit"], lambda x: float(x) if float(x) < 2 ** 60 else None, GAUGE),
-            "docker.mem.in_use": (["rss", "hierarchical_memory_limit"], lambda x,y: float(x)/float(y) if float(y) < 2 ** 60 else None, GAUGE),
-            "docker.mem.sw_in_use": (["swap", "rss", "hierarchical_memsw_limit"], lambda x,y,z: float(x + y)/float(z) if float(z) < 2 ** 60 else None, GAUGE)
+            "docker.mem.in_use": (["rss", "hierarchical_memory_limit"], lambda x, y: float(x)/float(y) if float(y) < 2 ** 60 else None, GAUGE),
+            "docker.mem.sw_in_use": (["swap", "rss", "hierarchical_memsw_limit"], lambda x, y, z: float(x + y)/float(z) if float(z) < 2 ** 60 else None, GAUGE)
 
         }
     },
@@ -153,6 +153,7 @@ IMAGE = "image"
 
 ERROR_ALERT_TYPE = ['oom', 'kill']
 
+
 def compile_filter_rules(rules):
     patterns = []
     tag_names = []
@@ -195,7 +196,7 @@ class DockerDaemon(AgentCheck):
                     self.kubeutil = KubeUtil()
                 except Exception as ex:
                     self.log.error("Couldn't instantiate the kubernetes client, "
-                        "subsequent kubernetes calls will fail as well. Error: %s" % str(ex))
+                                   "subsequent kubernetes calls will fail as well. Error: %s" % str(ex))
 
             # We configure the check with the right cgroup settings for this host
             # Just needs to be done once
@@ -232,7 +233,6 @@ class DockerDaemon(AgentCheck):
                 patterns, whitelist_tags = compile_filter_rules(health_scs_whitelist)
                 self.whitelist_patterns = set(patterns)
                 self.tag_names[HEALTHCHECK] = set(whitelist_tags)
-
 
             # Other options
             self.collect_image_stats = _is_affirmative(instance.get('collect_images_stats', False))
@@ -447,12 +447,11 @@ class DockerDaemon(AgentCheck):
                             k = "pod_name"
                             if "-" in pod_name:
                                 replication_controller = "-".join(pod_name.split("-")[:-1])
-                                if "/" in replication_controller: # k8s <= 1.1
+                                if "/" in replication_controller:  # k8s <= 1.1
                                     namespace, replication_controller = replication_controller.split("/", 1)
 
-                                elif KubeUtil.NAMESPACE_LABEL in labels: # k8s >= 1.2
+                                elif KubeUtil.NAMESPACE_LABEL in labels:  # k8s >= 1.2
                                     namespace = labels[KubeUtil.NAMESPACE_LABEL]
-                                    pod_name = "{0}/{1}".format(namespace, pod_name)
 
                                 tags.append("kube_namespace:%s" % namespace)
                                 tags.append("kube_replication_controller:%s" % replication_controller)
@@ -478,7 +477,7 @@ class DockerDaemon(AgentCheck):
                             tags.append(k)
 
                         else:
-                            tags.append("%s:%s" % (k,v))
+                            tags.append("%s:%s" % (k, v))
 
                     if k == KubeUtil.POD_NAME_LABEL and Platform.is_k8s() and k not in labels:
                         tags.append("pod_name:no_pod")
@@ -819,7 +818,6 @@ class DockerDaemon(AgentCheck):
             if filtered_events_count:
                 self.log.debug('%d events were filtered out because of ignored event type' % filtered_events_count)
 
-
             normal_event = self._create_dd_event(normal_prio_events, image_name, container_tags, priority='Normal')
             if normal_event:
                 events.append(normal_event)
@@ -893,7 +891,6 @@ class DockerDaemon(AgentCheck):
             'alert_type': alert_type,
             'priority': priority
         }
-
 
     def _report_disk_stats(self):
         """Report metrics about the volume space usage"""
@@ -1017,11 +1014,11 @@ class DockerDaemon(AgentCheck):
     def _is_container_cgroup(self, line, selinux_policy):
         if line[1] not in ('cpu,cpuacct', 'cpuacct,cpu', 'cpuacct') or line[2] == '/docker-daemon':
             return False
-        if 'docker' in line[2]: # general case
+        if 'docker' in line[2]:  # general case
             return True
-        if 'docker' in selinux_policy: # selinux
+        if 'docker' in selinux_policy:  # selinux
             return True
-        if line[2].startswith('/') and re.match(CONTAINER_ID_RE, line[2][1:]): # kubernetes
+        if line[2].startswith('/') and re.match(CONTAINER_ID_RE, line[2][1:]):  # kubernetes
             return True
         if line[2].startswith('/') and re.match(CONTAINER_ID_RE, line[2].split('/')[-1]): # kube 1.6+ qos hierarchy
             return True
@@ -1035,10 +1032,10 @@ class DockerDaemon(AgentCheck):
 
         if len(pid_dirs) == 0:
             self.warning("Unable to find any pid directory in {0}. "
-                "If you are running the agent in a container, make sure to "
-                'share the volume properly: "/proc:/host/proc:ro". '
-                "See https://github.com/DataDog/docker-dd-agent/blob/master/README.md for more information. "
-                "Network metrics will be missing".format(proc_path))
+                         "If you are running the agent in a container, make sure to "
+                         'share the volume properly: "/proc:/host/proc:ro". '
+                         "See https://github.com/DataDog/docker-dd-agent/blob/master/README.md for more information. "
+                         "Network metrics will be missing".format(proc_path))
             self._disable_net_metrics = True
             return container_dict
 
@@ -1100,4 +1097,4 @@ class DockerDaemon(AgentCheck):
                 if val > cap:
                     sample = metric.samples.pop()
                     self.log.debug("Dropped latest value %s (raw sample: %s) of "
-                        "metric %s as it was above the cap for this metric." % (val, sample, metric.name))
+                                   "metric %s as it was above the cap for this metric." % (val, sample, metric.name))

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -11,5 +11,5 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.4.0"
+  "version": "1.4.1"
 }

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -11,5 +11,5 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.4.1"
+  "version": "1.5.0"
 }

--- a/kubernetes/CHANGELOG.md
+++ b/kubernetes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - kubernetes
 
+1.5.0 / Unreleased
+==================
+### Changes
+
+* [IMPROVEMENT] remove namespace from pod_name tag. See [#770][]
+* [BUGFIX] stop reporting cAdvisor metrics about non-container objects. See [#770][]
+
 1.4.0 / 2017-09-12
 ==================
 ### Changes

--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -264,7 +264,7 @@ class Kubernetes(AgentCheck):
         # kube_container_name is the name of the Kubernetes container resource,
         # not the name of the docker container (that's tagged as container_name)
         kube_container_name = cont_labels[KubeUtil.CONTAINER_NAME_LABEL]
-        tags.append(u"pod_name:{0}/{1}".format(pod_namespace, pod_name))
+        tags.append(u"pod_name:{1}".format(pod_name))
         tags.append(u"kube_namespace:{0}".format(pod_namespace))
         tags.append(u"kube_container_name:{0}".format(kube_container_name))
 
@@ -319,8 +319,8 @@ class Kubernetes(AgentCheck):
             # The first alias seems to always match the docker container name
             container_name = subcontainer['aliases'][0]
         else:
-            # We default to the container id
-            container_name = subcontainer['name']
+            self.log.debug("Subcontainer doesn't have a name, skipping.")
+            return
 
         tags.append('container_name:%s' % container_name)
 
@@ -403,6 +403,9 @@ class Kubernetes(AgentCheck):
         container_tags = {}
         for subcontainer in metrics:
             c_id = subcontainer.get('id')
+            if 'aliases' not in subcontainer:
+                # it means the subcontainer is about a higher-level entity than a container
+                continue
             try:
                 tags = self._update_container_metrics(instance, subcontainer, kube_labels)
                 if c_id:

--- a/kubernetes/check.py
+++ b/kubernetes/check.py
@@ -264,7 +264,7 @@ class Kubernetes(AgentCheck):
         # kube_container_name is the name of the Kubernetes container resource,
         # not the name of the docker container (that's tagged as container_name)
         kube_container_name = cont_labels[KubeUtil.CONTAINER_NAME_LABEL]
-        tags.append(u"pod_name:{1}".format(pod_name))
+        tags.append(u"pod_name:{0}".format(pod_name))
         tags.append(u"kube_namespace:{0}".format(pod_namespace))
         tags.append(u"kube_container_name:{0}".format(kube_container_name))
 

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -11,5 +11,5 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.4.0"
+  "version": "1.5.0"
 }

--- a/kubernetes/test_kubernetes.py
+++ b/kubernetes/test_kubernetes.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2010-2016
+# # (C) Datadog, Inc. 2010-2017
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
@@ -129,18 +129,12 @@ class TestKubernetes(AgentCheckTest):
         self.run_check_twice(config, mocks=mocks, force_reload=True)
 
         expected_tags = [
-            (['container_name:/kubelet', 'pod_name:no_pod'], [MEM, CPU, NET, DISK]),
             (['kube_replication_controller:propjoe', 'kube_namespace:default', 'container_name:k8s_POD.e4cc795_propjoe-dhdzk_default_ba151259-36e0-11e5-84ce-42010af01c62_ef0ed5f9', 'pod_name:default/propjoe-dhdzk'], [MEM, CPU, FS, NET, NET_ERRORS]),
-            (['container_name:/kube-proxy', 'pod_name:no_pod'], [MEM, CPU, NET]),
             (['kube_replication_controller:kube-dns-v8', 'kube_namespace:kube-system', 'container_name:k8s_POD.2688308a_kube-dns-v8-smhcb_kube-system_b80ffab3-3619-11e5-84ce-42010af01c62_295f14ff', 'pod_name:kube-system/kube-dns-v8-smhcb'], [MEM, CPU, FS, NET, NET_ERRORS]),
-            (['container_name:/docker-daemon', 'pod_name:no_pod'], [MEM, CPU, DISK, NET]),
             (['kube_replication_controller:kube-dns-v8', 'kube_namespace:kube-system', 'container_name:k8s_etcd.2e44beff_kube-dns-v8-smhcb_kube-system_b80ffab3-3619-11e5-84ce-42010af01c62_e3e504ad', 'pod_name:kube-system/kube-dns-v8-smhcb'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
             (['kube_replication_controller:fluentd-cloud-logging-kubernetes-minion', 'kube_namespace:kube-system', 'container_name:k8s_POD.e4cc795_fluentd-cloud-logging-kubernetes-minion-mu4w_kube-system_d0feac1ad02da9e97c4bf67970ece7a1_49dd977d', 'pod_name:kube-system/fluentd-cloud-logging-kubernetes-minion-mu4w'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
             (['kube_replication_controller:kube-dns-v8', 'kube_namespace:kube-system', 'container_name:k8s_skydns.1e752dc0_kube-dns-v8-smhcb_kube-system_b80ffab3-3619-11e5-84ce-42010af01c62_7c1345a1', 'pod_name:kube-system/kube-dns-v8-smhcb'], [MEM, CPU, FS, NET, NET_ERRORS]),
-            (['container_name:/', 'pod_name:no_pod'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
-            (['container_name:/system/docker', 'pod_name:no_pod'], [MEM, CPU, DISK, NET]),
             (['kube_replication_controller:propjoe', 'kube_namespace:default', 'container_name:k8s_propjoe.21f63023_propjoe-dhdzk_default_ba151259-36e0-11e5-84ce-42010af01c62_19879457', 'pod_name:default/propjoe-dhdzk'], [MEM, CPU, FS, NET, NET_ERRORS]),
-            (['container_name:/system', 'pod_name:no_pod'], [MEM, CPU, NET, DISK]),
             (['kube_replication_controller:kube-ui-v1', 'kube_namespace:kube-system', 'container_name:k8s_POD.3b46e8b9_kube-ui-v1-sv2sq_kube-system_b7e8f250-3619-11e5-84ce-42010af01c62_209ed1dc', 'pod_name:kube-system/kube-ui-v1-sv2sq'], [MEM, CPU, FS, NET, NET_ERRORS]),
             (['kube_replication_controller:kube-dns-v8', 'kube_namespace:kube-system', 'container_name:k8s_kube2sky.1afa6a47_kube-dns-v8-smhcb_kube-system_b80ffab3-3619-11e5-84ce-42010af01c62_624bc34c', 'pod_name:kube-system/kube-dns-v8-smhcb'], [MEM, CPU, FS, NET, NET_ERRORS]),
             (['kube_replication_controller:propjoe', 'kube_namespace:default', 'container_name:k8s_POD.e4cc795_propjoe-lkc3l_default_3a9b1759-4055-11e5-84ce-42010af01c62_45d1185b', 'pod_name:default/propjoe-lkc3l'], [MEM, CPU, FS, NET, NET_ERRORS]),
@@ -259,17 +253,14 @@ class TestKubernetes(AgentCheckTest):
         self.run_check_twice(config, mocks=mocks, force_reload=True)
 
         expected_tags = [
-            (['container_name:/kubelet', 'pod_name:no_pod'], [MEM, CPU, NET, DISK]),
             (['container_name:k8s_POD.35220667_dd-agent-1rxlh_default_12c7be82-33ca-11e6-ac8f-42010af00003_f5cf585f',
               'container_image:gcr.io/google_containers/pause:2.0', 'image_name:gcr.io/google_containers/pause',
-              'image_tag:2.0', 'pod_name:default/dd-agent-1rxlh', 'kube_namespace:default', 'kube_app:dd-agent',
+              'image_tag:2.0', 'pod_name:dd-agent-1rxlh', 'kube_namespace:default', 'kube_app:dd-agent',
               'kube_foo:bar','kube_bar:baz', 'kube_replication_controller:dd-agent', 'kube_daemon_set:dd-agent', 'kube_container_name:POD'],
             [MEM, CPU, FS, NET, NET_ERRORS]),
-            (['container_name:/', 'pod_name:no_pod'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
-            (['container_name:/system', 'pod_name:no_pod'], [MEM, CPU, NET, DISK]),
             (['container_name:k8s_dd-agent.7b520f3f_dd-agent-1rxlh_default_12c7be82-33ca-11e6-ac8f-42010af00003_321fecb4',
               'container_image:datadog/docker-dd-agent:massi_ingest_k8s_events', 'image_name:datadog/docker-dd-agent',
-              'image_tag:massi_ingest_k8s_events','pod_name:default/dd-agent-1rxlh',
+              'image_tag:massi_ingest_k8s_events','pod_name:dd-agent-1rxlh',
               'kube_namespace:default', 'kube_app:dd-agent', 'kube_foo:bar',
               'kube_bar:baz', 'kube_replication_controller:dd-agent', 'kube_daemon_set:dd-agent', 'kube_container_name:dd-agent'], [LIM, REQ, MEM, CPU, NET, DISK, DISK_USAGE]),
             (['kube_replication_controller:dd-agent', 'kube_namespace:default', 'kube_daemon_set:dd-agent'], [PODS]),
@@ -317,14 +308,13 @@ class TestKubernetes(AgentCheckTest):
 
         expected_tags = [
             (['container_image:datadog/docker-dd-agent:massi_ingest_k8s_events', 'image_name:datadog/docker-dd-agent',
-              'image_tag:massi_ingest_k8s_events', 'pod_name:default/dd-agent-1rxlh',
+              'image_tag:massi_ingest_k8s_events', 'pod_name:dd-agent-1rxlh',
               'kube_namespace:default', 'kube_app:dd-agent', 'kube_foo:bar','kube_bar:baz',
               'kube_replication_controller:dd-agent', 'kube_daemon_set:dd-agent', 'kube_container_name:dd-agent'], [MEM, CPU, NET, DISK, DISK_USAGE, LIM, REQ]),
             (['container_image:gcr.io/google_containers/pause:2.0', 'image_name:gcr.io/google_containers/pause',
-              'image_tag:2.0', 'pod_name:default/dd-agent-1rxlh',
+              'image_tag:2.0', 'pod_name:dd-agent-1rxlh',
               'kube_namespace:default', 'kube_app:dd-agent', 'kube_foo:bar','kube_bar:baz',
               'kube_replication_controller:dd-agent', 'kube_daemon_set:dd-agent', 'kube_container_name:POD'], [MEM, CPU, NET, NET_ERRORS, DISK_USAGE]),
-            (['pod_name:no_pod'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
             (['kube_replication_controller:dd-agent', 'kube_namespace:default', 'kube_daemon_set:dd-agent'], [PODS]),
             ([], [LIM, REQ, CAP])  # container from kubernetes api doesn't have a corresponding entry in Cadvisor
         ]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

- remove the namespace from the pod_name tag in the docker, kubernetes check
- fix formatting
- stop reporting cadvisor metrics about non-container objects.

### Motivation

ugly container names and images

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

tied to https://github.com/DataDog/dd-agent/pull/3532