### PR TITLE
Parse package version numbers without importing dependencies

### DIFF
--- a/activemq_xml/setup.py
+++ b/activemq_xml/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.activemq_xml import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "activemq_xml", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/agent_metrics/setup.py
+++ b/agent_metrics/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.agent_metrics import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "agent_metrics", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/apache/setup.py
+++ b/apache/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.apache import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "apache", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/aspdotnet/setup.py
+++ b/aspdotnet/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.aspdotnet import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "aspdotnet", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/btrfs/setup.py
+++ b/btrfs/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.btrfs import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "btrfs", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -14,6 +14,9 @@ set -e -x
 # https://unix.stackexchange.com/a/240004
 shopt -s nullglob
 
+# Install prerequisites needed to build some wheels.
+yum install -y unixODBC-devel
+
 # Install any system package required by any integration.
 # Update pip.
 for PYBIN in /opt/python/cp27-cp27m*/bin; do

--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -20,15 +20,15 @@ for PYBIN in /opt/python/cp27-cp27m*/bin; do
   "${PYBIN}/pip" install -U pip
 done
 
-# Build and test datadog-base, upon which all other integrations depend on.
+# Build and test datadog-checks-base, upon which all other integrations depend on.
 # Also build external dependencies from PyPI.
 for PYBIN in /opt/python/cp27-cp27m*/bin; do
-  # Build datadog-base, which should have no requirements.
+  # Build datadog-checks-base, which should have no requirements.
   # NOTE: Deliberately use the wrong default address for PyPI, so that
   # external dependencies are not downloaded from PyPI.
-  "${PYBIN}/pip" wheel /shared/datadog-base/ -w dogehouse/ --index-url https://example.com
+  "${PYBIN}/pip" wheel /shared/datadog-checks-base/ -w dogehouse/ --index-url https://example.com
 
-  # TODO: Test datadog-base.
+  # TODO: Test datadog-checks-base.
 
   # Build wheels for external dependencies.
   # https://stackoverflow.com/a/2087038
@@ -40,7 +40,7 @@ for PYBIN in /opt/python/cp27-cp27m*/bin; do
 done
 
 # Build all other integrations.
