### PR TITLE
[docker] fix kubernetes tagging in docker_daemon metrics

### DIFF
--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -3,6 +3,7 @@
 1.6.0 / Unreleased
 ==================
 ### Changes
+* [BUGFIX] Fix lost kubernetes tags in 1.5.0. See [#817][]
 * [IMPROVEMENT] Add custom tags to all service checks. See [#782][]
 
 1.5.0 / 2017-10-10

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -438,6 +438,7 @@ class DockerDaemon(AgentCheck):
 
         if entity is not None:
             pod_name = None
+            namespace = None
             # Get labels as tags
             labels = entity.get("Labels")
             if labels is not None:
@@ -494,8 +495,8 @@ class DockerDaemon(AgentCheck):
                             tags.append('%s:%s' % (tag_name, str(t).strip()))
 
             # Add kube labels and creator/service tags
-            if Platform.is_k8s():
-                kube_tags = self.kube_pod_tags.get(pod_name)
+            if Platform.is_k8s() and namespace and pod_name:
+                kube_tags = self.kube_pod_tags.get("{0}/{1}".format(namespace, pod_name))
                 if kube_tags:
                     tags.extend(list(kube_tags))
 


### PR DESCRIPTION
### What does this PR do?

The lookup key for the kube_pod_tags dict is namespace/pod_name,
as we changed the `pod_name` tag to just be pod_name instead of
the old namespace/pod_name value, we can't reuse that variable
as a lookup key in the dict
This fixes the regression on 5.18.0 and 5.18.1


### Versioning

~~- [ ] Bumped the version check in `manifest.json`~~
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

