### PR TITLE
[mysql] bump pymysql version

### DIFF
--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [BUGFIX] Fixes the buffer pool metric to return the aggregated values
+* [DEPENDENCY] Bump the pymysql version from 0.6.6 to 0.8.0
 
 1.1.2 / 2018-02-13
 ==================

--- a/mysql/requirements.txt
+++ b/mysql/requirements.txt
@@ -1,2 +1,2 @@
 # integration pip requirements
-pymysql==0.6.6 --hash=sha256:84dfd838f49d784978084cf7536f91becea456325c4b84874ccd2f5dccaa35d3
+pymysql==0.8.0 --hash=sha256:04fa19fad017fdb21394fad2878c1d6bd346959d4fbfd1b66050a09fc636a321


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Bump pymysql version to support Azure Mysql instances.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
