### PR TITLE
Update Zk configuration file to support Log collection

### DIFF
--- a/zk/README.md
+++ b/zk/README.md
@@ -14,7 +14,11 @@ If you need the newest version of the Zookeeper check, install the `dd-check-zk`
 
 ### Configuration
 
-Create a file `zk.yaml` in the Agent's `conf.d` directory. See the [sample zk.yaml](https://github.com/DataDog/integrations-core/blob/master/zk/conf.yaml.example) for all available configuration options:
+Create a file `zk.yaml` in the Agent's `conf.d` directory. 
+
+#### Metric Collection
+
+*  Add this configuration setup to your `zk.yaml` file to start gathering your [Zookeeper Metrics](#metrics):
 
 ```
 init_config:
@@ -25,7 +29,58 @@ instances:
     timeout: 3
 ```
 
-[Restart the Agent](https://docs.datadoghq.com/agent/faq/start-stop-restart-the-datadog-agent) to start sending Zookeeper metrics to Datadog.
+* See the [sample zk.yaml](https://github.com/DataDog/integrations-core/blob/master/zk/conf.yaml.example) for all available configuration options.
+
+* [Restart the Agent](https://docs.datadoghq.com/agent/faq/start-stop-restart-the-datadog-agent) to start sending Zookeeper metrics to Datadog.
+
+#### Log Collection
+
+**Available for Agent >6.0** 
+
+Zookeeper uses the `log4j` logger per default. To activate the logging into a file and customize the format edit the `log4j.properties` file:
+
+```
+# Set root logger level to INFO and its only appender to R
+log4j.rootLogger=INFO, R
+log4j.appender.R.File=/var/log/zookeeper.log
+log4j.appender.R.layout=org.apache.log4j.PatternLayout
+log4j.appender.R.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+```
+
+By default, our integration pipeline support the following conversion patterns:
+
+  ```
+  %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+  %d [%t] %-5p %c - %m%n
+  %r [%t] %p %c %x - %m%n
+  ```
+
+Make sure you clone and edit the integration pipeline if you have a different format.
+
+* Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
+
+  ```
+  logs_enabled: true
+  ```
+   
+* Add this configuration setup to your `zk.yaml` file to start collecting your Zookeeper Logs:
+
+```
+logs:
+  - type: file
+    path: /var/log/zookeeper.log
+    source: zookeeper
+    service: myapp
+    #To handle multi line that starts with yyyy-mm-dd use the following pattern
+    #log_processing_rules:
+    #  - type: multi_line
+    #    name: log_start_with_date
+    #    pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
+```
+
+* See the [sample zk.yaml](https://github.com/DataDog/integrations-core/blob/master/zk/conf.yaml.example) for all available configuration options.
+
+* [Restart the Agent](https://docs.datadoghq.com/agent/faq/start-stop-restart-the-datadog-agent) to start sending Zookeeper Logs to Datadog.
 
 ### Validation
 

--- a/zk/conf.yaml.example
+++ b/zk/conf.yaml.example
@@ -17,3 +17,23 @@ instances:
     # For example if the current instance mode is `observer` - `zookeeper.instances.observer` reports as 1
     # and `zookeeper.instances.(leader|follower|standalone|etc.)` reports as 0
     # report_instance_mode: true
+
+## Log Section (Available for Agent >=6.0)
+#logs:
+
+    # - type : (mandatory) type of log input source (tcp / udp / file / docker)
+    #   port / path : (mandatory) Set port if type is tcp or udp. Set path if type is file
+    #   service : (mandatory) name of the service owning the log
+    #   source : (mandatory) attribute that defines which integration is sending the logs
+    #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
+    #   tags: (optional) add tags to each logs collected
+    
+   # - type: file
+   #   path: /var/log/zookeeper.log
+   #   source: zookeeper
+   #   service: myservice
+      #To handle multi line that starts with yyyy-mm-dd use the following pattern
+      #log_processing_rules:
+      # - type: multi_line
+      #   name: start_with_date
+      #   pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])

--- a/zk/manifest.json
+++ b/zk/manifest.json
@@ -13,7 +13,7 @@
   "version": "1.2.0",
   "guid": "5519c110-5183-438e-85ad-63678c072ac7",
   "public_title": "Datadog-Zookeeper Integration",
-  "categories":["orchestration", "notification"],
+  "categories":["orchestration", "notification", "log collection"],
   "type":"check",
   "doc_link": "https://docs.datadoghq.com/integrations/zk/",
   "is_public": true,


### PR DESCRIPTION
### What does this PR do?

Update default configuration file and documentation for Zookeeper log collection

### Motivation

Zookeeper integration was recently added for Log Collection

### Testing Guidelines

Send zookeeper logs with the recommended configuration.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
