### PR TITLE
Add metrics to monitor a rabbitmq cluster

### DIFF
--- a/rabbitmq/CHANGELOG.md
+++ b/rabbitmq/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [FEATURE] Add data collection for exchanges. See [#176][]. (Thanks [@wholroyd][])
 * [FEATURE] Add a metric illustrating the available disk space. See [#902][]. (Thanks [@dnavre][])
 * [BUGFIX] Assume a protocol if there isn't one, fixing a bug if you don't use a protocol. See [#909][].
+* [FEATURE] Add metrics to monitor a cluster. See [#924][]
 
 1.3.1 / 2017-10-10
 ==================
@@ -56,5 +57,9 @@
 [#635]: https://github.com/DataDog/integrations-core/issues/635
 [#674]: https://github.com/DataDog/integrations-core/issues/674
 [#729]: https://github.com/DataDog/integrations-core/issues/729
+[#902]: https://github.com/DataDog/integrations-core/issues/902
+[#909]: https://github.com/DataDog/integrations-core/issues/909
+[#924]: https://github.com/DataDog/integrations-core/issues/924
+[@dnavre]: https://github.com/dnavre
 [@ian28223]: https://github.com/ian28223
 [@jamescarr]: https://github.com/jamescarr

--- a/rabbitmq/check.py
+++ b/rabbitmq/check.py
@@ -94,7 +94,10 @@ NODE_ATTRIBUTES = [
     ('mem_used', 'mem_used', float),
     ('run_queue', 'run_queue', float),
     ('sockets_used', 'sockets_used', float),
-    ('partitions', 'partitions', len)
+    ('partitions', 'partitions', len),
+    ('running', 'running', float),
+    ('mem_alarm', 'mem_alarm', float),
+    ('disk_free_alarm', 'disk_alarm', float),
 ]
 
 ATTRIBUTES = {
@@ -361,6 +364,7 @@ class RabbitMQ(AgentCheck):
         for data_line in data[:max_detailed]:
             # We truncate the list if it's above the limit
             self._get_metrics(data_line, object_type, custom_tags)
+
 
         # get a list of the number of bindings on a given queue
         # /api/queues/vhost/name/bindings

--- a/rabbitmq/metadata.csv
+++ b/rabbitmq/metadata.csv
@@ -5,6 +5,9 @@ rabbitmq.node.mem_used,gauge,,byte,,Memory used in bytes,0,rabbitmq,mem used
 rabbitmq.node.run_queue,gauge,,process,,Average number of Erlang processes waiting to run,0,rabbitmq,run queue
 rabbitmq.node.sockets_used,gauge,,,,Number of file descriptors used as sockets,0,rabbitmq,skts used
 rabbitmq.node.partitions,gauge,,,,Number of network partitions this node is seeing,0,rabbitmq,partitions
+rabbitmq.node.running,gauge,,,,Is the node running or not,0,rabbitmq,running
+rabbitmq.node.mem_alarm,gauge,,,,Does the host has memory alarm,0,rabbitmq,mem_alarm
+rabbitmq.node.disk_alarm,gauge,,,,Does the node have disk alarm,0,rabbitmq,disk_alarm
 rabbitmq.exchange.messages.ack.count,gauge,,message,,Number of messages delivered to clients and acknowledged,0,rabbitmq,xchng msgs ack
 rabbitmq.exchange.messages.ack.rate,gauge,,message,,Rate of messages delivered to clients and acknowledged per second ,0,rabbitmq,xchng msgs ack rate
 rabbitmq.exchange.messages.confirm.count,gauge,,message,,Count of messages confirmed,0,rabbitmq,xchng msgs cnfrm

--- a/rabbitmq/test_rabbitmq.py
+++ b/rabbitmq/test_rabbitmq.py
@@ -87,7 +87,10 @@ COMMON_METRICS = [
     'rabbitmq.node.mem_used',
     'rabbitmq.node.run_queue',
     'rabbitmq.node.sockets_used',
-    'rabbitmq.node.partitions'
+    'rabbitmq.node.partitions',
+    'rabbitmq.node.running',
+    'rabbitmq.node.disk_alarm',
+    'rabbitmq.node.mem_alarm',
 ]
 
 E_METRICS = [


### PR DESCRIPTION
### What does this PR do?

Those metrics allow to monitor a rabbitmq cluster and provide the same
information as the 'cluster_status' from rabbitmqctl.

### Motivation

Ask on #922 

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.