### PR TITLE
moves aspdotnet and dotnet clr metrics to their own checks

### DIFF
--- a/aspdotnet/CHANGELOG.md
+++ b/aspdotnet/CHANGELOG.md
@@ -1,0 +1,8 @@
+# CHANGELOG - Aspdotnet
+
+0.1.0/ Unreleased
+==================
+
+### Changes
+
+* [FEATURE] adds aspdotnet integration.

--- a/aspdotnet/README.md
+++ b/aspdotnet/README.md
@@ -1,0 +1,32 @@
+# Aspdotnet Integration
+
+## Overview
+
+Get metrics from aspdotnet service in real time to:
+
+* Visualize and monitor aspdotnet states
+* Be notified about aspdotnet failovers and events.
+
+## Installation
+
+Install the `dd-check-aspdotnet` package manually or with your favorite configuration manager
+
+## Configuration
+
+Edit the `aspdotnet.yaml` file to point to your server and port, set the masters to monitor
+
+## Validation
+
+When you run `datadog-agent info` you should see something like the following:
+
+    Checks
+    ======
+
+        aspdotnet
+        -----------
+          - instance #0 [OK]
+          - Collected 39 metrics, 0 events & 7 service checks
+
+## Compatibility
+
+The aspdotnet check is compatible with all major platforms

--- a/aspdotnet/check.py
+++ b/aspdotnet/check.py
@@ -1,0 +1,35 @@
+# (C) Datadog, Inc. 2013-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# datadog
+try:
+    from checks.libs.win.pdhbasecheck import PDHBaseCheck
+except ImportError:
+    class PDHBaseCheck(*args, **kwargs):
+        return
+
+EVENT_TYPE = SOURCE_TYPE_NAME = 'aspdotnet'
+
+
+DEFAULT_COUNTERS = [
+    # counterset, instance of counter, counter name, metric name
+    # This set is from the Microsoft recommended counters to monitor exchange:
+    # https://technet.microsoft.com/en-us/library/dn904093%28v=exchg.150%29.aspx?f=255&MSPPError=-2147217396
+
+    # ASP.Net
+    ["ASP.NET",              None, "Application Restarts",          "aspdotnet.application_restarts",    "gauge"],
+    ["ASP.NET",              None, "Worker Process Restarts",       "aspdotnet.worker_process_restarts", "gauge"],
+    ["ASP.NET",              None, "Request Wait Time",             "aspdotnet.request.wait_time",       "gauge"],
+
+    # ASP.Net Applications
+    ["ASP.NET Applications", None, "Requests In Application Queue", "aspdotnet.applications.requests.in_queue",       "gauge"],
+    ["ASP.NET Applications", None, "Requests Executing",            "aspdotnet.applications.requests.executing",      "gauge"],
+    ["ASP.NET Applications", None, "Requests/Sec",                  "aspdotnet.applications.requests.persec",         "gauge"],
+    ["ASP.NET Applications", None, "Forms Authentication Failure", "aspdotnet.applications.forms_authentication.failure",       "gauge"],
+    ["ASP.NET Applications", None, "Forms Authentication Successes", "aspdotnet.applications.forms_authentication.successes",       "gauge"],
+]
+
+class AspdotnetCheck(PDHBaseCheck):
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        PDHBaseCheck.__init__(self, name, init_config, agentConfig, instances=instances, counter_list=DEFAULT_COUNTERS)

--- a/aspdotnet/check.py
+++ b/aspdotnet/check.py
@@ -6,7 +6,7 @@
 try:
     from checks.libs.win.pdhbasecheck import PDHBaseCheck
 except ImportError:
-    class PDHBaseCheck(*args, **kwargs):
+    def PDHBaseCheck(*args, **kwargs):
         return
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'aspdotnet'

