### PR TITLE
[nginx] allow proxy disabling

### DIFF
--- a/nginx/CHANGELOG.md
+++ b/nginx/CHANGELOG.md
@@ -1,18 +1,13 @@
 # CHANGELOG - nginx
 
-1.2.1 / Unreleased
-==================
-### Changes
-
-* [DOC] Adding configuration for log collection in `conf.yaml`
-
 1.2.0 / Unreleased
 ==================
 
 ### Changes
 
 * [IMPROVEMENT] Make the check compatible with the new Plus API. [#1013][]
-
+* [DOC] Adding configuration for log collection in `conf.yaml`
+* [FEATURE] allows the bypassing of proxy settings. See [#1051][].
 
 1.1.0 / 2017-07-18
 ==================

--- a/nginx/conf.yaml.example
+++ b/nginx/conf.yaml.example
@@ -10,7 +10,7 @@ instances:
   #   http://docs.datadoghq.com/integrations/nginx/
   #
   # If you are using the commercial version of nginx, for releases R13 and above,
-  # there is a new API to replace the extended status API. 
+  # there is a new API to replace the extended status API.
   # See https://www.nginx.com/blog/nginx-plus-r13-released/
   # To use it, you specify the URL in `nginx_status_url`, and use the option `use_plus_api`.
 
@@ -21,18 +21,23 @@ instances:
   # - nginx_status_url: http://example2.com:1234/nginx_status/
   #   ssl_validation: False
 
+  #   The (optional) skip_proxy parameter will bypass any proxy
+  #   settings enabled and attempt to reach the URL directly.
+  #
+  #   skip_proxy: false
+
   #   # Set this option to true if you are using the nginx Plus API. Default to false
   #   use_plus_api: False
-  #   # Specify the version of the Plus API to use. We support versions 1 & 2. Default to 2 
+  #   # Specify the version of the Plus API to use. We support versions 1 & 2. Default to 2
   #   plus_api_version: 2
-  
-  #   If the status page is behind basic auth. 
+
+  #   If the status page is behind basic auth.
   #   user: USER
   #   password: PASSWORD
-  
+
   #   tags:
   #     - instance:bar
- 
+
 ## Log section (Available for Agent >=6.0)
 
 #logs:
@@ -43,13 +48,13 @@ instances:
     #   source : (mandatory) attribute that defines which integration is sending the logs
     #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
     #   tags: (optional) add tags to each logs collected
-    
+
   # - type: file
   #   path: /var/log/nginx/access.log
   #   service: nginx
   #   source: nginx
   #   sourcecategory: http_web_access
-    
+
   # - type: file
   #   path: /var/log/nginx/error.log
   #   service: nginx

--- a/nginx/datadog_checks/nginx/__init__.py
+++ b/nginx/datadog_checks/nginx/__init__.py
@@ -2,6 +2,6 @@ from . import nginx
 
 Nginx = nginx.Nginx
 
-__version__ = "1.2.1"
+__version__ = "1.2.0"
 
 __all__ = ['nginx']

--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -121,7 +121,8 @@ class Nginx(AgentCheck):
 
     def _perform_request(self, instance, url, ssl_validation, auth):
         r = requests.get(url, auth=auth, headers=headers(self.agentConfig),
-                         verify=ssl_validation, timeout=self.default_integration_http_timeout)
+                         verify=ssl_validation, timeout=self.default_integration_http_timeout,
+                         proxies=self.get_instance_proxy(instance, url, proxies={}))
         r.raise_for_status()
         return r
 

--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -63,7 +63,7 @@ class Nginx(AgentCheck):
         url, ssl_validation, auth, use_plus_api, plus_api_version = self._get_instance_params(instance)
 
         if not use_plus_api:
-            response, content_type = self._get_data(instance, url, ssl_validation, auth)
+            response, content_type = self._get_data(url, ssl_validation, auth)
             self.log.debug(u"Nginx status `response`: {0}".format(response))
             self.log.debug(u"Nginx status `content_type`: {0}".format(content_type))
 
@@ -73,12 +73,12 @@ class Nginx(AgentCheck):
                 metrics = self.parse_text(response, tags)
         else:
             metrics = []
-            self._perform_service_check(instance, "/".join([url, plus_api_version]), ssl_validation, auth)
+            self._perform_service_check("/".join([url, plus_api_version]), ssl_validation, auth)
             # These are all the endpoints we have to call to get the same data as we did with the old API
             # since we can't get everything in one place anymore.
 
             for endpoint, nest in PLUS_API_ENDPOINTS.iteritems():
-                response = self._get_plus_api_data(instance, url, ssl_validation, auth, plus_api_version, endpoint, nest)
+                response = self._get_plus_api_data(url, ssl_validation, auth, plus_api_version, endpoint, nest)
                 self.log.debug(u"Nginx Plus API version {0} `response`: {1}".format(plus_api_version, response))
                 metrics.extend(self.parse_json(response, tags))
 
@@ -111,22 +111,21 @@ class Nginx(AgentCheck):
 
         return url, ssl_validation, auth, use_plus_api, plus_api_version
 
-    def _get_data(self, instance, url, ssl_validation, auth):
+    def _get_data(self, url, ssl_validation, auth):
 
-        r = self._perform_service_check(instance, url, ssl_validation, auth)
+        r = self._perform_service_check(url, ssl_validation, auth)
 
         body = r.content
         resp_headers = r.headers
         return body, resp_headers.get('content-type', 'text/plain')
 
-    def _perform_request(self, instance, url, ssl_validation, auth):
+    def _perform_request(self, url, ssl_validation, auth):
         r = requests.get(url, auth=auth, headers=headers(self.agentConfig),
-                         verify=ssl_validation, timeout=self.default_integration_http_timeout,
-                         proxies=self.get_instance_proxy(instance, url, proxies={}))
+                         verify=ssl_validation, timeout=self.default_integration_http_timeout)
         r.raise_for_status()
         return r
 
