### PR TITLE
[docker] Add short_image tag to container metrics

### DIFF
--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - docker_daemon
 
+1.8.0 / Unreleased
+==================
+### Changes
+
+* [IMPROVEMENT] Add `short_image` tag to container metrics. See [#986][]
+
 1.7.0 / 2018-01-10
 ==================
 ### Changes

--- a/docker_daemon/datadog_checks/docker_daemon/__init__.py
+++ b/docker_daemon/datadog_checks/docker_daemon/__init__.py
@@ -2,6 +2,6 @@ from . import docker_daemon
 
 DockerDaemon = docker_daemon.DockerDaemon
 
-__version__ = "1.7.0"
+__version__ = "1.8.0"
 
 __all__ = ['docker_daemon']

--- a/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py
+++ b/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py
@@ -109,6 +109,7 @@ CGROUP_METRICS = [
 
 DEFAULT_CONTAINER_TAGS = [
     "docker_image",
+    "short_image",
     "image_name",
     "image_tag",
 ]
@@ -134,6 +135,7 @@ TAG_EXTRACTORS = {
     "docker_image": lambda c: [DockerUtil().image_name_extractor(c)],
     "image_name": lambda c: DockerUtil().image_tag_extractor(c, 0),
     "image_tag": lambda c: DockerUtil().image_tag_extractor(c, 1),
+    "short_image": lambda c: [DockerUtil().image_name_extractor(c, short=True)],
     "container_command": lambda c: [c["Command"]],
     "container_name": DockerUtil.container_name_extractor,
     "container_id": lambda c: [c["Id"]],

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -2,7 +2,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
-  "min_agent_version": "5.15.0",
+  "min_agent_version": "5.22.0",
   "name": "docker_daemon",
   "short_description": "Correlate container performance with that of the services running inside them.",
   "guid": "08ee2733-0441-4438-8af8-e2f6fb926772",
@@ -11,7 +11,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.7.0",
+  "version": "1.8.0",
   "public_title": "Datadog-Docker Integration",
   "categories":["containers"],
   "type":"check",

--- a/docker_daemon/test/test_docker_daemon.py
+++ b/docker_daemon/test/test_docker_daemon.py
@@ -289,10 +289,10 @@ class TestCheckDockerDaemon(AgentCheckTest):
 
     def test_basic_config_single(self):
         expected_metrics = [
-            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest']),
-            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
-            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
-            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest']),
+            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'short_image:nginx:latest']),
+            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest', 'short_image:redis:latest']),
+            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest', 'short_image:redis:latest']),
+            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'short_image:nginx:latest']),
             ('docker.containers.running.total', None),
             ('docker.containers.stopped.total', None),
             ('docker.image.size', ['image_name:nginx', 'image_tag:latest']),
@@ -324,10 +324,10 @@ class TestCheckDockerDaemon(AgentCheckTest):
 
     def test_basic_config_twice(self):
         expected_metrics = [
-            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest']),
-            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
-            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
-            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest']),
+            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'short_image:nginx:latest']),
+            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest', 'short_image:redis:latest']),
+            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest', 'short_image:redis:latest']),
+            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'short_image:nginx:latest']),
             ('docker.containers.running.total', None),
             ('docker.containers.stopped.total', None),
             ('docker.images.available', None),
@@ -373,10 +373,10 @@ class TestCheckDockerDaemon(AgentCheckTest):
 
     def test_exclude_filter(self):
         expected_metrics = [
-            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest']),
-            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
-            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest']),
-            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
+            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'short_image:nginx:latest']),
+            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest', 'short_image:redis:latest']),
+            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'short_image:nginx:latest']),
+            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest', 'short_image:redis:latest']),
             ('docker.containers.running.total', None),
             ('docker.containers.stopped.total', None),
             ('docker.cpu.system', ['container_name:test-new-redis-latest', 'docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
@@ -430,10 +430,10 @@ class TestCheckDockerDaemon(AgentCheckTest):
 
     def test_include_filter(self):
         expected_metrics = [
-            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest']),
-            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
-            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest']),
-            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
+            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'short_image:nginx:latest']),
+            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest', 'short_image:redis:latest']),
+            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'short_image:nginx:latest']),
+            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest', 'short_image:redis:latest']),
             ('docker.containers.running.total', None),
             ('docker.containers.stopped.total', None),
             ('docker.cpu.system', ['container_name:test-new-redis-latest', 'docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
@@ -559,10 +559,10 @@ class TestCheckDockerDaemon(AgentCheckTest):
 
     def test_labels_collection(self):
         expected_metrics = [
-            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx']),
-            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
-            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
-            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx']),
+            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx', 'short_image:nginx:latest']),
+            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest', 'short_image:redis:latest']),
+            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest', 'short_image:redis:latest']),
+            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx', 'short_image:nginx:latest']),
             ('docker.containers.running.total', None),
             ('docker.containers.stopped.total', None),
             ('docker.image.size', ['image_name:redis', 'image_tag:latest']),
@@ -642,10 +642,10 @@ class TestCheckDockerDaemon(AgentCheckTest):
         metric_suffix = ["count", "avg", "median", "max", "95percentile"]
 
         expected_metrics = [
-            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest']),
-            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
-            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
-            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest']),
+            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'short_image:nginx:latest']),
+            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest', 'short_image:redis:latest']),
+            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest', 'short_image:redis:latest']),
+            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'short_image:nginx:latest']),
             ('docker.containers.running.total', None),
             ('docker.containers.stopped.total', None),
             ('docker.image.size', ['image_name:redis', 'image_tag:latest']),
