### PR TITLE
Update PDH-based checks

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
   NOSE_FILTER: not unix and not fixme and not winfixme
   PYWIN_PATH: C:\projects\integrations-core\.cache\pywin32-py2.7.exe
   SKIP_LINT: true
-  DD_AGENT_BRANCH: db/pdh_tags
+  DD_AGENT_BRANCH: master
   SDK_TESTING: true
   PYTHON: C:\\Python27-x64
   PYTHON_VERSION: 2.7.13
@@ -81,10 +81,11 @@ install:
 build: off
 test_script:
   - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
-  #- bundle exec rake ci:run[default]
-  #- bundle exec rake ci:run[sqlserver]
+  - bundle exec rake ci:run[default]
+  - bundle exec rake ci:run[sqlserver]
   - bundle exec rake ci:run[iis]
   - bundle exec rake ci:run[aspdotnet]
-  #- bundle exec rake ci:run[windows_service]
-  #- bundle exec rake ci:run[wmi_check]
-  #- bundle exec rake ci:run[pdh_check]
+  - bundle exec rake ci:run[dotnetclr]
+  - bundle exec rake ci:run[windows_service]
+  - bundle exec rake ci:run[wmi_check]
+  - bundle exec rake ci:run[pdh_check]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,9 +81,9 @@ install:
 build: off
 test_script:
   - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
-  - bundle exec rake ci:run[default]
-  - bundle exec rake ci:run[sqlserver]
+  #- bundle exec rake ci:run[default]
+  #- bundle exec rake ci:run[sqlserver]
   - bundle exec rake ci:run[iis]
-  - bundle exec rake ci:run[windows_service]
-  - bundle exec rake ci:run[wmi_check]
-  - bundle exec rake ci:run[pdh_check]
+  #- bundle exec rake ci:run[windows_service]
+  #- bundle exec rake ci:run[wmi_check]
+  #- bundle exec rake ci:run[pdh_check]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
   NOSE_FILTER: not unix and not fixme and not winfixme
   PYWIN_PATH: C:\projects\integrations-core\.cache\pywin32-py2.7.exe
   SKIP_LINT: true
-  DD_AGENT_BRANCH: master
+  DD_AGENT_BRANCH: db/pdh_tags
   SDK_TESTING: true
   PYTHON: C:\\Python27-x64
   PYTHON_VERSION: 2.7.13

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,6 +84,7 @@ test_script:
   #- bundle exec rake ci:run[default]
   #- bundle exec rake ci:run[sqlserver]
   - bundle exec rake ci:run[iis]
+  - bundle exec rake ci:run[aspdotnet]
   #- bundle exec rake ci:run[windows_service]
   #- bundle exec rake ci:run[wmi_check]
   #- bundle exec rake ci:run[pdh_check]

--- a/aspdotnet/CHANGELOG.md
+++ b/aspdotnet/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - Aspdotnet
 
+0.1.1 / Unreleased
+==================
+### Changes
+* [Fix] Fixed tag initialization & reporting.
+
 0.1.0 / 2018-01-10
 ==================
 

--- a/aspdotnet/datadog_checks/aspdotnet/__init__.py
+++ b/aspdotnet/datadog_checks/aspdotnet/__init__.py
@@ -2,6 +2,6 @@ from . import aspdotnet
 
 AspdotnetCheck = aspdotnet.AspdotnetCheck
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = ['aspdotnet']

--- a/aspdotnet/datadog_checks/aspdotnet/aspdotnet.py
+++ b/aspdotnet/datadog_checks/aspdotnet/aspdotnet.py
@@ -27,7 +27,7 @@ DEFAULT_COUNTERS = [
     ["ASP.NET Applications", None, "Requests Executing",            "aspdotnet.applications.requests.executing",      "gauge"],
     ["ASP.NET Applications", None, "Requests/Sec",                  "aspdotnet.applications.requests.persec",         "gauge"],
     ["ASP.NET Applications", None, "Forms Authentication Failure", "aspdotnet.applications.forms_authentication.failure",       "gauge"],
-    ["ASP.NET Applications", None, "Forms Authentication Successes", "aspdotnet.applications.forms_authentication.successes",       "gauge"],
+    ["ASP.NET Applications", None, "Forms Authentication Success", "aspdotnet.applications.forms_authentication.successes",       "gauge"],
 ]
 
 class AspdotnetCheck(PDHBaseCheck):

