### PR TITLE
[MySQL] Change default connect_timeout to 10

### DIFF
--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - mysql
 
+1.1.1 / Unreleased
+==================
+
+### Changes
+
+* [BUGFIX] Changes default value of `connect_timeout` to 10. See [#1020][]
+
 1.1.0 / 2018-01-10
 ==================
 
@@ -66,4 +73,5 @@
 [#586]: https://github.com/DataDog/integrations-core/issues/586
 [#637]: https://github.com/DataDog/integrations-core/issues/637
 [#660]: https://github.com/DataDog/integrations-core/issues/660
+[#1020]: https://github.com/DataDog/integrations-core/issues/1020
 [@EdwardMcConnell]: https://github.com/EdwardMcConnell

--- a/mysql/datadog_checks/mysql/__init__.py
+++ b/mysql/datadog_checks/mysql/__init__.py
@@ -2,6 +2,6 @@ from . import mysql
 
 MySql = mysql.MySql
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 __all__ = ['mysql']

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -324,7 +324,7 @@ class MySql(AgentCheck):
         options = instance.get('options', {}) or {} # options could be None if empty in the YAML
         queries = instance.get('queries', [])
         ssl = instance.get('ssl', {})
-        connect_timeout = instance.get('connect_timeout', None)
+        connect_timeout = instance.get('connect_timeout', 10)
 
         return (self.host, self.port, user, password, self.mysql_sock,
                 self.defaults_file, tags, options, queries, ssl, connect_timeout)

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1.1",
   "name": "MySQL",
   "display_name": "MySQL",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "support": "core",
   "supported_os": [
     "linux",


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Changes the default value of `connect_timeout` to be `10` when not defined in `mysql.yaml`

### Motivation

Newer versions of the pymysql driver require this value to be an integer between 1 and 31,536,000 when [instantiating the connection](http://pymysql.readthedocs.io/en/latest/modules/connections.html#module-pymysql.connections)

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

This is part of a change to update the pymysql driver version from v. `0.6.6` since a newer version is required to connect to Azure MySQL instances