### PR TITLE
[postgres][ci] pin to 9.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ env:
     - TRAVIS_FLAVOR=oracle FLAVOR_VERSION=latest
     - TRAVIS_FLAVOR=pgbouncer FLAVOR_VERSION=latest
     - TRAVIS_FLAVOR=php_fpm FLAVOR_VERSION=5.5
-    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION=latest
+    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION=9.6
     - TRAVIS_FLAVOR=powerdns_recursor FLAVOR_VERSION=3.7.3
     - TRAVIS_FLAVOR=powerdns_recursor FLAVOR_VERSION=4.0.3
     - TRAVIS_FLAVOR=rabbitmq FLAVOR_VERSION=3.5.0

--- a/postgres/ci/start-docker.sh
+++ b/postgres/ci/start-docker.sh
@@ -18,7 +18,7 @@ if docker ps | grep dd-test-postgres >/dev/null; then
   bash postgres/ci/stop-docker.sh
 fi
 
-POSTGRES00_ID=$(docker run -p $PORT:5432 --name $NAME -v $CI_PATH/resources:/docker-entrypoint-initdb.d -e POSTGRES_PASSWORD=datadog -d postgres:latest)
+POSTGRES00_ID=$(docker run -p $PORT:5432 --name $NAME -v $CI_PATH/resources:/docker-entrypoint-initdb.d -e POSTGRES_PASSWORD=datadog -d postgres:${FLAVOR_VERSION})
 POSTGRES00_IP=$(docker inspect ${POSTGRES00_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 POSTGRES00_IP=$(echo $POSTGRES00_IP | cut -d " " -f2)
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Pin postgres tests to version 9.6, we might have some issues, or discrepancies with PG10 that seem to break the tests (to be addressed in a future PR).

### Motivation

Spotted broken tests.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

No need to bump version as we're talking about a CI change.
