### PR TITLE
[elastic] Add cluster name tag to health service check

### DIFF
--- a/elastic/CHANGELOG.md
+++ b/elastic/CHANGELOG.md
@@ -6,8 +6,8 @@
 ### Changes
 
 * [IMPROVEMENT] Adds `admin_forwarder` option to keep URL intact when using forwarder. [#1050][].
-* [BUG] Fixes bug that causes poor failovers when authentication fails. [#1026][].
-
+* [BUG] Fixes bug that causes poor failovers when authentication fails. See [#1026][].
+* [IMPROVEMENT] Adds `cluster_name` tag to the `elasticsearch.cluster_health` service check. See [#1038][].
 
 1.4.0 / 2018-01-10
 ==================

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -27,6 +27,7 @@ ESInstanceConfig = namedtuple(
         'cluster_stats',
         'password',
         'service_check_tags',
+        'health_tags',
         'tags',
         'timeout',
         'url',
@@ -399,6 +400,7 @@ class ESCheck(AgentCheck):
             cluster_stats=cluster_stats,
             password=instance.get('password'),
             service_check_tags=service_check_tags,
+            health_tags=[],
             ssl_cert=instance.get('ssl_cert'),
             ssl_key=instance.get('ssl_key'),
             ssl_verify=instance.get('ssl_verify'),
@@ -433,7 +435,9 @@ class ESCheck(AgentCheck):
         if stats_data['cluster_name']:
             # retreive the cluster name from the data, and append it to the
             # master tag list.
-            config.tags.append("cluster_name:{}".format(stats_data['cluster_name']))
+            cluster_name_tag = "cluster_name:{}".format(stats_data['cluster_name'])
+            config.tags.append(cluster_name_tag)
+            config.health_tags.append(cluster_name_tag)
         self._process_stats_data(stats_data, stats_metrics, config)
 
         # Load clusterwise data
@@ -747,7 +751,7 @@ class ESCheck(AgentCheck):
             self.SERVICE_CHECK_CLUSTER_STATUS,
             status,
             message=msg,
-            tags=config.service_check_tags
+            tags=config.service_check_tags+config.health_tags
         )
 
     def _metric_not_found(self, metric, path):

--- a/elastic/test/test_elastic.py
+++ b/elastic/test/test_elastic.py
@@ -452,10 +452,10 @@ class TestElastic(AgentCheckTest):
             # Warning because elasticsearch status should be yellow, according to
             # http://chrissimpson.co.uk/elasticsearch-yellow-cluster-status-explained.html
             self.assertServiceCheckWarning('elasticsearch.cluster_health',
-                                           tags=good_sc_tags + tags,
+                                           tags=good_sc_tags + tags + cluster_tag,
                                            count=1)
             self.assertServiceCheckWarning('elasticsearch.cluster_health',
-                                           tags=good_sc_tags,
+                                           tags=good_sc_tags + cluster_tag,
                                            count=1)
             # Assert event
             self.assertEvent('ElasticSearch: foo just reported as yellow', count=1,
@@ -523,7 +523,7 @@ class TestElastic(AgentCheckTest):
 
     def test_health_event(self):
         dummy_tags = ['foo:bar', 'elastique:recherche']
-        server_tags = ['cluster_name:elasticsearch']
+        cluster_tag = ["cluster_name:elasticsearch"]
 
         config = {'instances': [
             {'url': 'http://localhost:9200', 'tags': dummy_tags}
@@ -536,12 +536,12 @@ class TestElastic(AgentCheckTest):
         self.assertEquals(len(self.events), 1)
         self.assertIn('yellow', self.events[0]['msg_title'])
         self.assertEquals(
-            ['url:http://localhost:9200'] + dummy_tags + server_tags,
+            ['url:http://localhost:9200'] + dummy_tags + cluster_tag,
             self.events[0]['tags']
         )
         self.assertServiceCheckWarning(
             'elasticsearch.cluster_health',
-            tags=['host:localhost', 'port:9200'] + dummy_tags,
+            tags=['host:localhost', 'port:9200'] + dummy_tags + cluster_tag,
             count=1
         )
 
@@ -554,12 +554,12 @@ class TestElastic(AgentCheckTest):
         self.assertEquals(len(self.events), 1)
         self.assertIn('green', self.events[0]['msg_title'])
         self.assertEquals(
-            ['url:http://localhost:9200'] + dummy_tags + server_tags,
+            ['url:http://localhost:9200'] + dummy_tags + cluster_tag,
             self.events[0]['tags']
         )
         self.assertServiceCheckOK(
             'elasticsearch.cluster_health',
-            tags=['host:localhost', 'port:9200'] + dummy_tags,
+            tags=['host:localhost', 'port:9200'] + dummy_tags + cluster_tag,
             count=1
         )
 

--- a/elastic/test/test_elastic.py
+++ b/elastic/test/test_elastic.py
@@ -315,7 +315,7 @@ CLUSTER_PENDING_TASKS = {
 def get_es_version():
     version = os.environ.get("FLAVOR_VERSION")
     if version is None:
-        return [1, 6, 0]
+        return [1, 3, 9]
     return [int(k) for k in version.split(".")]
 
 

--- a/elastic/test/test_elastic.py
+++ b/elastic/test/test_elastic.py
@@ -523,7 +523,7 @@ class TestElastic(AgentCheckTest):
 
     def test_health_event(self):
         dummy_tags = ['foo:bar', 'elastique:recherche']
-        cluster_tag = ["cluster_name:elasticsearch"]
+        cluster_tag = ['cluster_name:elasticsearch']
 
         config = {'instances': [
             {'url': 'http://localhost:9200', 'tags': dummy_tags}


### PR DESCRIPTION
### What does this PR do?

This PR tags the `elasticsearch.cluster_health` service check with `cluster_name` to allow alerting on different clusters.

### Motivation

Customer request.

### Versioning

- [x] Updated `CHANGELOG.md`.
- [x] Bump version.

### Additional Notes

Two service checks are sent : `elasticsearch.can_connect` and `elasticsearch.cluster_health`.
It does not make sense to tag `elasticsearch.can_connect` with the `cluster_name` since we can't obtain it if we can't connect.
