### PR TITLE
removing bad wording for installation process

### DIFF
--- a/activemq/README.md
+++ b/activemq/README.md
@@ -7,7 +7,9 @@ The ActiveMQ check lets you collect metrics for brokers and queues, producers an
 ## Setup
 ### Installation
 
-The Agent's ActiveMQ check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your ActiveMQ nodes.
+The Agent's ActiveMQ check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your ActiveMQ nodes.  
+
+If you need the newest version of the ActiveMQ XML check, install the `dd-check-activemq_xml` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 The check collects metrics via JMX, so you'll need a JVM on each node so the Agent can fork [jmxfetch](https://github.com/DataDog/jmxfetch). We recommend using an Oracle-provided JVM.
 

--- a/activemq/README.md
+++ b/activemq/README.md
@@ -9,7 +9,7 @@ The ActiveMQ check lets you collect metrics for brokers and queues, producers an
 
 The Agent's ActiveMQ check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your ActiveMQ nodes.  
 
-If you need the newest version of the ActiveMQ XML check, install the `dd-check-activemq_xml` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
+If you need the newest version of the ActiveMQ check, install the `dd-check-activemq` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 The check collects metrics via JMX, so you'll need a JVM on each node so the Agent can fork [jmxfetch](https://github.com/DataDog/jmxfetch). We recommend using an Oracle-provided JVM.
 

--- a/activemq_xml/README.md
+++ b/activemq_xml/README.md
@@ -10,7 +10,7 @@ Get metrics from activemq_xml service in real time to:
 ## Setup
 ### Installation
 
-Install the `dd-check-activemq_xml` package manually or with your favorite configuration manager
+The Activemq XML check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
 
 ### Configuration
 

--- a/activemq_xml/README.md
+++ b/activemq_xml/README.md
@@ -10,7 +10,9 @@ Get metrics from activemq_xml service in real time to:
 ## Setup
 ### Installation
 
-The Activemq XML check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
+The Activemq XML check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.  
+
+If you need the newest version of the ActiveMQ XML check, install the `dd-check-activemq_xml` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/agent_metrics/README.md
+++ b/agent_metrics/README.md
@@ -10,7 +10,9 @@ Get metrics from agent_metrics service in real time to:
 ## Setup
 ### Installation
 
-The Agent Metrics check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
+The Agent Metrics check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.  
+
+If you need the newest version of the Agent Metrics check, install the `dd-check-agent_metrics` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/agent_metrics/README.md
+++ b/agent_metrics/README.md
@@ -10,7 +10,7 @@ Get metrics from agent_metrics service in real time to:
 ## Setup
 ### Installation
 
-Install the `dd-check-agent_metrics` package manually or with your favorite configuration manager
+The Agent Metrics check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
 
 ### Configuration
 

--- a/aspdotnet/README.md
+++ b/aspdotnet/README.md
@@ -9,7 +9,7 @@ Get metrics from aspdotnet service in real time to:
 
 ## Installation
 
-Install the `dd-check-aspdotnet` package manually or with your favorite configuration manager
+The Aspdotnet check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
 
 ## Configuration
 

--- a/aspdotnet/README.md
+++ b/aspdotnet/README.md
@@ -9,7 +9,9 @@ Get metrics from aspdotnet service in real time to:
 
 ## Installation
 
-The Aspdotnet check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
+The Aspdotnet check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.  
+
+If you need the newest version of the Aspdotnet check, install the `dd-check-aspdotnet` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ## Configuration
 

--- a/btrfs/README.md
+++ b/btrfs/README.md
@@ -10,7 +10,9 @@ Get metrics from btrfs service in real time to:
 ## Setup
 ### Installation
 
-The Btrfs check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on every server that uses at least one Btrfs filesystem.
+The Btrfs check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on every server that uses at least one Btrfs filesystem.  
+
+If you need the newest version of the Btrfs check, install the `dd-check-btrfs` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/cacti/README.md
+++ b/cacti/README.md
@@ -10,7 +10,9 @@ Get metrics from cacti service in real time to:
 ## Setup
 ### Installation
 
-The Cacti check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Cacti servers.
+The Cacti check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Cacti servers.  
+
+If you need the newest version of the Cacti check, install the `dd-check-cacti` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -10,7 +10,9 @@ Get metrics from cassandra service in real time to:
 ## Setup
 ### Installation
 
-The Cassandra check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Cassandra nodes.
+The Cassandra check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Cassandra nodes.  
+
+If you need the newest version of the Cassandra check, install the `dd-check-cassandra` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 We recommend the use of Oracle's JDK for this integration. 
 

