### PR TITLE
Updating pod.phase Service Check

### DIFF
--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - docker_daemon
 
+1.7.0 / Unreleased
+==================
+### Changes
+
+* [FEATURE] Honor global collect_labels_as_tags if integration's collect_labels_as_tags is empty. See [#881][]
+
 1.6.0 / Unreleased
 ==================
 ### Changes

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -179,10 +179,15 @@ class DockerDaemon(AgentCheck):
             raise Exception("Docker check only supports one configured instance.")
         AgentCheck.__init__(self, name, init_config,
                             agentConfig, instances=instances)
-
         self.init_success = False
         self._service_discovery = agentConfig.get('service_discovery') and \
             agentConfig.get('service_discovery_backend') == 'docker'
+
+        global_labels_as_tags = agentConfig.get('docker_labels_as_tags')
+        if global_labels_as_tags:
+            self.collect_labels_as_tags = [label.strip() for label in global_labels_as_tags.split(',')]
+        else:
+            self.collect_labels_as_tags = DEFAULT_LABELS_AS_TAGS
         self.init()
 
     def init(self):
@@ -215,7 +220,12 @@ class DockerDaemon(AgentCheck):
             self._disable_net_metrics = False
 
             # Set tagging options
-            self.collect_labels_as_tags = instance.get("collect_labels_as_tags", DEFAULT_LABELS_AS_TAGS)
+            # The collect_labels_as_tags is legacy, only tagging docker metrics.
+            # It is replaced by docker_labels_as_tags in datadog.conf.
+            # We keep this line for backward compatibility.
+            if "collect_labels_as_tags" in instance:
+                self.collect_labels_as_tags = instance.get("collect_labels_as_tags")
+
             self.kube_pod_tags = {}
 
             self.use_histogram = _is_affirmative(instance.get('use_histogram', False))

--- a/docker_daemon/conf.yaml.example
+++ b/docker_daemon/conf.yaml.example
@@ -184,7 +184,9 @@ instances:
     #
     # container_tags: ["image_name", "image_tag", "docker_image"]
 
-    # List of container label names that should be collected and sent as tags.
+    # Option to tag docker metrics with container label names listed.
+    # Takes precedence over docker_labels_as_tags for docker metrics.
+    # Only use if you want different labels tagged for autodiscovery and docker_daemon metrics.
     # Default to None
     # Example:
     # collect_labels_as_tags: ["com.docker.compose.service", "com.docker.compose.project"]

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -11,7 +11,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.6.0",
+  "version": "1.7.0",
   "public_title": "Datadog-Docker Integration",
   "categories":["containers"],
   "type":"check",

