### PR TITLE
Jaime/oracledisable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,8 @@ tmp
 
 # Vi(m) stuff
 *.swp
+
+# Rbenv stuff
+.rbenv-gemsets
+.ruby-version
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ env:
     - TRAVIS_FLAVOR=nginx FLAVOR_VERSION=1.11.8
     - TRAVIS_FLAVOR=nginx FLAVOR_VERSION=1.10.2
     - TRAVIS_FLAVOR=openstack
-    - TRAVIS_FLAVOR=oracle FLAVOR_VERSION=latest
+    # - TRAVIS_FLAVOR=oracle FLAVOR_VERSION=latest
     - TRAVIS_FLAVOR=pgbouncer FLAVOR_VERSION=debian-jessie  # pgbouncer-1.5.4
     - TRAVIS_FLAVOR=pgbouncer FLAVOR_VERSION=debian-stretch # pgbouncer-1.7.2
     - TRAVIS_FLAVOR=pgbouncer FLAVOR_VERSION=ubuntu-xenial  # pgbouncer-1.7


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?
Disables oracle from the CI temporarily - `instantclient` download broken due to (yet another) authentication flow.

### Motivation

Broken CI

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning
No versioning changes necessary, CI-only change.

### Additional Notes

Anything else we should know when reviewing?
