### PR TITLE
zookeeper.bytes_received and zookeeper.bytes_sent are misnamed

### DIFF
--- a/zk/CHANGELOG.md
+++ b/zk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - zk
 
+1.2.0 / Unreleased
+==================
+
+* [IMPROVEMENT] Add `zookeeper.packets.received` and `zookeeper.packets.sent` as `rate` metrics
+  for the `stat` command output to correct the incorrect `zookeeper.bytes_received` and
+  `zookeeper.bytes_sent` metrics. See [#816][]
+
 1.1.0 / 2017-07-18
 ==================
 

--- a/zk/check.py
+++ b/zk/check.py
@@ -310,11 +310,17 @@ class ZookeeperCheck(AgentCheck):
 
         # Received: 101032173
         _, value = buf.readline().split(':')
+        # Fixme: This metric name is wrong. It should be removed in a major version of the agent
+        # See https://github.com/DataDog/integrations-core/issues/816
         metrics.append(ZKMetric('zookeeper.bytes_received', long(value.strip())))
+        metrics.append(ZKMetric('zookeeper.packets.received', long(value.strip()), "rate"))
 
         # Sent: 1324
         _, value = buf.readline().split(':')
+        # Fixme: This metric name is wrong. It should be removed in a major version of the agent
+        # See https://github.com/DataDog/integrations-core/issues/816
         metrics.append(ZKMetric('zookeeper.bytes_sent', long(value.strip())))
+        metrics.append(ZKMetric('zookeeper.packets.sent', long(value.strip()), "rate"))
 
         if has_connections_val:
             # Connections: 1

--- a/zk/manifest.json
+++ b/zk/manifest.json
@@ -10,7 +10,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.1.0",
+  "version": "1.2.0",
   "guid": "5519c110-5183-438e-85ad-63678c072ac7",
   "public_title": "Datadog-Zookeeper Integration",
   "categories":["orchestration", "notification"],

--- a/zk/metadata.csv
+++ b/zk/metadata.csv
@@ -3,6 +3,8 @@ zookeeper.bytes_received,gauge,,,,,0,zookeeper,
 zookeeper.bytes_sent,gauge,,,,,0,zookeeper,
 zookeeper.packets_received,gauge,,packet,second,The number of packets received.,0,zookeeper,packets received per second
 zookeeper.packets_sent,gauge,,packet,second,The number of packets sent.,0,zookeeper,packets sent per second
+zookeeper.packets.received,gauge,,packet,second,The number of packets received.,0,zookeeper,packets received per second
+zookeeper.packets.sent,gauge,,packet,second,The number of packets sent.,0,zookeeper,packets sent per second
 zookeeper.connections,gauge,,connection,,The total count of client connections.,0,zookeeper,conns
 zookeeper.datadog_client_exception,rate,,error,,The exception rate seen by the Datadog Agent when trying to collect stats.,-1,zookeeper,exceptions
 zookeeper.latency.avg,gauge,,millisecond,,The amount of time it takes for the server to respond to a client request.,0,zookeeper,avg latency

--- a/zk/test_zk.py
+++ b/zk/test_zk.py
@@ -51,6 +51,8 @@ class ZooKeeperTestCase(AgentCheckTest):
         'zookeeper.zxid.count',
         'zookeeper.nodes',
         'zookeeper.instances',
+        'zookeeper.packets.received',
+        'zookeeper.packets.sent'
     ]
 
     MNTR_METRICS = [


### PR DESCRIPTION
They represents packages sent/received, not bytes.

### What does this PR do?

Add aliases for` zookeeper.bytes_received` and `zookeeper.bytes_sent` as` zookeeper.packets.received` and `zookeeper.bytes.sent` in the form of `rate` metrics.

### Motivation

Closes #816 

### Testing Guidelines

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

` zookeeper.packets.received` and `zookeeper.bytes.sent` were selected as to not conflict with the ` zookeeper.packets_received` and `zookeeper.bytes_sent` metrics generated from the `mntr` command.