### PR TITLE
[mysql] Add custom tag support to service checks

### DIFF
--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - mysql
 
+1.2.0 / Unreleased
+==================
+### Changes
+
+* [FEATURE] Add custom tag support to service checks.
+
 1.1.3 / 2018-03-23
 ==================
 ### Changes

--- a/mysql/datadog_checks/mysql/__init__.py
+++ b/mysql/datadog_checks/mysql/__init__.py
@@ -2,6 +2,6 @@ from . import mysql
 
 MySql = mysql.MySql
 
-__version__ = "1.1.3"
+__version__ = "1.2.0"
 
 __all__ = ['mysql']

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -297,7 +297,7 @@ class MySql(AgentCheck):
             raise Exception("Mysql host and user are needed.")
 
         with self._connect(host, port, mysql_sock, user,
-                           password, defaults_file, ssl, connect_timeout) as db:
+                           password, defaults_file, ssl, connect_timeout, tags) as db:
             try:
                 # Metadata collection
                 self._collect_metadata(db, host)
@@ -358,11 +358,14 @@ class MySql(AgentCheck):
         return hostkey
 
     @contextmanager
-    def _connect(self, host, port, mysql_sock, user, password, defaults_file, ssl, connect_timeout):
+    def _connect(self, host, port, mysql_sock, user, password, defaults_file, ssl, connect_timeout, tags):
         self.service_check_tags = [
             'server:%s' % (mysql_sock if mysql_sock != '' else host),
             'port:%s' % ('unix_socket' if port == 0 else port)
         ]
+
+        if tags is not None:
+            self.service_check_tags.extend(tags)
 
         db = None
         try:
@@ -378,7 +381,7 @@ class MySql(AgentCheck):
                 self.service_check_tags = [
                     'server:{0}'.format(mysql_sock),
                     'port:unix_socket'
-                ]
+                ] + tags
                 db = pymysql.connect(
                     unix_socket=mysql_sock,
                     user=user,
@@ -403,6 +406,7 @@ class MySql(AgentCheck):
                     connect_timeout=connect_timeout
                 )
             self.log.debug("Connected to MySQL")
+            self.service_check_tags = list(set(self.service_check_tags))
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
                                tags=self.service_check_tags)
             yield db

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1.1",
   "name": "MySQL",
   "display_name": "MySQL",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "support": "core",
   "supported_os": [
     "linux",

--- a/mysql/test/test_mysql.py
+++ b/mysql/test/test_mysql.py
@@ -38,7 +38,7 @@ class TestMySql(AgentCheckTest):
         'pass': 'dog',
         'port': '13306',
         'options': {
-            'replication': True, 
+            'replication': True,
             'extra_status_metrics': True,
             'extra_innodb_metrics': True,
             'extra_performance_metrics': True,

--- a/mysql/test/test_mysql.py
+++ b/mysql/test/test_mysql.py
@@ -19,8 +19,8 @@ class TestMySql(AgentCheckTest):
     CHECK_NAME = 'mysql'
 
     METRIC_TAGS = ['tag1', 'tag2']
-    SC_TAGS = ['server:localhost', 'port:13306']
-    SC_TAGS_REPLICA = ['server:localhost', 'port:13307']
+    SC_TAGS = ['server:localhost', 'port:13306', 'tag1', 'tag2']
+    SC_TAGS_REPLICA = ['server:localhost', 'port:13307', 'tag1', 'tag2']
     SC_FAILURE_TAGS = ['server:localhost', 'port:unix_socket']
 
 

--- a/mysql/test/test_mysql.py
+++ b/mysql/test/test_mysql.py
@@ -20,6 +20,7 @@ class TestMySql(AgentCheckTest):
 
     METRIC_TAGS = ['tag1', 'tag2']
     SC_TAGS = ['server:localhost', 'port:13306', 'tag1', 'tag2']
+    SC_TAGS_MIN = ['server:localhost', 'port:13306']
     SC_TAGS_REPLICA = ['server:localhost', 'port:13307', 'tag1', 'tag2']
     SC_FAILURE_TAGS = ['server:localhost', 'port:unix_socket']
 
@@ -37,7 +38,7 @@ class TestMySql(AgentCheckTest):
         'pass': 'dog',
         'port': '13306',
         'options': {
-            'replication': True,
+            'replication': True, 
             'extra_status_metrics': True,
             'extra_innodb_metrics': True,
             'extra_performance_metrics': True,
@@ -332,7 +333,7 @@ class TestMySql(AgentCheckTest):
 
         # Test service check
         self.assertServiceCheck('mysql.can_connect', status=AgentCheck.OK,
-                                tags=self.SC_TAGS, count=1)
+                                tags=self.SC_TAGS_MIN, count=1)
 
         # Test metrics
         testable_metrics = (self.STATUS_VARS + self.VARIABLES_VARS + self.INNODB_VARS +


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
