### PR TITLE
Revert "Use sudo for privileged process checks on filedescriptors (#7…

### DIFF
--- a/process/README.md
+++ b/process/README.md
@@ -37,15 +37,6 @@ You can also configure the check to find any process by exact PID (`pid`) or pid
 
 To have the check search for processes in a path other than `/proc`, set `procfs_path: <your_proc_path>` in `datadog.conf`, NOT in `process.yaml` (its use has been deprecated there). Set this to `/host/proc` if you're running the Agent from a Docker container (i.e. [docker-dd-agent](https://github.com/DataDog/docker-dd-agent)) and want to monitor processes running on the server hosting your containers. You DON'T need to set this to monitor processes running _in_ your containers; the [Docker check](https://github.com/DataDog/integrations-core/tree/master/docker_daemon) monitors those.
 
-Some process metrics require either running the datadog collector as the same user as the monitored process or privileged access to be retrieved.
-Where the former option is not desired, and to avoid running the datadog collector as `root`, the `try_sudo` option lets the process check try using `sudo` to collect this metric.
-As of now, only the `open_fd` metric on Unix platforms is taking advantage of this setting.
-Note: the appropriate sudoers rules have to be configured for this to work, e.g. if packaged with the datadog agent:
-```
-dd-agent ALL=NOPASSWD: /opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/checks.d/process.py num_fds *
-dd-agent ALL=NOPASSWD: /opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/checks.d/process.pyc num_fds *
-```
-
 See the [example configuration](https://github.com/DataDog/integrations-core/blob/master/process/conf.yaml.example) for more details on configuration options.
 
 [Restart the Agent](https://docs.datadoghq.com/agent/faq/start-stop-restart-the-datadog-agent) to start sending process metrics and service checks to Datadog.

--- a/process/test/test_process.py
+++ b/process/test/test_process.py
@@ -188,8 +188,7 @@ class ProcessCheckTest(AgentCheckTest):
         name = self.check.psutil_wrapper(
             self.get_psutil_proc(),
             'name',
-            None,
-            False
+            None
         )
 
         self.assertNotEquals(name, None)
@@ -200,8 +199,7 @@ class ProcessCheckTest(AgentCheckTest):
         name = self.check.psutil_wrapper(
             self.get_psutil_proc(),
             'blah',
-            None,
-            False
+            None
         )
 
         self.assertEquals(name, None)
@@ -212,8 +210,7 @@ class ProcessCheckTest(AgentCheckTest):
         meminfo = self.check.psutil_wrapper(
             self.get_psutil_proc(),
             'memory_info',
-            ['rss', 'vms', 'foo'],
-            False
+            ['rss', 'vms', 'foo']
         )
 
         self.assertIn('rss', meminfo)
@@ -226,8 +223,7 @@ class ProcessCheckTest(AgentCheckTest):
         meminfo = self.check.psutil_wrapper(
             self.get_psutil_proc(),
             'memory_infoo',
-            ['rss', 'vms'],
-            False
+            ['rss', 'vms']
         )
 
         self.assertNotIn('rss', meminfo)
@@ -267,7 +263,7 @@ class ProcessCheckTest(AgentCheckTest):
             idx = search_string[0].split('_')[1]
         return self.CONFIG_STUBS[int(idx)]['mocked_processes']
 
-    def mock_psutil_wrapper(self, process, method, accessors, try_sudo, *args, **kwargs):
+    def mock_psutil_wrapper(self, process, method, accessors, *args, **kwargs):
         if method == 'num_handles':  # remove num_handles as it's win32 only
             return None
 


### PR DESCRIPTION
…15)"

This reverts commit e1f1d53f8e2d5e1c1064954c4d00aa9888f5570a.

Check is not sending the open_file_descriptor metric. Reverting for 5.22.0 release.

<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
