### PR TITLE
Collect_labels_as_tags as an environment variable

### DIFF
--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - docker_daemon
 
+1.7.0 / Unreleased
+==================
+### Changes
+
+* [FEATURE] Honor global collect_labels_as_tags if integration's collect_labels_as_tags is empty. See [#881][]
+
 1.6.0 / Unreleased
 ==================
 ### Changes
@@ -7,7 +13,6 @@
 * [IMPROVEMENT] Add custom tags to all service checks. See [#782][]
 * [IMPROVEMENT] Add docker memory soft limit metric. See [#760][]
 * [IMPROVEMENT] Add docker.containers.running.total & docker.containers.stopped.total metrics. See [#859][]
-* [FEATURE] Honor global collect_labels_as_tags if integration's collect_labels_as_tags is empty. See [#881][]
 
 1.5.1 / 2017-11-08
 ==================

--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [IMPROVEMENT] Add custom tags to all service checks. See [#782][]
 * [IMPROVEMENT] Add docker memory soft limit metric. See [#760][]
 * [IMPROVEMENT] Add docker.containers.running.total & docker.containers.stopped.total metrics. See [#859][]
-* [FEATURE] Add COLLECT_LABELS_AS_TAGS as an environment variable. See [#881][]
+* [FEATURE] Honor global collect_labels_as_tags if integration's collect_labels_as_tags is empty. See [#881][]
 
 1.5.1 / 2017-11-08
 ==================

--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [IMPROVEMENT] Add custom tags to all service checks. See [#782][]
 * [IMPROVEMENT] Add docker memory soft limit metric. See [#760][]
 * [IMPROVEMENT] Add docker.containers.running.total & docker.containers.stopped.total metrics. See [#859][]
+* [FEATURE] Add COLLECT_LABELS_AS_TAGS as an environment variable. See [#881][]
 
 1.5.1 / 2017-11-08
 ==================

--- a/docker_daemon/README.md
+++ b/docker_daemon/README.md
@@ -53,6 +53,7 @@ Note that in the command above, you are able to pass your API key to the Datadog
 | NON_LOCAL_TRAFFIC | Enabling this feature will allow statsd reporting from any external IP. For example, `-e NON_LOCAL_TRAFFIC=yes`. This can be used to report metrics from other containers or systems. See [network configuration](https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration) for more details.
 | PROXY_HOST, PROXY_PORT, PROXY_USER, PROXY_PASSWORD | Sets proxy configuration details. For more information, see the [Agent proxy documentation](https://github.com/DataDog/dd-agent/wiki/Proxy-Configuration#using-a-web-proxy-as-proxy) |
 | SD_BACKEND, SD_CONFIG_BACKEND, SD_BACKEND_HOST, SD_BACKEND_PORT, SD_TEMPLATE_DIR, SD_CONSUL_TOKEN | Enables and configures Autodiscovery. For more information, please see the [Autodiscovery guide](/guides/autodiscovery/). |
+| COLLECT_LABELS_AS_TAGS | Enables the collection of the listed labels as tags. Comma separated string, without spaces unless in quotes. Exemple: `-e COLLECT_LABELS_AS_TAGS='com.docker.label.foo, com.docker.label.bar'` or `-e COLLECT_LABELS_AS_TAGS=com.docker.label.foo,com.docker.label.bar`. |
 
 #### Running the agent container on Amazon Linux
 

--- a/docker_daemon/README.md
+++ b/docker_daemon/README.md
@@ -53,7 +53,6 @@ Note that in the command above, you are able to pass your API key to the Datadog
 | NON_LOCAL_TRAFFIC | Enabling this feature will allow statsd reporting from any external IP. For example, `-e NON_LOCAL_TRAFFIC=yes`. This can be used to report metrics from other containers or systems. See [network configuration](https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration) for more details.
 | PROXY_HOST, PROXY_PORT, PROXY_USER, PROXY_PASSWORD | Sets proxy configuration details. For more information, see the [Agent proxy documentation](https://github.com/DataDog/dd-agent/wiki/Proxy-Configuration#using-a-web-proxy-as-proxy) |
 | SD_BACKEND, SD_CONFIG_BACKEND, SD_BACKEND_HOST, SD_BACKEND_PORT, SD_TEMPLATE_DIR, SD_CONSUL_TOKEN | Enables and configures Autodiscovery. For more information, please see the [Autodiscovery guide](/guides/autodiscovery/). |
-| COLLECT_LABELS_AS_TAGS | Enables the collection of the listed labels as tags. Comma separated string, without spaces unless in quotes. Exemple: `-e COLLECT_LABELS_AS_TAGS='com.docker.label.foo, com.docker.label.bar'` or `-e COLLECT_LABELS_AS_TAGS=com.docker.label.foo,com.docker.label.bar`. |
 
 #### Running the agent container on Amazon Linux
 

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -183,9 +183,9 @@ class DockerDaemon(AgentCheck):
         self._service_discovery = agentConfig.get('service_discovery') and \
             agentConfig.get('service_discovery_backend') == 'docker'
 
-        self.global_labels_as_tags = agentConfig.get('docker_labels_as_tags')
-        if self.global_labels_as_tags:
-            self.collect_labels_as_tags = [label.strip() for label in self.global_labels_as_tags.split(',')]
+        global_labels_as_tags = agentConfig.get('docker_labels_as_tags')
+        if global_labels_as_tags:
+            self.collect_labels_as_tags = [label.strip() for label in global_labels_as_tags.split(',')]
         else:
             self.collect_labels_as_tags = DEFAULT_LABELS_AS_TAGS
         self.init()

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -183,11 +183,11 @@ class DockerDaemon(AgentCheck):
         self._service_discovery = agentConfig.get('service_discovery') and \
             agentConfig.get('service_discovery_backend') == 'docker'
 
-        self.collect_labels_as_tags = agentConfig.get('docker_labels_as_tags', ','.join(DEFAULT_LABELS_AS_TAGS))
-        if self.collect_labels_as_tags:
-            self.collect_labels_as_tags = [label.strip() for label in self.collect_labels_as_tags.split(',')]
+        self.global_labels_as_tags = agentConfig.get('docker_labels_as_tags')
+        if self.global_labels_as_tags:
+            self.collect_labels_as_tags = [label.strip() for label in self.global_labels_as_tags.split(',')]
         else:
-            self.collect_labels_as_tags = []
+            self.collect_labels_as_tags = DEFAULT_LABELS_AS_TAGS
         self.init()
 
     def init(self):
@@ -224,7 +224,7 @@ class DockerDaemon(AgentCheck):
             # It is replaced by docker_labels_as_tags in datadog.conf.
             # We keep this line for backward compatibility.
             if "collect_labels_as_tags" in instance:
-                self.collect_labels_as_tags = instance.get("collect_labels_as_tags", DEFAULT_LABELS_AS_TAGS)
+                self.collect_labels_as_tags = instance.get("collect_labels_as_tags")
 
             self.kube_pod_tags = {}
 

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -125,9 +125,7 @@ DEFAULT_IMAGE_TAGS = [
     'image_tag'
 ]
 
-DEFAULT_LABELS_AS_TAGS = [
-    SWARM_SVC_LABEL
-]
+DEFAULT_LABELS_AS_TAGS = SWARM_SVC_LABEL
 
 
 TAG_EXTRACTORS = {
@@ -215,7 +213,7 @@ class DockerDaemon(AgentCheck):
             self._disable_net_metrics = False
 
             # Set tagging options
-            self.collect_labels_as_tags = instance.get("collect_labels_as_tags", DEFAULT_LABELS_AS_TAGS)
+            self.collect_labels_as_tags = instance.get("collect_labels_as_tags", DEFAULT_LABELS_AS_TAGS).split(',')
             self.kube_pod_tags = {}
 
             self.use_histogram = _is_affirmative(instance.get('use_histogram', False))

--- a/docker_daemon/conf.yaml.example
+++ b/docker_daemon/conf.yaml.example
@@ -184,10 +184,10 @@ instances:
     #
     # container_tags: ["image_name", "image_tag", "docker_image"]
 
-    # List of container label names that should be collected and sent as tags.
+    # Container label names that should be collected and sent as tags.
     # Default to None
     # Example:
-    # collect_labels_as_tags: ["com.docker.compose.service", "com.docker.compose.project"]
+    # collect_labels_as_tags: com.docker.compose.service, com.docker.compose.project
     # List of docker event attributes to add as tags of the datadog events
     # Defaults to None.
     #

--- a/docker_daemon/conf.yaml.example
+++ b/docker_daemon/conf.yaml.example
@@ -186,7 +186,7 @@ instances:
 
     # Option to tag docker metrics with container label names listed.
     # Takes precedence over docker_labels_as_tags for docker metrics.
-    # Only use docker_labels_as_tags in datadog.conf to tag metrics from the autodiscovery and docker with labels listed.
+    # Only use if you want different labels tagged for autodiscovery and docker_daemon metrics.
     # Default to None
     # Example:
     # collect_labels_as_tags: ["com.docker.compose.service", "com.docker.compose.project"]

--- a/docker_daemon/conf.yaml.example
+++ b/docker_daemon/conf.yaml.example
@@ -184,10 +184,11 @@ instances:
     #
     # container_tags: ["image_name", "image_tag", "docker_image"]
 
-    # Container label names that should be collected and sent as tags.
+    # Legacy option for container label names that should be collected and sent as tags.
+    # Only affects docker metrics. Please use docker_labels_as_tags in datadog.conf for # AD metrics tagging as well.
     # Default to None
     # Example:
-    # collect_labels_as_tags: com.docker.compose.service, com.docker.compose.project
+    # collect_labels_as_tags: ["com.docker.compose.service", "com.docker.compose.project"]
     # List of docker event attributes to add as tags of the datadog events
     # Defaults to None.
     #

--- a/docker_daemon/conf.yaml.example
+++ b/docker_daemon/conf.yaml.example
@@ -184,8 +184,9 @@ instances:
     #
     # container_tags: ["image_name", "image_tag", "docker_image"]
 
-    # Legacy option for container label names that should be collected and sent as tags.
-    # Only affects docker metrics. Please use docker_labels_as_tags in datadog.conf for # AD metrics tagging as well.
+    # Option to tag docker metrics with container label names listed.
+    # Takes precedence over docker_labels_as_tags for docker metrics.
+    # Only use docker_labels_as_tags in datadog.conf to tag metrics from the autodiscovery and docker with labels listed.
     # Default to None
     # Example:
     # collect_labels_as_tags: ["com.docker.compose.service", "com.docker.compose.project"]

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -11,7 +11,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.6.0",
+  "version": "1.7.0",
   "public_title": "Datadog-Docker Integration",
   "categories":["containers"],
   "type":"check",

--- a/docker_daemon/test_docker_daemon.py
+++ b/docker_daemon/test_docker_daemon.py
@@ -13,6 +13,7 @@ from nose.plugins.attrib import attr
 # project
 from checks import AgentCheck
 from tests.checks.common import AgentCheckTest
+from tests.checks.common import load_check
 from utils.dockerutil import DockerUtil
 
 log = logging.getLogger('tests')
@@ -582,7 +583,7 @@ class TestCheckDockerDaemon(AgentCheckTest):
             "init_config": {},
             "instances": [{
                 "url": "unix://var/run/docker.sock",
-                "collect_labels_as_tags": 'label1',
+                "collect_labels_as_tags": ["label1"],
                 "collect_image_size": True,
                 "collect_images_stats": True,
                 "collect_container_count": True,
@@ -597,6 +598,43 @@ class TestCheckDockerDaemon(AgentCheckTest):
         DockerUtil(init_config=config['init_config'], instance=config['instances'][0])
 
         self.run_check(config, force_reload=True)
+        for mname, tags in expected_metrics:
+            self.assertMetric(mname, tags=tags, count=1, at_least=1)
+
+    def test_collect_labels_as_tags(self):
+        expected_metrics = [
+            ('docker.containers.stopped.total', None),
+            ('docker.containers.running.total', None),
+            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
+            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx']),
+            ('docker.mem.rss', ['container_name:test-new-nginx-latest', 'docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx']),
+            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
+            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx']),
+            ('docker.mem.rss', ['container_name:test-new-redis-latest', 'docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
+            ('docker.mem.limit', ['container_name:test-new-nginx-latest', 'docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx']),
+            ('docker.mem.cache', ['container_name:test-new-nginx-latest', 'docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx']),
+            ('docker.mem.cache', ['container_name:test-new-redis-latest', 'docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
+            ('docker.mem.in_use', ['container_name:test-new-nginx-latest', 'docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx']),
+            ]
+
+        config = {
+            "init_config": {},
+            "instances": [{
+                "url": "unix://var/run/docker.sock",
+            },
+            ],
+        }
+
+        DockerUtil._drop()
+        DockerUtil(init_config=config['init_config'], instance=config['instances'][0])
+
+        self.agentConfig = {
+            'docker_labels_as_tags': 'label1'
+        }
+        self.check = load_check('docker_daemon', config, self.agentConfig)
+
+        self.check.check(config)
+        self.metrics = self.check.get_metrics()
         for mname, tags in expected_metrics:
             self.assertMetric(mname, tags=tags, count=1, at_least=1)
 

--- a/docker_daemon/test_docker_daemon.py
+++ b/docker_daemon/test_docker_daemon.py
@@ -582,7 +582,7 @@ class TestCheckDockerDaemon(AgentCheckTest):
             "init_config": {},
             "instances": [{
                 "url": "unix://var/run/docker.sock",
-                "collect_labels_as_tags": ["label1"],
+                "collect_labels_as_tags": 'label1',
                 "collect_image_size": True,
                 "collect_images_stats": True,
                 "collect_container_count": True,

--- a/docker_daemon/test_docker_daemon.py
+++ b/docker_daemon/test_docker_daemon.py
@@ -615,7 +615,7 @@ class TestCheckDockerDaemon(AgentCheckTest):
             ('docker.mem.cache', ['container_name:test-new-nginx-latest', 'docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx']),
             ('docker.mem.cache', ['container_name:test-new-redis-latest', 'docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
             ('docker.mem.in_use', ['container_name:test-new-nginx-latest', 'docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx']),
-            ]
+        ]
 
         config = {
             "init_config": {},


### PR DESCRIPTION
### What does this PR do?

Modify the docker check to unify the label collection (with [docker_labels_as_tags](https://github.com/DataDog/dd-agent/blob/master/datadog.conf.example#L156)).
Using a string in the yaml to also allow easier parsing from the environment variable

### Motivation

Requested by the community.

### Testing Guidelines

Successfully tested locally.
- [ ] Create a Backported image

### Versioning

~- [ ] Bumped the version check in `manifest.json`~
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.