### PR TITLE
Add disk device tagging

### DIFF
--- a/disk/CHANGELOG.md
+++ b/disk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - disk
 
+1.2.0 / Unreleased
+==================
+
+### Changes
+
+* [FEATURE] Adds additional device/mount tagging based on regex
+
 1.0.2 / 2017-10-10
 ==================
 

--- a/disk/CHANGELOG.md
+++ b/disk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - disk
 
-1.2.0 / Unreleased
+1.1.0 / Unreleased
 ==================
 
 ### Changes

--- a/disk/conf.yaml.default
+++ b/disk/conf.yaml.default
@@ -41,3 +41,8 @@ instances:
     # get metrics for all partitions. use_mount should be set to yes (to avoid
     # collecting empty device names) when using this option.
     # all_partitions: no
+    #
+    # The (optional) device_tag_re parameter will instruct the check to apply additional tags
+    # to volumes/mountpoints matching these regexes
+    # device_tag_re:
+    #  - /san/.*: device_type:san

--- a/disk/conf.yaml.default
+++ b/disk/conf.yaml.default
@@ -43,6 +43,7 @@ instances:
     # all_partitions: no
     #
     # The (optional) device_tag_re parameter will instruct the check to apply additional tags
-    # to volumes/mountpoints matching these regexes
+    # to volumes/mountpoints matching these regexes. Multiple comma-separated tags are supported.
     # device_tag_re:
     #  - /san/.*: device_type:san
+    #  - /dev/sda3: role:db,disk_size:large

--- a/disk/conf.yaml.default
+++ b/disk/conf.yaml.default
@@ -45,5 +45,5 @@ instances:
     # The (optional) device_tag_re parameter will instruct the check to apply additional tags
     # to volumes/mountpoints matching these regexes. Multiple comma-separated tags are supported.
     # device_tag_re:
-    #  - /san/.*: device_type:san
-    #  - /dev/sda3: role:db,disk_size:large
+    #  /san/.*: device_type:san
+    #  /dev/sda3: role:db,disk_size:large

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -305,11 +305,11 @@ class Disk(AgentCheck):
         """
         Compile regex strings from device_tag_re option and return list of compiled regex/tag pairs
         """
-        device_tag_re = []
+        device_tag_list = []
         for pair in self._device_tag_re:
-            for regex_str, tag in pair.items():
+            for regex_str, tags in pair.items():
                 try:
-                    device_tag_re.append([re.compile(regex_str), [t.strip() for t in tag.split(",")]])
+                    device_tag_list.append([re.compile(regex_str), [t.strip() for t in tags.split(",")]])
                 except TypeError:
                     self.log.warning('{0} is not a valid regular expression and will be ignored'.format(regex_str))
-        self._device_tag_re = device_tag_re
+        self._device_tag_re = device_tag_list

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -62,7 +62,7 @@ class Disk(AgentCheck):
             instance.get('tag_by_filesystem', False))
         self._all_partitions = _is_affirmative(
             instance.get('all_partitions', False))
-        self._device_tag_re = instance.get('device_tag_re', [])
+        self._device_tag_re = instance.get('device_tag_re', {})
 
         # Force exclusion of CDROM (iso9660) from disk check
         self._excluded_filesystems.append('iso9660')
