### PR TITLE
[mysql] Only return the aggregated metrics for buffer pools

### DIFF
--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - mysql
 
+1.1.3 / Unreleased
+==================
+### Changes
+
+* [BUGFIX] Fixes the buffer pool metric to return the aggregated values
+
 1.1.2 / 2018-02-13
 ==================
 ### Changes

--- a/mysql/datadog_checks/mysql/__init__.py
+++ b/mysql/datadog_checks/mysql/__init__.py
@@ -2,6 +2,6 @@ from . import mysql
 
 MySql = mysql.MySql
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 __all__ = ['mysql']

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1.1",
   "name": "MySQL",
   "display_name": "MySQL",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "support": "core",
   "supported_os": [
     "linux",


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

We only grab the last set of Innodb buffer pool values, this PR makes sure we don't overwrite the overall aggregated stats with the individual buffer pools.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
