### PR TITLE
Update the list of log collection integration

### DIFF
--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -13,7 +13,7 @@
   ],
   "version": "1.9.0",
   "public_title": "Datadog-Docker Integration",
-  "categories":["containers"],
+  "categories":["containers"," log collection"],
   "type":"check",
   "doc_link": "https://docs.datadoghq.com/integrations/docker_daemon/",
   "is_public": true,

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -13,7 +13,7 @@
   ],
   "version": "1.9.0",
   "public_title": "Datadog-Docker Integration",
-  "categories":["containers"," log collection"],
+  "categories":["containers", "log collection"],
   "type":"check",
   "doc_link": "https://docs.datadoghq.com/integrations/docker_daemon/",
   "is_public": true,

--- a/go-metro/manifest.json
+++ b/go-metro/manifest.json
@@ -12,7 +12,7 @@
   "version": "1.0.0",
   "guid": "6d00688b-32b1-4755-98cd-44bd1bd40428",
   "public_title": "Datadog-Go-Metro Integration",
-  "categories":["languages"],
+  "categories":["languages", "log collection"],
   "type":"check",
   "doc_link": "https://docs.datadoghq.com/integrations/go-metro/",
   "is_public": true,

--- a/go_expvar/manifest.json
+++ b/go_expvar/manifest.json
@@ -14,7 +14,7 @@
   "version": "1.0.3",
   "guid": "33557f7a-5f24-43f3-9551-78432894e539",
   "public_title": "Datadog-Go-Expvar Integration",
-  "categories":["languages"],
+  "categories":["languages", "log collection"],
   "type":"check",
   "doc_link": "https://docs.datadoghq.com/integrations/go_expvar/",
   "is_public": true,

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -13,7 +13,7 @@
   ],
   "version": "1.5.0",
   "public_title": "Datadog-Kubernetes Integration",
-  "categories":["orchestration", "containers"],
+  "categories":["orchestration", "containers", "log collection"],
   "type":"check",
   "doc_link": "https://docs.datadoghq.com/integrations/kubernetes/",
   "is_public": true,

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -14,7 +14,7 @@
   "version": "1.5.1",
   "guid": "a790a556-fbaa-4208-9d39-c42c3d57084b",
   "public_title": "Datadog-RabbitMQ Integration",
-  "categories":["processing"],
+  "categories":["processing", "log collection"],
   "type":"check",
   "doc_link": "https://docs.datadoghq.com/integrations/rabbitmq/",
   "is_public": true,


### PR DESCRIPTION
### What does this PR do?

Update the list of Log integration integrations

### Motivation

Using this tag should display all the supported integrations for logs

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
