### PR TITLE
[http] Added configurable ssl_hostname

### DIFF
--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - http_check
 
+1.3.0 / UNRELEASED
+==================
+
+### Changes
+
+* [FEATURE] Add configurable ssl_hostaname. See[#905][].
+
 1.2.0 / 2017-10-10
 ==================
 
@@ -45,3 +52,4 @@
 [#688]: https://github.com/DataDog/integrations-core/issues/688
 [#758]: https://github.com/DataDog/integrations-core/issues/758
 [@xkrt]: https://github.com/xkrt
+[#905]:https://github.com/DataDog/integrations-core/pull/905

--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Changes
 
-* [FEATURE] Add configurable ssl_hostaname. See[#905][].
+* [FEATURE] Add configurable ssl server name for cert expiration check. See[#905][].
 
 1.2.0 / 2017-10-10
 ==================

--- a/http_check/check.py
+++ b/http_check/check.py
@@ -446,6 +446,7 @@ class HTTPCheck(NetworkCheck):
 
         o = urlparse(url)
         host = o.hostname
+        server_name = instance.get('ssl_server_name', o.hostname)
 
         port = o.port or 443
 
@@ -457,7 +458,7 @@ class HTTPCheck(NetworkCheck):
             context.verify_mode = ssl.CERT_REQUIRED
             context.check_hostname = True
             context.load_verify_locations(instance_ca_certs)
-            ssl_sock = context.wrap_socket(sock, server_hostname=host)
+            ssl_sock = context.wrap_socket(sock, server_hostname=server_name)
             cert = ssl_sock.getpeercert()
 
         except Exception as e:

--- a/http_check/conf.yaml.example
+++ b/http_check/conf.yaml.example
@@ -96,9 +96,9 @@ instances:
     # warning if the certificate is y days from the expiration date.
     # The SSL certificate will always be validated for this additional
     # service check regardless of the value of disable_ssl_validation.
-    # The Agent uses hostname by default to validate the SSL cert, but if
-    # necessary this can be overridden.
-    #
+    # By default, for the expiration check, the Agent validates the SSL certificate
+    # hostname against the host of the provided url. If necessary, you can override
+    # that hostname with ssl_server_name.
     # check_certificate_expiration: true
     # days_warning: 14
     # days_critical: 7

--- a/http_check/conf.yaml.example
+++ b/http_check/conf.yaml.example
@@ -95,11 +95,14 @@ instances:
     # left in the certificate, and alternatively raise a critical
     # warning if the certificate is y days from the expiration date.
     # The SSL certificate will always be validated for this additional
-    # service check regardless of the value of disable_ssl_validation
+    # service check regardless of the value of disable_ssl_validation.
+    # The Agent uses hostname by default to validate the SSL cert, but if
+    # necessary this can be overridden.
     #
     # check_certificate_expiration: true
     # days_warning: 14
     # days_critical: 7
+    # ssl_server_name: hostname
 
     # The (optional) headers parameter allows you to send extra headers
     # with the request. This is useful for explicitly specifying the host

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.2.0",
+  "version": "1.3.0",
   "guid": "eb133a1f-697c-4143-bad3-10e72541fa9c",
   "public_title": "Datadog-HTTP Check Integration",
   "categories":["web", "network"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Adds a field to the http_check configuration called `ssl_server_name` which, if set, is the name we'll pass as the `server_hostname` parameter when validating the instance's SSL certificate. The default value of this parameter is the hostname extracted from the instance's url.

### Motivation

If an SSL certificate is in a container & we try to check if it's expired, then the certification validation fails because the url of the container is just the IP address, which we can't properly extract the correct hostname from. In this case, it's useful to have the option to manual set the server hostname yourself.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

Anything else we should know when reviewing?

Small note:
As a sanity check I ran the `test_check_hostname_override` test against these 2 instances
```
{
        'name': 'overwrite_hostname',
        'url': 'https://54.230.9.50',
        'timeout': 1,
        'check_certificate_expiration': True,
        'days_warning': 14,
        'days_critical': 7,
        'ssl_server_name': 'www.datadoghq.com'
    }, {
        'name': 'dont_overwrite_hostname',
        'url': 'https://54.230.9.50',
        'timeout': 1,
        'check_certificate_expiration': True,
        'days_warning': 14,
        'days_critical': 7,
    }
```
in order to verify that the changes mentioned above would cause the 1st instance to successfully fetch the certificate's expiration while the 2nd instance would fail to do so. I think it's just worth noting that these tests were done and they did pass, but I had to remove them from the test suite because the IP address of the server hosting `www.datadoghq.com` is not constant over time. The test that was added instead simply tests that the hostname can successfully be overwritten, but it doesn't test the specific use case that this change was intended for.