### PR TITLE
Add try_sudo option to process config

### DIFF
--- a/process/conf.yaml.example
+++ b/process/conf.yaml.example
@@ -48,7 +48,7 @@ instances:
 #      warning if 1, 2, 6, 7 sshd processes are running
 #      warning: [3, 5]
 #      ok if 3, 4, 5 processes are running
-#	  try_sudo: False
+#.   try_sudo: False
 #
 #  - name: postgres
 #    search_string: ['postgres']

--- a/process/conf.yaml.example
+++ b/process/conf.yaml.example
@@ -33,6 +33,7 @@ instances:
 #    collect_children: BOOLEAN. If true, the check will also collect metrics from all child processes of a matched process. Default to false.
 #                      Please be aware that the collection is recursive, and might take some time depending on the use case.
 #    user: STRING. Only report processes belonging to a specific user.
+#	 try_sudo: (optional) Boolean. Default value of False. Value of True lets the process chck try using 'sudo' to collect this metric
 #
 # Examples:
 #
@@ -47,6 +48,7 @@ instances:
 #      warning if 1, 2, 6, 7 sshd processes are running
 #      warning: [3, 5]
 #      ok if 3, 4, 5 processes are running
+#	  try_sudo: False
 #
 #  - name: postgres
 #    search_string: ['postgres']

--- a/process/conf.yaml.example
+++ b/process/conf.yaml.example
@@ -33,7 +33,7 @@ instances:
 #    collect_children: BOOLEAN. If true, the check will also collect metrics from all child processes of a matched process. Default to false.
 #                      Please be aware that the collection is recursive, and might take some time depending on the use case.
 #    user: STRING. Only report processes belonging to a specific user.
-#	 try_sudo: (optional) Boolean. Default value of False. Value of True lets the process chck try using 'sudo' to collect this metric
+#    try_sudo: (optional) Boolean. If set to True (default is False), the check will try to use 'sudo' to collect the 'open_fd' metric on Unix platforms.
 #
 # Examples:
 #


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

There wasn't a `try_sudo` option in config template for process check.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