--- a/cassandra_nodetool/README.md
+++ b/cassandra_nodetool/README.md
@@ -9,7 +9,6 @@ It uses the `nodetool` utility to collect them.
 ### Installation
 
 The cassandra nodetool check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your cassandra nodes.
-If you need the newest version of the check, install the `dd-check-cassandra_nodetool` package.
 
 ### Configuration
 

--- a/cassandra_nodetool/README.md
+++ b/cassandra_nodetool/README.md
@@ -8,7 +8,9 @@ It uses the `nodetool` utility to collect them.
 ## Setup
 ### Installation
 
-The cassandra nodetool check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your cassandra nodes.
+The Cassandra nodetool check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your cassandra nodes.  
+
+If you need the newest version of the Cassandra nodetool check, install the `dd-check-cassandra-nodetool` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/ceph/README.md
+++ b/ceph/README.md
@@ -11,7 +11,9 @@ Enable the Datadog-Ceph integration to:
 ## Setup
 ### Installation
 
-The Ceph check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Ceph servers.
+The Ceph check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Ceph servers.  
+
+If you need the newest version of the Ceph check, install the `dd-check-ceph` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/consul/README.md
+++ b/consul/README.md
@@ -22,7 +22,9 @@ Finally, in addition to metrics, the Datadog Agent also sends a service check fo
 ## Setup
 ### Installation
 
-The Datadog Agent's Consul Check is included in the Agent package, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Consul nodes.
+The Datadog Agent's Consul Check is included in the Agent package, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Consul nodes.  
+
+If you need the newest version of the Consul check, install the `dd-check-consul` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/consul/README.md
+++ b/consul/README.md
@@ -22,7 +22,7 @@ Finally, in addition to metrics, the Datadog Agent also sends a service check fo
 ## Setup
 ### Installation
 
-The Datadog Agent's Consul Check is included in the Agent package, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Consul nodes. If you need the newest version of the Consul check, install the `dd-check-consul` package; this package's check will override the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
+The Datadog Agent's Consul Check is included in the Agent package, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Consul nodes.
 
 ### Configuration
 

--- a/couch/README.md
+++ b/couch/README.md
@@ -12,7 +12,9 @@ For performance reasons, the CouchDB version you're using is cached, so you cann
 ## Setup
 ### Installation
 
-The CouchDB check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your CouchDB servers.
+The CouchDB check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your CouchDB servers.  
+
+If you need the newest version of the CouchDB check, install the `dd-check-couchdb` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/couchbase/README.md
+++ b/couchbase/README.md
@@ -15,7 +15,9 @@ And many more.
 ## Setup
 ### Installation
 
-The Couchbase check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Couchbase nodes.
+The Couchbase check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Couchbase nodes.  
+
+If you need the newest version of the Couchbase check, install the `dd-check-couchbase` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/directory/README.md
+++ b/directory/README.md
@@ -12,7 +12,9 @@ Capture metrics from directories and files of your choosing. The Agent will coll
 ## Setup
 ### Installation
 
-The directory check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) anywhere you wish to use it.
+The directory check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) anywhere you wish to use it.  
+
+If you need the newest version of the Directory check, install the `dd-check-directory` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/disk/README.md
+++ b/disk/README.md
@@ -7,7 +7,9 @@ Collect metrics related to disk usage and IO.
 ## Setup
 ### Installation
 
-The disk check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) anywhere you wish to use it.
+The disk check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) anywhere you wish to use it.  
+
+If you need the newest version of the Disk check, install the `dd-check-disk` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/dotnetclr/README.md
+++ b/dotnetclr/README.md
@@ -9,7 +9,7 @@ Get metrics from dotnetclr service in real time to:
 
 ## Installation
 
-Install the `dd-check-dotnetclr` package manually or with your favorite configuration manager
+The Dotnetclr check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
 
 ## Configuration
 

--- a/dotnetclr/README.md
+++ b/dotnetclr/README.md
@@ -9,7 +9,9 @@ Get metrics from dotnetclr service in real time to:
 
 ## Installation
 
-The Dotnetclr check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
+The Dotnetclr check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.  
+
+If you need the newest version of the Dotnetclr check, install the `dd-check-dotnetclr` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ## Configuration
 

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -10,7 +10,9 @@ The Datadog Agent's Elasticsearch check collects metrics for search and indexing
 ## Setup
 ### Installation
 
