### PR TITLE
[ssh_check] Defaults exception message to string to prevent downstream error with datadog-agent 6.0.0-beta.2

### DIFF
--- a/ssh_check/CHANGELOG.md
+++ b/ssh_check/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - ssh_check
 
+Unreleased
+==========
+
+* If `ssh_check` passes and uses `None` as `exception_message`, downstream aggregator rejects it with a type error. 
+  Instead, specify a default message.
+
 1.1.1 / 2017-08-28
 ==================
 

--- a/ssh_check/check.py
+++ b/ssh_check/check.py
@@ -73,7 +73,7 @@ class CheckSSH(AgentCheck):
             client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         client.load_system_host_keys()
 
-        exception_message = None
+        exception_message = "No errors occured"
         try:
             # Try to connect to check status of SSH
             try:

--- a/ssh_check/manifest.json
+++ b/ssh_check/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.1.1",
+  "version": "1.1.2",
   "guid": "4eb195ef-554f-4cc2-80af-8f286c631fa8",
   "public_title": "Datadog-SSH Check Integration",
   "categories":["network"],


### PR DESCRIPTION
### What does this PR do?

Fixes a type error when running ssh_check with the datadog-beta.

### Motivation

Tried `ssh_check` with the beta.

### Testing Guidelines

Tested manually with datadog 6.0.0-beta.2.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

Possibly caused by change in agent/check code for the beta?
