### PR TITLE
[etcd] dont send canconnect service check if health check fails

### DIFF
--- a/etcd/test_etcd.py
+++ b/etcd/test_etcd.py
@@ -116,5 +116,6 @@ class CheckEtcdTest(AgentCheckTest):
         self.assertServiceCheckCritical(self.check.SERVICE_CHECK_NAME,
                                         count=1,
                                         tags=['url:http://localhost:2379/test'])
+        self.assertServiceCheckUnknown(self.check.HEALTH_SERVICE_CHECK_NAME)
 
         self.coverage_report()


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Separates the logic to fetch health status from the rest, so we don't send the _can't connect_ service check if health status is not available.
