### PR TITLE
IIS doc - link conf.d location in setup instruction

### DIFF
--- a/iis/README.md
+++ b/iis/README.md
@@ -38,7 +38,7 @@ The IIS check is packaged with the Agent. To start gathering your IIS metrics an
 
 ### Configuration
 
-Create a file `iis.yaml` in the Agent's `conf.d` directory.
+Create a file `iis.yaml` in the [Agent's `conf.d` directory](https://docs.datadoghq.com/agent/basic_agent_usage/windows/#agent-check-directory-structure).
 
 #### Prepare IIS
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Links doc on conf.d OS location in the setup portion of the IIS integration.

### Motivation

What inspired you to submit this pull request?
customer support request - https://datadog.zendesk.com/agent/tickets/138188

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
