### PR TITLE
Adding statefulset metrics

### DIFF
--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [IMPROVEMENT] Merge kubernetes-state pod.phase.[running|succeeded|pending|failed|unknown] service checks into one actionnable service check. Will be introduced in 5.20 and will change the behavior of the service check. [#874][]
+* [IMPROVEMENT] Adding statefulset metrics. [#936][]
 
 1.4.0 / 2017-11-21
 ==================

--- a/kubernetes_state/check.py
+++ b/kubernetes_state/check.py
@@ -93,6 +93,9 @@ class KubernetesState(PrometheusCheck):
             'kube_replicationcontroller_status_replicas': 'replicationcontroller.replicas',
             'kube_statefulset_replicas': 'statefulset.replicas_desired',
             'kube_statefulset_status_replicas': 'statefulset.replicas',
+            'kube_statefulset_status_replicas_current': 'statefulset.replicas.current',
+            'kube_statefulset_status_replicas_ready': 'statefulset.replicas.ready',
+            'kube_statefulset_status_replicas_updated': 'statefulset.replicas.updated',
         }
 
         self.ignore_metrics = [

--- a/kubernetes_state/check.py
+++ b/kubernetes_state/check.py
@@ -93,9 +93,9 @@ class KubernetesState(PrometheusCheck):
             'kube_replicationcontroller_status_replicas': 'replicationcontroller.replicas',
             'kube_statefulset_replicas': 'statefulset.replicas_desired',
             'kube_statefulset_status_replicas': 'statefulset.replicas',
-            'kube_statefulset_status_replicas_current': 'statefulset.replicas.current',
-            'kube_statefulset_status_replicas_ready': 'statefulset.replicas.ready',
-            'kube_statefulset_status_replicas_updated': 'statefulset.replicas.updated',
+            'kube_statefulset_status_replicas_current': 'statefulset.replicas_current',
+            'kube_statefulset_status_replicas_ready': 'statefulset.replicas_ready',
+            'kube_statefulset_status_replicas_updated': 'statefulset.replicas_updated',
         }
 
         self.ignore_metrics = [

--- a/kubernetes_state/ci/fixtures/prometheus/prometheus.txt
+++ b/kubernetes_state/ci/fixtures/prometheus/prometheus.txt
@@ -31,6 +31,18 @@ kube_cronjob_status_active{cronjob="hello",namespace="default"} 0
 # HELP kube_cronjob_status_last_schedule_time LastScheduleTime keeps information of when was the last time the job was successfully scheduled.
 # TYPE kube_cronjob_status_last_schedule_time gauge
 kube_cronjob_status_last_schedule_time{cronjob="hello",namespace="default"} 1.50999846e+09
+# HELP kube_statefulset_status_replicas The number of replicas per StatefulSet.
+# TYPE kube_statefulset_status_replicas gauge
+kube_statefulset_status_replicas{namespace="ns3",statefulset="statefulset3"} 7
+# HELP kube_statefulset_status_replicas_current The number of current replicas per StatefulSet.
+# TYPE kube_statefulset_status_replicas_current gauge
+kube_statefulset_status_replicas_current{namespace="ns2",statefulset="statefulset2"} 2
+# HELP kube_statefulset_status_replicas_ready The number of ready replicas per StatefulSet.
+# TYPE kube_statefulset_status_replicas_ready gauge
+kube_statefulset_status_replicas_ready{namespace="ns2",statefulset="statefulset2"} 5
+# HELP kube_statefulset_status_replicas_updated The number of updated replicas per StatefulSet.
+# TYPE kube_statefulset_status_replicas_updated gauge
+kube_statefulset_status_replicas_updated{namespace="ns2",statefulset="statefulset2"} 3
 # HELP kube_daemonset_created Unix creation timestamp
 # TYPE kube_daemonset_created gauge
 kube_daemonset_created{daemonset="jaundiced-numbat-dd-k8state",namespace="default"} 1.509985033e+09

--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -82,3 +82,6 @@ kubernetes_state.resourcequota.limits.cpu.limit,gauge,,cpu,,Hard limit on the su
 kubernetes_state.resourcequota.limits.memory.limit,gauge,,byte,,Hard limit on the sum of memory bytes limits for a resource quota,0,kubernetes,k8s_state.resourcequota.limits.mem.limit
 kubernetes_state.statefulset.replicas,gauge,,,,The number of replicas per statefulset,0,kubernetes,k8s_state.statefulset.replicas
 kubernetes_state.statefulset.replicas_desired,gauge,,,,The number of desired replicas per statefulset,0,kubernetes,k8s_state.statefulset.replicas_desired
+kubernetes_state.statefulset.replicas_current,gauge,,,,The number of current replicas per StatefulSet,0,kubernetes,k8s_state.statefulset.replicas_current
+kubernetes_state.statefulset.replicas_ready,gauge,,,,The number of ready replicas per StatefulSet,0,kubernetes,k8s_state.statefulset.replicas_ready
+kubernetes_state.statefulset.replicas_updated,gauge,,,,The number of updated replicas per StatefulSet,0,kubernetes,k8s_state.statefulset.replicas_updated

--- a/kubernetes_state/test_kubernetes_state.py
+++ b/kubernetes_state/test_kubernetes_state.py
@@ -68,9 +68,9 @@ class TestKubernetesState(AgentCheckTest):
         NAMESPACE + '.persistentvolumeclaim.status',
         # statefulset
         NAMESPACE + '.statefulset.replicas',
-        NAMESPACE + '.statefulset.replicas.current',
-        NAMESPACE + '.statefulset.replicas.ready',
-        NAMESPACE + '.statefulset.replicas.updated',
+        NAMESPACE + '.statefulset.replicas_current',
+        NAMESPACE + '.statefulset.replicas_ready',
+        NAMESPACE + '.statefulset.replicas_updated',
     ]
 
     ZERO_METRICS = [

--- a/kubernetes_state/test_kubernetes_state.py
+++ b/kubernetes_state/test_kubernetes_state.py
@@ -66,6 +66,11 @@ class TestKubernetesState(AgentCheckTest):
         NAMESPACE + '.replicaset.replicas_desired',
         # persistentvolume claim
         NAMESPACE + '.persistentvolumeclaim.status',
+        # statefulset
+        NAMESPACE + '.statefulset.replicas',
+        NAMESPACE + '.statefulset.replicas.current',
+        NAMESPACE + '.statefulset.replicas.ready',
+        NAMESPACE + '.statefulset.replicas.updated',
     ]
 
     ZERO_METRICS = [


### PR DESCRIPTION
### What does this PR do?

Adds new kubernetes_state metrics:

- kube_statefulset_status_replicas_current
- kube_statefulset_status_replicas_ready
- kube_statefulset_status_replicas_updated 

### Motivation
Per community inquiry:
https://github.com/DataDog/integrations-core/issues/802#issuecomment-349130210

### Testing Guidelines

Added metrics to the prometheus dump and to the test:
```
test__update_kube_state_metrics (test_kubernetes_state.TestKubernetesState) ... ok
test__update_kube_state_metrics_v040 (test_kubernetes_state.TestKubernetesState) ... ok

----------------------------------------------------------------------
Ran 2 tests in 0.203s

OK
```

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

Anything else we should know when reviewing?
