### PR TITLE
[HDFS_Namenode] fix missing tags crash

### DIFF
--- a/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
@@ -92,7 +92,7 @@ class HDFSNameNode(AgentCheck):
     def check(self, instance):
         jmx_address = instance.get('hdfs_namenode_jmx_uri')
         disable_ssl_validation = instance.get('disable_ssl_validation', False)
-        tags = instance.get('tags')
+        tags = instance.get('tags', [])
         if jmx_address is None:
             raise Exception('The JMX URL must be specified in the instance configuration')
 


### PR DESCRIPTION
### What does this PR do?

Fixes a bug introduced in https://github.com/DataDog/integrations-core/pull/1107

If no `tags` are specified for an instance in `hdfs_namenode.yaml`, the check crashes.

```
hdfs_namenode (5.22.0)
----------------------
  - instance #0 [ERROR]: "'NoneType' object has no attribute 'append'"
    Traceback (most recent call last):
      File "/opt/datadog-agent/agent/checks/__init__.py", line 812, in run
        self.check(copy.deepcopy(instance))
      File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/hdfs_namenode/hdfs_namenode.py", line 99, in check
        tags.append('namenode_url:' + jmx_address)
    AttributeError: 'NoneType' object has no attribute 'append'
```

Temporary workaround for those that don't use tags and are having this problem is to set `tags: []` in your instance yaml.

### Motivation

Our HDFS Namenode check was crashing. 
