### PR TITLE
[Doc] Mongo metrics

### DIFF
--- a/mongo/metadata.csv
+++ b/mongo/metadata.csv
@@ -94,22 +94,22 @@ mongodb.mem.mapped,gauge,,mebibyte,,Amount of mapped memory by the database.,0,m
 mongodb.mem.mappedwithjournal,gauge,,mebibyte,,"The amount of mapped memory, including the memory used for journaling.",0,mongodb,memory mapped with journal
 mongodb.mem.resident,gauge,,mebibyte,,Amount of memory currently used by the database process.,0,mongodb,mem resident
 mongodb.mem.virtual,gauge,,mebibyte,,Amount of virtual memory used by the mongod process.,0,mongodb,mem virtual
-mongodb.metrics.commands.count.failed,rate,,commands,,Number of times "count" failed,-1,mongodb,cmd count failed
-mongodb.metrics.commands.count.total,gauge,,commands,,Number of times "count" executed,0,mongodb,cmd count executed
-mongodb.metrics.commands.createIndexes.failed,rate,,commands,,Number of times "createIndexes" failed,-1,mongodb,cmd createIndexes failed
-mongodb.metrics.commands.createIndexes.total,gauge,,commands,,Number of times "createIndexes" executed,0,mongodb,cmd createIndexes executed
-mongodb.metrics.commands.delete.failed,rate,,commands,,Number of times "delete" failed,-1,mongodb,cmd delete failed
-mongodb.metrics.commands.delete.total,gauge,,commands,,Number of times "delete" executed,0,mongodb,cmd delete executed
-mongodb.metrics.commands.eval.failed,rate,,commands,,Number of times "eval" failed,-1,mongodb,cmd eval failed
-mongodb.metrics.commands.eval.total,gauge,,commands,,Number of times "eval" executed,0,mongodb,cmd eval executed
-mongodb.metrics.commands.findAndModify.failed,rate,,commands,,Number of times "findAndModify" failed,-1,mongodb,cmd findAndModify failed
-mongodb.metrics.commands.findAndModify.total,gauge,,commands,,Number of times "findAndModify" executed,0,mongodb,cmd findAndModify executed
-mongodb.metrics.commands.insert.failed,rate,,commands,,Number of times "insert" failed,-1,mongodb,cmd insert failed
-mongodb.metrics.commands.insert.total,gauge,,commands,,Number of times "insert" executed,0,mongodb,cmd insert executed
-mongodb.metrics.commands.update.failed,rate,,commands,,Number of times "update" failed,-1,mongodb,cmd update failed
-mongodb.metrics.commands.update.total,gauge,,commands,,Number of times "update" executed,0,mongodb,cmd update executed
-mongodb.metrics.cursor.open.notimeout,gauge,,cursor,,Number of open cursors with the option `DBQuery.Option.noTimeout` set to prevent timeout after a period of inactivity.,-1,mongodb,cursors open no timeout
-mongodb.metrics.cursor.open.pinned,gauge,,cursor,,Number of “pinned” open cursors.,0,mongodb,cursors open pinned
+mongodb.metrics.commands.count.failed,rate,,commands,,"Number of times count failed",-1,mongodb,cmd count failed
+mongodb.metrics.commands.count.total,gauge,,commands,,"Number of times count executed",0,mongodb,cmd count executed
+mongodb.metrics.commands.createIndexes.failed,rate,,commands,,"Number of times createIndexes failed",-1,mongodb,cmd createIndexes failed
+mongodb.metrics.commands.createIndexes.total,gauge,,commands,,"Number of times createIndexes executed",0,mongodb,cmd createIndexes executed
+mongodb.metrics.commands.delete.failed,rate,,commands,,"Number of times delete failed",-1,mongodb,cmd delete failed
+mongodb.metrics.commands.delete.total,gauge,,commands,,"Number of times delete executed",0,mongodb,cmd delete executed
+mongodb.metrics.commands.eval.failed,rate,,commands,,"Number of times eval failed",-1,mongodb,cmd eval failed
+mongodb.metrics.commands.eval.total,gauge,,commands,,"Number of times eval executed",0,mongodb,cmd eval executed
+mongodb.metrics.commands.findAndModify.failed,rate,,commands,,"Number of times findAndModify failed",-1,mongodb,cmd findAndModify failed
+mongodb.metrics.commands.findAndModify.total,gauge,,commands,,"Number of times findAndModify executed",0,mongodb,cmd findAndModify executed
+mongodb.metrics.commands.insert.failed,rate,,commands,,"Number of times insert failed",-1,mongodb,cmd insert failed
+mongodb.metrics.commands.insert.total,gauge,,commands,,"Number of times insert executed",0,mongodb,cmd insert executed
+mongodb.metrics.commands.update.failed,rate,,commands,,"Number of times update failed",-1,mongodb,cmd update failed
+mongodb.metrics.commands.update.total,gauge,,commands,,"Number of times update executed",0,mongodb,cmd update executed
+mongodb.metrics.cursor.open.notimeout,gauge,,cursor,,"Number of open cursors with the option `DBQuery.Option.noTimeout` set to prevent timeout after a period of inactivity.",-1,mongodb,cursors open no timeout
+mongodb.metrics.cursor.open.pinned,gauge,,cursor,,"Number of pinned open cursors.",0,mongodb,cursors open pinned
 mongodb.metrics.cursor.open.total,gauge,,cursor,,Number of cursors that MongoDB is maintaining for clients.,-1,mongodb,open cursors
 mongodb.metrics.cursor.timedoutps,gauge,,cursor,second,"Number of cursors that time out, per second.",-1,mongodb,timed out cursors per s
 mongodb.metrics.document.deletedps,gauge,,document,second,Number of documents deleted per second.,0,mongodb,document deleted ps

