### PR TITLE
[nfsstat][skip ci] updating version on manifest

### DIFF
--- a/nfsstat/manifest.json
+++ b/nfsstat/manifest.json
@@ -8,7 +8,7 @@
   "guid": "9f2fe3a7-ae19-4da9-a253-ae817a5557ab",
   "support": "contrib",
   "supported_os": ["linux"],
-  "version": "0.1.1",
+  "version": "0.2.0",
   "public_title": "Datadog-Nfsstat Integration",
   "categories":["os & system"],
   "type":"check",


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Although it's deprecated, and we'll be removing the integration versions from the manifest, I'm going to align the versions. Got to double check implications of straight-up removing it.

### Motivation

Inability to build

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
