### PR TITLE
Fix missing fs.total.disk* metrics with elastic >=5

### DIFF
--- a/elastic/CHANGELOG.md
+++ b/elastic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - elastic
 
+1.4.0 / Unreleased
+==================
+
+### Changes
+
+* [BUG] Fix missing fs metrics for elastic >= 5. See [#997][].
+
 1.3.0 / Unreleased
 ==================
 

--- a/elastic/check.py
+++ b/elastic/check.py
@@ -323,6 +323,14 @@ class ESCheck(AgentCheck):
         "elasticsearch.thread_pool.force_merge.rejected": ("rate", "thread_pool.force_merge.rejected"),
     }
 
+    ADDITIONAL_METRICS_5_x = {  # Stats are only valid for v5.x
+        "elasticsearch.fs.total.disk_io_op": ("rate", "fs.io_stats.total.operations"),
+        "elasticsearch.fs.total.disk_reads": ("rate", "fs.io_stats.total.read_operations"),
+        "elasticsearch.fs.total.disk_writes": ("rate", "fs.io_stats.total.write_operations"),
+        "elasticsearch.fs.total.disk_read_size_in_bytes": ("gauge", "fs.io_stats.total.read_kilobytes"),
+        "elasticsearch.fs.total.disk_write_size_in_bytes": ("gauge", "fs.io_stats.total.write_kilobytes"),
+    }
+
     CLUSTER_HEALTH_METRICS = {
         "elasticsearch.number_of_nodes": ("gauge", "number_of_nodes"),
         "elasticsearch.number_of_data_nodes": ("gauge", "number_of_data_nodes"),
@@ -552,6 +560,9 @@ class ESCheck(AgentCheck):
 
         if version >= [2, 1, 0]:
             stats_metrics.update(self.ADDITIONAL_METRICS_POST_2_1)
+
+        if version >= [5, 0, 0]:
+            stats_metrics.update(self.ADDITIONAL_METRICS_5_x)
 
         # Version specific stats metrics about the primary shards
         pshard_stats_metrics = dict(self.PRIMARY_SHARD_METRICS)

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.3.0",
+  "version": "1.4.0",
   "guid": "d91d91bd-4a8e-4489-bfb1-b119d4cc388a",
   "public_title": "Datadog-ElasticSearch Integration",
   "categories":["data store"],


### PR DESCRIPTION
### What does this PR do?

`fs.total` stats metrics path changed starting from elastic 5. This prevented the agent to report `fs.total.disk` metrics.

See: https://www.elastic.co/guide/en/elasticsearch/reference/5.4/cluster-nodes-stats.html#fs-info

### Motivation

Issue reported in #972 

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.