### PR TITLE
Use JSON output from varnishstat starting varnish 5.0.0

### DIFF
--- a/varnish/CHANGELOG.md
+++ b/varnish/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - varnish
 
+1.1.0 / Unreleased
+==================
+
+### Changes
+
+* [IMPROVEMENT] Use JSON with varnishstat starting varnish 5.0.0. See [#939][].
+
 1.0.6 2017-11-21
 ==================
 
@@ -59,5 +66,6 @@ and varnishadm in order to better support service discovery. See [#498][], thank
 [#739]: https://github.com/DataDog/integrations-core/issues/739
 [#795]: https://github.com/DataDog/integrations-core/issues/795
 [#805]: https://github.com/DataDog/integrations-core/issues/805
+[#805]: https://github.com/DataDog/integrations-core/issues/939
 [@adongy]: https://github.com/adongy
 [@philipseidel]: https://github.com/philipseidel

--- a/varnish/ci/fixtures/stats_output_json
+++ b/varnish/ci/fixtures/stats_output_json
@@ -1,0 +1,18 @@
+{
+  "timestamp": "2017-12-19T16:59:01",
+  "MAIN.fetch_304": {
+    "description": "Fetch no body (304)",
+    "type": "MAIN", "flag": "c", "format": "d",
+    "value": 0
+  },
+  "MAIN.n_sess_mem": {
+    "description": "N struct sess_mem",
+    "type": "MAIN", "flag": "g", "format": "i",
+    "value": 334
+  },
+  "LCK.vcl.creat": {
+    "description": "Created locks",
+    "type": "LCK", "ident": "vcl", "flag": "c", "format": "i",
+    "value": 1
+  }
+}

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.6",
+  "version": "1.1.0",
   "guid": "d2052eae-89b8-4cb1-b631-f373010da4b8",
   "public_title": "Datadog-Varnish Integration",
   "categories":["web", "caching"],


### PR DESCRIPTION
### What does this PR do?

varnishstat offers a JSON output which is much simpler to parse than
XML, let's make it the default starting varnish 5.0.0.

Also since varnish 5.2.0 the "type" attribute is no longer provided and
has been merged with the name. We remove the "MAIN." prefix to keep the
same metrics name across multiple versions.

<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### Motivation

Metrics where broken since varnish 5.2.0: #871

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.