### PR TITLE
Revert change to accomodate the kubelet check

### DIFF
--- a/kubernetes/datadog_checks/kubernetes/kubernetes.py
+++ b/kubernetes/datadog_checks/kubernetes/kubernetes.py
@@ -62,6 +62,26 @@ K8S_ALERT_MAP = {
     'Normal': 'info'
 }
 
+# Suffixes per
+# https://github.com/kubernetes/kubernetes/blob/8fd414537b5143ab039cb910590237cabf4af783/pkg/api/resource/suffix.go#L108
+FACTORS = {
+    'n': float(1)/(1000*1000*1000),
+    'u': float(1)/(1000*1000),
+    'm': float(1)/1000,
+    'k': 1000,
+    'M': 1000*1000,
+    'G': 1000*1000*1000,
+    'T': 1000*1000*1000*1000,
+    'P': 1000*1000*1000*1000*1000,
+    'E': 1000*1000*1000*1000*1000*1000,
+    'Ki': 1024,
+    'Mi': 1024*1024,
+    'Gi': 1024*1024*1024,
+    'Ti': 1024*1024*1024*1024,
+    'Pi': 1024*1024*1024*1024*1024,
+    'Ei': 1024*1024*1024*1024*1024*1024,
+}
+
 QUANTITY_EXP = re.compile(r'[-+]?\d+[\.]?\d*[numkMGTPE]?i?')
 
 
@@ -86,7 +106,7 @@ class Kubernetes(AgentCheck):
                 raise Exception('Unable to initialize Kubelet client. Try setting the host parameter. The Kubernetes check failed permanently.')
 
         if agentConfig.get('service_discovery') and \
-           agentConfig.get('service_discovery_backend') == 'docker':
+                agentConfig.get('service_discovery_backend') == 'docker':
             self._sd_backend = get_sd_backend(agentConfig)
         else:
             self._sd_backend = None
@@ -328,6 +348,7 @@ class Kubernetes(AgentCheck):
         try:
             cont_labels = subcontainer['spec']['labels']
         except KeyError:
+            self.log.debug("Subcontainer, doesn't have any labels")
             cont_labels = {}
 
         # Collect pod names, namespaces, rc...
@@ -367,6 +388,16 @@ class Kubernetes(AgentCheck):
         return tags
 
     def _update_metrics(self, instance, pods_list):
+        def parse_quantity(s):
+            number = ''
+            unit = ''
+            for c in s:
+                if c.isdigit() or c == '.':
+                    number += c
+                else:
+                    unit += c
+            return float(number) * FACTORS.get(unit, 1)
+
         metrics = self.kubeutil.retrieve_metrics()
 
         excluded_labels = instance.get('excluded_labels')
@@ -419,7 +450,7 @@ class Kubernetes(AgentCheck):
                 # limits
                 try:
                     for limit, value_str in container['resources']['limits'].iteritems():
-                        values = [self.kubeutil.parse_quantity(s) for s in QUANTITY_EXP.findall(value_str)]
+                        values = [parse_quantity(s) for s in QUANTITY_EXP.findall(value_str)]
                         if len(values) != 1:
                             self.log.warning("Error parsing limits value string: %s", value_str)
                             continue
@@ -430,7 +461,7 @@ class Kubernetes(AgentCheck):
                 # requests
                 try:
                     for request, value_str in container['resources']['requests'].iteritems():
-                        values = [self.kubeutil.parse_quantity(s) for s in QUANTITY_EXP.findall(value_str)]
+                        values = [parse_quantity(s) for s in QUANTITY_EXP.findall(value_str)]
                         if len(values) != 1:
                             self.log.warning("Error parsing requests value string: %s", value_str)
                             continue


### PR DESCRIPTION
### What does this PR do?

put the parse_quantity back as well as the factors to fix the tests and the `request` and `limit` metrics collection.

### Motivation

fix

### Testing Guidelines

```
rake ci:run[kubernetes]
[...]
test_historate_1_1 (test.test_kubernetes.TestKubernetes) ... ok
test_historate_1_2 (test.test_kubernetes.TestKubernetes) ... ok
test_kubelet_fail (test.test_kubernetes.TestKubernetes) ... ok
test_metrics_1_1 (test.test_kubernetes.TestKubernetes) ... ok
test_metrics_1_2 (test.test_kubernetes.TestKubernetes) ... ok
[...]
----------------------------------------------------------------------
Ran 30 tests in 8.151s

OK
[...]
```

### Versioning

- [ ] ~Bumped the check version in `manifest.json`~
- [ ] ~Bumped the check version in `datadog_checks/{integration}/__init__.py`~
- [ ] ~Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.~
- [ ] ~If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new)~

### Notes

The manifest/_init_.py and changelog were not modified when this modification was introduced.
Not updating anything and labeling with 6.xx but it really is a 5.22

Only adresses https://github.com/DataDog/integrations-core/pull/668/files#diff-1f54a7ca9a0765d495d67d3b6a4d41f7