### PR TITLE
Nick/varnish service check fix

### DIFF
--- a/varnish/check.py
+++ b/varnish/check.py
@@ -304,7 +304,7 @@ class Varnish(AgentCheck):
                         # If we can't parse a message still send a status.
                         self.log.exception('Error when parsing message from varnishadm')
                         message = ''
-                    backends_by_status[status].append((backend, message))
+                backends_by_status[status].append((backend, message))
 
         for status, backends in backends_by_status.iteritems():
             check_status = BackendStatus.to_check_status(status)

--- a/varnish/check.py
+++ b/varnish/check.py
@@ -280,14 +280,15 @@ class Varnish(AgentCheck):
         """
         # Process status by backend.
         backends_by_status = defaultdict(list)
-        backend, status, message = None, None, None
         for line in output.split("\n"):
+            backend, status, message = None, None, None
             # split string and remove all empty fields
             tokens = filter(None, line.strip().split(' '))
+
             if len(tokens) > 0:
                 if tokens == ['Backend', 'name', 'Admin', 'Probe']:
                     # skip the column headers that exist in new output format
-                    next
+                    continue
                 elif len(tokens) >= 4 and tokens[1] in ['probe', 'healthy', 'sick']:
                     # parse new output format
                     # the backend name will include the vcl name
@@ -297,14 +298,17 @@ class Varnish(AgentCheck):
                 elif tokens[0] == 'Backend':
                     backend = tokens[1]
                     status = tokens[-1].lower()
-                elif tokens[0] == 'Current' and backend is not None:
+
+                if tokens[0] == 'Current' and backend is not None:
                     try:
                         message = ' '.join(tokens[2:]).strip()
                     except Exception:
                         # If we can't parse a message still send a status.
                         self.log.exception('Error when parsing message from varnishadm')
                         message = ''
-                backends_by_status[status].append((backend, message))
+
+                if backend is not None:
+                    backends_by_status[status].append((backend, message))
 
         for status, backends in backends_by_status.iteritems():
             check_status = BackendStatus.to_check_status(status)

--- a/varnish/ci/fixtures/backend_list_output
+++ b/varnish/ci/fixtures/backend_list_output
@@ -1,0 +1,9 @@
+Backend name                   Admin      Probe
+boot.backend2                  probe      Healthy 4/4
+  Current states  good:  4 threshold:  3 window:  4
+  Average response time of good probes: 0.002504
+  Oldest ================================================== Newest
+  --------------------------------------------------------------44 Good IPv4
+  --------------------------------------------------------------XX Good Xmit
+  --------------------------------------------------------------RR Good Recv
+  ------------------------------------------------------------HHHH Happy

--- a/varnish/conf.yaml.example
+++ b/varnish/conf.yaml.example
@@ -35,6 +35,7 @@ instances:
     # NOTE: The Agent must be able to access varnishadm as with root
     # privileges. You can configure your sudoers file for this:
     #
+    # NOTE: These service checks only support up to version 4.x of Varnish
     # example /etc/sudoers entry:
     #   dd-agent ALL=(ALL) NOPASSWD:/usr/bin/varnishadm
     #

--- a/varnish/test_varnish.py
+++ b/varnish/test_varnish.py
@@ -78,12 +78,19 @@ VARNISHADM_PATH = "varnishadm"
 SECRETFILE_PATH = "secretfile"
 FIXTURE_DIR = os.path.join(os.path.dirname(__file__), 'ci')
 
+# Varnish < 4.x varnishadm output
 def debug_health_mock(*args, **kwargs):
     if args[0][0] == VARNISHADM_PATH or args[0][1] == VARNISHADM_PATH:
         return (Fixtures.read_file('debug_health_output', sdk_dir=FIXTURE_DIR), "", 0)
     else:
         return (Fixtures.read_file('stats_output', sdk_dir=FIXTURE_DIR), "", 0)
 
+# Varnish >= 4.x varnishadm output
+def backend_list_mock(*args, **kwargs):
+    if args[0][0] == VARNISHADM_PATH or args[0][1] == VARNISHADM_PATH:
+        return (Fixtures.read_file('backend_list_output', sdk_dir=FIXTURE_DIR), "", 0)
+    else:
+        return (Fixtures.read_file('stats_output', sdk_dir=FIXTURE_DIR), "", 0)
 
 @attr(requires='varnish')
 class VarnishCheckTest(AgentCheckTest):
@@ -140,6 +147,32 @@ class VarnishCheckTest(AgentCheckTest):
             elif 'varnish.uptime' not in mname:
                 self.assertMetric(mname, count=1, tags=['cluster:webs', 'varnish_name:default'])
 
+    # Test the Varnishadm output for version >= 4.x
+    @mock.patch('_varnish.geteuid')
+    @mock.patch('_varnish.Varnish._get_version_info')
+    @mock.patch('_varnish.get_subprocess_output', side_effect=backend_list_mock)
+    def test_command_line_post_varnish4(self, mock_subprocess, mock_version, mock_geteuid):
+        mock_version.return_value = LooseVersion('4.0.0'), True
+        mock_geteuid.return_value = 0
+
+        config = self._get_config_by_version()
+        config['instances'][0]['varnishadm'] = VARNISHADM_PATH
+        config['instances'][0]['secretfile'] = SECRETFILE_PATH
+
+        self.run_check(config)
+        args, _ = mock_subprocess.call_args
+        self.assertEquals(args[0], [VARNISHADM_PATH, '-S', SECRETFILE_PATH, 'debug.health'])
+        self.assertServiceCheckOK("varnish.backend_healthy", tags=['backend:backend2'], count=1)
+
+        mock_version.return_value = LooseVersion('4.1.0'), True
+        mock_geteuid.return_value = 1
+
+        self.run_check(config)
+        args, _ = mock_subprocess.call_args
+        self.assertEquals(args[0], ['sudo', VARNISHADM_PATH, '-S', SECRETFILE_PATH, 'backend.list', '-p'])
+
+
+    # Test the varnishadm output for Varnish < 4.x
     @mock.patch('_varnish.geteuid')
     @mock.patch('_varnish.Varnish._get_version_info')
     @mock.patch('_varnish.get_subprocess_output', side_effect=debug_health_mock)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Change how we add service checks to the backend dictionary we are using so that we only add after getting all the information for that service check. 

### Motivation

Currently we are only submitting a varnish check in one type of occasion, when there is a message with the check. We currently don't do anything with the other types of checks, such as Healthy. 

Additionally, even if there is a message, we just append a new check to the dictionary instead of appending one item containing everything, which could lead to duplicates. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

Added a new test and fixture for the new output type so we don't have any regressions going forward. 

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

These are already bumped in the current version and fix a PR that is merged but unreleased, so I don't think these are needed.

### Additional Notes

Anything else we should know when reviewing?
