### PR TITLE
[SSH] Check that the private file exists

### DIFF
--- a/ssh_check/CHANGELOG.md
+++ b/ssh_check/CHANGELOG.md
@@ -1,14 +1,14 @@
 # CHANGELOG - ssh_check
 
-Unreleased
-==========
+1.1.3 / Unreleased 
+==================
 
 ### Changes
 
 * [BUGFIX] Check that the private_key_file exists in the yaml configuration before attempting to access it. See [#988][]
 
-2017-11-21
-==========
+1.1.2 / 2017-11-21
+==================
 
 ### Changes
 

--- a/ssh_check/CHANGELOG.md
+++ b/ssh_check/CHANGELOG.md
@@ -3,13 +3,17 @@
 Unreleased
 ==========
 
-* [BUGFIX] Check that the private_key_file exists in the yaml configuration before attempting to access. See [#988][]
+### Changes
+
+* [BUGFIX] Check that the private_key_file exists in the yaml configuration before attempting to access it. See [#988][]
 
 2017-11-21
 ==========
 
-* If `ssh_check` passes and uses `None` as `exception_message`, downstream aggregator rejects it with a type error. 
-  Instead, specify a default message.
+### Changes
+
+* [BUGFIX] If `ssh_check` passes and uses `None` as `exception_message`, downstream aggregator rejects it with a type error. 
+  Instead, specify a default message. See [#852][]
 
 1.1.1 / 2017-08-28
 ==================
@@ -37,5 +41,6 @@ Unreleased
 [#416]: https://github.com/DataDog/integrations-core/issues/416
 [#426]: https://github.com/DataDog/integrations-core/issues/426
 [#454]: https://github.com/DataDog/integrations-core/issues/454
+[#852]: https://github.com/DataDog/integrations-core/issues/852
 [#988]: https://github.com/DataDog/integrations-core/issues/988
 [@ilkka]: https://github.com/ilkka

--- a/ssh_check/CHANGELOG.md
+++ b/ssh_check/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - ssh_check
 
+Unreleased
+==========
+
+* [BUGFIX] Check that the private_key_file exists in the yaml configuration before attempting to access. See [#988][]
+
 2017-11-21
 ==========
 
@@ -32,4 +37,5 @@
 [#416]: https://github.com/DataDog/integrations-core/issues/416
 [#426]: https://github.com/DataDog/integrations-core/issues/426
 [#454]: https://github.com/DataDog/integrations-core/issues/454
+[#988]: https://github.com/DataDog/integrations-core/issues/988
 [@ilkka]: https://github.com/ilkka

--- a/ssh_check/check.py
+++ b/ssh_check/check.py
@@ -56,17 +56,19 @@ class CheckSSH(AgentCheck):
         tags = ["instance:{0}-{1}".format(conf.host, conf.port)]
 
         private_key = None
-        try:
-            if conf.private_key_type == 'ecdsa':
-                private_key = paramiko.ECDSAKey.from_private_key_file(conf.private_key_file)
-            else:
-                private_key = paramiko.RSAKey.from_private_key_file(conf.private_key_file)
-        except IOError:
-            self.warning("Unable to find private key file: {}".format(conf.private_key_file))
-        except paramiko.ssh_exception.PasswordRequiredException:
-            self.warning("Private key file is encrypted but no password was given")
-        except paramiko.ssh_exception.SSHException:
-            self.warning("Private key file is invalid")
+
+        if conf.private_key_file is not None:
+            try:
+                if conf.private_key_type == 'ecdsa':
+                    private_key = paramiko.ECDSAKey.from_private_key_file(conf.private_key_file)
+                else:
+                    private_key = paramiko.RSAKey.from_private_key_file(conf.private_key_file)
+            except IOError:
+                self.warning("Unable to find private key file: {}".format(conf.private_key_file))
+            except paramiko.ssh_exception.PasswordRequiredException:
+                self.warning("Private key file is encrypted but no password was given")
+            except paramiko.ssh_exception.SSHException:
+                self.warning("Private key file is invalid")
 
         client = paramiko.SSHClient()
         if conf.add_missing_keys:

--- a/ssh_check/manifest.json
+++ b/ssh_check/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.1.2",
+  "version": "1.1.3",
   "guid": "4eb195ef-554f-4cc2-80af-8f286c631fa8",
   "public_title": "Datadog-SSH Check Integration",
   "categories":["network"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Checks that the private_key_file is specified in the yaml file before trying to access it with the paramiko library. 

Also fixes up the Changelog a bit for this check to adhere to current format.

### Motivation

Currently the user has the ability to specify [add_missing_keys](https://github.com/DataDog/integrations-core/blob/nick/ssh_check_private_file_exists/ssh_check/conf.yaml.example#L11) However, we still were attempting to read from the private key file, despite it never existing. So we were flooding the logs with this error - https://github.com/DataDog/integrations-core/blob/nick/ssh_check_private_file_exists/ssh_check/check.py#L71

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

Anything else we should know when reviewing?
