### PR TITLE
[ci skip] bump version

### DIFF
--- a/elastic/CHANGELOG.md
+++ b/elastic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - elastic
 
+1.3.0 / Unreleased
+==================
+
+### Changes
+
+* [IMPROVEMENT] get rid of pretty json. See [#893][].
+
 1.2.0 / 2017-11-21
 ==================
 ### Changes
@@ -35,3 +42,4 @@
 [#806]: https://github.com/DataDog/integrations-core/issues/806
 [#820]: https://github.com/DataDog/integrations-core/issues/820
 [#860]: https://github.com/DataDog/integrations-core/issues/860
+[#893]: https://github.com/DataDog/integrations-core/pull/893

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.2.0",
+  "version": "1.3.0",
   "guid": "d91d91bd-4a8e-4489-bfb1-b119d4cc388a",
   "public_title": "Datadog-ElasticSearch Integration",
   "categories":["data store"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Bump ES version after merging https://github.com/DataDog/integrations-core/pull/893

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.


