### PR TITLE
[snmp] service check warning status fix

### DIFF
--- a/snmp/CHANGELOG.md
+++ b/snmp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - snmp
 
+1.3.1 / Unreleased
+==================
+
+### Changes
+
+* [BUGFIX] Fix warning service check reporting. See [#1041][]
+
 1.3.0 / 2017-10-10
 ==================
 
@@ -32,3 +39,4 @@
 [#248]: https://github.com/DataDog/integrations-core/issues/248
 [#426]: https://github.com/DataDog/integrations-core/issues/426
 [#723]: https://github.com/DataDog/integrations-core/issues/723
+[#1041]: https://github.com/DataDog/integrations-core/issues/1041

--- a/snmp/datadog_checks/snmp/__init__.py
+++ b/snmp/datadog_checks/snmp/__init__.py
@@ -2,6 +2,6 @@ from . import snmp
 
 SnmpCheck = snmp.SnmpCheck
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 __all__ = ['snmp']

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -377,10 +377,8 @@ class SnmpCheck(NetworkCheck):
             if "service_check_error" not in instance:
                 instance["service_check_error"] = "Fail to collect metrics for {0} - {1}".format(instance['name'], e)
             self.warning(instance["service_check_error"])
-            return [(self.SC_STATUS, Status.CRITICAL, instance["service_check_error"])]
         finally:
             # Report service checks
-            tags = ["snmp_device:%s" % ip_address]
             if "service_check_error" in instance:
                 status = Status.DOWN
                 if "service_check_severity" in instance:

--- a/snmp/manifest.json
+++ b/snmp/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.3.0",
+  "version": "1.3.1",
   "guid": "080bb566-d1c8-428c-9d85-71cc2cdf393c",
   "public_title": "Datadog-SNMP Integration",
   "categories":["monitoring", "notification", "network"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Fixes reporting of SNMP service check.

### Motivation

Customer feedback

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
