### PR TITLE
[ssh_check] fix failing test

### DIFF
--- a/ssh_check/test/test_ssh.py
+++ b/ssh_check/test/test_ssh.py
@@ -57,7 +57,6 @@ class SshTestCase(unittest.TestCase):
 
         service = self.check.get_service_checks()
         self.assertEqual(service[0].get('status'), AgentCheck.OK)
-        self.assertEqual(service[0].get('message'), None)
         self.assertEqual(service[0].get('tags'), ["instance:io.netgarage.org-22"])
 
         # Testing that bad authentication will raise exception

--- a/ssh_check/test/test_ssh.py
+++ b/ssh_check/test/test_ssh.py
@@ -57,6 +57,7 @@ class SshTestCase(unittest.TestCase):
 
         service = self.check.get_service_checks()
         self.assertEqual(service[0].get('status'), AgentCheck.OK)
+        self.assertEqual(service[0].get('message'), "No errors occured")
         self.assertEqual(service[0].get('tags'), ["instance:io.netgarage.org-22"])
 
         # Testing that bad authentication will raise exception


### PR DESCRIPTION
### What does this PR do?

The test was asserting that an exception message was None. 

#852 Modified this behaviour and the exception message is no longer empty if there is no exception.

### Notes

It seems that the test was not always failing on CI, maybe this is worth investigating ? It failed 100% of the times localy.