### PR TITLE
[mongo] Fix the failing mongo tests

### DIFF
--- a/mongo/test/ci/mongo.rake
+++ b/mongo/test/ci/mongo.rake
@@ -17,7 +17,11 @@ namespace :ci do
       sh %(bash #{ENV['SDK_HOME']}/mongo/test/ci/start-docker.sh)
     end
 
-    task before_script: ['ci:common:before_script']
+    task before_script: ['ci:common:before_script'] do
+      # Some of the changes made above will not have propagated.
+      # Wait for an arbitrary time to make sure they do
+      sleep 10
+    end
 
     task script: ['ci:common:script'] do
       this_provides = [

--- a/mongo/test/ci/start-docker.sh
+++ b/mongo/test/ci/start-docker.sh
@@ -60,8 +60,8 @@ docker exec -it $NAME mongo --eval "printjson(rs.add('$SHARD01_IP:$PORT1')); pri
 # echo 'docker exec -it $NAME mongo --eval "printjson(rs.add(\'$SHARD02_IP:$PORT2\\')); printjson(rs.status());" localhost:$PORT'
 docker exec -it $NAME mongo --eval "printjson(rs.add('$SHARD02_IP:$PORT2')); printjson(rs.status());" localhost:$PORT
 
-docker exec -it $NAME bash -l -c "mongo --eval 'db.getMongo().getDBNames()' localhost:$PORT/test"
-docker exec -it $NAME bash -l -c "mongo --eval 'db.getCollectionNames()' localhost:$PORT/test"
+docker exec -it $NAME bash -l -c "mongo --eval 'db.getMongo().getDBNames()' --port $PORT localhost/test"
+docker exec -it $NAME bash -l -c "mongo --eval 'db.getCollectionNames()' --port $PORT localhost/test"
 
 sleep 2
 

--- a/mongo/test/ci/start-docker.sh
+++ b/mongo/test/ci/start-docker.sh
@@ -77,10 +77,10 @@ echo "The shards have been initialized"
 
 # echo 'docker exec -it $NAME mongo --eval cfg = rs.conf(); cfg.members[0].host = "localhost:$PORT"; rs.reconfig(cfg); printjson(rs.conf()); localhost:$PORT'
 # echo "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());"
-docker exec -it $NAME bash -l -c "mongo --eval \"cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());\" --host localhost --port $PORT"
+docker exec -it $NAME mongo --eval "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());" --host localhost --port $PORT
 
 echo "Setting test user"
-docker exec -it $NAME bash -l -c "mongo --eval \"db.createUser({ user: \"testUser\", pwd: \"testPass\", roles: [ { role: \"read\", db: \"test\" } ] })\" --host localhost --port $PORT authDB"
+docker exec -it $NAME mongo --eval "db.createUser({ user: 'testUser', pwd: 'testPass', roles: [ { role: 'read', db: 'test' } ] })" --host localhost --port $PORT authDB
 
 echo "Setting test user"
-docker exec -it $NAME bash -l -c "mongo --eval \"db.createUser({ user: \"testUser2\", pwd: \"testPass2\", roles: [ { role: \"read\", db: \"test\" } ] })\" --host localhost --port $PORT test"
+docker exec -it $NAME mongo --eval "db.createUser({ user: 'testUser2', pwd: 'testPass2', roles: [ { role: 'read', db: 'test' } ] })" --host localhost --port $PORT test

--- a/mongo/test/ci/start-docker.sh
+++ b/mongo/test/ci/start-docker.sh
@@ -45,26 +45,20 @@ do
     sleep 2
 done
 
-# echo 'docker exec -it $NAME mongo --eval "rs.initiate();" localhost:$PORT'
 docker exec -it $NAME mongo --eval "rs.initiate();" --host localhost --port $PORT
 
-# echo 'docker exec -it $NAME mongo --eval cfg = rs.conf(); cfg.members[0].host = "localhost:$PORT"; rs.reconfig(cfg); printjson(rs.conf()); localhost:$PORT'
-# echo "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());"
 docker exec -it $NAME mongo --eval "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());" --host localhost --port $PORT
 
 sleep 2
 
-# echo 'docker exec -it $NAME mongo --eval "printjson(rs.add(\'$SHARD01_IP:$PORT1\\')); printjson(rs.status());" localhost:$PORT'
 docker exec -it $NAME mongo --eval "printjson(rs.add('$SHARD01_IP:$PORT1')); printjson(rs.status());" --host localhost --port $PORT
-
-# echo 'docker exec -it $NAME mongo --eval "printjson(rs.add(\'$SHARD02_IP:$PORT2\\')); printjson(rs.status());" localhost:$PORT'
 docker exec -it $NAME mongo --eval "printjson(rs.add('$SHARD02_IP:$PORT2')); printjson(rs.status());" --host localhost --port $PORT
-
 docker exec -it $NAME bash -l -c "mongo --eval 'db.getMongo().getDBNames()' --port $PORT --host localhost test"
 docker exec -it $NAME bash -l -c "mongo --eval 'db.getCollectionNames()' --port $PORT --host localhost test"
 
 sleep 2
 
+# Don't print the commands within the loop, there's too much output.
 set +x
 echo "Checking if shards are initialized and then waiting until they are initialized"
 until docker exec -it $NAME mongo --eval "printjson(rs.status());" --host localhost --port $PORT | grep '"stateStr" : "SECONDARY"' >/dev/null;
@@ -75,8 +69,6 @@ set -x
 
 echo "The shards have been initialized"
 
-# echo 'docker exec -it $NAME mongo --eval cfg = rs.conf(); cfg.members[0].host = "localhost:$PORT"; rs.reconfig(cfg); printjson(rs.conf()); localhost:$PORT'
-# echo "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());"
 docker exec -it $NAME mongo --eval "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());" --host localhost --port $PORT
 
 echo "Setting test user"

--- a/mongo/test/ci/start-docker.sh
+++ b/mongo/test/ci/start-docker.sh
@@ -46,19 +46,19 @@ do
 done
 
 # echo 'docker exec -it $NAME mongo --eval "rs.initiate();" localhost:$PORT'
-docker exec -it $NAME mongo --eval "rs.initiate();" localhost:$PORT
+docker exec -it $NAME mongo --eval "rs.initiate();" --host localhost --port $PORT
 
 # echo 'docker exec -it $NAME mongo --eval cfg = rs.conf(); cfg.members[0].host = "localhost:$PORT"; rs.reconfig(cfg); printjson(rs.conf()); localhost:$PORT'
 # echo "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());"
-docker exec -it $NAME mongo --eval "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());" localhost:$PORT
+docker exec -it $NAME mongo --eval "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());" --host localhost --port $PORT
 
 sleep 2
 
 # echo 'docker exec -it $NAME mongo --eval "printjson(rs.add(\'$SHARD01_IP:$PORT1\\')); printjson(rs.status());" localhost:$PORT'
-docker exec -it $NAME mongo --eval "printjson(rs.add('$SHARD01_IP:$PORT1')); printjson(rs.status());" localhost:$PORT
+docker exec -it $NAME mongo --eval "printjson(rs.add('$SHARD01_IP:$PORT1')); printjson(rs.status());" --host localhost --port $PORT
 
 # echo 'docker exec -it $NAME mongo --eval "printjson(rs.add(\'$SHARD02_IP:$PORT2\\')); printjson(rs.status());" localhost:$PORT'
-docker exec -it $NAME mongo --eval "printjson(rs.add('$SHARD02_IP:$PORT2')); printjson(rs.status());" localhost:$PORT
+docker exec -it $NAME mongo --eval "printjson(rs.add('$SHARD02_IP:$PORT2')); printjson(rs.status());" --host localhost --port $PORT
 
 docker exec -it $NAME bash -l -c "mongo --eval 'db.getMongo().getDBNames()' --port $PORT --host localhost test"
 docker exec -it $NAME bash -l -c "mongo --eval 'db.getCollectionNames()' --port $PORT --host localhost test"

--- a/mongo/test/ci/start-docker.sh
+++ b/mongo/test/ci/start-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 PORT=47017
 PORT1=$(( $PORT + 1 ))

--- a/mongo/test/ci/start-docker.sh
+++ b/mongo/test/ci/start-docker.sh
@@ -60,8 +60,8 @@ docker exec -it $NAME mongo --eval "printjson(rs.add('$SHARD01_IP:$PORT1')); pri
 echo 'docker exec -it $NAME mongo --eval "printjson(rs.add(\'$SHARD02_IP:$PORT2\\')); printjson(rs.status());" localhost:$PORT'
 docker exec -it $NAME mongo --eval "printjson(rs.add('$SHARD02_IP:$PORT2')); printjson(rs.status());" localhost:$PORT
 