-# FIXME: shouldn't rebuild datadog-base again
+# FIXME: shouldn't rebuild datadog-checks-base again
 # FIXME: even though each INTEGRATION is in a separate directory, can one
 # accidentally / maliciously override another by using the same package name?
 for INTEGRATION in /shared/*/setup.py; do

--- a/cacti/setup.py
+++ b/cacti/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.cacti import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "cacti", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/cassandra_nodetool/setup.py
+++ b/cassandra_nodetool/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.cassandra_nodetool import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "cassandra_nodetool", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/ceph/datadog_checks/ceph/__init__.py
+++ b/ceph/datadog_checks/ceph/__init__.py
@@ -2,6 +2,6 @@ from . import ceph
 
 Ceph = ceph.Ceph
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 __all__ = ['ceph']

--- a/ceph/setup.py
+++ b/ceph/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.ceph import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "ceph", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/consul/setup.py
+++ b/consul/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.consul import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "consul", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/couch/setup.py
+++ b/couch/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.couch import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "couch", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/couchbase/setup.py
+++ b/couchbase/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.couchbase import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "couchbase", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/datadog-checks-base/setup.py
+++ b/datadog-checks-base/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks import __version__  # pylint: disable=import-error,no-name-in-module
+
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -12,9 +12,24 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "__init__.py")
+
 setup(
     name='datadog-checks-base',
-    version=__version__,
+    version=version,
     description='The Datadog Checks Base package',
     long_description=long_description,
     keywords='datadog checks base',

--- a/directory/setup.py
+++ b/directory/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.directory import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "directory", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/disk/setup.py
+++ b/disk/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.disk import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "disk", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/dns_check/setup.py
+++ b/dns_check/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.dns_check import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "dns_check", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/docker_daemon/setup.py
+++ b/docker_daemon/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.docker_daemon import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "docker_daemon", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/dotnetclr/setup.py
+++ b/dotnetclr/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.dotnetclr import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "dotnetclr", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/elastic/setup.py
+++ b/elastic/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.elastic import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "elastic", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/etcd/setup.py
+++ b/etcd/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.etcd import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "etcd", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/exchange_server/setup.py
+++ b/exchange_server/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.exchange_server import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "exchange_server", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/fluentd/setup.py
+++ b/fluentd/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.fluentd import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "fluentd", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/gearmand/setup.py
+++ b/gearmand/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.gearmand import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "gearmand", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/gitlab/setup.py
+++ b/gitlab/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.gitlab import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "gitlab", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/gitlab_runner/setup.py
+++ b/gitlab_runner/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.gitlab_runner import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "gitlab_runner", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/go_expvar/setup.py
+++ b/go_expvar/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.go_expvar import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "go_expvar", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/gunicorn/setup.py
+++ b/gunicorn/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.gunicorn import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "gunicorn", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/haproxy/setup.py
+++ b/haproxy/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.haproxy import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "haproxy", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/hdfs/setup.py
+++ b/hdfs/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.hdfs import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "hdfs", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/__init__.py
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/__init__.py
@@ -2,6 +2,6 @@ from . import hdfs_datanode
 
 HDFSDataNode = hdfs_datanode.HDFSDataNode
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 __all__ = ['hdfs_datanode']

--- a/hdfs_datanode/setup.py
+++ b/hdfs_datanode/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.hdfs_datanode import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "hdfs_datanode", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/__init__.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/__init__.py
@@ -2,6 +2,6 @@ from . import hdfs_namenode
 
 HDFSNameNode = hdfs_namenode.HDFSNameNode
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 __all__ = ['hdfs_namenode']

--- a/hdfs_namenode/setup.py
+++ b/hdfs_namenode/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.hdfs_namenode import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "hdfs_namenode", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/http_check/setup.py
+++ b/http_check/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.http_check import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "http_check", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/iis/setup.py
+++ b/iis/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.iis import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "iis", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/jenkins/setup.py
+++ b/jenkins/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.jenkins import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "jenkins", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/kafka_consumer/setup.py
+++ b/kafka_consumer/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.kafka_consumer import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "kafka_consumer", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/kong/setup.py
+++ b/kong/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.kong import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "kong", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/kube_dns/setup.py
+++ b/kube_dns/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.kube_dns import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "kube_dns", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/kubernetes/setup.py
+++ b/kubernetes/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.kubernetes import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "kubernetes", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/kubernetes_state/setup.py
+++ b/kubernetes_state/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.kubernetes_state import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "kubernetes_state", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/kyototycoon/setup.py
+++ b/kyototycoon/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.kyototycoon import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "kyototycoon", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/lighttpd/setup.py
+++ b/lighttpd/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.lighttpd import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "lighttpd", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/linux_proc_extras/setup.py
+++ b/linux_proc_extras/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.linux_proc_extras import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "linux_proc_extras", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/mapreduce/setup.py
+++ b/mapreduce/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.mapreduce import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "mapreduce", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/marathon/setup.py
+++ b/marathon/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.marathon import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "marathon", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/mcache/setup.py
+++ b/mcache/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.mcache import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "mcache", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/mesos/setup.py
+++ b/mesos/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.mesos import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "mesos", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/mesos_master/setup.py
+++ b/mesos_master/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.mesos_master import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "mesos_master", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/mesos_slave/setup.py
+++ b/mesos_slave/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.mesos_slave import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "mesos_slave", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/mongo/setup.py
+++ b/mongo/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.mongo import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "mongo", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/mysql/setup.py
+++ b/mysql/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.mysql import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "mysql", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/nagios/setup.py
+++ b/nagios/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.nagios import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "nagios", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/network/setup.py
+++ b/network/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.network import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "network", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/nfsstat/setup.py
+++ b/nfsstat/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.nfsstat import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "nfsstat", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/nginx/setup.py
+++ b/nginx/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.nginx import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "nginx", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/ntp/setup.py
+++ b/ntp/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.ntp import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "ntp", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/openstack/setup.py
+++ b/openstack/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.openstack import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "openstack", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/oracle/setup.py
+++ b/oracle/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.oracle import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "oracle", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/pdh_check/setup.py
+++ b/pdh_check/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.pdh_check import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "pdh_check", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/pgbouncer/setup.py
+++ b/pgbouncer/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.pgbouncer import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "pgbouncer", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/php_fpm/setup.py
+++ b/php_fpm/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.php_fpm import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "php_fpm", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/postfix/setup.py
+++ b/postfix/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.postfix import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "postfix", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/postgres/setup.py
+++ b/postgres/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.postgres import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "postgres", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/powerdns_recursor/setup.py
+++ b/powerdns_recursor/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.powerdns_recursor import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "powerdns_recursor", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/process/setup.py
+++ b/process/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.process import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "process", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/rabbitmq/setup.py
+++ b/rabbitmq/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.rabbitmq import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "rabbitmq", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/redisdb/setup.py
+++ b/redisdb/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.redisdb import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "redisdb", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/riak/setup.py
+++ b/riak/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.riak import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "riak", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/riakcs/setup.py
+++ b/riakcs/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.riakcs import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "riakcs", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/snmp/setup.py
+++ b/snmp/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.snmp import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "snmp", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/spark/datadog_checks/spark/__init__.py
+++ b/spark/datadog_checks/spark/__init__.py
@@ -2,6 +2,6 @@ from . import spark
 
 SparkCheck = spark.SparkCheck
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 
 __all__ = ['spark']

--- a/spark/setup.py
+++ b/spark/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.spark import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "spark", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/sqlserver/setup.py
+++ b/sqlserver/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.sqlserver import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "sqlserver", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/squid/setup.py
+++ b/squid/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.squid import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "squid", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/ssh_check/setup.py
+++ b/ssh_check/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.ssh_check import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "ssh_check", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/statsd/setup.py
+++ b/statsd/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.statsd import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "statsd", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/supervisord/setup.py
+++ b/supervisord/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.supervisord import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "supervisord", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/system_core/setup.py
+++ b/system_core/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.system_core import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "system_core", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/system_swap/setup.py
+++ b/system_swap/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.system_swap import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "system_swap", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/tcp_check/setup.py
+++ b/tcp_check/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.tcp_check import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "tcp_check", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/teamcity/setup.py
+++ b/teamcity/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.teamcity import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "teamcity", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/tokumx/setup.py
+++ b/tokumx/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.tokumx import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "tokumx", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/twemproxy/setup.py
+++ b/twemproxy/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.twemproxy import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "twemproxy", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/varnish/setup.py
+++ b/varnish/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.varnish import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "varnish", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/vsphere/setup.py
+++ b/vsphere/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.vsphere import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "vsphere", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/win32_event_log/setup.py
+++ b/win32_event_log/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.win32_event_log import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "win32_event_log", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/windows_service/setup.py
+++ b/windows_service/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.windows_service import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "windows_service", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/wmi_check/setup.py
+++ b/wmi_check/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.wmi_check import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "wmi_check", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/yarn/setup.py
+++ b/yarn/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.yarn import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "yarn", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)

--- a/zk/datadog_checks/zk/__init__.py
+++ b/zk/datadog_checks/zk/__init__.py
@@ -2,6 +2,6 @@ from . import zk
 
 ZookeeperCheck = zk.ZookeeperCheck
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 __all__ = ['zk']

--- a/zk/setup.py
+++ b/zk/setup.py
@@ -3,10 +3,9 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
-# module version
-from datadog_checks.zk import __version__  # pylint: disable=import-error,no-name-in-module
 
 import json
+import re
 
 here = path.abspath(path.dirname(__file__))
 
@@ -31,7 +30,21 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         else:
             runtime_reqs.append(req[0])
 
-version = __version__
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+version = find_version("datadog_checks", "zk", "__init__.py")
+
 manifest_version = None
 with open(path.join(here, 'manifest.json'), encoding='utf-8') as f:
     manifest = json.load(f)


### PR DESCRIPTION
### What does this PR do?

Parse package version numbers without importing dependencies.

Unfortunately, there is no one source of truth for version numbers, as
apparently there is a need for the same version number in both
package.__version, and manifest.json.

We have borrowed [the approach for parsing version numbers used by pip](https://github.com/pypa/pip/blob/f038fe47bd069dc8c72e7b05850d7136f81c6369/setup.py#L12-L42).

Also fix some other bugs in order to successfully build wheels.

### Motivation

To build wheels without necessarily installing dependencies first.

### Testing Guidelines

Run ```build-wheels.sh```.

### Versioning

N/A.

### Additional Notes

N/A.
  