--- a/aspdotnet/ci/aspdotnet.rake
+++ b/aspdotnet/ci/aspdotnet.rake
@@ -1,0 +1,65 @@
+require 'ci/common'
+
+def aspdotnet_version
+  ENV['FLAVOR_VERSION'] || 'latest'
+end
+
+def aspdotnet_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/aspdotnet_#{aspdotnet_version}"
+end
+
+namespace :ci do
+  namespace :aspdotnet do |flavor|
+    task before_install: ['ci:common:before_install']
+
+    task :install do
+      Rake::Task['ci:common:install'].invoke('aspdotnet')
+      # sample docker usage
+      # sh %(docker create -p XXX:YYY --name aspdotnet source/aspdotnet:aspdotnet_version)
+      # sh %(docker start aspdotnet)
+    end
+
+    task before_script: ['ci:common:before_script']
+
+    task script: ['ci:common:script'] do
+      this_provides = [
+        'aspdotnet'
+      ]
+      Rake::Task['ci:common:run_tests'].invoke(this_provides)
+    end
+
+    task before_cache: ['ci:common:before_cache']
+
+    task cleanup: ['ci:common:cleanup']
+    # sample cleanup task
+    # task cleanup: ['ci:common:cleanup'] do
+    #   sh %(docker stop aspdotnet)
+    #   sh %(docker rm aspdotnet)
+    # end
+
+    task :execute do
+      exception = nil
+      begin
+        %w[before_install install before_script].each do |u|
+          Rake::Task["#{flavor.scope.path}:#{u}"].invoke
+        end
+        if !ENV['SKIP_TEST']
+          Rake::Task["#{flavor.scope.path}:script"].invoke
+        else
+          puts 'Skipping tests'.yellow
+        end
+        Rake::Task["#{flavor.scope.path}:before_cache"].invoke
+      rescue => e
+        exception = e
+        puts "Failed task: #{e.class} #{e.message}".red
+      end
+      if ENV['SKIP_CLEANUP']
+        puts 'Skipping cleanup, disposable environments are great'.yellow
+      else
+        puts 'Cleaning up'
+        Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      raise exception if exception
+    end
+  end
+end

--- a/aspdotnet/conf.yaml.example
+++ b/aspdotnet/conf.yaml.example
@@ -1,0 +1,11 @@
+init_config:
+  # Any global configurable parameters should be added here
+
+instances:
+  #   A typical instance configuration might include a hostname and port
+  #   a set of customizable tags and other parameters we might need to
+  #   configure the behavior of our check.
+  #
+  # - host: localhost
+  #   port: 26379
+  #   tags: ['custom:tag']

--- a/aspdotnet/manifest.json
+++ b/aspdotnet/manifest.json
@@ -2,11 +2,11 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.0",
   "max_agent_version": "6.0.0",
-  "min_agent_version": "5.6.3",
+  "min_agent_version": "5.20.0",
   "name": "aspdotnet",
   "short_description": "aspdotnet description.",
   "guid": "475b0c6c-02e5-49ef-806b-9fab377f0839",
   "support": "contrib",
-  "supported_os": ["linux","mac_os","windows"],
+  "supported_os": ["windows"],
   "version": "0.1.0"
 }

--- a/aspdotnet/manifest.json
+++ b/aspdotnet/manifest.json
@@ -1,0 +1,12 @@
+{
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "0.1.0",
+  "max_agent_version": "6.0.0",
+  "min_agent_version": "5.6.3",
+  "name": "aspdotnet",
+  "short_description": "aspdotnet description.",
+  "guid": "475b0c6c-02e5-49ef-806b-9fab377f0839",
+  "support": "contrib",
+  "supported_os": ["linux","mac_os","windows"],
+  "version": "0.1.0"
+}

--- a/aspdotnet/metadata.csv
+++ b/aspdotnet/metadata.csv
@@ -1,0 +1,1 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name

--- a/aspdotnet/requirements.txt
+++ b/aspdotnet/requirements.txt
@@ -1,0 +1,1 @@
+# integration pip requirements

