### PR TITLE
Add log collection instruction for Elasticsearch

### DIFF
--- a/elastic/README.md
+++ b/elastic/README.md
@@ -14,7 +14,11 @@ The Elasticsearch check is packaged with the Datadog Agent, so simply [install t
 
 ### Configuration
 
-Create a file `elastic.yaml` in the Datadog Agent's `conf.d` directory. See the [sample elastic.yaml](https://github.com/DataDog/integrations-core/blob/master/elastic/conf.yaml.example) for all available configuration options:
+Create a file `elastic.yaml` in the Datadog Agent's `conf.d` directory. 
+
+#### Metric Collection
+
+*  Add this configuration setup to your `elastic.yaml` file to start gathering your [ElasticSearch Metrics](#metrics):
 
 ```
 init_config:
@@ -36,7 +40,32 @@ See the [sample elastic.yaml](https://github.com/Datadog/integrations-core/blob/
 
 Finally, [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent) to begin sending Elasticsearch metrics to Datadog.
 
+#### Log Collection
 
+**Available for Agent >6.0**
+
+* Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
+
+  ```
+  logs_enabled: true
+  ```
+
+* Add this configuration setup to your `apache.yaml` file to start collecting your Elasticsearch Logs:
+
+  ```
+    logs:
+        - type: file
+          path: /var/log/elasticsearch/*.log
+          source: elasticsearch
+          service: myservice
+  ```
+
+  Change the `path` and `service` parameter values and configure them for your environment.
+  
+  * [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent) to begin sending Elasticsearch logs to Datadog.
+  
+  **Learn more about log collection [on the log documentation](https://docs.datadoghq.com/logs)**
+  
 ### Validation
 
 [Run the Agent's `status` subcommand](https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information) and look for `elastic` under the Checks section:

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -18,7 +18,7 @@ Create a file `elastic.yaml` in the Datadog Agent's `conf.d` directory.
 
 #### Metric Collection
 
-*  Add this configuration setup to your `elastic.yaml` file to start gathering your [ElasticSearch Metrics](#metrics):
+*  Add this configuration setup to your `elastic.yaml` file to start gathering your [ElasticSearch metrics](#metrics):
 
 ```
 init_config:
@@ -44,13 +44,13 @@ Finally, [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands
 
 **Available for Agent >6.0**
 
-* Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
+* Collecting logs is disabled by default in the Datadog Agent, enable it in the `datadog.yaml` file with:
 
   ```
   logs_enabled: true
   ```
 
-* Add this configuration setup to your `apache.yaml` file to start collecting your Elasticsearch Logs:
+* Then add this configuration setup to your `apache.yaml` file to start collecting your Elasticsearch Logs:
 
   ```
     logs:

--- a/elastic/conf.yaml.example
+++ b/elastic/conf.yaml.example
@@ -47,3 +47,19 @@ instances:
     # tags:
     #   - 'tag1:key1'
     #   - 'tag2:key2'
+    
+## Log Section (Available for Agent >=6.0)
+
+#logs:
+
+    # - type : (mandatory) type of log input source (tcp / udp / file)
+    #   port / path : (mandatory) Set port if type is tcp or udp. Set path if type is file
+    #   service : (mandatory) name of the service owning the log
+    #   source : (mandatory) attribute that defines which integration is sending the logs
+    #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
+    #   tags: (optional) add tags to each logs collected
+    
+    # - type: file
+    #   path: /var/log/elasticsearch/*.log
+    #   source: elasticsearch
+    #   service: myservice

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -14,7 +14,7 @@
   "version": "1.5.0",
   "guid": "d91d91bd-4a8e-4489-bfb1-b119d4cc388a",
   "public_title": "Datadog-ElasticSearch Integration",
-  "categories":["data store"],
+  "categories":["data store", "log collection"],
   "type":"check",
   "doc_link": "https://docs.datadoghq.com/integrations/elasticsearch/",
   "is_public": true,


### PR DESCRIPTION
### What does this PR do?

Add documentation and instruction to collect elasticsearch logs

### Motivation

The integration is now supported for logs.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
