### PR TITLE
Allow all metrics to get collected alongside custom proc

### DIFF
--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - sqlserver
 
+1.2.1 / Unreleased
+==================
+
+### Changes
+
+* [BUGFIX] Fixes issue to collect all metrics when `stored_procedure` is defined. See [#830][].
+
 1.2.0 / 2017-10-10
 ==================
 
@@ -29,5 +36,6 @@
 [#357]: https://github.com/DataDog/integrations-core/issues/357
 [#456]: https://github.com/DataDog/integrations-core/issues/456
 [#573]: https://github.com/DataDog/integrations-core/issues/573
+[#830]: https://github.com/DataDog/integrations-core/issues/830
 [@rlaveycal]: https://github.com/rlaveycal
 [@themsquared]: https://github.com/themsquared

--- a/sqlserver/check.py
+++ b/sqlserver/check.py
@@ -135,9 +135,8 @@ class SQLServer(AgentCheck):
                     db_exists, context = self._check_db_exists(instance)
 
                 if db_exists:
-                    if instance.get('stored_procedure') is None:
-                        with self.open_managed_db_connections(instance, self.DEFAULT_DB_KEY):
-                            self._make_metric_list_to_collect(instance, self.custom_metrics)
+                    with self.open_managed_db_connections(instance, self.DEFAULT_DB_KEY):
+                        self._make_metric_list_to_collect(instance, self.custom_metrics)
                 else:
                     # How much do we care that the DB doesn't exist?
                     ignore = _is_affirmative(instance.get("ignore_missing_database", False))
@@ -153,7 +152,7 @@ class SQLServer(AgentCheck):
                 self.log.exception("Skipping SQL Server instance")
                 continue
             except Exception as e:
-                self.log.exception("INitialization exception %s", str(e))
+                self.log.exception("Initialization exception %s", str(e))
                 continue
 
     def _check_db_exists(self, instance):
@@ -445,10 +444,10 @@ class SQLServer(AgentCheck):
     def check(self, instance):
         if self.do_check[self._conn_key(instance, self.DEFAULT_DB_KEY)]:
             proc = instance.get('stored_procedure')
-            if proc is None:
+            self.do_stored_procedure_check(instance, proc)
+            if proc:
+                self.log.debug("Stored procedure detected, running proc: %s", proc)
                 self.do_perf_counter_check(instance)
-            else:
-                self.do_stored_procedure_check(instance, proc)
         else:
             self.log.debug("Skipping check")
 

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -10,7 +10,7 @@
     "linux",
     "windows"
   ],
-  "version": "1.2.0",
+  "version": "1.2.1",
   "guid": "635cb962-ee9f-4788-aa55-a7ffb9661498",
   "public_title": "Datadog-SQL Server Integration",
   "categories":["data store"],


### PR DESCRIPTION
### What does this PR do?

Allows all metrics to be collected if a custom stored procedure is defined. Removes a requirement in two lines where `stored_procedure` must an empty value to add custom metrics to the list of metrics to collect as well as fetching the metrics from the `sys.dm_os_performance_counters` table.

### Motivation

A customer reached out to report custom metrics were not collected when a stored procedure was defined.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

Anything else we should know when reviewing?