-The Elasticsearch check is packaged with the Datadog Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Elasticsearch nodes, or on some other server if you use a hosted Elasticsearch (e.g. Elastic Cloud).
+The Elasticsearch check is packaged with the Datadog Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Elasticsearch nodes, or on some other server if you use a hosted Elasticsearch (e.g. Elastic Cloud).  
+
+If you need the newest version of the Elasticsearch check, install the `dd-check-elastic` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/etcd/README.md
+++ b/etcd/README.md
@@ -11,7 +11,9 @@ Collect etcd metrics to:
 ## Setup
 ### Installation
 
-The etcd check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your etcd instance(s).
+The etcd check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your etcd instance(s).  
+
+If you need the newest version of the etcd check, install the `dd-check-etcd` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/exchange_server/README.md
+++ b/exchange_server/README.md
@@ -9,7 +9,9 @@ Get metrics from Microsoft Exchange Server
 ## Setup
 ### Installation
 
-The Exchange check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
+The Exchange check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.  
+
+If you need the newest version of the Exchange check, install the `dd-check-exchange_server` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/exchange_server/README.md
+++ b/exchange_server/README.md
@@ -9,7 +9,7 @@ Get metrics from Microsoft Exchange Server
 ## Setup
 ### Installation
 
-Install the `dd-check-exchange_server` package manually or with your favorite configuration manager
+The Exchange check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
 
 ### Configuration
 

--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -10,7 +10,9 @@ Get metrics from Fluentd to:
 ## Setup
 ### Installation
 
-The Fluentd check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Fluentd servers.
+The Fluentd check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Fluentd servers.  
+
+If you need the newest version of the Fluentd check, install the `dd-check-fluentd` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 #### Prepare Fluentd

--- a/gearmand/README.md
+++ b/gearmand/README.md
@@ -11,7 +11,8 @@ Collect Gearman metrics to:
 ## Setup
 ### Installation
 
-The Gearman check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Gearman job servers.
+The Gearman check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Gearman job servers.  
+If you need the newest version of the Gearman check, install the `dd-check-gearman` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -12,7 +12,7 @@ more information about Gitlab and its integration with Prometheus
 ## Setup
 ### Installation
 
-Install the `dd-check-gitlab` package manually or with your favorite configuration manager
+The Gitlab check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Gitlab servers.
 
 ### Configuration
 

--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -12,7 +12,9 @@ more information about Gitlab and its integration with Prometheus
 ## Setup
 ### Installation
 
-The Gitlab check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Gitlab servers.
+The Gitlab check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Gitlab servers.  
+
+If you need the newest version of the Gitlab check, install the `dd-check-gitlab` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/gitlab_runner/README.md
+++ b/gitlab_runner/README.md
@@ -13,7 +13,7 @@ more information about Gitlab Runner and its integration with Prometheus
 ## Setup
 ### Installation
 
-Install the `dd-check-gitlab_runner` package manually or with your favorite configuration manager
+The Gitlab Runner check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Gitlab servers.
 
 ### Configuration
 

--- a/gitlab_runner/README.md
+++ b/gitlab_runner/README.md
@@ -13,7 +13,9 @@ more information about Gitlab Runner and its integration with Prometheus
 ## Setup
 ### Installation
 
-The Gitlab Runner check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Gitlab servers.
+The Gitlab Runner check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Gitlab servers.  
+
+If you need the newest version of the Gitlab Runner check, install the `dd-check-gitlab_runner` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/gunicorn/README.md
+++ b/gunicorn/README.md
@@ -14,7 +14,9 @@ Gunicorn itself can provide further metrics via DogStatsD, including those for:
 ## Setup
 ### Installation
 
