### PR TITLE
[hdfs_datanode] Add custom tag support

### DIFF
--- a/hdfs_datanode/CHANGELOG.md
+++ b/hdfs_datanode/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - hdfs_datanode
 
+1.2.0 / Unreleased
+==================
+
+### Changes
+
+* [FEATURE] adds custom tag support.
+
 1.1.0 / 2018-01-10
 ==================
 

--- a/hdfs_datanode/conf.yaml.example
+++ b/hdfs_datanode/conf.yaml.example
@@ -14,3 +14,6 @@ instances:
   # Optionally disable SSL validation. Sometimes when using proxies or self-signed certs
   # we'll want to override validation.
   # disable_ssl_validation: false
+  # tags:
+  #   - optional_tags1
+  #   - optional_tags2

--- a/hdfs_datanode/conf.yaml.example
+++ b/hdfs_datanode/conf.yaml.example
@@ -15,5 +15,4 @@ instances:
   # we'll want to override validation.
   # disable_ssl_validation: false
   # tags:
-  #   - optional_tags1
-  #   - optional_tags2
+  #   - optional:tags1

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/__init__.py
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/__init__.py
@@ -2,6 +2,6 @@ from . import hdfs_datanode
 
 HDFSDataNode = hdfs_datanode.HDFSDataNode
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 __all__ = ['hdfs_datanode']

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/hdfs_datanode.py
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/hdfs_datanode.py
@@ -60,24 +60,28 @@ class HDFSDataNode(AgentCheck):
 
     def check(self, instance):
         jmx_address = instance.get('hdfs_datanode_jmx_uri')
+
         if jmx_address is None:
             raise Exception('The JMX URL must be specified in the instance configuration')
+
         disable_ssl_validation = instance.get('disable_ssl_validation', False)
+        custom_tags = instance.get('tags', [])
 
         # Get metrics from JMX
-        self._hdfs_datanode_metrics(jmx_address, disable_ssl_validation)
+        self._hdfs_datanode_metrics(jmx_address, disable_ssl_validation, custom_tags)
 
-    def _hdfs_datanode_metrics(self, jmx_uri, disable_ssl_validation):
+    def _hdfs_datanode_metrics(self, jmx_uri, disable_ssl_validation, tags):
         '''
         Get HDFS data node metrics from JMX
         '''
         response = self._rest_request_to_json(jmx_uri, disable_ssl_validation,
             JMX_PATH,
-            query_params={'qry':HDFS_DATANODE_BEAN_NAME})
+            query_params={'qry':HDFS_DATANODE_BEAN_NAME}, tags)
 
         beans = response.get('beans', [])
 
-        tags = ['datanode_url:' + jmx_uri]
+        tags.append('datanode_url:' + jmx_uri)
+        tags = list(set(tags))
 
         if beans:
 
@@ -102,13 +106,15 @@ class HDFSDataNode(AgentCheck):
         else:
             self.log.error('Metric type "%s" unknown' % (metric_type))
 
-    def _rest_request_to_json(self, address, disable_ssl_validation, object_path, query_params):
+    def _rest_request_to_json(self, address, disable_ssl_validation, object_path, query_params, tags):
         '''
         Query the given URL and return the JSON response
         '''
         response_json = None
 
         service_check_tags = ['datanode_url:' + address]
+        service_check_tags.extend(tags)
+        service_check_tags = list(set(service_check_tags))
 
         url = address
 

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/hdfs_datanode.py
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/hdfs_datanode.py
@@ -75,8 +75,8 @@ class HDFSDataNode(AgentCheck):
         Get HDFS data node metrics from JMX
         '''
         response = self._rest_request_to_json(jmx_uri, disable_ssl_validation,
-            JMX_PATH,
-            query_params={'qry':HDFS_DATANODE_BEAN_NAME}, tags)
+            JMX_PATH, tags,
+            query_params={'qry':HDFS_DATANODE_BEAN_NAME})
 
         beans = response.get('beans', [])
 
@@ -106,7 +106,7 @@ class HDFSDataNode(AgentCheck):
         else:
             self.log.error('Metric type "%s" unknown' % (metric_type))
 
-    def _rest_request_to_json(self, address, disable_ssl_validation, object_path, query_params, tags):
+    def _rest_request_to_json(self, address, disable_ssl_validation, object_path, tags, query_params):
         '''
         Query the given URL and return the JSON response
         '''

--- a/hdfs_datanode/manifest.json
+++ b/hdfs_datanode/manifest.json
@@ -10,7 +10,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.1.0",
+  "version": "1.2.0",
   "guid": "c1409bbd-ff4a-4616-9948-6dc7f4910942",
   "public_title": "Datadog-HDFS Datanode Integration",
   "categories":["processing", "os & system"],

--- a/hdfs_datanode/test/test_hdfs_datanode.py
+++ b/hdfs_datanode/test/test_hdfs_datanode.py
@@ -32,7 +32,8 @@ class HDFSDataNode(AgentCheckTest):
     CHECK_NAME = 'hdfs_datanode'
 
     HDFS_DATANODE_CONFIG = {
-        'hdfs_datanode_jmx_uri': 'http://localhost:50075'
+        'hdfs_datanode_jmx_uri': 'http://localhost:50075',
+        'tags': ['optional:tag1']
     }
 
     HDFS_DATANODE_METRICS_VALUES = {
@@ -50,7 +51,8 @@ class HDFSDataNode(AgentCheckTest):
     }
 
     HDFS_DATANODE_METRIC_TAGS = [
-        'datanode_url:' + HDFS_DATANODE_CONFIG['hdfs_datanode_jmx_uri']
+        'datanode_url:' + HDFS_DATANODE_CONFIG['hdfs_datanode_jmx_uri'],
+        'optional:tag1'
     ]
 
     @mock.patch('requests.get', side_effect=requests_get_mock)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Add custom tag support, including instance tag support for service check.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
