### PR TITLE
[nfsstat] properly poll nfsiostat

### DIFF
--- a/nfsstat/CHANGELOG.md
+++ b/nfsstat/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - Nfsstat
 
-Unreleased
+0.1.1 / Unreleased
 ==================
 
 ### Changes

--- a/nfsstat/CHANGELOG.md
+++ b/nfsstat/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - Nfsstat
 
+Unreleased
+==================
+
+### Changes
+
+* [BUGFIX] makes reports output stats in actual realtime. See [#974][].
+
 0.1.0/ 2017-10-10
 ==================
 

--- a/nfsstat/manifest.json
+++ b/nfsstat/manifest.json
@@ -8,7 +8,7 @@
   "guid": "9f2fe3a7-ae19-4da9-a253-ae817a5557ab",
   "support": "contrib",
   "supported_os": ["linux"],
-  "version": "0.1.0",
+  "version": "0.1.1",
   "public_title": "Datadog-Nfsstat Integration",
   "categories":["os & system"],
   "type":"check",

--- a/nfsstat/metadata.csv
+++ b/nfsstat/metadata.csv
@@ -6,12 +6,12 @@ system.nfs.read.ops,gauge,,operation,second,this is the number of read operation
 system.nfs.read_per_s,gauge,,kibibyte,second,this is the number of kibibytes read per second,0,nfsstat,reads per sec
 system.nfs.read.retrans,gauge,,operation,,this is the number of retransmissions in read operations,-1,nfsstat,read retransmissions
 system.nfs.read.retrans.pct,gauge,,percent,,this is the percent of retransmissions in read operations,-1,nfsstat,read percent retransmissions
-system.nfs.read.rtt,gauge,,millisecond,read operation round trip time,-1,nfsstat,read round trip time
-system.nfs.read.exe,gauge,,millisecond,this is the time between making a read rpc request and the request being completed,,-1,nfsstat,read execution time
-system.nfs.write_per_op,gauge,,kibibyte,operation,this is the number of kibibytes written per operation
-system.nfs.write.ops,gauge,,operation,second,this is the number of write operations per second
-system.nfs.write_per_s,gauge,,kibibyte,second,this is the number of kibibytes written per second
+system.nfs.read.rtt,gauge,,millisecond,,read operation round trip time,-1,nfsstat,read round trip time
+system.nfs.read.exe,gauge,,millisecond,,this is the time between making a read rpc request and the request being completed,-1,nfsstat,read execution time
+system.nfs.write_per_op,gauge,,kibibyte,operation,this is the number of kibibytes written per operation,0,nfsstat,write per operation
+system.nfs.write.ops,gauge,,operation,second,this is the number of write operations per second,0,nfsstat,operations per sec
+system.nfs.write_per_s,gauge,,kibibyte,second,this is the number of kibibytes written per second,0,nfsstat,writes per sec
 system.nfs.write.retrans,gauge,,operation,,this is the number of retransmissions in write operations,-1,nfsstat,retransmissions
 system.nfs.write.retrans.pct,gauge,,percent,,this is the percent of retransmissions in write operations,-1,nfsstat,percent retransmissions
 system.nfs.write.rtt,gauge,,millisecond,,write operation round trip time,-1,nfsstat,write round trip time
-system.nfs.write.exe,gauge,,millisecond,,this is the time between making a write rpc request and the request being completed,,-1,nfsstat,write execution time
+system.nfs.write.exe,gauge,,millisecond,,this is the time between making a write rpc request and the request being completed,-1,nfsstat,write execution time

--- a/nfsstat/test/ci/fixtures/nfsiostat
+++ b/nfsstat/test/ci/fixtures/nfsiostat
@@ -18,33 +18,3 @@ read:              ops/s            kB/s           kB/op         retrans    avg 
                    0.382           2.304           6.038        0 (0.0%)           0.302           0.493
 write:             ops/s            kB/s           kB/op         retrans    avg RTT (ms)    avg exe (ms)
                    5.976          33.733           5.645        0 (0.0%)           0.535           5.222
-
-192.168.34.1:/exports/nfs/datadog/three mounted on /mnt/datadog/three:
-
-           ops/s       rpc bklog
-         111.507           0.000
-
-read:              ops/s            kB/s           kB/op         retrans    avg RTT (ms)    avg exe (ms)
-                   0.382           2.304           6.038        0 (0.0%)           0.302           0.493
-write:             ops/s            kB/s           kB/op         retrans    avg RTT (ms)    avg exe (ms)
-                   5.976          33.733           5.645        0 (0.0%)           0.535           5.222
-
-192.168.34.1:/exports/nfs/datadog/four mounted on /mnt/datadog/four:
-
-           ops/s       rpc bklog
-         111.507           0.000
-
-read:              ops/s            kB/s           kB/op         retrans    avg RTT (ms)    avg exe (ms)
-                   0.382           2.304           6.038        0 (0.0%)           0.302           0.493
-write:             ops/s            kB/s           kB/op         retrans    avg RTT (ms)    avg exe (ms)
-                   5.976          33.733           5.645        0 (0.0%)           0.535           5.222
-
-192.168.34.1:/exports/nfs/datadog/five mounted on /mnt/datadog/five:
-
-           ops/s       rpc bklog
-         111.507           0.000
-
-read:              ops/s            kB/s           kB/op         retrans    avg RTT (ms)    avg exe (ms)
-                   0.382           2.304           6.038        0 (0.0%)           0.302           0.493
-write:             ops/s            kB/s           kB/op         retrans    avg RTT (ms)    avg exe (ms)
-                   5.976          33.733           5.645        0 (0.0%)           0.535           5.222

--- a/nfsstat/test/test_nfsstat.py
+++ b/nfsstat/test/test_nfsstat.py
@@ -65,7 +65,7 @@ class TestNfsstat(AgentCheckTest):
         nfs_export_tag = 'nfs_export:/exports/nfs/datadog/{0}'
         nfs_mount_tag = 'nfs_mount:/mnt/datadog/{0}'
 
-        folder_names = ['one', 'two', 'three', 'four', 'five']
+        folder_names = ['two']
 
         # self.assertTrue(False)
 


### PR DESCRIPTION
### What does this PR do?

Currently, we collect the very first report of every `nfsiostat` invocation. This is a mistake because the first report is always an average since the devices were mounted, not recent values. The solution is to request two reports and use the second one.

ref.
http://www.linux-mag.com/id/7919/
https://linux.die.net/man/8/nfsiostat

### Motivation

Support ticket