### PR TITLE
Couch changelog fix

### DIFF
--- a/couch/CHANGELOG.md
+++ b/couch/CHANGELOG.md
@@ -1,16 +1,11 @@
 # CHANGELOG - couch
 
-2.2.0 / Unreleased
-==================
-### Changes
-
-* [UPDATE] Update auto_conf template to support agent 6 and 5.20+. See [#860][]
-
-2.1.0 / 2017-10-5
+2.1.0 / Unreleased
 =================
 
 ### Changes
 
+* [UPDATE] Update auto_conf template to support agent 6 and 5.20+. See [#860][]
 * [FEATURE] collects Erlang VM stats from the `_system` endpoint. See [#793][] (Thanks [@calonso][])
 
 2.0.0 / 2017-09-01

--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1.0",
   "name": "couch",
   "display_name": "couch",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "support": "core",
   "supported_os": [
     "linux",


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Fixes the couch changelog/manifest
`* [FEATURE] collects Erlang VM stats from the _system endpoint` has not been released yet, current version is still `2.0.0` and the _next_ version is `2.1.0`

### Motivation

Was originally changed (incorrectly) here: https://github.com/DataDog/integrations-core/pull/793
Fixed here: https://github.com/DataDog/integrations-core/pull/865
Changed back by: https://github.com/DataDog/integrations-core/pull/860

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

Anything else we should know when reviewing?
