### PR TITLE
kubelet: scale the core metric to nano core

### DIFF
--- a/kubelet/CHANGELOG.md
+++ b/kubelet/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG - kubelet
 
+Unreleased
+==================
+
+### Changes
+
+* [FEATURE] Reports nanocores instead of cores.
+
+
 1.1.0/ 2018-03-23
 ==================
 

--- a/kubelet/datadog_checks/kubelet/__about__.py
+++ b/kubelet/datadog_checks/kubelet/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -492,6 +492,10 @@ class KubeletCheck(PrometheusCheck):
 
     def container_cpu_usage_seconds_total(self, message, **kwargs):
         metric_name = self.NAMESPACE + '.cpu.usage.total'
+        for metric in message.metric:
+            # convert cores in nano cores
+            metric.counter.value *= 10.**9
+
         self._process_container_rate(metric_name, message)
 
     def container_fs_reads_bytes_total(self, message, **kwargs):

--- a/kubelet/manifest.json
+++ b/kubelet/manifest.json
@@ -1,6 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "1.1.0",
+  "manifest_version": "1.1.1",
   "max_agent_version": "7.0.0",
   "min_agent_version": "6.0.0",
   "name": "kubelet",


### PR DESCRIPTION
### What does this PR do?

Convert the metric `kubernetes.cpu.usage.total` from core to nanocore.

### Motivation

The Kubelet cAdvisor reports nanocores for the metric `kubernetes.cpu.usage.total` in the [integration](https://github.com/DataDog/integrations-core/tree/master/kubernetes) used by the agent 5.

The kubelet check used by the agent 6 reports cores by default. 
It creates some confusion for the users when they migrate to it.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

