### PR TITLE
[openstack] properly disable the Agent's proxy settings

### DIFF
--- a/openstack/CHANGELOG.md
+++ b/openstack/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Changes
 
-* [BUGFIX] Properly disable the Agent's proxy settings when desired. See [][]
+* [BUGFIX] Properly disable the Agent's proxy settings when desired. See [#1123][]
 
 1.0.2 / 2017-11-21
 ==================

--- a/openstack/CHANGELOG.md
+++ b/openstack/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - openstack
 
+1.0.3 / Unreleased
+==================
+
+### Changes
+
+* [BUGFIX] Properly disable the Agent's proxy settings when desired. See [][]
+
 1.0.2 / 2017-11-21
 ==================
 
@@ -7,14 +14,12 @@
 
 * [IMPROVEMENT] Don't check on powered off VMs. See [#878][]
 
-
 1.0.1 / 2017-08-28
 ==================
 
 ### Changes
 
 * [IMPROVEMENT] Adds human friendly "project_name" tag in all cases. See [#515][]
-
 
 1.0.0 / 2017-03-22
 ==================

--- a/openstack/datadog_checks/openstack/__init__.py
+++ b/openstack/datadog_checks/openstack/__init__.py
@@ -2,6 +2,6 @@ from . import openstack
 
 OpenStackCheck = openstack.OpenStackCheck
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 __all__ = ['openstack']

--- a/openstack/manifest.json
+++ b/openstack/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.2",
+  "version": "1.0.3",
   "guid": "944452d0-208e-4d1c-8adb-495f517ce2c2",
   "public_title": "Datadog-OpenStack Integration",
   "categories":["cloud"],


### PR DESCRIPTION
### What does this PR do?

This properly disables the Agent's proxy settings when `use_agent_proxy` is `false`.

### Motivation

Potential customer encountered this

### Additional Notes

Setting proxies to `None` instead of an empty dict is important here as that means `requests` will still look for proxy environment variables.