### PR TITLE
KSM add node tag for pods + override hostname

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ env:
     - TRAVIS_FLAVOR=kong FLAVOR_VERSION=0.9.0
     - TRAVIS_FLAVOR=kube_dns FLAVOR_VERSION=0.1.0
     - TRAVIS_FLAVOR=kubernetes
+    - TRAVIS_FLAVOR=kubernetes_state
     - TRAVIS_FLAVOR=kyototycoon FLAVOR_VERSION=0.9.56
     - TRAVIS_FLAVOR=lighttpd
     - TRAVIS_FLAVOR=mcache FLAVOR_VERSION=1.4.22

--- a/circle.yml
+++ b/circle.yml
@@ -80,6 +80,7 @@ test:
         - rake ci:run[kafka]
         - rake ci:run[docker_daemon]
         - rake ci:run[kubernetes]
+        - rake ci:run[kubernetes_state]
         - rake ci:run[cassandra_nodetool]
         - rake ci:run[squid]
         - bundle exec rake requirements

--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - kubernetes_state
 
+2.1.0 / Unreleased
+==================
+### Changes
+
+* [IMPROVEMENT] Add the node label wherever the pod label is present [#1000][]
+* [IMPROVEMENT] Override hostname with the node label if present [#1000][]
+
 2.0.0 / 2018-01-10
 ==================
 ### Changes

--- a/kubernetes_state/datadog_checks/kubernetes_state/__init__.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/__init__.py
@@ -2,6 +2,6 @@ from . import kubernetes_state
 
 KubernetesState = kubernetes_state.KubernetesState
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 __all__ = ['kubernetes_state']

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -80,6 +80,8 @@ class KubernetesState(PrometheusCheck):
             'kube_pod_container_status_running': 'container.running',
             'kube_pod_container_resource_requests_nvidia_gpu_devices': 'container.gpu.request',
             'kube_pod_container_resource_limits_nvidia_gpu_devices': 'container.gpu.limit',
+            'kube_pod_status_ready': 'pod.ready',
+            'kube_pod_status_scheduled': 'pod.scheduled',
             'kube_replicaset_spec_replicas': 'replicaset.replicas_desired',
             'kube_replicaset_status_fully_labeled_replicas': 'replicaset.fully_labeled_replicas',
             'kube_replicaset_status_ready_replicas': 'replicaset.replicas_ready',
@@ -113,6 +115,7 @@ class KubernetesState(PrometheusCheck):
             'kube_node_labels',
             'kube_pod_created'
             'kube_pod_container_info',
+            'kube_pod_info',
             'kube_pod_owner',
             'kube_pod_start_time',
             'kube_pod_labels',
@@ -151,7 +154,14 @@ class KubernetesState(PrometheusCheck):
             'kube_job_status_start_time',
         ]
 
-        self.pod_node_mapping = {}
+        self.label_joins = {
+            'kube_pod_info': {
+                'label_to_match': 'pod',
+                'labels_to_get': ['node']
+            }
+        }
+
+        self.label_to_hostname = 'node'
 
     def check(self, instance):
         endpoint = instance.get('kube_state_url')
@@ -175,19 +185,12 @@ class KubernetesState(PrometheusCheck):
         self.job_succeeded_count = defaultdict(int)
         self.job_failed_count = defaultdict(int)
 
-        self.active_pod_set = set()
-
         self.process(endpoint, send_histograms_buckets=send_buckets, instance=instance)
 
         for job_tags, job_count in self.job_succeeded_count.iteritems():
             self.monotonic_count(self.NAMESPACE + '.job.succeeded', job_count, list(job_tags))
         for job_tags, job_count in self.job_failed_count.iteritems():
             self.monotonic_count(self.NAMESPACE + '.job.failed', job_count, list(job_tags))
-
-        #clean pod/node mapping
-        for key in self.pod_node_mapping.keys():
-            if key not in self.active_pod_set:
-                self.pod_node_mapping.pop(key, None)
 
     def _condition_to_service_check(self, metric, sc_name, mapping, tags=None):
         """
@@ -514,37 +517,3 @@ class KubernetesState(PrometheusCheck):
                 self.gauge(metric_base_name.format(resource, constraint), val, tags)
         else:
             self.log.error("Metric type %s unsupported for metric %s" % (message.type, message.name))
-
-    def _enrich_pod_with_node_tag(self, metric, metric_name, message_type):
-        for label in metric.label:
-            if label.name == "pod":
-                self.active_pod_set.add(label.value)
-                if label.value in self.pod_node_mapping.keys():
-                    tags = [
-                        self._label_to_tag("condition", metric.label),
-                        self._label_to_tag("namespace", metric.label),
-                        self._label_to_tag("pod", metric.label),
-                        self._format_tag("node", self.pod_node_mapping[label.value])
-                    ]
-                    self.gauge(metric_name, getattr(metric, METRIC_TYPES[message_type]).value, tags, hostname=self.pod_node_mapping[label.value])
-
-    def kube_pod_status_ready(self, message, **kwargs):
-        """ Whether the pod is ready to serve requests. """
-        for metric in message.metric:
-            self._enrich_pod_with_node_tag(metric, self.NAMESPACE + ".pod.ready", message.type)
-
-    def kube_pod_status_scheduled(self, message, **kwargs):
-        """ Describes the status of the scheduling process for the pod. """
-        for metric in message.metric:
-            self._enrich_pod_with_node_tag(metric, self.NAMESPACE + ".pod.scheduled", message.type)
-
-    def kube_pod_info(self, message, **kwargs):
-        """ Collect information about pod (no metric sent). """
-        for metric in message.metric:
-            pod_name = node_name =  ""
-            for label in metric.label:
-                if label.name == "pod":
-                    pod_name = label.value
-                elif label.name == "node":
-                    node_name = label.value
-            self.pod_node_mapping[pod_name] = node_name

--- a/kubernetes_state/manifest.json
+++ b/kubernetes_state/manifest.json
@@ -11,7 +11,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "2.0.0",
+  "version": "2.1.0",
   "use_omnibus_reqs": true,
   "public_title": "Datadog-Kubernetes State Integration",
   "categories":["orchestration", "containers"],

--- a/kubernetes_state/test/test_kubernetes_state.py
+++ b/kubernetes_state/test/test_kubernetes_state.py
@@ -6,11 +6,19 @@
 import mock
 import os
 
+# 3p
+from nose.plugins.attrib import attr
+
 # project
 from tests.checks.common import AgentCheckTest
 
 NAMESPACE = 'kubernetes_state'
 
+<<<<<<< HEAD
+=======
+@attr(requires='kubernetes_state')
+class TestKubernetesState(AgentCheckTest):
+>>>>>>> Add node tag for pod.ready/schedule metric
 
 class MockResponse:
     """
@@ -118,7 +126,8 @@ class TestKubernetesState(AgentCheckTest):
             }]
         }
 
