### PR TITLE
[oracle] fixing CI, getting rid of npm.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,7 @@ install:
   - git -C $HOME/integrations-extras pull || git clone -b $EXTRAS_BRANCH --depth 1 https://github.com/DataDog/integrations-extras.git $HOME/integrations-extras
   - echo "$HOME/dd-agent/" > $(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/datadog-agent.pth
   - if [ -e ~/dd-agent/requirements.txt ]; then pip install -r ~/dd-agent/requirements.txt; fi
+  - pip install -r requirements-test.txt
   - bundle exec rake setup_agent_libs
 script:
   - bundle exec rake prep_travis_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,6 @@ install:
   - echo "$HOME/dd-agent/" > $(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/datadog-agent.pth
   - if [ -e ~/dd-agent/requirements.txt ]; then pip install -r ~/dd-agent/requirements.txt; fi
   - bundle exec rake setup_agent_libs
-  - sudo apt-get -qqy install npm
 script:
   - bundle exec rake prep_travis_ci
   - bundle exec rake ci:run

--- a/oracle/ci/oracle.rake
+++ b/oracle/ci/oracle.rake
@@ -23,7 +23,6 @@ container_port_8080 = 80_80
 namespace :ci do
   namespace :oracle do |flavor|
     task before_install: ['ci:common:before_install'] do
-      sh %(pip install pexpect==4.2.1)
       sh %(mkdir -p #{ENV['ORACLE_DIR']})
       sh %(#{ENV['TRAVIS_BUILD_DIR']}/oracle/ci/resources/get_instantclient.py --agree=yes)
       sh %(echo #{ENV['ORACLE_HOME']} | sudo tee /etc/ld.so.conf.d/oracle_instantclient.conf)

--- a/oracle/ci/resources/get_instantclient.py
+++ b/oracle/ci/resources/get_instantclient.py
@@ -1,13 +1,145 @@
 #!/usr/bin/env python
 
-import pexpect
 import os
 import sys
 import getopt
+import logging
+import hashlib
+import urllib
 import platform
 
+import requests
+from requests import Session
+from bs4 import BeautifulSoup
+import simplejson as json
+from zipfile import ZipFile
 
-TARGET = 'instantclient'
+
+log = logging.getLogger(__file__)
+# logging.basicConfig(level=logging.DEBUG)
+
+
+ORACLE_DIR_TARGET = 'instantclient'
+DL_CONFIGS = "instantclient_config.json"
+
+def oracle_dl(target_url, target_local, sha, destination, username, password):
+    if os.path.isfile(target_local):
+        log.warn("File exists, will not download")
+        return False
+
+    s = Session()
+    s.cookies.set('oraclelicense', 'accept-ic_winx8664-cookie', domain='oracle.com')
+    s.cookies.set('oraclelicense', 'accept-ic_winx8664-cookie', domain='download.oracle.com')
+
+    login_url = 'http://www.oracle.com/webapps/redirect/signon'
+    login_url_redir = 'https://login.oracle.com/oaam_server/login.do'
+    login_steptwo_url = 'https://login.oracle.com:443/oaam_server/oamLoginPage.jsp'
+    login_form_url = 'https://login.oracle.com/oaam_server/loginAuth.do'
+
+    oam_headers = {
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+        'Connection': 'keep-alive',
+        'Upgrade-Insecure-Requests': '1',
+        'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.87 Safari/537.36',
+        'Accept-Encoding': 'gzip, deflate, sdch',
+        'Accept-Language': 'en-US,en;q=0.8'
+    }
+
+    response = s.get(target_url, headers=oam_headers, allow_redirects=True)
+
+    soup = BeautifulSoup(response.content, 'html.parser')
+    OAM_REQ = soup.find('input', attrs={'name': 'OAM_REQ'})['value']
+    token = soup.find('input', attrs={'name': 'tap_token'})['value']
+    tap_url = soup.find('input', attrs={'name': 'TapSubmitURL'})['value']
+
+    form = {
+        'OAM_REQ': OAM_REQ,
+        'tap_token': token,
+        'TapSubmitURL': tap_url,
+    }
+    response = s.post(login_steptwo_url, headers=oam_headers, data=form, allow_redirects=True)
+
+    soup = BeautifulSoup(response.content, 'html.parser')
+    fk = soup.find('input', attrs={'name': 'fk'})['value']
+
+    login_form = {
+        'fk': fk,
+        'clientOffset': 1,
+        'userid': username,
+        'pass': password,
+    }
+
+    login_headers = {
+        'Cache-Control': 'max-age=0',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+        'Connection': 'keep-alive',
+        'Upgrade-Insecure-Requests': '1',
+        'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.87 Safari/537.36',
+        'Accept-Encoding': 'gzip, deflate, sdch',
+        'Accept-Language': 'en-US,en;q=0.8'
+    }
+
+    response = s.post(login_form_url,
+                    headers=login_headers, data=login_form, allow_redirects=True)
+
+    jump_form = {
+        'jump': 'false',
+        'clientOffset': 1,
+    }
+
+    response = s.get('https://login.oracle.com/oaam_server/authJump.do?jump=false',
+                    headers=login_headers, data=jump_form, allow_redirects=True)
+
+    soup = BeautifulSoup(response.content, 'html.parser')
+    OAM_REQ = soup.find('input', attrs={'name': 'OAM_REQ'})['value']
+    token = soup.find('input', attrs={'name': 'oam_tap_token'})['value']
+
+    oam_form = {
+        'OAM_REQ': OAM_REQ,
+        'oam_tap_token': token,
+    }
+    response = s.post('https://login.oracle.com:443/oam/server/dap/cred_submit',
+                    headers=login_headers, data=oam_form, allow_redirects=True, stream=True)
+
+    hash_sha256 = hashlib.sha256()
+    with open(target_local, 'wb') as f:
+        for chunk in response.iter_content(chunk_size=1024):
+            if chunk:  # filter out keep-alive new chunks
+                f.write(chunk)
+                hash_sha256.update(chunk)
+
+    return (hash_sha256.hexdigest() == sha)
+
+def sha256(fname):
+    hash_sha256 = hashlib.sha256()
+    with open(fname, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_sha256.update(chunk)
+    return hash_md5.hexdigest()
+
+def get_members(zip):
+    parts = []
+    # get all the path prefixes
+    for name in zip.namelist():
+        # only check files (not directories)
+        if not name.endswith('/'):
+            # keep list of path elements (minus filename)
+            parts.append(name.split('/')[:-1])
+    # now find the common path prefix (if any)
+    prefix = os.path.commonprefix(parts)
+    if prefix:
+        # re-join the path elements
+        prefix = '/'.join(prefix) + '/'
+    # get the length of the common prefix
+    offset = len(prefix)
+    # now re-set the filenames
+    for zipinfo in zip.infolist():
+        name = zipinfo.filename
+        # only check files (not directories)
+        if len(name) > offset:
+            # remove the common prefix
+            zipinfo.filename = name[offset:]
+            yield zipinfo
 
 def usage():
     print 'usage: {} -a yes|no [-u user | -p pass | -d destination]'.format(sys.argv[0])
@@ -15,20 +147,14 @@ def usage():
     print '\t -u | --user= : user to oracle SSO'
     print '\t -p | --pass= : pass to oracle SSO'
     print '\t -d | --dest= : destination to download instantclient'
+    print '\t -o | --plat= : platform to download instantclient (linux, darwin, win32)'
     print '\n\n\t You may also specify user ane passwd with ORACLE_USER and ORACLE pass env vars.'
 
-def executable_in_path(cmd):
-    for directory in os.environ.get("PATH", "").split(os.pathsep):
-        cmd_candidate = os.path.join(directory, cmd)
-        if os.path.exists(cmd_candidate):
-            return True
-
-    return False
 
 def main():
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "ha:u:p:d:v",
-                                   ["help", "agree=", "user=", "pass=", "dest="])
+        opts, args = getopt.getopt(sys.argv[1:], "ha:u:p:d:o:v",
+                                   ["help", "agree=", "user=", "pass=", "dest=", "plat="])
     except getopt.GetoptError as err:
         # print help information and exit:
         print str(err)
@@ -39,6 +165,7 @@ def main():
     password = None
     agree = False
     destination = None
+    plat = None
     for o, a in opts:
         if o in ("-h", "--help"):
             usage()
@@ -51,6 +178,8 @@ def main():
             password = a
         elif o in ("-d", "--dest"):
             destination = a
+        elif o in ("-o", "--plat"):
+            plat = a
         else:
             assert False, "unhandled option"
 
@@ -71,42 +200,41 @@ def main():
         usage()
         sys.exit(2)
 
-    if not executable_in_path('npm'):
-        print 'npm required to continue. Please install npm or otherwise download instantclient manually.'
-        sys.exit(-1)
+    with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), DL_CONFIGS), "r") as fp:
+        configs = json.load(fp)
 
-    if os.path.isdir(os.path.join(destination, TARGET)):
-        print 'instantclient already installed or conflicting directory present - quitting'
-        sys.exit(0)
+    pkg_os = plat or platform.system().lower()
+    default_version = configs['defaultversion'][pkg_os]
+
+    for pkg in ['basic', 'sdk']:
+        target = configs[default_version][pkg_os]['x64'][pkg]['url']
+        target_sha256 = configs[default_version][pkg_os]['x64'][pkg]['sha256']
 
 
-    npm = pexpect.spawnu('npm install --prefix {} instantclient'.format(destination))
-    npm.logfile = sys.stdout
+        target_zip = os.path.join(destination, target.split('/')[-1])
+        target_dir = os.path.join(destination, ORACLE_DIR_TARGET)
 
-    npm.expect(u'Press \(Y\) to Install, anything else to Cancel\? ', timeout=120)
-    npm.sendline('Y')
-    npm.expect(u'Press \(Y\) to Accept the License Agreement, anything else to Cancel\? ')
-    npm.sendline('Y')
-    npm.logfile = None
+        if os.path.isdir(target_dir):
+            log.warn('instantclient folder contents will be overwritten')
 
-    npm.expect(u'Please enter your username: ')
-    npm.sendline(username)
-    npm.expect(u'Please enter your password: ')
-    npm.sendline(password)
-    npm.expect(u'Directory .* created.', timeout=120)
-    sys.stdout.flush()
-    npm.logfile = sys.stdout
-    if 'linux' in platform.system().lower():
-        npm.expect(u'instantclient@', timeout=120)
+        try:
+            if not os.path.isfile(target_zip):
+                if oracle_dl(target, target_zip, target_sha256, destination, username, password):
+                    print "download successful!"
+                else:
+                    print "unable to download artifact or artifact corrupt"
+                    sys.exit(1)
+            elif sha256(target_zip) is not target_sha256:
+                print "existing artifacts corrupt, please delete and try again"
+                sys.exit(1)
 
-    try:
-        npm.expect(pexpect.EOF, timeout=120)
-    except Exception:
-        pass
-    finally:
-        sys.stdout.flush()
+            zip = ZipFile(target_zip)
+            zip.extractall(target_dir, get_members(zip))
+        except Exception as e:
+            log.exception("There was a problem downloading the target")
 
     print 'InstantClient installation complete.'
+
 
 
 if __name__ == "__main__":

--- a/oracle/ci/resources/get_instantclient.py
+++ b/oracle/ci/resources/get_instantclient.py
@@ -5,10 +5,8 @@ import sys
 import getopt
 import logging
 import hashlib
-import urllib
 import platform
 
-import requests
 from requests import Session
 from bs4 import BeautifulSoup
 import simplejson as json
@@ -31,8 +29,6 @@ def oracle_dl(target_url, target_local, sha, destination, username, password):
     s.cookies.set('oraclelicense', 'accept-ic_winx8664-cookie', domain='oracle.com')
     s.cookies.set('oraclelicense', 'accept-ic_winx8664-cookie', domain='download.oracle.com')
 
-    login_url = 'http://www.oracle.com/webapps/redirect/signon'
-    login_url_redir = 'https://login.oracle.com/oaam_server/login.do'
     login_steptwo_url = 'https://login.oracle.com:443/oaam_server/oamLoginPage.jsp'
     login_form_url = 'https://login.oracle.com/oaam_server/loginAuth.do'
 
@@ -115,7 +111,7 @@ def sha256(fname):
     with open(fname, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
             hash_sha256.update(chunk)
-    return hash_md5.hexdigest()
+    return hash_sha256.hexdigest()
 
 def get_members(zip):
     parts = []
@@ -230,7 +226,7 @@ def main():
 
             zip = ZipFile(target_zip)
             zip.extractall(target_dir, get_members(zip))
-        except Exception as e:
+        except Exception:
             log.exception("There was a problem downloading the target")
 
     print 'InstantClient installation complete.'

--- a/oracle/ci/resources/instantclient_config.json
+++ b/oracle/ci/resources/instantclient_config.json
@@ -1,0 +1,48 @@
+{
+	"folder": "instantclient",
+	"defaultversion": {
+        "win32": "v12",
+        "linux": "v12",
+        "darwin": "v11"
+    },
+	"v12": {
+		"win32": {
+			"x64": {
+				"basic": {
+					"url": "http://download.oracle.com/otn/nt/instantclient/121020/instantclient-basic-windows.x64-12.1.0.2.0.zip",
+					"sha256": "5a4838d11f2995fdc86e1bbc5e7a195c20386e8de467a1b46a139254507ce974"
+				},
+				"sdk": {
+					"url": "http://download.oracle.com/otn/nt/instantclient/121020/instantclient-sdk-windows.x64-12.1.0.2.0.zip",
+					"sha256": "08381b0a3c2996be5acdc074c2c0cc5933c0ecc54cc801a384f491dc94532d50"
+				}
+			}
+		},
+		"linux": {
+			"x64": {
+				"basic": {
+					"url": "http://download.oracle.com/otn/linux/instantclient/122010/instantclient-basic-linux.x64-12.2.0.1.0.zip",
+					"sha256": "5015e3c9fba84e009f7519893f798a1622c37d1ae2c55104ff502c52a0fe5194"
+				},
+				"sdk": {
+					"url": "http://download.oracle.com/otn/linux/instantclient/122010/instantclient-sdk-linux.x64-12.2.0.1.0.zip",
+					"sha256": "7f404c3573c062ce487a51ac4cfe650c878d7edf8e73b364ec852645ed1098cb"
+				}
+			}
+		}
+	},
+	"v11": {
+		"darwin": {
+			"x64": {
+				"basic": {
+					"url": "http://download.oracle.com/otn/mac/instantclient/11204/instantclient-basic-macos.x64-11.2.0.4.0.zip",
+					"sha256": "6c079713ab0a65193f7bfcbad6c90e7806fa6634a3828052f8428e1533bb89d3"
+				},
+				"sdk": {
+					"url": "http://download.oracle.com/otn/mac/instantclient/11204/instantclient-sdk-macos.x64-11.2.0.4.0.zip",
+					"sha256": "aead0663c206a811cf1f61d3b2a533ff81e6e6109dd31544ad850a7ef6eb5d19"
+				}
+			}
+		}
+	}
+}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,3 +6,4 @@ pylint==1.6.4
 nose==1.3.4
 google_compute_engine
 pika==0.10.0
+beautifulsoup4==4.5.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,3 +7,4 @@ nose==1.3.4
 google_compute_engine
 pika==0.10.0
 beautifulsoup4==4.5.1
+simplejson==3.6.5


### PR DESCRIPTION
### What does this PR do?

Something must've changed in the oracle authentication flow because the instantclient npm module we were using to pull the instantclient stuff broke. After some reverse-engineering of the current flows I was able to get a script that works and allows us to pull the artifact ins an unattended fashion. It also drops that ugly dependency with npm and nodejs (that also made out build slower)

### Motivation
Oracle CI broke.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning
No versioning changes needed this a CI-only change.

### Additional Notes

Anything else we should know when reviewing?
