### PR TITLE
Update nfsstat init file to version 0.1.1

### DIFF
--- a/nfsstat/datadog_checks/nfsstat/__init__.py
+++ b/nfsstat/datadog_checks/nfsstat/__init__.py
@@ -2,6 +2,6 @@ from . import nfsstat
 
 NfsStatCheck = nfsstat.NfsStatCheck
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = ['nfsstat']


### PR DESCRIPTION
Should fix the current error I've been seeing when trying to build `datadog-agent` via omnibus
```
Processing .omnibus/src/datadog-agent-integrations/integrations-core/nfsstat
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-AXWPq9-build/setup.py", line 64, in <module>
        raise Exception("Inconsistent versioning in module and manifest - aborting wheel build")
    Exception: Inconsistent versioning in module and manifest - aborting wheel build
```