### PR TITLE
[iis] Adds the option to send the raw deltas of IIS WMI performance counters.

### DIFF
--- a/iis/conf.yaml.example
+++ b/iis/conf.yaml.example
@@ -38,6 +38,10 @@ instances:
                       # where perfmon reports TotalBytesTransferred as
                       # TotalBytesTransfered, you may have to enable this
                       # to grab the IIS metrics in that environment.
+      count_metrics: false # Send the raw deltas of the WMI performance
+                           # counters.
+      rate_metrics: true # Send the deltas of the WMI performance counters
+                         # normalized to per-second rates.
   #   tags:
   #     - myapp2
   #     - east


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Previously, the deltas of these performance counters were normalized to per-second rates, then submitted as gauges. The agent does not run checks at perfectly regular intervals, so it isn't possible to exactly derive the raw counts from the rate metrics. Furthermore, forcing a gauge to behave like a count requires advanced knowledge of the query system.

The agent did not have the monotonic_count method when this integration was changed to use the rate method:
https://github.com/DataDog/dd-agent/commit/d00a5e30bfd4542e37c95305a4aaf409e316c4d6
https://github.com/DataDog/dd-agent/pull/1012/files

This commit adds the count metrics with new metric names to allow the metadata to be updated without breaking existing agent deployments, and these new metrics are behind an option that is off by default. This commit also adds an option to control whether the rate metrics are sent. Some users may wish to keep the old metrics for backwards compatibility or to complement the raw count metrics.

### Motivation

A customer wished to view the sum of an IIS metric over some timespan.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

TODO: metadata.csv needs to be updated, and the "Data Collected" section in README.md should probably be changed to avoid showing most metrics twice for the rate and the count version.