### PR TITLE
[Doc] Displaying NTP server list

### DIFF
--- a/ntp/README.md
+++ b/ntp/README.md
@@ -8,6 +8,12 @@ The Network Time Protocol (NTP) integration is enabled by default and reports th
 * Metric delays
 * Gaps in graphs of metrics
 
+Default NTP servers reached:
+
+* `1.datadog.pool.ntp.org`
+* `2.datadog.pool.ntp.org`
+* `3.datadog.pool.ntp.org`
+
 ## Setup
 ### Installation
 


### PR DESCRIPTION
A customer request the default NTP servers 
(1.datadog.pool.ntp.org, 2.datadog.pool.ntp.org, 3.datadog.pool.ntp.org ) to be listed in the docs.