### PR TITLE
[consul] add maintenance metric to Consul catalog.

### DIFF
--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - consul
 
+1.3.1 / Unreleased
+=================
+
+* [IMPROVEMENT] Add maintenance metrics (services_maintenance and nodes_maintenance) 
+
 1.3.0 / 2018-01-10
 ==================
 

--- a/consul/datadog_checks/consul/__init__.py
+++ b/consul/datadog_checks/consul/__init__.py
@@ -2,6 +2,6 @@ from . import consul
 
 ConsulCheck = consul.ConsulCheck
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 __all__ = ['consul']

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.3.0",
+  "version": "1.3.1",
   "guid": "ec1e9fac-a339-49a3-b501-60656d2a5671",
   "public_title": "Datadog-Consul Integration",
   "categories":["containers", "orchestration", "configuration & deployment", "notification"],

--- a/consul/metadata.csv
+++ b/consul/metadata.csv
@@ -1,9 +1,11 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 consul.catalog.nodes_critical,gauge,,node,,Number of nodes with service status `critical` from those registered,-1,consul,nodes crit
+consul.catalog.nodes_maintenance,gauge,,node,,Number of nodes in maintenance from those registered,-1,consul,nodes maint
 consul.catalog.nodes_passing,gauge,,node,,Number of nodes with service status `passing` from those registered,1,consul,nodes pass
 consul.catalog.nodes_up,gauge,,node,,Number of nodes,0,consul,nodes up
 consul.catalog.nodes_warning,gauge,,node,,Number of nodes with service status `warning` from those registered,-1,consul,nodes warn
 consul.catalog.services_critical,gauge,,service,,Total critical services on nodes,-1,consul,svc crit
+consul.catalog.services_maintenance,gauge,,service,,Total services in maintenance on nodes,-1,consul,svc maint
 consul.catalog.services_passing,gauge,,service,,Total passing services on nodes,1,consul,svc pass
 consul.catalog.services_up,gauge,,service,,Total services registered on nodes,0,consul,svc up
 consul.catalog.services_warning,gauge,,service,,Total warning services on nodes,-1,consul,svc warn


### PR DESCRIPTION
### What does this PR do?

It adds two metrics called `consul.catalog.services_maintenance` and `consul.catalog.nodes_maintenance` to Datadog Consul integration catalog.

The expected behavior is explained below.

**All nodes in healthy states**

- Consul is green
![screen shot 2018-03-15 at 1 30 21 pm](https://user-images.githubusercontent.com/779938/37463366-52db916a-2855-11e8-9d72-f3c4b272bece.png)
- Metrics per node are:
```
passing: 3
critical: 0
maintenance: 0
```
![screen shot 2018-03-15 at 1 35 34 pm](https://user-images.githubusercontent.com/779938/37463549-d7b11202-2855-11e8-9384-7a04c07cd293.png)

- Metrics per service are:
```
passing: 3
critical: 0
maintenance: 0
```
![screen shot 2018-03-15 at 1 35 23 pm](https://user-images.githubusercontent.com/779938/37463553-da67aaec-2855-11e8-81dc-84fa451ded64.png)

**One (1) node in faulty**

- Consul is failing for the faulty node
![screen shot 2018-03-15 at 1 40 52 pm](https://user-images.githubusercontent.com/779938/37463885-df2116d0-2856-11e8-88b4-63a415b00567.png)

- Metrics per node are:
```
passing: 2
critical: 1
maintenance: 0
```
![screen shot 2018-03-15 at 1 44 18 pm](https://user-images.githubusercontent.com/779938/37463927-037a84bc-2857-11e8-8add-8a136ef60c36.png)

- Metrics per service are:
```
passing: 2
critical: 1
maintenance: 0
```
![screen shot 2018-03-15 at 1 44 03 pm](https://user-images.githubusercontent.com/779938/37463928-05b9413c-2857-11e8-9c23-19460da3ba09.png)

**The faulty node is put in maintenance**

- Consul is failing for the faulty node and showing it also in maintenance
![screen shot 2018-03-15 at 1 47 03 pm](https://user-images.githubusercontent.com/779938/37464027-605dbc3a-2857-11e8-9db0-f24e7bbf8c9d.png)

- Metrics per node are:
```
passing: 2
critical: 0
maintenance: 1
```
![screen shot 2018-03-15 at 1 48 25 pm](https://user-images.githubusercontent.com/779938/37464093-a056a2e8-2857-11e8-95b8-e7e9f491a9bd.png)

- Metrics per service are:
```
passing: 2
critical: 0
maintenance: 1
```
![screen shot 2018-03-15 at 1 48 18 pm](https://user-images.githubusercontent.com/779938/37464097-a42ca4a8-2857-11e8-8794-f65f6c69af8f.png)

### Motivation

What inspired you to submit this pull request?

Currently, if a node in Consul is set into maintenance state, it is reported
as a node in critical state to Datadog metrics. This makes it confusing to
determine by the metric whether it is a node failing with problems or an planned
intervention.

A user made a PR to Datadog some time ago, but it was not merged due to
Datadog code organization changes and got forgotten (DataDog/dd-agent#2496).
I'm pushing the change forward. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [x] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 
   https://github.com/DataDog/documentation/issues/2187

### Additional Notes

This PR also depends on https://github.com/DataDog/dd-agent/pull/3708.
The screenshots and tests were done using dd-agent version 5.8.0.
I've ported the code to the latest version here available, but didn't have the opportunity to actually test it against the latest version. Anyways, I added tests, which I believe to cover the functionality. Please, let me know how to improve it.

