### PR TITLE
updating unitest for k8s events

### DIFF
--- a/kubernetes/test_kubernetes.py
+++ b/kubernetes/test_kubernetes.py
@@ -767,12 +767,14 @@ class TestKubeutil(unittest.TestCase):
         events = json.loads(Fixtures.read_file("events.json", sdk_dir=FIXTURE_DIR, string_escape=False))['items']
         for ev in events:
             tags = KubeUtil().extract_event_tags(ev)
-            # there should be 4 tags except for some events where source.host is missing
-            self.assertTrue(len(tags) >= 3)
+            # there should be 6 tags except for some events where source.host is missing
+            self.assertTrue(len(tags) >= 5)
 
             tag_names = [tag.split(':')[0] for tag in tags]
             self.assertIn('reason', tag_names)
             self.assertIn('namespace', tag_names)
             self.assertIn('object_type', tag_names)
-            if len(tags) == 4:
+            self.assertIn('object_name', tag_names)
+            self.assertIn('source_component', tag_names)
+            if len(tags) == 6:
                 self.assertIn('node_name', tag_names)


### PR DESCRIPTION
### What does this PR do?

Updates unit test to comply with the new tags added to the kubernetes events by this PR:
https://github.com/DataDog/dd-agent/compare/charly/k8s_events_extratags

### Motivation

Updating the CI.

### Testing Guidelines

`rake ci:run[kubernetes]`

```
test_critical_service_check_tagging (test_kubernetes.TestKubernetes) ... ok
test_events (test_kubernetes.TestKubernetes) ... ok
test_fail_1_1 (test_kubernetes.TestKubernetes) ... ok
test_fail_1_2 (test_kubernetes.TestKubernetes) ... ok
test_fail_service_check_tagging (test_kubernetes.TestKubernetes) ... ok
test_historate_1_1 (test_kubernetes.TestKubernetes) ... ok
test_historate_1_2 (test_kubernetes.TestKubernetes) ... ok
test_kubelet_fail (test_kubernetes.TestKubernetes) ... ok
test_metrics_1_1 (test_kubernetes.TestKubernetes) ... ok
test_metrics_1_2 (test_kubernetes.TestKubernetes) ... ok
test_namespaced_events (test_kubernetes.TestKubernetes) ... ok
test_ok_service_check_tagging (test_kubernetes.TestKubernetes) ... ok
Test with both 1.1 and 1.2 version payloads ... ok
test_extract_event_tags (test_kubernetes.TestKubeutil) ... ok
Test kube_pod_tags with both 1.1 and 1.2 version payloads ... ok
test_get_auth_token (test_kubernetes.TestKubeutil) ... ok
test_get_kube_pod_tags (test_kubernetes.TestKubeutil) ... ok
test_get_node_hostname (test_kubernetes.TestKubeutil) ... ok
test_get_node_info (test_kubernetes.TestKubeutil) ... ok
test_init_tls_settings (test_kubernetes.TestKubeutil) ... ok
test_is_k8s (test_kubernetes.TestKubeutil) ... ok
test_locate_kubelet_no_auth_no_ssl (test_kubernetes.TestKubeutil) ... ok
test_locate_kubelet_no_auth_no_verify (test_kubernetes.TestKubeutil) ... ok
Test kubelet connection with TLS. Also look for auth token. ... ok
test_perform_kubelet_query (test_kubernetes.TestKubeutil) ... ok
test_retrieve_json_auth (test_kubernetes.TestKubeutil) ... ok
test_retrieve_machine_info (test_kubernetes.TestKubeutil) ... ok
test_retrieve_metrics (test_kubernetes.TestKubeutil) ... ok
test_retrieve_pods_list (test_kubernetes.TestKubeutil) ... ok

----------------------------------------------------------------------
Ran 29 tests in 5.061s
```

### Versioning

- No bump necessary as only tests are updated.