-    def _perform_service_check(self, instance, url, ssl_validation, auth):
+    def _perform_service_check(self, url, ssl_validation, auth):
         # Submit a service check for status page availability.
         parsed_url = urlparse.urlparse(url)
         nginx_host = parsed_url.hostname
@@ -135,7 +134,7 @@ class Nginx(AgentCheck):
         service_check_tags = ['host:%s' % nginx_host, 'port:%s' % nginx_port]
         try:
             self.log.debug(u"Querying URL: {0}".format(url))
-            r = self._perform_request(instance, url, ssl_validation, auth)
+            r = self._perform_request(url, ssl_validation, auth)
         except Exception:
             self.service_check(service_check_name, AgentCheck.CRITICAL,
                                tags=service_check_tags)
@@ -154,7 +153,7 @@ class Nginx(AgentCheck):
                 keys[0]: self._nest_payload(keys[1:], payload)
             }
 
-    def _get_plus_api_data(self, instance, api_url, ssl_validation, auth, plus_api_version, endpoint, nest):
+    def _get_plus_api_data(self, api_url, ssl_validation, auth, plus_api_version, endpoint, nest):
         # Get the data from the Plus API and reconstruct a payload similar to what the old API returned
         # so we can treat it the same way
 
@@ -162,7 +161,7 @@ class Nginx(AgentCheck):
         payload = {}
         try:
             self.log.debug(u"Querying URL: {0}".format(url))
-            r = self._perform_request(instance, url, ssl_validation, auth)
+            r = self._perform_request(url, ssl_validation, auth)
             payload = self._nest_payload(nest, r.json())
         except Exception as e:
             self.log.exception("Error querying %s metrics at %s: %s", endpoint, url, e)

--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -121,8 +121,7 @@ class Nginx(AgentCheck):
 
     def _perform_request(self, instance, url, ssl_validation, auth):
         r = requests.get(url, auth=auth, headers=headers(self.agentConfig),
-                         verify=ssl_validation, timeout=self.default_integration_http_timeout,
-                         proxies=self.get_instance_proxy(instance, url, proxies={}))
+                         verify=ssl_validation, timeout=self.default_integration_http_timeout)
         r.raise_for_status()
         return r
 

--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -63,7 +63,7 @@ class Nginx(AgentCheck):
         url, ssl_validation, auth, use_plus_api, plus_api_version = self._get_instance_params(instance)
 
         if not use_plus_api:
-            response, content_type = self._get_data(url, ssl_validation, auth)
+            response, content_type = self._get_data(instance, url, ssl_validation, auth)
             self.log.debug(u"Nginx status `response`: {0}".format(response))
             self.log.debug(u"Nginx status `content_type`: {0}".format(content_type))
 
