### PR TITLE
deprecate no_proxy config option

### DIFF
--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - http_check
 
+1.4.0 / Unreleased
+==================
+
+### Changes
+
+* [IMPROVEMENT] begin deprecation of `no_proxy` config flag in favor of `skip_proxy`. See [#1057][].
+
 1.3.1 / 2018-01-17
 ==================
 

--- a/http_check/README.md
+++ b/http_check/README.md
@@ -57,7 +57,7 @@ See the [sample http_check.yaml](https://github.com/DataDog/integrations-core/bl
 | `days_warning` & `days_critical` | When `check_certificate_expiration` is enabled, these settings will raise a warning or critical alert when the SSL certificate is within the specified number of days from expiration. |
 | `headers` | This parameter allows you to send additional headers with the request. Please see the [example YAML file](https://github.com/DataDog/integrations-core/blob/master/http_check/conf.yaml.example) for additional information and caveats. |
 | `skip_event` | When enabled, the check will not create an event. This is useful to avoid duplicates with a server side service check. This defaults to `false`. |
-| `no_proxy` | If set, the check will bypass proxy settings and attempt to reach the check url directly. This defaults to `false`. |
+| `skip_proxy` | If set, the check will bypass proxy settings and attempt to reach the check url directly. This defaults to `false`. |
 | `allow_redirects` | This setting allows the service check to follow HTTP redirects and defaults to `true`.
 | `tags` | A list of arbitrary tags that will be associated with the check. For more information about tags, please see our [Guide to tagging](/guides/tagging/) and blog post, [The power of tagged metrics](https://www.datadoghq.com/blog/the-power-of-tagged-metrics/) |
 

--- a/http_check/conf.yaml.example
+++ b/http_check/conf.yaml.example
@@ -123,12 +123,12 @@ instances:
     #
     skip_event: true
 
-    # The (optional) no_proxy parameter would bypass any proxy settings enabled
+    # The (optional) skip_proxy parameter would bypass any proxy settings enabled
     # and attempt to reach the the URL directly.
     # If no proxy is defined at any level, this flag bears no effect.
     # Defaults to False.
     #
-    # no_proxy: false
+    # skip_proxy: false
 
     # The (optional) allow_redirects parameter can enable redirection.
     # Defaults to True.

--- a/http_check/datadog_checks/http_check/__init__.py
+++ b/http_check/datadog_checks/http_check/__init__.py
@@ -2,6 +2,6 @@ from . import http_check
 
 HTTPCheck = http_check.HTTPCheck
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"
 
 __all__ = ['http_check']

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -190,7 +190,8 @@ class HTTPCheck(NetworkCheck):
         instance_ca_certs = instance.get('ca_certs', self.ca_certs)
         weakcipher = _is_affirmative(instance.get('weakciphers', False))
         ignore_ssl_warning = _is_affirmative(instance.get('ignore_ssl_warning', False))
-        skip_proxy = _is_affirmative(instance.get('no_proxy', False))
+        skip_proxy = _is_affirmative(
+            instance.get('skip_proxy', instance.get('no_proxy', False)))
         allow_redirects = _is_affirmative(instance.get('allow_redirects', True))
 
         return url, username, password, client_cert, client_key, method, data, http_response_status_code, timeout, include_content,\

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.3.1",
+  "version": "1.4.0",
   "guid": "eb133a1f-697c-4143-bad3-10e72541fa9c",
   "public_title": "Datadog-HTTP Check Integration",
   "categories":["web", "network"],

--- a/rabbitmq/CHANGELOG.md
+++ b/rabbitmq/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - rabbitmq
 
+1.5.0 / Unreleased
+==================
+
+### Changes
+
+* [IMPROVEMENT] begin deprecation of `no_proxy` config flag in favor of `skip_proxy`. See [#1057][].
 
 1.4.0 / 2018-01-10
 ==================

--- a/rabbitmq/conf.yaml.example
+++ b/rabbitmq/conf.yaml.example
@@ -20,12 +20,12 @@ instances:
     #
     # ssl_verify: false
 
-    # The (optional) no_proxy parameter would bypass any proxy settings enabled
+    # The (optional) skip_proxy parameter would bypass any proxy settings enabled
     # and attempt to reach the the URL directly.
     # If no proxy is defined at any level, this flag bears no effect.
     # Defaults to False.
     #
-    # no_proxy: false
+    # skip_proxy: false
 
     # tag_families: true
     # Use the `nodes` or `nodes_regexes` parameters to specify the nodes you'd like to

--- a/rabbitmq/datadog_checks/rabbitmq/__init__.py
+++ b/rabbitmq/datadog_checks/rabbitmq/__init__.py
@@ -2,6 +2,6 @@ from . import rabbitmq
 
 RabbitMQ = rabbitmq.RabbitMQ
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 __all__ = ['rabbitmq']

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.4.0",
+  "version": "1.5.0",
   "guid": "a790a556-fbaa-4208-9d39-c42c3d57084b",
   "public_title": "Datadog-RabbitMQ Integration",
   "categories":["processing"],


### PR DESCRIPTION
### What does this PR do?

This deprecates the `no_proxy` config option for the http and rabbitmq checks, replacing it with `skip_proxy`.

### Motivation

This removes confusion for our customers, as there is already an env var named `no_proxy` in use that does something completely different.

https://github.com/DataDog/dd-agent/blob/08a507c669a31dde3d1397bdd95c34038004fd14/utils/proxy.py#L96

### Additional Notes

Merge only after the following:
https://github.com/DataDog/dd-agent/pull/3647
https://github.com/DataDog/datadog-agent/pull/1111