### PR TITLE
[postgres] fix metric types in metadata CSV

### DIFF
--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -1,18 +1,18 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 postgresql.connections,gauge,,connection,,The number of active connections to this database.,0,postgres,conns
-postgresql.commits,gauge,,transaction,second,The number of transactions that have been committed in this database.,0,postgres,commits
-postgresql.rollbacks,gauge,,transaction,second,The number of transactions that have been rolled back in this database.,-1,postgres,rollbacks
-postgresql.disk_read,gauge,,block,second,The number of disk blocks read in this database.,0,postgres,disk read
-postgresql.buffer_hit,gauge,,hit,second,"The number of times disk blocks were found in the buffer cache, preventing the need to read from the database. ",1,postgres,buff hit
-postgresql.rows_returned,gauge,,row,second,The number of rows returned by queries in this database,0,postgres,rows ret
-postgresql.rows_fetched,gauge,,row,second,The number of rows fetched by queries in this database,0,postgres,rows fetch
-postgresql.rows_inserted,gauge,,row,second,The number of rows inserted by queries in this database,0,postgres,rows insrt
-postgresql.rows_updated,gauge,,row,second,The number of rows updated by queries in this database,0,postgres,rows updt
-postgresql.rows_deleted,gauge,,row,second,The number of rows deleted by queries in this database,0,postgres,rows del
+postgresql.commits,rate,,transaction,second,The number of transactions that have been committed in this database.,0,postgres,commits
+postgresql.rollbacks,rate,,transaction,second,The number of transactions that have been rolled back in this database.,-1,postgres,rollbacks
+postgresql.disk_read,rate,,block,second,The number of disk blocks read in this database.,0,postgres,disk read
+postgresql.buffer_hit,rate,,hit,second,"The number of times disk blocks were found in the buffer cache, preventing the need to read from the database. ",1,postgres,buff hit
+postgresql.rows_returned,rate,,row,second,The number of rows returned by queries in this database,0,postgres,rows ret
+postgresql.rows_fetched,rate,,row,second,The number of rows fetched by queries in this database,0,postgres,rows fetch
+postgresql.rows_inserted,rate,,row,second,The number of rows inserted by queries in this database,0,postgres,rows insrt
+postgresql.rows_updated,rate,,row,second,The number of rows updated by queries in this database,0,postgres,rows updt
+postgresql.rows_deleted,rate,,row,second,The number of rows deleted by queries in this database,0,postgres,rows del
 postgresql.database_size,gauge,,byte,,The disk space used by this database.,0,postgres,db size
-postgresql.deadlocks,gauge,,,,The number of deadlocks detected in this database,-1,postgres,deadlocks
-postgresql.temp_bytes,gauge,,byte,second,The amount of data written to temporary files by queries in this database.,0,postgres,temp bytes
-postgresql.temp_files,gauge,,file,second,The number of temporary files created by queries in this database.,0,postgres,temp files
+postgresql.deadlocks,rate,,,,The number of deadlocks detected in this database,-1,postgres,deadlocks
+postgresql.temp_bytes,rate,,byte,second,The amount of data written to temporary files by queries in this database.,0,postgres,temp bytes
+postgresql.temp_files,rate,,file,second,The number of temporary files created by queries in this database.,0,postgres,temp files
 postgresql.bgwriter.checkpoints_timed,count,,,,The number of scheduled checkpoints that were performed.,0,postgres,bgw cp timed
 postgresql.bgwriter.checkpoints_requested,count,,,,The number of requested checkpoints that were performed.,0,postgres,bgw cp req
 postgresql.bgwriter.buffers_checkpoint,count,,,,The number of buffers written during checkpoints.,0,postgres,bgw buff cp
@@ -24,14 +24,14 @@ postgresql.bgwriter.buffers_backend_fsync,count,,,,The of times a backend had to
 postgresql.bgwriter.write_time,count,,millisecond,,The total amount of checkpoint processing time spent writing files to disk.,0,postgres,bgw wrt time
 postgresql.bgwriter.sync_time,count,,millisecond,,The total amount of checkpoint processing time spent synchronizing files to disk.,0,postgres,bgw sync time
 postgresql.locks,gauge,,lock,,The number of locks active for this database.,0,postgres,locks