@@ -73,12 +73,12 @@ class Nginx(AgentCheck):
                 metrics = self.parse_text(response, tags)
         else:
             metrics = []
-            self._perform_service_check("/".join([url, plus_api_version]), ssl_validation, auth)
+            self._perform_service_check(instance, "/".join([url, plus_api_version]), ssl_validation, auth)
             # These are all the endpoints we have to call to get the same data as we did with the old API
             # since we can't get everything in one place anymore.
 
             for endpoint, nest in PLUS_API_ENDPOINTS.iteritems():
-                response = self._get_plus_api_data(url, ssl_validation, auth, plus_api_version, endpoint, nest)
+                response = self._get_plus_api_data(instance, url, ssl_validation, auth, plus_api_version, endpoint, nest)
                 self.log.debug(u"Nginx Plus API version {0} `response`: {1}".format(plus_api_version, response))
                 metrics.extend(self.parse_json(response, tags))
 
@@ -111,21 +111,22 @@ class Nginx(AgentCheck):
 
         return url, ssl_validation, auth, use_plus_api, plus_api_version
 
-    def _get_data(self, url, ssl_validation, auth):
+    def _get_data(self, instance, url, ssl_validation, auth):
 
-        r = self._perform_service_check(url, ssl_validation, auth)
+        r = self._perform_service_check(instance, url, ssl_validation, auth)
 
         body = r.content
         resp_headers = r.headers
         return body, resp_headers.get('content-type', 'text/plain')
 
-    def _perform_request(self, url, ssl_validation, auth):
+    def _perform_request(self, instance, url, ssl_validation, auth):
         r = requests.get(url, auth=auth, headers=headers(self.agentConfig),
-                         verify=ssl_validation, timeout=self.default_integration_http_timeout)
+                         verify=ssl_validation, timeout=self.default_integration_http_timeout,
+                         proxies=self.get_instance_proxy(instance, url, proxies={}))
         r.raise_for_status()
         return r
 
-    def _perform_service_check(self, url, ssl_validation, auth):
+    def _perform_service_check(self, instance, url, ssl_validation, auth):
         # Submit a service check for status page availability.
         parsed_url = urlparse.urlparse(url)
         nginx_host = parsed_url.hostname
@@ -134,7 +135,7 @@ class Nginx(AgentCheck):
         service_check_tags = ['host:%s' % nginx_host, 'port:%s' % nginx_port]
         try:
             self.log.debug(u"Querying URL: {0}".format(url))
-            r = self._perform_request(url, ssl_validation, auth)
+            r = self._perform_request(instance, url, ssl_validation, auth)
         except Exception:
             self.service_check(service_check_name, AgentCheck.CRITICAL,
                                tags=service_check_tags)
@@ -153,7 +154,7 @@ class Nginx(AgentCheck):
                 keys[0]: self._nest_payload(keys[1:], payload)
             }
 
-    def _get_plus_api_data(self, api_url, ssl_validation, auth, plus_api_version, endpoint, nest):
+    def _get_plus_api_data(self, instance, api_url, ssl_validation, auth, plus_api_version, endpoint, nest):
         # Get the data from the Plus API and reconstruct a payload similar to what the old API returned
         # so we can treat it the same way
 
@@ -161,7 +162,7 @@ class Nginx(AgentCheck):
         payload = {}
         try:
             self.log.debug(u"Querying URL: {0}".format(url))
-            r = self._perform_request(url, ssl_validation, auth)
+            r = self._perform_request(instance, url, ssl_validation, auth)
             payload = self._nest_payload(nest, r.json())
         except Exception as e:
             self.log.exception("Error querying %s metrics at %s: %s", endpoint, url, e)

--- a/nginx/manifest.json
+++ b/nginx/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.2.1",
+  "version": "1.2.0",
   "guid": "88620208-3919-457c-ba51-d844d09ac97f",
   "public_title": "Datadog-Nginx Integration",
   "categories":["web"],

