### PR TITLE
[CI/appveyor] Always upgrade pip

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,7 @@ install:
   - "%PYTHON%/Scripts/easy_install.exe %PYWIN_PATH%"
   - ps: mkdir -p $(python -m site --user-site)
   - ps: echo "C:\projects\dd-agent" | out-file "$(python -m site --user-site)/datadog-agent.pth" -encoding ASCII
+  - ps: (& "$env:PYTHON/python.exe" -m pip install --upgrade pip)
   - ps: '& "$env:PYTHON/Scripts/pip.exe" install -r c:\projects\dd-agent\requirements.txt'
   # Remove the adodbapi module shipped with pywin32: it conflicts with the pip-installed adodbapi
   - ps: rm $env:PYTHON/lib/site-packages/$env:PYWIN32_INSTALL_DIR/adodbapi/__init__.py


### PR DESCRIPTION
### What does this PR do?

 Always upgrades pip on Appveyor, to avoid having pip installs fail when pip is not at the latest
version

### Motivation

AppVeyor build is currently failing because of this
