### PR TITLE
Adding disable_ssl_validation to php_fpm

### DIFF
--- a/php_fpm/check.py
+++ b/php_fpm/check.py
@@ -8,6 +8,7 @@ import requests
 # project
 from checks import AgentCheck
 from util import headers
+from config import _is_affirmative
 
 DEFAULT_TIMEOUT = 20
 
@@ -48,6 +49,8 @@ class PHPFPMCheck(AgentCheck):
 
         timeout = instance.get('timeout', DEFAULT_TIMEOUT)
 
+        disable_ssl_validation = _is_affirmative(instance.get('disable_ssl_validation', False))
+
         if user and password:
             auth = (user, password)
 
@@ -58,25 +61,26 @@ class PHPFPMCheck(AgentCheck):
         status_exception = None
         if status_url is not None:
             try:
-                pool = self._process_status(status_url, auth, tags, http_host, timeout)
+                pool = self._process_status(status_url, auth, tags, http_host, disable_ssl_validation)
             except Exception as e:
                 status_exception = e
                 pass
 
         if ping_url is not None:
-            self._process_ping(ping_url, ping_reply, auth, tags, pool, http_host, timeout)
+            self._process_ping(ping_url, ping_reply, auth, tags, pool, http_host, timeout, disable_ssl_validation)
 
         # pylint doesn't understand that we are raising this only if it's here
         if status_exception is not None:
             raise status_exception  # pylint: disable=E0702
 
-    def _process_status(self, status_url, auth, tags, http_host, timeout):
+    def _process_status(self, status_url, auth, tags, http_host, timeout, disable_ssl_validation):
         data = {}
         try:
             # TODO: adding the 'full' parameter gets you per-process detailed
             # informations, which could be nice to parse and output as metrics
             resp = requests.get(status_url, auth=auth, timeout=timeout,
                                 headers=headers(self.agentConfig, http_host=http_host),
+                                verify=not disable_ssl_validation,
                                 params={'json': True})
             resp.raise_for_status()
 
@@ -105,7 +109,7 @@ class PHPFPMCheck(AgentCheck):
         # return pool, to tag the service check with it if we have one
         return pool_name
 
-    def _process_ping(self, ping_url, ping_reply, auth, tags, pool_name, http_host, timeout):
+    def _process_ping(self, ping_url, ping_reply, auth, tags, pool_name, http_host, timeout, disable_ssl_validation):
         if ping_reply is None:
             ping_reply = 'pong'
 
@@ -117,7 +121,9 @@ class PHPFPMCheck(AgentCheck):
             # TODO: adding the 'full' parameter gets you per-process detailed
             # informations, which could be nice to parse and output as metrics
             resp = requests.get(ping_url, auth=auth, timeout=timeout,
-                                headers=headers(self.agentConfig, http_host=http_host))
+                                headers=headers(self.agentConfig, 
+                                http_host=http_host,
+                                verify=not disable_ssl_validation ))
             resp.raise_for_status()
 
             if ping_reply not in resp.text:

--- a/php_fpm/conf.yaml.example
+++ b/php_fpm/conf.yaml.example
@@ -27,6 +27,12 @@ instances:
     # If you need to specify a custom timeout in seconds (default is 20):
     # timeout: 20
     #
+    # The (optional) disable_ssl_validation will instruct the check
+    # to skip the validation of the SSL certificate of the URL being tested.
+    # Defaults to false, set to true if you want to disable SSL certificate validation.
+    #
+    # disable_ssl_validation: true
+    #
     # Array of custom tags
     # By default metrics and service check will be tagged by pool and host
     # tags:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Our system does not have proper certs for localhost, since we go though a load balancer. I looked at the apache client and made simular changes to the php-fpm.  

I did this manually on my agent, and it seems to be working so I made this fork and put the changes here.


### Motivation

Figured other people may have similar problems.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes


