### PR TITLE
Add new line & adjust spacing around tags

### DIFF
--- a/cassandra/CHANGELOG.md
+++ b/cassandra/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - cassandra
 
+1.2.1 / Unreleased
+==================
+
+### Changes
+
+* [IMPROVEMENT] Adjusted comment whitespacing to avoid confusion around indent level for `user` and `password`. See [#1075][]
+
 1.2.0 / 2017-11-21
 ==================
 

--- a/cassandra/conf.yaml.example
+++ b/cassandra/conf.yaml.example
@@ -13,12 +13,13 @@ instances:
     tags:
       environment: default_environment
       datacenter: default_datacenter
-  #   user: username
-  #   password: password
-  #   process_name_regex: .*process_name.* # Instead of specifying a host, and port. The agent can connect using the attach api.
-  #                                        # This requires the JDK to be installed and the path to tools.jar to be set below.
-  #   tools_jar_path: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar # To be set when process_name_regex is set
-  #   name: cassandra_instance
+      
+  # user: username
+  # password: password
+  # process_name_regex: .*process_name.* # Instead of specifying a host, and port. The agent can connect using the attach api.
+                                         # This requires the JDK to be installed and the path to tools.jar to be set below.
+  # tools_jar_path: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar # To be set when process_name_regex is set
+  # name: cassandra_instance
   #   # java_bin_path: /path/to/java # Optional, should be set if the agent cannot find your java executable
   #   # java_options: "-Xmx200m -Xms50m" # Optional, Java JVM options
   #   # trust_store_path: /path/to/trustStore.jks # Optional, should be set if ssl is enabled

--- a/cassandra/conf.yaml.example
+++ b/cassandra/conf.yaml.example
@@ -10,20 +10,20 @@ instances:
     # This will prevent aggregating metrics matchingly named clusters in distinct environments.
     #
     # The 'datacenter' tag should be the name of the Cassandra data center the node belongs to.
-    tags:
-      environment: default_environment
-      datacenter: default_datacenter
-      
-  # user: username
-  # password: password
-  # process_name_regex: .*process_name.* # Instead of specifying a host, and port. The agent can connect using the attach api.
-                                         # This requires the JDK to be installed and the path to tools.jar to be set below.
-  # tools_jar_path: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar # To be set when process_name_regex is set
-  # name: cassandra_instance
-  #   # java_bin_path: /path/to/java # Optional, should be set if the agent cannot find your java executable
-  #   # java_options: "-Xmx200m -Xms50m" # Optional, Java JVM options
-  #   # trust_store_path: /path/to/trustStore.jks # Optional, should be set if ssl is enabled
-  #   # trust_store_password: password
+    # tags:
+    #  environment: default_environment
+    #  datacenter: default_datacenter
+    
+    # user: username
+    # password: password
+    # process_name_regex: .*process_name.* # Instead of specifying a host, and port. The agent can connect using the attach api.
+                                           # This requires the JDK to be installed and the path to tools.jar to be set below.
+    # tools_jar_path: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar # To be set when process_name_regex is set
+    # name: cassandra_instance
+    # java_bin_path: /path/to/java # Optional, should be set if the agent cannot find your java executable
+    # java_options: "-Xmx200m -Xms50m" # Optional, Java JVM options
+    # trust_store_path: /path/to/trustStore.jks # Optional, should be set if ssl is enabled
+    # trust_store_password: password
 
 init_config:
   is_jmx: true

--- a/cassandra/conf.yaml.example
+++ b/cassandra/conf.yaml.example
@@ -11,8 +11,8 @@ instances:
     #
     # The 'datacenter' tag should be the name of the Cassandra data center the node belongs to.
     # tags:
-    #  environment: default_environment
-    #  datacenter: default_datacenter
+    #   environment: default_environment
+    #   datacenter: default_datacenter
     
     # user: username
     # password: password

--- a/cassandra/manifest.json
+++ b/cassandra/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.2.0",
+  "version": "1.2.1",
   "guid": "03ba454d-425c-4f61-9e9c-54682c3ebce5",
   "public_title": "Datadog-Cassandra Integration",
   "categories":["data store"],


### PR DESCRIPTION
I've had several customers, most recently T-Mobile, improperly indent `user` and `password` beneath tags because of the structure of commented out configuration items. This will lead to an error message that states `username and password are null`.

### What does this PR do?

Adds a new line and adjusts spacing/indent for cassandra comments surrounding `tags`, `user`, and `password` (they could be taking the `user` and `password` keys all the way back to the space before the comment character, but this seems to have tripped them up). Hopefully is is somewhat more clear now, I tried to follow the convention of `# ` where a space occurs after the hash and aligning the keys so that they're inline.

### Motivation

Have had customers get tripped up by simply removing the single comment character `#` which aligns `user` and `password` beneath `tags` and causes an error (to which they couldn't figure out since YAML isn't in their wheelhouse and the YAML validates).

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
    - _Kelner: There is no such file for this integration_
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [x] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 
    - _Kelner: @olivielpeau has confirmed not necessary for this change_
