### PR TITLE
[Marathon] Removing useless param

### DIFF
--- a/marathon/README.md
+++ b/marathon/README.md
@@ -20,7 +20,6 @@ Create a file `marathon.yaml` in the Agent's `conf.d` directory. See the [sample
 
 ```
 init_config:
-  - default_timeout: 5 # how many seconds to wait for Marathon API response
 
 instances:
   - url: https://<server>:<port> # the API endpoint of your Marathon master; required


### PR DESCRIPTION
### What does this PR do?

Client was having issues following our documentation here: https://docs.datadoghq.com/integrations/marathon/#configuration

It seems that the second line of the config "- default_timeout: 5" breaks the integration.

It looks like we also have it the default timeout set here anyway: https://github.com/DataDog/integrations-core/blob/master/marathon/datadog_checks/marathon/marathon.py#L20