### PR TITLE
[elasticsearch] Correct the default behavior for admin_forwarder

### DIFF
--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -371,7 +371,7 @@ class ESCheck(AgentCheck):
             cluster_stats = _is_affirmative(instance.get('is_external', False))
 
         pending_task_stats = _is_affirmative(instance.get('pending_task_stats', True))
-        admin_forwarder = _is_affirmative(instance.get('admin_forwarder', True))
+        admin_forwarder = _is_affirmative(instance.get('admin_forwarder', False))
         # Support URLs that have a path in them from the config, for
         # backwards-compatibility.
         parsed = urlparse.urlparse(url)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?
Change the default value for `admin_forwarder` to false according to the default behavior.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