-        self.run_check(config)
+        # run check twice to have pod/node mapping
+        self.run_check_twice(config)
 
         self.assertServiceCheck(NAMESPACE + '.node.ready', self.check.OK)
         self.assertServiceCheck(NAMESPACE + '.node.out_of_disk', self.check.OK)
@@ -156,7 +165,8 @@ class TestKubernetesState(AgentCheckTest):
             }]
         }
 
-        self.run_check(config)
+        # run check twice to have pod/node mapping
+        self.run_check_twice(config)
 
         self.assertServiceCheck(NAMESPACE + '.node.ready', self.check.OK)
         self.assertServiceCheck(NAMESPACE + '.node.out_of_disk', self.check.OK)

--- a/kubernetes_state/test/test_kubernetes_state.py
+++ b/kubernetes_state/test/test_kubernetes_state.py
@@ -14,12 +14,6 @@ from tests.checks.common import AgentCheckTest
 
 NAMESPACE = 'kubernetes_state'
 
-<<<<<<< HEAD
-=======
-@attr(requires='kubernetes_state')
-class TestKubernetesState(AgentCheckTest):
->>>>>>> Add node tag for pod.ready/schedule metric
-
 class MockResponse:
     """
     MockResponse is used to simulate the object requests.Response commonly returned by requests.get
@@ -37,6 +31,7 @@ class MockResponse:
         pass
 
 
+@attr(requires='kubernetes_state')
 class TestKubernetesState(AgentCheckTest):
     CHECK_NAME = 'kubernetes_state'
 

--- a/kubernetes_state/test/test_kubernetes_state.py
+++ b/kubernetes_state/test/test_kubernetes_state.py
@@ -93,6 +93,16 @@ class TestKubernetesState(AgentCheckTest):
         NAMESPACE + '.statefulset.replicas_updated',
     ]
 
+    TAGS = {
+        NAMESPACE + '.pod.ready': ['node:minikube'],
+        NAMESPACE + '.pod.scheduled': ['node:minikube']
+    }
+
+    HOSTNAMES = {
+        NAMESPACE + '.pod.ready': 'minikube',
+        NAMESPACE + '.pod.scheduled': 'minikube'
+    }
+
     ZERO_METRICS = [
         NAMESPACE + '.deployment.replicas_unavailable',
         NAMESPACE + '.deployment.paused',
@@ -141,7 +151,14 @@ class TestKubernetesState(AgentCheckTest):
                                 tags=['namespace:default', 'pod:hello-1509998460-tzh8k'])  # Unknown
 
         for metric in self.METRICS:
-            self.assertMetric(metric)
+            self.assertMetric(
+                metric,
+                hostname=self.HOSTNAMES.get(metric, None)
+            )
+            tags = self.TAGS.get(metric, None)
+            if tags:
+                for tag in tags:
+                    self.assertMetricTag(metric, tag)
             if metric not in self.ZERO_METRICS:
                 self.assertMetricNotAllZeros(metric)
 


### PR DESCRIPTION
### What does this PR do?

* Add the the `node` label for every metric containing the `pod` label 🏷 
* Override the hostname with the value of the `node` label if present

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
