### PR TITLE
[consul] Fixes TypeError if/when services are culled

### DIFF
--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -4,6 +4,7 @@
 ==================
 
 * [IMPROVEMENT] Add support for Consul 1.0. See [#876][], thanks [@byronwolfman][]
+* [BUG FIX] Fixes TypeError if/when services are culled. See [#][]
 
 
 1.2.0 2017-11-21

--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - consul
 
-1.3.1 / Unreleased
+1.3.0 / Unreleased
 ==================
 
 * [IMPROVEMENT] Add support for Consul 1.0. See [#876][], thanks [@byronwolfman][]

--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG - consul
 
-1.3.0 / Unreleased
+1.3.1 / Unreleased
 ==================
 
 * [IMPROVEMENT] Add support for Consul 1.0. See [#876][], thanks [@byronwolfman][]
-* [BUG FIX] Fixes TypeError if/when services are culled. See [#][]
+* [BUG FIX] Fixes TypeError if/when services are culled. See [#968][]
 
 
 1.2.0 2017-11-21
@@ -32,4 +32,5 @@
 [#521]: https://github.com/DataDog/integrations-core/issues/521
 [#860]: https://github.com/DataDog/integrations-core/issues/860
 [#876]: https://github.com/DataDog/integrations-core/pull/876
+[#968]: https://github.com/DataDog/integrations-core/pull/968
 [@byronwolfman]: https://github.com/byronwolfman

--- a/consul/check.py
+++ b/consul/check.py
@@ -219,13 +219,13 @@ class ConsulCheck(AgentCheck):
             if len(service_whitelist) > max_services:
                 self.warning('More than %d services in whitelist. Service list will be truncated.' % max_services)
 
-            services = [s for s in services if s in service_whitelist][:max_services]
+            services = {s:services[s] for s in [s for s in services if s in service_whitelist][:max_services]}
         else:
             if len(services) <= max_services:
                 self.log.debug('Consul service whitelist not defined. Agent will poll for all %d services found', len(services))
             else:
                 self.warning('Consul service whitelist not defined. Agent will poll for at most %d services' % max_services)
-                services = list(islice(services.iterkeys(), 0, max_services))
+                services = {s:services[s] for s in list(islice(services.iterkeys(), 0, max_services))}
 
         return services
 

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.3.0",
+  "version": "1.3.1",
   "guid": "ec1e9fac-a339-49a3-b501-60656d2a5671",
   "public_title": "Datadog-Consul Integration",
   "categories":["containers", "orchestration", "configuration & deployment", "notification"],

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.3.1",
+  "version": "1.3.0",
   "guid": "ec1e9fac-a339-49a3-b501-60656d2a5671",
   "public_title": "Datadog-Consul Integration",
   "categories":["containers", "orchestration", "configuration & deployment", "notification"],


### PR DESCRIPTION
### What does this PR do?

The data type of 'services' returned by the function `_cull_services_list` changes from a <dict> to a <list> if/when the list of services are culled. 

Below error will then be encountered when the function `_get_service_tags(service, services[service])` is called with "services" being of type <list>.

`TypeError: list indices must be integers, not unicode.`

### Motivation

Client issue.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [/ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

Anything else we should know when reviewing?
Error is not encountered if service_whitelist is empty or the list of services is below the number of MAX_SERVICES