-docker exec -it $NAME mongo --eval "db.getMongo().getDBNames()" localhost:$PORT/test
-docker exec -it $NAME mongo --eval "db.getCollectionNames()" localhost:$PORT/test
+docker exec -it $NAME bash -l -c 'mongo --eval "db.getMongo().getDBNames()" localhost:$PORT/test'
+docker exec -it $NAME bash -l -c 'mongo --eval "db.getCollectionNames()" localhost:$PORT/test'
 
 sleep 2
 
@@ -75,10 +75,10 @@ echo "The shards have been initialized"
 
 echo 'docker exec -it $NAME mongo --eval cfg = rs.conf(); cfg.members[0].host = "localhost:$PORT"; rs.reconfig(cfg); printjson(rs.conf()); localhost:$PORT'
 echo "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());"
-docker exec -it $NAME mongo --eval "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());" localhost:$PORT
+docker exec -it $NAME bash -l -c 'mongo --eval "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());" localhost:$PORT'
 
 echo "Setting test user"
-docker exec -it $NAME mongo --eval 'db.createUser({ user: "testUser", pwd: "testPass", roles: [ { role: "read", db: "test" } ] })' localhost:$PORT/authDB
+docker exec -it $NAME bash -l -c 'mongo --eval "db.createUser({ user: \"testUser\", pwd: \"testPass\", roles: [ { role: \"read\", db: \"test\" } ] })" localhost:$PORT/authDB'
 
 echo "Setting test user"
