### PR TITLE
[kubernetes_state] fix missing columns in metadata.csv

### DIFF
--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -4,6 +4,7 @@
 ==================
 
 * [BUGFIX] Fix fetching kubernetes_state.container.restarts with kube-state-metrics v1.2.0 [#1137][]
+* [BUGFIX] Fix rows with mismatch columns in metadata.csv [#1195][]
 
 2.2.0 / 2018-02-13
 ==================

--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -5,8 +5,8 @@ kubernetes_state.container.terminated,gauge,,,,Whether the container is currentl
 kubernetes_state.container.status_report.count.terminated,count,,,,Count of the containers currently reporting a in terminated state with the reason as a tag,-1,kubernetes,k8s_state.container.status_report.count.term
 kubernetes_state.container.waiting,gauge,,,,Whether the container is currently in waiting state,0,kubernetes,k8s_state.container.wait
 kubernetes_state.container.status_report.count.waiting,count,,,,Count of the containers currently reporting a in waiting state with the reason as a tag,-1,kubernetes,k8s_state.container.status_report.count.wait
-kubernetes_state.container.gpu.request,gauge,,,The number of requested gpu devices by a container,0,kubernetes,k8s_state.container.gpu.request
-kubernetes_state.container.gpu.limit,gauge,,,The limit on gpu devices to be used by a container,0,kubernetes,k8s_state.container.gpu.limit
+kubernetes_state.container.gpu.request,gauge,,,,The number of requested gpu devices by a container,0,kubernetes,k8s_state.container.gpu.request
+kubernetes_state.container.gpu.limit,gauge,,,,The limit on gpu devices to be used by a container,0,kubernetes,k8s_state.container.gpu.limit
 kubernetes_state.container.restarts,gauge,,,,The number of restarts per container,-1,kubernetes,k8s_state.container.restarts
 kubernetes_state.container.cpu_requested,gauge,,cpu,,The number of requested cpu cores by a container,0,kubernetes,k8s_state.container.cpu_req
 kubernetes_state.container.memory_requested,gauge,,byte,,The number of requested memory bytes by a container,0,kubernetes,k8s_state.container.mem_req
@@ -38,9 +38,9 @@ kubernetes_state.limitrange.memory.max_limit_request_ratio,gauge,,,,Maximum memo
 kubernetes_state.node.cpu_capacity,gauge,,cpu,,The total CPU resources of the node,0,kubernetes,k8s_state.node.cpu_capacity
 kubernetes_state.node.memory_capacity,gauge,,byte,,The total memory resources of the node,0,kubernetes,k8s_state.node.memory_capacity
 kubernetes_state.node.pods_capacity,gauge,,,,The total pod resources of the node,0,kubernetes,k8s_state.node.pods_capacity
-kubernetes_state.node.gpu.cards_allocatable,gauge,,,The GPU resources of a node that are available for scheduling,0,kubernetes,k8s_state.node.gpu.cards_allocatable
-kubernetes_state.node.gpu.cards_capacity,gauge,,,The total GPU resources of the node,0,kubernetes,k8s_state.node.gpu.cards_capacity
-kubernetes_state.persistentvolumeclaim.status,gauge,,,The phase the persistent volume claim is currently in,-1,kubernetes,k8s_state.persistentvolumeclaim.status
+kubernetes_state.node.gpu.cards_allocatable,gauge,,,,The GPU resources of a node that are available for scheduling,0,kubernetes,k8s_state.node.gpu.cards_allocatable
+kubernetes_state.node.gpu.cards_capacity,gauge,,,,The total GPU resources of the node,0,kubernetes,k8s_state.node.gpu.cards_capacity
+kubernetes_state.persistentvolumeclaim.status,gauge,,,,The phase the persistent volume claim is currently in,-1,kubernetes,k8s_state.persistentvolumeclaim.status
 kubernetes_state.node.cpu_allocatable,gauge,,cpu,,The CPU resources of a node that are available for scheduling,0,kubernetes,k8s_state.node.cpu_allocatable
 kubernetes_state.node.memory_allocatable,gauge,,byte,,The memory resources of a node that are available for scheduling,0,kubernetes,k8s_state.node.memory_allocatable
 kubernetes_state.node.pods_allocatable,gauge,,,,The pod resources of a node that are available for scheduling,0,kubernetes,k8s_state.node.pods_allocatable


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

This pr fixes some rows with a missing column in metadata.csv.

### Motivation

I was looking at the file to see the available metrics and saw GitHub warning about the mismatch in the number of columns.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

GitHub editor automatically added a newline at the end of file. I hope that doesn't break the parser.
