### PR TITLE
Fix vSpere password leak in collector logs

### DIFF
--- a/vsphere/CHANGELOG.md
+++ b/vsphere/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - vsphere
 
+1.0.4 / Unreleased
+==================
+
+### Changes
+
+* [BUGFIX] Fix a possible leak of the vSphere password in the collector logs.
+
 1.0.3 / 2017-08-28
 ==================
 

--- a/vsphere/check.py
+++ b/vsphere/check.py
@@ -532,8 +532,8 @@ class VSphereCheck(AgentCheck):
 
             if not mor_by_mor_name:
                 self.log.warning(
-                    u"Unable to extract hosts' tags for `%s` vSphere instance."
-                    u"Is the check failing on this instance?", instance
+                    u"Unable to extract hosts' tags for vSphere instance named %s"
+                    u"Is the check failing on this instance?", i_key
                 )
                 continue
 

--- a/vsphere/manifest.json
+++ b/vsphere/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.3",
+  "version": "1.0.4",
   "guid": "930b1839-cc1f-4e7a-b706-0e8cf3218464"
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Fix a possible leak of vSphere password in the collector logs

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

Anything else we should know when reviewing?
