### PR TITLE
[docker_daemon] add custom tags to all service checks

### DIFF
--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - docker_daemon
 
+1.6.0 / Unreleased
+==================
+### Changes
+* [IMPROVEMENT] Add custom tags to all service checks. See [#782][]
 
 1.5.0 / 2017-10-10
 ==================
@@ -100,7 +104,9 @@
 [#616]: https://github.com/DataDog/integrations-core/issues/616
 [#641]: https://github.com/DataDog/integrations-core/issues/641
 [#701]: https://github.com/DataDog/integrations-core/issues/701
+<<<<<<< HEAD
 [#722]: https://github.com/DataDog/integrations-core/issues/722
 [#744]: https://github.com/DataDog/integrations-core/issues/744
 [#770]: https://github.com/DataDog/integrations-core/issues/770
+[#782]: https://github.com/DataDog/integrations-core/issues/782
 [@sophaskins]: https://github.com/sophaskins

--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -104,7 +104,6 @@
 [#616]: https://github.com/DataDog/integrations-core/issues/616
 [#641]: https://github.com/DataDog/integrations-core/issues/641
 [#701]: https://github.com/DataDog/integrations-core/issues/701
-<<<<<<< HEAD
 [#722]: https://github.com/DataDog/integrations-core/issues/722
 [#744]: https://github.com/DataDog/integrations-core/issues/744
 [#770]: https://github.com/DataDog/integrations-core/issues/770

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -263,7 +263,7 @@ class DockerDaemon(AgentCheck):
             # https://github.com/DataDog/dd-agent/issues/1896
             self.init()
             # TODO: delete (added for test) (possible init failure)
-            self.custom_tags = instance.get("tags", [])
+            # self.custom_tags = instance.get("tags", [])
 
             try:
                 if self.docker_util.client is None:

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -262,6 +262,8 @@ class DockerDaemon(AgentCheck):
             # Initialization can fail if cgroups are not ready or docker daemon is down. So we retry if needed
             # https://github.com/DataDog/dd-agent/issues/1896
             self.init()
+            # TODO: delete (added for test) (possible init failure)
+            self.custom_tags = instance.get("tags", [])
 
             try:
                 if self.docker_util.client is None:

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -266,12 +266,14 @@ class DockerDaemon(AgentCheck):
             try:
                 if self.docker_util.client is None:
                     message = "Unable to connect to Docker daemon"
+                    tags = list(self.custom_tags)
                     self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-                                       message=message)
+                                       message=message, tags=tags)
                     return
             except Exception as ex:
+                tags = list(self.custom_tags)
                 self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-                                   message=str(ex))
+                                   message=str(ex), tags=tags)
                 return
 
             if not self.init_success:
@@ -358,12 +360,14 @@ class DockerDaemon(AgentCheck):
             containers = self.docker_util.client.containers(all=True, size=must_query_size)
         except Exception as e:
             message = "Unable to list Docker containers: {0}".format(e)
+            tags = list(self.custom_tags)
             self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-                               message=message)
+                               message=message, tags=tags)
             raise Exception(message)
 
         else:
-            self.service_check(SERVICE_CHECK_NAME, AgentCheck.OK)
+            tags = list(self.custom_tags)
+            self.service_check(SERVICE_CHECK_NAME, AgentCheck.OK, tags=tags)
 
         # Create a set of filtered containers based on the exclude/include rules
         # and cache these rules in docker_util

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -183,6 +183,9 @@ class DockerDaemon(AgentCheck):
         try:
             instance = self.instances[0]
 
+            # Getting custom tags for service checks when docker is down
+            self.custom_tags = instance.get("tags", [])
+
             self.docker_util = DockerUtil()
             if not self.docker_util.client:
                 raise Exception("Failed to initialize Docker client.")
@@ -206,7 +209,6 @@ class DockerDaemon(AgentCheck):
             self._disable_net_metrics = False
 
             # Set tagging options
-            self.custom_tags = instance.get("tags", [])
             self.collect_labels_as_tags = instance.get("collect_labels_as_tags", DEFAULT_LABELS_AS_TAGS)
             self.kube_pod_tags = {}
 
@@ -262,8 +264,6 @@ class DockerDaemon(AgentCheck):
             # Initialization can fail if cgroups are not ready or docker daemon is down. So we retry if needed
             # https://github.com/DataDog/dd-agent/issues/1896
             self.init()
-            # TODO: delete (added for test) (possible init failure)
-            # self.custom_tags = instance.get("tags", [])
 
             try:
                 if self.docker_util.client is None:

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -268,14 +268,12 @@ class DockerDaemon(AgentCheck):
             try:
                 if self.docker_util.client is None:
                     message = "Unable to connect to Docker daemon"
-                    tags = list(self.custom_tags)
                     self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-                                       message=message, tags=tags)
+                                       message=message, tags=self.custom_tags)
                     return
             except Exception as ex:
-                tags = list(self.custom_tags)
                 self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-                                   message=str(ex), tags=tags)
+                                   message=str(ex), tags=self.custom_tags)
                 return
 
             if not self.init_success:
@@ -362,14 +360,12 @@ class DockerDaemon(AgentCheck):
             containers = self.docker_util.client.containers(all=True, size=must_query_size)
         except Exception as e:
             message = "Unable to list Docker containers: {0}".format(e)
-            tags = list(self.custom_tags)
             self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-                               message=message, tags=tags)
+                               message=message, tags=self.custom_tags)
             raise Exception(message)
 
         else:
-            tags = list(self.custom_tags)
-            self.service_check(SERVICE_CHECK_NAME, AgentCheck.OK, tags=tags)
+            self.service_check(SERVICE_CHECK_NAME, AgentCheck.OK, tags=self.custom_tags)
 
         # Create a set of filtered containers based on the exclude/include rules
         # and cache these rules in docker_util

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -11,5 +11,5 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.5.0"
+  "version": "1.6.0"
 }

--- a/docker_daemon/test_docker_daemon.py
+++ b/docker_daemon/test_docker_daemon.py
@@ -23,11 +23,14 @@ CONTAINERS_TO_RUN = [
 
 ]
 
+DEFAULT_CUSTOM_TAGS = ["env:test", "docker:test"]
+
 MOCK_CONFIG = {
     "init_config": {},
     "instances": [{
         "url": "unix://var/run/w00t.sock",
         "collect_disk_stats": True,
+        "tags": DEFAULT_CUSTOM_TAGS
     }]
 }
 
@@ -52,7 +55,7 @@ class TestCheckDockerDaemonDown(AgentCheckTest):
         DockerUtil().left_init_retries = 10
         DockerUtil()._client = None
         self.run_check(MOCK_CONFIG, force_reload=True)
-        self.assertServiceCheck("docker.service_up", status=AgentCheck.CRITICAL, tags=None, count=1)
+        self.assertServiceCheck("docker.service_up", status=AgentCheck.CRITICAL, tags=DEFAULT_CUSTOM_TAGS, count=1)
 
 @attr(requires='docker_daemon')
 class TestCheckDockerDaemonNoSetUp(AgentCheckTest):
@@ -164,18 +167,25 @@ class TestCheckDockerDaemon(AgentCheckTest):
         }
 
     @mock.patch('docker.Client.info')
