### PR TITLE
Removing system.processes.open_file_descriptors metric

### DIFF
--- a/process/metadata.csv
+++ b/process/metadata.csv
@@ -14,7 +14,6 @@ system.processes.mem.real,gauge,,byte,,The non-swapped physical memory a process
 system.processes.mem.rss,gauge,,byte,,"The non-swapped physical memory a process has used. aka ""Resident Set Size"".",0,system,processes mem rss
 system.processes.mem.vms,gauge,,byte,,"The total amount of virtual memory used by the process. aka ""Virtual Memory Size"".",0,system,processes mem vms
 system.processes.number,gauge,,process,,The number of processes.,0,system,processes number
-system.processes.open_file_descriptors,gauge,,,,The number of file descriptors used by this process.,0,system,processes open fds
 system.processes.open_handles,gauge,,,,The number of handles used by this process.,0,system,processes open handles
 system.processes.threads,gauge,,thread,,The number of threads used by this process.,0,system,processes threads
 system.processes.voluntary_ctx_switches,gauge,,event,,The number of voluntary context switches performed by this process.,0,system,processes vol ctx switches

--- a/process/metadata.csv
+++ b/process/metadata.csv
@@ -14,6 +14,7 @@ system.processes.mem.real,gauge,,byte,,The non-swapped physical memory a process
 system.processes.mem.rss,gauge,,byte,,"The non-swapped physical memory a process has used. aka ""Resident Set Size"".",0,system,processes mem rss
 system.processes.mem.vms,gauge,,byte,,"The total amount of virtual memory used by the process. aka ""Virtual Memory Size"".",0,system,processes mem vms
 system.processes.number,gauge,,process,,The number of processes.,0,system,processes number
+system.processes.open_file_descriptors,gauge,,,,"The number of file descriptors used by this process (only available for processes run as the dd-agent user)",0,system,processes open fds
 system.processes.open_handles,gauge,,,,The number of handles used by this process.,0,system,processes open handles
 system.processes.threads,gauge,,thread,,The number of threads used by this process.,0,system,processes threads
 system.processes.voluntary_ctx_switches,gauge,,event,,The number of voluntary context switches performed by this process.,0,system,processes vol ctx switches


### PR DESCRIPTION
### What does this PR do?

It removes `system.processes.open_file_descriptors` from `/process/metadata.csv` file

### Motivation

On Linux, the metric `system.processes.open_file_descriptors`, which is documented [here](https://docs.datadoghq.com/integrations/process/), can only be viewed for processes running as the same user as the agent (dd-agent), so it is useless. [This metric isn't available on Windows](https://psutil.readthedocs.io/en/latest/#psutil.Process.num_fds). I don't know if it works on some other unix, but barely any of our customers use those.

Because this metric isn't available on Linux or Windows, it should be removed from the documentation. It is a frequent source of confusion, to the point that there is [a KB article that explains why you can't use this metric](https://help.datadoghq.com/hc/en-us/articles/115000066506). Why list it, only to have to tell customers that they can't use it?