### PR TITLE
[gitlab_runner/gitlab] Add service checks for local Prometheus endpoint

### DIFF
--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -31,7 +31,7 @@ The `allowed_metrics` item in the `init_config` section allows to specify the me
         gitlab
         -----------
           - instance #0 [OK]
-          - Collected 8 metrics, 0 events & 2 service checks
+          - Collected 8 metrics, 0 events & 3 service checks
 
 ## Compatibility
 
@@ -46,6 +46,7 @@ The Gitlab check does not include any event at this time.
 
 ### Service Checks
 The Gitlab check includes a readiness and a liveness service check.
+Moreover, it provides a service check to ensure that the local Prometheus endpoint is available.
 
 ## Troubleshooting
 Need help? Contact [Datadog Support](http://docs.datadoghq.com/help/).

--- a/gitlab_runner/README.md
+++ b/gitlab_runner/README.md
@@ -37,7 +37,7 @@ The `allowed_metrics` item in the `init_config` section allows to specify the me
         gitlab_runner
         -----------
           - instance #0 [OK]
-          - Collected 10 metrics, 0 events & 1 service checks
+          - Collected 10 metrics, 0 events & 2 service checks
 
 ## Compatibility
 
@@ -51,7 +51,8 @@ See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/gitl
 The Gitlab Runner check does not include any event at this time.
 
 ### Service Checks
-The Gitlab Runner check currently provides a service check to ensure that the Runner can talk to the Gitlab master.
+The Gitlab Runner check currently provides a service check to ensure that the Runner can talk to the Gitlab master and another one to ensure that the
+local Prometheus endpoint is available.
 
 ## Troubleshooting
 Need help? Contact [Datadog Support](http://docs.datadoghq.com/help/).

--- a/gitlab_runner/check.py
+++ b/gitlab_runner/check.py
@@ -12,7 +12,8 @@ from util import headers
 class GitlabRunnerCheck(PrometheusCheck):
 
     EVENT_TYPE = SOURCE_TYPE_NAME = NAMESPACE = 'gitlab_runner'
-    SERVICE_CHECK_NAME = 'gitlab_runner.can_connect'
+    MASTER_SERVICE_CHECK_NAME = 'gitlab_runner.can_connect'
+    PROMETHEUS_SERVICE_CHECK_NAME = 'gitlab_runner.prometheus_endpoint_up'
 
     DEFAULT_CONNECT_TIMEOUT = 5
     DEFAULT_RECEIVE_TIMEOUT = 15
@@ -41,7 +42,14 @@ class GitlabRunnerCheck(PrometheusCheck):
         # By default we send the buckets
         send_buckets = _is_affirmative(instance.get('send_histograms_buckets', True))
 
-        self.process(endpoint, send_histograms_buckets=send_buckets, instance=instance)
+        try:
+            self.process(endpoint, send_histograms_buckets=send_buckets, instance=instance)
+            self.service_check(self.PROMETHEUS_SERVICE_CHECK_NAME, PrometheusCheck.OK)
+        except requests.exceptions.ConnectionError as e:
+            # Unable to connect to the metrics endpoint
+            self.service_check(self.PROMETHEUS_SERVICE_CHECK_NAME, PrometheusCheck.CRITICAL,
+                               message="Unable to retrieve Prometheus metrics from endpoint %s: %s" % (endpoint, e.message))
+
 
         #### Service check to check whether the Runner can talk to the Gitlab master
         self._check_connectivity_to_master(instance)
@@ -89,7 +97,7 @@ class GitlabRunnerCheck(PrometheusCheck):
             r = requests.get(url, auth=auth, verify=verify_ssl, timeout=timeouts,
                              headers=headers(self.agentConfig))
             if r.status_code != 200:
-                self.service_check(self.SERVICE_CHECK_NAME, PrometheusCheck.CRITICAL,
+                self.service_check(self.MASTER_SERVICE_CHECK_NAME, PrometheusCheck.CRITICAL,
                                    message="Got %s when hitting %s" % (r.status_code, url),
                                    tags=service_check_tags)
                 raise Exception("Http status code {0} on url {1}".format(r.status_code, url))
@@ -98,15 +106,15 @@ class GitlabRunnerCheck(PrometheusCheck):
 
         except requests.exceptions.Timeout:
             # If there's a timeout
-            self.service_check(self.SERVICE_CHECK_NAME, PrometheusCheck.CRITICAL,
+            self.service_check(self.MASTER_SERVICE_CHECK_NAME, PrometheusCheck.CRITICAL,
                                message="Timeout when hitting %s" % url,
                                tags=service_check_tags)
             raise
         except Exception as e:
-            self.service_check(self.SERVICE_CHECK_NAME, PrometheusCheck.CRITICAL,
+            self.service_check(self.MASTER_SERVICE_CHECK_NAME, PrometheusCheck.CRITICAL,
                                message="Error hitting %s. Error: %s" % (url, e.message),
                                tags=service_check_tags)
             raise
         else:
-            self.service_check(self.SERVICE_CHECK_NAME, PrometheusCheck.OK, tags=service_check_tags)
+            self.service_check(self.MASTER_SERVICE_CHECK_NAME, PrometheusCheck.OK, tags=service_check_tags)
         self.log.debug("gitlab check succeeded")


### PR DESCRIPTION
### What does this PR do?

It adds a service check for `gitlab` and `gitlab_runner` to validate that the local Prometheus endpoint is available. 

### Motivation

The previous code fails if the endpoint isn't available and stops reporting at all.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