-docker exec -it $NAME mongo --eval 'db.createUser({ user: "testUser2", pwd: "testPass2", roles: [ { role: "read", db: "test" } ] })' localhost:$PORT/test
+docker exec -it $NAME bash -l -c 'mongo --eval "db.createUser({ user: \"testUser2\", pwd: \"testPass2\", roles: [ { role: \"read\", db: \"test\" } ] })" localhost:$PORT/test'

--- a/mongo/test/ci/start-docker.sh
+++ b/mongo/test/ci/start-docker.sh
@@ -67,7 +67,7 @@ sleep 2
 
 set +x
 echo "Checking if shards are initialized and then waiting until they are initialized"
-until docker exec -it $NAME mongo --eval "printjson(rs.status());" localhost:$PORT | grep '"stateStr" : "SECONDARY"' >/dev/null;
+until docker exec -it $NAME mongo --eval "printjson(rs.status());" --host localhost --port $PORT | grep '"stateStr" : "SECONDARY"' >/dev/null;
 do
     sleep 2
 done
@@ -77,10 +77,10 @@ echo "The shards have been initialized"
 
 # echo 'docker exec -it $NAME mongo --eval cfg = rs.conf(); cfg.members[0].host = "localhost:$PORT"; rs.reconfig(cfg); printjson(rs.conf()); localhost:$PORT'
 # echo "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());"
