### PR TITLE
[Rabbit MQ] Phrasing update

### DIFF
--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -54,7 +54,7 @@ Configuration Options
 * `tag_families` - **optional** - Defaults to false - Tag queue "families" based off of regex matching
 * `nodes` or `nodes_regexes` - **optional** - Use the `nodes` or `nodes_regexes` parameters to specify the nodes you'd like to collect metrics on (up to 100 nodes). If you have less than 100 nodes, you don't have to set this parameter, the metrics will be collected on all the nodes by default. See the link to the example YAML below for more.
 * `queues` or `queues_regexes` - **optional** - Use the `queues` or `queues_regexes` parameters to specify the queues you'd like to collect metrics on (up to 200 queues). If you have less than 200 queues, you don't have to set this parameter, the metrics will be collected on all the queues by. default. If you have set up vhosts, set the queue names as `vhost_name/queue_name`. If you have `tag_families` enabled, the first captured group in the regex will be used as the queue_family tag.  See the link to the example YAML below for more.
-* `vhosts` - **optional** - By default a list of all vhosts is fetched and each one will be checked using the aliveness API. If you prefer only certain vhosts to be monitored with service checks then you can list the vhosts you care about.
+* `vhosts` - **optional** - By default a list of all vhosts is fetched and each one will be checked using the aliveness API. If you prefer only certain vhosts to be monitored, list the vhosts you care about.
 
 [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent) to begin sending RabbitMQ metrics, events, and service checks to Datadog.
 


### PR DESCRIPTION
### What does this PR do?

A phrasing update

### Motivation

Customer is stating that this line here:
```
vhosts - optional - By default a list of all vhosts is fetched and each one will be checked using the aliveness API. If you prefer only certain vhosts to be monitored with service checks then you can list the vhosts you care about.
````

is confusing because they state that it implies that it's merely as setting for the Service checks, which was the case with an older version of the RabbitMQ check,
