### PR TITLE
[mcache] Fix wheel name

### DIFF
--- a/mcache/setup.py
+++ b/mcache/setup.py
@@ -24,7 +24,7 @@ def get_requirements(fpath):
 
 
 setup(
-    name='datadog-redisdb',
+    name='datadog-mcache',
     version=ABOUT["__version__"],
     description='The Memcache check',
     long_description=long_description,


### PR DESCRIPTION
### What does this PR do?

Fixes the name of the `mcache` wheel, probably a bad copy-paste.

### Motivation

Nightlies currently don't ship the `mcache` check because of this.

### Versioning

no version change required.

### Additional Notes

Should we have tests to catch such mistakes and/or have most of the `setup.py` code extracted out in some "setup util module" to try and avoid this kind of issues?

I noticed this because the `mcache` check wasn't shipped in the nightlies and we use it on staging, but we'd probably have missed it otherwise, and I could see this happen again.