### PR TITLE
[hdfs_namenode] Add instance level tags to metrics and service check

### DIFF
--- a/hdfs_namenode/CHANGELOG.md
+++ b/hdfs_namenode/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - hdfs_namenode
 
+1.1.1 / Unreleased
+==================
+
+### Changes
+* [BUGFIX] add instance level tags to metrics and service check
+
 1.1.0 / 2018-01-10
 ==================
 

--- a/hdfs_namenode/CHANGELOG.md
+++ b/hdfs_namenode/CHANGELOG.md
@@ -4,7 +4,7 @@
 ==================
 
 ### Changes
-* [BUGFIX] add instance level tags to metrics and service check
+* [BUGFIX] add instance level tags to metrics and service check. See [#1047][]
 
 1.1.0 / 2018-01-10
 ==================

--- a/hdfs_namenode/CHANGELOG.md
+++ b/hdfs_namenode/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG - hdfs_namenode
 
-1.1.1 / Unreleased
+1.2.0 / Unreleased
 ==================
 
 ### Changes
-* [BUGFIX] add instance level tags to metrics and service check. See [#1047][]
+* [FEATURE] add instance level tags to metrics and service check. See [#1047][]
 
 1.1.0 / 2018-01-10
 ==================

--- a/hdfs_namenode/conf.yaml.example
+++ b/hdfs_namenode/conf.yaml.example
@@ -10,7 +10,9 @@ instances:
   # the property dfs.http.address or dfs.namenode.http-address
   #
   -  hdfs_namenode_jmx_uri: http://localhost:50070
-
+  #   tags:
+  #      - optional_tag1
+  #      - optional_tag2
   # Optionally disable SSL validation. Sometimes when using proxies or self-signed certs
   # we'll want to override validation.
   # disable_ssl_validation: false

--- a/hdfs_namenode/conf.yaml.example
+++ b/hdfs_namenode/conf.yaml.example
@@ -10,6 +10,7 @@ instances:
   # the property dfs.http.address or dfs.namenode.http-address
   #
   -  hdfs_namenode_jmx_uri: http://localhost:50070
+  # Optional tags to be applied to every emitted metric and service check.
   #   tags:
   #      - optional_tag1
   #      - optional_tag2

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/__init__.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/__init__.py
@@ -2,6 +2,6 @@ from . import hdfs_namenode
 
 HDFSNameNode = hdfs_namenode.HDFSNameNode
 
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 
 __all__ = ['hdfs_namenode']

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/__init__.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/__init__.py
@@ -2,6 +2,6 @@ from . import hdfs_namenode
 
 HDFSNameNode = hdfs_namenode.HDFSNameNode
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 __all__ = ['hdfs_namenode']

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
@@ -96,9 +96,7 @@ class HDFSNameNode(AgentCheck):
         if jmx_address is None:
             raise Exception('The JMX URL must be specified in the instance configuration')
 
-
-        namenode_url = ['namenode_url:' + jmx_address]
-        tags.extend(namenode_url)
+        tags.append('namenode_url:' + jmx_address)
         tags = list(set(tags))
 
         # Get metrics from JMX

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
@@ -92,24 +92,30 @@ class HDFSNameNode(AgentCheck):
     def check(self, instance):
         jmx_address = instance.get('hdfs_namenode_jmx_uri')
         disable_ssl_validation = instance.get('disable_ssl_validation', False)
+        tags = instance.get('tags')
         if jmx_address is None:
             raise Exception('The JMX URL must be specified in the instance configuration')
+
+
+        namenode_url = ['namenode_url:' + jmx_address]
+        tags.extend(namenode_url)
+        tags = list(set(tags))
 
         # Get metrics from JMX
         self._hdfs_namenode_metrics(jmx_address, disable_ssl_validation,
             HDFS_NAME_SYSTEM_STATE_BEAN,
-            HDFS_NAME_SYSTEM_STATE_METRICS)
+            HDFS_NAME_SYSTEM_STATE_METRICS, tags)
 
         self._hdfs_namenode_metrics(jmx_address, disable_ssl_validation,
             HDFS_NAME_SYSTEM_BEAN,
-            HDFS_NAME_SYSTEM_METRICS)
+            HDFS_NAME_SYSTEM_METRICS, tags)
 
         self.service_check(JMX_SERVICE_CHECK,
             AgentCheck.OK,
-            tags=['namenode_url:' + jmx_address],
+            tags=tags,
             message='Connection to %s was successful' % jmx_address)
 
-    def _hdfs_namenode_metrics(self, jmx_uri, disable_ssl_validation, bean_name, metrics):
+    def _hdfs_namenode_metrics(self, jmx_uri, disable_ssl_validation, bean_name, metrics, tags):
         '''
         Get HDFS namenode metrics from JMX
         '''
@@ -118,8 +124,6 @@ class HDFSNameNode(AgentCheck):
             query_params={'qry':bean_name})
 
         beans = response.get('beans', [])
-
-        tags = ['namenode_url:' + jmx_uri]
 
         if beans:
 

--- a/hdfs_namenode/manifest.json
+++ b/hdfs_namenode/manifest.json
@@ -10,7 +10,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.1.0",
+  "version": "1.1.1",
   "guid": "41454590-0a25-4146-9c74-9d377db42764",
   "public_title": "Datadog-HDFS Namenode Integration",
   "categories":["processing", "os & system"],

--- a/hdfs_namenode/manifest.json
+++ b/hdfs_namenode/manifest.json
@@ -10,7 +10,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.1.1",
+  "version": "1.2.0",
   "guid": "41454590-0a25-4146-9c74-9d377db42764",
   "public_title": "Datadog-HDFS Namenode Integration",
   "categories":["processing", "os & system"],

--- a/hdfs_namenode/test/test_hdfs_namenode.py
+++ b/hdfs_namenode/test/test_hdfs_namenode.py
@@ -51,7 +51,8 @@ class HDFSNameNode(AgentCheckTest):
     CHECK_NAME = 'hdfs_namenode'
 
     HDFS_NAMENODE_CONFIG = {
-        'hdfs_namenode_jmx_uri': 'http://localhost:50070'
+        'hdfs_namenode_jmx_uri': 'http://localhost:50070',
+        'tags': ['cluster_name:hdfs_dev', 'cluster_name:hdfs_dev', 'instance:level_tags'],
     }
 
     HDFS_NAMESYSTEM_STATE_METRICS_VALUES = {
@@ -85,7 +86,9 @@ class HDFSNameNode(AgentCheckTest):
     }
 
     HDFS_NAMESYSTEM_METRIC_TAGS = [
-        'namenode_url:' + HDFS_NAMENODE_CONFIG['hdfs_namenode_jmx_uri']
+        'namenode_url:' + HDFS_NAMENODE_CONFIG['hdfs_namenode_jmx_uri'],
+        'cluster_name:hdfs_dev',
+        'instance:level_tags',
     ]
 
     @mock.patch('requests.get', side_effect=requests_get_mock)
@@ -98,6 +101,5 @@ class HDFSNameNode(AgentCheckTest):
 
         for metric, value in self.HDFS_NAMESYSTEM_STATE_METRICS_VALUES.iteritems():
             self.assertMetric(metric, value=value, tags=self.HDFS_NAMESYSTEM_METRIC_TAGS)
-
         for metric, value in self.HDFS_NAMESYSTEM_METRICS_VALUES.iteritems():
             self.assertMetric(metric, value=value, tags=self.HDFS_NAMESYSTEM_METRIC_TAGS)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Adds instance level tags to both metrics and service check
### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