@@ -306,10 +306,9 @@ class Disk(AgentCheck):
         Compile regex strings from device_tag_re option and return list of compiled regex/tag pairs
         """
         device_tag_list = []
-        for pair in self._device_tag_re:
-            for regex_str, tags in pair.items():
-                try:
-                    device_tag_list.append([re.compile(regex_str), [t.strip() for t in tags.split(",")]])
-                except TypeError:
-                    self.log.warning('{0} is not a valid regular expression and will be ignored'.format(regex_str))
+        for regex_str, tags in self._device_tag_re.iteritems():
+            try:
+                device_tag_list.append([re.compile(regex_str), [t.strip() for t in tags.split(",")]])
+            except TypeError:
+                self.log.warning('{0} is not a valid regular expression and will be ignored'.format(regex_str))
         self._device_tag_re = device_tag_list

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -37,6 +37,7 @@ class Disk(AgentCheck):
                             agentConfig, instances=instances)
         # Get the configuration once for all
         self._load_conf(instances[0])
+        self._compile_tag_re()
 
     def check(self, instance):
         """Get disk space/inode stats"""
@@ -61,6 +62,7 @@ class Disk(AgentCheck):
             instance.get('tag_by_filesystem', False))
         self._all_partitions = _is_affirmative(
             instance.get('all_partitions', False))
+        self._device_tag_re = instance.get('device_tag_re', [])
 
         # Force exclusion of CDROM (iso9660) from disk check
         self._excluded_filesystems.append('iso9660')
@@ -114,6 +116,11 @@ class Disk(AgentCheck):
 
             tags = [part.fstype, 'filesystem:{}'.format(part.fstype)] if self._tag_by_filesystem else []
             device_name = part.mountpoint if self._use_mount else part.device
+
+            # apply device/mountpoint specific tags
+            for regex, device_tags in self._device_tag_re:
+                if regex.match(device_name):
+                    tags += device_tags
 
             # legacy check names c: vs psutil name C:\\
             if Platform.is_win32():
@@ -224,6 +231,10 @@ class Disk(AgentCheck):
             self.log.debug("Passed: {0}".format(device))
             tags = [device[1], 'filesystem:{}'.format(device[1])] if self._tag_by_filesystem else []
             device_name = device[-1] if self._use_mount else device[0]
+            # apply device/mountpoint specific tags
+            for regex, device_tags in self._device_tag_re:
+                if regex.match(device_name):
+                    tags += device_tags
             for metric_name, value in self._collect_metrics_manually(device).iteritems():
                 self.gauge(metric_name, value, tags=tags,
                            device_name=device_name)
@@ -289,3 +300,16 @@ class Disk(AgentCheck):
 
         # Filter fake or unwanteddisks.
         return [d for d in flattened_devices if self._keep_device(d)]
+
+    def _compile_tag_re(self):
+        """
+        Compile regex strings from device_tag_re option and return list of compiled regex/tag pairs
+        """
+        device_tag_re = []
+        for pair in self._device_tag_re:
+            for regex_str, tag in pair.items():
+                try:
+                    device_tag_re.append([re.compile(regex_str), [t.strip() for t in tag.split(",")]])
+                except TypeError:
+                    self.log.warning('{0} is not a valid regular expression and will be ignored'.format(regex_str))
+        self._device_tag_re = device_tag_re

--- a/disk/manifest.json
+++ b/disk/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.2",
+  "version": "1.2.0",
   "guid": "94588b23-111e-4ed2-a2af-fd6e4caeea04",
   "public_title": "Datadog-Disk Integration",
   "categories":["os & system"],

--- a/disk/manifest.json
+++ b/disk/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.2.0",
+  "version": "1.1.0",
   "guid": "94588b23-111e-4ed2-a2af-fd6e4caeea04",
   "public_title": "Datadog-Disk Integration",
   "categories":["os & system"],

--- a/disk/test/test_disk.py
+++ b/disk/test/test_disk.py
@@ -257,6 +257,7 @@ class TestCheckDisk(AgentCheckTest):
         self.assertFalse(self.check._tag_by_filesystem)
         self.assertFalse(self.check._all_partitions)
         self.assertEqual(self.check._excluded_disk_re, re.compile('^$'))
+        self.assertEqual(self.check._device_tag_re, [])
 
     def test_ignore_empty_regex(self):
         """
@@ -266,3 +267,22 @@ class TestCheckDisk(AgentCheckTest):
         self.load_check({'instances': [{}]}, agent_config={'device_blacklist_re': ''})
         self.check._load_conf({})
         self.assertEqual(self.check._excluded_disk_re, re.compile('^$'))
+
+    @mock.patch('psutil.disk_partitions', return_value=[MockPart()])
+    @mock.patch('psutil.disk_usage', return_value=MockDiskMetrics())
+    @mock.patch('os.statvfs', return_value=MockInodesMetrics())
+    def test_device_tagging(self, mock_partitions, mock_usage, mock_inodes):
+        # Mocking
+        mock_usage.__name__ = "foo"
+        mock_inodes.__name__ = "foo"
+        mock_partitions.__name__ = "foo"
+        self.run_check({'instances': [{'use_mount': 'no',
+                                       'device_tag_re': [{"/dev/sda.*": "type:dev,tag:two"}]}]},
+                       mocks={'collect_metrics': lambda: None})
+
+        # Assert metrics
+        for metric, value in self.GAUGES_VALUES.iteritems():
+            self.assertMetric(metric, value=value, tags=["type:dev", "tag:two"],
+                              device_name=DEFAULT_DEVICE_NAME)
+
+        self.coverage_report()

--- a/disk/test/test_disk.py
+++ b/disk/test/test_disk.py
@@ -257,7 +257,7 @@ class TestCheckDisk(AgentCheckTest):
         self.assertFalse(self.check._tag_by_filesystem)
         self.assertFalse(self.check._all_partitions)
         self.assertEqual(self.check._excluded_disk_re, re.compile('^$'))
-        self.assertEqual(self.check._device_tag_re, [])
+        self.assertEqual(self.check._device_tag_re, {})
 
     def test_ignore_empty_regex(self):
         """
@@ -277,7 +277,7 @@ class TestCheckDisk(AgentCheckTest):
         mock_inodes.__name__ = "foo"
         mock_partitions.__name__ = "foo"
         self.run_check({'instances': [{'use_mount': 'no',
-                                       'device_tag_re': [{"/dev/sda.*": "type:dev,tag:two"}]}]},
+                                       'device_tag_re': {"/dev/sda.*": "type:dev,tag:two"}}]},
                        mocks={'collect_metrics': lambda: None})
 
         # Assert metrics


### PR DESCRIPTION
### What does this PR do?

This adds a new parameter for the disk integration called `device_tag_re`. This is a dictionary with key-value pairs consisting of a regex string and related tags. When the device name (or mount point if `use_mount` is enabled) matches the regex, the related tags will be added to the disk metrics.

### Motivation

Currently disk metrics only have `device` and possibly `filesystem` tags. Creating monitors for specific groups of disks, such as `/san/*`, can be a challenging manual process. Being able to apply specific tags to those devices helps with this.

### Testing Guidelines

Set the new `device_tag_re` parameter, which is a list consisting of regex/tag key-value pairs:

```
    device_tag_re:
      - vagrant.*: device_type:virtual
      - /dev/.*: device_type:dev,tag:two
```

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

