### PR TITLE
add option to ignore docker cloud containers

### DIFF
--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - docker_daemon
 
+1.9.0 / Unreleased
+==================
+### Changes
+
+* [IMPROVEMENT] Add the `ignore_docker_cloud_containers` option to ignore Docker Cloud agent's containers.
+* [BUGFIX] Ignore the excluded containers in the containers.{running|stopped} metrics.
+
 1.8.0 / Unreleased
 ==================
 ### Changes

--- a/docker_daemon/conf.yaml.example
+++ b/docker_daemon/conf.yaml.example
@@ -149,7 +149,10 @@ instances:
     # To customize this default behavior, override exclude.
     # If you do so, default exclusion patterns won't apply anymore and will need to be added explicitly.
 
-
+    # Use `ignore_docker_cloud_containers` if you are running the agent in Docker Cloud
+    # and you want the Docker check to ignore the containers used for the Docker cloud agent.
+    # The agent will ignore the docker images starting with `dockercloud/*` (i.e.: dockercloud/network-daemon).
+    # ignore_docker_cloud_containers: true
 
     ## Tagging
     ##

--- a/docker_daemon/datadog_checks/docker_daemon/__init__.py
+++ b/docker_daemon/datadog_checks/docker_daemon/__init__.py
@@ -2,6 +2,6 @@ from . import docker_daemon
 
 DockerDaemon = docker_daemon.DockerDaemon
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"
 
 __all__ = ['docker_daemon']

--- a/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py
+++ b/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py
@@ -394,16 +394,16 @@ class DockerDaemon(AgentCheck):
         for container in containers:
             container_name = DockerUtil.container_name_extractor(container)[0]
 
+            # Check if the container is included/excluded via its tags
+            if self._is_container_excluded(container):
+                self.log.debug("Container {0} is excluded".format(container_name))
+                continue
+
             container_status_tags = self._get_tags(container, CONTAINER)
 
             all_containers_count[tuple(sorted(container_status_tags))] += 1
             if self._is_container_running(container):
                 running_containers_count[tuple(sorted(container_status_tags))] += 1
-
-            # Check if the container is included/excluded via its tags
-            if self._is_container_excluded(container):
-                self.log.debug("Container {0} is excluded".format(container_name))
-                continue
 
             containers_by_id[container['Id']] = container
 

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -11,7 +11,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.8.0",
+  "version": "1.9.0",
   "public_title": "Datadog-Docker Integration",
   "categories":["containers"],
   "type":"check",


### PR DESCRIPTION
### What does this PR do?

Adds the option to ignore the docker cloud containers.
Also change the logic to not ignore the excluded containers in the metrics:
- `docker.containers.running`
- `docker.containers.running.total`
- `docker.containers.stopped`
- `docker.containers.stopped.total`

### Motivation

Community request.

### Testing Guidelines

- Launched a stack with the agent and verified that uncommenting this option ignores the tags.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
~- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) ~

