### PR TITLE
Add Documentation for Tomcat Log integration

### DIFF
--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -254,7 +254,7 @@ log4j.logger.org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/hos
   INFO, HOST-MANAGER
 ```
 
-Check Tomcat [logging documentation](http://tomcat.apache.org/tomcat-7.0-doc/logging.html)For more information about Tomcat logging capabilities.
+Check Tomcat [logging documentation](http://tomcat.apache.org/tomcat-7.0-doc/logging.html) for more information about Tomcat logging capabilities.
 
 By default, our integration pipeline support the following conversion patterns:
 

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -23,7 +23,7 @@ Create a file `tomcat.yaml` in the Agent's `conf.d` directory.
 
 #### Metric Collection
 
-*  Add this configuration setup to your `tomcat.yaml` file to start gathering your [Tomcat Metrics](#metrics):
+*  Add this configuration setup to your `tomcat.yaml` file to start gathering your [Tomcat metrics](#metrics):
 
 ```
 instances:
@@ -211,7 +211,7 @@ List of filters is only supported in Datadog Agent > 5.3.0. If you are using an 
 
 **Available for Agent >6.0**
 
-Tomcat uses the `log4j` logger per default. To activate the logging into a file and customize the format edit the `log4j.properties` file in the `$CATALINA_BASE/lib` directory as follows:
+Tomcat uses by default the `log4j` logger. To activate the logging into a file and customize the log format edit the `log4j.properties` file in the `$CATALINA_BASE/lib` directory as follows:
 
 ```
 log4j.rootLogger = INFO, CATALINA

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -258,10 +258,11 @@ Check Tomcat [logging documentation](http://tomcat.apache.org/tomcat-7.0-doc/log
 
 By default, our integration pipeline support the following conversion patterns:
 
-  ```
+   ```
   %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
-  %d [%t] %-5p %c - %m%n
-  ```
+  %d [%t] %-5p %c - %m%n
+  
+  ```
 
 Make sure you clone and edit the [integration pipeline](https://docs.datadoghq.com/logs/processing/#integration-pipelines) if you have a different format.
 

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -19,7 +19,11 @@ This check is JMX-based, so you'll need to enable JMX Remote on your Tomcat serv
 
 ### Configuration
 
-Create a file `tomcat.yaml` in the Agent's `conf.d` directory. See the [sample tomcat.yaml](https://github.com/DataDog/integrations-core/blob/master/tomcat/conf.yaml.example) for all available configuration options:
+Create a file `tomcat.yaml` in the Agent's `conf.d` directory. 
+
+#### Metric Collection
+
+*  Add this configuration setup to your `tomcat.yaml` file to start gathering your [Tomcat Metrics](#metrics):
 
 ```
 instances:
