### PR TITLE
pin mock to 2.0.0 to fix failing test

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 ./datadog-checks-base
-mock
+mock==2.0.0
 pytest
 tox


### PR DESCRIPTION
### What does this PR do?

If there's a requirements mismatch, all tests will fail. An unpinned mock was causing such a mismatch.

