### PR TITLE
[wheels] setuptools unneeded by the actual wheels

### DIFF
--- a/gitlab/requirements.txt
+++ b/gitlab/requirements.txt
@@ -1,7 +1,4 @@
 # integration pip requirements
-setuptools==38.2.4 \
-    --hash=sha256:ca69216173b631cc29314bbce4d0b7e8a69784c8b6d7ea6b9e4952ac9ec0897d \
-    --hash=sha256:9c671a6291a5b1171fb9da81665eb4f9625c7dbddc613d82abdc6002a4bce896
 six==1.11.0 \
     --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb \
     --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9

--- a/gitlab_runner/requirements.txt
+++ b/gitlab_runner/requirements.txt
@@ -1,7 +1,4 @@
 # integration pip requirements
-setuptools==38.2.4 \
-    --hash=sha256:ca69216173b631cc29314bbce4d0b7e8a69784c8b6d7ea6b9e4952ac9ec0897d \
-    --hash=sha256:9c671a6291a5b1171fb9da81665eb4f9625c7dbddc613d82abdc6002a4bce896
 six==1.11.0 \
     --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb \
     --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9

--- a/hdfs/requirements.txt
+++ b/hdfs/requirements.txt
@@ -1,9 +1,6 @@
 # integration pip requirements
 snakebite==1.3.11 \
     --hash=sha256:dadea7ec58eef4a4ba4528a8c2b52a499dfa52b9097cd6956063a992c34dece9
-setuptools==38.2.4 \
-    --hash=sha256:ca69216173b631cc29314bbce4d0b7e8a69784c8b6d7ea6b9e4952ac9ec0897d \
-    --hash=sha256:9c671a6291a5b1171fb9da81665eb4f9625c7dbddc613d82abdc6002a4bce896
 six==1.11.0 \
     --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb \
     --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9

--- a/kube_dns/requirements.txt
+++ b/kube_dns/requirements.txt
@@ -1,7 +1,4 @@
 # integration pip requirements
-setuptools==38.2.4 \
-    --hash=sha256:ca69216173b631cc29314bbce4d0b7e8a69784c8b6d7ea6b9e4952ac9ec0897d \
-    --hash=sha256:9c671a6291a5b1171fb9da81665eb4f9625c7dbddc613d82abdc6002a4bce896
 six==1.11.0 \
     --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb \
     --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9

--- a/kubernetes_state/requirements.txt
+++ b/kubernetes_state/requirements.txt
@@ -1,7 +1,4 @@
 # integration pip requirements
-setuptools==38.2.4 \
-    --hash=sha256:ca69216173b631cc29314bbce4d0b7e8a69784c8b6d7ea6b9e4952ac9ec0897d \
-    --hash=sha256:9c671a6291a5b1171fb9da81665eb4f9625c7dbddc613d82abdc6002a4bce896
 six==1.11.0 \
     --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb \
     --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Removes setuptools as requirement for the actual wheels - it's a build dependency, not a runtime dep.

### Motivation

Failed omnibus build

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

No need for versioning changes.

### Additional Notes

Anything else we should know when reviewing?
