### PR TITLE
Adding db.rollback when transaction fails so we can get metrics from old postgres

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - postgres
 
+2.1.1 / 2018-03-13
+=================
+### Changes
+* [BUGFIX] Adding db rollback when transaction fails in postgres metrics collection. See[#1193][].
+
 2.1.0 / 2018-03-07
 ==================
 ### Changes

--- a/postgres/datadog_checks/postgres/__init__.py
+++ b/postgres/datadog_checks/postgres/__init__.py
@@ -2,6 +2,6 @@ from . import postgres
 
 PostgreSql = postgres.PostgreSql
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 __all__ = ['postgres']

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -543,6 +543,7 @@ SELECT s.schemaname,
             results = cursor.fetchall()
         except programming_error as e:
             log_func("Not all metrics may be available: %s" % str(e))
+            db.rollback()
             return None
 
         if not results:

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
+  "manifest_version": "0.1.2",
   "max_agent_version": "6.0.0",
   "min_agent_version": "5.6.3",
   "name": "postgres",


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

This change adds a rollback to the metrics collection logic. When a query fails on an older version of postgres, the transaction will be rolled back in the event of a failure. Without this patch, no metrics are collected on older versions of postgres. (<=8).

### Motivation

We installed datadog on an older version of postgres and no metrics were collected. We traced down the issue, added the rollback and now metrics are shipping.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ x] Bumped the check version in `manifest.json`
- [ x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

This addresses issue https://github.com/DataDog/integrations-core/issues/1193