### PR TITLE
[Kafka] Check if the broker_id is None over zero

### DIFF
--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - kafka_consumer
 
+1.2.2 / Unreleased
+==================
+
+### Changes
+
+* [BUGFIX] Check explicitly that node_id is None instead of 0. See [][]
+
 1.2.1 / 2017-11-29
 ==================
 

--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Changes
 
-* [BUGFIX] Check explicitly that node_id is None instead of 0. See [][]
+* [BUGFIX] Check explicitly that node_id is None instead of 0. See [#1022][]
 
 1.2.1 / 2017-11-29
 ==================
@@ -64,4 +64,5 @@
 [#733]: https://github.com/DataDog/integrations-core/issues/733
 [#753]: https://github.com/DataDog/integrations-core/issues/753
 [#904]: https://github.com/DataDog/integrations-core/issues/904
+[#1022]: https://github.com/DataDog/integrations-core/issues1022
 [@jeffwidman]: https://github.com/jeffwidman

--- a/kafka_consumer/datadog_checks/kafka_consumer/__init__.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/__init__.py
@@ -2,6 +2,6 @@ from . import kafka_consumer
 
 KafkaCheck = kafka_consumer.KafkaCheck
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 __all__ = ['kafka_consumer']

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -195,7 +195,7 @@ class KafkaCheck(AgentCheck):
         return node_id
 
     def _make_req_async(self, client, request, node_id=None, cb=None):
-        if not node_id:
+        if node_id is None:
             node_id = self._get_random_node_id(client)
 
         future = client.send(node_id, request)
@@ -203,7 +203,7 @@ class KafkaCheck(AgentCheck):
             future.add_callback(cb, request, node_id, self.current_ts)
 
     def _ensure_ready_node(self, client, node_id):
-        if not node_id:
+        if node_id is None:
             raise Exception("node_id is None")
 
         attempts = 0
@@ -226,7 +226,7 @@ class KafkaCheck(AgentCheck):
                 raise future.exception
 
     def _make_blocking_req(self, client, request, node_id=None):
-        if not node_id:
+        if node_id is None:
             node_id = self._get_random_node_id(client)
 
         self._ensure_ready_node(client, node_id)
@@ -239,7 +239,7 @@ class KafkaCheck(AgentCheck):
         return response
 
     def _get_kafka_version(self, client, node_id=None):
-        if node_id:
+        if node_id is not None:
             return client.check_version(node_id=node_id)
 
         for broker in client.cluster.brokers():

--- a/kafka_consumer/manifest.json
+++ b/kafka_consumer/manifest.json
@@ -10,7 +10,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.2.1",
+  "version": "1.2.2",
   "guid": "74e1ce9c-dee9-4ad5-9b6a-05eeee7f5259",
   "public_title": "Datadog-Kafka Consumer Integration",
   "categories":["processing", "messaging"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Modifies a few places in the check to explicitly check for None type instead of boolean.

### Motivation

Support Case where a user had a broker ID of 0, and we skipped components of the check.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [X ] Bumped the check version in `manifest.json`
- [ X] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ X] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

### Additional Notes

Anything else we should know when reviewing?
