### PR TITLE
Rework postgres check to split server metrics from db metrics

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -1,10 +1,11 @@
 # CHANGELOG - postgres
 
-1.2.2 / Unreleased
+2.0.0 / Unreleased
 ==================
 ### Changes
 
 * [DOC] Adding configuration for log collection in `conf.yaml`
+* [DEPRECATING] Starting with agent6 the postgres check no longer tag server wide metrics with instance tags. See [#1073][]
 
 1.2.1 / Unreleased
 ==================

--- a/postgres/datadog_checks/postgres/__init__.py
+++ b/postgres/datadog_checks/postgres/__init__.py
@@ -2,6 +2,6 @@ from . import postgres
 
 PostgreSql = postgres.PostgreSql
 
-__version__ = "1.2.2"
+__version__ = "2.0.0"
 
 __all__ = ['postgres']

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -12,7 +12,7 @@
     "windows"
   ],
   "package_deps": false,
-  "version": "1.2.2",
+  "version": "2.0.0",
   "guid": "e9ca29d5-5b4f-4478-8989-20d89afda0c9",
   "public_title": "Datadog-Postgres SQL Integration",
   "categories":["data store"],


### PR DESCRIPTION
### What does this PR do?

Rework postgres check to split server metrics from db metrics

For postgres some metrics are collected only once per postgres server
(even if the user is monitoring multiple databases on the server from
one agent).

This rework is needed so the postgres check work properly on agent6
where check instances don't share the same check instance.

The check detect the version of the agent running by trying to import `datadog_agent` and only apply instance tags to `COMMON_METRICS`, `NEWER_92_METRICS`, `DATABASE_SIZE_METRICS`, `COMMON_BGW_METRICS`, `NEWER_91_BGW_METRICS` and `COMMON_ARCHIVER_METRICS` if its running on agent5.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 