### PR TITLE
[riak] Don't fail when a stat is "undefined".

### DIFF
--- a/riak/datadog_checks/riak/riak.py
+++ b/riak/datadog_checks/riak/riak.py
@@ -265,7 +265,7 @@ class Riak(AgentCheck):
             self.SERVICE_CHECK_NAME, AgentCheck.OK, tags=service_check_tags)
 
         for k in self.keys:
-            if k in stats:
+            if k in stats and stats[k] != 'undefined':
                 self.gauge("riak." + k, stats[k], tags=tags)
 
         coord_redirs_total = stats["coord_redirs_total"]


### PR DESCRIPTION
For issue #1306 so it does not crash with a ValueError.

<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Fixes #1306 

### Motivation

I got no metrics from riak

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