@@ -98,7 +102,7 @@ See the [JMX Check documentation](http://docs.datadoghq.com/integrations/java/) 
 
 [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent) to start sending Tomcat metrics to Datadog.
 
-Configuration Options
+Configuration Options:
 
 * `user` and `password` (Optional) - Username and password.
 * `process_name_regex` - (Optional) - Instead of specifying a host and port or jmx_url, the agent can connect using the attach api. This requires the JDK to be installed and the path to tools.jar to be set.
@@ -120,7 +124,9 @@ Your metric will be mydomain (or some variation depending on the attribute insid
 
 If you specify an alias in an `include` key that is formatted as *camel case*, it will be converted to *snake case*. For example, `MyMetricName` will be shown in Datadog as `my_metric_name`.
 
-#### The `attribute` filter
+  See the [sample tomcat.yaml](https://github.com/DataDog/integrations-core/blob/master/tomcat/conf.yaml.example) for all available configuration options.
+
+##### The `attribute` filter
 
 The `attribute` filter can accept two types of values:
 
@@ -201,6 +207,88 @@ List of filters is only supported in Datadog Agent > 5.3.0. If you are using an 
             domain: domain_name
             bean: second_bean_name
 
+#### Log Collection
+
+**Available for Agent >6.0**
+
+Tomcat uses the `log4j` logger per default. To activate the logging into a file and customize the format edit the `log4j.properties` file in the `$CATALINA_BASE/lib` directory as follows:
+
+```
+log4j.rootLogger = INFO, CATALINA
+
+# Define all the appenders
+log4j.appender.CATALINA = org.apache.log4j.DailyRollingFileAppender
+log4j.appender.CATALINA.File = /var/log/tomcat/catalina.log
+log4j.appender.CATALINA.Append = true
+# Roll-over the log once per day
+log4j.appender.CATALINA.layout = org.apache.log4j.PatternLayout
+log4j.appender.CATALINA.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+
+log4j.appender.LOCALHOST = org.apache.log4j.DailyRollingFileAppender
+log4j.appender.LOCALHOST.File = /var/log/tomcat/localhost.log
+log4j.appender.LOCALHOST.Append = true
+log4j.appender.LOCALHOST.layout = org.apache.log4j.PatternLayout
+log4j.appender.LOCALHOST.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+
+log4j.appender.MANAGER = org.apache.log4j.DailyRollingFileAppender
+log4j.appender.MANAGER.File = /var/log/tomcat/manager.log
+log4j.appender.MANAGER.Append = true
+log4j.appender.MANAGER.layout = org.apache.log4j.PatternLayout
+log4j.appender.MANAGER.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+
+log4j.appender.HOST-MANAGER = org.apache.log4j.DailyRollingFileAppender
+log4j.appender.HOST-MANAGER.File = /var/log/tomcat/host-manager.log
+log4j.appender.HOST-MANAGER.Append = true
+log4j.appender.HOST-MANAGER.layout = org.apache.log4j.PatternLayout
+log4j.appender.HOST-MANAGER.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+
+log4j.appender.CONSOLE = org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout = org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+
+# Configure which loggers log to which appenders
+log4j.logger.org.apache.catalina.core.ContainerBase.[Catalina].[localhost] = INFO, LOCALHOST
+log4j.logger.org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager] =\
+  INFO, MANAGER
+log4j.logger.org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager] =\
+  INFO, HOST-MANAGER
+```
+
+Check Tomcat [logging documentation](http://tomcat.apache.org/tomcat-7.0-doc/logging.html)For more information about Tomcat logging capabilities.
+
+By default, our integration pipeline support the following conversion patterns:
+
+  ```
+  %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+  %d [%t] %-5p %c - %m%n
+  ```
+
+Make sure you clone and edit the [integration pipeline](https://docs.datadoghq.com/logs/processing/#integration-pipelines) if you have a different format.
+
+* Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file with:
+
+  ```
+  logs_enabled: true
+  ```
+
+* Add this configuration setup to your `tomcat.yaml` file to start collecting your Tomcat Logs:
+
+  ```
+  logs:
+    - type: file
+      path: /var/log/tomcat/*.log
+      source: tomcat
+      service: myapp
+      #To handle multi line that starts with yyyy-mm-dd use the following pattern
+      #log_processing_rules:
+      #  - type: multi_line
+      #    name: log_start_with_date
+      #    pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
+  ```
+
+  Change the `path` and `service` parameter values and configure them for your environment.
+    see the [sample tomcat.yaml](https://github.com/DataDog/integrations-core/blob/master/tomcat/conf.yaml.example) for all available configuration options.
+    * [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent). 
 
 ### Validation
 

--- a/tomcat/conf.yaml.example
+++ b/tomcat/conf.yaml.example
@@ -87,3 +87,19 @@ init_config:
           jspReloadCount:
             alias: tomcat.jsp.reload_count
             metric_type: counter
+            
+## Log Section (Available for Agent >=6.0)
+
+#logs:
+
+    # - type : (mandatory) type of log input source (tcp / udp / file)
+    #   port / path : (mandatory) Set port if type is tcp or udp. Set path if type is file
+    #   service : (mandatory) name of the service owning the log
+    #   source : (mandatory) attribute that defines which integration is sending the logs
+    #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
+    #   tags: (optional) add tags to each logs collected
+    
+    # - type: file
+    #   path: /var/log/tomcat/*.log
+    #   source: tomcat
+    #   service: myservice

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -14,7 +14,7 @@
   "version": "1.0.1",
   "guid": "60f37d34-3bb7-43c9-9b52-2659b8898997",
   "public_title": "Datadog-Tomcat Integration",
-  "categories":["web"],
+  "categories":["web", "log collection"],
   "type":"check",
   "doc_link": "https://docs.datadoghq.com/integrations/tomcat/",
   "is_public": true,


### PR DESCRIPTION
### What does this PR do?

Update the Tomcat documentation with Log instructions

### Motivation

The tomcat integration is now available for logs.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
