### PR TITLE
Monitor the available disk space of RabbitMQ

### DIFF
--- a/rabbitmq/CHANGELOG.md
+++ b/rabbitmq/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changes
 
+* [FEATURE] Add a metric illustrating the available disk space. See [#902][]. (Thanks [@dnavre][])
 * [BUGFIX] Assume a protocol if there isn't one, fixing a bug if you don't use a protocol. See [#909][].
 
 1.3.1 / 2017-10-10
@@ -14,7 +15,6 @@
 ### Changes
 
 * [BUGFIX] Add a key check before updating connection state metric. See [#729][]. (Thanks [@ian28223][])
-
 
 1.3.0 / 2017-08-28
 ==================

--- a/rabbitmq/CHANGELOG.md
+++ b/rabbitmq/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG - rabbitmq
 
 
-1.3.2 / Unreleased
+1.4.0 / Unreleased
 ==================
 
 ### Changes

--- a/rabbitmq/check.py
+++ b/rabbitmq/check.py
@@ -62,6 +62,7 @@ QUEUE_ATTRIBUTES = [
 
 NODE_ATTRIBUTES = [
     ('fd_used', 'fd_used', float),
+    ('disk_free', 'disk_free', float),
     ('mem_used', 'mem_used', float),
     ('run_queue', 'run_queue', float),
     ('sockets_used', 'sockets_used', float),

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.3.2",
+  "version": "1.4.0",
   "guid": "a790a556-fbaa-4208-9d39-c42c3d57084b",
   "public_title": "Datadog-RabbitMQ Integration",
   "categories":["processing"],

--- a/rabbitmq/metadata.csv
+++ b/rabbitmq/metadata.csv
@@ -1,5 +1,6 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 rabbitmq.node.fd_used,gauge,,,,Used file descriptors,0,rabbitmq,fd used
+rabbitmq.node.disk_free,gauge,,byte,,Current free disk space,0,rabbitmq,disk free
 rabbitmq.node.mem_used,gauge,,byte,,Memory used in bytes,0,rabbitmq,mem used
 rabbitmq.node.run_queue,gauge,,process,,Average number of Erlang processes waiting to run,0,rabbitmq,run queue
 rabbitmq.node.sockets_used,gauge,,,,Number of file descriptors used as sockets,0,rabbitmq,skts used

--- a/rabbitmq/test_rabbitmq.py
+++ b/rabbitmq/test_rabbitmq.py
@@ -80,6 +80,7 @@ CONFIG_TEST_VHOSTS = {
 
 COMMON_METRICS = [
     'rabbitmq.node.fd_used',
+    'rabbitmq.node.disk_free',
     'rabbitmq.node.mem_used',
     'rabbitmq.node.run_queue',
     'rabbitmq.node.sockets_used',


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Monitor the available disk space of RabbitMQ

### Motivation

In some cases monitoring this metric from the system is troublesome ( i.e. if RabbmitMQ is running in an environment such as kubernetes or in another dockerized setup). The disk_free metric is added to ease the monitoring in such cases.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