--- a/aspdotnet/manifest.json
+++ b/aspdotnet/manifest.json
@@ -1,12 +1,12 @@
 {
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.0",
-  "max_agent_version": "6.0.0",
-  "min_agent_version": "5.20.0",
+  "max_agent_version": "6.1.0",
+  "min_agent_version": "5.22.2",
   "name": "aspdotnet",
   "short_description": "aspdotnet description.",
   "guid": "475b0c6c-02e5-49ef-806b-9fab377f0839",
   "support": "contrib",
   "supported_os": ["windows"],
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/aspdotnet/test/test_aspdotnet.py
+++ b/aspdotnet/test/test_aspdotnet.py
@@ -11,14 +11,6 @@ from nose.plugins.attrib import attr
 from tests.checks.common import AgentCheckTest
 
 
-# 3p
-from nose.plugins.attrib import attr
-
-# project
-from tests.checks.common import AgentCheckTest
-from checks import AgentCheck
-
-
 MINIMAL_INSTANCE = {
     'host': '.',
 }

--- a/aspdotnet/test/test_aspdotnet.py
+++ b/aspdotnet/test/test_aspdotnet.py
@@ -10,16 +10,9 @@ from nose.plugins.attrib import attr
 # project
 from tests.checks.common import AgentCheckTest
 
-# (C) Datadog, Inc. 2010-2017
-# All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
-
-# stdlib
-import re
 
 # 3p
 from nose.plugins.attrib import attr
-from mock import Mock
 
 # project
 from tests.checks.common import AgentCheckTest
@@ -65,7 +58,7 @@ class ASPDotNetTest(AgentCheckTest):
             self.assertMetric(metric, tags=None, count=1)
 
         for metric in self.ASP_APP_METRICS:
-            self.assertMetric(metric, tags=["instance:__TOTAL__"], count=1)
+            self.assertMetric(metric, tags=["instance:__Total__"], count=1)
 
         self.coverage_report()
 
@@ -76,6 +69,6 @@ class ASPDotNetTest(AgentCheckTest):
             self.assertMetric(metric, tags=['tag1', 'another:tag'], count=1)
 
         for metric in self.ASP_APP_METRICS:
-            self.assertMetric(metric, tags=['tag1', 'another:tag', 'instance:__TOTAL__'], count=1)
+            self.assertMetric(metric, tags=['tag1', 'another:tag', 'instance:__Total__'], count=1)
 
         self.coverage_report()

--- a/datadog-checks-base/datadog_checks/checks/win/winpdh_base.py
+++ b/datadog-checks-base/datadog_checks/checks/win/winpdh_base.py
@@ -36,8 +36,11 @@ class PDHBaseCheck(AgentCheck):
 
                 cfg_tags = instance.get('tags')
                 if cfg_tags is not None:
-                    tags = ",".join(cfg_tags)
-                    self._tags[key] = list(tags) if tags else []
+                    if not isinstance(cfg_tags, list):
+                        self.log.error("Tags must be configured as a list")
+                        raise ValueError("Tags must be type list, not %s" % str(type(cfg_tags)))
+                    self._tags[key] = list(cfg_tags)
+
                 remote_machine = None
                 host = instance.get('host')
                 self._metrics[key] = []
@@ -94,7 +97,7 @@ class PDHBaseCheck(AgentCheck):
                 for instance_name, val in vals.iteritems():
                     tags = []
                     if key in self._tags:
-                        tags = self._tags[key]
+                        tags = list(self._tags[key])
 
                     if not counter.is_single_instance():
                         tag = "instance:%s" % instance_name

--- a/dotnetclr/CHANGELOG.md
+++ b/dotnetclr/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - Dotnetclr
 
+0.1.1 / Unreleased
+==================
+### Changes
+* [Fix] Fixed tag initialization & reporting.
+
 0.1.0 / 2018-01-10
 ==================
 

--- a/dotnetclr/datadog_checks/dotnetclr/__init__.py
+++ b/dotnetclr/datadog_checks/dotnetclr/__init__.py
@@ -2,6 +2,6 @@ from . import dotnetclr
 
 DotnetclrCheck = dotnetclr.DotnetclrCheck
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = ['dotnetclr']

--- a/dotnetclr/datadog_checks/dotnetclr/dotnetclr.py
+++ b/dotnetclr/datadog_checks/dotnetclr/dotnetclr.py
@@ -21,8 +21,8 @@ DEFAULT_COUNTERS = [
 
     # .NET Framework counters
     [".NET CLR Memory",     None, "% Time in GC",             "dotnetclr.memory.time_in_gc",           "gauge"],
-    [".NET CLR Memory",     None, "# Total committed Bytes",     "dotnetclr.memory.heap_bytes",        "gauge"],
-    [".NET CLR Memory",     None, "# Total reserved Bytes",     "dotnetclr.memory.heap_bytes",        "gauge"],
+    [".NET CLR Memory",     None, "# Total committed Bytes",  "dotnetclr.memory.committed.heap_bytes", "gauge"],
+    [".NET CLR Memory",     None, "# Total reserved Bytes",   "dotnetclr.memory.reserved.heap_bytes",  "gauge"],
 ]
 
 class DotnetclrCheck(PDHBaseCheck):

--- a/dotnetclr/manifest.json
+++ b/dotnetclr/manifest.json
@@ -2,11 +2,11 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.0",
   "max_agent_version": "6.0.0",
-  "min_agent_version": "5.20.0",
+  "min_agent_version": "5.22.2",
   "name": "dotnetclr",
   "short_description": "dotnetclr description.",
   "guid": "3d21557e-65bd-4b66-99b9-5521f32b5957",
   "support": "contrib",
   "supported_os": ["windows"],
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/dotnetclr/test/test_dotnetclr.py
+++ b/dotnetclr/test/test_dotnetclr.py
@@ -10,29 +10,47 @@ from nose.plugins.attrib import attr
 # project
 from tests.checks.common import AgentCheckTest
 
+MINIMAL_INSTANCE = {
+    'host': '.',
+}
 
-instance = {
-    'host': 'localhost',
-    'port': 26379,
-    'password': 'datadog-is-devops-best-friend'
+INSTANCE_WITH_TAGS = {
+    'host': '.',
+    'tags': ['tag1', 'another:tag']
 }
 
 
-# NOTE: Feel free to declare multiple test classes if needed
-
+@attr('windows')
 @attr(requires='dotnetclr')
-class TestDotnetclr(AgentCheckTest):
-    """Basic Test for dotnetclr integration."""
+class DotNetCLRTest(AgentCheckTest):
     CHECK_NAME = 'dotnetclr'
 
-    def test_check(self):
-        """
-        Testing Dotnetclr check.
-        """
-        self.load_check({}, {})
+    CLR_METRICS = (
+        "dotnetclr.exceptions.thrown_persec",
+        "dotnetclr.memory.time_in_gc",
+        "dotnetclr.memory.committed.heap_bytes",
+        "dotnetclr.memory.reserved.heap_bytes",
+    )
 
-        # run your actual tests...
+    EXPECTED_INSTANCES = (
+        "_Global_",
+        "sqlservr",
+        "Appveyor.BuildAgent.Interactive"
+    )
+    def test_basic_check(self):
+        self.run_check_twice({'instances': [MINIMAL_INSTANCE]})
 
-        self.assertTrue(True)
-        # Raises when COVERAGE=true and coverage < 100%
+        for metric in self.CLR_METRICS:
+            for inst in self.EXPECTED_INSTANCES:
+                self.assertMetric(metric, tags=["instance:{0}".format(inst)], count=1)
+
+        self.coverage_report()
+
+    def test_with_tags(self):
+        self.run_check_twice({'instances': [INSTANCE_WITH_TAGS]})
+
+        for metric in self.CLR_METRICS:
+            for inst in self.EXPECTED_INSTANCES:
+                self.assertMetric(metric, tags=['tag1', 'another:tag', "instance:{0}".format(inst)], count=1)
+
         self.coverage_report()

--- a/dotnetclr/test/test_dotnetclr.py
+++ b/dotnetclr/test/test_dotnetclr.py
@@ -37,6 +37,7 @@ class DotNetCLRTest(AgentCheckTest):
         "sqlservr",
         "Appveyor.BuildAgent.Interactive"
     )
+
     def test_basic_check(self):
         self.run_check_twice({'instances': [MINIMAL_INSTANCE]})
 

--- a/iis/CHANGELOG.md
+++ b/iis/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG - iis
+2.0.2 / Unreleased
+==================
+### Changes
+* [Fix] Fixed tag initialization & reporting.
 
 2.0.1 / 2018-02-13
 ==================

--- a/iis/datadog_checks/iis/__init__.py
+++ b/iis/datadog_checks/iis/__init__.py
@@ -2,6 +2,6 @@ from . import iis
 
 IIS = iis.IIS
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 __all__ = ['iis']

--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -80,7 +80,7 @@ class IIS(PDHBaseCheck):
                 for sitename, val in vals.iteritems():
                     tags = []
                     if key in self._tags:
-                        tags = self._tags[key]
+                        tags = list(self._tags[key])
 
                     try:
                         if not counter.is_single_instance():
@@ -106,7 +106,7 @@ class IIS(PDHBaseCheck):
                     if dd_name == "iis.uptime":
                         uptime = int(val)
                         status = AgentCheck.CRITICAL if uptime == 0 else AgentCheck.OK
-                        self.service_check(self.SERVICE_CHECK, status, tags=['site:{0}'.format(self.normalize(sitename))])
+                        self.service_check(self.SERVICE_CHECK, status, tags)
                         if sitename in expected_sites:
                             self.log.debug("Removing %s from expected sites" % sitename)
                             expected_sites.remove(sitename)
@@ -119,5 +119,8 @@ class IIS(PDHBaseCheck):
                 pass
 
         for site in expected_sites:
-            self.service_check(self.SERVICE_CHECK, AgentCheck.CRITICAL,
-                            tags=['site:{0}'.format(self.normalize(site))])
+            tags = []
+            if key in self._tags:
+                tags = list(self._tags[key])
+            tags.append("site:{0}".format(self.normalize(site)))
+            self.service_check(self.SERVICE_CHECK, AgentCheck.CRITICAL, tags)

--- a/iis/manifest.json
+++ b/iis/manifest.json
@@ -2,14 +2,14 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "0.1.1",
   "max_agent_version": "6.0.0",
-  "min_agent_version": "5.18.0",
+  "min_agent_version": "5.22.2",
   "name": "iis",
   "short_description": "Track total or per-site metrics and monitor each site's up/down status.",
   "support": "core",
   "supported_os": [
     "windows"
   ],
-  "version": "2.0.1",
+  "version": "2.0.2",
   "guid": "6ad932f0-8816-467a-8860-72af44d4f3ba",
   "public_title": "Datadog-IIS Integration",
   "categories":["web", "log collection"],

--- a/iis/test/test_iis.py
+++ b/iis/test/test_iis.py
@@ -12,7 +12,6 @@ from mock import Mock
 # project
 from tests.checks.common import AgentCheckTest
 from checks import AgentCheck
-from tests.core.test_wmi import TestCommonWMI
 
 
 MINIMAL_INSTANCE = {
@@ -102,8 +101,8 @@ class IISTest(AgentCheckTest):
         self.coverage_report()
 
 @attr('windows')
-@attr(requires='windows')
-class IISTestCase(AgentCheckTest, TestCommonWMI):
+@attr(requires='iis')
+class IISTestCase(AgentCheckTest):
     CHECK_NAME = 'iis'
 
     WIN_SERVICES_MINIMAL_CONFIG = {


### PR DESCRIPTION

### What does this PR do?

Fixes broken tag initialization when reading tags from the check conf yaml.
Fixes unit test that was not enabled that would have caught the above.
Adds unit tests for additional pdh based checks

### Motivation

customer bug report


### Versioning

- [ x ] Bumped the check version in `manifest.json`
- [ x ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ x ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

requires https://github.com/DataDog/datadog-agent/pull/1388
requires https://github.com/DataDog/dd-agent/pull/3693; appveyor tests will not pass until this is merged.