### PR TITLE
Add wildcard support for prometheus generic check

### DIFF
--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -15,7 +15,8 @@ Each instance is at least composed of:
 * a `prometheus_url` that points to the metric route (⚠️ this has to be unique)
 * a `namespace` that will be prepended to all metrics (to avoid metrics name collision)
 * a list of `metrics` that you want to retrieve as custom metrics, for each metric you can either
-simply add it to the list `- metric_name` or renaming it like `- metric_name: renamed`
+simply add it to the list `- metric_name` or renaming it like `- metric_name: renamed`.
+It's also possible to use a `*` wildcard such as `- metric*` that would fetch all matching metrics (to use with caution as it can potentially send a lot of custom metrics)
 
 There is also a couple of more advanced settings (ssl, labels joining, custom tags,...) that are documented in the [example configuration](conf.yaml.example)
 

--- a/prometheus/tests/test_prometheus.py
+++ b/prometheus/tests/test_prometheus.py
@@ -62,6 +62,19 @@ def test_prometheus_check(aggregator, poll_mock):
     aggregator.assert_metric(CHECK_NAME + '.metric2', tags=['timestamp:123', 'node:host2', 'matched_label:foobar'])
     assert aggregator.metrics_asserted_pct == 100.0
 
+def test_prometheus_wildcard(aggregator, poll_mock):
+    instance_wildcard = {
+        'prometheus_url': 'http://localhost:10249/metrics',
+        'namespace': 'prometheus',
+        'metrics': ['metric*'],
+    }
+
+    c = PrometheusCheck('prometheus', None, {}, [instance_wildcard])
+    c.check(instance)
+    aggregator.assert_metric(CHECK_NAME + '.metric1', tags=['node:host1', 'flavor:test', 'matched_label:foobar'])
+    aggregator.assert_metric(CHECK_NAME + '.metric2', tags=['timestamp:123', 'node:host2', 'matched_label:foobar'])
+    assert aggregator.metrics_asserted_pct == 100.0
+
 def test_prometheus_default_instance(aggregator, poll_mock):
     """
     Testing prometheus with default instance


### PR DESCRIPTION
### What does this PR do?

Add a wildcard `*` support for matching metrics

### Motivation

If you want to retrieve a bunch of metrics without the tedious listing, you can use a wildcard syntax in the generic prometheus check (to be used with caution, because it's custom metrics)
