### PR TITLE
Add log collection instruction in the consul integration

### DIFF
--- a/consul/README.md
+++ b/consul/README.md
@@ -26,9 +26,11 @@ The Datadog Agent's Consul Check is included in the Agent package, so simply [in
 
 ### Configuration
 
-#### Connect Datadog Agent to Consul Agent
+Create a `consul.yaml` in the Datadog Agent's `conf.d` directory.
 
-Create a `consul.yaml` in the Datadog Agent's `conf.d` directory. See the [sample consul.yaml](https://github.com/DataDog/integrations-core/blob/master/consul/conf.yaml.example) for all available configuration options:
+#### Metric Collection
+
+*  Add this configuration setup to your `consul.yaml` file to start gathering your [Consul Metrics](#metrics):
 
 ```
 init_config:
@@ -68,6 +70,32 @@ In the main Consul configuration file, add your `dogstatsd_addr` nested under th
 ```
 
 Reload the Consul Agent to start sending more Consul metrics to DogStatsD.
+
+#### Log Collection
+
+**Available for Agent >6.0**
+
+* Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
+
+  ```
+  logs_enabled: true
+  ```
+
+* Add this configuration setup to your `consul.yaml` file to start collecting your Consul Logs:
+
+  ```
+    logs:
+        - type: file
+          path: /var/log/consul_server.log
+          source: consul
+          service: myservice
+  ```
+Change the `path` and `service` parameter values and configure them for your environment.
+  See the [sample consul.yaml](https://github.com/DataDog/integrations-core/blob/master/consul/conf.yaml.example) for all available configuration options.
+
+* [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent).
+
+**Learn more about log collection [on the log documentation](https://docs.datadoghq.com/logs)**
 
 ### Validation
 

--- a/consul/README.md
+++ b/consul/README.md
@@ -75,7 +75,7 @@ Reload the Consul Agent to start sending more Consul metrics to DogStatsD.
 
 **Available for Agent >6.0**
 
-* Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
+* Collecting logs is disabled by default in the Datadog Agent, enable it in `datadog.yaml` with:
 
   ```
   logs_enabled: true

--- a/consul/conf.yaml.example
+++ b/consul/conf.yaml.example
@@ -59,3 +59,19 @@ instances:
       # on the same agent.
       # tags:
       #   - 'consul_server:server1'
+
+## Log Section (Available for Agent >=6.0)
+
+#logs:
+
+    # - type : (mandatory) type of log input source (tcp / udp / file)
+    #   port / path : (mandatory) Set port if type is tcp or udp. Set path if type is file
+    #   service : (mandatory) name of the service owning the log
+    #   source : (mandatory) attribute that defines which integration is sending the logs
+    #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
+    #   tags: (optional) add tags to each logs collected
+    
+    # - type: file
+    #   path: /var/log/consul_server.log
+    #   source: consul
+    #   service: myservice

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -14,7 +14,7 @@
   "version": "1.3.0",
   "guid": "ec1e9fac-a339-49a3-b501-60656d2a5671",
   "public_title": "Datadog-Consul Integration",
-  "categories":["containers", "orchestration", "configuration & deployment", "notification"],
+  "categories":["containers", "orchestration", "configuration & deployment", "notification", "log collection"],
   "type":"check",
   "doc_link": "https://docs.datadoghq.com/integrations/consul/",
   "is_public": true,


### PR DESCRIPTION
### What does this PR do?

Add log collection instruction in the consul integration documentation

### Motivation

Consul logs now have their own integration

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
