### PR TITLE
Lewis/http check lowercase post method

### DIFF
--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - http_check
 
+1.3.1 / 2018-01-17
+==================
+
+### Changes
+
+* [BUGFIX] Use lowercase in an `if statement` for a user defined HTTP method.
+
 1.3.0 / 2018-01-10
 ==================
 

--- a/http_check/datadog_checks/http_check/__init__.py
+++ b/http_check/datadog_checks/http_check/__init__.py
@@ -2,6 +2,6 @@ from . import http_check
 
 HTTPCheck = http_check.HTTPCheck
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 __all__ = ['http_check']

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -245,8 +245,8 @@ class HTTPCheck(NetworkCheck):
             r = sess.request(method.upper(), addr, auth=auth, timeout=timeout, headers=headers,
                              proxies = instance_proxy, allow_redirects=allow_redirects,
                              verify=False if disable_ssl_validation else instance_ca_certs,
-                             json = data if method == 'post' and isinstance(data, dict) else None,
-                             data = data if method == 'post' and isinstance(data, basestring) else None,
+                             json = data if method.lower() == 'post' and isinstance(data, dict) else None,
+                             data = data if method.lower() == 'post' and isinstance(data, basestring) else None,
                              cert = (client_cert, client_key) if client_cert and client_key else None)
 
         except (socket.timeout, requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.3.0",
+  "version": "1.3.1",
   "guid": "eb133a1f-697c-4143-bad3-10e72541fa9c",
   "public_title": "Datadog-HTTP Check Integration",
   "categories":["web", "network"],


### PR DESCRIPTION
value. The fix will apply the lower() function to the string.

<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Fix an `if statement` where a user defined value is compared to a lowercase value. 

### Motivation

Customer added `method: POST` in `http_check.yaml` which did not set the desired HTTP method of `post`.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?