### PR TITLE
[SQLServer] Adds ability to configure custom connection string.

### DIFF
--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Changes
 
-* [IMPROVEMENT] Allow custom connection string to connect. See [#1065][].
+* [IMPROVEMENT] Allow custom connection string to connect. See [#1068][].
 
 1.2.1 / 2018-01-10
 ==================
@@ -46,6 +46,6 @@
 [#573]: https://github.com/DataDog/integrations-core/issues/573
 [#959]: https://github.com/DataDog/integrations-core/issues/959
 [#975]: https://github.com/DataDog/integrations-core/pull/975
-[#1065]: https://github.com/DataDog/integrations-core/pull/1065
+[#1068]: https://github.com/DataDog/integrations-core/pull/1065
 [@rlaveycal]: https://github.com/rlaveycal
 [@themsquared]: https://github.com/themsquared

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - sqlserver
 
+1.3.0 / Unreleased
+==================
+
+### Changes
+
+* [IMPROVEMENT] Allow custom connection string to connect. See [#1065][].
+
 1.2.1 / 2018-01-10
 ==================
 
@@ -39,5 +46,6 @@
 [#573]: https://github.com/DataDog/integrations-core/issues/573
 [#959]: https://github.com/DataDog/integrations-core/issues/959
 [#975]: https://github.com/DataDog/integrations-core/pull/975
+[#1065]: https://github.com/DataDog/integrations-core/pull/1065
 [@rlaveycal]: https://github.com/rlaveycal
 [@themsquared]: https://github.com/themsquared

--- a/sqlserver/conf.yaml.example
+++ b/sqlserver/conf.yaml.example
@@ -98,6 +98,10 @@ instances:
     # dsn: DSN_NAME
     username: my_username
     password: my_password
+
+    # Optional, specify a custom connection string to be used
+    # Ex: "ApplicationIntent=ReadWrite" or "MultiSubnetFailover=True"
+    # connection_string: "my_connection_string"
     
     # Optional, timeout in seconds for the connection and each command run
     # command_timeout: 30

--- a/sqlserver/datadog_checks/sqlserver/__init__.py
+++ b/sqlserver/datadog_checks/sqlserver/__init__.py
@@ -2,6 +2,6 @@ from . import sqlserver
 
 SQLServer = sqlserver.SQLServer
 
-__version__ = "1.2.1"
+__version__ = "1.3.0"
 
 __all__ = ['sqlserver']

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -591,13 +591,19 @@ class SQLServer(AgentCheck):
             'db:%s' % database
         ]
 
+        cs = instance.get('connection_string', '')
+        cs += ';' if cs != '' else ''
+
         try:
             if self._get_connector(instance) == 'adodbapi':
-                cs = self._conn_string_adodbapi(db_key, instance=instance, db_name=db_name)
+                cs += self._conn_string_adodbapi(db_key, instance=instance, db_name=db_name)
+                self.log.debug("Formatted connection string: {0}".format(cs))
+
                 # autocommit: true disables implicit transaction
                 rawconn = adodbapi.connect(cs, {'timeout':timeout, 'autocommit':True})
             else:
-                cs = self._conn_string_odbc(db_key, instance=instance, db_name=db_name)
+                cs += self._conn_string_odbc(db_key, instance=instance, db_name=db_name)
+                self.log.debug("Formatted connection string: {0}".format(cs))
                 rawconn = pyodbc.connect(cs, timeout=timeout)
 
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -10,7 +10,7 @@
     "linux",
     "windows"
   ],
-  "version": "1.2.1",
+  "version": "1.3.0",
   "guid": "635cb962-ee9f-4788-aa55-a7ffb9661498",
   "public_title": "Datadog-SQL Server Integration",
   "categories":["data store"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Allows a user to specify a custom connection string for SQL Server. It looks like you can supply some connection string parameters to use similar to Environment Variables - https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/sql/sqlclient-support-for-high-availability-disaster-recovery

Additionally adds some debug lines to help debug cases in the future. 

### Motivation

Customer Request

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`

### Additional Notes

Anything else we should know when reviewing?
The connection strings don't appear to be ordered, (can't find any documentation surrounding this) 
Additionally, since the connection_string uses a key=value type syntax, this implies the arguments aren't positional. 

@dixonscottr Was able to test this using a SQLServer instance and changing some default connection strings. 

Original PR was here - https://github.com/DataDog/integrations-core/pull/703/ Closed in favor of this one. 