+    def test_main_service_check(self, mock_info):
+        mock_info.return_value = self.mock_normal_get_info()
+
+        self.run_check(MOCK_CONFIG, force_reload=True)
+        self.assertServiceCheck("docker.service_up", status=AgentCheck.OK, tags=DEFAULT_CUSTOM_TAGS, count=1)
+
+    @mock.patch('docker.Client.info')
     def test_devicemapper_disk_metrics(self, mock_info):
         mock_info.return_value = self.mock_normal_get_info()
 
         self.run_check(MOCK_CONFIG, force_reload=True)
-        self.assertMetric('docker.data.free', value=9e9)
-        self.assertMetric('docker.data.used', value=1e9)
-        self.assertMetric('docker.data.total', value=10e9)
-        self.assertMetric('docker.data.percent', value=10.0)
-        self.assertMetric('docker.metadata.free', value=9e6)
-        self.assertMetric('docker.metadata.used', value=1e6)
-        self.assertMetric('docker.metadata.total', value=10e6)
-        self.assertMetric('docker.metadata.percent', value=10.0)
+        self.assertMetric('docker.data.free', value=9e9, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.data.used', value=1e9, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.data.total', value=10e9, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.data.percent', value=10.0, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.metadata.free', value=9e6, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.metadata.used', value=1e6, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.metadata.total', value=10e6, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.metadata.percent', value=10.0, tags=DEFAULT_CUSTOM_TAGS)
 
     @mock.patch('docker.Client.info')
     def test_devicemapper_no_used_info(self, mock_info):
@@ -183,12 +193,12 @@ class TestCheckDockerDaemon(AgentCheckTest):
         mock_info.return_value = self.mock_get_info_no_used()
 
         self.run_check(MOCK_CONFIG, force_reload=True)
-        self.assertMetric('docker.data.free', value=9e9)
-        self.assertMetric('docker.data.total', value=10e9)
-        self.assertMetric('docker.data.percent', value=10.0)
-        self.assertMetric('docker.metadata.free', value=9e6)
-        self.assertMetric('docker.metadata.total', value=10e6)
-        self.assertMetric('docker.metadata.percent', value=10.0)
+        self.assertMetric('docker.data.free', value=9e9, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.data.total', value=10e9, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.data.percent', value=10.0, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.metadata.free', value=9e6, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.metadata.total', value=10e6, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.metadata.percent', value=10.0, tags=DEFAULT_CUSTOM_TAGS)
 
     @mock.patch('docker.Client.info')
     def test_devicemapper_no_data_info(self, mock_info):
@@ -196,9 +206,9 @@ class TestCheckDockerDaemon(AgentCheckTest):
         mock_info.return_value = self.mock_get_info_no_data()
 
         self.run_check(MOCK_CONFIG, force_reload=True)
-        self.assertMetric('docker.metadata.free', value=9e6)
-        self.assertMetric('docker.metadata.total', value=10e6)
-        self.assertMetric('docker.metadata.percent', value=10.0)
+        self.assertMetric('docker.metadata.free', value=9e6, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.metadata.total', value=10e6, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.metadata.percent', value=10.0, tags=DEFAULT_CUSTOM_TAGS)
 
     @mock.patch('docker.Client.info')
     def test_devicemapper_invalid_values(self, mock_info):
@@ -206,10 +216,10 @@ class TestCheckDockerDaemon(AgentCheckTest):
         mock_info.return_value = self.mock_get_info_invalid_values()
 
         self.run_check(MOCK_CONFIG, force_reload=True)
-        self.assertMetric('docker.metadata.free', value=9e6)
-        self.assertMetric('docker.metadata.used', value=11e6)
-        self.assertMetric('docker.metadata.total', value=10e6)
-        self.assertMetric('docker.metadata.percent', value=55)
+        self.assertMetric('docker.metadata.free', value=9e6, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.metadata.used', value=11e6, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.metadata.total', value=10e6, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.metadata.percent', value=55, tags=DEFAULT_CUSTOM_TAGS)
 
     @mock.patch('docker.Client.info')
     def test_devicemapper_all_zeros(self, mock_info):
@@ -218,9 +228,9 @@ class TestCheckDockerDaemon(AgentCheckTest):
 
         self.run_check(MOCK_CONFIG, force_reload=True)
         metric_names = [metric[0] for metric in self.metrics]
-        self.assertMetric('docker.data.free', value=0)
-        self.assertMetric('docker.data.used', value=0)
-        self.assertMetric('docker.data.total', value=0)
+        self.assertMetric('docker.data.free', value=0, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.data.used', value=0, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.data.total', value=0, tags=DEFAULT_CUSTOM_TAGS)
         self.assertNotIn('docker.data.percent', metric_names)
 
     @mock.patch('docker.Client.info')
@@ -228,14 +238,14 @@ class TestCheckDockerDaemon(AgentCheckTest):
         mock_info.return_value = self.mock_get_info_no_spaces()
 
         self.run_check(MOCK_CONFIG, force_reload=True)
-        self.assertMetric('docker.data.free', value=9e9)
-        self.assertMetric('docker.data.used', value=1e9)
-        self.assertMetric('docker.data.total', value=10e9)
-        self.assertMetric('docker.data.percent', value=10.0)
-        self.assertMetric('docker.metadata.free', value=9e6)
-        self.assertMetric('docker.metadata.used', value=1e6)
-        self.assertMetric('docker.metadata.total', value=10e6)
-        self.assertMetric('docker.metadata.percent', value=10.0)
+        self.assertMetric('docker.data.free', value=9e9, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.data.used', value=1e9, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.data.total', value=10e9, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.data.percent', value=10.0, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.metadata.free', value=9e6, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.metadata.used', value=1e6, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.metadata.total', value=10e6, tags=DEFAULT_CUSTOM_TAGS)
+        self.assertMetric('docker.metadata.percent', value=10.0, tags=DEFAULT_CUSTOM_TAGS)
 
     # integration tests #
 


### PR DESCRIPTION
### What does this PR do?
It adds the custom tags specified in the docker_daemon.yaml into the integration

### Motivation
Customer request: the customer wants to distinguish service checks between his different environments

### Testing Guidelines
Local tests successful

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
