### PR TITLE
[supervisord][ci] Test against the latest 3.3.3

### DIFF
--- a/supervisord/ci/supervisord.rake
+++ b/supervisord/ci/supervisord.rake
@@ -1,7 +1,7 @@
 require 'ci/common'
 
 def supervisord_version
-  ENV['FLAVOR_VERSION'] || '3.3.0'
+  ENV['FLAVOR_VERSION'] || '3.3.3'
 end
 
 def supervisord_rootdir
@@ -24,7 +24,7 @@ namespace :ci do
     task :install do
       Rake::Task['ci:common:install'].invoke('supervisord')
       sh %(docker run -d --name #{container_name} -p #{container_port}:#{container_port} \
-           -v #{supervisord_rootdir}:/supervisor datadog/docker-library:supervisord_3_3_0)
+           -v #{supervisord_rootdir}:/supervisor datadog/docker-library:supervisord_3_3_3)
     end
 
     task before_script: ['ci:common:before_script'] do


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Test against supervisor 3.3.3, while at the job, use a smaller Docker image (~80Mb) to speed up tests.

### Motivation

3.3.0 had a security issue and we tests time out from time to time because the old docker image was ~680Mb
