### PR TITLE
[openstack] Nova API call optimizations

### DIFF
--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -866,7 +866,8 @@ class OpenStackCheck(AgentCheck):
             query_params["host"] = filter_by_host
 
         # If we don't have a timestamp for this instance, default to None
-        query_params['changes-since'] = self.changes_since_time.get(i_key)
+        if i_key in self.changes_since_time:
+            query_params['changes-since'] = self.changes_since_time.get(i_key)
 
         url = '{0}/servers/detail'.format(self.get_nova_endpoint())
         headers = {'X-Auth-Token': self.get_auth_token()}

--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -931,11 +931,10 @@ class OpenStackCheck(AgentCheck):
     def get_stats_for_single_server(self, server_details, tags=None):
         def _is_valid_metric(label):
             return label in NOVA_SERVER_METRICS or any(seg in label for seg in NOVA_SERVER_INTERFACE_SEGMENTS)
-
-        server_id = server_details.get('id')
-        state = server_details.get('status')
-        server_name = server_details.get('name')
-        hypervisor_hostname = server_details.get('OS-EXT-SRV-ATTR:hypervisor_hostname')
+        server_id = server_details.get('server_id')
+        state = server_details.get('state')
+        server_name = server_details.get('server_name')
+        hypervisor_hostname = server_details.get('hypervisor_hostname')
         tenant_id = server_details.get('tenant_id')
         project_name = self.get_project_name_from_id(tenant_id)
 
@@ -1141,8 +1140,8 @@ class OpenStackCheck(AgentCheck):
                     if project and 'name' in project:
                         server_tags.append('project_name:{0}'.format(project['name']))
 
-                    self.external_host_tags[server.get('id')] = host_tags
-                    self.get_stats_for_single_server(server, tags=server_tags)
+                    self.external_host_tags[server] = host_tags
+                    self.get_stats_for_single_server(servers[server], tags=server_tags)
 
                 if hyp:
                     self.get_stats_for_single_hypervisor(hyp, instance, host_tags=host_tags)

--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -866,11 +866,7 @@ class OpenStackCheck(AgentCheck):
             query_params["host"] = filter_by_host
 
         # If we don't have a timestamp for this instance, default to None
-        if i_key not in self.changes_since_time:
-            self.changes_since_time[i_key] = None
-
-        if self.changes_since_time[i_key]:
-            query_params['changes-since'] = self.changes_since_time[i_key]
+        query_params['changes-since'] = self.changes_since_time.get(i_key)
 
         url = '{0}/servers/detail'.format(self.get_nova_endpoint())
         headers = {'X-Auth-Token': self.get_auth_token()}

--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -882,7 +882,7 @@ class OpenStackCheck(AgentCheck):
             # Get a list of deleted serversTimestamp used to filter the call to get the list
             # Need to have admin perms for this to take affect
             query_params['deleted'] = 'true'
-            query_params['status'] = ''
+            query_params['status'] = None
             resp = self._make_request_with_auth_fallback(url, headers, params=query_params)
             servers.extend(resp['servers'])
             query_params['deleted'] = 'false'
@@ -908,7 +908,7 @@ class OpenStackCheck(AgentCheck):
             new_server['project_name'] = self.get_project_name_from_id(new_server['tenant_id'])
 
             # Update our cached list of servers
-            if new_server['server_id'] not in self.server_details_by_id and new_server['state'] not in DIAGNOSTICABLE_STATES:
+            if new_server['server_id'] not in self.server_details_by_id and new_server['state'] in DIAGNOSTICABLE_STATES:
                 self.server_details_by_id[new_server['server_id']] = new_server
             elif new_server['server_id'] in self.server_details_by_id and new_server['state'] in REMOVED_STATES:
                 del self.server_details_by_id[new_server['server_id']]

--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -852,7 +852,7 @@ class OpenStackCheck(AgentCheck):
 
     # Get all of the server IDs and their metadata and cache them
     # After the first run, we will only get servers that have changed state since the last collection run
-    def get_all_servers(self, filter_by_host=None, i_key):
+    def get_all_servers(self, i_key, filter_by_host=None):
         query_params = {}
         if filter_by_host:
             query_params["host"] = filter_by_host
@@ -1241,7 +1241,7 @@ class OpenStackCheck(AgentCheck):
         return self.init_config.get("os_host") or self.hostname
 
     def get_servers_managed_by_hypervisor(self, instance_key):
