### PR TITLE
[docs][kyototycoon] Fix tags type in example file

### DIFF
--- a/kyototycoon/conf.yaml.example
+++ b/kyototycoon/conf.yaml.example
@@ -11,5 +11,5 @@ instances:
 - report_url: http://localhost:1978/rpc/report
 #   name: my_kyoto_instance
 #   tags:
-#     foo: bar
-#     baz: bat
+#     - "foo:bar"
+#     - "baz:bat"


### PR DESCRIPTION
### What does this PR do?

Fixes `tags` type in example file. Should be a list instead of a map.

### Versioning

No bump/update necessary.
