### PR TITLE
[wmi_check] Custom tag bug fix

### DIFF
--- a/wmi_check/datadog_checks/wmi_check/wmi_check.py
+++ b/wmi_check/datadog_checks/wmi_check/wmi_check.py
@@ -38,9 +38,11 @@ class WMICheck(WinWMICheck):
         tag_queries = instance.get('tag_queries', [])
 
         constant_tags = instance.get('constant_tags')
+        custom_tags = instance.get('tags', [])
         if constant_tags is None:
-            constant_tags = instance.get('tags', [])
+            constant_tags = list(custom_tags)
         else:
+            constant_tags.extend(custom_tags)
             self.log.warning("`constant_tags` is being deprecated, please use `tags`")
 
         # Create or retrieve an existing WMISampler

--- a/wmi_check/test/test_wmi_check.py
+++ b/wmi_check/test/test_wmi_check.py
@@ -48,6 +48,18 @@ class WMICheckTest(AgentCheckTest):
 
         self.coverage_report()
 
+    def test_tags(self):
+        instance = copy.deepcopy(INSTANCE)
+        instance['filters'] = [{'Name': 'svchost'}]
+        instance['tags'] = ["optional:tag1"]
+        instance['constant_tags'] = ["instance:tag2"]
+        self.run_check({'instances': [instance]})
+
+        for metric in INSTANCE_METRICS:
+            self.assertMetric(metric, tags=['name:svchost', 'optional:tag1', 'instance:tag2'], count=1)
+
+        self.coverage_report()
+
     def test_check_with_wildcard(self):
         instance = copy.deepcopy(INSTANCE)
         instance['filters'] = [{'Name': 'svchost%'}]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

The wmi_check config changed `constant_tag` to `tags` for consistency but we should append both tag lists if a user has both fields in their configuration.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
