### PR TITLE
[kubernetes_state] modifies default autoconf

### DIFF
--- a/kubernetes_state/auto_conf.yaml
+++ b/kubernetes_state/auto_conf.yaml
@@ -5,7 +5,7 @@ init_config:
 
 instances:
   # To enable Kube State metrics you must specify the url exposing the API
-  - kube_state_url: http://%%host%%:%%port%%/metrics
+  - kube_state_url: http://kube-state-metrics:%%port_0%%/metrics
     # Tags are reported as set by kube-state-metrics. If you want to translate
     # them to other tags, you can use the labels_mapper dictionary
     # labels_mapper:

--- a/kubernetes_state/auto_conf.yaml
+++ b/kubernetes_state/auto_conf.yaml
@@ -5,7 +5,7 @@ init_config:
 
 instances:
   # To enable Kube State metrics you must specify the url exposing the API
-  - kube_state_url: http://kube-state-metrics:%%port_0%%/metrics
+  - kube_state_url: http://%%host%%:%%port_0%%/metrics
     # Tags are reported as set by kube-state-metrics. If you want to translate
     # them to other tags, you can use the labels_mapper dictionary
     # labels_mapper:


### PR DESCRIPTION
### What does this PR do?

Modifies the default auto conf file to be more ready OOB

### Motivation

Assumption: [these files](https://github.com/kubernetes/kube-state-metrics/tree/master/kubernetes) were used to deploy kube-state-metrics

Currently:
%%host%% returns the PodIP
%%port%% returns 2 ports, [8080, 8081]; 8081 will be used (last element used if no index)
PodIP:8081 - wouldn't work

Use %%port_0%% instead to return to 8080.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
