### PR TITLE
[couch] Fix an error if there is no database

### DIFF
--- a/couch/CHANGELOG.md
+++ b/couch/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG - couch
 
+
+
+2.2.1 / Unreleased
+=================
+
+### Changes
+
+* [BUGFIX] Handle the case where there is no database.
+
 2.2.0 / 2018-01-10
 =================
 

--- a/couch/datadog_checks/couch/__init__.py
+++ b/couch/datadog_checks/couch/__init__.py
@@ -2,6 +2,6 @@ from . import couch
 
 CouchDb = couch.CouchDb
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 __all__ = ['couch']

--- a/couch/datadog_checks/couch/couch.py
+++ b/couch/datadog_checks/couch/couch.py
@@ -214,7 +214,10 @@ class CouchDB2:
                     queue_tags = list(tags)
                     queue_tags.append("queue:{0}".format(queue))
                     if type(val) is dict:
-                        self.gauge("{0}.{1}.size".format(prefix, key), val['count'], queue_tags)
+                        if 'count' in val:
+                            self.gauge("{0}.{1}.size".format(prefix, key), val['count'], queue_tags)
+                        else:
+                            self.agent_check.log.debug("Queue %s does not have a key 'count'. It will be ignored." % queue)
                     else:
                         self.gauge("{0}.{1}.size".format(prefix, key), val, queue_tags)
             elif key == "distribution":

--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1.1",
   "name": "couch",
   "display_name": "couch",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "support": "core",
   "supported_os": [
     "linux",


### PR DESCRIPTION
### What does this PR do?

The `message_queues` data from couchdb may contain an empty dictionary for the key `couch_db_updater` if no database exist.

The check was assuming that all queue dictionaries contained the `count` key which led to an error.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.