### PR TITLE
[Doc] Add redirect for redis in doc

### DIFF
--- a/redisdb/manifest.json
+++ b/redisdb/manifest.json
@@ -17,6 +17,7 @@
   "categories":["data store", "caching", "log collection"],
   "type":"check",
   "doc_link": "https://docs.datadoghq.com/integrations/redisdb/",
+  "aliases":["/integrations/redis/"]
   "is_public": true,
   "has_logo": true
 }

--- a/redisdb/manifest.json
+++ b/redisdb/manifest.json
@@ -17,7 +17,7 @@
   "categories":["data store", "caching", "log collection"],
   "type":"check",
   "doc_link": "https://docs.datadoghq.com/integrations/redisdb/",
-  "aliases":["/integrations/redis/"]
+  "aliases":["/integrations/redis/"],
   "is_public": true,
   "has_logo": true
 }


### PR DESCRIPTION
### What does this PR do?

https://docs.datadoghq.com/integrations/redis/ should redirect to https://docs.datadoghq.com/integrations/redisdb/