### PR TITLE
[kong] add ssl_validation flag

### DIFF
--- a/kong/datadog_checks/kong/kong.py
+++ b/kong/datadog_checks/kong/kong.py
@@ -33,6 +33,7 @@ class Kong(AgentCheck):
             raise Exception('missing "kong_status_url" value')
         tags = instance.get('tags', [])
         url = instance.get('kong_status_url')
+        ssl_validation = instance.get('ssl_validation', True)
 
         parsed_url = urlparse.urlparse(url)
         host = parsed_url.hostname
@@ -42,7 +43,7 @@ class Kong(AgentCheck):
 
         try:
             self.log.debug(u"Querying URL: {0}".format(url))
-            response = requests.get(url, headers=headers(self.agentConfig))
+            response = requests.get(url, headers=headers(self.agentConfig), verify=ssl_validation)
             self.log.debug(u"Kong status `response`: {0}".format(response))
             response.raise_for_status()
         except Exception:

--- a/kong/manifest.json
+++ b/kong/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.1.0",
+  "version": "1.1.1",
   "guid": "f1098d6f-b393-4374-81c0-47c0a142aeef",
   "public_title": "Datadog-Kong Integration",
   "categories":["web", "api"],


### PR DESCRIPTION
### What does this PR do?

Allows kong integration to toggle ssl_validation

### Motivation

Use kong in full ssl mode (with custom certs), and dd-agent failed to evaluate kong (even when setting the ca-bundle in centos7 system pki)

### Testing Guidelines

I did not add ssl to the testing checks of kong

### Versioning

- [x] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 