--- a/aspdotnet/test_aspdotnet.py
+++ b/aspdotnet/test_aspdotnet.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+from nose.plugins.attrib import attr
+
+# 3p
+
+# project
+from tests.checks.common import AgentCheckTest
+
+
+instance = {
+    'host': 'localhost',
+    'port': 26379,
+    'password': 'datadog-is-devops-best-friend'
+}
+
+
+# NOTE: Feel free to declare multiple test classes if needed
+
+@attr(requires='aspdotnet')
+class TestAspdotnet(AgentCheckTest):
+    """Basic Test for aspdotnet integration."""
+    CHECK_NAME = 'aspdotnet'
+
+    def test_check(self):
+        """
+        Testing Aspdotnet check.
+        """
+        self.load_check({}, {})
+
+        # run your actual tests...
+
+        self.assertTrue(True)
+        # Raises when COVERAGE=true and coverage < 100%
+        self.coverage_report()

--- a/dotnetclr/CHANGELOG.md
+++ b/dotnetclr/CHANGELOG.md
@@ -1,0 +1,8 @@
+# CHANGELOG - Dotnetclr
+
+0.1.0/ Unreleased
+==================
+
+### Changes
+
+* [FEATURE] adds dotnetclr integration.

--- a/dotnetclr/README.md
+++ b/dotnetclr/README.md
@@ -1,0 +1,32 @@
+# Dotnetclr Integration
+
+## Overview
+
+Get metrics from dotnetclr service in real time to:
+
+* Visualize and monitor dotnetclr states
+* Be notified about dotnetclr failovers and events.
+
+## Installation
+
+Install the `dd-check-dotnetclr` package manually or with your favorite configuration manager
+
+## Configuration
+
+Edit the `dotnetclr.yaml` file to point to your server and port, set the masters to monitor
+
+## Validation
+
+When you run `datadog-agent info` you should see something like the following:
+
+    Checks
+    ======
+
+        dotnetclr
+        -----------
+          - instance #0 [OK]
+          - Collected 39 metrics, 0 events & 7 service checks
+
+## Compatibility
+
+The dotnetclr check is compatible with all major platforms

--- a/dotnetclr/check.py
+++ b/dotnetclr/check.py
@@ -1,0 +1,30 @@
+# (C) Datadog, Inc. 2013-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# datadog
+try:
+    from checks.libs.win.pdhbasecheck import PDHBaseCheck
+except ImportError:
+    class PDHBaseCheck(*args, **kwargs):
+        return
+
+EVENT_TYPE = SOURCE_TYPE_NAME = 'dotnetclr'
+
+DEFAULT_COUNTERS = [
+    # counterset, instance of counter, counter name, metric name
+    # This set is from the Microsoft recommended counters to monitor exchange:
+    # https://technet.microsoft.com/en-us/library/dn904093%28v=exchg.150%29.aspx?f=255&MSPPError=-2147217396
+
+    # .NET Exceptions counters
+    [".NET CLR Exceptions", None, "# of Exceps Thrown / sec", "dotnetclr.exceptions.thrown_persec", "gauge"],
+
+    # .NET Framework counters
+    [".NET CLR Memory",     None, "% Time in GC",             "dotnetclr.memory.time_in_gc",           "gauge"],
+    [".NET CLR Memory",     None, "# Total committed Bytes",     "dotnetclr.memory.heap_bytes",        "gauge"],
+    [".NET CLR Memory",     None, "# Total reserved Bytes",     "dotnetclr.memory.heap_bytes",        "gauge"],
+]
+
+class DotnetclrCheck(PDHBaseCheck):
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        PDHBaseCheck.__init__(self, name, init_config, agentConfig, instances=instances, counter_list=DEFAULT_COUNTERS)

--- a/dotnetclr/check.py
+++ b/dotnetclr/check.py
@@ -6,7 +6,7 @@
 try:
     from checks.libs.win.pdhbasecheck import PDHBaseCheck
 except ImportError:
-    class PDHBaseCheck(*args, **kwargs):
+    def PDHBaseCheck(*args, **kwargs):
         return
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'dotnetclr'

