### PR TITLE
Adding doc notification

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ is available in our contribution guidelines.
 - [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
 - [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
   for the new section.
-- [ ] Notified Documentation team, or [opened an issue on the documentation repo](https://github.com/DataDog/documentation/issues/new)
+- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 
 
 ### Additional Notes
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,7 @@ is available in our contribution guidelines.
 - [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
 - [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
   for the new section.
+- [ ] Notified Documentation team, or [opened an issue on the documentation repo](https://github.com/DataDog/documentation/issues/new)
 
 ### Additional Notes
 


### PR DESCRIPTION
### What does this PR do?

Adding a doc notification checkbox to notify doc team about integrations-core updates

### Motivation

Doc pages are most of the time behind the repo in terms of documentation, this tries to fix this.