### PR TITLE
[kafka_consumer] addressing multiple server regression

### DIFF
--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - kafka_consumer
 
+1.2.1 / Unelreased 
+==================
+
+### Changes
+
+* [BUGFIX] Use instance key to retrieve cached kafka_client, See #900
+
 1.2.0 / 2017-11-21
 ==================
 

--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -1,11 +1,11 @@
 # CHANGELOG - kafka_consumer
 
-1.2.1 / Unelreased 
+1.2.1 / Unreleased 
 ==================
 
 ### Changes
 
-* [BUGFIX] Use instance key to retrieve cached kafka_client, See #900
+* [BUGFIX] Use instance key to retrieve cached kafka_client, See [#904][]
 
 1.2.0 / 2017-11-21
 ==================
@@ -56,4 +56,5 @@
 [#684]: https://github.com/DataDog/integrations-core/issues/684
 [#733]: https://github.com/DataDog/integrations-core/issues/733
 [#753]: https://github.com/DataDog/integrations-core/issues/753
+[#904]: https://github.com/DataDog/integrations-core/issues/904
 [@jeffwidman]: https://github.com/jeffwidman

--- a/kafka_consumer/check.py
+++ b/kafka_consumer/check.py
@@ -155,7 +155,17 @@ class KafkaCheck(AgentCheck):
             cli.close()
 
     def _get_instance_key(self, instance):
-        return self._read_config(instance, 'kafka_connect_str')
+        servers = self._read_config(instance, 'kafka_connect_str')
+        key = None
+        if isinstance(servers, basestring):
+            key = servers
+        elif isinstance(servers, list):
+            key = ",".join(servers)
+        else:
+            raise BadKafkaConsumerConfiguration('kafka_connect_str should be string or list of strings')
+
+        return key
+
 
     def _get_kafka_client(self, instance):
         kafka_conn_str = self._read_config(instance, 'kafka_connect_str')
@@ -163,7 +173,7 @@ class KafkaCheck(AgentCheck):
             raise BadKafkaConsumerConfiguration('Bad instance configuration')
 
         instance_key = self._get_instance_key(instance)
-        if kafka_conn_str not in self.kafka_clients:
+        if instance_key not in self.kafka_clients:
             cli = KafkaClient(bootstrap_servers=kafka_conn_str, client_id='dd-agent')
             self.kafka_clients[instance_key] = cli
 

--- a/kafka_consumer/manifest.json
+++ b/kafka_consumer/manifest.json
@@ -10,7 +10,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.2.0",
+  "version": "1.2.1",
   "guid": "74e1ce9c-dee9-4ad5-9b6a-05eeee7f5259",
   "public_title": "Datadog-Kafka Consumer Integration",
   "categories":["processing", "messaging"],

--- a/kafka_consumer/test_kafka_consumer.py
+++ b/kafka_consumer/test_kafka_consumer.py
@@ -247,6 +247,33 @@ class TestKafka(AgentCheckTest):
         self.assertMetric('kafka.broker_offset', at_least=1)
         self.coverage_report()
 
+    def test_multiple_servers_zk(self):
+        """
+        Testing Kafka_consumer check.
+        """
+
+        if not self.is_supported(['zookeeper']):
+            raise SkipTest("Skipping test - not supported in current environment")
+
+        multiple_server_zk_instance = copy.deepcopy(zk_instance)
+        multiple_server_zk_instance['kafka_connect_str'] = [
+            multiple_server_zk_instance['kafka_connect_str'],
+            'localhost:9092']
+
+        instances = [multiple_server_zk_instance]
+        self.run_check({'instances': instances})
+
+        for instance in instances:
+            for name, consumer_group in instance['consumer_groups'].iteritems():
+                for topic, partitions in consumer_group.iteritems():
+                    for partition in partitions:
+                        tags = ["topic:{}".format(topic),
+                                "partition:{}".format(partition)]
+                        for mname in BROKER_METRICS:
+                            self.assertMetric(mname, tags=tags, at_least=1)
+                        for mname in CONSUMER_METRICS:
+                            self.assertMetric(mname, tags=tags + ["source:zk", "consumer_group:{}".format(name)], at_least=1)
+
 
     def test_check_nogroups_zk(self):
         """


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

We weren't properly using instance key to get cached client.
Adds a test so that we don't get bit by this in the future.

### Motivation

Regression reported in #899

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

Anything else we should know when reviewing?
