### PR TITLE
prometheus: requests can have an insecure option

### DIFF
--- a/datadog-checks-base/CHANGELOG.md
+++ b/datadog-checks-base/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - datadog_checks
 
+## 1.2.2 / Unreleased
+
+* [BUG] Prometheus requests can use an insecure option
+
 ## 1.2.1 / 2018-03-23
 
 * [BUG] Correctly handle internationalized versions of Windows in the PDH library.
@@ -7,7 +11,6 @@
 ## 1.1.0 / 2018-03-23
 
 * [FEATURE] Add a generic prometheus check base class & rework prometheus check using a mixin
-
 
 ## 1.0.0 / 2017-03-22
 

--- a/datadog-checks-base/datadog_checks/__about__.py
+++ b/datadog-checks-base/datadog_checks/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/datadog-checks-base/datadog_checks/checks/prometheus/mixins.py
+++ b/datadog-checks-base/datadog_checks/checks/prometheus/mixins.py
@@ -4,6 +4,9 @@
 
 from fnmatch import fnmatchcase
 import requests
+import urllib3
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
 from collections import defaultdict
 from google.protobuf.internal.decoder import _DecodeVarint32  # pylint: disable=E0611,E0401
 from ...utils.prometheus import metrics_pb2
@@ -463,6 +466,9 @@ class PrometheusScraper(object):
         verify = True
         if isinstance(self.ssl_ca_cert, basestring):
             verify = self.ssl_ca_cert
+        elif self.ssl_ca_cert is False:
+            urllib3.disable_warnings(InsecureRequestWarning)
+            verify = False
         try:
             response = requests.get(endpoint, headers=headers, stream=True, timeout=1, cert=cert, verify=verify)
         except (requests.exceptions.SSLError):

--- a/datadog-checks-base/datadog_checks/checks/prometheus/mixins.py
+++ b/datadog-checks-base/datadog_checks/checks/prometheus/mixins.py
@@ -4,9 +4,8 @@
 
 from fnmatch import fnmatchcase
 import requests
-import urllib3
+from urllib3 import disable_warnings
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
-
 from collections import defaultdict
 from google.protobuf.internal.decoder import _DecodeVarint32  # pylint: disable=E0611,E0401
 from ...utils.prometheus import metrics_pb2
@@ -467,7 +466,7 @@ class PrometheusScraper(object):
         if isinstance(self.ssl_ca_cert, basestring):
             verify = self.ssl_ca_cert
         elif self.ssl_ca_cert is False:
-            urllib3.disable_warnings(InsecureRequestWarning)
+            disable_warnings(InsecureRequestWarning)
             verify = False
         try:
             response = requests.get(endpoint, headers=headers, stream=True, timeout=1, cert=cert, verify=verify)


### PR DESCRIPTION
### What does this PR do?

Allows to run the kubelet check insecurely.

I disabled the associated warnings because it's too spammy.

```text
2018-03-27 12:59:32 UTC | INFO | (runner.go:246 in work) | Running check kubelet
/opt/datadog-agent/embedded/lib/python2.7/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
/opt/datadog-agent/embedded/lib/python2.7/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
/opt/datadog-agent/embedded/lib/python2.7/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
/opt/datadog-agent/embedded/lib/python2.7/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
```
This warning is still displayed but only once, when the check is run for the first time.

### Motivation

This is a bug fix, because currently the only working setup is fully secured or with HTTP.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
