### PR TITLE
[changelog][skip ci] setting release dates 6.0.1/6.0.2

### DIFF
--- a/aspdotnet/CHANGELOG.md
+++ b/aspdotnet/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - Aspdotnet
 
-0.1.1 / Unreleased
+0.1.1 / 2018-03-07
 ==================
 ### Changes
 * [Fix] Fixed tag initialization & reporting.
@@ -11,3 +11,4 @@
 ### Changes
 
 * [FEATURE] adds aspdotnet integration.
+

--- a/dotnetclr/CHANGELOG.md
+++ b/dotnetclr/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - Dotnetclr
 
-0.1.1 / Unreleased
+0.1.1 / 2018-03-07
 ==================
 ### Changes
 * [Fix] Fixed tag initialization & reporting.
@@ -11,3 +11,4 @@
 ### Changes
 
 * [FEATURE] adds dotnetclr integration.
+

--- a/iis/CHANGELOG.md
+++ b/iis/CHANGELOG.md
@@ -1,5 +1,5 @@
 # CHANGELOG - iis
-2.0.2 / Unreleased
+2.0.2 / 2018-03-07
 ==================
 ### Changes
 * [Fix] Fixed tag initialization & reporting.

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - postgres
 
-2.1.0 / Unreleased
+2.1.0 / 2018-03-07
 ==================
 ### Changes
 
@@ -74,5 +74,7 @@
 [#699]: https://github.com/DataDog/integrations-core/issues/699
 [#740]: https://github.com/DataDog/integrations-core/issues/740
 [#776]: https://github.com/DataDog/integrations-core/issues/776
+[#1042]: https://github.com/DataDog/integrations-core/issues/1042
+[#1073]: https://github.com/DataDog/integrations-core/issues/1073
 [@Erouan50]: https://github.com/Erouan50
 [@infothrill]: https://github.com/infothrill


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Adds release dates to changelogs

### Motivation
6.0.1/6.0.2 release