--- a/mongo/metadata.csv
+++ b/mongo/metadata.csv
@@ -10,6 +10,7 @@ mongodb.backgroundflushing.last_ms,gauge,,millisecond,,Amount of time that the l
 mongodb.backgroundflushing.total_ms,gauge,,millisecond,,Total number of time that the `mongod` processes have spent writing (i.e. flushing) data to disk.,0,mongodb,background flushing total ms
 mongodb.connections.available,gauge,,connection,,Number of unused available incoming connections the database can provide.,0,mongodb,connections available
 mongodb.connections.current,gauge,,connection,,Number of connections to the database server from clients.,0,mongodb,connections current
+mongodb.connections.totalcreated,gauge,,connection,,Total number of connections created.,0,mongodb,connections created
 mongodb.cursors.timedout,gauge,,cursor,,Total number of cursors that have timed out since the server process started.,0,mongodb,cursors timed out
 mongodb.cursors.totalopen,gauge,,cursor,,Number of cursors that MongoDB is maintaining for clients,0,mongodb,cursors open
 mongodb.dbs,gauge,,item,,Total number of existing databases,0,mongodb,databases
@@ -27,6 +28,7 @@ mongodb.dur.timems.writetodatafiles,gauge,,millisecond,,Amount of time spent wri
 mongodb.dur.timems.writetojournal,gauge,,millisecond,,Amount of time spent writing to the journal,-1,mongodb,dur time ms write to journal
 mongodb.dur.writetodatafilesmb,gauge,,mebibyte,,Amount of data written from journal to the data files during the last journal group commit interval.,-1,mongodb,dur write to data files mb
 mongodb.extra_info.page_faultsps,gauge,,fault,second,Number of page faults per second that require disk operations.,0,mongodb,pagefaults ps
