### PR TITLE
Mysql user precision update

### DIFF
--- a/mysql/README.md
+++ b/mysql/README.md
@@ -26,6 +26,8 @@ mysql> CREATE USER 'datadog'@'localhost' IDENTIFIED BY '<UNIQUEPASSWORD>';
 Query OK, 0 rows affected (0.00 sec)
 ```
 
+Please note that `@'localhost'` is only for local connections, and either the wildcard `%` or the hostname/IP of the agent should be used for remote connections, learn more [here](https://dev.mysql.com/doc/refman/5.7/en/adding-users.html)
+
 Verify that the user was created successfully using the following command, replacing ```<UNIQUEPASSWORD>``` with the password above:
 
 ```

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -26,7 +26,7 @@ mysql> CREATE USER 'datadog'@'localhost' IDENTIFIED BY '<UNIQUEPASSWORD>';
 Query OK, 0 rows affected (0.00 sec)
 ```
 
-Please note that `@'localhost'` is only for local connections, and either the wildcard `%` or the hostname/IP of the agent should be used for remote connections, learn more [here](https://dev.mysql.com/doc/refman/5.7/en/adding-users.html)
+Please note that `@'localhost'` is only for local connections, use the hostname/IP of your agent for remote connections, learn more [here](https://dev.mysql.com/doc/refman/5.7/en/adding-users.html)
 
 Verify that the user was created successfully using the following command, replacing ```<UNIQUEPASSWORD>``` with the password above:
 


### PR DESCRIPTION
In our MySQL documentation both in-app and in our docs, we provide the queries to setup a new datadog user. This is set as 'datadog'@'localhost'. This works well when the Agent is on the same host as the MySQL instance, but users have run into issues when connecting to remote hosts. The error returned mentions a bad password, which adds to the confusion, but makes sense.

From the MySQL docs:

https://dev.mysql.com/doc/refman/5.7/en/adding-users.html

The 'finley'@'localhost' account can be used only when connecting from the local host. The 'finley'@'%' account uses the '%' wildcard for the host part, so it can be used to connect from any host.

We should mention that @'localhost' is only for local connections, and either the wildcard % or the hostname/IP of the agent should be used for remote connections.