### PR TITLE
[SQLServver] Remove debug lines about connector string

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -597,13 +597,10 @@ class SQLServer(AgentCheck):
         try:
             if self._get_connector(instance) == 'adodbapi':
                 cs += self._conn_string_adodbapi(db_key, instance=instance, db_name=db_name)
-                self.log.debug("Formatted connection string: {0}".format(cs))
-
                 # autocommit: true disables implicit transaction
                 rawconn = adodbapi.connect(cs, {'timeout':timeout, 'autocommit':True})
             else:
                 cs += self._conn_string_odbc(db_key, instance=instance, db_name=db_name)
-                self.log.debug("Formatted connection string: {0}".format(cs))
                 rawconn = pyodbc.connect(cs, timeout=timeout)
 
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,


### PR DESCRIPTION
These could contain passwords

<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Remove debug lines about formatted connection strings

### Motivation

These could contain passwords and wouldn't be obfuscated in the logs currently. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [NA ] Bumped the check version in `manifest.json`
- [ NA] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ NA] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ NA] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Since this wasn't released no changelog changes needed. 