### PR TITLE
[kube_state] add kubernetes_state.nodes.by_condition count

### DIFF
--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - kubernetes_state
 
+2.4.0 / unrelease
+==================
+
+* [IMPROVEMENT] Add kubernetes_state.nodes.by_condition count metric [#1277][]
+
 2.3.0 / 2018-02-28
 ==================
 

--- a/kubernetes_state/datadog_checks/kubernetes_state/__init__.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/__init__.py
@@ -2,6 +2,6 @@ from . import kubernetes_state
 
 KubernetesState = kubernetes_state.KubernetesState
 
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 
 __all__ = ['kubernetes_state']

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -422,42 +422,52 @@ class KubernetesState(PrometheusCheck):
             self.job_succeeded_count[frozenset(tags)] += metric.gauge.value
 
     def kube_node_status_condition(self, message, **kwargs):
-        """ The ready status of a cluster node. >v1.0.0"""
+        """ The ready status of a cluster node. v1.0+"""
         base_check_name = self.NAMESPACE + '.node'
+        metric_name = self.NAMESPACE + '.nodes.by_condition'
+
         for metric in message.metric:
             self._condition_to_tag_check(metric, base_check_name, self.condition_to_status_positive,
                                          tags=[self._label_to_tag("node", metric.label)])
 
+            # Counts aggregated cluster-wide to avoid no-data issues on node churn,
+            # node granularity available in the service checks
+            tags = [
+                self._label_to_tag("condition", metric.label),
+                self._label_to_tag("status", metric.label)
+            ]
+            self.count(metric_name, metric.gauge.value, tags)
+
     def kube_node_status_ready(self, message, **kwargs):
-        """ The ready status of a cluster node."""
+        """ The ready status of a cluster node (legacy)"""
         service_check_name = self.NAMESPACE + '.node.ready'
         for metric in message.metric:
             self._condition_to_service_check(metric, service_check_name, self.condition_to_status_positive,
                                              tags=[self._label_to_tag("node", metric.label)])
 
     def kube_node_status_out_of_disk(self, message, **kwargs):
-        """ Whether the node is out of disk space. """
+        """ Whether the node is out of disk space (legacy)"""
         service_check_name = self.NAMESPACE + '.node.out_of_disk'
         for metric in message.metric:
             self._condition_to_service_check(metric, service_check_name, self.condition_to_status_negative,
                                              tags=[self._label_to_tag("node", metric.label)])
 
     def kube_node_status_memory_pressure(self, message, **kwargs):
-        """ Whether the node is in a memory pressure state. """
+        """ Whether the node is in a memory pressure state (legacy)"""
         service_check_name = self.NAMESPACE + '.node.memory_pressure'
         for metric in message.metric:
             self._condition_to_service_check(metric, service_check_name, self.condition_to_status_negative,
                                              tags=[self._label_to_tag("node", metric.label)])
 
     def kube_node_status_disk_pressure(self, message, **kwargs):
-        """ Whether the node is in a disk pressure state. """
+        """ Whether the node is in a disk pressure state (legacy)"""
         service_check_name = self.NAMESPACE + '.node.disk_pressure'
         for metric in message.metric:
             self._condition_to_service_check(metric, service_check_name, self.condition_to_status_negative,
                                              tags=[self._label_to_tag("node", metric.label)])
 
     def kube_node_status_network_unavailable(self, message, **kwargs):
-        """ Whether the node is in a network unavailable state. """
+        """ Whether the node is in a network unavailable state (legacy)"""
         service_check_name = self.NAMESPACE + '.node.network_unavailable'
         for metric in message.metric:
             self._condition_to_service_check(metric, service_check_name, self.condition_to_status_negative,

--- a/kubernetes_state/manifest.json
+++ b/kubernetes_state/manifest.json
@@ -11,7 +11,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "2.3.0",
+  "version": "2.4.0",
   "use_omnibus_reqs": true,
   "public_title": "Datadog-Kubernetes State Integration",
   "categories":["orchestration", "containers"],

--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -45,6 +45,7 @@ kubernetes_state.node.cpu_allocatable,gauge,,cpu,,The CPU resources of a node th
 kubernetes_state.node.memory_allocatable,gauge,,byte,,The memory resources of a node that are available for scheduling,0,kubernetes,k8s_state.node.memory_allocatable
 kubernetes_state.node.pods_allocatable,gauge,,,,The pod resources of a node that are available for scheduling,0,kubernetes,k8s_state.node.pods_allocatable
 kubernetes_state.node.status,gauge,,,,Submitted with a value of 1 for each node and tagged either 'status:schedulable' or 'status:unschedulable'; Sum this metric by either status to get the number of nodes in that status.,0,kubernetes,k8s_state.node.status
+kubernetes_state.nodes.by_condition,count,,,,To sum by `condition` and `status` to get number of nodes in a given condition.,0,kubernetes,k8s_state.nodes.by_cond
 kubernetes_state.hpa.min_replicas,gauge,,,,Lower limit for the number of pods that can be set by the autoscaler,0,kubernetes,k8s_state.hpa.min_replicas
 kubernetes_state.hpa.max_replicas,gauge,,,,Upper limit for the number of pods that can be set by the autoscaler,0,kubernetes,k8s_state.hpa.max_replicas
 kubernetes_state.hpa.target_cpu,gauge,,,,Target CPU percentage of pods managed by this autoscaler,0,kubernetes,k8s_state.hpa.target_cpu


### PR DESCRIPTION
### What does this PR do?

Add a count metric `kubernetes_state.nodes.by_condition` extracted from the [`kube_node_status_condition` ksm metric](https://github.com/kubernetes/kube-state-metrics/blob/master/Documentation/node-metrics.md).

Current known tag values:
- condition:
  - MemoryPressure
  - DiskPressure
  - OutOfDisk
  - Ready
- status:
  - true
  - false
  - unknown

Aggregation is done client-side, and we report zeroes for all statuses to avoid non-data graphing issues. That makes for 12 new timeseries per cluster. Node-specific state is visible via the existing service checks.

### Motivation

Although the `kubernetes_state.node.*` service check allow to set alerts, we cannot graph them. This count could allow a user to graph their ready node count alongside their autoscaling group size for example. This count would not superseede the existing SCs, that offer node granularity.

Having node granularity on these counts would bring the `no data` issues we have with `kubernetes_state.pod.ready` when churning.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
