### PR TITLE
[mongo] Replicaset error raised in standalone mode

### DIFF
--- a/mongo/CHANGELOG.md
+++ b/mongo/CHANGELOG.md
@@ -66,7 +66,7 @@
 [#747]: https://github.com/DataDog/integrations-core/issues/747
 [#769]: https://github.com/DataDog/integrations-core/issues/769
 [#823]: https://github.com/DataDog/integrations-core/issues/823
-[#915]: https://github.com/DataDog/integrations-core/issue/915
+[#915]: https://github.com/DataDog/integrations-core/issues/915
 [@dnavre]: https://github.com/dnavre
 [@dtbartle]: https://github.com/dtbartle
 [@hindmanj]: https://github.com/hindmanj

--- a/mongo/CHANGELOG.md
+++ b/mongo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - mongo
 
+1.5.0 / Unreleased
+==================
+### Changes
+
+* [BUGFIX] Pass replica set metric collection if not running standalone instance instead of raising exception See [#915][]
+
 1.5.0 / 2017-11-21
 ==================
 ### Changes
@@ -60,6 +66,7 @@
 [#747]: https://github.com/DataDog/integrations-core/issues/747
 [#769]: https://github.com/DataDog/integrations-core/issues/769
 [#823]: https://github.com/DataDog/integrations-core/issues/823
+[#915]: https://github.com/DataDog/integrations-core/issue/915
 [@dnavre]: https://github.com/dnavre
 [@dtbartle]: https://github.com/dtbartle
 [@hindmanj]: https://github.com/hindmanj

--- a/mongo/CHANGELOG.md
+++ b/mongo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - mongo
 
-1.5.0 / Unreleased
+1.5.1 / Unreleased
 ==================
 ### Changes
 

--- a/mongo/check.py
+++ b/mongo/check.py
@@ -847,7 +847,7 @@ class MongoDb(AgentCheck):
                 )
 
         except Exception as e:
-            if "OperationFailure" in repr(e) and "replSetGetStatus" in str(e):
+            if "OperationFailure" in repr(e) and "not running with --replSet" in str(e):
                 pass
             else:
                 raise e

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.5.0",
+  "version": "1.5.1",
   "guid": "d51c342e-7a02-4611-a47f-1e8eade5735c",
   "public_title": "Datadog-Mongo DB Integration",
   "categories":["data store"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

The check was raising an exception when gathering replica set metrics despite running a standalone mongo instance. The error from pymongo when getting querying for replica set metrics changed from `command SON([('replSetGetStatus', 1)]) on namespace admin.$cmd failed: not running with --replSet` to `not running with --replSet`, which caused the check to raise an exception. This change takes the new error format into account.

### Motivation

Customer running standalone mongo instance reached out reporting the check failed when checking for replica set metrics

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

Anything else we should know when reviewing?
