### PR TITLE
[HDFS_Namenode] Include tags for Critical Service checks

### DIFF
--- a/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
@@ -119,7 +119,7 @@ class HDFSNameNode(AgentCheck):
         '''
         response = self._rest_request_to_json(jmx_uri, disable_ssl_validation,
             JMX_PATH,
-            query_params={'qry':bean_name})
+            query_params={'qry':bean_name}, tags)
 
         beans = response.get('beans', [])
 
@@ -150,13 +150,11 @@ class HDFSNameNode(AgentCheck):
         else:
             self.log.error('Metric type "%s" unknown' % (metric_type))
 
-    def _rest_request_to_json(self, address, disable_ssl_validation, object_path, query_params):
+    def _rest_request_to_json(self, address, disable_ssl_validation, object_path, query_params, tags=None):
         '''
         Query the given URL and return the JSON response
         '''
         response_json = None
-
-        service_check_tags = ['namenode_url:' + address]
 
         url = address
 
@@ -178,7 +176,7 @@ class HDFSNameNode(AgentCheck):
         except Timeout as e:
             self.service_check(JMX_SERVICE_CHECK,
                 AgentCheck.CRITICAL,
-                tags=service_check_tags,
+                tags=tags,
                 message="Request timeout: {0}, {1}".format(url, e))
             raise
 
@@ -187,21 +185,21 @@ class HDFSNameNode(AgentCheck):
                 ConnectionError) as e:
             self.service_check(JMX_SERVICE_CHECK,
                 AgentCheck.CRITICAL,
-                tags=service_check_tags,
+                tags=tags,
                 message="Request failed: {0}, {1}".format(url, e))
             raise
 
         except JSONDecodeError as e:
             self.service_check(JMX_SERVICE_CHECK,
                 AgentCheck.CRITICAL,
-                tags=service_check_tags,
+                tags=tags,
                 message='JSON Parse failed: {0}, {1}'.format(url, e))
             raise
 
         except ValueError as e:
             self.service_check(JMX_SERVICE_CHECK,
                 AgentCheck.CRITICAL,
-                tags=service_check_tags,
+                tags=tags,
                 message=str(e))
             raise
 

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
@@ -119,7 +119,7 @@ class HDFSNameNode(AgentCheck):
         '''
         response = self._rest_request_to_json(jmx_uri, disable_ssl_validation,
             JMX_PATH,
-            query_params={'qry':bean_name}, tags)
+            query_params={'qry':bean_name}, tags=tags)
 
         beans = response.get('beans', [])
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Add instance tags to Critical Service checks for HDFS 

### Motivation

Currently instance tags are only applied to the OK service checks and metrics. This would cause issues with Monitors not alerting properly if they are setup over these instance tags. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ NA] Bumped the check version in `manifest.json`
- [ NA] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ NA] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ NA] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
