### PR TITLE
Adding indexes use metric

### DIFF
--- a/mongo/CHANGELOG.md
+++ b/mongo/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - mongo
 
+1.5.0 / Unreleased
+==================
+
+* [FEATURE] Collect metrics about indexes usage. See [#823][]
+
 1.4.0 / 2017-10-10
 ==================
 ### Changes
@@ -48,5 +53,6 @@
 [#627]: https://github.com/DataDog/integrations-core/issues/627
 [#691]: https://github.com/DataDog/integrations-core/issues/691
 [#769]: https://github.com/DataDog/integrations-core/issues/769
+[#823]: https://github.com/DataDog/integrations-core/issues/823
 [@dnavre]: https://github.com/dnavre
 [@dtbartle]: https://github.com/dtbartle

--- a/mongo/check.py
+++ b/mongo/check.py
@@ -9,6 +9,8 @@ import pymongo
 # project
 from checks import AgentCheck
 from urlparse import urlsplit
+from config import _is_affirmative
+from distutils.version import LooseVersion # pylint: disable=E0611,E0401
 
 DEFAULT_TIMEOUT = 30
 GAUGE = AgentCheck.gauge
@@ -624,6 +626,22 @@ class MongoDb(AgentCheck):
 
         return username, password, db_name, nodelist, clean_server_name, auth_source
 
+    def _collect_indexes_stats(self, instance, db, tags):
+        """
+        Collect indexes statistics for all collections in the configuration.
+        This use the "$indexStats" command.
+        """
+        for coll_name in instance.get('collections', []):
+            try:
+                for stats in db[coll_name].aggregate([{"$indexStats": {}}], cursor={}):
+                    idx_tags = tags + [
+                        "name:{0}".format(stats.get('name', 'unknown')),
+                        "collection:{0}".format(coll_name),
+                    ]
+                    self.gauge('mongodb.collection.indexes.accesses.ops', int(stats.get('accesses', {}).get('ops', 0)), idx_tags)
+            except Exception as e:
+                self.log.error("Could not fetch indexes stats for collection %s: %s", coll_name, e)
+
     def check(self, instance):
         """
         Returns a dictionary that looks a lot like what's sent back by
@@ -905,6 +923,13 @@ class MongoDb(AgentCheck):
                 submit_method, metric_name_alias = \
                     self._resolve_metric(metric_name, metrics_to_collect)
                 submit_method(self, metric_name_alias, val, tags=metrics_tags)
+
+        if _is_affirmative(instance.get('collections_indexes_stats')):
+            mongo_version = cli.server_info().get('version', '0.0')
+            if LooseVersion(mongo_version) >= LooseVersion("3.2"):
+                self._collect_indexes_stats(instance, db, tags)
+            else:
+                self.log.error("'collections_indexes_stats' is only available starting from mongo 3.2: your mongo version is %s", mongo_version)
 
         # Report the usage metrics for dbs/collections
         if 'top' in additional_metrics:

--- a/mongo/conf.yaml.example
+++ b/mongo/conf.yaml.example
@@ -46,3 +46,6 @@ instances:
     #   - my_collection
     #   - my_other_collection
     #
+    # Collect indexes access metrics for every index in every collections in
+    # the 'collections' list. This is available starting mongo 3.2.
+    # collections_indexes_stats: false

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.4.0",
+  "version": "1.5.0",
   "guid": "d51c342e-7a02-4611-a47f-1e8eade5735c",
   "public_title": "Datadog-Mongo DB Integration",
   "categories":["data store"],

--- a/mongo/metadata.csv
+++ b/mongo/metadata.csv
@@ -182,3 +182,4 @@ mongodb.collection.maxSize,gauge,,byte,,Maximum size of a capped collection in b
 mongodb.collection.storageSize,gauge,,byte,,Total storage space allocated to this collection for document storage.,0,mongodb,storage space of collection
 mongodb.collection.nindexes,gauge,,index,,Total number of indices on the collection.,0,mongodb,number of indices on collection
 mongodb.collection.indexSizes,gauge,,byte,,Size of index in bytes.,0,mongodb,index size
+mongodb.collection.indexes.accesses.ops,gauge,,access,,Number of time the index was used.,0,mongodb,index usage


### PR DESCRIPTION
### What does this PR do?
Starting mongo 3.2 we now collect how many times an index was used. This is useful to detect unused indexes.

The documentation: https://docs.mongodb.com/manual/reference/operator/aggregation/indexStats/#pipe._S_indexStats

### Motivation

Feature request.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.