### PR TITLE
[Zookeeper] Remove incorrect metric name

### DIFF
--- a/zk/check.py
+++ b/zk/check.py
@@ -327,9 +327,6 @@ class ZookeeperCheck(AgentCheck):
 
         # Outstanding: 0
         _, value = buf.readline().split(':')
-        # Fixme: This metric name is wrong. It should be removed in a major version of the agent
-        # See https://github.com/DataDog/dd-agent/issues/1383
-        metrics.append(ZKMetric('zookeeper.bytes_outstanding', long(value.strip())))
         metrics.append(ZKMetric('zookeeper.outstanding_requests', long(value.strip())))
 
         # Zxid: 0x1034799c7


### PR DESCRIPTION
Deprecated in https://github.com/DataDog/dd-agent/pull/1443/files during Agent v5. Now that the Agent is on v6 this can be removed. Or possibly by bumping the zookeeper check version to 2.x... I'm not sure how you're handling versioning now that checks are separate from the agent.

Further background in https://github.com/DataDog/dd-agent/issues/1383.