### PR TITLE
[protobuf] bumping to 3.5.1

### DIFF
--- a/gitlab/requirements.txt
+++ b/gitlab/requirements.txt
@@ -1,2 +1,2 @@
 # integration pip requirements
-protobuf==3.1.0
+protobuf==3.5.1

--- a/gitlab_runner/requirements.txt
+++ b/gitlab_runner/requirements.txt
@@ -1,2 +1,2 @@
 # integration pip requirements
-protobuf==3.1.0
+protobuf==3.5.1

--- a/kube_dns/CHANGELOG.md
+++ b/kube_dns/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - Kube-dns
 
+1.2.0 / Unreleased 
+==================
+### Changes
+
+* [IMPROVEMENT] Bumping protobuf to version 3.5.1. See [#965][]
+
 1.1.0 / 2017-11-21
 ==================
 ### Changes
@@ -17,4 +23,5 @@
 [#410]: https://github.com/DataDog/integrations-core/issues/410
 [#451]: https://github.com/DataDog/integrations-core/issues/451
 [#860]: https://github.com/DataDog/integrations-core/issues/860
+[#965]: https://github.com/DataDog/integrations-core/issues/965
 [@aerostitch]: https://github.com/aerostitch

--- a/kube_dns/manifest.json
+++ b/kube_dns/manifest.json
@@ -8,7 +8,7 @@
   "guid": "3c05ed97-bf34-4061-83c4-e742d7daa5f8",
   "support": "contrib",
   "supported_os": ["linux","mac_os","windows"],
-  "version": "1.1.0",
+  "version": "1.2.0",
   "public_title": "Datadog-Kube DNS Integration",
   "categories":["web", "network"],
   "type":"check",

--- a/kube_dns/requirements.txt
+++ b/kube_dns/requirements.txt
@@ -1,2 +1,2 @@
 # integration pip requirements
-protobuf==3.1.0
+protobuf==3.5.1

--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [IMPROVEMENT] Merge kubernetes-state pod.phase.[running|succeeded|pending|failed|unknown] service checks into one actionnable service check. Will be introduced in 5.20 and will change the behavior of the service check. [#874][]
 * [IMPROVEMENT] Adding statefulset metrics. [#936][]
+* [IMPROVEMENT] Bumping protobuf to version 3.5.1. See [#965][]
 
 1.4.0 / 2017-11-21
 ==================
@@ -54,3 +55,6 @@
 [#801]: https://github.com/DataDog/integrations-core/issues/801
 [#853]: https://github.com/DataDog/integrations-core/issues/853
 [#860]: https://github.com/DataDog/integrations-core/issues/860
+[#874]: https://github.com/DataDog/integrations-core/issues/874
+[#936]: https://github.com/DataDog/integrations-core/issues/936
+[#965]: https://github.com/DataDog/integrations-core/issues/965

--- a/kubernetes_state/requirements.txt
+++ b/kubernetes_state/requirements.txt
@@ -1,2 +1,2 @@
 # integration pip requirements
-protobuf==3.1.0
+protobuf==3.5.1


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

This PR bumps protobuf to version 3.5.1 for affected integrations in line with dd-agent (https://github.com/DataDog/dd-agent/pull/3619)

### Motivation

New protobuf version available, should be of help with wheels project as well.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

Anything else we should know when reviewing?
