### PR TITLE
kubernetes: fix the nodeName in the fixtures

### DIFF
--- a/kubernetes/ci/fixtures/pods_list_1.2.json
+++ b/kubernetes/ci/fixtures/pods_list_1.2.json
@@ -408,7 +408,7 @@
         "dnsPolicy": "ClusterFirst",
         "serviceAccountName": "default",
         "serviceAccount": "default",
-        "nodeName": "kubernetes-massi-minion-txyy",
+        "nodeName": "kubernetes-massi-minion-k23m",
         "securityContext": {}
       },
       "status": {
@@ -421,7 +421,7 @@
             "lastTransitionTime": "2016-06-16T13:56:09Z"
           }
         ],
-        "hostIP": "10.240.0.5",
+        "hostIP": "10.240.0.9",
         "podIP": "10.244.1.4",
         "startTime": "2016-06-16T13:56:07Z",
         "containerStatuses": [
@@ -562,7 +562,7 @@
         "dnsPolicy": "ClusterFirst",
         "serviceAccountName": "default",
         "serviceAccount": "default",
-        "nodeName": "kubernetes-massi-minion-ze6g",
+        "nodeName": "kubernetes-massi-minion-k23m",
         "securityContext": {}
       },
       "status": {
@@ -575,7 +575,7 @@
             "lastTransitionTime": "2016-06-16T13:56:09Z"
           }
         ],
-        "hostIP": "10.240.0.4",
+        "hostIP": "10.240.0.9",
         "podIP": "10.244.2.5",
         "startTime": "2016-06-16T13:56:07Z",
         "containerStatuses": [

--- a/kubernetes/test_kubernetes.py
+++ b/kubernetes/test_kubernetes.py
@@ -734,9 +734,20 @@ class TestKubeutil(unittest.TestCase):
             self.assertEqual(name, 'bar')
             f.assert_not_called()
 
-    def test__fetch_host_data(self):
+    def test__fetch_host_data_1_1(self):
         """
-        Test with both 1.1 and 1.2 version payloads
+        Test with 1.1 version payload
+        """
+        with mock.patch('utils.kubernetes.KubeUtil.retrieve_pods_list') as mock_pods:
+            self.kubeutil.pod_name = 'heapster-v11-l8sh1'
+            mock_pods.return_value = json.loads(Fixtures.read_file("pods_list_1.1.json", sdk_dir=FIXTURE_DIR, string_escape=False))
+            self.kubeutil._fetch_host_data()
+            self.assertEqual(self.kubeutil._node_ip, '10.240.0.9')
+            self.assertEqual(self.kubeutil._node_name, 'gke-cluster-1-8046fdfa-node-ld35')
+
+    def test__fetch_host_data_1_2(self):
+        """
+        Test with 1.2 version payload
         """
         with mock.patch('utils.kubernetes.KubeUtil.retrieve_pods_list') as mock_pods:
             self.kubeutil.pod_name = 'dd-agent-1rxlh'
@@ -744,12 +755,6 @@ class TestKubeutil(unittest.TestCase):
             self.kubeutil._fetch_host_data()
             self.assertEqual(self.kubeutil._node_ip, '10.240.0.9')
             self.assertEqual(self.kubeutil._node_name, 'kubernetes-massi-minion-k23m')
-
-            self.kubeutil.pod_name = 'heapster-v11-l8sh1'
-            mock_pods.return_value = json.loads(Fixtures.read_file("pods_list_1.1.json", sdk_dir=FIXTURE_DIR, string_escape=False))
-            self.kubeutil._fetch_host_data()
-            self.assertEqual(self.kubeutil._node_ip, '10.240.0.9')
-            self.assertEqual(self.kubeutil._node_name, 'gke-cluster-1-8046fdfa-node-ld35')
 
     def test_get_auth_token(self):
         KubeUtil.AUTH_TOKEN_PATH = '/foo/bar'

--- a/kubernetes/test_kubernetes.py
+++ b/kubernetes/test_kubernetes.py
@@ -486,6 +486,7 @@ class TestKubeutil(unittest.TestCase):
     @mock.patch('utils.kubernetes.KubeUtil._locate_kubelet', return_value='http://172.17.0.1:10255')
     def setUp(self, _locate_kubelet):
         self.kubeutil = KubeUtil()
+        self.kubeutil.__init__()  # It's a singleton, force re-init
 
     @mock.patch('utils.kubernetes.KubeUtil.retrieve_pods_list', side_effect=['foo'])
     @mock.patch('utils.kubernetes.KubeUtil.extract_kube_pod_tags')


### PR DESCRIPTION
### What does this PR do?

As we changed the way we are getting the `nodeName` and `hostIP` in [#3614](https://github.com/DataDog/dd-agent/pull/3614), one fixture become flaky because not coherent.

The `.items[].spec.nodeName` and the `.items[].status.hostIP` of a `PodList` have to be the same in each Pod.

