### PR TITLE
Do not report default mem soft limit

### DIFF
--- a/docker_daemon/test_docker_daemon.py
+++ b/docker_daemon/test_docker_daemon.py
@@ -853,7 +853,9 @@ class TestCheckDockerDaemon(AgentCheckTest):
                 return {'user': 1000 * self.run, 'system': 1000 * self.run}
                 self.run += 1
             elif 'memory.soft_limit_in_bytes' in stat_file:
-                return dict({'softlimit': int(fp.read())})
+                    value = int(fp.read())
+                    if value < 2 ** 60:
+                        return dict({'softlimit': value})
             else:
                 return dict(map(lambda x: x.split(' ', 1), fp.read().splitlines()))
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Do not report kernel max default value (uint64 * 4096) for `memory.soft_limit_in_bytes`

### Additional Notes

See https://github.com/torvalds/linux/blob/5b36577109be007a6ecf4b65b54cbc9118463c2b/mm/memcontrol.c#L2844-L2845
