### PR TITLE
Update conf.yaml.example

### DIFF
--- a/kafka_consumer/conf.yaml.example
+++ b/kafka_consumer/conf.yaml.example
@@ -45,7 +45,8 @@ instances:
     consumer_groups:
       my_consumer:  # consumer group name
         my_topic: [0, 1, 4, 12]  # topic_name: list of partitions
-      # Note that each level of values is optional. Any omitted values will be
+      # Note that each level of values is optional (this is currently only available
+      # when using zookeeper, to store consumer groups). Any omitted values will be
       # fetched from Zookeeper. You can omit partitions (example: myconsumer2),
       # topics (example: myconsumer3), and even consumer_groups. If you omit
       # consumer_groups, you must set 'monitor_unlisted_consumer_groups': True.

--- a/kafka_consumer/conf.yaml.example
+++ b/kafka_consumer/conf.yaml.example
@@ -46,7 +46,7 @@ instances:
       my_consumer:  # consumer group name
         my_topic: [0, 1, 4, 12]  # topic_name: list of partitions
       # Note that each level of values is optional (this is currently only available
-      # when using zookeeper, to store consumer groups). Any omitted values will be
+      # when using zookeeper to store consumer groups). Any omitted values will be
       # fetched from Zookeeper. You can omit partitions (example: myconsumer2),
       # topics (example: myconsumer3), and even consumer_groups. If you omit
       # consumer_groups, you must set 'monitor_unlisted_consumer_groups': True.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Shelled out how the auto-discovery only applies to consumer groups in ZK with a little more detail.

### Motivation

Customer thought that having to explicitly state partitions when consumer groups were stored in kafka was a bug, but it was just not explicitly stated in the docs how it worked.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.
-- no change to anything but the comment sections, this should be OK.

### Versioning
 Just a comment update, below shouldn't be necessary.
- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
