### PR TITLE
[docker_daemon] Add a comment for the support of ServiceCheck tags.

### DIFF
--- a/docker_daemon/conf.yaml.example
+++ b/docker_daemon/conf.yaml.example
@@ -154,7 +154,7 @@ instances:
     ## Tagging
     ##
 
-    # You can add extra tags to your Docker metrics with the tags list option.
+    # You can add extra tags to your Docker metrics and ServiceCheck with the tags list option.
     # Example: ["extra_tag", "env:testing"]
     #
     # tags: []


### PR DESCRIPTION
### What does this PR do?

Improve the comment into the docker_daemon configuration file to add **ServiceCheck** for `tags`.

### Additional Notes

Following the PR #782 
