### PR TITLE
[gitlab] fix Prometheus port in example yaml

### DIFF
--- a/gitlab/conf.yaml.example
+++ b/gitlab/conf.yaml.example
@@ -117,7 +117,7 @@ instances:
   - gitlab_url: http://localhost
 
     # url of the metrics endpoint of prometheus
-    prometheus_endpoint: http://localhost:9
+    prometheus_endpoint: http://localhost:9090
     # The histogram buckets can be noisy and generate a lot of tags.
     # send_histograms_buckets controls whether or not you want to pull them.
     #


### PR DESCRIPTION
### What does this PR do?

It fixes a typo for the Prometheus port in the example yaml.

### Motivation

We kind of like having a valid URL in our example :)

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
