### PR TITLE
[Elasticsearch] Add option to access through forwarder application

### DIFF
--- a/elastic/CHANGELOG.md
+++ b/elastic/CHANGELOG.md
@@ -1,10 +1,11 @@
 # CHANGELOG - elastic
 
-1.4.0 / Unreleased
+1.5.0 / Unreleased
 ==================
 
 ### Changes
 
+* [IMPROVEMENT] Adds `admin_forwarder` option to keep URL intact when using forwarder. [#1050][].
 * [BUG] Fixes bug that causes poor failovers when authentication fails. [#1026][].
 
 
@@ -60,3 +61,5 @@
 [#820]: https://github.com/DataDog/integrations-core/issues/820
 [#860]: https://github.com/DataDog/integrations-core/issues/860
 [#893]: https://github.com/DataDog/integrations-core/issues/893
+[#1026]: https://github.com/DataDog/integrations-core/issues/1026
+[#1050]: https://github.com/DataDog/integrations-core/issues/1050

--- a/elastic/conf.yaml.example
+++ b/elastic/conf.yaml.example
@@ -29,6 +29,10 @@ instances:
   # Some managed ElasticSearch services (e.g. AWS ElasticSearch) do not expose this endpoint.
   # Set `pending_task_stats` to false if you use such a service.
 
+  # `admin_forwarder` (defaults to False) is used to signify a URL that includes a
+  # context roote needed for a forwarder application to access Elasticsearch REST services
+  # for example: https://www.ibm.com/support/knowledgecenter/SSFTN5_8.5.6/com.ibm.wbpm.main.doc/topics/tadm_fps_esearch.html
+
   - url: http://localhost:9200
     # username: username
     # password: password
@@ -36,6 +40,7 @@ instances:
     # pshard_stats: false
     # pshard_graceful_timeout: false  # continue gracefully if pshard stats TO
     # pending_task_stats: true
+    # admin_forwarder: false
     # ssl_verify: false
     # ssl_cert: /path/to/cert.pem
     # ssl_key: /path/to/cert.key

--- a/elastic/datadog_checks/elastic/__init__.py
+++ b/elastic/datadog_checks/elastic/__init__.py
@@ -2,6 +2,6 @@ from . import elastic
 
 ESCheck = elastic.ESCheck
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 __all__ = ['elastic']

--- a/elastic/datadog_checks/elastic/__init__.py
+++ b/elastic/datadog_checks/elastic/__init__.py
@@ -2,6 +2,6 @@ from . import elastic
 
 ESCheck = elastic.ESCheck
 
-__version__ = "1.4.1"
+__version__ = "1.5.0"
 
 __all__ = ['elastic']

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -370,10 +370,11 @@ class ESCheck(AgentCheck):
             cluster_stats = _is_affirmative(instance.get('is_external', False))
 
         pending_task_stats = _is_affirmative(instance.get('pending_task_stats', True))
+        admin_forwarder = _is_affirmative(instance.get('admin_forwarder', True))
         # Support URLs that have a path in them from the config, for
         # backwards-compatibility.
         parsed = urlparse.urlparse(url)
-        if parsed[2] != "":
+        if parsed[2] != "" and not admin_forwarder:
             url = "%s://%s" % (parsed[0], parsed[1])
         port = parsed.port
         host = parsed.hostname

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.4.0",
+  "version": "1.4.1",
   "guid": "d91d91bd-4a8e-4489-bfb1-b119d4cc388a",
   "public_title": "Datadog-ElasticSearch Integration",
   "categories":["data store"],

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.4.1",
+  "version": "1.5.0",
   "guid": "d91d91bd-4a8e-4489-bfb1-b119d4cc388a",
   "public_title": "Datadog-ElasticSearch Integration",
   "categories":["data store"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Adds `admin_forwarder` parameter to `elasticsearch.yaml` to have the Agent access Elasticsearch services through a forwarder service ([example](https://www.ibm.com/support/knowledgecenter/SSFTN5_8.5.6/com.ibm.wbpm.main.doc/topics/tadm_fps_esearch.html)) by keeping the URL intact

### Motivation

Customer was using a forwarder application and was not able to connect to their Elasticsearch instance since the check normalized URLs and stripped the necessary path

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Support has seen this issue come up a couple times and it seems that adding custom URIs isn't an uncommon use case, especially when using a forwarder application to access Elasticsearch