### PR TITLE
[ceph] Fix typo in parameter of example yaml

### DIFF
--- a/ceph/conf.yaml.example
+++ b/ceph/conf.yaml.example
@@ -12,12 +12,12 @@ instances:
 # to your sudoers file, and uncomment the below option.
 #
 #    use_sudo: True
-#    
+#
 #    # If you wish to customize the health checks that will be sent as a service check, uncomment and edit the list below.
 #    # It will by default collect the health check listed below.
 #    # The list of health checks is available here: http://docs.ceph.com/docs/master/rados/operations/health-checks/
-#    # The health checks are only available if you're running ceph luminous or later 
-#    collect_service_checks_for:
+#    # The health checks are only available if you're running ceph luminous or later
+#    collect_service_check_for:
 #      - OSD_DOWN
 #      - OSD_ORPHAN
 #      - OSD_FULL


### PR DESCRIPTION
### What does this PR do?

Fixes typo in parameter of example yaml. The check actually pulls the `collect_service_check_for` parameter (without an `s` on `service_check`). 

### Versioning

No need for version bump nor changelog update

~- [ ] Bumped the version check in `manifest.json`~
~- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.~