--- a/nginx/test/test_nginx.py
+++ b/nginx/test/test_nginx.py
@@ -31,29 +31,24 @@ class TestNginx(unittest.TestCase):
                 {
                     'nginx_status_url': 'http://localhost:44441/nginx_status/',
                     'tags': ['first_one'],
-                    'skip_proxy': True,
                 },
                 {
                     'nginx_status_url': 'http://dummyurl:44441/nginx_status/',
                     'tags': ['dummy'],
-                    'skip_proxy': True,
                 },
                 {
                     'nginx_status_url': 'http://localhost:44441/nginx_status/',
                     'tags': ['second'],
-                    'skip_proxy': True,
                 },
                 {
                     'nginx_status_url': 'https://localhost:44442/https_nginx_status/',
                     'tags': ['ssl_enabled'],
                     'ssl_validation': True,
-                    'skip_proxy': True,
                 },
                 {
                     'nginx_status_url': 'https://localhost:44442/https_nginx_status/',
                     'tags': ['ssl_disabled'],
                     'ssl_validation': False,
-                    'skip_proxy': True,
                 },
             ]
         }

--- a/nginx/test/test_nginx.py
+++ b/nginx/test/test_nginx.py
@@ -31,24 +31,29 @@ class TestNginx(unittest.TestCase):
                 {
                     'nginx_status_url': 'http://localhost:44441/nginx_status/',
                     'tags': ['first_one'],
+                    'skip_proxy': True,
                 },
                 {
                     'nginx_status_url': 'http://dummyurl:44441/nginx_status/',
                     'tags': ['dummy'],
+                    'skip_proxy': True,
                 },
                 {
                     'nginx_status_url': 'http://localhost:44441/nginx_status/',
                     'tags': ['second'],
+                    'skip_proxy': True,
                 },
                 {
                     'nginx_status_url': 'https://localhost:44442/https_nginx_status/',
                     'tags': ['ssl_enabled'],
                     'ssl_validation': True,
+                    'skip_proxy': True,
                 },
                 {
                     'nginx_status_url': 'https://localhost:44442/https_nginx_status/',
                     'tags': ['ssl_disabled'],
                     'ssl_validation': False,
+                    'skip_proxy': True,
                 },
             ]
         }

--- a/nginx/test/test_nginx.py
+++ b/nginx/test/test_nginx.py
@@ -125,28 +125,29 @@ class dummy_http_response:
 def api_call(*args, **kwargs):
 
     json = ""
+    url = args[1]
 
-    if "nginx" in args[0]:
+    if "nginx" in url:
         json = Fixtures.read_file('plus_api_nginx.json', sdk_dir=FIXTURE_DIR)
-    elif "processes" in args[0]:
+    elif "processes" in url:
         json = Fixtures.read_file('plus_api_processes.json', sdk_dir=FIXTURE_DIR)
-    elif "connections" in args[0]:
+    elif "connections" in url:
         json = Fixtures.read_file('plus_api_connections.json', sdk_dir=FIXTURE_DIR)
-    elif "ssl" in args[0]:
+    elif "ssl" in url:
         json = Fixtures.read_file('plus_api_ssl.json', sdk_dir=FIXTURE_DIR)
-    elif "slabs" in args[0]:
+    elif "slabs" in url:
         json = Fixtures.read_file('plus_api_slabs.json', sdk_dir=FIXTURE_DIR)
-    elif "http/requests" in args[0]:
+    elif "http/requests" in url:
         json = Fixtures.read_file('plus_api_http_requests.json', sdk_dir=FIXTURE_DIR)
-    elif "http/server_zones" in args[0]:
+    elif "http/server_zones" in url:
         json = Fixtures.read_file('plus_api_http_server_zones.json', sdk_dir=FIXTURE_DIR)
-    elif "http/caches" in args[0]:
+    elif "http/caches" in url:
         json = Fixtures.read_file('plus_api_http_caches.json', sdk_dir=FIXTURE_DIR)
-    elif "http/upstreams" in args[0]:
+    elif "http/upstreams" in url:
         json = Fixtures.read_file('plus_api_http_upstreams.json', sdk_dir=FIXTURE_DIR)
-    elif "stream/upstreams" in args[0]:
+    elif "stream/upstreams" in url:
         json = Fixtures.read_file('plus_api_stream_upstreams.json', sdk_dir=FIXTURE_DIR)
-    elif "stream/server_zones" in args[0]:
+    elif "stream/server_zones" in url:
         json = Fixtures.read_file('plus_api_stream_server_zones.json', sdk_dir=FIXTURE_DIR)
 
     return dummy_http_response(json)


### PR DESCRIPTION
### What does this PR do?

This allows users of the nginx check to bypass proxy settings. It is particularly useful for auto discovery with Docker.

### Motivation

Customer request

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.