### PR TITLE
[elastic] Add index level metrics to elasticsearch check

### DIFF
--- a/elastic/CHANGELOG.md
+++ b/elastic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - elastic
 
+1.6.0 / Unreleased
+==================
+
+### Changes
+
+* [FEATURE] adds `index_stats` to collect index level metrics.
+
 1.5.0 / 2018-02-13
 ==================
 

--- a/elastic/conf.yaml.example
+++ b/elastic/conf.yaml.example
@@ -15,8 +15,8 @@ instances:
   # This parameter was also called `is_external` and you can still use it but it
   # will be removed in version 6.
   #
-  # If you enable the "index_stats" flag, you will collect metrics for index 
-  # level metrics.
+  # If you enable the "index_stats" flag, you will collect metrics for individual 
+  # indices.
   #
   # If you enable the "pshard_stats" flag, statistics over primary shards
   # will be collected by the check and sent to the backend with the

--- a/elastic/conf.yaml.example
+++ b/elastic/conf.yaml.example
@@ -15,6 +15,9 @@ instances:
   # This parameter was also called `is_external` and you can still use it but it
   # will be removed in version 6.
   #
+  # If you enable the "index_stats" flag, you will collect metrics for index 
+  # level metrics.
+  #
   # If you enable the "pshard_stats" flag, statistics over primary shards
   # will be collected by the check and sent to the backend with the
   # 'elasticsearch.primary' prefix. It is particularly useful if you want to
@@ -37,6 +40,7 @@ instances:
     # username: username
     # password: password
     # cluster_stats: false
+    # index_stats: false
     # pshard_stats: false
     # pshard_graceful_timeout: false  # continue gracefully if pshard stats TO
     # pending_task_stats: true

--- a/elastic/datadog_checks/elastic/__init__.py
+++ b/elastic/datadog_checks/elastic/__init__.py
@@ -2,6 +2,6 @@ from . import elastic
 
 ESCheck = elastic.ESCheck
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 
 __all__ = ['elastic']

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.5.0",
+  "version": "1.6.0",
   "guid": "d91d91bd-4a8e-4489-bfb1-b119d4cc388a",
   "public_title": "Datadog-ElasticSearch Integration",
   "categories":["data store", "log collection"],

--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -223,3 +223,10 @@ jvm.mem.pools.survivor.used,gauge,,byte,,The amount of memory in bytes currently
 jvm.mem.pools.survivor.max,gauge,,byte,,The maximum amount of memory that can be used by the Survivor Space.,0,elasticsearch,jvm survivor max
 jvm.threads.count,gauge,,thread,,The number of active threads in the JVM.,0,elasticsearch,jvm threads
 jvm.threads.peak_count,gauge,,thread,,The peak number of threads used by the JVM.,0,elasticsearch,jvm peak threads
+elasticsearch.index.health,gauge,,,,The status of the index,0,elasticsearch,index health
+elasticsearch.index.docs.count,gauge,,document,,The number of documents in the index,0,elasticsearch,index doc count
+elasticsearch.index.docs.deleted,gauge,,document,,The number of deleted documents in the index,0,elasticsearch,index doc deleted count
+elasticsearch.index.primary_shards,gauge,,shard,,The number of primary shards in the index,0,elasticsearch,index primary shards count
+elasticsearch.index.replica_shards,gauge,,shard,,The number of replica shards in the index,0,elasticsearch,index replica shards count
+elasticsearch.index.primary_store_size,gauge,,byte,,The store size of primary shards in the index,0,elasticsearch,index primary store size
+elasticsearch.index.store_size,gauge,,byte,,The store size of primary and replica shards in the index,0,elasticsearch,index pri and rep store size

--- a/elastic/test/test_elastic.py
+++ b/elastic/test/test_elastic.py
@@ -168,7 +168,7 @@ STATS_METRICS = {  # Metrics that are common to all Elasticsearch versions
 }
 
 INDEX_STATS_METRICS = { # Metrics for index level
-    "elasticsearch.index.health": ("guage", "health"),
+    "elasticsearch.index.health": ("gauge", "health"),
     "elasticsearch.index.docs.count": ("gauge", "docs_count"),
     "elasticsearch.index.docs.deleted": ("gauge", "docs_deleted"),
     "elasticsearch.index.primary_shards": ("gauge", "primary_shards"),
@@ -585,7 +585,6 @@ class TestElastic(AgentCheckTest):
         # Cleaning up everything won't hurt.
         req = requests.get('http://localhost:9200/_cat/indices?v')
         indices_info = req.text.split('\n')[1::-1]
-        print "HELLOOOO", indices_info
         for index_info in indices_info:
             index_name = index_info.split()[1]
             requests.delete('http://localhost:9200/' + index_name)
@@ -617,8 +616,8 @@ class TestElastic(AgentCheckTest):
             {'url': 'http://localhost:9200', 'index_stats': True}
         ]}
 
-        if get_es_version() >= [1, 3, 0]:
-            index_metrics = INDEX_STATS_METRICS
-            self.run_check(config)
+        index_metrics = dict(INDEX_STATS_METRICS)
+        self.run_check(config)
+        if get_es_version() >= [1, 0, 0]:
             for m_name, desc in index_metrics.iteritems():
                 self.assertMetric(m_name, count=1)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Customer requested index level metrics because they provide more insight to individual indices than cluster level metrics.

Metrics added: index health, index document count, index documented deleted count, number of primary shards, number of replica shards, primary store size (equivalent to space taken by primary shards), and store size (space taken by primary and replica shards).

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
