### PR TITLE
[Elasticsearch] Remove faulty pshard code for elasticsearch.indices

### DIFF
--- a/elastic/CHANGELOG.md
+++ b/elastic/CHANGELOG.md
@@ -1,4 +1,10 @@
 # CHANGELOG - elastic
+1.0.2 / Unreleased
+==================
+
+### Changes
+
+* [BUG] Fixes bug for retreiving indices count. See [#806][]
 
 1.0.1 / 2017-08-28
 ==================

--- a/elastic/check.py
+++ b/elastic/check.py
@@ -635,10 +635,6 @@ class ESCheck(AgentCheck):
                 )
 
     def _process_pshard_stats_data(self, data, config, pshard_stats_metrics):
-        # Process number of indexes in cluster
-        if "indexes" in data:
-            self.gauge(self.PRIMARY_SHARD_INDEX_COUNT, len(data["indices"]), tags=config.tags)
-
         for metric, desc in pshard_stats_metrics.iteritems():
             self._process_metric(data, metric, *desc, tags=config.tags)
 

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -11,6 +11,6 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "guid": "d91d91bd-4a8e-4489-bfb1-b119d4cc388a"
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

This is an incredibly tiny fix for this PR https://github.com/DataDog/integrations-core/pull/617 that removes a piece of code that was left there seemingly by mistake.

### Motivation

I am in need of the `elasticsearch.indices.count` metric that the above mentioned PR adds but in its current form it seems broken.

### Testing Guidelines

I have not run a complete test as described in [this file](https://github.com/DataDog/dd-agent/blob/master/tests/README.md) but can do so if necessary.
I did change this code on a live production elasticsearch node which passed configtest and gave me the correct metrics in DataDog and when running `sudo -u dd-agent dd-agent -v check -v elastic`

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

Anything else we should know when reviewing?
