### PR TITLE
[gitlab/gitlab_runner] Infer port from scheme

### DIFF
--- a/gitlab/check.py
+++ b/gitlab/check.py
@@ -72,7 +72,7 @@ class GitlabCheck(PrometheusCheck):
     def _service_check_tags(self, url):
         parsed_url = urlparse.urlparse(url)
         gitlab_host = parsed_url.hostname
-        gitlab_port = parsed_url.port or 80
+        gitlab_port = 443 if parsed_url.scheme == 'https' else (parsed_url.port or 80)
         return ['gitlab_host:%s' % gitlab_host, 'gitlab_port:%s' % gitlab_port]
 
     # Validates an health endpoint

--- a/gitlab_runner/check.py
+++ b/gitlab_runner/check.py
@@ -68,7 +68,7 @@ class GitlabRunnerCheck(PrometheusCheck):
 
         parsed_url = urlparse.urlparse(url)
         gitlab_host = parsed_url.hostname
-        gitlab_port = parsed_url.port or 80
+        gitlab_port = 443 if parsed_url.scheme == 'https' else (parsed_url.port or 80)
         service_check_tags = ['gitlab_host:%s' % gitlab_host, 'gitlab_port:%s' % gitlab_port]
 
         ## Load the ssl configuration


### PR DESCRIPTION
### What does this PR do?

This code infers the Gitlab port from the scheme of the URL provided.

### Motivation

The previous code would still report port 80 for https.

### Testing Guidelines

Use an https endpoint and ensure that the inferred port is 443.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.