### PR TITLE
Ability to pull version info from Disk and Base Checks

### DIFF
--- a/datadog-checks-base/datadog_checks/__init__.py
+++ b/datadog-checks-base/datadog_checks/__init__.py
@@ -1,3 +1,8 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from .__about__ import __version__
+
+all = [
+  '__version__'
+]

--- a/datadog-checks-base/datadog_checks/__init__.py
+++ b/datadog-checks-base/datadog_checks/__init__.py
@@ -3,6 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from .__about__ import __version__
 
-all = [
-  '__version__'
+__all__ = [
+    '__version__'
 ]

--- a/disk/datadog_checks/disk/__init__.py
+++ b/disk/datadog_checks/disk/__init__.py
@@ -1,6 +1,9 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from .__about__ import __version__
 from .disk import Disk
 
-__all__ = ['Disk']
+all = [
+  '__version__', 'Disk'
+]

--- a/disk/datadog_checks/disk/__init__.py
+++ b/disk/datadog_checks/disk/__init__.py
@@ -1,9 +1,10 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from .__about__ import __version__  # NOQA F401
-from .disk import Disk  # NOQA F401
+from .__about__ import __version__
+from .disk import Disk
 
-all = [
-    '__version__', 'Disk'
+__all__ = [
+    '__version__',
+    'Disk'
 ]

--- a/disk/datadog_checks/disk/__init__.py
+++ b/disk/datadog_checks/disk/__init__.py
@@ -1,9 +1,9 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from .__about__ import __version__
-from .disk import Disk
+from .__about__ import __version__  # NOQA F401
+from .disk import Disk  # NOQA F401
 
 all = [
-  '__version__', 'Disk'
+    '__version__', 'Disk'
 ]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Adds ability to pull in versioning info from Disk wheel check

### Motivation

When testing the Agent couldn't pull the versioning info from __about__.py for the Disk Integration and showed up with `(Unknown Wheel)` instead of the version. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
