### PR TITLE
Add docker metric "docker.cpu.shares"

### DIFF
--- a/docker_daemon/CHANGELOG.md
+++ b/docker_daemon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - docker_daemon
 
+1.10.0 / Unreleased
+==================
+### Changes
+
+* [IMPROVEMENT] Add docker.cpu.shares metric. See [#1358][]
+
 1.9.0 / 2018-03-23
 ==================
 ### Changes

--- a/docker_daemon/datadog_checks/docker_daemon/__init__.py
+++ b/docker_daemon/datadog_checks/docker_daemon/__init__.py
@@ -2,6 +2,6 @@ from . import docker_daemon
 
 DockerDaemon = docker_daemon.DockerDaemon
 
-__version__ = "1.9.0"
+__version__ = "1.10.0"
 
 __all__ = ['docker_daemon']

--- a/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py
+++ b/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py
@@ -1035,7 +1035,7 @@ class DockerDaemon(AgentCheck):
                         return dict({'softlimit': value})
                 elif 'cpu.shares' in stat_file:
                     value = int(fp.read())
-                    return dict({'shares': value})
+                    return {'shares': value}
                 else:
                     return dict(map(lambda x: x.split(' ', 1), fp.read().splitlines()))
         except IOError:

--- a/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py
+++ b/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py
@@ -98,6 +98,13 @@ CGROUP_METRICS = [
         },
     },
     {
+        "cgroup": "cpu",
+        "file": "cpu.shares",
+        "metrics": {
+            "shares": ("docker.cpu.shares", GAUGE)
+        },
+    },
+    {
         "cgroup": "blkio",
         "file": 'blkio.throttle.io_service_bytes',
         "metrics": {
@@ -1026,6 +1033,9 @@ class DockerDaemon(AgentCheck):
                     # 2 ** 60 is kept for consistency of other cgroups metrics
                     if value < 2 ** 60:
                         return dict({'softlimit': value})
+                elif 'cpu.shares' in stat_file:
+                    value = int(fp.read())
+                    return dict({'shares': value})
                 else:
                     return dict(map(lambda x: x.split(' ', 1), fp.read().splitlines()))
         except IOError:

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -11,7 +11,7 @@
     "linux",
     "mac_os"
   ],
-  "version": "1.9.0",
+  "version": "1.10.0",
   "public_title": "Datadog-Docker Integration",
   "categories":["containers", "log collection"],
   "type":"check",

--- a/docker_daemon/metadata.csv
+++ b/docker_daemon/metadata.csv
@@ -13,7 +13,7 @@ docker.cpu.user.max,gauge,,percent,,Max value of docker.cpu.user,0,docker,cpu us
 docker.cpu.user.median,gauge,,percent,,Median value of docker.cpu.user,0,docker,cpu user median
 docker.cpu.usage,gauge,,percent,,The percent of CPU time obtained by this container,0,docker,docker.cpu.usage
 docker.cpu.throttled,gauge,,,,Number of times the cgroup has been throttled,-1,docker,cpu throttled
-docker.cpu.shares,gauge,,,,Available CPU time weight,0,docker,cpu shars
+docker.cpu.shares,gauge,,,,Shares of CPU usage allocated to the container,0,docker,cpu shares
 docker.mem.cache,gauge,,byte,,The amount of memory that is being used to cache data from disk (e.g. memory contents that can be associated precisely with a block on a block device),0,docker,mem cache
 docker.mem.cache.95percentile,gauge,,byte,,95th percentile value of docker.mem.cache,0,docker,mem cache 95%
 docker.mem.cache.avg,gauge,,byte,,Average value of docker.mem.cache,0,docker,mem cache avg

--- a/docker_daemon/metadata.csv
+++ b/docker_daemon/metadata.csv
@@ -13,6 +13,7 @@ docker.cpu.user.max,gauge,,percent,,Max value of docker.cpu.user,0,docker,cpu us
 docker.cpu.user.median,gauge,,percent,,Median value of docker.cpu.user,0,docker,cpu user median
 docker.cpu.usage,gauge,,percent,,The percent of CPU time obtained by this container,0,docker,docker.cpu.usage
 docker.cpu.throttled,gauge,,,,Number of times the cgroup has been throttled,-1,docker,cpu throttled
+docker.cpu.shares,gauge,,,,Available CPU time weight,0,docker,cpu shars
 docker.mem.cache,gauge,,byte,,The amount of memory that is being used to cache data from disk (e.g. memory contents that can be associated precisely with a block on a block device),0,docker,mem cache
 docker.mem.cache.95percentile,gauge,,byte,,95th percentile value of docker.mem.cache,0,docker,mem cache 95%
 docker.mem.cache.avg,gauge,,byte,,Average value of docker.mem.cache,0,docker,mem cache avg


### PR DESCRIPTION
### What does this PR do?

Adds `docker.cpu.shares` metric to the datadog agent.
It is the value of `/sys/fs/cgroup/cpu/cpu.shares`.

<img width="1062" alt="2018-04-07 21 39 22" src="https://user-images.githubusercontent.com/117768/38454975-292c903a-3aac-11e8-8708-26ecafb80ff9.png">

### Motivation

from https://help.datadoghq.com/hc/en-us/requests/138307 .

I want normalized CPU usage for container CPU monitoring.

`docker.cpu.usage: 100%` has a different meaning depending on the value of cpu.shares (=ECS task definition "cpu" parameter). 
If cps.shares is 1024, it reaches the limit. 

If the agent can get cpu.shares, I can make a monitor like this:

```
avg:docker.cpu.usage{*} by {container_name} * 1024 / avg:docker.cpu.shares{*} by {container_name}
```

<img width="908" alt="2018-04-07 21 50 09" src="https://user-images.githubusercontent.com/117768/38455090-ab703dfc-3aad-11e8-93e5-e16363dbc122.png">

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [x] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Pull request for version 6: https://github.com/DataDog/datadog-agent/pull/1562
