### PR TITLE
[kube_dns] adding count metric kubedns.request_count.count

### DIFF
--- a/kube_dns/CHANGELOG.md
+++ b/kube_dns/CHANGELOG.md
@@ -4,7 +4,7 @@
 ==================
 ### Changes
 
-* [IMPROVEMENT] Add metric `kubedns.request_duration.seconds.count`. See [#1341][]
+* [IMPROVEMENT] Add metrics `kubedns.request_count.count`, `kubedns.error_count.count` and `cachemiss_count.count`, alternative metrics submitted as monotonic\_counts. See [#1341][]
 
 1.2.0 / 2018-01-10
 ==================
@@ -16,7 +16,7 @@
 ==================
 ### Changes
 
-* [UPDATE] Update auto_conf template to support agent 6 and 5.20+. See [#860][]
+* [UPDATE] Update auto\_conf template to support agent 6 and 5.20+. See [#860][]
 
 1.0.0 / 2017-07-18
 ==================

--- a/kube_dns/CHANGELOG.md
+++ b/kube_dns/CHANGELOG.md
@@ -4,7 +4,7 @@
 ==================
 ### Changes
 
-* [IMPROVEMENT] Add metrics `kubedns.request_count.as_count`, `kubedns.error_count.as_count` and `cachemiss_count.as_count`, alternative metrics submitted as monotonic\_counts. See [#1341][]
+* [IMPROVEMENT] Add metrics `kubedns.request_count.count`, `kubedns.error_count.count` and `cachemiss_count.count`, alternative metrics submitted as monotonic\_counts. See [#1341][]
 
 1.2.0 / 2018-01-10
 ==================

--- a/kube_dns/CHANGELOG.md
+++ b/kube_dns/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG - Kube-dns
 
-1.2.0 / 2018-01-10 
+1.3.0 / Unreleased
+==================
+### Changes
+
+* [IMPROVEMENT] Add metric `kubedns.request_duration.seconds.count`. See [#1341][]
+
+1.2.0 / 2018-01-10
 ==================
 ### Changes
 
@@ -24,4 +30,5 @@
 [#451]: https://github.com/DataDog/integrations-core/issues/451
 [#860]: https://github.com/DataDog/integrations-core/issues/860
 [#965]: https://github.com/DataDog/integrations-core/issues/965
+[#1341]: https://github.com/DataDog/integrations-core/issues/1341
 [@aerostitch]: https://github.com/aerostitch

--- a/kube_dns/CHANGELOG.md
+++ b/kube_dns/CHANGELOG.md
@@ -4,7 +4,7 @@
 ==================
 ### Changes
 
-* [IMPROVEMENT] Add metrics `kubedns.request_count.count`, `kubedns.error_count.count` and `cachemiss_count.count`, alternative metrics submitted as monotonic\_counts. See [#1341][]
+* [IMPROVEMENT] Add metrics `kubedns.request_count.as_count`, `kubedns.error_count.as_count` and `cachemiss_count.as_count`, alternative metrics submitted as monotonic\_counts. See [#1341][]
 
 1.2.0 / 2018-01-10
 ==================

--- a/kube_dns/datadog_checks/kube_dns/__init__.py
+++ b/kube_dns/datadog_checks/kube_dns/__init__.py
@@ -2,6 +2,6 @@ from . import kube_dns
 
 KubeDNSCheck = kube_dns.KubeDNSCheck
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 __all__ = ['kube_dns']

--- a/kube_dns/datadog_checks/kube_dns/kube_dns.py
+++ b/kube_dns/datadog_checks/kube_dns/kube_dns.py
@@ -43,7 +43,7 @@ class KubeDNSCheck(PrometheusCheck):
 
     def submit_as_gauge_and_monotonic_count(self, metric_suffix, message, **kwargs):
         """
-        submit a kube_dns metric both as a gauge (for compatibility) and as amonotonic_count
+        submit a kube_dns metric both as a gauge (for compatibility) and as a monotonic_count
         """
         metric_name = self.NAMESPACE + metric_suffix
         for metric in message.metric:
@@ -51,17 +51,17 @@ class KubeDNSCheck(PrometheusCheck):
             # submit raw metric
             self.gauge(metric_name, metric.counter.value, tags)
             # submit rate metric
-            self.monotonic_count(metric_name + '.count', metric.counter.value, tags)
+            self.monotonic_count(metric_name + '.as_count', metric.counter.value, tags)
 
     # metrics names for kubernetes >= 1.6.0
     def kubedns_kubedns_dns_request_count_total(self, message, **kwargs):
-        submit_as_gauge_and_monotonic_count('.request_count', message, **kwargs)
+        self.submit_as_gauge_and_monotonic_count('.request_count', message, **kwargs)
 
-    def kubedns_kubedns_dns_error_count_total:
-        submit_as_gauge_and_monotonic_count('.error_count', message, **kwargs)
+    def kubedns_kubedns_dns_error_count_total(self, message, **kwargs):
+        self.submit_as_gauge_and_monotonic_count('.error_count', message, **kwargs)
 
-    def kubedns_kubedns_dns_cachemiss_count_total:
-        submit_as_gauge_and_monotonic_count('.cachemiss_count', message, **kwargs)
+    def kubedns_kubedns_dns_cachemiss_count_total(self, message, **kwargs):
+        self.submit_as_gauge_and_monotonic_count('.cachemiss_count', message, **kwargs)
 
     # metrics names for kubernetes < 1.6.0
     def skydns_skydns_dns_request_count_total(self, message, **kwargs):

--- a/kube_dns/datadog_checks/kube_dns/kube_dns.py
+++ b/kube_dns/datadog_checks/kube_dns/kube_dns.py
@@ -20,13 +20,13 @@ class KubeDNSCheck(PrometheusCheck):
             # metrics have been renamed to kubedns in kubernetes 1.6.0
             'kubedns_kubedns_dns_response_size_bytes': 'response_size.bytes',
             'kubedns_kubedns_dns_request_duration_seconds': 'request_duration.seconds',
-            'kubedns_kubedns_dns_request_count_total': 'request_count',
+            # 'kubedns_kubedns_dns_request_count_total': 'request_count',
             'kubedns_kubedns_dns_error_count_total': 'error_count',
             'kubedns_kubedns_dns_cachemiss_count_total': 'cachemiss_count',
             # metrics names for kubernetes < 1.6.0
             'skydns_skydns_dns_response_size_bytes': 'response_size.bytes',
             'skydns_skydns_dns_request_duration_seconds': 'request_duration.seconds',
-            'skydns_skydns_dns_request_count_total': 'request_count',
+            # 'skydns_skydns_dns_request_count_total': 'request_count',
             'skydns_skydns_dns_error_count_total': 'error_count',
             'skydns_skydns_dns_cachemiss_count_total': 'cachemiss_count',
         }
@@ -45,3 +45,15 @@ class KubeDNSCheck(PrometheusCheck):
             send_buckets = True
 
         self.process(endpoint, send_histograms_buckets=send_buckets, instance=instance)
+
+    def kubedns_kubedns_dns_request_count_total(self, message, **kwargs):
+        metric_name = self.NAMESPACE + '.request_count'
+        for metric in message.metric:
+            tags = []
+            # submit raw metric
+            self.gauge(metric_name, metric.counter.value, tags)
+            # submit rate metric
+            self.monotonic_count(metric_name + '.count', metric.counter.value, tags)
+
+    def skydns_skydns_dns_request_count_total(self, message, **kwargs):
+        self.kubedns_kubedns_dns_request_count_total(message, **kwargs)

--- a/kube_dns/datadog_checks/kube_dns/kube_dns.py
+++ b/kube_dns/datadog_checks/kube_dns/kube_dns.py
@@ -53,7 +53,7 @@ class KubeDNSCheck(PrometheusCheck):
             # submit raw metric
             self.gauge(metric_name, metric.counter.value, _tags)
             # submit rate metric
-            self.monotonic_count(metric_name + '.as_count', metric.counter.value, _tags)
+            self.monotonic_count(metric_name + '.count', metric.counter.value, _tags)
 
     # metrics names for kubernetes >= 1.6.0
     def kubedns_kubedns_dns_request_count_total(self, message, **kwargs):

--- a/kube_dns/datadog_checks/kube_dns/kube_dns.py
+++ b/kube_dns/datadog_checks/kube_dns/kube_dns.py
@@ -42,9 +42,9 @@ class KubeDNSCheck(PrometheusCheck):
         self.process(endpoint, send_histograms_buckets=send_buckets, instance=instance)
 
     def submit_as_gauge_and_monotonic_count(self, metric_suffix, message, **kwargs):
-    """
-    submit a kube_dns metric both as a gauge (for compatibility) and as amonotonic_count
-    """
+        """
+        submit a kube_dns metric both as a gauge (for compatibility) and as amonotonic_count
+        """
         metric_name = self.NAMESPACE + metric_suffix
         for metric in message.metric:
             tags = []

--- a/kube_dns/datadog_checks/kube_dns/kube_dns.py
+++ b/kube_dns/datadog_checks/kube_dns/kube_dns.py
@@ -23,7 +23,7 @@ class KubeDNSCheck(PrometheusCheck):
             # metrics names for kubernetes < 1.6.0
             'skydns_skydns_dns_response_size_bytes': 'response_size.bytes',
             'skydns_skydns_dns_request_duration_seconds': 'request_duration.seconds',
-            # Note: count metrics were moved to specific function to be also submitted as monotonic_counts
+            # Note: the count metrics were moved to specific functions below to be submitted as both gauges and monotonic_counts
         }
 
 
@@ -53,6 +53,7 @@ class KubeDNSCheck(PrometheusCheck):
             # submit rate metric
             self.monotonic_count(metric_name + '.count', metric.counter.value, tags)
 
+    # metrics names for kubernetes >= 1.6.0
     def kubedns_kubedns_dns_request_count_total(self, message, **kwargs):
         submit_as_gauge_and_monotonic_count('.request_count', message, **kwargs)
 

--- a/kube_dns/datadog_checks/kube_dns/kube_dns.py
+++ b/kube_dns/datadog_checks/kube_dns/kube_dns.py
@@ -47,11 +47,13 @@ class KubeDNSCheck(PrometheusCheck):
         """
         metric_name = self.NAMESPACE + metric_suffix
         for metric in message.metric:
-            tags = []
+            _tags = []
+            for label in metric.label:
+                _tags.append('{}:{}'.format(label.name, label.value))
             # submit raw metric
-            self.gauge(metric_name, metric.counter.value, tags)
+            self.gauge(metric_name, metric.counter.value, _tags)
             # submit rate metric
-            self.monotonic_count(metric_name + '.as_count', metric.counter.value, tags)
+            self.monotonic_count(metric_name + '.as_count', metric.counter.value, _tags)
 
     # metrics names for kubernetes >= 1.6.0
     def kubedns_kubedns_dns_request_count_total(self, message, **kwargs):

--- a/kube_dns/manifest.json
+++ b/kube_dns/manifest.json
@@ -8,7 +8,7 @@
   "guid": "3c05ed97-bf34-4061-83c4-e742d7daa5f8",
   "support": "contrib",
   "supported_os": ["linux","mac_os","windows"],
-  "version": "1.2.0",
+  "version": "1.3.0",
   "public_title": "Datadog-Kube DNS Integration",
   "categories":["web", "network"],
   "type":"check",

--- a/kube_dns/metadata.csv
+++ b/kube_dns/metadata.csv
@@ -4,6 +4,8 @@ kubedns.response_size.bytes.count,gauge,,response,,Number of responses on which 
 kubedns.request_duration.seconds.sum,gauge,,second,second,Time (in seconds) each request took to resolve.,-1,kube_dns,request duration time
 kubedns.request_duration.seconds.count,gauge,,request,,Number of requests on which the kubedns.request_duration.seconds.sum metric is evaluated.,0,kube_dns,request duration sample
 kubedns.request_count,gauge,,request,,Total number of DNS requests made.,0,kube_dns,total requests
-kubedns.request_count.count,count,30,request,,Instant number of DNS requests made.,0,kube_dns,dns requests
+kubedns.request_count.count,count,30,request,,Instant number of DNS requests made.,0,kube_dns,requests
 kubedns.error_count,gauge,,error,,Number of DNS requests resulting in an error.,-1,kube_dns,requests errors
-kubedns.cachemiss_count,gauge,,request,,Number of DNS requests that result in a cache miss.,-1,kube_dns,cache miss
+kubedns.error_count.count,count,30,error,,Instant number of DNS requests made resulting in an error.,-1,kube_dns,requests errors
+kubedns.cachemiss_count,gauge,,request,,Number of DNS requests resulting in a cache miss.,-1,kube_dns,cache miss
+kubedns.cachemiss_count.count,count,30,request,,Instant number of DNS requests made resulting in a cache miss.,-1,kube_dns,cache miss

--- a/kube_dns/metadata.csv
+++ b/kube_dns/metadata.csv
@@ -4,8 +4,8 @@ kubedns.response_size.bytes.count,gauge,,response,,Number of responses on which 
 kubedns.request_duration.seconds.sum,gauge,,second,second,Time (in seconds) each request took to resolve.,-1,kube_dns,request duration time
 kubedns.request_duration.seconds.count,gauge,,request,,Number of requests on which the kubedns.request_duration.seconds.sum metric is evaluated.,0,kube_dns,request duration sample
 kubedns.request_count,gauge,,request,,Total number of DNS requests made.,0,kube_dns,total requests
-kubedns.request_count.count,count,30,request,,Instant number of DNS requests made.,0,kube_dns,requests
+kubedns.request_count.as_count,count,30,request,,Instant number of DNS requests made.,0,kube_dns,requests
 kubedns.error_count,gauge,,error,,Number of DNS requests resulting in an error.,-1,kube_dns,requests errors
-kubedns.error_count.count,count,30,error,,Instant number of DNS requests made resulting in an error.,-1,kube_dns,requests errors
+kubedns.error_count.as_count,count,30,error,,Instant number of DNS requests made resulting in an error.,-1,kube_dns,requests errors
 kubedns.cachemiss_count,gauge,,request,,Number of DNS requests resulting in a cache miss.,-1,kube_dns,cache miss
-kubedns.cachemiss_count.count,count,30,request,,Instant number of DNS requests made resulting in a cache miss.,-1,kube_dns,cache miss
+kubedns.cachemiss_count.as_count,count,30,request,,Instant number of DNS requests made resulting in a cache miss.,-1,kube_dns,cache miss

--- a/kube_dns/metadata.csv
+++ b/kube_dns/metadata.csv
@@ -4,8 +4,8 @@ kubedns.response_size.bytes.count,gauge,,response,,Number of responses on which 
 kubedns.request_duration.seconds.sum,gauge,,second,second,Time (in seconds) each request took to resolve.,-1,kube_dns,request duration time
 kubedns.request_duration.seconds.count,gauge,,request,,Number of requests on which the kubedns.request_duration.seconds.sum metric is evaluated.,0,kube_dns,request duration sample
 kubedns.request_count,gauge,,request,,Total number of DNS requests made.,0,kube_dns,total requests
-kubedns.request_count.as_count,count,30,request,,Instant number of DNS requests made.,0,kube_dns,requests
+kubedns.request_count.count,count,30,request,,Instant number of DNS requests made.,0,kube_dns,requests
 kubedns.error_count,gauge,,error,,Number of DNS requests resulting in an error.,-1,kube_dns,requests errors
-kubedns.error_count.as_count,count,30,error,,Instant number of DNS requests made resulting in an error.,-1,kube_dns,requests errors
+kubedns.error_count.count,count,30,error,,Instant number of DNS requests made resulting in an error.,-1,kube_dns,requests errors
 kubedns.cachemiss_count,gauge,,request,,Number of DNS requests resulting in a cache miss.,-1,kube_dns,cache miss
-kubedns.cachemiss_count.as_count,count,30,request,,Instant number of DNS requests made resulting in a cache miss.,-1,kube_dns,cache miss
+kubedns.cachemiss_count.count,count,30,request,,Instant number of DNS requests made resulting in a cache miss.,-1,kube_dns,cache miss

--- a/kube_dns/metadata.csv
+++ b/kube_dns/metadata.csv
@@ -3,6 +3,7 @@ kubedns.response_size.bytes.sum,gauge,,byte,,Size of the returns response in byt
 kubedns.response_size.bytes.count,gauge,,response,,Number of responses on which the kubedns.response_size.bytes.sum metric is evaluated.,0,kube_dns,response size sample count
 kubedns.request_duration.seconds.sum,gauge,,second,second,Time (in seconds) each request took to resolve.,-1,kube_dns,request duration time
 kubedns.request_duration.seconds.count,gauge,,request,,Number of requests on which the kubedns.request_duration.seconds.sum metric is evaluated.,0,kube_dns,request duration sample
-kubedns.request_count,gauge,,request,,Number of DNS requests made.,0,kube_dns,total requests
+kubedns.request_count,gauge,,request,,Total number of DNS requests made.,0,kube_dns,total requests
+kubedns.request_count.count,count,30,request,,Instant number of DNS requests made.,0,kube_dns,dns requests
 kubedns.error_count,gauge,,error,,Number of DNS requests resulting in an error.,-1,kube_dns,requests errors
 kubedns.cachemiss_count,gauge,,request,,Number of DNS requests that result in a cache miss.,-1,kube_dns,cache miss

--- a/kube_dns/test/test_kube_dns.py
+++ b/kube_dns/test/test_kube_dns.py
@@ -44,11 +44,11 @@ class TestKubeDNS(AgentCheckTest):
         NAMESPACE + '.request_duration.seconds.count',
         NAMESPACE + '.request_duration.seconds.sum',
         NAMESPACE + '.request_count',
-        NAMESPACE + '.request_count.count',
+        NAMESPACE + '.request_count.as_count',
         NAMESPACE + '.error_count',
-        NAMESPACE + '.error_count.count',
+        NAMESPACE + '.error_count.as_count',
         NAMESPACE + '.cachemiss_count',
-        NAMESPACE + '.cachemiss_count.count',
+        NAMESPACE + '.cachemiss_count.as_count',
     ]
 
     def test_check(self):

--- a/kube_dns/test/test_kube_dns.py
+++ b/kube_dns/test/test_kube_dns.py
@@ -68,6 +68,7 @@ class TestKubeDNS(AgentCheckTest):
 
         self.run_check({'instances': [instance]}, mocks=mocks)
         # check that we have gauge metrics, and NOT rate metrics (as we should then only have one point for them)
+        # (Can happen if some labels are not picked up as tags when reading up the prometheus output)
         for metric in self.METRICS:
             self.assertMetric(metric)
         self.coverage_report()

--- a/kube_dns/test/test_kube_dns.py
+++ b/kube_dns/test/test_kube_dns.py
@@ -44,6 +44,7 @@ class TestKubeDNS(AgentCheckTest):
         NAMESPACE + '.request_duration.seconds.count',
         NAMESPACE + '.request_duration.seconds.sum',
         NAMESPACE + '.request_count',
+        NAMESPACE + '.request_count.count',
         NAMESPACE + '.error_count',
         NAMESPACE + '.cachemiss_count',
     ]

--- a/kube_dns/test/test_kube_dns.py
+++ b/kube_dns/test/test_kube_dns.py
@@ -46,7 +46,9 @@ class TestKubeDNS(AgentCheckTest):
         NAMESPACE + '.request_count',
         NAMESPACE + '.request_count.count',
         NAMESPACE + '.error_count',
+        NAMESPACE + '.error_count.count',
         NAMESPACE + '.cachemiss_count',
+        NAMESPACE + '.cachemiss_count.count',
     ]
 
     def test_check(self):

--- a/kube_dns/test/test_kube_dns.py
+++ b/kube_dns/test/test_kube_dns.py
@@ -48,9 +48,9 @@ class TestKubeDNS(AgentCheckTest):
         NAMESPACE + '.cachemiss_count',
     ]
     COUNT_METRICS = [
-        NAMESPACE + '.request_count.as_count',
-        NAMESPACE + '.error_count.as_count',
-        NAMESPACE + '.cachemiss_count.as_count',
+        NAMESPACE + '.request_count.count',
+        NAMESPACE + '.error_count.count',
+        NAMESPACE + '.cachemiss_count.count',
     ]
 
     def test_check(self):
@@ -67,12 +67,12 @@ class TestKubeDNS(AgentCheckTest):
         }
 
         self.run_check({'instances': [instance]}, mocks=mocks)
-        # check that we have gauge metrics
+        # check that we have gauge metrics, and NOT rate metrics (as we should then only have one point for them)
         for metric in self.METRICS:
             self.assertMetric(metric)
         self.coverage_report()
 
-        # check that we get then the count metrics
+        # check that we then get the count metrics also
         self.run_check({'instances': [instance]}, mocks=mocks)
         for metric in self.METRICS + self.COUNT_METRICS:
             self.assertMetric(metric)

--- a/kube_dns/test/test_kube_dns.py
+++ b/kube_dns/test/test_kube_dns.py
@@ -44,10 +44,12 @@ class TestKubeDNS(AgentCheckTest):
         NAMESPACE + '.request_duration.seconds.count',
         NAMESPACE + '.request_duration.seconds.sum',
         NAMESPACE + '.request_count',
-        NAMESPACE + '.request_count.as_count',
         NAMESPACE + '.error_count',
-        NAMESPACE + '.error_count.as_count',
         NAMESPACE + '.cachemiss_count',
+    ]
+    COUNT_METRICS = [
+        NAMESPACE + '.request_count.as_count',
+        NAMESPACE + '.error_count.as_count',
         NAMESPACE + '.cachemiss_count.as_count',
     ]
 
@@ -65,7 +67,14 @@ class TestKubeDNS(AgentCheckTest):
         }
 
         self.run_check({'instances': [instance]}, mocks=mocks)
+        # check that we have gauge metrics
         for metric in self.METRICS:
+            self.assertMetric(metric)
+        self.coverage_report()
+
+        # check that we get then the count metrics
+        self.run_check({'instances': [instance]}, mocks=mocks)
+        for metric in self.METRICS + self.COUNT_METRICS:
             self.assertMetric(metric)
 
         self.coverage_report()


### PR DESCRIPTION
### What does this PR do?

Adding metric `kubedns.request_count.count` to kube_dns check, since it is easier to use in graphs.

### Motivation

Github issue: https://github.com/DataDog/integrations-core/issues/1303

### Testing Guidelines

Tested on a GKE cluster + added test

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 