### PR TITLE
fix base_check metrics merge

### DIFF
--- a/datadog-checks-base/datadog_checks/checks/prometheus/base_check.py
+++ b/datadog-checks-base/datadog_checks/checks/prometheus/base_check.py
@@ -95,12 +95,17 @@ class GenericPrometheusCheck(AgentCheck):
         # Metrics are preprocessed if no mapping
         metrics_mapper = {}
         # We merge list and dictionnaries from optional defaults & instance settings
-        metrics = default_instance.get("metrics", []) + instance.get("metrics", [])
-        for metric in metrics:
+        for metric in default_instance.get("metrics", []):
             if isinstance(metric, basestring):
                 metrics_mapper[metric] = metric
             else:
                 metrics_mapper.update(metric)
+        for metric in instance.get("metrics", []):
+            if isinstance(metric, basestring):
+                metrics_mapper[metric] = metric
+            else:
+                metrics_mapper.update(metric)
+
         scraper.metrics_mapper = metrics_mapper
         scraper.labels_mapper = default_instance.get("labels_mapper", {})
         scraper.labels_mapper.update(instance.get("labels_mapper", {}))


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Fixes a bug in the generic prometheus check when merging metrics definitions from the default configuration and the instance configuration. 

If one of them was passed as a `dict` and the other one as an `array`, this line was throwing an error :

https://github.com/DataDog/integrations-core/blob/b61db360e4e77b1bfeb0ecc7eb537fae8771a22f/datadog-checks-base/datadog_checks/checks/prometheus/base_check.py#L98

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