-        servers = self.get_all_servers(filter_by_host=self.get_my_hostname(), instance_key)
+        servers = self.get_all_servers(instance_key, filter_by_host=self.get_my_hostname())
         if self.exclude_server_id_rules:
             # Filter out excluded servers
             servers = [

--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -942,6 +942,7 @@ class OpenStackCheck(AgentCheck):
         project_name = self.get_project_name_from_id(tenant_id)
 
         server_stats = {}
+        headers = {'X-Auth-Token': self.get_auth_token()}
         url = '{0}/servers/{1}/diagnostics'.format(self.get_nova_endpoint(), server_id)
         try:
             server_stats = self._make_request_with_auth_fallback(url, headers)
@@ -1271,7 +1272,7 @@ class OpenStackCheck(AgentCheck):
             # Filter out excluded servers
             for exclude_id_rule in self.exclude_server_id_rules:
                 for server_id in self.server_details_by_id:
-                    if rem.atch(exclude_id_rule, server_id):
+                    if re.match(exclude_id_rule, server_id):
                         del self.server_details_by_id[server_id]
 
     def _get_tags_for_host(self):

--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -847,8 +847,7 @@ class OpenStackCheck(AgentCheck):
             for i, avg in enumerate([1, 5, 15]):
                 self.gauge('openstack.nova.hypervisor_load.{0}'.format(avg), load_averages[i], tags=tags)
 
-    def get_all_server_ids(self, filter_by_host=None):
-        i_key = self._instance_key(instance)
+    def get_all_server_ids(self, filter_by_host=None, i_key):
         if i_key not in self.changes_since:
             self.changes_since[i_key] = None
 
@@ -1097,7 +1096,7 @@ class OpenStackCheck(AgentCheck):
                     projects.append(project)
 
                 # Restrict monitoring to non-excluded servers
-                server_ids = self.get_servers_managed_by_hypervisor()
+                server_ids = self.get_servers_managed_by_hypervisor(instance)
 
                 host_tags = self._get_tags_for_host()
 
@@ -1233,8 +1232,9 @@ class OpenStackCheck(AgentCheck):
         """
         return self.init_config.get("os_host") or self.hostname
 
-    def get_servers_managed_by_hypervisor(self):
-        server_ids = self.get_all_server_ids(filter_by_host=self.get_my_hostname())
+    def get_servers_managed_by_hypervisor(self, instance):
+        instance_key = self._instance_key(instance)
+        server_ids = self.get_all_server_ids(filter_by_host=self.get_my_hostname(), instance_key)
         if self.exclude_server_id_rules:
             # Filter out excluded servers
             server_ids = [

--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -877,7 +877,6 @@ class OpenStackCheck(AgentCheck):
 
         servers = []
 
-        server_ids = []
         try:
             # Get a list of active servers
             query_params['status'] = 'ACTIVE'
@@ -1274,7 +1273,7 @@ class OpenStackCheck(AgentCheck):
                 for server_id in self.server_details_by_id:
                     if rem.atch(exclude_id_rule, server_id):
                         del self.server_details_by_id[server_id]
-                        
+
     def _get_tags_for_host(self):
         hostname = self.get_my_hostname()
 

--- a/openstack/test/test_openstack.py
+++ b/openstack/test/test_openstack.py
@@ -323,7 +323,7 @@ class TestOpenstack(AgentCheckTest):
     # .. server/network
     ALL_SERVER_DETAILS = {
         "server-1":{"id":"server-1", "name":"server-name-1", "status":"ACTIVE"},
-        "server-2":{"id":"server-2", "name":"server-name-2", "status":"DELETED"},
+        "server-2":{"id":"server-2", "name":"server-name-2", "status":"ACTIVE"},
         "other-1":{"id":"other-1", "name":"server-name-other-1", "status":"ACTIVE"},
         "other-2":{"id":"other-2", "name":"server-name-other-2", "status":"ACTIVE"}
     }
@@ -332,6 +332,80 @@ class TestOpenstack(AgentCheckTest):
     EXCLUDED_SERVER_IDS = ['server-2', 'other-.*']
     FILTERED_NETWORK_ID = 'server-2'
     FILTERED_SERVER_ID = 'server-1'
+
+
+    # Example response from - https://developer.openstack.org/api-ref/compute/#list-servers-detailed
+    # ID and server-name values have been changed for test readability
+    MOCK_NOVA_SERVERS = {
+        "servers": [
+            {
+                "OS-DCF:diskConfig": "AUTO",
+                "OS-EXT-AZ:availability_zone": "nova",
+                "OS-EXT-SRV-ATTR:host": "compute",
+                "OS-EXT-SRV-ATTR:hostname": "server-1",
+                "OS-EXT-SRV-ATTR:hypervisor_hostname": "fake-mini",
+                "OS-EXT-SRV-ATTR:instance_name": "instance-00000001",
+                "OS-EXT-SRV-ATTR:kernel_id": "",
+                "OS-EXT-SRV-ATTR:launch_index": 0,
+                "OS-EXT-SRV-ATTR:ramdisk_id": "",
+                "OS-EXT-SRV-ATTR:reservation_id": "r-iffothgx",
+                "OS-EXT-SRV-ATTR:root_device_name": "/dev/sda",
+                "OS-EXT-SRV-ATTR:user_data": "IyEvYmluL2Jhc2gKL2Jpbi9zdQplY2hvICJJIGFtIGluIHlvdSEiCg==",
+                "OS-EXT-STS:power_state": 1,
+                "OS-EXT-STS:task_state": 'null',
+                "OS-EXT-STS:vm_state": "active",
+                "OS-SRV-USG:launched_at": "2017-02-14T19:24:43.891568",
+                "OS-SRV-USG:terminated_at": 'null',
+                "accessIPv4": "1.2.3.4",
+                "accessIPv6": "80fe::",
+                "hostId": "2091634baaccdc4c5a1d57069c833e402921df696b7f970791b12ec6",
+                "host_status": "UP",
+                "id": "server-1",
+                "metadata": {
+                    "My Server Name": "Apache1"
+                },
+                "name": "new-server-test",
+                "status": "DELETED",
+                "tags": [],
+                "tenant_id": "6f70656e737461636b20342065766572",
+                "updated": "2017-02-14T19:24:43Z",
+                "user_id": "fake"
+            },
+            {
+                "OS-DCF:diskConfig": "AUTO",
+                "OS-EXT-AZ:availability_zone": "nova",
+                "OS-EXT-SRV-ATTR:host": "compute",
+                "OS-EXT-SRV-ATTR:hostname": "server-2",
+                "OS-EXT-SRV-ATTR:hypervisor_hostname": "fake-mini",
+                "OS-EXT-SRV-ATTR:instance_name": "instance-00000001",
+                "OS-EXT-SRV-ATTR:kernel_id": "",
+                "OS-EXT-SRV-ATTR:launch_index": 0,
+                "OS-EXT-SRV-ATTR:ramdisk_id": "",
+                "OS-EXT-SRV-ATTR:reservation_id": "r-iffothgx",
+                "OS-EXT-SRV-ATTR:root_device_name": "/dev/sda",
+                "OS-EXT-SRV-ATTR:user_data": "IyEvYmluL2Jhc2gKL2Jpbi9zdQplY2hvICJJIGFtIGluIHlvdSEiCg==",
+                "OS-EXT-STS:power_state": 1,
+                "OS-EXT-STS:task_state": 'null',
+                "OS-EXT-STS:vm_state": "active",
+                "OS-SRV-USG:launched_at": "2017-02-14T19:24:43.891568",
+                "OS-SRV-USG:terminated_at": 'null',
+                "accessIPv4": "1.2.3.4",
+                "accessIPv6": "80fe::",
+                "hostId": "2091634baaccdc4c5a1d57069c833e402921df696b7f970791b12ec6",
+                "host_status": "UP",
+                "id": "server_newly_added",
+                "metadata": {
+                    "My Server Name": "Apache1"
+                },
+                "name": "newly_added_server",
+                "status": "ACTIVE",
+                "tags": [],
+                "tenant_id": "6f70656e737461636b20342065766572",
+                "updated": "2017-02-14T19:24:43Z",
+                "user_id": "fake"
+            }
+        ]
+    }
 
     # .. config
     MOCK_CONFIG = {
@@ -392,18 +466,18 @@ class TestOpenstack(AgentCheckTest):
     @patch('datadog_checks.openstack.OpenStackCheck.get_all_servers', return_value=ALL_SERVER_DETAILS)
     def test_server_exclusion(self, *args):
         """
-        Exclude networks using regular expressions.
+        Exclude servers using regular expressions.
         """
-        A = OpenStackCheck("test", {
+        openstackCheck = OpenStackCheck("test", {
             'keystone_server_url': 'http://10.0.2.15:5000',
             'ssl_verify': False,
             'exclude_server_ids': self.EXCLUDED_SERVER_IDS
         }, {}, instances=self.MOCK_CONFIG)
 
         # Retrieve servers
-        A.server_details_by_id = self.ALL_SERVER_DETAILS
+        openstackCheck.server_details_by_id = copy.deepcopy(self.ALL_SERVER_DETAILS)
         i_key = "test_instance"
-        server_ids = A.get_servers_managed_by_hypervisor(i_key)
+        server_ids = openstackCheck.get_servers_managed_by_hypervisor(i_key)
     
         # Assert
         # .. 1 out of 4 server ids filtered
@@ -436,3 +510,28 @@ class TestOpenstack(AgentCheckTest):
 
             # cleanup
             self.check.exclude_network_id_rules = set([])
+
+    @patch('datadog_checks.openstack.OpenStackCheck._make_request_with_auth_fallback', return_value=MOCK_NOVA_SERVERS)
+    @patch('datadog_checks.openstack.OpenStackCheck.get_nova_endpoint', return_value="http://10.0.2.15:8774/v2.1/0850707581fe4d738221a72db0182876")
+    @patch('datadog_checks.openstack.OpenStackCheck.get_auth_token', return_value="test_auth_token")
+    @patch('datadog_checks.openstack.OpenStackCheck.get_project_name_from_id', return_value="tenant-1")
+    def test_cache_between_runs(self, *args):
+        """
+        Ensure the cache contains the expected VMs between check runs.
+        """
+
+        openstackCheck = OpenStackCheck("test", {
+            'keystone_server_url': 'http://10.0.2.15:5000',
+            'ssl_verify': False,
+            'exclude_server_ids': self.EXCLUDED_SERVER_IDS
+        }, {}, instances=self.MOCK_CONFIG)
+
+        # Start off with a list of servers 
+        openstackCheck.server_details_by_id = copy.deepcopy(self.ALL_SERVER_DETAILS)
+        i_key = "test_instance"
+
+        # Update the cached list of servers based on what the endpoint returns
+        cached_servers = openstackCheck.get_all_servers(i_key)
+
+        assert 'server-1' not in cached_servers
+        assert 'server_newly_added' in cached_servers

--- a/openstack/test/test_openstack.py
+++ b/openstack/test/test_openstack.py
@@ -319,6 +319,10 @@ class TestOpenstack(AgentCheckTest):
 
     # Samples
     # .. server/network
+    ALL_SERVER_DETAILS = {
+        "1":{"id":"1", "name":"server-1", "status":"ACTIVE"},
+        "2":{"id":"2", "name":"server-2", "status":"DELETED"}
+    }
     ALL_IDS = ['server-1', 'server-2', 'other-1', 'other-2']
     EXCLUDED_NETWORK_IDS = ['server-1', 'other-.*']
     EXCLUDED_SERVER_IDS = ['server-2', 'other-.*']
@@ -381,7 +385,7 @@ class TestOpenstack(AgentCheckTest):
             sleep(1.5)
             self.assertTrue(self.check._is_expired('aggregates'))
 
-    @patch('datadog_checks.openstack.OpenStackCheck.get_all_server_ids', return_value=ALL_IDS)
+    @patch('datadog_checks.openstack.OpenStackCheck.get_all_servers', return_value=ALL_IDS)
     def test_server_exclusion(self, *args):
         """
         Exclude networks using regular expressions.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Uses the optional `changes-since` portion of the Nova API to not query a full list of things every time we hit the `/servers`/ endpoint. 

Additionally, we currently call the `servers` endpoint to get a list of all servers, then check `servers/{id}` to get some metadata about each individual server, then call the diagnostics endpoint. on that server if the server is in an active state.

Instead, we now call the `servers/detail` endpoint on the first check run, which will cache all metadata and server ids. We let nova filter this to only get servers in the `ACTIVE` state, to reduce payload sizes. Then we call the diagnostic method on all active servers. This removes the call to `server/{id}` entirely (which is called once for each server running)

On top of that, now we cache the list of servers, so that heavy call to `servers/details` only occurs on the first check run. Then we keep a timestamp of when we last called it, and on subsequent calls/check runs only get the list of servers that have had their state changed. 

### Motivation

We are making heavy calls to the Nova API, and a lot of them. Which causes the check to run long, and put a burden on the Openstack API when there are a large number of hosts. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