--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [UPDATE] Update auto_conf template to support agent 6 and 5.20+. See [#860][]
 * [FEATURE] Adding HPA metrics. See [#801][]
 * [FEATURE] Add metrics for GPU, PVC, CronJobs and other added in kubernetes_state 1.1.0. See [#853][]
+* [IMPROVEMENT] Merge kubernetes-state pod.phase.[running|succeeded|pending|failed|unknown] checks into one actionnable check [#874][]
 
 1.3.0 / 2017-08-28
 ==================

--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -4,7 +4,7 @@
 ==================
 ### Changes
 
-* [IMPROVEMENT] Merge kubernetes-state pod.phase.[running|succeeded|pending|failed|unknown] checks into one actionnable check. Will be introduced in 5.20 and will change the behavior of the check. [#874][]
+* [IMPROVEMENT] Merge kubernetes-state pod.phase.[running|succeeded|pending|failed|unknown] service checks into one actionnable service check. Will be introduced in 5.20 and will change the behavior of the service check. [#874][]
 
 1.4.0 / Unreleased
 ==================

--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - kubernetes_state
 
+2.0.0 / Unreleased
+==================
+### Changes
+
+* [IMPROVEMENT] Merge kubernetes-state pod.phase.[running|succeeded|pending|failed|unknown] checks into one actionnable check. Will be introduced in 5.20 and will change the behavior of the check. [#874][]
+
 1.4.0 / Unreleased
 ==================
 ### Changes
@@ -7,7 +13,6 @@
 * [UPDATE] Update auto_conf template to support agent 6 and 5.20+. See [#860][]
 * [FEATURE] Adding HPA metrics. See [#801][]
 * [FEATURE] Add metrics for GPU, PVC, CronJobs and other added in kubernetes_state 1.1.0. See [#853][]
-* [IMPROVEMENT] Merge kubernetes-state pod.phase.[running|succeeded|pending|failed|unknown] checks into one actionnable check [#874][]
 
 1.3.0 / 2017-08-28
 ==================

--- a/kubernetes_state/check.py
+++ b/kubernetes_state/check.py
@@ -223,7 +223,7 @@ class KubernetesState(PrometheusCheck):
         """
         if bool(metric.gauge.value) is False:
             return  # Ignore if gauge is not 1 and we are not processing the pod phase check
-        
+
         label_value, condition_map = self._get_metric_condition_map(base_sc_name, metric.label)
         service_check_name = condition_map['service_check_name']
         mapping = condition_map['mapping']

--- a/kubernetes_state/check.py
+++ b/kubernetes_state/check.py
@@ -221,23 +221,23 @@ class KubernetesState(PrometheusCheck):
         This function evaluates metrics containing conditions and sends a service check
         based on a provided condition->check mapping dict
         """
-        if bool(metric.gauge.value) is True:
-            label_value, condition_map = self._get_metric_condition_map(base_sc_name, metric.label)
-            service_check_name = condition_map['service_check_name']
-            mapping = condition_map['mapping']
-
-            if base_sc_name == 'kubernetes_state.pod.phase':
-                message = "%s is currently reporting %s" % (self._label_to_tag('pod', metric.label), self._label_to_tag('phase', metric.label))
-            else:
-                message = "%s is currently reporting %s" % (self._label_to_tag('node', metric.label), self._label_to_tag('condition', metric.label))
-
-            if condition_map['service_check_name'] is None:
-                self.log.debug("Unable to handle %s - unknown condition %s" % (service_check_name, label_value))
-            else:
-                self.service_check(service_check_name, mapping[label_value], tags=tags, message=message)
-                self.log.debug("%s %s %s" % (service_check_name, mapping[label_value], tags))
-        else:
+        if bool(metric.gauge.value) is False:
             return  # Ignore if gauge is not 1 and we are not processing the pod phase check
+        
+        label_value, condition_map = self._get_metric_condition_map(base_sc_name, metric.label)
+        service_check_name = condition_map['service_check_name']
+        mapping = condition_map['mapping']
+
+        if base_sc_name == 'kubernetes_state.pod.phase':
+            message = "%s is currently reporting %s" % (self._label_to_tag('pod', metric.label), self._label_to_tag('phase', metric.label))
+        else:
+            message = "%s is currently reporting %s" % (self._label_to_tag('node', metric.label), self._label_to_tag('condition', metric.label))
+
+        if condition_map['service_check_name'] is None:
+            self.log.debug("Unable to handle %s - unknown condition %s" % (service_check_name, label_value))
+        else:
+            self.service_check(service_check_name, mapping[label_value], tags=tags, message=message)
+            self.log.debug("%s %s %s" % (service_check_name, mapping[label_value], tags))
 
     def _get_metric_condition_map(self, base_sc_name, labels):
         if base_sc_name == 'kubernetes_state.node':

--- a/kubernetes_state/check.py
+++ b/kubernetes_state/check.py
@@ -25,11 +25,11 @@ class KubernetesState(PrometheusCheck):
         self.NAMESPACE = 'kubernetes_state'
 
         self.pod_phase_to_status = {
-            'pending':   self.WARNING,
-            'running':   self.OK,
-            'succeeded': self.OK,
-            'failed':    self.CRITICAL,
-            'unknown':   self.UNKNOWN
+            'Pending':   self.WARNING,
+            'Running':   self.OK,
+            'Succeeded': self.OK,
+            'Failed':    self.CRITICAL,
+            'Unknown':   self.UNKNOWN
         }
 
         self.condition_to_status_positive = {
@@ -221,27 +221,39 @@ class KubernetesState(PrometheusCheck):
         This function evaluates metrics containing conditions and sends a service check
         based on a provided condition->check mapping dict
         """
-        if bool(metric.gauge.value) is False:
-            return  # Ignore if gauge is not 1
-        label_value, condition_map = self._get_metric_condition_map(base_sc_name, metric.label)
-        service_check_name = condition_map['service_check_name']
-        mapping = condition_map['mapping']
-        if condition_map['service_check_name'] is None:
-            self.log.debug("Unable to handle %s - unknown condition %s" % (service_check_name, label_value))
+        if bool(metric.gauge.value) is True:
+            label_value, condition_map = self._get_metric_condition_map(base_sc_name, metric.label)
+            service_check_name = condition_map['service_check_name']
+            mapping = condition_map['mapping']
+
+            if base_sc_name == 'kubernetes_state.pod.phase':
+                message = "%s is currently reporting %s" % (self._label_to_tag('pod', metric.label), self._label_to_tag('phase', metric.label))
+            else:
+                message = "%s is currently reporting %s" % (self._label_to_tag('node', metric.label), self._label_to_tag('condition', metric.label))
+
+            if condition_map['service_check_name'] is None:
+                self.log.debug("Unable to handle %s - unknown condition %s" % (service_check_name, label_value))
+            else:
+                self.service_check(service_check_name, mapping[label_value], tags=tags, message=message)
+                self.log.debug("%s %s %s" % (service_check_name, mapping[label_value], tags))
         else:
-            self.service_check(service_check_name, mapping[label_value], tags=tags)
-            self.log.debug("%s %s %s" % (service_check_name, mapping[label_value], tags))
+            return  # Ignore if gauge is not 1 and we are not processing the pod phase check
 
     def _get_metric_condition_map(self, base_sc_name, labels):
-        switch = {
-            'Ready': {'service_check_name': base_sc_name + '.ready', 'mapping': self.condition_to_status_positive},
-            'OutOfDisk': {'service_check_name': base_sc_name + '.out_of_disk', 'mapping': self.condition_to_status_negative},
-            'DiskPressure': {'service_check_name': base_sc_name + '.disk_pressure', 'mapping': self.condition_to_status_negative},
-            'NetworkUnavailable': {'service_check_name': base_sc_name + '.network_unavailable', 'mapping': self.condition_to_status_negative},
-            'MemoryPressure': {'service_check_name': base_sc_name + '.memory_pressure', 'mapping': self.condition_to_status_negative}
-        }
-        label_value = self._extract_label_value('status', labels)
-        return label_value, switch.get(self._extract_label_value('condition', labels), {'service_check_name': None, 'mapping': None})
+        if base_sc_name == 'kubernetes_state.node':
+            switch = {
+                'Ready': {'service_check_name': base_sc_name + '.ready', 'mapping': self.condition_to_status_positive},
+                'OutOfDisk': {'service_check_name': base_sc_name + '.out_of_disk', 'mapping': self.condition_to_status_negative},
+                'DiskPressure': {'service_check_name': base_sc_name + '.disk_pressure', 'mapping': self.condition_to_status_negative},
+                'NetworkUnavailable': {'service_check_name': base_sc_name + '.network_unavailable', 'mapping': self.condition_to_status_negative},
+                'MemoryPressure': {'service_check_name': base_sc_name + '.memory_pressure', 'mapping': self.condition_to_status_negative}
+            }
+            label_value = self._extract_label_value('status', labels)
+            return label_value, switch.get(self._extract_label_value('condition', labels), {'service_check_name': None, 'mapping': None})
+
+        elif base_sc_name == 'kubernetes_state.pod.phase':
+            label_value = self._extract_label_value('phase', labels)
+            return label_value, {'service_check_name': base_sc_name, 'mapping': self.pod_phase_to_status}
 
     def _extract_label_value(self, name, labels):
         """
@@ -280,23 +292,17 @@ class KubernetesState(PrometheusCheck):
         pattern = "(-\d{4,10}$)"
         return re.sub(pattern, '', name)
 
-    # Labels attached: namespace, pod, phase=Pending|Running|Succeeded|Failed|Unknown
-    # The phase gets not passed through; rather, it becomes the service check suffix.
+    # Labels attached: namespace, pod
+    # As a message the phase=Pending|Running|Succeeded|Failed|Unknown
+    # From the phase the check will update its status
     def kube_pod_status_phase(self, message, **kwargs):
         """ Phase a pod is in. """
-        check_basename = self.NAMESPACE + '.pod.phase.'
+        # Will submit a service check which status is given by its phase.
+        # More details about the phase in the message of the check.
+        check_basename = self.NAMESPACE + '.pod.phase'
         for metric in message.metric:
-            # The gauge value is always 1, no point in fetching it.
-            phase = ''
-            tags = []
-            for label in metric.label:
-                if label.name == 'phase':
-                    phase = label.value.lower()
-                else:
-                    tags.append(self._format_tag(label.name, label.value))
-            #TODO: add deployment/replicaset?
-            status = self.pod_phase_to_status.get(phase, self.UNKNOWN)
-            self.service_check(check_basename + phase, status, tags=tags)
+            self._condition_to_tag_check(metric, check_basename, self.pod_phase_to_status,
+                                         tags=[self._label_to_tag("pod", metric.label),self._label_to_tag("namespace", metric.label)])
 
     def kube_pod_container_status_waiting_reason(self, message, **kwargs):
         metric_name = self.NAMESPACE + '.container.status_report.count.waiting'

--- a/kubernetes_state/ci/fixtures/prometheus/prometheus.txt
+++ b/kubernetes_state/ci/fixtures/prometheus/prometheus.txt
@@ -547,7 +547,7 @@ kube_pod_status_phase{namespace="default",phase="Running",pod="task-pv-pod"} 1
 kube_pod_status_phase{namespace="default",phase="Succeeded",pod="failingtest-f585bbd4-2fsml"} 0
 kube_pod_status_phase{namespace="default",phase="Succeeded",pod="hello-1509998340-k4f8q"} 1
 kube_pod_status_phase{namespace="default",phase="Succeeded",pod="hello-1509998400-rb8bs"} 1
-kube_pod_status_phase{namespace="default",phase="Succeeded",pod="hello-1509998460-tzh8k"} 1
+kube_pod_status_phase{namespace="default",phase="Succeeded",pod="hello-1509998460-tzh8k"} 0
 kube_pod_status_phase{namespace="default",phase="Succeeded",pod="jaundiced-numbat-dd-k8state-b6s77"} 0
 kube_pod_status_phase{namespace="default",phase="Succeeded",pod="jaundiced-numbat-kube-state-metrics-b7fbc487d-4phhj"} 0
 kube_pod_status_phase{namespace="default",phase="Succeeded",pod="nxf-126"} 0
@@ -556,7 +556,7 @@ kube_pod_status_phase{namespace="default",phase="Succeeded",pod="task-pv-pod"} 0
 kube_pod_status_phase{namespace="default",phase="Unknown",pod="failingtest-f585bbd4-2fsml"} 0
 kube_pod_status_phase{namespace="default",phase="Unknown",pod="hello-1509998340-k4f8q"} 0
 kube_pod_status_phase{namespace="default",phase="Unknown",pod="hello-1509998400-rb8bs"} 0
-kube_pod_status_phase{namespace="default",phase="Unknown",pod="hello-1509998460-tzh8k"} 0
+kube_pod_status_phase{namespace="default",phase="Unknown",pod="hello-1509998460-tzh8k"} 1
 kube_pod_status_phase{namespace="default",phase="Unknown",pod="jaundiced-numbat-dd-k8state-b6s77"} 0
 kube_pod_status_phase{namespace="default",phase="Unknown",pod="jaundiced-numbat-kube-state-metrics-b7fbc487d-4phhj"} 0
 kube_pod_status_phase{namespace="default",phase="Unknown",pod="nxf-126"} 0

--- a/kubernetes_state/manifest.json
+++ b/kubernetes_state/manifest.json
@@ -11,7 +11,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.4.0",
+  "version": "2.0.0",
   "use_omnibus_reqs": true,
   "public_title": "Datadog-Kubernetes State Integration",
   "categories":["orchestration", "containers"],

--- a/kubernetes_state/test_kubernetes_state.py
+++ b/kubernetes_state/test_kubernetes_state.py
@@ -10,6 +10,7 @@ import os
 from tests.checks.common import AgentCheckTest
 
 NAMESPACE = 'kubernetes_state'
+
 class TestKubernetesState(AgentCheckTest):
 
     CHECK_NAME = 'kubernetes_state'
@@ -102,11 +103,11 @@ class TestKubernetesState(AgentCheckTest):
         self.assertServiceCheck(NAMESPACE + '.node.memory_pressure', self.check.OK)
         self.assertServiceCheck(NAMESPACE + '.node.network_unavailable', self.check.OK)
         self.assertServiceCheck(NAMESPACE + '.node.disk_pressure', self.check.OK)
-        self.assertServiceCheck(NAMESPACE + '.pod.phase.running', self.check.OK)
-        self.assertServiceCheck(NAMESPACE + '.pod.phase.pending', self.check.WARNING)
-        self.assertServiceCheck(NAMESPACE + '.pod.phase.succeeded', self.check.OK)
-        self.assertServiceCheck(NAMESPACE + '.pod.phase.failed', self.check.CRITICAL)
-        self.assertServiceCheck(NAMESPACE + '.pod.phase.unknown', self.check.UNKNOWN)
+        self.assertServiceCheck(NAMESPACE + '.pod.phase', self.check.OK,tags=['namespace:default','pod:task-pv-pod']) # Running
+        self.assertServiceCheck(NAMESPACE + '.pod.phase', self.check.WARNING,tags=['namespace:default','pod:failingtest-f585bbd4-2fsml']) # Pending
+        self.assertServiceCheck(NAMESPACE + '.pod.phase', self.check.OK,tags=['namespace:default','pod:hello-1509998340-k4f8q']) # Succeeded
+        self.assertServiceCheck(NAMESPACE + '.pod.phase', self.check.CRITICAL,tags=['namespace:default','pod:should-run-once']) # Failed
+        self.assertServiceCheck(NAMESPACE + '.pod.phase', self.check.UNKNOWN,tags=['namespace:default','pod:hello-1509998460-tzh8k']) # Unknown
 
         for metric in self.METRICS:
             self.assertMetric(metric)
@@ -132,8 +133,6 @@ class TestKubernetesState(AgentCheckTest):
 
         self.assertServiceCheck(NAMESPACE + '.node.ready', self.check.OK)
         self.assertServiceCheck(NAMESPACE + '.node.out_of_disk', self.check.OK)
-        self.assertServiceCheck(NAMESPACE + '.pod.phase.running', self.check.OK)
-        self.assertServiceCheck(NAMESPACE + '.pod.phase.pending', self.check.WARNING)
 
 
         for metric in self.METRICS:


### PR DESCRIPTION
### What does this PR do?

The kubernetes_state.pod.phase check was not easily actionable.
This is a revamp to have a service check that is more actionable.

Before:
![a06ed8ae4477f61f75374498490baad5 _image 202017-11-15 20at 207 01 42 20pm](https://user-images.githubusercontent.com/7433560/32852200-81d40a64-ca37-11e7-96f7-d0b4ee442b23.png)

Now:
![image 2017-11-15 at 6 53 58 pm](https://user-images.githubusercontent.com/7433560/32852128-56f11e7c-ca37-11e7-8322-97e712235568.png)

As you can see, the phase.failed would be associate the state to the status - i.e. as the pod reported a failed check (not necessarily reporting that it's failing) the status would be critical and so on and so forth for pending etc.
The new version aggregates all the checks in 1 and leverages the tags to specify the phase.
The status equivalence goes as follows:
```
        self.pod_phase_to_status = {
            'Pending':   self.WARNING,
            'Running':   self.OK,
            'Succeeded': self.OK,
            'Failed':    self.CRITICAL,
            'Unknown':   self.UNKNOWN
        }
```
### Motivation

Improve the usage of our Service Checks.

### Testing Guidelines

Testing locally using:
```
        self.assertServiceCheck(NAMESPACE + '.pod.phase', self.check.OK,tags=['namespace:default','phase:Running','pod:task-pv-pod'])
        self.assertServiceCheck(NAMESPACE + '.pod.phase', self.check.WARNING,tags=['namespace:default','phase:Pending','pod:failingtest-f585bbd4-2fsml'])
        self.assertServiceCheck(NAMESPACE + '.pod.phase', self.check.OK,tags=['namespace:default','phase:Succeeded','pod:nxf-126'])
        self.assertServiceCheck(NAMESPACE + '.pod.phase', self.check.CRITICAL,tags=['namespace:default','phase:Failed','pod:should-run-once'])
        self.assertServiceCheck(NAMESPACE + '.pod.phase', self.check.UNKNOWN,tags=['namespace:default','phase:Unknown','pod:hello-1509998460-tzh8k'])
```
Against the prometheus.txt output.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes


