### PR TITLE
[gitlab/gitlab_runner] ensure metrics namespace is set

### DIFF
--- a/gitlab/check.py
+++ b/gitlab/check.py
@@ -13,7 +13,7 @@ class GitlabCheck(PrometheusCheck):
 
     # Readiness signals ability to serve traffic, liveness that Gitlab is healthy overall
     ALLOWED_SERVICE_CHECKS = ['readiness', 'liveness']
-    EVENT_TYPE = SOURCE_TYPE_NAME = NAMESPACE = 'gitlab'
+    EVENT_TYPE = SOURCE_TYPE_NAME = 'gitlab'
     DEFAULT_CONNECT_TIMEOUT = 5
     DEFAULT_RECEIVE_TIMEOUT = 15
 
@@ -33,6 +33,7 @@ class GitlabCheck(PrometheusCheck):
             raise CheckException("At least one metric must be whitelisted in `allowed_metrics`.")
 
         self.metrics_mapper = dict(zip(allowed_metrics, allowed_metrics))
+        self.NAMESPACE = 'gitlab'
 
     def check(self, instance):
         #### Metrics collection

--- a/gitlab/test_gitlab.py
+++ b/gitlab/test_gitlab.py
@@ -44,7 +44,7 @@ class TestGitlab(AgentCheckTest):
         """
         self.run_check(self.BASE_CONFIG)
         for metric in self.ALLOWED_METRICS:
-            self.assertMetric(".%s" % metric)
+            self.assertMetric("gitlab.%s" % metric)
 
     def test_service_checks_success(self):
         self.run_check(self.BASE_CONFIG)

--- a/gitlab_runner/check.py
+++ b/gitlab_runner/check.py
@@ -11,7 +11,7 @@ from util import headers
 
 class GitlabRunnerCheck(PrometheusCheck):
 
-    EVENT_TYPE = SOURCE_TYPE_NAME = NAMESPACE = 'gitlab_runner'
+    EVENT_TYPE = SOURCE_TYPE_NAME = 'gitlab_runner'
     MASTER_SERVICE_CHECK_NAME = 'gitlab_runner.can_connect'
     PROMETHEUS_SERVICE_CHECK_NAME = 'gitlab_runner.prometheus_endpoint_up'
 
@@ -32,6 +32,7 @@ class GitlabRunnerCheck(PrometheusCheck):
             raise CheckException("At least one metric must be whitelisted in `allowed_metrics`.")
 
         self.metrics_mapper = dict(zip(allowed_metrics, allowed_metrics))
+        self.NAMESPACE = 'gitlab_runner'
 
     def check(self, instance):
         #### Metrics collection

--- a/gitlab_runner/test_gitlab_runner.py
+++ b/gitlab_runner/test_gitlab_runner.py
@@ -46,7 +46,7 @@ class TestGitlabRunner(AgentCheckTest):
         """
         self.run_check(self.BASE_CONFIG)
         for metric in self.ALLOWED_METRICS:
-            self.assertMetric(".%s" % metric)
+            self.assertMetric("gitlab_runner.%s" % metric)
 
     def test_connection_success(self):
         self.run_check(self.BASE_CONFIG)


### PR DESCRIPTION
### What does this PR do?

Ensures that valid namespaces are used for the two checks.

### Motivation

The namespace weren't being picked up correctly and metrics were reported incorrectly.
