### PR TITLE
Update Rabbitmq integration with Log collection instruction

### DIFF
--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -15,13 +15,16 @@ And more.
 The RabbitMQ check is packaged with the Agent, so simply [install the Agent](https://app.datadoghq.com/account/settings#agent) on your RabbitMQ servers.
 
 ### Configuration
+
+Create a file `rabbitmq.yaml` in the Agent's `conf.d` directory.
+
 #### Prepare RabbitMQ
 
 You must enable the RabbitMQ management plugin. See [RabbitMQ's documentation](https://www.rabbitmq.com/management.html) to enable it.
 
-#### Connect the Agent
+#### Metric Collection
 
-Create a file `rabbitmq.yaml` in the Agent's `conf.d` directory. See the [sample rabbitmq.yaml](https://github.com/DataDog/integrations-core/blob/master/rabbitmq/conf.yaml.example) for all available configuration options:
+* Add this configuration setup to your `rabbitmq.yaml` file to start gathering your [RabbitMQ metrics](#metrics):
 
 ```
 init_config:
@@ -54,7 +57,44 @@ Configuration Options
 * `queues` or `queues_regexes` - **optional** - Use the `queues` or `queues_regexes` parameters to specify the queues you'd like to collect metrics on (up to 200 queues). If you have less than 200 queues, you don't have to set this parameter, the metrics will be collected on all the queues by. default. If you have set up vhosts, set the queue names as `vhost_name/queue_name`. If you have `tag_families` enabled, the first captured group in the regex will be used as the queue_family tag.  See the link to the example YAML below for more.
 * `vhosts` - **optional** - By default a list of all vhosts is fetched and each one will be checked using the aliveness API. If you prefer only certain vhosts to be monitored, list the vhosts you care about.
 
-[Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent) to begin sending RabbitMQ metrics, events, and service checks to Datadog.
+ See the [sample rabbitmq.yaml](https://github.com/DataDog/integrations-core/blob/master/rabbitmq/conf.yaml.example) for all available configuration options.
+* [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent) to begin sending RabbitMQ metrics, events, and service checks to Datadog.
+
+#### Log Collection
+
+**Available for Agent >6.0**
+
+1. To modify the default log file location either set the `RABBITMQ_LOGS` environment variable or add the following in your rabbitmq configuration file (`/etc/rabbitmq/rabbitmq.conf`):
+
+```
+log.dir = /var/log/rabbit
+log.file = rabbit.log
+```
+
+2. Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
+
+    ```
+    logs_enabled: true
+    ```
+    
+3. Add this configuration setup to your `rabbitmq.yaml` file to start collecting your RabbitMQ logs:
+
+```
+logs:
+    
+    - type: file
+      path: /var/log/rabbit/*.log
+      source: rabbitmq
+      service: myservice
+      log_processing_rules:
+        - type: multi_line
+          name: logs_starts_with_equal_sign
+          pattern: =
+```
+
+See the [sample rabbitmq.yaml](https://github.com/DataDog/integrations-core/blob/master/rabbitmq/conf.yaml.example) for all available configuration options.
+
+4. [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent).
 
 ### Validation
 

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -16,11 +16,11 @@ The RabbitMQ check is packaged with the Agent, so simply [install the Agent](htt
 
 ### Configuration
 
-Create a file `rabbitmq.yaml` in the Agent's `conf.d` directory.
+Create a `rabbitmq.yaml` file in the Agent's `conf.d` directory.
 
 #### Prepare RabbitMQ
 
-You must enable the RabbitMQ management plugin. See [RabbitMQ's documentation](https://www.rabbitmq.com/management.html) to enable it.
+Enable the RabbitMQ management plugin. See [RabbitMQ's documentation](https://www.rabbitmq.com/management.html) to enable it.
 
 #### Metric Collection
 
@@ -71,7 +71,7 @@ log.dir = /var/log/rabbit
 log.file = rabbit.log
 ```
 
-2. Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
+2. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
     ```
     logs_enabled: true

--- a/rabbitmq/conf.yaml.example
+++ b/rabbitmq/conf.yaml.example
@@ -69,3 +69,22 @@ instances:
     # tags:
     #   - "key:value"
     #   - "instance:production"
+    
+## Log Section (Available for Agent >=6.0)
+#logs:
+
+    # - type : (mandatory) type of log input source (tcp / udp / file / docker)
+    #   port / path : (mandatory) Set port if type is tcp or udp. Set path if type is file
+    #   service : (mandatory) name of the service owning the log
+    #   source : (mandatory) attribute that defines which integration is sending the logs
+    #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
+    #   tags: (optional) add tags to each logs collected
+    
+   # - type: file
+   #   path: /var/log/rabbit/*.log
+   #   source: rabbitmq
+   #   service: myservice
+   #   log_processing_rules:
+   #     - type: multi_line
+   #       name: logs_starts_with_equal_sign
+   #       pattern: =

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -14,7 +14,7 @@
   "version": "1.5.1",
   "guid": "a790a556-fbaa-4208-9d39-c42c3d57084b",
   "public_title": "Datadog-RabbitMQ Integration",
-  "categories":["processing"],
+  "categories":["processing", "log collection"],
   "type":"check",
   "doc_link": "https://docs.datadoghq.com/integrations/rabbitmq/",
   "is_public": true,


### PR DESCRIPTION
### What does this PR do?

Add log instruction for RabbitMQ integration

### Motivation

RabbitMQ is now supported for logs and the documentation should be updated.

### Testing Guidelines


### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
