### PR TITLE
elastic should not interpret incorrect creds as meaning the server is v1

### DIFF
--- a/elastic/CHANGELOG.md
+++ b/elastic/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG - elastic
 
+1.4.0 / Unreleased
+==================
+
+### Changes
+
+* [BUG] Fixes bug that causes poor failovers when authentication fails. [#1026][].
+
+
 1.4.0 / 2018-01-10
 ==================
 

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -603,6 +603,7 @@ class ESCheck(AgentCheck):
         else:
             cert = None
 
+        resp = None
         try:
             resp = requests.get(
                 url,

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -615,7 +615,7 @@ class ESCheck(AgentCheck):
             resp.raise_for_status()
         except Exception as e:
             # this means we've hit a particular kind of auth error that means the config is broken
-            if resp.status_code == 400:
+            if resp && resp.status_code == 400:
                 raise AuthenticationError("The ElasticSearch credentials are incorrect")
 
             if send_sc:

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -616,7 +616,7 @@ class ESCheck(AgentCheck):
             resp.raise_for_status()
         except Exception as e:
             # this means we've hit a particular kind of auth error that means the config is broken
-            if resp && resp.status_code == 400:
+            if resp and resp.status_code == 400:
                 raise AuthenticationError("The ElasticSearch credentials are incorrect")
 
             if send_sc:

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -414,7 +414,11 @@ class ESCheck(AgentCheck):
 
         # Check ES version for this instance and define parameters
         # (URLs and metrics) accordingly
-        version = self._get_es_version(config)
+        try:
+            version = self._get_es_version(config)
+        except AuthenticationError as e:
+            self.log.exception("The ElasticSearch credentials are incorrect")
+            raise
 
         health_url, stats_url, pshard_stats_url, pending_tasks_url, stats_metrics, \
             pshard_stats_metrics = self._define_params(version, config.cluster_stats)
@@ -472,6 +476,8 @@ class ESCheck(AgentCheck):
             # peel that off so that the map below doesn't error out
             version = data['version']['number'].split('-')[0]
             version = map(int, version.split('.')[0:3])
+        except AuthenticationError as e:
+            raise
         except Exception as e:
             self.warning(
                 "Error while trying to get Elasticsearch version "
@@ -608,6 +614,10 @@ class ESCheck(AgentCheck):
             )
             resp.raise_for_status()
         except Exception as e:
+            # this means we've hit a particular kind of auth error that means the config is broken
+            if resp.status_code == 400:
+                raise AuthenticationError("The ElasticSearch credentials are incorrect")
+
             if send_sc:
                 self.service_check(
                     self.SERVICE_CHECK_CONNECT_NAME,
@@ -769,3 +779,7 @@ class ESCheck(AgentCheck):
             'event_object': hostname,
             'tags': tags
         }
+
+
+class AuthenticationError(requests.exceptions.HTTPError):
+    """Authentication Error, unable to reach server"""


### PR DESCRIPTION
### What does this PR do?

Currently, if we cannot grab the version, we fallback to v1. This is not right. Some responses mean that the authentication credentials are incorrect and the check should fail immediately. This change will ensure it fails immediately.