--- a/dotnetclr/ci/dotnetclr.rake
+++ b/dotnetclr/ci/dotnetclr.rake
@@ -1,0 +1,65 @@
+require 'ci/common'
+
+def dotnetclr_version
+  ENV['FLAVOR_VERSION'] || 'latest'
+end
+
+def dotnetclr_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/dotnetclr_#{dotnetclr_version}"
+end
+
+namespace :ci do
+  namespace :dotnetclr do |flavor|
+    task before_install: ['ci:common:before_install']
+
+    task :install do
+      Rake::Task['ci:common:install'].invoke('dotnetclr')
+      # sample docker usage
+      # sh %(docker create -p XXX:YYY --name dotnetclr source/dotnetclr:dotnetclr_version)
+      # sh %(docker start dotnetclr)
+    end
+
+    task before_script: ['ci:common:before_script']
+
+    task script: ['ci:common:script'] do
+      this_provides = [
+        'dotnetclr'
+      ]
+      Rake::Task['ci:common:run_tests'].invoke(this_provides)
+    end
+
+    task before_cache: ['ci:common:before_cache']
+
+    task cleanup: ['ci:common:cleanup']
+    # sample cleanup task
+    # task cleanup: ['ci:common:cleanup'] do
+    #   sh %(docker stop dotnetclr)
+    #   sh %(docker rm dotnetclr)
+    # end
+
+    task :execute do
+      exception = nil
+      begin
+        %w[before_install install before_script].each do |u|
+          Rake::Task["#{flavor.scope.path}:#{u}"].invoke
+        end
+        if !ENV['SKIP_TEST']
+          Rake::Task["#{flavor.scope.path}:script"].invoke
+        else
+          puts 'Skipping tests'.yellow
+        end
+        Rake::Task["#{flavor.scope.path}:before_cache"].invoke
+      rescue => e
+        exception = e
+        puts "Failed task: #{e.class} #{e.message}".red
+      end
+      if ENV['SKIP_CLEANUP']
+        puts 'Skipping cleanup, disposable environments are great'.yellow
+      else
+        puts 'Cleaning up'
+        Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      raise exception if exception
+    end
+  end
+end

--- a/dotnetclr/conf.yaml.example
+++ b/dotnetclr/conf.yaml.example
@@ -1,0 +1,11 @@
+init_config:
+  # Any global configurable parameters should be added here
+
+instances:
+  #   A typical instance configuration might include a hostname and port
+  #   a set of customizable tags and other parameters we might need to
+  #   configure the behavior of our check.
+  #
+  # - host: localhost
+  #   port: 26379
+  #   tags: ['custom:tag']

--- a/dotnetclr/manifest.json
+++ b/dotnetclr/manifest.json
@@ -2,11 +2,11 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.0",
   "max_agent_version": "6.0.0",
-  "min_agent_version": "5.6.3",
+  "min_agent_version": "5.20.0",
   "name": "dotnetclr",
   "short_description": "dotnetclr description.",
   "guid": "3d21557e-65bd-4b66-99b9-5521f32b5957",
   "support": "contrib",
-  "supported_os": ["linux","mac_os","windows"],
+  "supported_os": ["windows"],
   "version": "0.1.0"
 }

--- a/dotnetclr/manifest.json
+++ b/dotnetclr/manifest.json
@@ -1,0 +1,12 @@
+{
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "0.1.0",
+  "max_agent_version": "6.0.0",
+  "min_agent_version": "5.6.3",
+  "name": "dotnetclr",
+  "short_description": "dotnetclr description.",
+  "guid": "3d21557e-65bd-4b66-99b9-5521f32b5957",
+  "support": "contrib",
+  "supported_os": ["linux","mac_os","windows"],
+  "version": "0.1.0"
+}

--- a/dotnetclr/metadata.csv
+++ b/dotnetclr/metadata.csv
@@ -1,0 +1,1 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name

--- a/dotnetclr/requirements.txt
+++ b/dotnetclr/requirements.txt
@@ -1,0 +1,1 @@
+# integration pip requirements

--- a/dotnetclr/test_dotnetclr.py
+++ b/dotnetclr/test_dotnetclr.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+from nose.plugins.attrib import attr
+
+# 3p
+
+# project
+from tests.checks.common import AgentCheckTest
+
+
+instance = {
+    'host': 'localhost',
+    'port': 26379,
+    'password': 'datadog-is-devops-best-friend'
+}
+
+
+# NOTE: Feel free to declare multiple test classes if needed
+
+@attr(requires='dotnetclr')
+class TestDotnetclr(AgentCheckTest):
+    """Basic Test for dotnetclr integration."""
+    CHECK_NAME = 'dotnetclr'
+
+    def test_check(self):
+        """
+        Testing Dotnetclr check.
+        """
+        self.load_check({}, {})
+
+        # run your actual tests...
+
+        self.assertTrue(True)
+        # Raises when COVERAGE=true and coverage < 100%
+        self.coverage_report()

