### PR TITLE
[RabbitMQ] add a protocol if there isn't one

### DIFF
--- a/rabbitmq/CHANGELOG.md
+++ b/rabbitmq/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG - rabbitmq
 
 
-1.3.2 / 2017-10-10
+1.3.2 / Unreleased
 ==================
 
 ### Changes

--- a/rabbitmq/CHANGELOG.md
+++ b/rabbitmq/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG - rabbitmq
 
 
+1.3.2 / 2017-10-10
+==================
+
+### Changes
+
+* [BUGFIX] Assume a protocol if there isn't one, fixing a bug if you don't use a protocol. See [#909][].
+
 1.3.1 / 2017-10-10
 ==================
 

--- a/rabbitmq/check.py
+++ b/rabbitmq/check.py
@@ -119,6 +119,14 @@ class RabbitMQ(AgentCheck):
         password = instance.get('rabbitmq_pass', 'guest')
         custom_tags = instance.get('tags', [])
         parsed_url = urlparse.urlparse(base_url)
+        if not parsed_url.scheme:
+            self.log.warning('The rabbit url did not include a protocol, assuming http')
+            # urlparse.urljoin cannot add a protocol to the rest of the url for some reason.
+            # This still leaves the potential for errors, but such urls would never have been valid, either
+            # and it's not likely to be useful to attempt to catch all possible mistakes people could make
+            base_url = 'http://' + base_url
+            parsed_url = urlparse.urlparse(base_url)
+
         ssl_verify = _is_affirmative(instance.get('ssl_verify', True))
         if not ssl_verify and parsed_url.scheme == 'https':
             self.log.warning('Skipping SSL cert validation for %s based on configuration.' % (base_url))

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.3.1",
+  "version": "1.3.2",
   "guid": "a790a556-fbaa-4208-9d39-c42c3d57084b",
   "public_title": "Datadog-RabbitMQ Integration",
   "categories":["processing"],


### PR DESCRIPTION
### What does this PR do?

Right now if a protocol isn't specified, a bunch of rabbit requests will fail. This is not great. They shouldn't fail. To be specific, if a url has no protocol, `urlparse.urljoin` will behave in an anomalous manner. 

For example:

```python
urlparse.urljoin('gmmeyer.com','test') # => test
```

So, we have to assign it a protocol. We'll assume http.

### Motivation

This is an old bug that has tripped up a bunch of people.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

There are other ways people can mess up urls. If someone puts in a url like: '//gmmeyer.com' or '://gmmeyer.com' or something, it should fail. We cannot attempt to fix every permutation of how people can get their urls wrong. This just assumes that if a url is bare, it's meant to have an http protocol--which is what requests does anyway