### PR TITLE
Making gitlab integration public on doc

### DIFF
--- a/gitlab/manifest.json
+++ b/gitlab/manifest.json
@@ -7,11 +7,15 @@
   "short_description": "Track all your Gitlab metrics with Datadog",
   "guid": "1cab328c-5560-4737-ad06-92ebc54af901",
   "support": "core",
-  "supported_os": ["linux","mac_os","windows"],
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
   "version": "1.0.0",
   "public_title": "Datadog-Gitlab Integration",
   "categories":["web", "network"],
   "doc_link": "https://docs.datadoghq.com/integrations/gitlab/",
-  "is_public": false,
+  "is_public": true,
   "has_logo": false
 }

--- a/gitlab_runner/manifest.json
+++ b/gitlab_runner/manifest.json
@@ -12,6 +12,6 @@
   "public_title": "Datadog-Gitlab Runners Integration",
   "categories":["web", "network"],
   "doc_link": "https://docs.datadoghq.com/integrations/gitlab_runner/",
-  "is_public": false,
+  "is_public": true,
   "has_logo": false
 }


### PR DESCRIPTION
### What does this PR do?

Edit manifest param value to make gitlab integration public on doc

### Motivation

It wasn't public before