-postgresql.seq_scans,gauge,,,,The number of sequential scans initiated on this table.,0,postgres,seq scans
-postgresql.seq_rows_read,gauge,,row,second,The number of live rows fetched by sequential scans.,0,postgres,seq rows rd
-postgresql.index_scans,gauge,,,,The number of index scans initiated on this table.,0,postgres,idx scans
-postgresql.index_rows_fetched,gauge,,row,second,The number of live rows fetched by index scans.,0,postgres,idx rows fetch
-postgresql.rows_hot_updated,gauge,,row,second,"The number of rows HOT updated, meaning no separate index update was needed.",0,postgres,rows hot updated
+postgresql.seq_scans,rate,,,,The number of sequential scans initiated on this table.,0,postgres,seq scans
+postgresql.seq_rows_read,rate,,row,second,The number of live rows fetched by sequential scans.,0,postgres,seq rows rd
+postgresql.index_scans,rate,,,,The number of index scans initiated on this table.,0,postgres,idx scans
+postgresql.index_rows_fetched,rate,,row,second,The number of live rows fetched by index scans.,0,postgres,idx rows fetch
+postgresql.rows_hot_updated,rate,,row,second,"The number of rows HOT updated, meaning no separate index update was needed.",0,postgres,rows hot updated
 postgresql.live_rows,gauge,,row,,The estimated number of live rows.,0,postgres,live rows
 postgresql.dead_rows,gauge,,row,,The estimated number of dead rows.,0,postgres,dead rows
-postgresql.index_rows_read,gauge,,row,second,The number of index entries returned by scans on this index.,0,postgres,idx rows read
+postgresql.index_rows_read,rate,,row,second,The number of index entries returned by scans on this index.,0,postgres,idx rows read
 postgresql.table_size,gauge,,byte,,"The total disk space used by the specified table. Includes TOAST, free space map, and visibility map. Excludes indexes.",0,postgres,tbl size
 postgresql.index_size,gauge,,byte,,The total disk space used by indexes attached to the specified table.,0,postgres,idx size
 postgresql.total_size,gauge,,byte,,"The total disk space used by the table, including indexes and TOAST data.",0,postgres,tot size
@@ -41,11 +41,11 @@ postgresql.percent_usage_connections,gauge,,fraction,,The number of connections 
 postgresql.replication_delay,gauge,,second,,The current replication delay in seconds. Only available with postgresql 9.1 and newer,-1,postgres,repl delay
 postgres.replication_delay_bytes,gauge,,byte,,Deprecated please use postgresql.replication_delay_bytes instead,-1,postgres,repl delay bytes
 postgresql.replication_delay_bytes,gauge,,byte,,The current replication delay in bytes. Only available with postgresql 9.2 and newer,-1,postgres,repl delay bytes
-postgresql.heap_blocks_read,gauge,,block,second,The number of disk blocks read from this table.,0,postgres,heap blks read
-postgresql.heap_blocks_hit,gauge,,hit,second,The number of buffer hits in this table.,0,postgres,heap blks hit
-postgresql.index_blocks_read,gauge,,block,second,The number of disk blocks read from all indexes on this table.,0,postgres,idx blks read
-postgresql.index_blocks_hit,gauge,,hit,second,The number of buffer hits in all indexes on this table.,0,postgres,idx blks hit
-postgresql.toast_blocks_read,gauge,,block,second,The number of disk blocks read from this table's TOAST table.,0,postgres,toast blks read
-postgresql.toast_blocks_hit,gauge,,hit,second,The number of buffer hits in this table's TOAST table.,0,postgres,toast blks hit
-postgresql.toast_index_blocks_read,gauge,,block,second,The number of disk blocks read from this table's TOAST table index.,0,postgres,toast idx blks read
-postgresql.toast_index_blocks_hit,gauge,,block,second,The number of buffer hits in this table's TOAST table index.,0,postgres,toast idx blks hit
+postgresql.heap_blocks_read,rate,,block,second,The number of disk blocks read from this table.,0,postgres,heap blks read
+postgresql.heap_blocks_hit,rate,,hit,second,The number of buffer hits in this table.,0,postgres,heap blks hit
+postgresql.index_blocks_read,rate,,block,second,The number of disk blocks read from all indexes on this table.,0,postgres,idx blks read
+postgresql.index_blocks_hit,rate,,hit,second,The number of buffer hits in all indexes on this table.,0,postgres,idx blks hit
+postgresql.toast_blocks_read,rate,,block,second,The number of disk blocks read from this table's TOAST table.,0,postgres,toast blks read
+postgresql.toast_blocks_hit,rate,,hit,second,The number of buffer hits in this table's TOAST table.,0,postgres,toast blks hit
+postgresql.toast_index_blocks_read,rate,,block,second,The number of disk blocks read from this table's TOAST table index.,0,postgres,toast idx blks read
+postgresql.toast_index_blocks_hit,rate,,block,second,The number of buffer hits in this table's TOAST table index.,0,postgres,toast idx blks hit


### PR DESCRIPTION
### What does this PR do?

Change incorrect metric types

### Motivation

Several metrics are documented as GAUGE type metrics but are actually RATE based on the actual check.
