### PR TITLE
[kubelet] port cadvisor metric collection from legacy kubernetes check

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ the new testing approach:
 
 For checks that are not listed here, please refer to [Legacy development Setup](docs/dev/legacy.md).
 
+If you updated the test requirements for a check, run `tox --recreate` for changes to be effective.
+
 ### Building
 
 `setup.py` provides the setuptools setup script that will help us package and

--- a/kubelet/CHANGELOG.md
+++ b/kubelet/CHANGELOG.md
@@ -5,8 +5,9 @@
 
 ### Changes
 
-* [FEATURE] Reports nanocores instead of cores.
-* [FEATURE] Add instance tags to all metrics. Improve the coverage of the check.
+* [FEATURE] Collect metrics directly from cadvisor, for kubenetes version older than 1.7.6. See [#1339][]
+* [FEATURE] Add instance tags to all metrics. Improve the coverage of the check. See [#1377][]
+* [FEATURE] Reports nanocores instead of cores. See [#1361][]
 
 
 1.1.0 / 2018-03-23

--- a/kubelet/README.md
+++ b/kubelet/README.md
@@ -29,4 +29,7 @@ Edit the `kubelet.yaml` file to point to your server and port, set tags to send 
 
 ## Compatibility
 
-The kubelet check is compatible with Kubernetes version 1.8 or superior.
+The kubelet check can run in two modes:
+
+- the default prometheus mode is compatible with Kubernetes version 1.7.6 or superior
+- the cAdvisor mode (enabled by setting the `cadvisor_port` option) should be compatible with versions 1.3 and up. Consistent tagging and filtering requires at least version 6.2 of the Agent.

--- a/kubelet/conf.yaml.example
+++ b/kubelet/conf.yaml.example
@@ -1,8 +1,20 @@
 init_config:
 
 instances:
+  - enabled: true
+    ###
+    ### Common additional tags for all metrics from this check
+    ###
+    #
+    # tags:
+    #   - 'mytag1:myValue1'
+    #
+    ###
+    ### 1.7.6+ clusters expose container metrics in the prometheus format.
+    ### This is the default setting. See next section for legacy clusters.
+    ###
+    #
     # url of the kubelet metrics endpoint
-  - {}
     # metrics_endpoint: http://10.8.0.1:10255/metrics/cadvisor
     #
     # The histogram buckets can be noisy and generate a lot of tags.
@@ -10,8 +22,20 @@ instances:
     #
     # send_histograms_buckets: True
     #
-    # Like all checks based on the PrometheusCheck class, you can add tags
-    # to the instance that will be added to all the metrics of this check instance.
+    ###
+    ### Metric collection for legacy (< 1.7.6) clusters via the kubelet's
+    ### cadvisor port.
+    ### This port is closed by default on k8s 1.7+ and OpenShift, enable it
+    ### via the `--cadvisor-port=4194` kubelet option.
+    ###
     #
-    # tags:
-    #   - 'mytag1:myValue1'
+    # Port to connect to, uncomment and set accordingly to enable collection.
+    # cadvisor_port: 4194
+    #
+    # Whitelist of metrics to collect from cadvisor, these are the default
+    #
+    # enabled_rates:
+    #   - cpu.*
+    #   - network.*
+    # enabled_gauges:
+    #   - filesystem.*

--- a/kubelet/datadog_checks/kubelet/__about__.py
+++ b/kubelet/datadog_checks/kubelet/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "1.1.2"
+__version__ = "1.2.0"

--- a/kubelet/datadog_checks/kubelet/__init__.py
+++ b/kubelet/datadog_checks/kubelet/__init__.py
@@ -1,7 +1,11 @@
 from .kubelet import KubeletCheck
 from .__about__ import __version__
+from .common import ContainerFilter, get_pod_by_uid, is_static_pending_pod
 
 __all__ = [
     'KubeletCheck',
     '__version__',
+    'ContainerFilter',
+    'get_pod_by_uid',
+    'is_static_pending_pod'
 ]

--- a/kubelet/datadog_checks/kubelet/cadvisor.py
+++ b/kubelet/datadog_checks/kubelet/cadvisor.py
@@ -1,0 +1,183 @@
+# (C) Datadog, Inc. 2010-2018
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+"""kubernetes check
+Collects metrics from cAdvisor instance
+"""
+# stdlib
+from fnmatch import fnmatch
+import numbers
+from urlparse import urlparse
+
+# 3p
+import requests
+
+# check
+from .common import tags_for_docker, tags_for_pod, is_static_pending_pod, get_pod_by_uid
+
+NAMESPACE = "kubernetes"
+DEFAULT_MAX_DEPTH = 10
+DEFAULT_ENABLED_RATES = [
+    'diskio.io_service_bytes.stats.total',
+    'network.??_bytes',
+    'cpu.*.total']
+DEFAULT_ENABLED_GAUGES = [
+    'memory.usage',
+    'filesystem.usage']
+DEFAULT_POD_LEVEL_METRICS = [
+    'network.*']
+
+NET_ERRORS = ['rx_errors', 'tx_errors', 'rx_dropped', 'tx_dropped']
+
+LEGACY_CADVISOR_METRICS_PATH = '/api/v1.3/subcontainers/'
+
+
+class CadvisorScraper(object):
+    """
+    CadvisorScraper is a mixin intended to be inherited by an AgentCheck
+    class, as it uses its AgentCheck facilities and class members.
+    It is not possible to run it standalone.
+    """
+
+    @staticmethod
+    def detect_cadvisor(kubelet_url, cadvisor_port):
+        """
+        Tries to connect to the cadvisor endpoint, with given params
+        :return: url if OK, raises exception if NOK
+        """
+        if cadvisor_port == 0:
+            raise ValueError("cAdvisor port set to 0 in configuration")
+        kubelet_hostname = urlparse(kubelet_url).hostname
+        if not kubelet_hostname:
+            raise ValueError("kubelet hostname empty")
+        url = "http://{}:{}{}".format(kubelet_hostname, cadvisor_port,
+                                      LEGACY_CADVISOR_METRICS_PATH)
+
+        # Test the endpoint is present
+        r = requests.head(url, timeout=1)
+        r.raise_for_status()
+
+        return url
+
+    def process_cadvisor(self, instance, cadvisor_url, pod_list, container_filter):
+        """
+        Scrape and submit metrics from cadvisor
+        :param: instance: check instance object
+        :param: cadvisor_url: valid cadvisor url, as returned by detect_cadvisor()
+        :param: pod_list: fresh podlist object from the kubelet
+        :param: container_filter: already initialised ContainerFilter object
+        """
+        self.max_depth = instance.get('max_depth', DEFAULT_MAX_DEPTH)
+        enabled_gauges = instance.get('enabled_gauges', DEFAULT_ENABLED_GAUGES)
+        self.enabled_gauges = ["{0}.{1}".format(NAMESPACE, x) for x in enabled_gauges]
+        enabled_rates = instance.get('enabled_rates', DEFAULT_ENABLED_RATES)
+        self.enabled_rates = ["{0}.{1}".format(NAMESPACE, x) for x in enabled_rates]
+        pod_level_metrics = instance.get('pod_level_metrics', DEFAULT_POD_LEVEL_METRICS)
+        self.pod_level_metrics = ["{0}.{1}".format(NAMESPACE, x) for x in pod_level_metrics]
+
+        self._update_metrics(instance, cadvisor_url, pod_list, container_filter)
+
+    @staticmethod
+    def _retrieve_cadvisor_metrics(cadvisor_url, timeout=10):
+        return requests.get(cadvisor_url, timeout=timeout).json()
+
+    def _update_metrics(self, instance, cadvisor_url, pod_list, container_filter):
+        metrics = self._retrieve_cadvisor_metrics(cadvisor_url)
+
+        if not metrics:
+            self.warning('cAdvisor returned no metrics')
+            return
+
+        for subcontainer in metrics:
+            c_id = subcontainer.get('id')
+            if 'aliases' not in subcontainer:
+                # it means the subcontainer is about a higher-level entity than a container
+                continue
+            try:
+                self._update_container_metrics(instance, subcontainer, pod_list, container_filter)
+            except Exception as e:
+                self.log.error("Unable to collect metrics for container: {0} ({1})".format(c_id, e))
+
+    def _publish_raw_metrics(self, metric, dat, tags, is_pod, depth=0):
+        """
+        Recusively parses and submit metrics for a given entity, until
+        reaching self.max_depth.
+        Nested metric names are flattened: memory/usage -> memory.usage
+        :param: metric: parent's metric name (check namespace for root stat objects)
+        :param: dat: metric dictionnary to parse
+        :param: tags: entity tags to use when submitting
+        :param: is_pod: is the entity a pod (bool)
+        :param: depth: current depth of recursion
+        """
+        if depth >= self.max_depth:
+            self.log.warning('Reached max depth on metric=%s' % metric)
+            return
+
+        if isinstance(dat, numbers.Number):
+            # Pod level metric filtering
+            is_pod_metric = False
+            if self.pod_level_metrics and any([fnmatch(metric, pat) for pat in self.pod_level_metrics]):
+                is_pod_metric = True
+            if is_pod_metric != is_pod:
+                return
+
+            # Metric submission
+            if self.enabled_rates and any([fnmatch(metric, pat) for pat in self.enabled_rates]):
+                self.rate(metric, float(dat), tags)
+            elif self.enabled_gauges and any([fnmatch(metric, pat) for pat in self.enabled_gauges]):
+                self.gauge(metric, float(dat), tags)
+
+        elif isinstance(dat, dict):
+            for k, v in dat.iteritems():
+                self._publish_raw_metrics(metric + '.%s' % k.lower(), v, tags, is_pod, depth + 1)
+
+        elif isinstance(dat, list):
+            self._publish_raw_metrics(metric, dat[-1], tags, is_pod, depth + 1)
+
+    def _update_container_metrics(self, instance, subcontainer, pod_list, container_filter):
+        is_pod = False
+        in_static_pod = False
+        cid = subcontainer.get('id')
+        pod_uid = subcontainer.get('labels', {}).get('io.kubernetes.pod.uid')
+        k_container_name = subcontainer.get('labels', {}).get('io.kubernetes.container.name')
+
+        # We want to collect network metrics at the pod level
+        if k_container_name == "POD" and pod_uid:
+            is_pod = True
+
+        # FIXME we are forced to do that because the Kubelet PodList isn't updated
+        # for static pods, see https://github.com/kubernetes/kubernetes/pull/59948
+        pod = get_pod_by_uid(pod_uid, pod_list)
+        if pod is not None and is_static_pending_pod(pod):
+            in_static_pod = True
+
+        # Let's see who we have here
+        if is_pod:
+            tags = tags_for_pod(pod_uid, True)
+        elif in_static_pod and k_container_name:
+            tags = tags_for_docker(cid, True)
+            tags += tags_for_pod(pod_uid, True)
+            tags.append("kube_container_name:%s" % k_container_name)
+        else:  # Standard container
+            if container_filter.is_excluded(cid):
+                self.log.debug("Filtering out " + cid)
+                return
+            tags = tags_for_docker(cid, True)
+
+        if not tags:
+            self.log.debug("Subcontainer {} doesn't have tags, skipping.".format(cid))
+            return
+        tags = list(set(tags + instance.get('tags', [])))
+
+        stats = subcontainer['stats'][-1]  # take the latest
+        self._publish_raw_metrics(NAMESPACE, stats, tags, is_pod)
+
+        if is_pod is False and subcontainer.get("spec", {}).get("has_filesystem") and stats.get('filesystem'):
+            fs = stats['filesystem'][-1]
+            fs_utilization = float(fs['usage']) / float(fs['capacity'])
+            self.gauge(NAMESPACE + '.filesystem.usage_pct', fs_utilization, tags=tags)
+
+        if is_pod and subcontainer.get("spec", {}).get("has_network"):
+            net = stats['network']
+            self.rate(NAMESPACE + '.network_errors', sum(float(net[x]) for x in NET_ERRORS), tags=tags)

--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -1,4 +1,102 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+
+from tagger import get_tags
+
+try:
+    from container import is_excluded
+except ImportError:
+    # Don't fail on < 6.2
+    def is_excluded(name, image):
+        return False
+
 SOURCE_TYPE = 'kubelet'
+
+CADVISOR_DEFAULT_PORT = 0
+
+
+def tags_for_pod(pod_id, cardinality):
+    """
+    Queries the tagger for a given pod uid
+    :return: string array, empty if pod not found
+    """
+    return get_tags('kubernetes_pod://%s' % pod_id, cardinality)
+
+
+def tags_for_docker(cid, cardinality):
+    """
+    Queries the tagger for a given container id
+    :return: string array, empty if container not found
+    """
+    return get_tags('docker://%s' % cid, cardinality)
+
+
+def get_pod_by_uid(uid, podlist):
+    """
+    Searches for a pod uid in the podlist and returns the pod if found
+    :param uid: pod uid
+    :param podlist: podlist dict object
+    :return: pod dict object if found, None if not found
+    """
+    for pod in podlist.get("items", []):
+        try:
+            if pod["metadata"]["uid"] == uid:
+                return pod
+        except KeyError:
+            continue
+    return None
+
+
+def is_static_pending_pod(pod):
+    """
+    Return if the pod is a static pending pod
+    See https://github.com/kubernetes/kubernetes/pull/57106
+    :param pod: dict
+    :return: bool
+    """
+    try:
+        if pod["metadata"]["annotations"]["kubernetes.io/config.source"] == "api":
+            return False
+
+        pod_status = pod["status"]
+        if pod_status["phase"] != "Pending":
+            return False
+
+        return "containerStatuses" not in pod_status
+    except KeyError:
+        return False
+
+
+class ContainerFilter(object):
+    def __init__(self, podlist):
+        self.containers = {}
+
+        for pod in podlist.get('items'):
+            for ctr in pod['status'].get('containerStatuses', []):
+                cid = ctr.get('containerID')
+                if not cid:
+                    continue
+                self.containers[cid] = ctr
+                if "://" in cid:
+                    # cAdvisor pushes cids without orchestrator scheme
+                    # re-register without the scheme
+                    short_cid = cid.split("://", 1)[-1]
+                    self.containers[short_cid] = ctr
+
+    def is_excluded(self, cid):
+        """
+        Queries the agent6 container filter interface. It retrieves container
+        name + image from the podlist, so static pod filtering is not supported.
+        :param cid: container id
+        :return: bool
+        """
+        if cid not in self.containers:
+            # Filter out metrics not coming from a container (system slices)
+            return True
+        ctr = self.containers[cid]
+        if not ("name" in ctr and "image" in ctr):
+            # Filter out invalid containers
+            return True
+
+        return is_excluded(ctr.get("name"), ctr.get("image"))

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -17,6 +17,10 @@ from datadog_checks.checks.prometheus import PrometheusCheck
 from kubeutil import get_connection_info
 from tagger import get_tags
 
+# check
+from .common import CADVISOR_DEFAULT_PORT, ContainerFilter, is_static_pending_pod, get_pod_by_uid
+from .cadvisor import CadvisorScraper
+
 METRIC_TYPES = ['counter', 'gauge', 'summary']
 # container-specific metrics should have all these labels
 CONTAINER_LABELS = ['container_name', 'namespace', 'pod_name', 'name', 'image', 'id']
@@ -49,7 +53,7 @@ FACTORS = {
 log = logging.getLogger('collector')
 
 
-class KubeletCheck(PrometheusCheck):
+class KubeletCheck(PrometheusCheck, CadvisorScraper):
     """
     Collect container metrics from Kubelet.
     """
@@ -63,6 +67,9 @@ class KubeletCheck(PrometheusCheck):
         inst = instances[0] if instances else None
 
         self.kube_node_labels = inst.get('node_labels_to_host_tags', {})
+        self.cadvisor_legacy_port = inst.get('cadvisor_port', CADVISOR_DEFAULT_PORT)
+        self.cadvisor_legacy_url = None
+
         self.metrics_mapper = {
             'kubelet_runtime_operations_errors': 'kubelet.runtime.errors',
         }
@@ -109,6 +116,12 @@ class KubeletCheck(PrometheusCheck):
         self.node_spec_url = urljoin(endpoint, NODE_SPEC_PATH)
         self.pod_list_url = urljoin(endpoint, POD_LIST_PATH)
 
+        # Legacy cadvisor support
+        try:
+            self.cadvisor_legacy_url = self.detect_cadvisor(endpoint, self.cadvisor_legacy_port)
+        except Exception as e:
+            self.log.debug('cAdvisor not found, running in prometheus mode: %s' % str(e))
+
         # By default we send the buckets.
         send_buckets = instance.get('send_histograms_buckets', True)
         if send_buckets is not None and str(send_buckets).lower() == 'false':
@@ -118,15 +131,27 @@ class KubeletCheck(PrometheusCheck):
 
         try:
             self.pod_list = self.retrieve_pod_list()
+            if self.pod_list.get("items") is None:
+                # Sanitize input: if no pod are running, 'items' is a NoneObject
+                self.pod_list['items'] = []
         except Exception:
             self.pod_list = None
+
+        self.container_filter = ContainerFilter(self.pod_list)
 
         instance_tags = instance.get('tags', [])
         self._perform_kubelet_check(instance_tags)
         self._report_node_metrics(instance_tags)
         self._report_pods_running(self.pod_list, instance_tags)
         self._report_container_spec_metrics(self.pod_list, instance_tags)
-        self.process(self.metrics_url, send_histograms_buckets=send_buckets, instance=instance)
+
+        if self.cadvisor_legacy_url:  # Legacy cAdvisor
+            self.process_cadvisor(instance, self.cadvisor_legacy_url, self.pod_list, self.container_filter)
+        else:  # Prometheus
+            self.process(self.metrics_url, send_histograms_buckets=send_buckets, instance=instance)
+
+        # Free up memory
+        self.pod_list = None
 
     def perform_kubelet_query(self, url, verbose=True, timeout=10):
         """
@@ -387,34 +412,7 @@ class KubeletCheck(PrometheusCheck):
         :return:
         """
         pod_uid = self._get_pod_uid(labels)
-        for pod in self.pod_list["items"]:
-            try:
-                if pod["metadata"]["uid"] == pod_uid:
-                    return pod
-            except KeyError:
-                continue
-
-        return None
-
-    @staticmethod
-    def _is_static_pending_pod(pod):
-        """
-        Return if the pod is a static pending pod
-        See https://github.com/kubernetes/kubernetes/pull/57106
-        :param pod: dict
-        :return: bool
-        """
-        try:
-            if pod["metadata"]["annotations"]["kubernetes.io/config.source"] == "api":
-                return False
-
-            pod_status = pod["status"]
-            if pod_status["phase"] != "Pending":
-                return False
-
-            return "containerStatuses" not in pod_status
-        except KeyError:
-            return False
+        return get_pod_by_uid(pod_uid, self.pod_list)
 
     @staticmethod
     def _get_kube_container_name(labels):
@@ -446,7 +444,7 @@ class KubeletCheck(PrometheusCheck):
                 # FIXME we are forced to do that because the Kubelet PodList isn't updated
                 # for static pods, see https://github.com/kubernetes/kubernetes/pull/59948
                 pod = self._get_pod_by_metric_label(metric.label)
-                if pod is not None and self._is_static_pending_pod(pod):
+                if pod is not None and is_static_pending_pod(pod):
                     tags += get_tags('kubernetes_pod://%s' % pod["metadata"]["uid"], True)
                     tags += self._get_kube_container_name(metric.label)
                     tags = list(set(tags))
@@ -488,7 +486,7 @@ class KubeletCheck(PrometheusCheck):
                 # FIXME we are forced to do that because the Kubelet PodList isn't updated
                 # for static pods, see https://github.com/kubernetes/kubernetes/pull/59948
                 pod = self._get_pod_by_metric_label(metric.label)
-                if pod is not None and self._is_static_pending_pod(pod):
+                if pod is not None and is_static_pending_pod(pod):
                     tags += get_tags('kubernetes_pod://%s' % pod["metadata"]["uid"], True)
                     tags += self._get_kube_container_name(metric.label)
                     tags = list(set(tags))

--- a/kubelet/manifest.json
+++ b/kubelet/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "1.1.2",
+  "manifest_version": "1.2.0",
   "max_agent_version": "7.0.0",
   "min_agent_version": "6.0.0",
   "name": "kubelet",

--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -16,3 +16,4 @@ kubernetes.network.rx_errors,gauge,,error,second,The amount of rx errors per sec
 kubernetes.network.tx_bytes,gauge,,byte,second,The amount of bytes per second transmitted,-1,kubelet,k8s.net.tx
 kubernetes.network.tx_dropped,gauge,,packet,second,The amount of tx packets dropped per second,-1,kubelet,k8s.net.tx.drop
 kubernetes.network.tx_errors,gauge,,error,second,The amount of tx errors per second,-1,kubelet,k8s.net.tx.errors
+kubernetes.diskio.io_service_bytes.stats.total,gauge,,byte,,The amount of disk space the container uses.,-1,kubernetes,k8s.disk.total

--- a/kubelet/tests/fixtures/cadvisor_1.2.json
+++ b/kubelet/tests/fixtures/cadvisor_1.2.json
@@ -1,0 +1,7545 @@
+[
+  {
+    "name": "/system",
+    "spec": {
+      "creation_time": "2016-06-03T18:09:19.215272Z",
+      "has_cpu": true,
+      "cpu": {
+        "limit": 1024,
+        "max_limit": 0,
+        "mask": "0-1"
+      },
+      "has_memory": true,
+      "memory": {
+        "limit": 18446744073709551615
+      },
+      "has_network": false,
+      "has_filesystem": false,
+      "has_diskio": true,
+      "has_custom_metrics": false
+    },
+    "stats": [
+      {
+        "timestamp": "2016-06-17T16:06:04.78767617Z",
+        "cpu": {
+          "usage": {
+            "total": 9191944896812,
+            "per_cpu_usage": [
+              4562797469082,
+              4629147427730
+            ],
+            "user": 6063910000000,
+            "system": 2910120000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18264064,
+                "Read": 18264064,
+                "Sync": 1231773696,
+                "Total": 1250037760,
+                "Write": 1231773696
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1153,
+                "Read": 1153,
+                "Sync": 8949,
+                "Total": 10102,
+                "Write": 8949
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2441480
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1262509386,
+                "Read": 1262509386,
+                "Sync": 612091543602,
+                "Total": 613354052988,
+                "Write": 612091543602
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 361179477,
+                "Read": 361179477,
+                "Sync": 28191821920,
+                "Total": 28553001397,
+                "Write": 28191821920
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 30,
+                "Read": 30,
+                "Sync": 72,
+                "Total": 102,
+                "Write": 72
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2367
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 1068859392,
+          "cache": 1025363968,
+          "rss": 43405312,
+          "working_set": 382758912,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 488857191,
+            "pgmajfault": 536
+          },
+          "hierarchical_data": {
+            "pgfault": 488857191,
+            "pgmajfault": 536
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:24.750670773Z",
+        "cpu": {
+          "usage": {
+            "total": 9192107007848,
+            "per_cpu_usage": [
+              4562899766191,
+              4629207241657
+            ],
+            "user": 6064000000000,
+            "system": 2910180000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18264064,
+                "Read": 18264064,
+                "Sync": 1231773696,
+                "Total": 1250037760,
+                "Write": 1231773696
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1153,
+                "Read": 1153,
+                "Sync": 8949,
+                "Total": 10102,
+                "Write": 8949
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2441480
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1262509386,
+                "Read": 1262509386,
+                "Sync": 612091543602,
+                "Total": 613354052988,
+                "Write": 612091543602
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 361179477,
+                "Read": 361179477,
+                "Sync": 28191821920,
+                "Total": 28553001397,
+                "Write": 28191821920
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 30,
+                "Read": 30,
+                "Sync": 72,
+                "Total": 102,
+                "Write": 72
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2367
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 1068822528,
+          "cache": 1025363968,
+          "rss": 43409408,
+          "working_set": 382722048,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 488866687,
+            "pgmajfault": 536
+          },
+          "hierarchical_data": {
+            "pgfault": 488866687,
+            "pgmajfault": 536
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:36.90598914Z",
+        "cpu": {
+          "usage": {
+            "total": 9192175569640,
+            "per_cpu_usage": [
+              4562942156940,
+              4629233412700
+            ],
+            "user": 6064050000000,
+            "system": 2910200000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18264064,
+                "Read": 18264064,
+                "Sync": 1231773696,
+                "Total": 1250037760,
+                "Write": 1231773696
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1153,
+                "Read": 1153,
+                "Sync": 8949,
+                "Total": 10102,
+                "Write": 8949
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2441480
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1262509386,
+                "Read": 1262509386,
+                "Sync": 612091543602,
+                "Total": 613354052988,
+                "Write": 612091543602
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 361179477,
+                "Read": 361179477,
+                "Sync": 28191821920,
+                "Total": 28553001397,
+                "Write": 28191821920
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 30,
+                "Read": 30,
+                "Sync": 72,
+                "Total": 102,
+                "Write": 72
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2367
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 1068773376,
+          "cache": 1025363968,
+          "rss": 43409408,
+          "working_set": 382672896,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 488870176,
+            "pgmajfault": 536
+          },
+          "hierarchical_data": {
+            "pgfault": 488870176,
+            "pgmajfault": 536
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:53.940285874Z",
+        "cpu": {
+          "usage": {
+            "total": 9192237889901,
+            "per_cpu_usage": [
+              4562982412364,
+              4629255477537
+            ],
+            "user": 6064090000000,
+            "system": 2910230000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18264064,
+                "Read": 18264064,
+                "Sync": 1231773696,
+                "Total": 1250037760,
+                "Write": 1231773696
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1153,
+                "Read": 1153,
+                "Sync": 8949,
+                "Total": 10102,
+                "Write": 8949
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2441480
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1262509386,
+                "Read": 1262509386,
+                "Sync": 612091543602,
+                "Total": 613354052988,
+                "Write": 612091543602
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 361179477,
+                "Read": 361179477,
+                "Sync": 28191821920,
+                "Total": 28553001397,
+                "Write": 28191821920
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 30,
+                "Read": 30,
+                "Sync": 72,
+                "Total": 102,
+                "Write": 72
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2367
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 1068765184,
+          "cache": 1025363968,
+          "rss": 43401216,
+          "working_set": 382664704,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 488873655,
+            "pgmajfault": 536
+          },
+          "hierarchical_data": {
+            "pgfault": 488873655,
+            "pgmajfault": 536
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:12.072940622Z",
+        "cpu": {
+          "usage": {
+            "total": 9192364942229,
+            "per_cpu_usage": [
+              4563078620548,
+              4629286321681
+            ],
+            "user": 6064160000000,
+            "system": 2910280000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18264064,
+                "Read": 18264064,
+                "Sync": 1231773696,
+                "Total": 1250037760,
+                "Write": 1231773696
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1153,
+                "Read": 1153,
+                "Sync": 8949,
+                "Total": 10102,
+                "Write": 8949
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2441480
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1262509386,
+                "Read": 1262509386,
+                "Sync": 612091543602,
+                "Total": 613354052988,
+                "Write": 612091543602
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 361179477,
+                "Read": 361179477,
+                "Sync": 28191821920,
+                "Total": 28553001397,
+                "Write": 28191821920
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 30,
+                "Read": 30,
+                "Sync": 72,
+                "Total": 102,
+                "Write": 72
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2367
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 1068773376,
+          "cache": 1025363968,
+          "rss": 43409408,
+          "working_set": 382672896,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 488880873,
+            "pgmajfault": 536
+          },
+          "hierarchical_data": {
+            "pgfault": 488880873,
+            "pgmajfault": 536
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:26.834587365Z",
+        "cpu": {
+          "usage": {
+            "total": 9192503656920,
+            "per_cpu_usage": [
+              4563133565996,
+              4629370090924
+            ],
+            "user": 6064260000000,
+            "system": 2910320000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18264064,
+                "Read": 18264064,
+                "Sync": 1231773696,
+                "Total": 1250037760,
+                "Write": 1231773696
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1153,
+                "Read": 1153,
+                "Sync": 8949,
+                "Total": 10102,
+                "Write": 8949
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2441480
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1262509386,
+                "Read": 1262509386,
+                "Sync": 612091543602,
+                "Total": 613354052988,
+                "Write": 612091543602
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 361179477,
+                "Read": 361179477,
+                "Sync": 28191821920,
+                "Total": 28553001397,
+                "Write": 28191821920
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 30,
+                "Read": 30,
+                "Sync": 72,
+                "Total": 102,
+                "Write": 72
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2367
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 1068769280,
+          "cache": 1025363968,
+          "rss": 43405312,
+          "working_set": 382668800,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 488889777,
+            "pgmajfault": 536
+          },
+          "hierarchical_data": {
+            "pgfault": 488889777,
+            "pgmajfault": 536
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:37.710788065Z",
+        "cpu": {
+          "usage": {
+            "total": 9192560639497,
+            "per_cpu_usage": [
+              4563158820732,
+              4629401818765
+            ],
+            "user": 6064290000000,
+            "system": 2910340000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18264064,
+                "Read": 18264064,
+                "Sync": 1231773696,
+                "Total": 1250037760,
+                "Write": 1231773696
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1153,
+                "Read": 1153,
+                "Sync": 8949,
+                "Total": 10102,
+                "Write": 8949
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2441480
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1262509386,
+                "Read": 1262509386,
+                "Sync": 612091543602,
+                "Total": 613354052988,
+                "Write": 612091543602
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 361179477,
+                "Read": 361179477,
+                "Sync": 28191821920,
+                "Total": 28553001397,
+                "Write": 28191821920
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 30,
+                "Read": 30,
+                "Sync": 72,
+                "Total": 102,
+                "Write": 72
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2367
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 1068761088,
+          "cache": 1025363968,
+          "rss": 43397120,
+          "working_set": 382660608,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 488892687,
+            "pgmajfault": 536
+          },
+          "hierarchical_data": {
+            "pgfault": 488892687,
+            "pgmajfault": 536
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:48.63605798Z",
+        "cpu": {
+          "usage": {
+            "total": 9192616604693,
+            "per_cpu_usage": [
+              4563197945547,
+              4629418659146
+            ],
+            "user": 6064330000000,
+            "system": 2910350000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18264064,
+                "Read": 18264064,
+                "Sync": 1231773696,
+                "Total": 1250037760,
+                "Write": 1231773696
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1153,
+                "Read": 1153,
+                "Sync": 8949,
+                "Total": 10102,
+                "Write": 8949
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2441480
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1262509386,
+                "Read": 1262509386,
+                "Sync": 612091543602,
+                "Total": 613354052988,
+                "Write": 612091543602
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 361179477,
+                "Read": 361179477,
+                "Sync": 28191821920,
+                "Total": 28553001397,
+                "Write": 28191821920
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 30,
+                "Read": 30,
+                "Sync": 72,
+                "Total": 102,
+                "Write": 72
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2367
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 1068773376,
+          "cache": 1025363968,
+          "rss": 43409408,
+          "working_set": 382672896,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 488895886,
+            "pgmajfault": 536
+          },
+          "hierarchical_data": {
+            "pgfault": 488895886,
+            "pgmajfault": 536
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      }
+    ]
+  },
+  {
+    "id": "1d6e5db3abbfbb69718899748a882e2519da5b5d798b4b6bf1ec7dd6b5f26a60",
+    "name": "/1d6e5db3abbfbb69718899748a882e2519da5b5d798b4b6bf1ec7dd6b5f26a60",
+    "aliases": [
+      "k8s_dd-agent.7b520f3f_dd-agent-1rxlh_default_12c7be82-33ca-11e6-ac8f-42010af00003_321fecb4",
+      "1d6e5db3abbfbb69718899748a882e2519da5b5d798b4b6bf1ec7dd6b5f26a60"
+    ],
+    "namespace": "docker",
+    "labels": {
+      "io.kubernetes.container.hash": "7b520f3f",
+      "io.kubernetes.container.name": "dd-agent",
+      "io.kubernetes.container.restartCount": "0",
+      "io.kubernetes.container.terminationMessagePath": "/dev/termination-log",
+      "io.kubernetes.pod.name": "dd-agent-1rxlh",
+      "io.kubernetes.pod.namespace": "default",
+      "io.kubernetes.pod.terminationGracePeriod": "30",
+      "io.kubernetes.pod.uid": "12c7be82-33ca-11e6-ac8f-42010af00003"
+    },
+    "spec": {
+      "creation_time": "2016-06-16T13:56:08.429573036Z",
+      "labels": {
+        "io.kubernetes.container.hash": "7b520f3f",
+        "io.kubernetes.container.name": "dd-agent",
+        "io.kubernetes.container.restartCount": "0",
+        "io.kubernetes.container.terminationMessagePath": "/dev/termination-log",
+        "io.kubernetes.pod.name": "dd-agent-1rxlh",
+        "io.kubernetes.pod.namespace": "default",
+        "io.kubernetes.pod.terminationGracePeriod": "30",
+        "io.kubernetes.pod.uid": "12c7be82-33ca-11e6-ac8f-42010af00003"
+      },
+      "has_cpu": true,
+      "cpu": {
+        "limit": 256,
+        "max_limit": 0,
+        "mask": "0-1"
+      },
+      "has_memory": true,
+      "memory": {
+        "limit": 134217728,
+        "swap_limit": 18446744073709551615
+      },
+      "has_network": false,
+      "has_filesystem": true,
+      "has_diskio": true,
+      "has_custom_metrics": false,
+      "image": "datadog/docker-dd-agent:massi_ingest_k8s_events"
+    },
+    "stats": [
+      {
+        "timestamp": "2016-06-17T16:05:57.64670846Z",
+        "cpu": {
+          "usage": {
+            "total": 1634848700452,
+            "per_cpu_usage": [
+              814746181291,
+              820102519161
+            ],
+            "user": 937600000000,
+            "system": 656690000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 14802944,
+                "Read": 14802944,
+                "Sync": 3379200,
+                "Total": 18182144,
+                "Write": 3379200
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 439,
+                "Read": 439,
+                "Sync": 335,
+                "Total": 774,
+                "Write": 335
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 35512
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1907661653,
+                "Read": 1907661653,
+                "Sync": 277170727,
+                "Total": 2184832380,
+                "Write": 277170727
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 298588569,
+                "Read": 298588569,
+                "Sync": 1436416786,
+                "Total": 1735005355,
+                "Write": 1436416786
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 10,
+                "Read": 10,
+                "Sync": 0,
+                "Total": 10,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 974
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 97558528,
+          "cache": 19447808,
+          "rss": 78110720,
+          "working_set": 90456064,
+          "failcnt": 10636,
+          "container_data": {
+            "pgfault": 17726582,
+            "pgmajfault": 55
+          },
+          "hierarchical_data": {
+            "pgfault": 17726582,
+            "pgmajfault": 55
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 57810944,
+            "base_usage": 57790464,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:17.420933191Z",
+        "cpu": {
+          "usage": {
+            "total": 1635254620441,
+            "per_cpu_usage": [
+              814953401532,
+              820301218909
+            ],
+            "user": 937780000000,
+            "system": 656900000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 15151104,
+                "Read": 15151104,
+                "Sync": 3379200,
+                "Total": 18530304,
+                "Write": 3379200
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 470,
+                "Read": 470,
+                "Sync": 335,
+                "Total": 805,
+                "Write": 335
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 36192
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2046335181,
+                "Read": 2046335181,
+                "Sync": 277170727,
+                "Total": 2323505908,
+                "Write": 277170727
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 298831824,
+                "Read": 298831824,
+                "Sync": 1436416786,
+                "Total": 1735248610,
+                "Write": 1436416786
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 10,
+                "Read": 10,
+                "Sync": 0,
+                "Total": 10,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1005
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 100651008,
+          "cache": 19836928,
+          "rss": 80814080,
+          "working_set": 93540352,
+          "failcnt": 10636,
+          "container_data": {
+            "pgfault": 17731898,
+            "pgmajfault": 55
+          },
+          "hierarchical_data": {
+            "pgfault": 17731898,
+            "pgmajfault": 55
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 57810944,
+            "base_usage": 57790464,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:34.752028641Z",
+        "cpu": {
+          "usage": {
+            "total": 1635377578105,
+            "per_cpu_usage": [
+              815016183684,
+              820361394421
+            ],
+            "user": 937880000000,
+            "system": 656930000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 15392768,
+                "Read": 15392768,
+                "Sync": 3379200,
+                "Total": 18771968,
+                "Write": 3379200
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 488,
+                "Read": 488,
+                "Sync": 335,
+                "Total": 823,
+                "Write": 335
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 36664
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2150066629,
+                "Read": 2150066629,
+                "Sync": 277170727,
+                "Total": 2427237356,
+                "Write": 277170727
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 298985452,
+                "Read": 298985452,
+                "Sync": 1436416786,
+                "Total": 1735402238,
+                "Write": 1436416786
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 10,
+                "Read": 10,
+                "Sync": 0,
+                "Total": 10,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1026
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 102555648,
+          "cache": 20086784,
+          "rss": 82468864,
+          "working_set": 95449088,
+          "failcnt": 10636,
+          "container_data": {
+            "pgfault": 17732545,
+            "pgmajfault": 55
+          },
+          "hierarchical_data": {
+            "pgfault": 17732545,
+            "pgmajfault": 55
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 57892864,
+            "base_usage": 57872384,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:52.101541457Z",
+        "cpu": {
+          "usage": {
+            "total": 1635742144956,
+            "per_cpu_usage": [
+              815130325898,
+              820611819058
+            ],
+            "user": 938070000000,
+            "system": 657090000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 15392768,
+                "Read": 15392768,
+                "Sync": 3379200,
+                "Total": 18771968,
+                "Write": 3379200
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 488,
+                "Read": 488,
+                "Sync": 335,
+                "Total": 823,
+                "Write": 335
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 36664
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2150066629,
+                "Read": 2150066629,
+                "Sync": 277170727,
+                "Total": 2427237356,
+                "Write": 277170727
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 298985452,
+                "Read": 298985452,
+                "Sync": 1436416786,
+                "Total": 1735402238,
+                "Write": 1436416786
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 10,
+                "Read": 10,
+                "Sync": 0,
+                "Total": 10,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1026
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 100925440,
+          "cache": 20119552,
+          "rss": 80805888,
+          "working_set": 93818880,
+          "failcnt": 10636,
+          "container_data": {
+            "pgfault": 17737838,
+            "pgmajfault": 55
+          },
+          "hierarchical_data": {
+            "pgfault": 17737838,
+            "pgmajfault": 55
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 57892864,
+            "base_usage": 57872384,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:05.989800285Z",
+        "cpu": {
+          "usage": {
+            "total": 1636003536413,
+            "per_cpu_usage": [
+              815224331260,
+              820779205153
+            ],
+            "user": 938240000000,
+            "system": 657170000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18366464,
+                "Read": 18366464,
+                "Sync": 3379200,
+                "Total": 21745664,
+                "Write": 3379200
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 751,
+                "Read": 751,
+                "Sync": 335,
+                "Total": 1086,
+                "Write": 335
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 42472
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2720237570,
+                "Read": 2720237570,
+                "Sync": 277170727,
+                "Total": 2997408297,
+                "Write": 277170727
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 307131077,
+                "Read": 307131077,
+                "Sync": 1436416786,
+                "Total": 1743547863,
+                "Write": 1436416786
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 10,
+                "Read": 10,
+                "Sync": 0,
+                "Total": 10,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1184
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 117256192,
+          "cache": 23101440,
+          "rss": 94154752,
+          "working_set": 110149632,
+          "failcnt": 10636,
+          "container_data": {
+            "pgfault": 17743275,
+            "pgmajfault": 55
+          },
+          "hierarchical_data": {
+            "pgfault": 17743275,
+            "pgmajfault": 55
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 57892864,
+            "base_usage": 57872384,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:17.564225474Z",
+        "cpu": {
+          "usage": {
+            "total": 1636429715422,
+            "per_cpu_usage": [
+              815388768290,
+              821040947132
+            ],
+            "user": 938490000000,
+            "system": 657350000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18366464,
+                "Read": 18366464,
+                "Sync": 3379200,
+                "Total": 21745664,
+                "Write": 3379200
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 751,
+                "Read": 751,
+                "Sync": 335,
+                "Total": 1086,
+                "Write": 335
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 42472
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2720237570,
+                "Read": 2720237570,
+                "Sync": 277170727,
+                "Total": 2997408297,
+                "Write": 277170727
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 307131077,
+                "Read": 307131077,
+                "Sync": 1436416786,
+                "Total": 1743547863,
+                "Write": 1436416786
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 10,
+                "Read": 10,
+                "Sync": 0,
+                "Total": 10,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1184
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 101531648,
+          "cache": 23130112,
+          "rss": 78155776,
+          "working_set": 94425088,
+          "failcnt": 10636,
+          "container_data": {
+            "pgfault": 17749444,
+            "pgmajfault": 55
+          },
+          "hierarchical_data": {
+            "pgfault": 17749444,
+            "pgmajfault": 55
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 57892864,
+            "base_usage": 57872384,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:35.59670058Z",
+        "cpu": {
+          "usage": {
+            "total": 1636539574210,
+            "per_cpu_usage": [
+              815443742737,
+              821095831473
+            ],
+            "user": 938600000000,
+            "system": 657380000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18366464,
+                "Read": 18366464,
+                "Sync": 3379200,
+                "Total": 21745664,
+                "Write": 3379200
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 751,
+                "Read": 751,
+                "Sync": 335,
+                "Total": 1086,
+                "Write": 335
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 42472
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2720237570,
+                "Read": 2720237570,
+                "Sync": 277170727,
+                "Total": 2997408297,
+                "Write": 277170727
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 307131077,
+                "Read": 307131077,
+                "Sync": 1436416786,
+                "Total": 1743547863,
+                "Write": 1436416786
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 10,
+                "Read": 10,
+                "Sync": 0,
+                "Total": 10,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1184
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 101298176,
+          "cache": 23142400,
+          "rss": 78155776,
+          "working_set": 94191616,
+          "failcnt": 10636,
+          "container_data": {
+            "pgfault": 17750130,
+            "pgmajfault": 55
+          },
+          "hierarchical_data": {
+            "pgfault": 17750130,
+            "pgmajfault": 55
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 57970688,
+            "base_usage": 57950208,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:53.544235192Z",
+        "cpu": {
+          "usage": {
+            "total": 1636943556502,
+            "per_cpu_usage": [
+              815669021273,
+              821274535229
+            ],
+            "user": 938860000000,
+            "system": 657510000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18366464,
+                "Read": 18366464,
+                "Sync": 3379200,
+                "Total": 21745664,
+                "Write": 3379200
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 751,
+                "Read": 751,
+                "Sync": 335,
+                "Total": 1086,
+                "Write": 335
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 42472
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2720237570,
+                "Read": 2720237570,
+                "Sync": 277170727,
+                "Total": 2997408297,
+                "Write": 277170727
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 307131077,
+                "Read": 307131077,
+                "Sync": 1436416786,
+                "Total": 1743547863,
+                "Write": 1436416786
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 10,
+                "Read": 10,
+                "Sync": 0,
+                "Total": 10,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1184
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 101560320,
+          "cache": 23179264,
+          "rss": 78155776,
+          "working_set": 94449664,
+          "failcnt": 10636,
+          "container_data": {
+            "pgfault": 17755275,
+            "pgmajfault": 55
+          },
+          "hierarchical_data": {
+            "pgfault": 17755275,
+            "pgmajfault": 55
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 57970688,
+            "base_usage": 57950208,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      }
+    ]
+  },
+  {
+    "name": "/",
+    "subcontainers": [
+      {
+        "name": "/04a2cbd416c0fc4b33a64d70ff97aa6c91714da8011065241cbef7cd30f26f03"
+      },
+      {
+        "name": "/1d6e5db3abbfbb69718899748a882e2519da5b5d798b4b6bf1ec7dd6b5f26a60"
+      },
+      {
+        "name": "/22ce1054bb0ddb446b910b41f0f5812d103fe3695e8cb63ae4aff96c58dbfb1a"
+      },
+      {
+        "name": "/4110c0dfdccfc11115b1aa653af4483e286d03179439ac17369d554c999c45ee"
+      },
+      {
+        "name": "/4f269da73287845650fce62e0b4ab40a76489e646a79d30a39ce961912f0833e"
+      },
+      {
+        "name": "/59fb6c47177e23255821a3b13561b756b764057d009f017670fc784df9a27a54"
+      },
+      {
+        "name": "/84105ff06547050d06d1e660cbfbf6047a9320f272f492293d0445bd9b97d366"
+      },
+      {
+        "name": "/91a2c7cdd3d92b484bad9841dbf7c26c8ff162fb644e844f474679a1f5a8dc7a"
+      },
+      {
+        "name": "/93af471dce34e270324e5ff6bd60864987c21a1583896d6c3be28fa04596702d"
+      },
+      {
+        "name": "/95d825d9028d9d2cec80026bce445d51252b74ae3883e104f79533c4b503e95d"
+      },
+      {
+        "name": "/a5154bd791e0772090b639a8258cb66844435b1fc21d093e8ca9c69560925a0f"
+      },
+      {
+        "name": "/b32dbc427781a0518bd93d604a2192117eba2cf95f7b005e2aa68949f4c1ca21"
+      },
+      {
+        "name": "/c527db6142bf0d1c59144e7ca560d87cd61898522543ae3c97a6c3c13deec61e"
+      },
+      {
+        "name": "/cff492f36458780b0a8d2087a15f01508ea8f2047e32d91de7713caadcee2925"
+      },
+      {
+        "name": "/d77f3323403c90613e2af712c054e6322ceeb1eccb85c54eacfa61b7f7ed1e49"
+      },
+      {
+        "name": "/docker-daemon"
+      },
+      {
+        "name": "/e417974bac19012b5e529150d5143a587d359fe95669651461be6ecbf70b4d48"
+      },
+      {
+        "name": "/kubelet"
+      },
+      {
+        "name": "/system"
+      }
+    ],
+    "spec": {
+      "creation_time": "2016-06-03T18:08:06.908607Z",
+      "has_cpu": true,
+      "cpu": {
+        "limit": 1024,
+        "max_limit": 0,
+        "mask": "0-1"
+      },
+      "has_memory": true,
+      "memory": {
+        "limit": 7864135680
+      },
+      "has_network": true,
+      "has_filesystem": true,
+      "has_diskio": true,
+      "has_custom_metrics": false
+    },
+    "stats": [
+      {
+        "timestamp": "2016-06-17T16:05:56.340368492Z",
+        "cpu": {
+          "usage": {
+            "total": 179042041063101,
+            "per_cpu_usage": [
+              93200485881604,
+              85841555181497
+            ],
+            "user": 54180060000000,
+            "system": 24269760000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18377934848,
+                "Read": 192600064,
+                "Sync": 60708503552,
+                "Total": 79086438400,
+                "Write": 78893838336
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2671941,
+                "Read": 7783,
+                "Sync": 4867950,
+                "Total": 7539891,
+                "Write": 7532108
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154465700
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12745689693976,
+                "Read": 11861990478,
+                "Sync": 5277324407048,
+                "Total": 18023014101024,
+                "Write": 18011152110546
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866609812853,
+                "Read": 8519871772,
+                "Sync": 18427163373106,
+                "Total": 21293773185959,
+                "Write": 21285253314187
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15242069
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3849244672,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1948114944,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15010981908,
+          "rx_packets": 23100180,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10487196318,
+          "tx_packets": 25882767,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15010981908,
+              "rx_packets": 23100180,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10487196318,
+              "tx_packets": 25882767,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295416867,
+              "rx_packets": 29315400,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26578448003,
+              "tx_packets": 24711003,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037447680,
+            "base_usage": 0,
+            "available": 97096818688,
+            "inodes_free": 6452350,
+            "reads_completed": 7298,
+            "reads_merged": 665,
+            "sectors_read": 371906,
+            "read_time": 19932,
+            "writes_completed": 9953743,
+            "writes_merged": 10022113,
+            "sectors_written": 173462608,
+            "write_time": 42514100,
+            "io_in_progress": 0,
+            "io_time": 30343812,
+            "weighted_io_time": 42533336
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:07.395683905Z",
+        "cpu": {
+          "usage": {
+            "total": 179043530512776,
+            "per_cpu_usage": [
+              93201252697084,
+              85842277815692
+            ],
+            "user": 54180450000000,
+            "system": 24269920000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18377967616,
+                "Read": 192600064,
+                "Sync": 60709015552,
+                "Total": 79086983168,
+                "Write": 78894383104
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2671949,
+                "Read": 7783,
+                "Sync": 4867994,
+                "Total": 7539943,
+                "Write": 7532160
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154466764
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12745696647304,
+                "Read": 11861990478,
+                "Sync": 5277361175313,
+                "Total": 18023057822617,
+                "Write": 18011195832139
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866609909691,
+                "Read": 8519871772,
+                "Sync": 18427331809977,
+                "Total": 21293941719668,
+                "Write": 21285421847896
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15242207
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3850002432,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1948868608,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15011182316,
+          "rx_packets": 23100566,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10487258895,
+          "tx_packets": 25883139,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15011182316,
+              "rx_packets": 23100566,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10487258895,
+              "tx_packets": 25883139,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295468713,
+              "rx_packets": 29315686,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26578642729,
+              "tx_packets": 24711247,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037480448,
+            "base_usage": 0,
+            "available": 97096785920,
+            "inodes_free": 6452350,
+            "reads_completed": 7298,
+            "reads_merged": 665,
+            "sectors_read": 371906,
+            "read_time": 19932,
+            "writes_completed": 9953817,
+            "writes_merged": 10022193,
+            "sectors_written": 173463848,
+            "write_time": 42514368,
+            "io_in_progress": 0,
+            "io_time": 30344080,
+            "weighted_io_time": 42533604
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:27.391689204Z",
+        "cpu": {
+          "usage": {
+            "total": 179046568018248,
+            "per_cpu_usage": [
+              93202840116878,
+              85843727901370
+            ],
+            "user": 54181340000000,
+            "system": 24270480000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18378987520,
+                "Read": 193189888,
+                "Sync": 60710166528,
+                "Total": 79089154048,
+                "Write": 78895964160
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2672077,
+                "Read": 7832,
+                "Sync": 4868075,
+                "Total": 7540152,
+                "Write": 7532320
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154471004
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12746543126199,
+                "Read": 12104395454,
+                "Sync": 5277434916980,
+                "Total": 18023978043179,
+                "Write": 18011873647725
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866612975632,
+                "Read": 8520268655,
+                "Sync": 18427657144392,
+                "Total": 21294270120024,
+                "Write": 21285749851369
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15242502
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3855687680,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1954549760,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15011464513,
+          "rx_packets": 23101224,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10487376574,
+          "tx_packets": 25883836,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15011464513,
+              "rx_packets": 23101224,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10487376574,
+              "tx_packets": 25883836,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295559318,
+              "rx_packets": 29316192,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26579154760,
+              "tx_packets": 24711667,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037533696,
+            "base_usage": 0,
+            "available": 97096732672,
+            "inodes_free": 6452350,
+            "reads_completed": 7347,
+            "reads_merged": 665,
+            "sectors_read": 373058,
+            "read_time": 20168,
+            "writes_completed": 9954017,
+            "writes_merged": 10022406,
+            "sectors_written": 173467256,
+            "write_time": 42515376,
+            "io_in_progress": 0,
+            "io_time": 30344840,
+            "weighted_io_time": 42534848
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:42.169306136Z",
+        "cpu": {
+          "usage": {
+            "total": 179048706533910,
+            "per_cpu_usage": [
+              93204025336324,
+              85844681197586
+            ],
+            "user": 54181920000000,
+            "system": 24270750000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18379065344,
+                "Read": 193189888,
+                "Sync": 60710838272,
+                "Total": 79089903616,
+                "Write": 78896713728
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2672092,
+                "Read": 7832,
+                "Sync": 4868133,
+                "Total": 7540225,
+                "Write": 7532393
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154472468
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12746561033226,
+                "Read": 12104395454,
+                "Sync": 5277488165199,
+                "Total": 18024049198425,
+                "Write": 18011944802971
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866613139955,
+                "Read": 8520268655,
+                "Sync": 18427875822195,
+                "Total": 21294488962150,
+                "Write": 21285968693495
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15242678
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3851542528,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1950404608,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15011544108,
+          "rx_packets": 23101532,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10487436320,
+          "tx_packets": 25884153,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15011544108,
+              "rx_packets": 23101532,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10487436320,
+              "tx_packets": 25884153,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295608099,
+              "rx_packets": 29316451,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26579217854,
+              "tx_packets": 24711874,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037500928,
+            "base_usage": 0,
+            "available": 97096765440,
+            "inodes_free": 6452348,
+            "reads_completed": 7347,
+            "reads_merged": 665,
+            "sectors_read": 373058,
+            "read_time": 20168,
+            "writes_completed": 9954119,
+            "writes_merged": 10022511,
+            "sectors_written": 173468952,
+            "write_time": 42515732,
+            "io_in_progress": 0,
+            "io_time": 30345196,
+            "weighted_io_time": 42535204
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:59.618565812Z",
+        "cpu": {
+          "usage": {
+            "total": 179051236542906,
+            "per_cpu_usage": [
+              93205314439243,
+              85845922103663
+            ],
+            "user": 54182770000000,
+            "system": 24271090000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18382309376,
+                "Read": 196163584,
+                "Sync": 60711763968,
+                "Total": 79094073344,
+                "Write": 78897909760
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2672402,
+                "Read": 8095,
+                "Sync": 4868203,
+                "Total": 7540605,
+                "Write": 7532510
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154480612
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12747384571506,
+                "Read": 12674566395,
+                "Sync": 5277546702522,
+                "Total": 18024931274028,
+                "Write": 18012256707633
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866623224311,
+                "Read": 8528414280,
+                "Sync": 18428240734510,
+                "Total": 21294863958821,
+                "Write": 21286335544541
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15243055
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3870437376,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1969303552,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15011706862,
+          "rx_packets": 23102117,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10487523080,
+          "tx_packets": 25884707,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15011706862,
+              "rx_packets": 23102117,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10487523080,
+              "tx_packets": 25884707,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295671774,
+              "rx_packets": 29316833,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26579663262,
+              "tx_packets": 24712182,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037550080,
+            "base_usage": 0,
+            "available": 97096716288,
+            "inodes_free": 6452350,
+            "reads_completed": 7610,
+            "reads_merged": 665,
+            "sectors_read": 378866,
+            "read_time": 20740,
+            "writes_completed": 9954272,
+            "writes_merged": 10022677,
+            "sectors_written": 173471576,
+            "write_time": 42516464,
+            "io_in_progress": 0,
+            "io_time": 30346220,
+            "weighted_io_time": 42536508
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:10.211012449Z",
+        "cpu": {
+          "usage": {
+            "total": 179052786041383,
+            "per_cpu_usage": [
+              93206161600436,
+              85846624440947
+            ],
+            "user": 54183210000000,
+            "system": 24271310000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18382325760,
+                "Read": 196163584,
+                "Sync": 60712280064,
+                "Total": 79094605824,
+                "Write": 78898442240
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2672406,
+                "Read": 8095,
+                "Sync": 4868245,
+                "Total": 7540651,
+                "Write": 7532556
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154481652
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12747387670643,
+                "Read": 12674566395,
+                "Sync": 5277582536121,
+                "Total": 18024970206764,
+                "Write": 18012295640369
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866623304691,
+                "Read": 8528414280,
+                "Sync": 18428401571755,
+                "Total": 21295024876446,
+                "Write": 21286496462166
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15243168
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3870306304,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1969172480,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15011873809,
+          "rx_packets": 23102557,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10487589710,
+          "tx_packets": 25885119,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15011873809,
+              "rx_packets": 23102557,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10487589710,
+              "tx_packets": 25885119,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295725082,
+              "rx_packets": 29317139,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26579820478,
+              "tx_packets": 24712437,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037574656,
+            "base_usage": 0,
+            "available": 97096691712,
+            "inodes_free": 6452348,
+            "reads_completed": 7610,
+            "reads_merged": 665,
+            "sectors_read": 378866,
+            "read_time": 20740,
+            "writes_completed": 9954339,
+            "writes_merged": 10022761,
+            "sectors_written": 173472784,
+            "write_time": 42516720,
+            "io_in_progress": 0,
+            "io_time": 30346476,
+            "weighted_io_time": 42536764
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:21.214787552Z",
+        "cpu": {
+          "usage": {
+            "total": 179054329110335,
+            "per_cpu_usage": [
+              93206896270740,
+              85847432839595
+            ],
+            "user": 54183850000000,
+            "system": 24271560000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18382723072,
+                "Read": 196163584,
+                "Sync": 60712935424,
+                "Total": 79095658496,
+                "Write": 78899494912
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2672465,
+                "Read": 8095,
+                "Sync": 4868290,
+                "Total": 7540755,
+                "Write": 7532660
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154483708
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12747806674999,
+                "Read": 12674566395,
+                "Sync": 5277621162064,
+                "Total": 18025427837063,
+                "Write": 18012753270668
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866626274496,
+                "Read": 8528414280,
+                "Sync": 18428578071212,
+                "Total": 21295204345708,
+                "Write": 21286675931428
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15243286
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3854356480,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1953222656,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15012051337,
+          "rx_packets": 23102848,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10487638692,
+          "tx_packets": 25885414,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15012051337,
+              "rx_packets": 23102848,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10487638692,
+              "tx_packets": 25885414,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295767620,
+              "rx_packets": 29317409,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26580250840,
+              "tx_packets": 24712660,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037599232,
+            "base_usage": 0,
+            "available": 97096667136,
+            "inodes_free": 6452350,
+            "reads_completed": 7610,
+            "reads_merged": 665,
+            "sectors_read": 378866,
+            "read_time": 20740,
+            "writes_completed": 9954465,
+            "writes_merged": 10022913,
+            "sectors_written": 173475016,
+            "write_time": 42517336,
+            "io_in_progress": 0,
+            "io_time": 30346760,
+            "weighted_io_time": 42537380
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:34.68462852Z",
+        "cpu": {
+          "usage": {
+            "total": 179055886272683,
+            "per_cpu_usage": [
+              93207725236369,
+              85848161036314
+            ],
+            "user": 54184390000000,
+            "system": 24271740000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18382854144,
+                "Read": 196163584,
+                "Sync": 60713603072,
+                "Total": 79096457216,
+                "Write": 78900293632
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2672486,
+                "Read": 8095,
+                "Sync": 4868344,
+                "Total": 7540830,
+                "Write": 7532735
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154485268
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12747830692415,
+                "Read": 12674566395,
+                "Sync": 5277667632724,
+                "Total": 18025498325139,
+                "Write": 18012823758744
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866626460503,
+                "Read": 8528414280,
+                "Sync": 18428787988281,
+                "Total": 21295414448784,
+                "Write": 21286886034504
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15243470
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3854516224,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1953378304,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15012206451,
+          "rx_packets": 23103347,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10487982441,
+          "tx_packets": 25885949,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15012206451,
+              "rx_packets": 23103347,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10487982441,
+              "tx_packets": 25885949,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295839126,
+              "rx_packets": 29317789,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26580662832,
+              "tx_packets": 24712962,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037619712,
+            "base_usage": 0,
+            "available": 97096646656,
+            "inodes_free": 6452350,
+            "reads_completed": 7610,
+            "reads_merged": 665,
+            "sectors_read": 378866,
+            "read_time": 20740,
+            "writes_completed": 9954567,
+            "writes_merged": 10023021,
+            "sectors_written": 173476792,
+            "write_time": 42517664,
+            "io_in_progress": 0,
+            "io_time": 30347088,
+            "weighted_io_time": 42537708
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:50.026851815Z",
+        "cpu": {
+          "usage": {
+            "total": 179058059341746,
+            "per_cpu_usage": [
+              93208756590673,
+              85849302751073
+            ],
+            "user": 54185060000000,
+            "system": 24272070000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18382895104,
+                "Read": 196163584,
+                "Sync": 60714319872,
+                "Total": 79097214976,
+                "Write": 78901051392
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2672495,
+                "Read": 8095,
+                "Sync": 4868406,
+                "Total": 7540901,
+                "Write": 7532806
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154486748
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12747838785738,
+                "Read": 12674566395,
+                "Sync": 5277718029508,
+                "Total": 18025556815246,
+                "Write": 18012882248851
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866626590137,
+                "Read": 8528414280,
+                "Sync": 18429027490183,
+                "Total": 21295654080320,
+                "Write": 21287125666040
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15243643
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3854888960,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1953751040,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15012305689,
+          "rx_packets": 23103617,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10488381037,
+          "tx_packets": 25886314,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15012305689,
+              "rx_packets": 23103617,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10488381037,
+              "tx_packets": 25886314,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295887677,
+              "rx_packets": 29318104,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26581366889,
+              "tx_packets": 24713218,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037660672,
+            "base_usage": 0,
+            "available": 97096605696,
+            "inodes_free": 6452350,
+            "reads_completed": 7610,
+            "reads_merged": 665,
+            "sectors_read": 378866,
+            "read_time": 20740,
+            "writes_completed": 9954669,
+            "writes_merged": 10023134,
+            "sectors_written": 173478520,
+            "write_time": 42518036,
+            "io_in_progress": 0,
+            "io_time": 30347460,
+            "weighted_io_time": 42538080
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      }
+    ]
+  },
+  {
+    "id": "4f269da73287845650fce62e0b4ab40a76489e646a79d30a39ce961912f0833e",
+    "name": "/4f269da73287845650fce62e0b4ab40a76489e646a79d30a39ce961912f0833e",
+    "aliases": [
+      "k8s_POD.35220667_dd-agent-1rxlh_default_12c7be82-33ca-11e6-ac8f-42010af00003_f5cf585f",
+      "4f269da73287845650fce62e0b4ab40a76489e646a79d30a39ce961912f0833e"
+    ],
+    "namespace": "docker",
+    "labels": {
+      "io.kubernetes.container.hash": "35220667",
+      "io.kubernetes.container.name": "POD",
+      "io.kubernetes.container.restartCount": "0",
+      "io.kubernetes.container.terminationMessagePath": "",
+      "io.kubernetes.pod.name": "dd-agent-1rxlh",
+      "io.kubernetes.pod.namespace": "default",
+      "io.kubernetes.pod.terminationGracePeriod": "30",
+      "io.kubernetes.pod.uid": "12c7be82-33ca-11e6-ac8f-42010af00003"
+    },
+    "spec": {
+      "creation_time": "2016-06-16T13:56:07.429624077Z",
+      "labels": {
+        "io.kubernetes.container.hash": "35220667",
+        "io.kubernetes.container.name": "POD",
+        "io.kubernetes.container.restartCount": "0",
+        "io.kubernetes.container.terminationMessagePath": "",
+        "io.kubernetes.pod.name": "dd-agent-1rxlh",
+        "io.kubernetes.pod.namespace": "default",
+        "io.kubernetes.pod.terminationGracePeriod": "30",
+        "io.kubernetes.pod.uid": "12c7be82-33ca-11e6-ac8f-42010af00003"
+      },
+      "has_cpu": true,
+      "cpu": {
+        "limit": 2,
+        "max_limit": 0,
+        "mask": "0-1"
+      },
+      "has_memory": true,
+      "memory": {
+        "limit": 18446744073709551615,
+        "swap_limit": 18446744073709551615
+      },
+      "has_network": true,
+      "has_filesystem": true,
+      "has_diskio": true,
+      "has_custom_metrics": false,
+      "image": "gcr.io/google_containers/pause:2.0"
+    },
+    "stats": [
+      {
+        "timestamp": "2016-06-17T16:06:07.215780953Z",
+        "cpu": {
+          "usage": {
+            "total": 144151891,
+            "per_cpu_usage": [
+              82147059,
+              62004832
+            ],
+            "user": 50000000,
+            "system": 20000000
+          },
+          "load_average": 0
+        },
+        "diskio": {},
+        "memory": {
+          "usage": 1482752,
+          "cache": 12288,
+          "rss": 1470464,
+          "working_set": 1482752,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          },
+          "hierarchical_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 1215086584,
+          "rx_packets": 433288,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 85937915,
+          "tx_packets": 474878,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 1215086584,
+              "rx_packets": 433288,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 85937915,
+              "tx_packets": 474878,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 40960,
+            "base_usage": 12288,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:23.346328555Z",
+        "cpu": {
+          "usage": {
+            "total": 144195836,
+            "per_cpu_usage": [
+              82147059,
+              62048777
+            ],
+            "user": 50000000,
+            "system": 20000000
+          },
+          "load_average": 0
+        },
+        "diskio": {},
+        "memory": {
+          "usage": 1482752,
+          "cache": 12288,
+          "rss": 1470464,
+          "working_set": 1482752,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          },
+          "hierarchical_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 1215421096,
+          "rx_packets": 433353,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 85946733,
+          "tx_packets": 474957,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 1215421096,
+              "rx_packets": 433353,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 85946733,
+              "tx_packets": 474957,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 40960,
+            "base_usage": 12288,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:34.379448136Z",
+        "cpu": {
+          "usage": {
+            "total": 144195836,
+            "per_cpu_usage": [
+              82147059,
+              62048777
+            ],
+            "user": 50000000,
+            "system": 20000000
+          },
+          "load_average": 0
+        },
+        "diskio": {},
+        "memory": {
+          "usage": 1482752,
+          "cache": 12288,
+          "rss": 1470464,
+          "working_set": 1482752,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          },
+          "hierarchical_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 1215445040,
+          "rx_packets": 433415,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 85963763,
+          "tx_packets": 475020,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 1215445040,
+              "rx_packets": 433415,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 85963763,
+              "tx_packets": 475020,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 40960,
+            "base_usage": 12288,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:45.228077482Z",
+        "cpu": {
+          "usage": {
+            "total": 144195836,
+            "per_cpu_usage": [
+              82147059,
+              62048777
+            ],
+            "user": 50000000,
+            "system": 20000000
+          },
+          "load_average": 0
+        },
+        "diskio": {},
+        "memory": {
+          "usage": 1482752,
+          "cache": 12288,
+          "rss": 1470464,
+          "working_set": 1482752,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          },
+          "hierarchical_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 1215778374,
+          "rx_packets": 433480,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 85972174,
+          "tx_packets": 475095,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 1215778374,
+              "rx_packets": 433480,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 85972174,
+              "tx_packets": 475095,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 40960,
+            "base_usage": 12288,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:58.687312616Z",
+        "cpu": {
+          "usage": {
+            "total": 144195836,
+            "per_cpu_usage": [
+              82147059,
+              62048777
+            ],
+            "user": 50000000,
+            "system": 20000000
+          },
+          "load_average": 0
+        },
+        "diskio": {},
+        "memory": {
+          "usage": 1482752,
+          "cache": 12288,
+          "rss": 1470464,
+          "working_set": 1482752,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          },
+          "hierarchical_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 1215794444,
+          "rx_packets": 433523,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 85985319,
+          "tx_packets": 475139,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 1215794444,
+              "rx_packets": 433523,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 85985319,
+              "tx_packets": 475139,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 40960,
+            "base_usage": 12288,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:16.871361033Z",
+        "cpu": {
+          "usage": {
+            "total": 144237834,
+            "per_cpu_usage": [
+              82147059,
+              62090775
+            ],
+            "user": 50000000,
+            "system": 20000000
+          },
+          "load_average": 0
+        },
+        "diskio": {},
+        "memory": {
+          "usage": 1482752,
+          "cache": 12288,
+          "rss": 1470464,
+          "working_set": 1482752,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          },
+          "hierarchical_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 1216135061,
+          "rx_packets": 433608,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 85997868,
+          "tx_packets": 475237,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 1216135061,
+              "rx_packets": 433608,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 85997868,
+              "tx_packets": 475237,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 40960,
+            "base_usage": 12288,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:35.339682222Z",
+        "cpu": {
+          "usage": {
+            "total": 144237834,
+            "per_cpu_usage": [
+              82147059,
+              62090775
+            ],
+            "user": 50000000,
+            "system": 20000000
+          },
+          "load_average": 0
+        },
+        "diskio": {},
+        "memory": {
+          "usage": 1482752,
+          "cache": 12288,
+          "rss": 1470464,
+          "working_set": 1482752,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          },
+          "hierarchical_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 1216449517,
+          "rx_packets": 433697,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 86017114,
+          "tx_packets": 475330,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 1216449517,
+              "rx_packets": 433697,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 86017114,
+              "tx_packets": 475330,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 40960,
+            "base_usage": 12288,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:55.23647675Z",
+        "cpu": {
+          "usage": {
+            "total": 144237834,
+            "per_cpu_usage": [
+              82147059,
+              62090775
+            ],
+            "user": 50000000,
+            "system": 20000000
+          },
+          "load_average": 0
+        },
+        "diskio": {},
+        "memory": {
+          "usage": 1482752,
+          "cache": 12288,
+          "rss": 1470464,
+          "working_set": 1482752,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          },
+          "hierarchical_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 1217092163,
+          "rx_packets": 433830,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 86040599,
+          "tx_packets": 475476,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 1217092163,
+              "rx_packets": 433830,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 86040599,
+              "tx_packets": 475476,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 40960,
+            "base_usage": 12288,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      }
+    ]
+  },
+  {
+    "name": "/kubelet",
+    "spec": {
+      "creation_time": "2016-06-03T18:09:19.215272Z",
+      "has_cpu": true,
+      "cpu": {
+        "limit": 1024,
+        "max_limit": 0,
+        "mask": "0-1"
+      },
+      "has_memory": true,
+      "memory": {
+        "limit": 18446744073709551615
+      },
+      "has_network": false,
+      "has_filesystem": false,
+      "has_diskio": true,
+      "has_custom_metrics": false
+    },
+    "stats": [
+      {
+        "timestamp": "2016-06-17T16:06:00.948755171Z",
+        "cpu": {
+          "usage": {
+            "total": 16123089672810,
+            "per_cpu_usage": [
+              8035337123629,
+              8087752549181
+            ],
+            "user": 9728340000000,
+            "system": 6800630000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28196864,
+          "cache": 2928640,
+          "rss": 25137152,
+          "working_set": 28028928,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958270167,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958270167,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:12.173521573Z",
+        "cpu": {
+          "usage": {
+            "total": 16123237019970,
+            "per_cpu_usage": [
+              8035399671598,
+              8087837348372
+            ],
+            "user": 9728410000000,
+            "system": 6800710000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28065792,
+          "cache": 2928640,
+          "rss": 25137152,
+          "working_set": 27897856,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958277439,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958277439,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:26.767741807Z",
+        "cpu": {
+          "usage": {
+            "total": 16123487061408,
+            "per_cpu_usage": [
+              8035498502302,
+              8087988559106
+            ],
+            "user": 9728520000000,
+            "system": 6800840000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28188672,
+          "cache": 2928640,
+          "rss": 25137152,
+          "working_set": 28020736,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958294283,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958294283,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:42.532779778Z",
+        "cpu": {
+          "usage": {
+            "total": 16123637588626,
+            "per_cpu_usage": [
+              8035570853507,
+              8088066735119
+            ],
+            "user": 9728600000000,
+            "system": 6800900000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28151808,
+          "cache": 2928640,
+          "rss": 25137152,
+          "working_set": 27983872,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958300819,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958300819,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:58.57437104Z",
+        "cpu": {
+          "usage": {
+            "total": 16123912176618,
+            "per_cpu_usage": [
+              8035724584592,
+              8088187592026
+            ],
+            "user": 9728820000000,
+            "system": 6801000000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28188672,
+          "cache": 2928640,
+          "rss": 25137152,
+          "working_set": 28020736,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958316092,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958316092,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:11.831640168Z",
+        "cpu": {
+          "usage": {
+            "total": 16124089954108,
+            "per_cpu_usage": [
+              8035827605670,
+              8088262348438
+            ],
+            "user": 9728920000000,
+            "system": 6801080000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28065792,
+          "cache": 2928640,
+          "rss": 25137152,
+          "working_set": 27897856,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958327494,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958327494,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:26.52679237Z",
+        "cpu": {
+          "usage": {
+            "total": 16124335383034,
+            "per_cpu_usage": [
+              8035944558049,
+              8088390824985
+            ],
+            "user": 9729060000000,
+            "system": 6801170000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28192768,
+          "cache": 2932736,
+          "rss": 25137152,
+          "working_set": 28020736,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958342702,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958342702,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:37.023709829Z",
+        "cpu": {
+          "usage": {
+            "total": 16124475873350,
+            "per_cpu_usage": [
+              8036016777741,
+              8088459095609
+            ],
+            "user": 9729150000000,
+            "system": 6801230000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28164096,
+          "cache": 2932736,
+          "rss": 25137152,
+          "working_set": 27992064,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958350016,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958350016,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:51.445118458Z",
+        "cpu": {
+          "usage": {
+            "total": 16124680036088,
+            "per_cpu_usage": [
+              8036124966364,
+              8088555069724
+            ],
+            "user": 9729290000000,
+            "system": 6801320000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28364800,
+          "cache": 2932736,
+          "rss": 25309184,
+          "working_set": 28196864,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958361262,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958361262,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      }
+    ]
+  }
+]

--- a/kubelet/tests/fixtures/pods_list_1.2.json
+++ b/kubelet/tests/fixtures/pods_list_1.2.json
@@ -1,0 +1,600 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/namespaces/default/pods",
+    "resourceVersion": "495497"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "dd-agent",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/dd-agent",
+        "uid": "ca906dc1-29bd-11e6-ac8f-42010af00003",
+        "resourceVersion": "1522",
+        "creationTimestamp": "2016-06-03T19:03:00Z",
+        "annotations": {
+          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"dd-agent\",\"uid\":\"12c56a58-33ca-11e6-ac8f-42010af00003\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"456736\"}}\n",
+          "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container dd-agent"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "dockersocket",
+            "hostPath": {
+              "path": "/var/run/docker.sock"
+            }
+          },
+          {
+            "name": "procdir",
+            "hostPath": {
+              "path": "/proc"
+            }
+          },
+          {
+            "name": "cgroups",
+            "hostPath": {
+              "path": "/sys/fs/cgroup"
+            }
+          },
+          {
+            "name": "default-token-racjk",
+            "secret": {
+              "secretName": "default-token-racjk"
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "dd-agent",
+            "image": "datadog/docker-dd-agent:massi_ingest_k8s_events",
+            "ports": [
+              {
+                "name": "dogstatsdport",
+                "containerPort": 8125,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "PROBE_MODE",
+                "value": "true"
+              },
+              {
+                "name": "API_KEY",
+                "value": "51bdfb1e67a5b2097feeed5603f3cc7d"
+              },
+              {
+                "name": "SD_BACKEND",
+                "value": "docker"
+              },
+              {
+                "name": "SD_CONFIG_BACKEND",
+                "value": "etcd"
+              },
+              {
+                "name": "SD_BACKEND_HOST",
+                "value": "etcd-client"
+              },
+              {
+                "name": "SD_BACKEND_PORT",
+                "value": "2379"
+              },
+              {
+                "name": "LOG_LEVEL",
+                "value": "DEBUG"
+              }
+            ],
+            "resources": {
+              "requests": {
+                "cpu": "100m"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "dockersocket",
+                "mountPath": "/var/run/docker.sock"
+              },
+              {
+                "name": "procdir",
+                "readOnly": true,
+                "mountPath": "/host/proc"
+              },
+              {
+                "name": "cgroups",
+                "readOnly": true,
+                "mountPath": "/host/sys/fs/cgroup"
+              },
+              {
+                "name": "default-token-racjk",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "nodeSelector": {
+          "ddagent": "probe"
+        },
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "securityContext": {}
+      },
+      "status": {
+        "phase": "Pending"
+      }
+    },
+    {
+      "metadata": {
+        "name": "dd-agent-1rxlh",
+        "generateName": "dd-agent-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/dd-agent-1rxlh",
+        "uid": "12c7be82-33ca-11e6-ac8f-42010af00003",
+        "resourceVersion": "456745",
+        "creationTimestamp": "2016-06-16T13:56:07Z",
+        "labels": {
+          "app": "dd-agent",
+          "foo": "bar",
+          "bar": "baz"
+        },
+        "annotations": {
+          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"dd-agent\",\"uid\":\"12c56a58-33ca-11e6-ac8f-42010af00003\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"456736\"}}\n"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "dockersocket",
+            "hostPath": {
+              "path": "/var/run/docker.sock"
+            }
+          },
+          {
+            "name": "procdir",
+            "hostPath": {
+              "path": "/proc"
+            }
+          },
+          {
+            "name": "cgroups",
+            "hostPath": {
+              "path": "/sys/fs/cgroup"
+            }
+          },
+          {
+            "name": "default-token-racjk",
+            "secret": {
+              "secretName": "default-token-racjk"
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "dd-agent",
+            "image": "datadog/docker-dd-agent:massi_ingest_k8s_events",
+            "ports": [
+              {
+                "name": "dogstatsdport",
+                "containerPort": 8125,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "API_KEY",
+                "value": "51bdfb1e67a5b2097feeed5603f3cc7d"
+              },
+              {
+                "name": "SD_BACKEND",
+                "value": "docker"
+              },
+              {
+                "name": "SD_CONFIG_BACKEND",
+                "value": "etcd"
+              },
+              {
+                "name": "SD_BACKEND_HOST",
+                "value": "etcd-client"
+              },
+              {
+                "name": "SD_BACKEND_PORT",
+                "value": "2379"
+              },
+              {
+                "name": "LOG_LEVEL",
+                "value": "DEBUG"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "1",
+                "memory": "128Mi"
+              },
+              "requests": {
+                "cpu": "250m",
+                "memory": "64Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "dockersocket",
+                "mountPath": "/var/run/docker.sock"
+              },
+              {
+                "name": "procdir",
+                "readOnly": true,
+                "mountPath": "/host/proc"
+              },
+              {
+                "name": "cgroups",
+                "readOnly": true,
+                "mountPath": "/host/sys/fs/cgroup"
+              },
+              {
+                "name": "default-token-racjk",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "kubernetes-massi-minion-k23m",
+        "securityContext": {}
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2016-06-16T13:56:08Z"
+          }
+        ],
+        "hostIP": "10.240.0.9",
+        "podIP": "10.244.0.5",
+        "startTime": "2016-06-16T13:56:07Z",
+        "containerStatuses": [
+          {
+            "name": "dd-agent",
+            "state": {
+              "running": {
+                "startedAt": "2016-06-16T13:56:08Z"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "datadog/docker-dd-agent:massi_ingest_k8s_events",
+            "imageID": "docker://22c8298aadea7bae69765758a88fc373118c9a0c332d23aa99869d4f84d75a8e",
+            "containerID": "docker://1d6e5db3abbfbb69718899748a882e2519da5b5d798b4b6bf1ec7dd6b5f26a60"
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "dd-agent-iw7mo",
+        "generateName": "dd-agent-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/dd-agent-iw7mo",
+        "uid": "12c88531-33ca-11e6-ac8f-42010af00003",
+        "resourceVersion": "456747",
+        "creationTimestamp": "2016-06-16T13:56:07Z",
+        "labels": {
+          "app": "dd-agent",
+          "k8s-app": "api"
+        },
+        "annotations": {
+          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"dd-agent\",\"uid\":\"12c56a58-33ca-11e6-ac8f-42010af00003\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"456736\"}}\n"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "dockersocket",
+            "hostPath": {
+              "path": "/var/run/docker.sock"
+            }
+          },
+          {
+            "name": "procdir",
+            "hostPath": {
+              "path": "/proc"
+            }
+          },
+          {
+            "name": "cgroups",
+            "hostPath": {
+              "path": "/sys/fs/cgroup"
+            }
+          },
+          {
+            "name": "default-token-racjk",
+            "secret": {
+              "secretName": "default-token-racjk"
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "dd-agent",
+            "image": "datadog/docker-dd-agent:massi_ingest_k8s_events",
+            "ports": [
+              {
+                "name": "dogstatsdport",
+                "containerPort": 8125,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "API_KEY",
+                "value": "51bdfb1e67a5b2097feeed5603f3cc7d"
+              },
+              {
+                "name": "SD_BACKEND",
+                "value": "docker"
+              },
+              {
+                "name": "SD_CONFIG_BACKEND",
+                "value": "etcd"
+              },
+              {
+                "name": "SD_BACKEND_HOST",
+                "value": "etcd-client"
+              },
+              {
+                "name": "SD_BACKEND_PORT",
+                "value": "2379"
+              },
+              {
+                "name": "LOG_LEVEL",
+                "value": "DEBUG"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "1",
+                "memory": "128Mi"
+              },
+              "requests": {
+                "cpu": "250m",
+                "memory": "64Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "dockersocket",
+                "mountPath": "/var/run/docker.sock"
+              },
+              {
+                "name": "procdir",
+                "readOnly": true,
+                "mountPath": "/host/proc"
+              },
+              {
+                "name": "cgroups",
+                "readOnly": true,
+                "mountPath": "/host/sys/fs/cgroup"
+              },
+              {
+                "name": "default-token-racjk",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "kubernetes-massi-minion-k23m",
+        "securityContext": {}
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2016-06-16T13:56:09Z"
+          }
+        ],
+        "hostIP": "10.240.0.9",
+        "podIP": "10.244.1.4",
+        "startTime": "2016-06-16T13:56:07Z",
+        "containerStatuses": [
+          {
+            "name": "dd-agent",
+            "state": {
+              "running": {
+                "startedAt": "2016-06-16T13:56:08Z"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "datadog/docker-dd-agent:massi_ingest_k8s_events",
+            "imageID": "docker://22c8298aadea7bae69765758a88fc373118c9a0c332d23aa99869d4f84d75a8e",
+            "containerID": "docker://9a4d1a5dc416b805f015efb2a0f310180ec3d9c7026ace523f29a1e5e8be2e2b"
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "dd-agent-ntepl",
+        "generateName": "dd-agent-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/dd-agent-ntepl",
+        "uid": "12ceeaa9-33ca-11e6-ac8f-42010af00003",
+        "resourceVersion": "456746",
+        "creationTimestamp": "2016-06-16T13:56:07Z",
+        "labels": {
+          "app": "dd-agent"
+        },
+        "annotations": {
+          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"dd-agent\",\"uid\":\"12c56a58-33ca-11e6-ac8f-42010af00003\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"456736\"}}\n"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "dockersocket",
+            "hostPath": {
+              "path": "/var/run/docker.sock"
+            }
+          },
+          {
+            "name": "procdir",
+            "hostPath": {
+              "path": "/proc"
+            }
+          },
+          {
+            "name": "cgroups",
+            "hostPath": {
+              "path": "/sys/fs/cgroup"
+            }
+          },
+          {
+            "name": "default-token-racjk",
+            "secret": {
+              "secretName": "default-token-racjk"
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "dd-agent",
+            "image": "datadog/docker-dd-agent:massi_ingest_k8s_events",
+            "ports": [
+              {
+                "name": "dogstatsdport",
+                "containerPort": 8125,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "API_KEY",
+                "value": "51bdfb1e67a5b2097feeed5603f3cc7d"
+              },
+              {
+                "name": "SD_BACKEND",
+                "value": "docker"
+              },
+              {
+                "name": "SD_CONFIG_BACKEND",
+                "value": "etcd"
+              },
+              {
+                "name": "SD_BACKEND_HOST",
+                "value": "etcd-client"
+              },
+              {
+                "name": "SD_BACKEND_PORT",
+                "value": "2379"
+              },
+              {
+                "name": "LOG_LEVEL",
+                "value": "DEBUG"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "1",
+                "memory": "128Mi"
+              },
+              "requests": {
+                "cpu": "250m",
+                "memory": "64Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "dockersocket",
+                "mountPath": "/var/run/docker.sock"
+              },
+              {
+                "name": "procdir",
+                "readOnly": true,
+                "mountPath": "/host/proc"
+              },
+              {
+                "name": "cgroups",
+                "readOnly": true,
+                "mountPath": "/host/sys/fs/cgroup"
+              },
+              {
+                "name": "default-token-racjk",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "kubernetes-massi-minion-k23m",
+        "securityContext": {}
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2016-06-16T13:56:09Z"
+          }
+        ],
+        "hostIP": "10.240.0.9",
+        "podIP": "10.244.2.5",
+        "startTime": "2016-06-16T13:56:07Z",
+        "containerStatuses": [
+          {
+            "name": "dd-agent",
+            "state": {
+              "running": {
+                "startedAt": "2016-06-16T13:56:08Z"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "datadog/docker-dd-agent:massi_ingest_k8s_events",
+            "imageID": "docker://22c8298aadea7bae69765758a88fc373118c9a0c332d23aa99869d4f84d75a8e",
+            "containerID": "docker://32fc50ecfe24df055f6d56037acb966337eef7282ad5c203a1be58f2dd2fe743"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kubelet/tests/requirements.txt
+++ b/kubelet/tests/requirements.txt
@@ -1,2 +1,3 @@
 mock==2.0.0
+requests-mock==1.4.0
 pytest

--- a/kubelet/tests/test_cadvisor.py
+++ b/kubelet/tests/test_cadvisor.py
@@ -1,0 +1,84 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import sys
+import json
+import mock
+import pytest
+import requests_mock
+from requests.exceptions import HTTPError
+
+from datadog_checks.kubelet import KubeletCheck
+
+from .test_kubelet import mock_from_file, EXPECTED_METRICS_COMMON, NODE_SPEC
+
+# Skip the whole tests module on Windows
+pytestmark = pytest.mark.skipif(sys.platform == 'win32', reason='tests for linux only')
+
+EXPECTED_METRICS_CADVISOR = [
+    'kubernetes.network_errors',
+    'kubernetes.diskio.io_service_bytes.stats.total',
+]
+
+
+@pytest.fixture
+def aggregator():
+    from datadog_checks.stubs import aggregator
+    aggregator.reset()
+    return aggregator
+
+
+@requests_mock.mock()
+def test_detect_cadvisor_nominal(m):
+    m.head('http://kubelet:4192/api/v1.3/subcontainers/', text='{}')
+    url = KubeletCheck.detect_cadvisor("http://kubelet:10250", 4192)
+    assert url == "http://kubelet:4192/api/v1.3/subcontainers/"
+
+
+@requests_mock.mock()
+def test_detect_cadvisor_404(m):
+    m.head('http://kubelet:4192/api/v1.3/subcontainers/', status_code=404)
+    with pytest.raises(HTTPError):
+        url = KubeletCheck.detect_cadvisor("http://kubelet:10250", 4192)
+        assert url == ""
+
+
+def test_detect_cadvisor_port_zero():
+    with pytest.raises(ValueError):
+        url = KubeletCheck.detect_cadvisor("http://kubelet:10250", 0)
+        assert url == ""
+
+
+def test_kubelet_check_cadvisor(monkeypatch, aggregator):
+    cadvisor_url = "http://valid:port/url"
+    check = KubeletCheck('kubelet', None, {}, [{}])
+    monkeypatch.setattr(check, 'retrieve_pod_list',
+                        mock.Mock(return_value=json.loads(mock_from_file('pods_list_1.2.json'))))
+    monkeypatch.setattr(check, '_retrieve_node_spec', mock.Mock(return_value=NODE_SPEC))
+    monkeypatch.setattr(check, '_perform_kubelet_check', mock.Mock(return_value=None))
+    monkeypatch.setattr(check, '_retrieve_cadvisor_metrics',
+                        mock.Mock(return_value=json.loads(mock_from_file('cadvisor_1.2.json'))))
+    monkeypatch.setattr(check, 'process', mock.Mock(return_value=None))
+    monkeypatch.setattr(check, 'detect_cadvisor', mock.Mock(return_value=cadvisor_url))
+
+    # We filter out slices unknown by the tagger, mock a non-empty taglist
+    monkeypatch.setattr('datadog_checks.kubelet.cadvisor.tags_for_docker',
+                        mock.Mock(return_value=["foo:bar"]))
+    monkeypatch.setattr('datadog_checks.kubelet.cadvisor.tags_for_pod',
+                        mock.Mock(return_value=["foo:bar"]))
+
+    check.check({})
+    assert check.cadvisor_legacy_url == cadvisor_url
+    check.retrieve_pod_list.assert_called_once()
+    check._retrieve_node_spec.assert_called_once()
+    check._retrieve_cadvisor_metrics.assert_called_once()
+    check._perform_kubelet_check.assert_called_once()
+    check.process.assert_not_called()
+
+    # called twice so pct metrics are guaranteed to be there
+    check.check({})
+    for metric in EXPECTED_METRICS_COMMON:
+        aggregator.assert_metric(metric)
+    for metric in EXPECTED_METRICS_CADVISOR:
+        aggregator.assert_metric(metric)
+    assert aggregator.metrics_asserted_pct == 100.0

--- a/kubelet/tests/test_common.py
+++ b/kubelet/tests/test_common.py
@@ -1,0 +1,78 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import sys
+import os
+
+import mock
+import pytest
+import json
+
+from datadog_checks.kubelet import ContainerFilter, get_pod_by_uid, is_static_pending_pod
+
+from .test_kubelet import mock_from_file
+
+# Skip the whole tests module on Windows
+pytestmark = pytest.mark.skipif(sys.platform == 'win32', reason='tests for linux only')
+
+# Constants
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+def test_container_filter(monkeypatch):
+    is_excluded = mock.Mock(return_value=False)
+    monkeypatch.setattr('datadog_checks.kubelet.common.is_excluded', is_excluded)
+
+    long_cid = "docker://a335589109ce5506aa69ba7481fc3e6c943abd23c5277016c92dac15d0f40479"
+    short_cid = "a335589109ce5506aa69ba7481fc3e6c943abd23c5277016c92dac15d0f40479"
+    ctr_name = "datadog-agent"
+    ctr_image = "datadog/agent-dev:haissam-tagger-pod-entity"
+
+    pods = json.loads(mock_from_file('pods.json'))
+    filter = ContainerFilter(pods)
+
+    assert filter is not None
+    assert len(filter.containers) == 5 * 2
+    assert long_cid in filter.containers
+    assert short_cid in filter.containers
+    is_excluded.assert_not_called()
+
+    # Test non-existing container
+    is_excluded.reset_mock()
+    assert filter.is_excluded("invalid") is True
+    is_excluded.assert_not_called()
+
+    # Test existing unfiltered container
+    is_excluded.reset_mock()
+    assert filter.is_excluded(short_cid) is False
+    is_excluded.assert_called_once()
+    is_excluded.assert_called_with(ctr_name, ctr_image)
+
+    # Test existing filtered container
+    is_excluded.reset_mock()
+    is_excluded.return_value = True
+    assert filter.is_excluded(short_cid) is True
+    is_excluded.assert_called_once()
+    is_excluded.assert_called_with(ctr_name, ctr_image)
+
+
+def test_pod_by_uid():
+    podlist = json.loads(mock_from_file('pods.json'))
+
+    pod = get_pod_by_uid("260c2b1d43b094af6d6b4ccba082c2db", podlist)
+    assert pod is not None
+    assert pod["metadata"]["name"] == "kube-proxy-gke-haissam-default-pool-be5066f1-wnvn"
+
+
+def test_is_static_pod():
+    podlist = json.loads(mock_from_file('pods.json'))
+
+    # kube-proxy-gke-haissam-default-pool-be5066f1-wnvn is static
+    pod = get_pod_by_uid("260c2b1d43b094af6d6b4ccba082c2db", podlist)
+    assert pod is not None
+    assert is_static_pending_pod(pod) is True
+
+    # fluentd-gcp-v2.0.10-9q9t4 is not static
+    pod = get_pod_by_uid("2edfd4d9-10ce-11e8-bd5a-42010af00137", podlist)
+    assert pod is not None
+    assert is_static_pending_pod(pod) is False

--- a/kubernetes/metadata.csv
+++ b/kubernetes/metadata.csv
@@ -12,3 +12,4 @@ kubernetes.memory.usage,gauge,,byte,,The amount of memory used,-1,kubernetes,k8s
 kubernetes.network.rx_bytes,gauge,,byte,second,The amount of bytes per second received,0,kubernetes,k8s.net.rx
 kubernetes.network.tx_bytes,gauge,,byte,second,The amount of bytes per second transmitted,0,kubernetes,k8s.net.tx
 kubernetes.network_errors,gauge,,error,second,The amount of network errors per second,-1,kubernetes,k8s.net.errors
+kubernetes.diskio.io_service_bytes.stats.total,gauge,,byte,,The amount of disk space the container uses.,-1,kubernetes,k8s.disk.total


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Port the cadvisor collection logic from agent5's kubernetes check to agent6. This PR:

- adds the `ContainerFilter` helper class to consume the [new agent interface](https://github.com/DataDog/datadog-agent/pull/1560). **Only used for cadvisor mode for now**, prometheus mode will be patched in another PR
- factors-out common parts to a `common.py` file
- copy [agent5 cadvisor logic](https://github.com/DataDog/integrations-core/blob/0d60fa0790e02fe6648bf174e8640d7401d4600a/kubernetes/datadog_checks/kubernetes/kubernetes.py#L243-L388) to a `CadvisorScraper` helper class for clearer separation
- update the cadvisor logic to support agent6 facilities (tagger, filter)
- update the cadvisor logic to report network metrics at the pod cardinality for consistency with prometheus mode (change from agent5): see comment lower
- add the missing disk metric in the `kubernetes.csv` metadata file

### Motivation

Support legacy k8s clusters

### Testing Guidelines

Pushed the `datadog/agent-dev:xvello-test1-3` image for testing

Cadvisor mode can be triggered with the following confd configmap:

```
  confd:
    kubelet.yaml: |-
      init_config:
      instances:
        - cadvisor_port: 4194
```

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [X] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
