### PR TITLE
[agent_metrics] Fix instance defined in default yaml

### DIFF
--- a/agent_metrics/conf.yaml.default
+++ b/agent_metrics/conf.yaml.default
@@ -17,8 +17,8 @@ init_config:
           type: gauge
           active: no
 
-instances: 
-# Optional tags to be applied to every emitted metric and service check.
-#   tags:
-#      - optional_tag1
-#      - optional_tag2
+instances:
+  - tags:
+    # Optional tags to be applied to every emitted metric and service check.
+    #   - optional_tag1
+    #   - optional_tag2


### PR DESCRIPTION
### What does this PR do?

Fixes instance defined in default yaml.

### Motivation

Regression introduced with custom tag support.

Without this fix, by default the agent_metrics checks would fail to
load and be shown on the info page as `failed to initialize`, i.e.:

```
    agent_metrics (unknown)
    -----------------------
      - initialize check class [ERROR]: 'You need to have at least one instance defined in the YAML file for this check'
```

### Testing Guidelines

Double checked the check works out-of-box with the fixed default conf

### Versioning

No need for bump since the regression hasn't been released yet.

~- [ ] Bumped the check version in `manifest.json`~
~- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`~
~- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.~
~- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new)~

