### PR TITLE
Adding ceph service check

### DIFF
--- a/ceph/README.md
+++ b/ceph/README.md
@@ -40,10 +40,10 @@ dd-agent ALL=(ALL) NOPASSWD:/path/to/your/ceph
   ======
     [...]
 
-    ceph
-    -------
-      - instance #0 [OK]
-      - Collected 26 metrics, 0 events & 1 service check
+   ceph (5.19.0) 
+   ------------- 
+   - instance #0 [OK] 
+   - Collected 24 metrics, 0 events & 1 service check
 
     [...]
 ```
@@ -57,7 +57,8 @@ See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/ceph
 The Ceph check does not include any event at this time.
 
 ### Service Checks
-The Ceph check does not include any service check at this time.
+
+* `ceph.overall_status` : The Datadog Agent submits a service check for each of Ceph's host health checks.
 
 ## Troubleshooting
 Need help? Contact [Datadog Support](http://docs.datadoghq.com/help/).


### PR DESCRIPTION
A customer reached out wondering if the CEPH integration collected a service check because currently the docs don't mention any:
https://docs.datadoghq.com/integrations/ceph/#service-checks

But the output of the Agent's info command shows 1 service check being collected:

```
ceph (5.19.0) 
------------- 
- instance #0 [OK] 
- Collected 24 metrics, 0 events & 1 service check
```
Looks like we collect a service check, and in their account it was called `ceph.overall_status`.

Here is where in the CEPH check where this gets collected:

https://github.com/DataDog/integrations-core/blob/5.19.x/ceph/check.py#L223