### PR TITLE
 Add timeout configuration to StatsD integration

### DIFF
--- a/statsd/CHANGELOG.md
+++ b/statsd/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - statsd
 
+1.1.0 / Unreleased
+==================
+
+### Changes
+
+* [FEATURE] Add timeout configuration.
+
 1.0.0 / 2017-03-22
 ==================
 

--- a/statsd/README.md
+++ b/statsd/README.md
@@ -23,6 +23,13 @@ instances:
     port: 8126 # or wherever your statsd listens
 ```
 
+Configuration Options
+
+* `host` (Optional) - Host to be checked. This will be included as a tag: `host:<host>`. Defaults to `localhost`.
+* `port` (Optional) - Port to be checked. This will be included as a tag: `port:<port>`. Defaults to `8126`.
+* `timeout` (Optional) - Timeout for the check. Defaults to 10 seconds.
+* `tags` (Optional) - Tags to be assigned to the metric.
+
 [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent) to start sending StatsD metrics and service checks to Datadog.
 
 ### Validation

--- a/statsd/conf.yaml.example
+++ b/statsd/conf.yaml.example
@@ -3,6 +3,7 @@ init_config:
 instances:
   - host: localhost
     port: 8126
+    # timeout: 10
     # tags:
     #  - optional_tag1
     #  - optional_tag2

--- a/statsd/datadog_checks/statsd/__init__.py
+++ b/statsd/datadog_checks/statsd/__init__.py
@@ -2,6 +2,6 @@ from . import statsd
 
 StatsCheck = statsd.StatsCheck
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 __all__ = ['statsd']

--- a/statsd/manifest.json
+++ b/statsd/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "guid": "4830acf3-626b-42ff-a1db-3f37babd0ae6",
   "public_title": "Datadog-StatsD Integration",
   "categories":["monitoring"],


### PR DESCRIPTION
### What does this PR do?

Add timeout configuration to StatsD integration

### Motivation

On a server that is not very performant, it can be quite frequent that the `collector-queue` would get stuck because StatsD check would not timeout.

### Testing Guidelines

No tests were added as it can be quite complex to create a case where the service will timeout.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title for the new section.