### PR TITLE
[HTTP Check] Update CACert embedded path to work for Linux and Windows

### DIFF
--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - http_check
 
+2.0.1 / Unreleased
+==================
+
+### Changes
+
+* [BUGFIX] Properly detect default certificate file for all supported Platforms. See [#1340][]
+
 2.0.0 / 2018-03-23
 ==================
 
@@ -80,3 +87,4 @@
 [@xkrt]: https://github.com/xkrt
 [#905]:https://github.com/DataDog/integrations-core/pull/905
 [#1054]:https://github.com/DataDog/integrations-core/pull/1054
+[#1340]:https://github.com/DataDog/integrations-core/pull/1340

--- a/http_check/datadog_checks/http_check/__init__.py
+++ b/http_check/datadog_checks/http_check/__init__.py
@@ -2,6 +2,6 @@ from . import http_check
 
 HTTPCheck = http_check.HTTPCheck
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 __all__ = ['http_check']

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -149,8 +149,7 @@ def get_ca_certs_path():
             break
         embedded_root = os.path.dirname(embedded_root)
     else:
-        self.log.debug("Unable to locate the Agent's embedded CACERT. Please specify a ca_certs section in your yaml configuration")
-        raise OSError('Unable to locate `embedded` directory')
+        raise OSError('Unable to locate `embedded` directory. Please specify ca_certs in your http yaml configuration file.')
 
     try:
         import tornado

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -28,6 +28,7 @@ from requests.packages.urllib3.packages.ssl_match_hostname import \
 
 # project
 from checks.network_checks import NetworkCheck, Status
+from datadog_checks.utils.platform import Platform
 from config import _is_affirmative
 from util import headers as agent_headers
 
@@ -132,12 +133,17 @@ def get_ca_certs_path():
     Get a path to the trusted certificates of the system
     """
     """
-    check is installed via pip to embedded/lib/site-packages/datadog_checks/http_check
+    check is installed via pip to:
+    Windows: embedded/lib/site-packages/datadog_checks/http_check
+    Linux: embedded/lib/python2.7/site-packages/datadog_checks/http_check
     certificate is installed to   embedded/ssl/certs/cacert.pem
 
     walk up to embedded, and back down to ssl/certs to find the certificate file
     """
-    ca_certs = [os.path.normpath(os.path.join(os.path.dirname(__file__), '../../../..', 'ssl/certs', 'cacert.pem'))]
+    if Platform.is_windows():
+        ca_certs = [os.path.normpath(os.path.join(os.path.dirname(__file__), '../../../..', 'ssl/certs', 'cacert.pem'))]
+    else:
+        ca_certs = [os.path.normpath(os.path.join(os.path.dirname(__file__), '../../../../..', 'ssl/certs', 'cacert.pem'))]
 
     try:
         import tornado

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "2.0.0",
+  "version": "2.0.1",
   "guid": "eb133a1f-697c-4143-bad3-10e72541fa9c",
   "public_title": "Datadog-HTTP Check Integration",
   "categories":["web", "network"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

update path of embedded ca_cert to work for windows and linux

### Motivation

Customers noticed the ssl_days_left metric reports 0. We have to validate the certificate we attempt to pull the expiration date from before we can get the expiration date. If there is no ca_cert specified in the http yaml file, we try to use the one embedded with the Agent. Currently the path to that file is correct for Windows but not for Linux. This fixes that. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