-The Datadog Agent's Gunicorn check is included in the Agent package, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Gunicorn servers. If you need the newest version of the Gunicorn check, install the `dd-check-gunicorn` package; this package's check will override the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
+The Datadog Agent's Gunicorn check is included in the Agent package, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Gunicorn servers.  
+
+If you need the newest version of the Gunicorn check, install the `dd-check-gunicorn` package; this package's check will override the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 The Gunicorn check requires your Gunicorn app's Python environment to have the [`setproctitle`](https://pypi.python.org/pypi/setproctitle) package; without it, the Datadog Agent will always report that it cannot find a `gunicorn` master process (and hence, cannot find workers, either). Install the `setproctitle` package in your app's Python environment if you want to collect the `gunicorn.workers` metric.
 

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -11,7 +11,9 @@ Capture HAProxy activity in Datadog to:
 ## Setup
 ### Installation
 
-The HAProxy check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your HAProxy servers.
+The HAProxy check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your HAProxy servers.  
+
+If you need the newest version of the HAProxy check, install the `dd-check-haproxy` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 Make sure that stats are enabled on your HAProxy configuration. See [this post for guidance on doing this](https://www.datadoghq.com/blog/how-to-collect-haproxy-metrics/).
 

--- a/iis/README.md
+++ b/iis/README.md
@@ -7,7 +7,9 @@ Collect IIS metrics aggregated across all of your sites, or on a per-site basis.
 ## Setup
 ### Installation
 
-The IIS check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your IIS servers.
+The IIS check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your IIS servers.  
+
+If you need the newest version of the IIS check, install the `dd-check-iis` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 Also, your IIS servers must have the `Win32_PerfFormattedData_W3SVC_WebService` WMI class installed. 
 You can check for this using the following command:

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -14,7 +14,9 @@ To collect Kafka consumer metrics, see the [kafka_consumer check](https://docs.d
 ## Setup
 ### Installation
 
-The Agent's Kafka check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Kafka nodes.
+The Agent's Kafka check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Kafka nodes.  
+
+If you need the newest version of the Kafka check, install the `dd-check-kafka` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 The check collects metrics via JMX, so you'll need a JVM on each kafka node so the Agent can fork [jmxfetch](https://github.com/DataDog/jmxfetch). You can use the same JVM that Kafka uses.
 

--- a/kafka_consumer/README.md
+++ b/kafka_consumer/README.md
@@ -11,7 +11,9 @@ This check does NOT support Kafka versions > 0.8—it can't collect consumer off
 ## Setup
 ### Installation
 
-The Agent's Kafka consumer check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Kafka nodes. If you need the newest version of the check, install the `dd-check-kafka-consumer` package.
+The Agent's Kafka consumer check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Kafka nodes.  
+
+If you need the newest version of the DNS check, install the `dd-check-kafka-consumer` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/kong/README.md
+++ b/kong/README.md
@@ -7,7 +7,9 @@ The Agent's Kong check tracks total requests, response codes, client connections
 ## Setup
 ### Installation
 
-The Kong check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Kong servers. If you need the newest version of the check, install the `dd-check-kong` package.
+The Kong check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Kong servers.  
+
+If you need the newest version of the Kong check, install the `dd-check-kong` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/kube_dns/README.md
+++ b/kube_dns/README.md
@@ -13,7 +13,7 @@ more informations about kube-dns
 ## Setup
 ### Installation
 
-Install the `dd-check-kube_dns` package manually or with your favorite configuration manager
+The Kube-dns check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
 
 ### Configuration
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -10,7 +10,7 @@ Get metrics from kubernetes service in real time to:
 ## Setup
 ### Installation
 
-Install the `dd-check-kubernetes` package manually or with your favorite configuration manager
+The Kubernetes check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Kubernetes servers.
 
 ### Configuration
 

--- a/kubernetes_state/README.md
+++ b/kubernetes_state/README.md
@@ -10,7 +10,7 @@ Get metrics from kubernetes_state service in real time to:
 ## Setup
 ### Installation
 
-Install the `dd-check-kubernetes_state` package manually or with your favorite configuration manager
+The Kubernetes-Sate check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Kubernetes servers.
 
 ### Configuration
 

--- a/kyototycoon/README.md
+++ b/kyototycoon/README.md
@@ -7,7 +7,8 @@ The Agent's Kyototycoon check tracks get, set, and delete operations, and lets y
 ## Setup
 ### Installation
 
-The Kyototycoon check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Kyototycoon servers. If you need the newest version of the check, install the `dd-check-kyototycoon` package.
+The Kyototycoon check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Kyototycoon servers.  
+If you need the newest version of the Kyototycoon check, install the `dd-check-kyototycoon` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/lighttpd/README.md
+++ b/lighttpd/README.md
@@ -7,7 +7,9 @@ The Agent's lighttpd check tracks uptime, bytes served, requests per second, res
 ## Setup
 ### Installation
 
-The lighttpd check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your lighttpd servers. If you need the newest version of the check, install the `dd-check-lighttpd` package.
+The lighttpd check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your lighttpd servers.  
+
+If you need the newest version of the Lighttpd check, install the `dd-check-lighttpd` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 You'll also need to install `mod_status` on your Lighttpd servers.
 

--- a/linux_proc_extras/README.md
+++ b/linux_proc_extras/README.md
@@ -9,7 +9,7 @@ Get metrics from linux_proc_extras service in real time to:
 ## Setup
 ### Installation
 
-Install the `dd-check-linux_proc_extras` package manually or with your favorite configuration manager
+The Linux_proc_extras check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
 
 ### Configuration
 

--- a/mapreduce/README.md
+++ b/mapreduce/README.md
@@ -10,7 +10,7 @@ Get metrics from mapreduce service in real time to:
 ## Setup
 ### Installation
 
-Install the `dd-check-mapreduce` package manually or with your favorite configuration manager
+The Mapreduce check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
 
 ### Configuration
 

--- a/marathon/README.md
+++ b/marathon/README.md
@@ -10,7 +10,9 @@ The Agent's Marathon check lets you:
 ## Setup
 ### Installation
 
-The Marathon check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Marathon master. If you need the newest version of the check, install the `dd-check-marathon` package.
+The Marathon check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Marathon master.
+
+If you need the newest version of the Marathon check, install the `dd-check-marathon` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/mcache/README.md
+++ b/mcache/README.md
@@ -7,7 +7,9 @@ The Agent's memcache check lets you track memcache's memory use, hits, misses, e
 ## Setup
 ### Installation
 
-The memcache check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your memcache servers. If you need the newest version of the check, install the `dd-check-mcache` package.
+The memcache check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your memcache servers.
+
+If you need the newest version of the Memcache check, install the `dd-check-mcache` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -10,7 +10,9 @@ Connect MongoDB to Datadog in order to:
 ## Setup
 ### Installation
 
-The MongoDB check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your MongoDB masters. If you need the newest version of the check, install the `dd-check-mongo` package.
+The MongoDB check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your MongoDB masters. 
+
+If you need the newest version of the MongoDB check, install the `dd-check-mongo` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 #### Prepare MongoDB

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -14,7 +14,9 @@ And many more. You can also invent your own metrics using custom SQL queries.
 ## Setup
 ### Installation
 
-The MySQL check is included in the Datadog Agent package, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your MySQL servers. If you need the newest version of the check, install the `dd-check-mysql` package.
+The MySQL check is included in the Datadog Agent package, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your MySQL servers.  
+
+If you need the newest version of the MySQL check, install the `dd-check-mysql` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 #### Prepare MySQL

--- a/nagios/README.md
+++ b/nagios/README.md
@@ -13,7 +13,9 @@ The check emits events for service flaps, host state changes, passive service ch
 ## Setup
 ### Installation
 
-The Nagios check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Nagios servers. If you need the newest version of the check, install the `dd-check-nagios` package.
+The Nagios check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Nagios servers.  
+
+If you need the newest version of the Nagios check, install the `dd-check-nagios` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/network/README.md
+++ b/network/README.md
@@ -7,7 +7,9 @@ The network check collects TCP/IP stats from the host operating system.
 ## Setup
 ### Installation
 
-The network check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any host. If you need the newest version of the check, install the `dd-check-network` package.
+The network check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any host.  
+
+If you need the newest version of the Network check, install the `dd-check-network` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/nfsstat/README.md
+++ b/nfsstat/README.md
@@ -7,7 +7,9 @@ nfsiostat is a tool that gets metrics from NFS mounts. This check grabs these me
 ## Setup
 ### Installation
 
-The NFSstat check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
+The NFSstat check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.  
+
+If you need the newest version of the NFSstat check, install the `dd-check-nfsstat` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/nfsstat/README.md
+++ b/nfsstat/README.md
@@ -7,7 +7,7 @@ nfsiostat is a tool that gets metrics from NFS mounts. This check grabs these me
 ## Setup
 ### Installation
 
-Install the `dd-check-nfsstat` package manually or with your favorite configuration manager
+The NFSstat check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
 
 ### Configuration
 

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -20,7 +20,9 @@ And many more.
 ## Setup
 ### Installation
 
-The NGINX check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your NGINX servers. If you need the newest version of the check, install the `dd-check-nginx` package.
+The NGINX check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your NGINX servers.  
+
+If you need the newest version of the NGINX check, install the `dd-check-nginx` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 #### NGINX status module
 

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -10,13 +10,11 @@ Get metrics from openstack service in real time to:
 ## Setup
 ### Installation
 
-Install the `dd-check-openstack` package manually or with your favorite configuration manager.
+To capture OpenStack metrics you need to [install the Agent](https://app.datadoghq.com/account/settings#agent) on your hosts running hypervisors.
 
-Installing the OpenStack Integration could increase the number of VMs that Datadog monitors. For more information on how this may affect your billing, please visit our Billing FAQ.
+**Note**: Installing the OpenStack Integration could increase the number of VMs that Datadog monitors. For more information on how this may affect your billing, please visit our Billing FAQ.
 
 ### Configuration
-
-To capture OpenStack metrics you need to install the Datadog Agent on your hosts running hypervisors.
 
 1. First configure a Datadog role and user with your identity server
 

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -7,8 +7,6 @@ Get metrics from Oracle Database servers in real time to visualize and monitor a
 ## Setup
 ### Installation
 
-Install the `dd-check-oracle` package manually or with your favorite configuration manager.
-
 In order to use the Oracle integration you must install the Oracle Instant Client libraries. Due to licensing restrictions we are unable to include these libraries in our agent, but you can [download them directly frrom Oracle](https://www.oracle.com/technetwork/database/features/instant-client/index.htm).
 
 You will need to install the Instant Client Basic and SDK packages.

--- a/pdh_check/README.md
+++ b/pdh_check/README.md
@@ -9,7 +9,7 @@ Get metrics from Windows performance counters in real time to:
 ## Setup
 ### Installation
 
-Install the `dd-check-pdh_check` package manually or with your favorite configuration manager
+The PDH check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
 
 ### Configuration
 

--- a/pgbouncer/README.md
+++ b/pgbouncer/README.md
@@ -7,7 +7,9 @@ The PgBouncer check tracks connection pool metrics and lets you monitor traffic 
 ## Setup
 ### Installation
 
-The PgBouncer check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your PgBouncer nodes. If you need the newest version of the check, install the `dd-check-pgbouncer` package.
+The PgBouncer check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your PgBouncer nodes.  
+
+If you need the newest version of the PgBouncer check, install the `dd-check-pgbouncer` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/php_fpm/README.md
+++ b/php_fpm/README.md
@@ -7,7 +7,9 @@ The PHP-FPM check monitors the state of your FPM pool and tracks request perform
 ## Setup
 ### Installation
 
-The PHP-FPM check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any servers that use PHP-FPM. If you need the newest version of the check, install the `dd-check-php-fpm` package.
+The PHP-FPM check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any servers that use PHP-FPM.  
+
+If you need the newest version of the PHP-FPM check, install the `dd-check-php-fpm` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/postfix/README.md
+++ b/postfix/README.md
@@ -7,7 +7,9 @@ This check monitors the size of all your Postfix queues.
 ## Setup
 ### Installation
 
-The Postfix check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Postfix servers. If you need the newest version of the check, install the `dd-check-postfix` package.
+The Postfix check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Postfix servers.  
+
+If you need the newest version of the Postfix check, install the `dd-check-postfix` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ## Configuration
 This check can be configured to use the `find` command which requires granting the dd-agent user sudo access to get a count of messages in the `incoming`, `active`, and `deferred` mail queues.

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -11,7 +11,7 @@ Get metrics from postgres service in real time to:
 ## Setup
 ### Installation
 
-Install the `dd-check-postgres` package manually or with your favorite configuration manager
+The Postgres check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your servers.
 
 To get started with the PostgreSQL integration, create at least a read-only datadog user with proper access to your PostgreSQL Server. Start psql on your PostgreSQL database and run:
 

--- a/process/README.md
+++ b/process/README.md
@@ -10,7 +10,9 @@ The process check lets you:
 ## Setup
 ### Installation
 
-The process check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) anywhere you want to use the check. If you need the newest version of the check, install the `dd-check-process` package.
+The process check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) anywhere you want to use the check.  
+
+If you need the newest version of the Process check, install the `dd-check-process` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -12,7 +12,9 @@ And more.
 ## Setup
 ### Installation
 
-The RabbitMQ check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your RabbitMQ servers. If you need the newest version of the check, install the `dd-check-rabbitmq` package.
+The RabbitMQ check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your RabbitMQ servers.  
+
+If you need the newest version of the RabbitMQ check, install the `dd-check-rabbitmq` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 #### Prepare RabbitMQ

--- a/redisdb/README.md
+++ b/redisdb/README.md
@@ -7,7 +7,9 @@ Whether you use Redis as a database, cache, or message queue, this integration h
 ## Setup
 ### Installation
 
-The Redis check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Redis servers. If you need the newest version of the check, install the `dd-check-redis` package.
+The Redis check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Redis servers.  
+
+If you need the newest version of the Redis check, install the `dd-check-redis` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/riak/README.md
+++ b/riak/README.md
@@ -8,7 +8,9 @@ This check lets you track node, vnode and ring performance metrics from RiakKV o
 ## Setup
 ### Installation
 
-The Riak check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Riak servers. If you need the newest version of the check, install the `dd-check-riak` package.
+The Riak check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Riak servers.  
+
+If you need the newest version of the Riak check, install the `dd-check-riak` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/riakcs/README.md
+++ b/riakcs/README.md
@@ -10,7 +10,9 @@ Capture RiakCS metrics in Datadog to:
 ## Setup
 ### Installation
 
-The RiakCS check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your RiakCS nodes. If you need the newest version of the check, install the `dd-check-riakcs` package.
+The RiakCS check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your RiakCS nodes.  
+
+If you need the newest version of the RiakCS check, install the `dd-check-riakcs` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/snmp/README.md
+++ b/snmp/README.md
@@ -7,7 +7,9 @@ This check lets you collect SNMP metrics from your network devices.
 ## Setup
 ### Installation
 
-The SNMP check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any host where you want to run the check. If you need the newest version of the check, install the `dd-check-snmp` package.
+The SNMP check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any host where you want to run the check.  
+
+If you need the newest version of the SNMP check, install the `dd-check-snmp` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/solr/README.md
+++ b/solr/README.md
@@ -7,7 +7,9 @@ The Solr check tracks the state and performance of a Solr cluster. It collects m
 ## Setup
 ### Installation
 
-The Solr check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Solr nodes.
+The Solr check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Solr nodes.  
+
+If you need the newest version of the Solr check, install the `dd-check-solr` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 This check is JMX-based, so you'll need to enable JMX Remote on your Tomcat servers. Read the [JMX Check documentation](http://docs.datadoghq.com/integrations/java/) for more information on that.
 

--- a/spark/README.md
+++ b/spark/README.md
@@ -18,7 +18,8 @@ The Spark check is packaged with the Agent, so simply [install the Agent](https:
 - YARN ResourceManager (if you're running Spark on YARN), or
 - Spark master (if you're running Standalone Spark)
 
-If you need the newest version of the check, install the `dd-check-spark` package.
+
+If you need the newest version of the Spark check, install the `dd-check-spark` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/sqlserver/README.md
+++ b/sqlserver/README.md
@@ -9,7 +9,9 @@ You can also create your own metrics by having the check run custom queries.
 ## Setup
 ### Installation
 
-The SQL Server check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your SQL Server instances. If you need the newest version of the check, install the `dd-check-sqlserver` package.
+The SQL Server check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your SQL Server instances.  
+
+If you need the newest version of the SQL Server check, install the `dd-check-sqlserver` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.  
 
 Make sure that your SQL Server instance supports SQL Server authentication by enabling "SQL Server and Windows Authentication mode" in the server properties. 
 **Server Properties** -> **Security** -> **SQL Server and Windows Authentication mode**

--- a/squid/README.md
+++ b/squid/README.md
@@ -8,7 +8,9 @@ This integration lets you monitor your Squid metrics from the Cache Manager dire
 
 ### Installation
 
-The Agent's Squid integration is packaged with the Agent, so simply [install the agent](https://app.datadoghq.com/account/settings#agent) on your Squid server. If you need the newest version of the check, install the `dd-check-squid` package.
+The Agent's Squid integration is packaged with the Agent, so simply [install the agent](https://app.datadoghq.com/account/settings#agent) on your Squid server.  
+
+If you need the newest version of the Squid check, install the `dd-check-squid` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ## Configuration
 

--- a/ssh_check/README.md
+++ b/ssh_check/README.md
@@ -7,7 +7,9 @@ This check lets you monitor SSH connectivity to remote hosts and SFTP response t
 ## Setup
 ### Installation
 
-The SSH/SFTP check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) anywhere from which you'd like to test SSH connectivity. If you need the newest version of the check, install the `dd-check-ssh-check` package.
+The SSH/SFTP check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) anywhere from which you'd like to test SSH connectivity.  
+
+If you need the newest version of the SSH check, install the `dd-check-ssh-check` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/statsd/README.md
+++ b/statsd/README.md
@@ -9,7 +9,9 @@ This check does **NOT** forward application metrics from StatsD servers to Datad
 ## Setup
 ### Installation
 
-The StatsD check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any servers that run StatsD. If you need the newest version of the check, install the `dd-check-statsd` package.
+The StatsD check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any servers that run StatsD.  
+
+If you need the newest version of the StatsD check, install the `dd-check-statsd` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/supervisord/README.md
+++ b/supervisord/README.md
@@ -7,7 +7,9 @@ This check monitors the uptime, status, and number of processes running under su
 ## Setup
 ### Installation
 
-The Supervisor check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any servers that use Supervisor to manage processes. If you need the newest version of the check, install the `dd-check-supervisord` package.
+The Supervisor check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any servers that use Supervisor to manage processes.  
+
+If you need the newest version of the Supervisor check, install the `dd-check-supervisord` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 #### Prepare supervisord

--- a/tcp_check/README.md
+++ b/tcp_check/README.md
@@ -7,9 +7,9 @@ Monitor TCP connectivity and response time for any host and port.
 ## Setup
 ### Installation
 
-The TCP check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any host from which you want to probe TCP ports. Though many metrics-oriented checks are best run on the same host(s) as the monitored service, you'll probably want to run this check from hosts that do not run the monitored TCP services, i.e. to test remote connectivity.
+The TCP check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on any host from which you want to probe TCP ports. Though many metrics-oriented checks are best run on the same host(s) as the monitored service, you'll probably want to run this check from hosts that do not run the monitored TCP services, i.e. to test remote connectivity.  
 
-If you need the newest version of the TCP check, install the `dd-check-tcp` package.
+If you need the newest version of the TCP check, install the `dd-check-tcp` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/teamcity/README.md
+++ b/teamcity/README.md
@@ -9,7 +9,9 @@ Unlike most Agent checks, this one doesn't collect any metrics—just events.
 ## Setup
 ### Installation
 
-The Teamcity check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Teamcity servers. If you need the newest version of the check, install the `dd-check-teamcity` package.
+The Teamcity check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Teamcity servers.  
+
+If you need the newest version of the Teamcity check, install the `dd-check-teamcity` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 #### Prepare Teamcity

--- a/tokumx/README.md
+++ b/tokumx/README.md
@@ -13,7 +13,9 @@ And more.
 ## Setup
 ### Installation
 
-The TokuMX check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your TokuMX servers. If you need the newest version of the check, install the `dd-check-tokumx` package.
+The TokuMX check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your TokuMX servers.  
+
+If you need the newest version of the TokuMX check, install the `dd-check-tokumx` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 #### Prepare TokuMX

--- a/varnish/README.md
+++ b/varnish/README.md
@@ -14,7 +14,9 @@ It also submits service checks for the health of each backend.
 ## Setup
 ### Installation
 
-The varnish check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your varnish servers. If you need the newest version of the check, install the `dd-check-varnish` package.
+The varnish check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your varnish servers.  
+
+If you need the newest version of the Varnish check, install the `dd-check-varnish` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/vsphere/README.md
+++ b/vsphere/README.md
@@ -7,7 +7,9 @@ This check collects resource usage metrics from your vSphere cluster—CPU, disk
 ## Setup
 ### Installation
 
-The vSphere check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your vCenter server. If you need the newest version of the check, install the `dd-check-mcache` package.
+The vSphere check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your vCenter server.  
+
+If you need the newest version of the vSphere check, install the `dd-check-vsphere` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -12,7 +12,8 @@ And more.
 ## Setup
 ### Installation
 
-The YARN check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your YARN ResourceManager. If you need the newest version of the check, install the `dd-check-yarn` package.
+The YARN check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your YARN ResourceManager.  
+If you need the newest version of the YARN check, install the `dd-check-yarn` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 

--- a/zk/README.md
+++ b/zk/README.md
@@ -7,7 +7,10 @@ The Zookeeper check tracks client connections and latencies, monitors the number
 ## Setup
 ### Installation
 
-The Zookeeper check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Zookeeper servers. If you need the newest version of the check, install the `dd-check-zk` package.
+The Zookeeper check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your Zookeeper servers.  
+
+
+If you need the newest version of the Zookeeper check, install the `dd-check-zk` package; this package's check overrides the one packaged with the Agent. See the [integrations-core](https://github.com/DataDog/integrations-core#installing-the-integrations) repository for more details.
 
 ### Configuration
 


### PR DESCRIPTION
### What does this PR do?

Update installation process for some integartions

### Motivation

All agent-check-based integration pages mention something like:

https://docs.datadoghq.com/integrations/process/#installation

> The process check is packaged with the Agent, so simply install the Agent anywhere you want to use the check. If you need the newest version of the check, install the dd-check-process package.

But it's not possible to install any kind of `dd-check-process` package.