-docker exec -it $NAME bash -l -c 'mongo --eval "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());" localhost:$PORT'
+docker exec -it $NAME bash -l -c "mongo --eval \"cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());\" --host localhost --port $PORT"
 
 echo "Setting test user"
-docker exec -it $NAME bash -l -c 'mongo --eval "db.createUser({ user: \"testUser\", pwd: \"testPass\", roles: [ { role: \"read\", db: \"test\" } ] })" localhost:$PORT/authDB'
+docker exec -it $NAME bash -l -c "mongo --eval \"db.createUser({ user: \"testUser\", pwd: \"testPass\", roles: [ { role: \"read\", db: \"test\" } ] })\" --host localhost --port $PORT authDB"
 
 echo "Setting test user"
-docker exec -it $NAME bash -l -c 'mongo --eval "db.createUser({ user: \"testUser2\", pwd: \"testPass2\", roles: [ { role: \"read\", db: \"test\" } ] })" localhost:$PORT/test'
+docker exec -it $NAME bash -l -c "mongo --eval \"db.createUser({ user: \"testUser2\", pwd: \"testPass2\", roles: [ { role: \"read\", db: \"test\" } ] })\" --host localhost --port $PORT test"

--- a/mongo/test/ci/start-docker.sh
+++ b/mongo/test/ci/start-docker.sh
@@ -60,8 +60,8 @@ docker exec -it $NAME mongo --eval "printjson(rs.add('$SHARD01_IP:$PORT1')); pri
 echo 'docker exec -it $NAME mongo --eval "printjson(rs.add(\'$SHARD02_IP:$PORT2\\')); printjson(rs.status());" localhost:$PORT'
 docker exec -it $NAME mongo --eval "printjson(rs.add('$SHARD02_IP:$PORT2')); printjson(rs.status());" localhost:$PORT
 
-docker exec -it $NAME bash -l -c 'mongo --eval "db.getMongo().getDBNames()" localhost:$PORT/test'
-docker exec -it $NAME bash -l -c 'mongo --eval "db.getCollectionNames()" localhost:$PORT/test'
+docker exec -it $NAME bash -l -c "mongo --eval 'db.getMongo().getDBNames()' localhost:$PORT/test"
+docker exec -it $NAME bash -l -c "mongo --eval 'db.getCollectionNames()' localhost:$PORT/test"
 
 sleep 2
 

--- a/mongo/test/ci/start-docker.sh
+++ b/mongo/test/ci/start-docker.sh
@@ -45,19 +45,19 @@ do
     sleep 2
 done
 
-echo 'docker exec -it $NAME mongo --eval "rs.initiate();" localhost:$PORT'
+# echo 'docker exec -it $NAME mongo --eval "rs.initiate();" localhost:$PORT'
 docker exec -it $NAME mongo --eval "rs.initiate();" localhost:$PORT
 
-echo 'docker exec -it $NAME mongo --eval cfg = rs.conf(); cfg.members[0].host = "localhost:$PORT"; rs.reconfig(cfg); printjson(rs.conf()); localhost:$PORT'
-echo "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());"
+# echo 'docker exec -it $NAME mongo --eval cfg = rs.conf(); cfg.members[0].host = "localhost:$PORT"; rs.reconfig(cfg); printjson(rs.conf()); localhost:$PORT'
+# echo "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());"
 docker exec -it $NAME mongo --eval "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());" localhost:$PORT
 
 sleep 2
 
-echo 'docker exec -it $NAME mongo --eval "printjson(rs.add(\'$SHARD01_IP:$PORT1\\')); printjson(rs.status());" localhost:$PORT'
+# echo 'docker exec -it $NAME mongo --eval "printjson(rs.add(\'$SHARD01_IP:$PORT1\\')); printjson(rs.status());" localhost:$PORT'
 docker exec -it $NAME mongo --eval "printjson(rs.add('$SHARD01_IP:$PORT1')); printjson(rs.status());" localhost:$PORT
 
