### PR TITLE
[Oracle] Installation update

### DIFF
--- a/oracle/README.md
+++ b/oracle/README.md
@@ -49,7 +49,7 @@ GRANT SELECT ON gv_$sysmetric TO datadog;
 GRANT SELECT ON sys.dba_data_files TO datadog;
 ```
 
-**Note**: If you're using Oracle 11g (or lower), there's no need to run the following line:
+**Note**: If you're using Oracle 11g, there's no need to run the following line:
 ```
 ALTER SESSION SET "_ORACLE_SCRIPT"=true;
 ```

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -53,6 +53,7 @@ GRANT SELECT ON gv_$sysmetric TO datadog;
 Edit the `oracle.yaml` file to point to your server and port, set the masters to monitor. See the [sample oracle.yaml](https://github.com/DataDog/integrations-core/blob/master/oracle/conf.yaml.example) for all available configuration options.
 
 Configuration Options:
+
 * **`server`** (Required) - The IP address or hostname of the Oracle Database server.
 * **`service_name`** (Required) - The Oracle Database service name. To view the services available on your server, run the following query: `SELECT value FROM v$parameter WHERE name='service_names'`.
 * **`user`** (Required) - If you followed [the instructions above](#installation), set this to the read-only user `datadog`. Otherwise set it to a user with sufficient privileges to connect to the database and read system metrics.

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -7,7 +7,7 @@ Get metrics from Oracle Database servers in real time to visualize and monitor a
 ## Setup
 ### Installation
 
-In order to use the Oracle integration you must install the Oracle Instant Client libraries. Due to licensing restrictions we are unable to include these libraries in our agent, but you can [download them directly frrom Oracle](https://www.oracle.com/technetwork/database/features/instant-client/index.htm).
+In order to use the Oracle integration, install the Oracle Instant Client libraries. Due to licensing restrictions we are unable to include these libraries in our agent, but you can [download them directly frrom Oracle](https://www.oracle.com/technetwork/database/features/instant-client/index.htm).
 
 You will need to install the Instant Client Basic and SDK packages.
 
@@ -22,7 +22,7 @@ sudo sh -c "echo /usr/lib/oracle/12.2/client64/lib > \
 sudo ldconfig
 ```
 
-Alternately, you can update your `LD_LIBRARY_PATH` to include the location of the Instant Client libraries. For example:
+Alternately, update your `LD_LIBRARY_PATH` to include the location of the Instant Client libraries. For example:
 
 ```
 mkdir -p /opt/oracle/ && cd /opt/oracle/
@@ -34,7 +34,7 @@ unzip /opt/oracle/instantclient-sdk-linux.x64-12.1.0.2.0.zip
 export LD_LIBRARY_PATH=/opt/oracle/instantclient/lib:$LD_LIBRARY_PATH
 ```
 
-Finally, you will need to create a read-only datadog user with proper access to your Oracle Database Server. Connect to your Oracle database with an administrative user (e.g. `SYSDBA` or `SYSOPER`) and run:
+Finally, create a read-only datadog user with proper access to your Oracle Database Server. Connect to your Oracle database with an administrative user (e.g. `SYSDBA` or `SYSOPER`) and run:
 
 ```
 -- Enable Oracle Script.
@@ -46,6 +46,12 @@ CREATE USER datadog IDENTIFIED BY <password>;
 -- Grant access to the datadog user.
 GRANT CONNECT TO datadog;
 GRANT SELECT ON gv_$sysmetric TO datadog;
+GRANT SELECT ON sys.dba_data_files TO datadog;
+```
+
+**Note**: If you're using Oracle 11g (or lower), there's no need to run the following line:
+```
+ALTER SESSION SET "_ORACLE_SCRIPT"=true;
 ```
 
 ### Configuration


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

* **Subject 1:**

```
-- Enable Oracle Script.
ALTER SESSION SET "_ORACLE_SCRIPT"=true;
```

The _oracle_script parameter was introduced in the version 12c of oracle db.
If so, if users are using Oracle 11g, they don't need to run this command.

* http://www.dba-oracle.com/t_oracle_script_parameter.htm

* https://docs.oracle.com/apps/search/search.jsp?q=_ORACLE_SCRIPT&category=database&product=en%2Fdatabase%2Foracle%2Foracle-database

* **Subject 2:**
in `/opt/datadog-agent/agent/checks.d/oracle.py`, line 109, do the following request:
`SELECT TABLESPACE_NAME, sum(BYTES), sum(MAXBYTES) FROM sys.dba_data_files GROUP BY TABLESPACE_NAME` although we didn't grant the user Datadog any rights on sys.dba_data_files table.

We need to do a  `GRANT SELECT ON sys.dba_data_files TO datadog;` connected as sysdba on Oracle before starting the agent.