### PR TITLE
[apache] revert fix #1071 for now

### DIFF
--- a/apache/CHANGELOG.md
+++ b/apache/CHANGELOG.md
@@ -1,12 +1,17 @@
 # CHANGELOG - apache
 
+1.1.2 / Unreleased
+==================
+### Changes
+
+* [BUGFIX] revert metric collection fix for `bytes_per_s` and `request_per_s`. See [#1145][].
+
 1.1.1 / 2018-02-13
 ==================
 ### Changes
 
 * [BUGFIX] fixes metric collection for `bytes_per_s` and `request_per_s`. See [#1071][].
 * [DOC] Adding configuration for log collection in `conf.yaml`
-
 
 1.1.0 / 2017-11-21
 ==================

--- a/apache/datadog_checks/apache/__init__.py
+++ b/apache/datadog_checks/apache/__init__.py
@@ -2,6 +2,6 @@ from . import apache
 
 Apache = apache.Apache
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 __all__ = ['apache']

--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -29,9 +29,12 @@ class Apache(AgentCheck):
         'ConnsTotal': 'apache.conns_total',
         'ConnsAsyncWriting': 'apache.conns_async_writing',
         'ConnsAsyncKeepAlive': 'apache.conns_async_keep_alive',
-        'ConnsAsyncClosing' : 'apache.conns_async_closing',
-        'BytesPerSec': 'apache.net.bytes_per_s',
-        'ReqPerSec': 'apache.net.request_per_s'
+        'ConnsAsyncClosing' : 'apache.conns_async_closing'
+    }
+
+    RATES = {
+        'Total kBytes': 'apache.net.bytes_per_s',
+        'Total Accesses': 'apache.net.request_per_s'
     }
 
     def __init__(self, name, init_config, agentConfig, instances=None):
@@ -98,6 +101,12 @@ class Apache(AgentCheck):
                     metric_count += 1
                     metric_name = self.GAUGES[metric]
                     self.gauge(metric_name, value, tags=tags)
+
+                # Send metric as a rate, if applicable
+                if metric in self.RATES:
+                    metric_count += 1
+                    metric_name = self.RATES[metric]
+                    self.rate(metric_name, value, tags=tags)
 
         if metric_count == 0:
             if self.assumed_url.get(instance['apache_status_url'], None) is None and url[-5:] != '?auto':

--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1.1",
   "name": "Apache",
   "display_name": "Apache",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "support": "core",
   "supported_os": [
     "linux",

--- a/apache/test/test_apache.py
+++ b/apache/test/test_apache.py
@@ -39,7 +39,10 @@ class TestCheckApache(AgentCheckTest):
         'apache.conns_total',
         'apache.conns_async_writing',
         'apache.conns_async_keep_alive',
-        'apache.conns_async_closing',
+        'apache.conns_async_closing'
+    ]
+
+    APACHE_RATES = [
         'apache.net.bytes_per_s',
         'apache.net.request_per_s'
     ]
@@ -55,7 +58,7 @@ class TestCheckApache(AgentCheckTest):
         for stub in self.CONFIG_STUBS:
             expected_tags = stub['tags']
 
-            for mname in self.APACHE_GAUGES:
+            for mname in self.APACHE_GAUGES + self.APACHE_RATES:
                 self.assertMetric(mname, tags=expected_tags, count=1)
 
         # Assert service checks


### PR DESCRIPTION
### What does this PR do?

Reverts #1071

### Motivation

Customers were reporting unusually high/incorrect values (e.g. 1M req/s). This was reproduced and the thought was that the 2 metrics weren't being collected properly as `rate`s. After changing to `gauge`s, multiple tests showed that the behavior ceased.

However, it seems the majority of customers were indeed seeing correct values previously. We'll revert and again look into why high values are appearing.