### PR TITLE
[Consul] Fixing sentence to enable metrics table display

### DIFF
--- a/consul/README.md
+++ b/consul/README.md
@@ -116,7 +116,7 @@ The Consul check is compatible with all major platforms.
 ## Data Collected
 ### Metrics
 
-See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/consul/metadata.csv) for a list of metrics provided by the Datadog Agent's Consul check.
+See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/consul/metadata.csv) for a list of metrics provided by this integration.
 
 See [Consul's Telemetry doc](https://www.consul.io/docs/agent/telemetry.html) for a description of metrics the Consul Agent sends to DogStatsD.
 


### PR DESCRIPTION
### What does this PR do?

Fix the metrics metadata.csv sentence to enable the metrics table display that is currently missing:

https://docs.datadoghq.com/integrations/consul/#metrics

### Motivation

https://github.com/DataDog/documentation/issues/2187