### PR TITLE
Allows custom metrics to be collected from all instances

### DIFF
--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - sqlserver
 
+1.2.1 / Unreleased
+==================
+
+### Changes
+
+* [BUGFIX] Allows metric collection from all instances in custom query. See [#959][].
+
 1.2.0 / 2017-10-10
 ==================
 
@@ -29,5 +36,6 @@
 [#357]: https://github.com/DataDog/integrations-core/issues/357
 [#456]: https://github.com/DataDog/integrations-core/issues/456
 [#573]: https://github.com/DataDog/integrations-core/issues/573
+[#959]: https://github.com/DataDog/integrations-core/issues/959
 [@rlaveycal]: https://github.com/rlaveycal
 [@themsquared]: https://github.com/themsquared

--- a/sqlserver/check.py
+++ b/sqlserver/check.py
@@ -685,7 +685,8 @@ class SqlSimpleMetric(SqlServerMetric):
                         metric_tags = metric_tags + ['%s:%s' % (self.tag_by, instance_name.strip())]
                     self.report_function(self.datadog_name, cntr_value,
                                         tags=metric_tags)
-                    break
+                    if self.instance != ALL_INSTANCES:
+                        break
 
 
 class SqlFractionMetric(SqlServerMetric):

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -10,7 +10,7 @@
     "linux",
     "windows"
   ],
-  "version": "1.2.0",
+  "version": "1.2.1",
   "guid": "635cb962-ee9f-4788-aa55-a7ffb9661498",
   "public_title": "Datadog-SQL Server Integration",
   "categories":["data store"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Adds a condition to loop through all instances when collecting metrics from a custom SQL query

### Motivation

Customer reached out after specifying [ALL](https://github.com/DataDog/integrations-core/blob/master/sqlserver/conf.yaml.example#L33) in terms of the instances to collect in a custom SQL query. But the custom query was only returning the first instance from [the collected rows](https://github.com/DataDog/integrations-core/blob/master/sqlserver/check.py#L688)

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

Anything else we should know when reviewing?
