### PR TITLE
Add a docker.pids.count metric

### DIFF
--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -654,6 +654,12 @@ class DockerDaemon(AgentCheck):
         if not container.get('_pid'):
             raise BogusPIDException('Cannot report on bogus pid(0)')
 
+        # Count the number of processes running in the cgroup.
+        procs_file = self._get_cgroup_from_proc("cpu", container['_pid'], "cgroup.procs")
+        total_procs = sum(1 for line in open(procs_file))
+        metric_func = FUNC_MAP[GAUGE][self.use_histogram]
+        metric_func(self, "docker.pids.count", int(total_procs), tags=tags)
+
         for cgroup in CGROUP_METRICS:
             try:
                 stat_file = self._get_cgroup_from_proc(cgroup["cgroup"], container['_pid'], cgroup['file'])


### PR DESCRIPTION
### What does this PR do?

This adds a new `docker.pids.count` metric, which counts the total number of process running within a container.

### Motivation

In order to correctly tweak pid limits, it's important for us to get a good understanding of what "normal" looks like for a container. Without this, we don't have any visibility into how many processes are running within a container.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

According to [`man 7 cgroups`](http://man7.org/linux/man-pages/man7/cgroups.7.html):

> The cgroup.procs file can be read to obtain a list of the processes
       that are members of a cgroup.  The returned list of PIDs is not guar‐
       anteed to be in order.  Nor is it guaranteed to be free of dupli‐
       cates.  (For example, a PID may be recycled while reading from the
       list.)