### PR TITLE
fixes error checking on tokumx

### DIFF
--- a/tokumx/check.py
+++ b/tokumx/check.py
@@ -379,7 +379,7 @@ class TokuMX(AgentCheck):
                 self.check_last_state(data['state'], server, self.agentConfig)
                 status['replSet'] = data
         except Exception as e:
-            if "OperationFailure" in repr(e) and "replSetGetStatus" in str(e):
+            if "OperationFailure" in repr(e) and ("replSetGetStatus" in str(e) or "not running with --replSet" in str(e)):
                 pass
             else:
                 raise e


### PR DESCRIPTION
### What does this PR do?

The tokumx check was broken after upgrading pymongo. We were checking to see the form of an error string that changed with the version upgrade. This includes the new form of the error string.
