### PR TITLE
[windows_service] Add custom tag support

### DIFF
--- a/windows_service/CHANGELOG.md
+++ b/windows_service/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG - windows_service
+
+1.2.0 / Unreleased
+==================
+
+### Changes
+
+* [FEATURE] adds custom tag support
+
 1.1.1 / 2018-02-13
+==================
+
+### Changes
 
 * [FEATURE] Allow wildcards for service names 
 * [FEATURE] Allow ALL for service names to report all registered services.

--- a/windows_service/conf.yaml.example
+++ b/windows_service/conf.yaml.example
@@ -23,6 +23,10 @@ instances:
         services:
           - wmiApSrv
 
+    # The optional tag field allows custom tagging for each metric
+    #   tags:
+    #     - optional:tag1
+
     # NOTE when using wildcards or the "ALL" option, the check will NOT report
     # services that are not registered with the SCM.  When a service is explicitly
     # requested, then the check will report CRITICAL if the service is not found.

--- a/windows_service/datadog_checks/windows_service/__init__.py
+++ b/windows_service/datadog_checks/windows_service/__init__.py
@@ -2,6 +2,6 @@ from . import windows_service
 
 WindowsService = windows_service.WindowsService
 
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 
 __all__ = ['windows_service']

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -30,11 +30,13 @@ class WindowsService(WinWMICheck):
         user = instance.get('username', "")
         password = instance.get('password', "")
         services = instance.get('services', [])
+        custom_tags = instace.get('tags', [])
 
         instance_hash = hash_mutable(instance)
         instance_key = self._get_instance_key(host, self.NAMESPACE, self.CLASS, instance_hash)
         tags = [] if (host == "localhost" or host == ".") else [u'host:{0}'.format(host)]
-
+        tags.extend(custom_tags)
+        
         if len(services) == 0:
             raise Exception('No services defined in windows_service.yaml')
 

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -30,13 +30,13 @@ class WindowsService(WinWMICheck):
         user = instance.get('username', "")
         password = instance.get('password', "")
         services = instance.get('services', [])
-        custom_tags = instace.get('tags', [])
+        custom_tags = instance.get('tags', [])
 
         instance_hash = hash_mutable(instance)
         instance_key = self._get_instance_key(host, self.NAMESPACE, self.CLASS, instance_hash)
         tags = [] if (host == "localhost" or host == ".") else [u'host:{0}'.format(host)]
         tags.extend(custom_tags)
-        
+
         if len(services) == 0:
             raise Exception('No services defined in windows_service.yaml')
 

--- a/windows_service/manifest.json
+++ b/windows_service/manifest.json
@@ -9,7 +9,7 @@
   "supported_os": [
     "windows"
   ],
-  "version": "1.1.1",
+  "version": "1.2.0",
   "guid": "2289acf0-e413-4384-83f7-88157b430805",
   "public_title": "Datadog-Windows Services Integration",
   "categories":["os & system"],

--- a/windows_service/test/test_windows_service.py
+++ b/windows_service/test/test_windows_service.py
@@ -13,6 +13,7 @@ from tests.core.test_wmi import TestCommonWMI
 INSTANCE = {
     'host': '.',
     'services': ['EventLog', 'Dnscache', 'NonExistingService'],
+    'tags': ['optional:tag1']
 }
 
 INVALID_HOST_INSTANCE = {
@@ -40,9 +41,9 @@ class TestWindowsService(AgentCheckTest):
 
     def test_basic_check(self):
         self.run_check({'instances': [INSTANCE]})
-        self.assertServiceCheckOK(self.SERVICE_CHECK_NAME, tags=['service:EventLog'], count=1)
-        self.assertServiceCheckOK(self.SERVICE_CHECK_NAME, tags=['service:Dnscache'], count=1)
-        self.assertServiceCheckCritical(self.SERVICE_CHECK_NAME, tags=['service:NonExistingService'], count=1)
+        self.assertServiceCheckOK(self.SERVICE_CHECK_NAME, tags=['service:EventLog', 'optional:tag1'], count=1)
+        self.assertServiceCheckOK(self.SERVICE_CHECK_NAME, tags=['service:Dnscache', 'optional:tag1'], count=1)
+        self.assertServiceCheckCritical(self.SERVICE_CHECK_NAME, tags=['service:NonExistingService', 'optional:tag1'], count=1)
         self.coverage_report()
 
     def test_invalid_host(self):


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Add custom tag support for windows_service integrations.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
