### PR TITLE
[rabbitmq] validate the parsedurl actually has a schema

### DIFF
--- a/rabbitmq/check.py
+++ b/rabbitmq/check.py
@@ -158,11 +158,13 @@ class RabbitMQ(AgentCheck):
         password = instance.get('rabbitmq_pass', 'guest')
         custom_tags = instance.get('tags', [])
         parsed_url = urlparse.urlparse(base_url)
-        if not parsed_url.scheme:
+        if not parsed_url.scheme or "://" not in parsed_url.geturl():
             self.log.warning('The rabbit url did not include a protocol, assuming http')
             # urlparse.urljoin cannot add a protocol to the rest of the url for some reason.
             # This still leaves the potential for errors, but such urls would never have been valid, either
-            # and it's not likely to be useful to attempt to catch all possible mistakes people could make
+            # and it's not likely to be useful to attempt to catch all possible mistakes people could make.
+            # urlparse also has a known issue parsing url with no schema, but a port in the host section
+            # mistakingly taking the host for the schema, hence the additional validation
             base_url = 'http://' + base_url
             parsed_url = urlparse.urlparse(base_url)
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?
Hard validation on the the parsed url checking if it does indeed have a schema. If we don't find one after the parsing, let's just default to `http` as intended in the original PR here: https://github.com/DataDog/integrations-core/pull/909

### Motivation
There's a known long-standing issue regarding urlparse behavior when no schema is specified but the host does indeed have a port: https://bugs.python.org/issue754016

I'm not sure if there was a regression or if the patch never made it to 2.7. 

This issue was identified while testing for `5.21.0`

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning
Unnecessary versioning changes as this is a fix to an unreleased check.

### Additional Notes

Anything else we should know when reviewing?