-echo 'docker exec -it $NAME mongo --eval "printjson(rs.add(\'$SHARD02_IP:$PORT2\\')); printjson(rs.status());" localhost:$PORT'
+# echo 'docker exec -it $NAME mongo --eval "printjson(rs.add(\'$SHARD02_IP:$PORT2\\')); printjson(rs.status());" localhost:$PORT'
 docker exec -it $NAME mongo --eval "printjson(rs.add('$SHARD02_IP:$PORT2')); printjson(rs.status());" localhost:$PORT
 
 docker exec -it $NAME bash -l -c "mongo --eval 'db.getMongo().getDBNames()' localhost:$PORT/test"
@@ -65,16 +65,18 @@ docker exec -it $NAME bash -l -c "mongo --eval 'db.getCollectionNames()' localho
 
 sleep 2
 
+set +x
 echo "Checking if shards are initialized and then waiting until they are initialized"
 until docker exec -it $NAME mongo --eval "printjson(rs.status());" localhost:$PORT | grep '"stateStr" : "SECONDARY"' >/dev/null;
 do
     sleep 2
 done
+set -x
 
 echo "The shards have been initialized"
 
-echo 'docker exec -it $NAME mongo --eval cfg = rs.conf(); cfg.members[0].host = "localhost:$PORT"; rs.reconfig(cfg); printjson(rs.conf()); localhost:$PORT'
-echo "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());"
+# echo 'docker exec -it $NAME mongo --eval cfg = rs.conf(); cfg.members[0].host = "localhost:$PORT"; rs.reconfig(cfg); printjson(rs.conf()); localhost:$PORT'
+# echo "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());"
 docker exec -it $NAME bash -l -c 'mongo --eval "cfg = rs.conf(); cfg.members[0].host = '$SHARD00_IP:$PORT'; rs.reconfig(cfg); printjson(rs.conf());" localhost:$PORT'
 
 echo "Setting test user"

--- a/mongo/test/ci/start-docker.sh
+++ b/mongo/test/ci/start-docker.sh
@@ -60,8 +60,8 @@ docker exec -it $NAME mongo --eval "printjson(rs.add('$SHARD01_IP:$PORT1')); pri
 # echo 'docker exec -it $NAME mongo --eval "printjson(rs.add(\'$SHARD02_IP:$PORT2\\')); printjson(rs.status());" localhost:$PORT'
 docker exec -it $NAME mongo --eval "printjson(rs.add('$SHARD02_IP:$PORT2')); printjson(rs.status());" localhost:$PORT
 
-docker exec -it $NAME bash -l -c "mongo --eval 'db.getMongo().getDBNames()' --port $PORT localhost/test"
-docker exec -it $NAME bash -l -c "mongo --eval 'db.getCollectionNames()' --port $PORT localhost/test"
+docker exec -it $NAME bash -l -c "mongo --eval 'db.getMongo().getDBNames()' --port $PORT --host localhost test"
+docker exec -it $NAME bash -l -c "mongo --eval 'db.getCollectionNames()' --port $PORT --host localhost test"
 
 sleep 2
 


### PR DESCRIPTION
### What does this PR do?

The mongo test shouldn't be failing. The culprit seems to be that the newest mongo container has some settings in its shell that causes some weird escaping of the commands when run through exec. 

That means that `localhost:47017` became `localhost%3A47017`. It caused all the commands to fail in mongo 3.4. 

Mongo allows setting port and host through `--host` and `--port`, using those instead allows us to avoid this escaping. I have not determined why it was escaping like that, but this works! So, it's a good enough fix for me. 

Luckily this escaping seems to be in the shell and not in mongo itself, as the mongo library seems to be working just fine. However, 3.4 seems to be causing a small issue with propagation of the auth information. It does propagate, but it seems a bit slower. So another sleep was added to account for that.

