### PR TITLE
[elastic] robots do not care about pretty json

### DIFF
--- a/elastic/check.py
+++ b/elastic/check.py
@@ -476,8 +476,8 @@ class ESCheck(AgentCheck):
 
         if version >= [0, 90, 10]:
             # ES versions 0.90.10 and above
-            health_url = "/_cluster/health?pretty=true"
-            pending_tasks_url = "/_cluster/pending_tasks?pretty=true"
+            health_url = "/_cluster/health"
+            pending_tasks_url = "/_cluster/pending_tasks"
 
             # For "external" clusters, we want to collect from all nodes.
             if cluster_stats:
@@ -491,7 +491,7 @@ class ESCheck(AgentCheck):
 
             additional_metrics = self.JVM_METRICS_POST_0_90_10
         else:
-            health_url = "/_cluster/health?pretty=true"
+            health_url = "/_cluster/health"
             pending_tasks_url = None
             if cluster_stats:
                 stats_url = "/_cluster/nodes/stats?all=true"


### PR DESCRIPTION
### What does this PR do?

Helps the robots on either end of the equation generate/transfer/process fewer bytes.

### Motivation

When tuning some timeout issues I noticed we use the pretty URLs. That's silly and I want my clock cycles back.

### Versioning

Really wasn't sure what to do about this because the CHANGELOG appears to be the start of a :dumpsterfire:
