### PR TITLE
[ci skip] Bumped kafka consumer version

### DIFF
--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - kafka_consumer
 
+1.2.0 / Unreleased
+==================
+
+### Changes
+
+* [FEATURE] Support collection of consumer offsets from Kafka, in addition to ZK. See #654
+
 1.1.0 / 2017-10-10
 ==================
 

--- a/kafka_consumer/README.md
+++ b/kafka_consumer/README.md
@@ -43,7 +43,11 @@ The kafka_consumer check is compatible with all major platforms.
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/kafka_consumer/metadata.csv) for a list of metrics provided by this check.
 
 ### Events
-The Kafka-consumer check does not include any event at this time.
+
+`consumer_lag`:
+
+The Datadog Agent emits an event when the value of the `consumer_lag` metric goes below 0, tagging it with `topic`,
+`partition` and `consumer_group`.
 
 ### Service Checks
 The Kafka-consumer check does not include any service check at this time.

--- a/kafka_consumer/manifest.json
+++ b/kafka_consumer/manifest.json
@@ -10,7 +10,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.1.0",
+  "version": "1.2.0",
   "guid": "74e1ce9c-dee9-4ad5-9b6a-05eeee7f5259",
   "public_title": "Datadog-Kafka Consumer Integration",
   "categories":["processing", "messaging"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

It contains docs and version updates to reflect latest changes to the check.

### Versioning

- [ x] Bumped the version check in `manifest.json`
- [ x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

