### PR TITLE
Mfpierre/add kubelet auth

### DIFF
--- a/datadog-checks-base/datadog_checks/checks/prometheus/base_check.py
+++ b/datadog-checks-base/datadog_checks/checks/prometheus/base_check.py
@@ -109,6 +109,8 @@ class GenericPrometheusCheck(AgentCheck):
         scraper.type_overrides = default_instance.get("type_overrides", {})
         scraper.type_overrides.update(instance.get("type_overrides", {}))
         scraper.exclude_labels = default_instance.get("exclude_labels", []) + instance.get("exclude_labels", [])
+        scraper.extra_headers = default_instance.get("extra_headers", {})
+        scraper.extra_headers.update(instance.get("extra_headers", {}))
         # For simple values instance settings overrides optional defaults
         scraper.label_to_hostname = instance.get("label_to_hostname", default_instance.get("prometheus_url", ""))
         scraper.health_service_check = instance.get("health_service_check", default_instance.get("health_service_check", True))

--- a/datadog-checks-base/datadog_checks/checks/prometheus/mixins.py
+++ b/datadog-checks-base/datadog_checks/checks/prometheus/mixins.py
@@ -129,6 +129,9 @@ class PrometheusScraper(object):
         # The path to the trusted CA used for generating custom certificates
         self.ssl_ca_cert = None
 
+        # Extra http headers to be sent when polling endpoint
+        self.extra_headers = {}
+
     def parse_metric_family(self, response):
         """
         Parse the MetricFamily from a valid requests.Response object to provide a MetricFamily object (see [0])
@@ -436,6 +439,7 @@ class PrometheusScraper(object):
             headers['accept'] = 'application/vnd.google.protobuf; ' \
                                 'proto=io.prometheus.client.MetricFamily; ' \
                                 'encoding=delimited'
+        headers.update(self.extra_headers)
         cert = None
         if isinstance(self.ssl_cert, basestring):
             cert = self.ssl_cert

--- a/kubelet/CHANGELOG.md
+++ b/kubelet/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG - kubelet
 
+1.1.0/ Unreleased
+==================
+
+### Changes
+
+* [FEATURE] Support TLS
+
+
 1.0.0 / 2018-02-28
 ==================
 

--- a/kubelet/datadog_checks/kubelet/__about__.py
+++ b/kubelet/datadog_checks/kubelet/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -138,7 +138,10 @@ class KubeletCheck(PrometheusCheck):
         else:
             self.ssl_cert = cert  # prometheus check setting
 
-        verify = self.kubelet_conn_info.get('ca_cert') or self.kubelet_conn_info.get('verify_tls')
+        if self.kubelet_conn_info.get('verify_tls') == 'false':
+            verify = False
+        else:
+            verify = self.kubelet_conn_info.get('ca_cert')
         self.ssl_ca_cert = verify  # prometheus check setting
 
         # if cert-based auth is enabled, don't use the token.

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -135,12 +135,16 @@ class KubeletCheck(PrometheusCheck):
         cert = (self.kubelet_conn_info.get('client_crt'), self.kubelet_conn_info.get('client_key'))
         if not cert[0] or not cert[1]:
             cert = None
+        else:
+            self.ssl_cert = cert  # prometheus check setting
 
         verify = self.kubelet_conn_info.get('ca_cert') or self.kubelet_conn_info.get('verify_tls')
+        self.ssl_ca_cert = verify  # prometheus check setting
 
         # if cert-based auth is enabled, don't use the token.
         if not cert and url.lower().startswith('https') and 'token' in self.kubelet_conn_info:
             headers = {'Authorization': 'Bearer {}'.format(self.kubelet_conn_info['token'])}
+            self.extra_headers = headers  # prometheus check setting
 
         return requests.get(url, timeout=timeout, verify=verify,
                             cert=cert, headers=headers, params={'verbose': verbose})

--- a/kubelet/manifest.json
+++ b/kubelet/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "1.0.0",
+  "manifest_version": "1.1.0",
   "max_agent_version": "7.0.0",
   "min_agent_version": "6.0.0",
   "name": "kubelet",


### PR DESCRIPTION
### What does this PR do?

* Add extra headers to prometheus check
* Pass creds between kubelet & prom check

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [x] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 
