### PR TITLE
[docs] Document that go-metro is not available with A6

### DIFF
--- a/go-metro/README.md
+++ b/go-metro/README.md
@@ -4,7 +4,7 @@
 
 The TCP RTT check reports on roundtrip times between the host the agent is running on and any host it is communicating with. This check is passive and will only report RTT times for packets being sent and received from outside the check. The check itself will not send any packets.
 
-This check is only shipped in the 64-bit DEB and RPM Datadog Agent packages.
+This check is only shipped in the 64-bit DEB and RPM Datadog Agent v5 packages. The check is currently _not_ available with Datadog Agent v6.
 
 ## Setup
 ### Installation


### PR DESCRIPTION
### What does this PR do?

Documents that go-metro is not available with A6 (for now at least)

### Additional Notes

pinging @l0k0ms since this affects docs

See also counterpart PR on `datadog-agent`: https://github.com/DataDog/datadog-agent/pull/1419