### PR TITLE
[Gitlab] logo is now available

### DIFF
--- a/gitlab/manifest.json
+++ b/gitlab/manifest.json
@@ -17,5 +17,5 @@
   "categories":["web", "network"],
   "doc_link": "https://docs.datadoghq.com/integrations/gitlab/",
   "is_public": true,
-  "has_logo": false
+  "has_logo": true
 }

--- a/gitlab_runner/manifest.json
+++ b/gitlab_runner/manifest.json
@@ -13,5 +13,5 @@
   "categories":["web", "network"],
   "doc_link": "https://docs.datadoghq.com/integrations/gitlab_runner/",
   "is_public": true,
-  "has_logo": false
+  "has_logo": true
 }


### PR DESCRIPTION
### What does this PR do?

We now have a logo for Gitlab doc, this PR update the manifest to reflect it
