### PR TITLE
Add log collection default configuration for Kafka

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -70,6 +70,7 @@ logs:
     path: /var/log/kafka/server.log
     source: kafka
     service: myapp
+    #To handle multi line that starts with yyyy-mm-dd use the following pattern
     #log_processing_rules:
     #  - type: multi_line
     #    name: log_start_with_date

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -22,11 +22,66 @@ The check collects metrics via JMX, so you'll need a JVM on each kafka node so t
 
 ### Configuration
 
+Create a file `kafka.yaml` in the Datadog Agent's `conf.d` directory.
+
+#### Metric Collection
+
 **The following instructions are for the Datadog agent >= 5.0. For agents before that, refer to the [older documentation](https://github.com/DataDog/dd-agent/wiki/Deprecated-instructions-to-install-python-dependencies-for-the-Datadog-Agent).**
 
-Configure a `kafka.yaml` in the Datadog Agent's `conf.d` directory. Kafka bean names depend on the exact Kafka version you're running. You should always use the example that comes packaged with the Agent as a base since that will be the most up-to-date configuration. Use [this sample conf file](https://github.com/DataDog/integrations-core/blob/master/kafka/conf.yaml.example) as an example, but note that the version there may be for a newer version of the Agent than what you've got installed.
+Kafka bean names depend on the exact Kafka version you're running. You should always use the example that comes packaged with the Agent as a base since that will be the most up-to-date configuration. Use [this sample conf file](https://github.com/DataDog/integrations-core/blob/master/kafka/conf.yaml.example) as an example, but note that the version there may be for a newer version of the Agent than what you've got installed.
 
 After you've configured `kafka.yaml`, [restart the Agent](https://docs.datadoghq.com/agent/faq/start-stop-restart-the-datadog-agent) to begin sending Kafka metrics to Datadog.
+
+#### Log Collection
+
+**Available for Agent >6.0** 
+
+Kafka uses the `log4j` logger per default. To activate the logging into a file and customize the format edit the `log4j.properties` file:
+
+```
+# Set root logger level to INFO and its only appender to R
+log4j.rootLogger=INFO, R
+log4j.appender.R.File=/var/log/kafka/server.log
+log4j.appender.R.layout=org.apache.log4j.PatternLayout
+log4j.appender.R.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+```
+
+By default, our integration pipeline support the following conversion patterns:
+
+  ```
+  %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+  %d [%t] %-5p %c - %m%n
+  %r [%t] %p %c %x - %m%n
+  ```
+
+Make sure you clone and edit the integration pipeline if you have a different format.
+
+* Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
+
+  ```
+  logs_enabled: true
+  ```
+   
+* Add this configuration setup to your `kafka.yaml` file to start collecting your Kafka Logs:
+
+```
+logs:
+  - type: file
+    path: /var/log/kafka/server.log
+    source: kafka
+    service: myapp
+    #log_processing_rules:
+    #  - type: multi_line
+    #    name: log_start_with_date
+    #    pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
+```
+  
+  Change the `path` and `service` parameter values and configure them for your environment.  
+  See the [sample kafka.yaml](https://github.com/DataDog/integrations-core/blob/master/kafka/conf.yaml.example) for all available configuration options.
+
+* [Restart the Agent](https://docs.datadoghq.com/agent/faq/start-stop-restart-the-datadog-agent). 
+
+**Learn more about log collection [on the log documentation](https://docs.datadoghq.com/logs)**  
 
 ### Validation
 

--- a/kafka/conf.yaml.example
+++ b/kafka/conf.yaml.example
@@ -55,8 +55,7 @@ instances:
       # - type: multi_line
       #   name: start_with_date
       #   pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
-```
-       
+      
 
 init_config:
   is_jmx: true

--- a/kafka/conf.yaml.example
+++ b/kafka/conf.yaml.example
@@ -33,6 +33,24 @@ instances:
   #     kafka: consumer0
   #     env: stage
   #     newTag: test
+  
+  
+  
+## Log Section (Available for Agent >=6.0)
+#logs:
+
+    # - type : (mandatory) type of log input source (tcp / udp / file / docker)
+    #   port / path : (mandatory) Set port if type is tcp or udp. Set path if type is file
+    #   service : (mandatory) name of the service owning the log
+    #   source : (mandatory) attribute that defines which integration is sending the logs
+    #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
+    #   tags: (optional) add tags to each logs collected
+    
+   # - type: file
+   #   path: /var/log/kafka/server.log
+   #   source: kafka
+   #   service: myservice
+       
 
 init_config:
   is_jmx: true

--- a/kafka/conf.yaml.example
+++ b/kafka/conf.yaml.example
@@ -50,6 +50,12 @@ instances:
    #   path: /var/log/kafka/server.log
    #   source: kafka
    #   service: myservice
+      #To handle multi line that starts with yyyy-mm-dd use the following pattern
+      #log_processing_rules:
+      # - type: multi_line
+      #   name: start_with_date
+      #   pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
+```
        
 
 init_config:

--- a/kafka/manifest.json
+++ b/kafka/manifest.json
@@ -14,7 +14,7 @@
   "version": "1.0.2",
   "guid": "f201c0b7-4b31-4528-9955-ae756a4580b8",
   "public_title": "Datadog-Kafka Integration",
-  "categories":["processing", "messaging"],
+  "categories":["processing", "messaging", "log collection"],
   "type":"check",
   "doc_link": "https://docs.datadoghq.com/integrations/kafka/",
   "is_public": true,


### PR DESCRIPTION
### What does this PR do?

Add default setup for Log collection in Kafka and update the documentation.

### Motivation

We recently added the Kafka Log collection integration.

### Testing Guidelines

Send Kafka logs with the provided configuration.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
