### PR TITLE
[docker] improve logging for "bogus pid" error to help debuging

### DIFF
--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [FEATURE] Honor global collect_labels_as_tags if integration's collect_labels_as_tags is empty. See [#881][]
+* [IMPROVEMENT] Improve logging when cgroup metrics can't be retrieved. See [#914][]
 
 1.6.0 / 2017-11-21
 ==================

--- a/docker_daemon/check.py
+++ b/docker_daemon/check.py
@@ -650,7 +650,7 @@ class DockerDaemon(AgentCheck):
     def _report_performance_metrics(self, containers_by_id):
 
         containers_without_proc_root = []
-        for container in containers_by_id.itervalues():
+        for container_id, container in containers_by_id.iteritems():
             if self._is_container_excluded(container) or not self._is_container_running(container):
                 continue
 
@@ -663,7 +663,7 @@ class DockerDaemon(AgentCheck):
                     continue
                 self._report_net_metrics(container, tags)
             except BogusPIDException as e:
-                self.log.warning('Unable to report cgroup metrics: %s', e)
+                self.log.warning('Unable to report cgroup metrics for container %s: %s', container_id[:12], e)
 
         if containers_without_proc_root:
             message = "Couldn't find pid directory for containers: {0}. They'll be missing network metrics".format(


### PR DESCRIPTION
### What does this PR do?

Include the container ID in the warning log line to help pinpoint in what state this container exactly is to trigger the error.

```
2017-11-29 10:52:11,246 | WARNING | dd.collector | checks.docker_daemon(docker_daemon.py:657) | Unable to report cgroup metrics for container 1d51d6a4c1e6: Cannot report on bogus pid(0)
```

### Motivation

Helping debugging why this spuriously happens on some hosts

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

~~- [ ] Bumped the version check in `manifest.json`~~
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
