### PR TITLE
Adds support for service checks for Varnish v5

### DIFF
--- a/varnish/CHANGELOG.md
+++ b/varnish/CHANGELOG.md
@@ -4,7 +4,7 @@
 ==================
 ### Changes
 
-* [IMPROVEMENT] Add support for collecting varnishadm service checks for Varnish 5. See [#1127][].
+* [IMPROVEMENT] Add support for collecting varnishadm service checks for Varnish 5. See [#1130][].
 
 1.1.1 / 2018-02-13
 ==================
@@ -79,6 +79,6 @@ and varnishadm in order to better support service discovery. See [#498][], thank
 [#795]: https://github.com/DataDog/integrations-core/issues/795
 [#805]: https://github.com/DataDog/integrations-core/issues/805
 [#805]: https://github.com/DataDog/integrations-core/issues/939
-[#1127]: https://github.com/DataDog/integrations-core/issues/1127
+[#1130]: https://github.com/DataDog/integrations-core/issues/1130
 [@adongy]: https://github.com/adongy
 [@philipseidel]: https://github.com/philipseidel

--- a/varnish/CHANGELOG.md
+++ b/varnish/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - varnish
 
+1.1.2 / Unreleased
+==================
+### Changes
+
+* [IMPROVEMENT] Add support for collecting varnishadm service checks for Varnish 5. See [#1127][].
+
 1.1.1 / 2018-02-13
 ==================
 ### Changes
@@ -73,5 +79,6 @@ and varnishadm in order to better support service discovery. See [#498][], thank
 [#795]: https://github.com/DataDog/integrations-core/issues/795
 [#805]: https://github.com/DataDog/integrations-core/issues/805
 [#805]: https://github.com/DataDog/integrations-core/issues/939
+[#1127]: https://github.com/DataDog/integrations-core/issues/1127
 [@adongy]: https://github.com/adongy
 [@philipseidel]: https://github.com/philipseidel

--- a/varnish/conf.yaml.example
+++ b/varnish/conf.yaml.example
@@ -35,7 +35,6 @@ instances:
     # NOTE: The Agent must be able to access varnishadm as with root
     # privileges. You can configure your sudoers file for this:
     #
-    # NOTE: These service checks only support up to version 4.x of Varnish
     # example /etc/sudoers entry:
     #   dd-agent ALL=(ALL) NOPASSWD:/usr/bin/varnishadm
     #
@@ -44,6 +43,11 @@ instances:
     # The (optional) path to the varnish secretfile will be used in the
     # varnishadm command, if enabled.
     # secretfile: /etc/varnish/secret
+
+    # The (optional) parameters for specifying the host and port to connect to varnishadm
+    # Defaults to "localhost" and "6082" 
+    # daemon_host: localhost
+    # daemon_port: 6082
     
 ## Log section (Available for Agent >=6.0)
 #logs:

--- a/varnish/datadog_checks/varnish/__init__.py
+++ b/varnish/datadog_checks/varnish/__init__.py
@@ -2,6 +2,6 @@ from . import varnish
 
 Varnish = varnish.Varnish
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 __all__ = ['varnish']

--- a/varnish/datadog_checks/varnish/varnish.py
+++ b/varnish/datadog_checks/varnish/varnish.py
@@ -133,7 +133,7 @@ class Varnish(AgentCheck):
             secretfile_path = instance.get('secretfile', '/etc/varnish/secret')
 
             daemon_host = instance.get('daemon_host', 'localhost')
-            daemon_host = instance.get('daemon_port', '6082')
+            daemon_port = instance.get('daemon_port', '6082')
 
             cmd = []
             if geteuid() != 0:

--- a/varnish/datadog_checks/varnish/varnish.py
+++ b/varnish/datadog_checks/varnish/varnish.py
@@ -132,6 +132,9 @@ class Varnish(AgentCheck):
             varnishadm_path = shlex.split(instance.get('varnishadm'))
             secretfile_path = instance.get('secretfile', '/etc/varnish/secret')
 
+            daemon_host = instance.get('daemon_host', 'localhost')
+            daemon_host = instance.get('daemon_port', '6082')
+
             cmd = []
             if geteuid() != 0:
                 cmd.append('sudo')
@@ -139,7 +142,7 @@ class Varnish(AgentCheck):
             if version < LooseVersion('4.1.0'):
                 cmd.extend(varnishadm_path + ['-S', secretfile_path, 'debug.health'])
             else:
-                cmd.extend(varnishadm_path + ['-S', secretfile_path, 'backend.list', '-p'])
+                cmd.extend(varnishadm_path + ['-T', '{}:{}'.format(daemon_host, daemon_port), '-S', secretfile_path, 'backend.list', '-p'])
 
             try:
                 output, err, _ = get_subprocess_output(cmd, self.log)

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.1.1",
+  "version": "1.1.2",
   "guid": "d2052eae-89b8-4cb1-b631-f373010da4b8",
   "public_title": "Datadog-Varnish Integration",
   "categories":["web", "caching"],

--- a/varnish/test/test_varnish.py
+++ b/varnish/test/test_varnish.py
@@ -235,7 +235,7 @@ class VarnishCheckTest(AgentCheckTest):
 
         self.run_check(config)
         args, _ = mock_subprocess.call_args
-        self.assertEquals(args[0], ['sudo', VARNISHADM_PATH, '-S', SECRETFILE_PATH, 'backend.list', '-p'])
+        self.assertEquals(args[0], [VARNISHADM_PATH, '-T', DAEMON_ADDRESS, '-S', SECRETFILE_PATH, 'backend.list', '-p'])
 
     # Test the varnishadm output for Varnish < 4.x
     @mock.patch('datadog_checks.varnish.varnish.geteuid')

--- a/varnish/test/test_varnish.py
+++ b/varnish/test/test_varnish.py
@@ -185,7 +185,7 @@ class VarnishCheckTest(AgentCheckTest):
 
         self.run_check(config)
         args, _ = mock_subprocess.call_args
-        self.assertEquals(args[0], ['sudo', VARNISHADM_PATH, '-S', SECRETFILE_PATH, 'backend.list', '-p'])
+        self.assertEquals(args[0], ['sudo', VARNISHADM_PATH, '-T', DAEMON_ADDRESS, '-S', SECRETFILE_PATH, 'backend.list', '-p'])
 
 
 
@@ -211,7 +211,7 @@ class VarnishCheckTest(AgentCheckTest):
 
         self.run_check(config)
         args, _ = mock_subprocess.call_args
-        self.assertEquals(args[0], ['sudo', VARNISHADM_PATH, '-S', SECRETFILE_PATH, 'backend.list', '-p'])
+        self.assertEquals(args[0], ['sudo', VARNISHADM_PATH, '-T', DAEMON_ADDRESS, '-S', SECRETFILE_PATH, 'backend.list', '-p'])
 
     # Test the Varnishadm output for version >= 5.x
     @mock.patch('datadog_checks.varnish.varnish.geteuid')
@@ -235,7 +235,7 @@ class VarnishCheckTest(AgentCheckTest):
 
         self.run_check(config)
         args, _ = mock_subprocess.call_args
-        self.assertEquals(args[0], [VARNISHADM_PATH, '-T', DAEMON_ADDRESS, '-S', SECRETFILE_PATH, 'backend.list', '-p'])
+        self.assertEquals(args[0], ['sudo', VARNISHADM_PATH, '-T', DAEMON_ADDRESS, '-S', SECRETFILE_PATH, 'backend.list', '-p'])
 
     # Test the varnishadm output for Varnish < 4.x
     @mock.patch('datadog_checks.varnish.varnish.geteuid')
@@ -259,7 +259,7 @@ class VarnishCheckTest(AgentCheckTest):
 
         self.run_check(config)
         args, _ = mock_subprocess.call_args
-        self.assertEquals(args[0], ['sudo', VARNISHADM_PATH, '-S', SECRETFILE_PATH, 'backend.list', '-p'])
+        self.assertEquals(args[0], ['sudo', VARNISHADM_PATH, '-T', DAEMON_ADDRESS, '-S', SECRETFILE_PATH, 'backend.list', '-p'])
 
     # This the docker image is in a different repository, we check that the
     # verison requested in the FLAVOR_VERSION is the on running inside the

--- a/varnish/test/test_varnish.py
+++ b/varnish/test/test_varnish.py
@@ -76,7 +76,7 @@ COMMON_METRICS = [
 VARNISH_DEFAULT_VERSION = "4.1.7"
 VARNISHADM_PATH = "varnishadm"
 SECRETFILE_PATH = "secretfile"
-DAEMON_ADDRESS = "localhost:8062"
+DAEMON_ADDRESS = "localhost:6082"
 FIXTURE_DIR = os.path.join(os.path.dirname(__file__), 'ci')
 
 # Varnish < 4.x varnishadm output

--- a/varnish/test/test_varnish.py
+++ b/varnish/test/test_varnish.py
@@ -76,6 +76,7 @@ COMMON_METRICS = [
 VARNISH_DEFAULT_VERSION = "4.1.7"
 VARNISHADM_PATH = "varnishadm"
 SECRETFILE_PATH = "secretfile"
+DAEMON_ADDRESS = "localhost:8062"
 FIXTURE_DIR = os.path.join(os.path.dirname(__file__), 'ci')
 
 # Varnish < 4.x varnishadm output
@@ -226,7 +227,7 @@ class VarnishCheckTest(AgentCheckTest):
 
         self.run_check(config)
         args, _ = mock_subprocess.call_args
-        self.assertEquals(args[0], [VARNISHADM_PATH, '-S', SECRETFILE_PATH, 'backend.list', '-p'])
+        self.assertEquals(args[0], [VARNISHADM_PATH, '-T', DAEMON_ADDRESS, '-S', SECRETFILE_PATH, 'backend.list', '-p'])
         self.assertServiceCheckOK("varnish.backend_healthy", tags=['backend:backend2'], count=1)
 
         mock_version.return_value = LooseVersion('5.0.0'), 'json'


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Adds support for collecting service checks for Varnish v5. This requires the use of the `-T` field for varnishadm which just includes the host/port to connect to to retrieve this information.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

The values and format are the same, and the host/port has a default, but is nice to have it be configurable since you can change the defaults in Varnish in `/etc/default/varnish`

Tested on version 4.1.1 of Varnish locally and explicitly specifying `-T` is ok here. 