+mongodb.fsynclocked,gauge,,,,Number of fsynclocked performed on a mongo instance.,0,mongodb,fsynclocked
 mongodb.globallock.activeclients.readers,gauge,,connection,,Count of the active client connections performing read operations.,0,mongodb,active clients readers
 mongodb.globallock.activeclients.total,gauge,,connection,,Total number of active client connections to the database.,0,mongodb,active clients total
 mongodb.globallock.activeclients.writers,gauge,,connection,,Count of active client connections performing write operations.,0,mongodb,active clients writers
@@ -87,6 +89,7 @@ mongodb.locks.oplog.acquirewaitcount.intent_exclusiveps,gauge,,wait,second,Numbe
 mongodb.locks.oplog.acquirewaitcount.sharedps,gauge,,wait,second,Number of times the oplog lock type acquisition in the Shared (S) mode encountered waits because the locks were held in a conflicting mode.,-1,mongodb,locks oplog wait count shared
 mongodb.locks.oplog.timeacquiringmicros.intent_exclusiveps,gauge,,fraction,,Wait time for the oplog lock type acquisitions in the Intent Exclusive (IX) mode.,-1,mongodb,locks oplog wait time intent_exclusive
 mongodb.locks.oplog.timeacquiringmicros.sharedps,gauge,,fraction,,Wait time for the oplog lock type acquisitions in the Shared (S) mode.,-1,mongodb,locks oplog wait time shared
+mongodb.mem.bits,gauge,,mebibyte,,Size of the in-memory storage engine.,0,mongodb,mem bits
 mongodb.mem.mapped,gauge,,mebibyte,,Amount of mapped memory by the database.,0,mongodb,mem mapped
 mongodb.mem.mappedwithjournal,gauge,,mebibyte,,"The amount of mapped memory, including the memory used for journaling.",0,mongodb,memory mapped with journal
 mongodb.mem.resident,gauge,,mebibyte,,Amount of memory currently used by the database process.,0,mongodb,mem resident
@@ -118,6 +121,7 @@ mongodb.metrics.getlasterror.wtime.totalmillisps,gauge,,fraction,,Fraction of ti
 mongodb.metrics.getlasterror.wtimeoutsps,gauge,,event,second,Number of times per second that write concern operations have timed out as a result of the wtimeout threshold to getLastError,0,mongodb,getlasterror wtimeouts ps
 mongodb.metrics.operation.fastmodps,gauge,,operation,second,Number of update operations per second that neither cause documents to grow nor require updates to the index.,0,mongodb,operation fastmod ps
 mongodb.metrics.operation.idhackps,gauge,,query,second,Number of queries per second that contain the _id field.,0,mongodb,operation idhack ps
+mongodb.metrics.operation.writeconflictsps,rate,,event,,Number of times per second that write concern operations has encounter a conflict.,0,mongodb,wite conflict
 mongodb.metrics.operation.scanandorderps,gauge,,query,second,Number of queries per second that return sorted numbers that cannot perform the sort operation using an index.,0,mongodb,operation scanandorder ps
 mongodb.metrics.queryexecutor.scannedps,gauge,,operation,second,Number of index items scanned per second during queries and query-plan evaluation.,0,mongodb,queryexecutor scanned ps
 mongodb.metrics.record.movesps,gauge,,operation,second,Number of times per second documents move within the on-disk representation of the MongoDB data set.,0,mongodb,record moves ps
@@ -132,8 +136,15 @@ mongodb.metrics.repl.network.getmores.numps,gauge,,operation,second,Number of ge
 mongodb.metrics.repl.network.getmores.totalmillisps,gauge,,fraction,,Fraction of time (ms/s) required to collect data from getmore operations.,0,mongodb,repl network getmores totalmillis ps
 mongodb.metrics.repl.network.opsps,gauge,,operation,second,Number of operations read from the replication source per second.,0,mongodb,repl network ops ps
 mongodb.metrics.repl.network.readerscreatedps,gauge,,process,second,Number of oplog query processes created per second.,0,mongodb,repl network readerscreated ps
