### PR TITLE
Change loading of default certificate file to relative rather than

### DIFF
--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG - http_check
 
+1.4.1 / Unreleased
+==================
+
+### Changes
+
+* [BUGFIX] Make import of default certificate file relative rather than absolute
+  Fixes loading problem on Windows, and/or allows check to be installed in other
+  location
+
 1.4.0 / 2018-02-13
 ==================
 

--- a/http_check/datadog_checks/http_check/__init__.py
+++ b/http_check/datadog_checks/http_check/__init__.py
@@ -2,6 +2,6 @@ from . import http_check
 
 HTTPCheck = http_check.HTTPCheck
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 __all__ = ['http_check']

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -131,7 +131,13 @@ def get_ca_certs_path():
     """
     Get a path to the trusted certificates of the system
     """
-    ca_certs = ['/opt/datadog-agent/embedded/ssl/certs/cacert.pem']
+    """
+    check is installed via pip to embedded/lib/site-packages/datadog_checks/http_check
+    certificate is installed to   embedded/ssl/certs/cacert.pem
+
+    walk up to embedded, and back down to ssl/certs to find the certificate file
+    """
+    ca_certs = [os.path.normpath(os.path.join(os.path.dirname(__file__), '../../../..', 'ssl/certs', 'cacert.pem'))]
 
     try:
         import tornado

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.4.0",
+  "version": "1.4.1",
   "guid": "eb133a1f-697c-4143-bad3-10e72541fa9c",
   "public_title": "Datadog-HTTP Check Integration",
   "categories":["web", "network"],


### PR DESCRIPTION
absolute.  Fixes loading certificate on Windows, and allows for
agent to be installed in alternate locations

### Motivation

customer bug report

- [ x ] Bumped the check version in `manifest.json`
- [ x ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ x ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
