### PR TITLE
[Testing] Updates global tox to properly ignore testing files

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
-exclude = venv/*,embedded/*,.git/*
+exclude = venv/*,embedded/*,.git/*,*/.tox/*,*/.eggs/*,*/build/*,.eggs/*,.tox/*,build/*
 max-line-length = 700
 ignore = E128,E203,E226,E231,E241,E251,E261,E265,E302,E303,E731,W503,E266


### PR DESCRIPTION
### What does this PR do?
Right now the global flake8 will attempt to lint every file in the tox venvs. We don't want this and it produces inexplicable errors. This should fix it! 