### PR TITLE
[gitlab] wait for Prometheus to be up before testing

### DIFF
--- a/gitlab/ci/gitlab.rake
+++ b/gitlab/ci/gitlab.rake
@@ -21,6 +21,7 @@ namespace :ci do
       Rake::Task['ci:common:install'].invoke('gitlab')
       sh %(#{GITLAB_COMPOSE_ARGS} docker-compose -f gitlab/ci/docker-compose.yml up -d)
       Wait.for "http://localhost:#{GITLAB_LOCAL_PORT}", 900
+      Wait.for "http://localhost:#{GITLAB_LOCAL_PROMETHEUS_PORT}", 900
     end
 
     task before_script: ['ci:common:before_script'] do


### PR DESCRIPTION
### What does this PR do?

It adds a wait_for step to ensure that the Prometheus endpoint is available before testing.

### Motivation

Every now and then, that endpoint can take a few seconds to become available.
