### PR TITLE
[disk] Added missing tests about latency

### DIFF
--- a/datadog-checks-base/datadog_checks/stubs/aggregator.py
+++ b/datadog-checks-base/datadog_checks/stubs/aggregator.py
@@ -74,7 +74,7 @@ class AggregatorStub(object):
         """
         Return the metrics assertion coverage
         """
-        return len(self._asserted) / len(self._metrics) * 100.0
+        return len(self._asserted) / float(len(self._metrics)) * 100.0
 
     @property
     def metric_names(self):

--- a/disk/tests/test_check.py
+++ b/disk/tests/test_check.py
@@ -20,7 +20,11 @@ DISK_GAUGES = [
     'system.disk.free',
     'system.disk.in_use',
     'system.disk.total',
-    'system.disk.used'
+    'system.disk.used',
+]
+DISK_RATES = [
+    'system.disk.write_time_pct',
+    'system.disk.read_time_pct',
 ]
 INODE_GAUGES = [
     'system.fs.inodes.total',
@@ -38,6 +42,10 @@ GAUGES_VALUES = {
     'system.fs.inodes.free': 9,
     'system.fs.inodes.in_use': .10
 }
+RATES_VALUES = {
+    'system.disk.write_time_pct': 9.0,
+    'system.disk.read_time_pct': 5.0,
+}
 
 
 class MockPart(object):
@@ -52,6 +60,14 @@ class MockDiskMetrics(object):
     used = 4 * 1024
     free = 1 * 1024
     percent = 80
+    read_time = 50
+    write_time = 90
+
+
+class MockDiskIOMetrics(dict):
+    def __init__(self, device=DEFAULT_DEVICE_NAME):
+        super(MockDiskIOMetrics, self).__init__()
+        self[device] = MockDiskMetrics()
 
 
 class MockInodesMetrics(object):
@@ -78,12 +94,14 @@ def psutil_mocks():
                     __name__="disk_usage")
     p3 = mock.patch('os.statvfs', return_value=MockInodesMetrics(),
                     __name__="statvfs")
+    p4 = mock.patch('psutil.disk_io_counters', return_value=MockDiskIOMetrics())
 
-    yield p1.start(), p2.start(), p3.start()
+    yield p1.start(), p2.start(), p3.start(), p4.start()
 
     p1.stop()
     p2.stop()
     p3.stop()
+    p4.stop()
 
 def test_bad_config():
     """
@@ -110,7 +128,7 @@ def test_disk_check(aggregator):
     """
     c = Disk('disk', None, {}, [{'use_mount': 'no'}])
     c.check({'use_mount': 'no'})
-    for name in DISK_GAUGES + INODE_GAUGES:
+    for name in DISK_GAUGES + INODE_GAUGES + DISK_RATES:
         aggregator.assert_metric(name, tags=[])
 
     assert aggregator.metrics_asserted_pct == 100.0
@@ -184,6 +202,10 @@ def test_psutil(aggregator, psutil_mocks):
 
         for name, value in GAUGES_VALUES.iteritems():
             aggregator.assert_metric(name, value=value, tags=tags)
+
+        for name, value in RATES_VALUES.iteritems():
+            aggregator.assert_metric(name, value=value, tags=['device:{}'.format(DEFAULT_DEVICE_NAME)])
+
     assert aggregator.metrics_asserted_pct == 100.0
 
 def test_use_mount(aggregator, psutil_mocks):
@@ -196,6 +218,10 @@ def test_use_mount(aggregator, psutil_mocks):
 
     for name, value in GAUGES_VALUES.iteritems():
         aggregator.assert_metric(name, value=value, tags=['device:/'])
+
+    for name, value in RATES_VALUES.iteritems():
+        aggregator.assert_metric(name, value=value, tags=['device:{}'.format(DEFAULT_DEVICE_NAME)])
+
     assert aggregator.metrics_asserted_pct == 100.0
 
 def mock_df_output(fname):
@@ -284,4 +310,8 @@ def test_device_tagging(aggregator, psutil_mocks):
     tags = ["type:dev", "tag:two", "device:{}".format(DEFAULT_DEVICE_NAME)]
     for name, value in GAUGES_VALUES.iteritems():
         aggregator.assert_metric(name, value=value, tags=tags)
+
+    for name, value in RATES_VALUES.iteritems():
+        aggregator.assert_metric(name, value=value, tags=['device:{}'.format(DEFAULT_DEVICE_NAME)])
+
     assert aggregator.metrics_asserted_pct == 100.0


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Adds missing tests to metrics collected by the disk check

### Motivation

Metrics coverage was failing
