### PR TITLE
Adding note for postgres permissions

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -20,6 +20,8 @@ To get started with the PostgreSQL integration, create at least a read-only data
     grant SELECT ON pg_stat_database to datadog;
 ```
 
+**Note**: `grant SELECT ON pg_stat_database to datadog;` is for most cases, but Postgres instances with more tables locked down or custom queries require granting `CONNECT` to additional tables.
+
 To verify the correct permissions run the following command:
 
 ```


### PR DESCRIPTION
### What does this PR do?

Add a note to the setup instructions that `grant SELECT ON pg_stat_database to datadog;` is for most cases, but postgres instances with more tables locked down or custom queries may require granting `CONNECT` to additional tables

### Motivation

On the [Postgres integration page](https://docs.datadoghq.com/integrations/postgres/#setup) we ask users to grant `SELECT` privileges to a datadog user so that they can run the check. But depending on how a user's postgres environment is set up this may not be enough. e.g. if they have locked down access to any of the tables in the `pg_stat_database` schema or if they are accessing a table through a custom query that needs to be granted those permissions.