+mongodb.metrics.repl.preload.docs.numps,rate,,doc,,"Number of documents loaded during the pre-fetch stage of replication.",0,mongodb,repl docs nums
+mongodb.metrics.repl.preload.docs.totalmillisps,rate,,millisecond,,"Amount of time spent loading documents as part of the pre-fetch stage of replication.",0,mongodb,repl docs nums
+mongodb.metrics.repl.preload.indexes.numps,rate,,doc,,"Number of index entries loaded by members before updating documents as part of the pre-fetch stage of replication.",0,mongodb,repl docs nums
+mongodb.metrics.repl.preload.indexes.totalmillisps,rate,,millisecond,,"Amount of time spent loading documents as part of the pre-fetch stage of replication.",0,mongodb,repl docs nums
 mongodb.metrics.ttl.deleteddocumentsps,gauge,,document,second,Number of documents deleted from collections with a ttl index per second.,0,mongodb,ttl deleted docs ps
 mongodb.metrics.ttl.passesps,gauge,,operation,second,Number of times per second the background process removes documents from collections with a ttl index.,0,mongodb,ttl passes ps
+mongodb.network.bytesinps,rate,,byte,,"The number of bytes that reflects the amount of network traffic received by this database.",0,mongodb,bytes inps
+mongodb.network.bytesoutps,rate,,byte,,"The number of bytes that reflects the amount of network traffic sent from this database.",0,mongodb,bytes outps
+mongodb.network.numrequestsps,rate,,request,,"Number of distinct requests that the server has received.",0,mongodb,num requests ps
 mongodb.opcounters.commandps,gauge,,command,second,Total number of commands per second issued to the database.,0,mongodb,opcounters command ps
 mongodb.opcounters.deleteps,gauge,,operation,second,Number of delete operations per second.,0,mongodb,opcounters delete ps
 mongodb.opcounters.getmoreps,gauge,,operation,second,Number of getmore operations per second.,0,mongodb,opcounters getmore ps
@@ -151,6 +162,9 @@ mongodb.oplog.timediff,gauge,,second,,Oplog window: difference between the first
 mongodb.oplog.usedsizemb,gauge,,mebibyte,,Total amount of space used by the oplog.,0,mongodb,oplog used size mb
 mongodb.replset.health,gauge,,,,Member health value of the replica set: conveys if the member is up (i.e. 1) or down (i.e. 0).,1,mongodb,replset health
 mongodb.replset.replicationlag,gauge,,second,,Delay between a write operation on the primary and its copy to a secondary.,-1,mongodb,replication lag
+mongodb.replset.state,gauge,,,,"State of a replica that reflects its disposition within the set.",0,mongodb,replset state
+mongodb.replset.votefraction,gauge,,fraction,,"Fraction of votes a server will cast in a replica set election.",0,mongodb,votes fraction
+mongodb.replset.votes,gauge,,vote,,"The number of votes a server will cast in a replica set election.",0,mongodb,replset votes
 mongodb.stats.datasize,gauge,,byte,,Total size of the data held in this database including the padding factor.,0,mongodb,stats datasize
 mongodb.stats.indexes,gauge,,index,,Total number of indexes across all collections in the database.,0,mongodb,stats indexes
 mongodb.stats.indexsize,gauge,,byte,,Total size of all indexes created on this database.,0,mongodb,stats indexsize


### PR DESCRIPTION
### What does this PR do?

1. adding the following missing metrics:

mongodb.connections.totalcreated
mongodb.fsynclocked
mongodb.mem.bits
mongodb.metrics.operation.writeconflictsps
mongodb.metrics.repl.preload.docs.numps
mongodb.metrics.repl.preload.docs.totalmillisps
mongodb.metrics.repl.preload.indexes.numps
mongodb.metrics.repl.preload.indexes.totalmillisps
mongodb.network.bytesinps
mongodb.network.bytesoutps
mongodb.network.numrequestsps
mongodb.replset.state
mongodb.replset.votefraction
mongodb.replset.votes

2. Fixing metrics desc to fix csv layout