### PR TITLE
[docker_daemon] add `exec_die` to default event exclusion list

### DIFF
--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - docker_daemon
 
+1.9.0 / Unreleased
+==================
+### Changes
+
+* [IMPROVEMENT] add the new `exec_die` event type to default exclusion list. See [#1240][]
+
 1.8.0 / 2018-02-13
 ==================
 ### Changes

--- a/docker_daemon/conf.yaml.example
+++ b/docker_daemon/conf.yaml.example
@@ -53,13 +53,14 @@ instances:
     #
     # collect_events: false
 
-    # By default we do not collect events with a status ['top', 'exec_start', 'exec_create'].
+    # By default we do not collect events with a status ['top', 'exec_start', 'exec_create', 'exec_die'].
     # Here can be added additional statuses to be filtered.
     # List of available statuses can be found here https://docs.docker.com/engine/reference/commandline/events/#object-types
     # filtered_event_types:
     #    - 'top'
     #    - 'exec_start'
     #    - 'exec_create'
+    #    - 'exec_die'
 
     # Collect disk usage per container with docker.container.size_rw and
     # docker.container.size_rootfs metrics.

--- a/docker_daemon/datadog_checks/docker_daemon/__init__.py
+++ b/docker_daemon/datadog_checks/docker_daemon/__init__.py
@@ -2,6 +2,6 @@ from . import docker_daemon
 
 DockerDaemon = docker_daemon.DockerDaemon
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"
 
 __all__ = ['docker_daemon']

--- a/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py
+++ b/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py
@@ -151,6 +151,7 @@ DEFAULT_FILTERED_EVENT_TYPES = [
     'top',
     'exec_create',
     'exec_start',
+    'exec_die',
 ]
 
 CONTAINER = "container"

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -11,7 +11,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.8.0",
+  "version": "1.9.0",
   "public_title": "Datadog-Docker Integration",
   "categories":["containers"],
   "type":"check",


### PR DESCRIPTION
Backport the new event exclusion list from https://github.com/DataDog/datadog-agent/pull/1438