### PR TITLE
Ignore locally built wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ tmp
 
 # wheels
 wheelhouse/
+*.whl


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Ignore built wheel files

### Motivation

For testing purposes it's common to build the wheel locally, we should not track the built artifact.