### PR TITLE
[apache] Add custom tag to service check

### DIFF
--- a/apache/CHANGELOG.md
+++ b/apache/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - apache
 
+1.2.0 / Unreleased
+==================
+### Changes
+
+* [FEATURE] Add custom tag to service check.
+
 1.1.2 / 2018-02-28
 ==================
 ### Changes

--- a/apache/datadog_checks/apache/__init__.py
+++ b/apache/datadog_checks/apache/__init__.py
@@ -2,6 +2,6 @@ from . import apache
 
 Apache = apache.Apache
 
-__version__ = "1.1.2"
+__version__ = "1.2.0"
 
 __all__ = ['apache']

--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -63,7 +63,7 @@ class Apache(AgentCheck):
         apache_host = parsed_url.hostname
         apache_port = parsed_url.port or 80
         service_check_name = 'apache.can_connect'
-        service_check_tags = ['host:%s' % apache_host, 'port:%s' % apache_port]
+        service_check_tags = ['host:%s' % apache_host, 'port:%s' % apache_port] + tags
         try:
             self.log.debug('apache check initiating request, connect timeout %d receive %d' %
                            (connect_timeout, receive_timeout))

--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1.1",
   "name": "Apache",
   "display_name": "Apache",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "support": "core",
   "supported_os": [
     "linux",

--- a/apache/test/test_apache.py
+++ b/apache/test/test_apache.py
@@ -63,7 +63,7 @@ class TestCheckApache(AgentCheckTest):
 
         # Assert service checks
         self.assertServiceCheck('apache.can_connect', status=AgentCheck.OK,
-                                tags=['host:localhost', 'port:8180'], count=2)
+                                tags=['host:localhost', 'port:8180', 'instance:second'], count=2)
 
         self.coverage_report()
 

--- a/apache/test/test_apache.py
+++ b/apache/test/test_apache.py
@@ -61,9 +61,9 @@ class TestCheckApache(AgentCheckTest):
             for mname in self.APACHE_GAUGES + self.APACHE_RATES:
                 self.assertMetric(mname, tags=expected_tags, count=1)
 
-        # Assert service checks
-        self.assertServiceCheck('apache.can_connect', status=AgentCheck.OK,
-                                tags=['host:localhost', 'port:8180', 'instance:second'], count=2)
+            # Assert service checks
+            self.assertServiceCheck('apache.can_connect', status=AgentCheck.OK,
+                                tags=['host:localhost', 'port:8180'] + expected_tags, count=2)
 
         self.coverage_report()
 

--- a/apache/test/test_apache.py
+++ b/apache/test/test_apache.py
@@ -63,7 +63,7 @@ class TestCheckApache(AgentCheckTest):
 
             # Assert service checks
             self.assertServiceCheck('apache.can_connect', status=AgentCheck.OK,
-                                tags=['host:localhost', 'port:8180'] + expected_tags, count=2)
+                                tags=['host:localhost', 'port:8180'] + expected_tags, count=1)
 
         self.coverage_report()
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Add custom tag support to service checks.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
