### PR TITLE
ignore data from common IDEs/editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ tmp
 .rbenv-gemsets
 .ruby-version
 
+# Common IDEs & editors
+.idea/
+.vscode/


### PR DESCRIPTION
### What does this PR do?

This automatically ignores the settings/metadata directory of popular IDEs & editors so contributors don't have to manually exclude them every time. Specifically, this ignores JetBrains products and Visual Studio Code.