### PR TITLE
[Vsphere] Add instance tags to all histogram metrics

### DIFF
--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -494,6 +494,7 @@ class VSphereCheck(AgentCheck):
         i_key = self._instance_key(instance)
         server_instance = self._get_server_instance(instance)
         perfManager = server_instance.content.perfManager
+        custom_tags = instance.get('tags', [])
 
         self.log.debug(
             "job_atomic: Querying available metrics"
@@ -517,7 +518,7 @@ class VSphereCheck(AgentCheck):
         self.morlist[i_key][mor_name]['last_seen'] = time.time()
 
         # ## <TEST-INSTRUMENTATION>
-        self.histogram('datadog.agent.vsphere.morlist_process_atomic.time', t.total())
+        self.histogram('datadog.agent.vsphere.morlist_process_atomic.time', t.total(), tags=custom_tags)
         # ## </TEST-INSTRUMENTATION>
 
     def _cache_morlist_process(self, instance):
@@ -662,7 +663,7 @@ class VSphereCheck(AgentCheck):
                 )
 
         # ## <TEST-INSTRUMENTATION>
-        self.histogram('datadog.agent.vsphere.metric_colection.time', t.total())
+        self.histogram('datadog.agent.vsphere.metric_colection.time', t.total(), tags=custom_tags)
         # ## </TEST-INSTRUMENTATION>
 
     def collect_metrics(self, instance):


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Adds instance tags to the other histogram metrics reported by this Integration.

### Motivation

There were two histogram metrics missing the instance level tags. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

Didn't bump as the original instance tags support hasn't been released yet. 

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