--- a/exchange_server/check.py
+++ b/exchange_server/check.py
@@ -26,10 +26,6 @@ DEFAULT_COUNTERS = [
     # Memory Counters
     ["Memory", None, "Available MBytes",         "exchange.memory.available", "gauge"],
     ["Memory", None, "% Committed Bytes In Use", "exchange.memory.committed", "gauge"],
-    # .NET Framework counters
-    [".NET CLR Memory",     None, "% Time in GC",             "exchange.dotnet_clr_mem.time_in_gc",           "gauge"],
-    [".NET CLR Exceptions", None, "# of Exceps Thrown / sec", "exchange.dotnet_clr_exceptions.thrown_persec", "gauge"],
-    [".NET CLR Memory",     None, "# Bytes in all Heaps",     "exchange.dotnet_clr_memory.heap_bytes",        "gauge"],
     # Network Counters
     ["Network Interface", None, "Packets Outbound Errors", "exchange.network.outbound_errors",           "gauge"],
     ["TCPv6",             None, "Connection Failures",     "exchange.network.tcpv6.connection_failures", "gauge"],
@@ -52,14 +48,6 @@ DEFAULT_COUNTERS = [
     ["MSExchange Database ==> Instances", None,     "I/O Database Writes (Attached)/sec",             "exchange.database.io_db_writes_attached_persec",      "gauge"],
     ["MSExchange Database ==> Instances", None,     "I/O Log Writes/sec",                             "exchange.database.io_log_writes_persec",              "gauge"],
     ["MSExchange Active Manager",         "_total", "Database Mounted",                               "exchange.activemanager.database_mounted",             "gauge"],
-
-    # ASP.Net
-    ["ASP.NET",              None, "Application Restarts",          "exchange.asp_net.application_restarts",    "gauge"],
-    ["ASP.NET",              None, "Worker Process Restarts",       "exchange.asp_net.worker_process_restarts", "gauge"],
-    ["ASP.NET",              None, "Request Wait Time",             "exchange.asp_net.request_wait_time",       "gauge"],
-    ["ASP.NET Applications", None, "Requests In Application Queue", "exchange.asp_net.requests_in_queue",       "gauge"],
-    ["ASP.NET Applications", None, "Requests Executing",            "exchange.asp_net.requests_executing",      "gauge"],
-    ["ASP.NET Applications", None, "Requests/Sec",                  "exchange.asp_net.requests_persec",         "gauge"],
 
     # RPC Client Access Counters
     ["MSExchange RpcClientAccess", None, "RPC Averaged Latency", "exchange.rpc.averaged_latency",  "gauge"],

--- a/exchange_server/check.py
+++ b/exchange_server/check.py
@@ -6,7 +6,7 @@
 try:
     from checks.libs.win.pdhbasecheck import PDHBaseCheck
 except ImportError:
-    def PDHBaseCheck(*args, **kwargs):
+    class PDHBaseCheck(*args, **kwargs):
         return
 
 DEFAULT_COUNTERS = [

--- a/exchange_server/check.py
+++ b/exchange_server/check.py
@@ -6,7 +6,7 @@
 try:
     from checks.libs.win.pdhbasecheck import PDHBaseCheck
 except ImportError:
-    class PDHBaseCheck(*args, **kwargs):
+    def PDHBaseCheck(*args, **kwargs):
         return
 
 DEFAULT_COUNTERS = [


### PR DESCRIPTION
### What does this PR do?

This moves the metrics from ASP.NET and .Net CLR into their own checks. I think this separation makes sense. If you don't we'll change it.

### Testing Guidelines

I haven't tested this yet, I will, though! (We need to figure out a testing strategy for exchange and such.)