### PR TITLE
Fix CI - supervisord, etcd, elastc

### DIFF
--- a/elastic/test/test_elastic.py
+++ b/elastic/test/test_elastic.py
@@ -536,7 +536,7 @@ class TestElastic(AgentCheckTest):
         self.assertEquals(len(self.events), 1)
         self.assertIn('yellow', self.events[0]['msg_title'])
         self.assertEquals(
-            ['url:http://localhost:9200'] + dummy_tags + cluster_tag,
+            sorted(set(['url:http://localhost:9200'] + dummy_tags + cluster_tag)),
             self.events[0]['tags']
         )
         self.assertServiceCheckWarning(
@@ -554,7 +554,7 @@ class TestElastic(AgentCheckTest):
         self.assertEquals(len(self.events), 1)
         self.assertIn('green', self.events[0]['msg_title'])
         self.assertEquals(
-            ['url:http://localhost:9200'] + dummy_tags + cluster_tag,
+            sorted(set(['url:http://localhost:9200'] + dummy_tags + cluster_tag)),
             self.events[0]['tags']
         )
         self.assertServiceCheckOK(

--- a/etcd/test/test_etcd.py
+++ b/etcd/test/test_etcd.py
@@ -50,7 +50,7 @@ class CheckEtcdTest(AgentCheckTest):
         self.assertServiceCheckOK(self.check.SERVICE_CHECK_NAME, count=1,
                                   tags=['url:http://localhost:2379', 'etcd_state:leader'])
         self.assertServiceCheckOK(self.check.HEALTH_SERVICE_CHECK_NAME, count=1,
-                                  tags=['url:http://localhost:2379', 'etcd_state:leader'])
+                                  tags=['url:http://localhost:2379'])
         self.coverage_report()
 
     # FIXME: not really an integration test, should be pretty easy

--- a/supervisord/test/test_supervisord.py
+++ b/supervisord/test/test_supervisord.py
@@ -428,6 +428,10 @@ Stop time: {time_stop}\nExit Status: 0""".format(
 
     def assert_metrics(self, expected, actual):
         actual = [TestSupervisordCheck.norm_metric(metric) for metric in actual]
+        for metric in expected:
+            metric[2]['tags'] = sorted(metric[2]['tags'])
+        for metric in actual:
+            metric[2]['tags'] = sorted(metric[2]['tags'])
         self.assertEquals(len(actual), len(expected), msg='Invalid # metrics reported.\n'
             'Expected: {0}. Found: {1}'.format(len(expected), len(actual)))
         self.assertTrue(all([expected_metric in actual for expected_metric in expected]),
@@ -437,6 +441,10 @@ Stop time: {time_stop}\nExit Status: 0""".format(
     def assert_service_checks(self, expected, actual):
         actual = [TestSupervisordCheck.norm_service_check(service_check)
                   for service_check in actual]
+        for sc in expected:
+            sc['tags'] = sorted(sc['tags'])
+        for sc in actual:
+            sc['tags'] = sorted(sc['tags'])
         self.assertEquals(len(actual), len(expected), msg='Invalid # service checks reported.'
             '\nExpected: {0}. Found: {1}.'.format(expected, actual))
         self.assertTrue(all([expected_service_check in actual


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

A few tests broke as a consequence of some changes to the logic in the agent core's aggregator. This PR addresses the broken tests that resulted from those changes. This is the PR that introduced the changes to the aggregator if you wish to dive deeper: https://github.com/DataDog/dd-agent/pull/3641

Note: Although there is some sorting and deduplication in the aggregator, there are still additional functions getting called, like the `agent_formatter()` that may shuffle the tags - so in general don't assume much about the tags order.

### Motivation
Broken CI

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

Testing changes/fixes no need to bump checks versions.

### Additional Notes

Anything else we should know when reviewing?
