### PR TITLE
Update prometheus metric for container restarts

### DIFF
--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - kubernetes_state
 
+2.3.0 / Unreleased
+==================
+
+* [BUGFIX] Fix fetching kubernetes_state.container.restarts with kube-state-metrics v1.2.0 [#1137][]
+
 2.2.0 / 2018-02-13
 ==================
 ### Changes
@@ -66,3 +71,4 @@
 [#874]: https://github.com/DataDog/integrations-core/issues/874
 [#936]: https://github.com/DataDog/integrations-core/issues/936
 [#965]: https://github.com/DataDog/integrations-core/issues/965
+[#1137]: https://github.com/DataDog/integrations-core/issues/1137

--- a/kubernetes_state/datadog_checks/kubernetes_state/__init__.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/__init__.py
@@ -2,6 +2,6 @@ from . import kubernetes_state
 
 KubernetesState = kubernetes_state.KubernetesState
 
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 
 __all__ = ['kubernetes_state']

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -77,6 +77,7 @@ class KubernetesState(PrometheusCheck):
             'kube_pod_container_resource_requests_memory_bytes': 'container.memory_requested',
             'kube_pod_container_status_ready': 'container.ready',
             'kube_pod_container_status_restarts': 'container.restarts',
+            'kube_pod_container_status_restarts_total': 'container.restarts',
             'kube_pod_container_status_running': 'container.running',
             'kube_pod_container_resource_requests_nvidia_gpu_devices': 'container.gpu.request',
             'kube_pod_container_resource_limits_nvidia_gpu_devices': 'container.gpu.limit',

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -76,8 +76,8 @@ class KubernetesState(PrometheusCheck):
             'kube_pod_container_resource_requests_cpu_cores': 'container.cpu_requested',
             'kube_pod_container_resource_requests_memory_bytes': 'container.memory_requested',
             'kube_pod_container_status_ready': 'container.ready',
-            'kube_pod_container_status_restarts': 'container.restarts',
-            'kube_pod_container_status_restarts_total': 'container.restarts',
+            'kube_pod_container_status_restarts': 'container.restarts', # up to kube-state-metrics 1.1.x
+            'kube_pod_container_status_restarts_total': 'container.restarts', # from kube-state-metrics 1.2.0
             'kube_pod_container_status_running': 'container.running',
             'kube_pod_container_resource_requests_nvidia_gpu_devices': 'container.gpu.request',
             'kube_pod_container_resource_limits_nvidia_gpu_devices': 'container.gpu.limit',

--- a/kubernetes_state/manifest.json
+++ b/kubernetes_state/manifest.json
@@ -11,7 +11,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "2.2.0",
+  "version": "2.3.0",
   "use_omnibus_reqs": true,
   "public_title": "Datadog-Kubernetes State Integration",
   "categories":["orchestration", "containers"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Add an alternate prometheus name for the metric kubernetes_state.container.restarts, as it updated without being documented in [this commit](https://github.com/kubernetes/kube-state-metrics/commit/bd621e00c00f6538580137163f632d1a47b8dc04) from the kube-state-metrics project.

### Motivation

With kube_state_metrics v1.2.0, we were missing the kubernetes_state.container.restarts  metric

### Testing Guidelines
Tested on GKE

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes
Since the test is using directly a file for mocking the output from kube_state_metrics, we would need two files (or adding a special case) to test both cases. So I think it would add too much complexity to the test compared to the benefits.