@@ -735,10 +735,10 @@ class TestCheckDockerDaemon(AgentCheckTest):
 
     def test_container_size(self):
         expected_metrics = [
-            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest']),
-            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
-            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
-            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest']),
+            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'short_image:nginx:latest']),
+            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest', 'short_image:redis:latest']),
+            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest', 'short_image:redis:latest']),
+            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'short_image:nginx:latest']),
             ('docker.containers.running.total', None),
             ('docker.containers.stopped.total', None),
             ('docker.image.size', ['image_name:redis', 'image_tag:latest']),
@@ -817,8 +817,8 @@ class TestCheckDockerDaemon(AgentCheckTest):
         DockerUtil().set_docker_settings(config['init_config'], config['instances'][0])
 
         expected_service_checks = [
-            (AgentCheck.OK, ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'container_name:test-exit-ok']),
-            (AgentCheck.CRITICAL, ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'container_name:test-exit-fail']),
+            (AgentCheck.OK, ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'container_name:test-exit-ok', 'short_image:nginx:latest']),
+            (AgentCheck.CRITICAL, ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'container_name:test-exit-fail', 'short_image:nginx:latest']),
         ]
 
         container_ok = self.docker_client.create_container(

--- a/docker_daemon/test/test_docker_daemon.py
+++ b/docker_daemon/test/test_docker_daemon.py
@@ -605,11 +605,11 @@ class TestCheckDockerDaemon(AgentCheckTest):
         expected_metrics = [
             ('docker.containers.stopped.total', None),
             ('docker.containers.running.total', None),
-            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
-            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx']),
+            ('docker.containers.running', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest', 'short_image:redis:latest']),
+            ('docker.containers.running', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'short_image:nginx:latest', 'label1:nginx']),
             ('docker.mem.rss', ['container_name:test-new-nginx-latest', 'docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx']),
-            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
-            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx']),
+            ('docker.containers.stopped', ['docker_image:redis:latest', 'image_name:redis', 'image_tag:latest', 'short_image:redis:latest']),
+            ('docker.containers.stopped', ['docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'short_image:nginx:latest', 'label1:nginx']),
             ('docker.mem.rss', ['container_name:test-new-redis-latest', 'docker_image:redis:latest', 'image_name:redis', 'image_tag:latest']),
             ('docker.mem.limit', ['container_name:test-new-nginx-latest', 'docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx']),
             ('docker.mem.cache', ['container_name:test-new-nginx-latest', 'docker_image:nginx:latest', 'image_name:nginx', 'image_tag:latest', 'label1:nginx']),
@@ -633,8 +633,7 @@ class TestCheckDockerDaemon(AgentCheckTest):
         }
         self.check = load_check('docker_daemon', config, self.agentConfig)
 
-        self.check.check(config)
-        self.metrics = self.check.get_metrics()
+        self.run_check(config)
         for mname, tags in expected_metrics:
             self.assertMetric(mname, tags=tags, count=1, at_least=1)
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Add a `short_image` tag to container metrics (like container counts).

### Motivation

user request

### Testing Guidelines

should be tested with https://github.com/DataDog/dd-agent/pull/3622

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

The sister PR is set for 5.22.0 so I didn't add this one to 1.7.0 but created a 1.8.0 version that bumps the minimal agent version to 5.22.0. Happy to discuss it if that's an issue.