### PR TITLE
[mcache] Add support for SASL authentication

### DIFF
--- a/mcache/CHANGELOG.md
+++ b/mcache/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changes
 
 * [FEATURE] Add custom tag support for service check.
+* [FEATURE] Add support for SASL authentication.
 
 1.1.0 / 2017-11-21
 ==================

--- a/mcache/datadog_checks/mcache/mcache.py
+++ b/mcache/datadog_checks/mcache/mcache.py
@@ -1,68 +1,14 @@
 # (C) Datadog, Inc. 2010-2017
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-import memcache
+import bmemcached
+import pkg_resources
 
 from datadog_checks.checks import AgentCheck
 
-# Ref: http://code.sixapart.com/svn/memcached/trunk/server/doc/protocol.txt
-# Name              Type     Meaning
-# ----------------------------------
-# pid               32u      Process id of this server process
-# uptime            32u      Number of seconds this server has been running
-# time              32u      current UNIX time according to the server
-# version           string   Version string of this server
-# pointer_size      32       Default size of pointers on the host OS
-#                            (generally 32 or 64)
-# rusage_user       32u:32u  Accumulated user time for this process
-#                            (seconds:microseconds)
-# rusage_system     32u:32u  Accumulated system time for this process
-#                            (seconds:microseconds)
-# curr_items        32u      Current number of items stored by the server
-# total_items       32u      Total number of items stored by this server
-#                            ever since it started
-# bytes             64u      Current number of bytes used by this server
-#                            to store items
-# curr_connections  32u      Number of open connections
-# total_connections 32u      Total number of connections opened since
-#                            the server started running
-# connection_structures 32u  Number of connection structures allocated
-#                            by the server
-# cmd_get           64u      Cumulative number of retrieval requests
-# cmd_set           64u      Cumulative number of storage requests
-# get_hits          64u      Number of keys that have been requested and
-#                            found present
-# get_misses        64u      Number of items that have been requested
-#                            and not found
-# delete_misses     64u      Number of deletions reqs for missing keys
-# delete_hits       64u      Number of deletion reqs resulting in
-#                            an item being removed.
-# evictions         64u      Number of valid items removed from cache
-#                            to free memory for new items
-# bytes_read        64u      Total number of bytes read by this server
-#                            from network
-# bytes_written     64u      Total number of bytes sent by this server to
-#                            network
-# limit_maxbytes    32u      Number of bytes this server is allowed to
-#                            use for storage.
-# threads           32u      Number of worker threads requested.
-#                            (see doc/threads.txt)
-# listen_disabled_num 32u    How many times the server has reached maxconns
-#                            (see https://code.google.com/p/memcached/wiki/Timeouts)
-#     >>> mc.get_stats()
-# [('127.0.0.1:11211 (1)', {'pid': '2301', 'total_items': '2',
-# 'uptime': '80', 'listen_disabled_num': '0', 'version': '1.2.8',
-# 'limit_maxbytes': '67108864', 'rusage_user': '0.002532',
-# 'bytes_read': '51', 'accepting_conns': '1', 'rusage_system':
-# '0.007445', 'cmd_get': '0', 'curr_connections': '4', 'threads': '2',
-# 'total_connections': '5', 'cmd_set': '2', 'curr_items': '0',
-# 'get_misses': '0', 'cmd_flush': '0', 'evictions': '0', 'bytes': '0',
-# 'connection_structures': '5', 'bytes_written': '25', 'time':
-# '1306364220', 'pointer_size': '64', 'get_hits': '0'})]
 
-# For Membase it gets worse
-# http://www.couchbase.org/wiki/display/membase/Membase+Statistics
-# https://github.com/membase/ep-engine/blob/master/docs/stats.org
+class BadResponseError(Exception):
+    pass
 
 
 class Memcache(AgentCheck):
@@ -163,17 +109,26 @@ class Memcache(AgentCheck):
     SERVICE_CHECK = 'memcache.can_connect'
 
     def get_library_versions(self):
-        return {"memcache": memcache.__version__}
+        return {
+            "memcache": pkg_resources.get_distribution("python-binary-memcached").version
+        }
+
+    def _process_response(self, response):
+        """
+        Examine the response and raise an error is something is off
+        """
+        if len(response) != 1:
+            raise BadResponseError("Malformed response: {}".format(response))
+
+        stats = response.values()[0]
+        if not len(stats):
+            raise BadResponseError("Malformed response for host: {}".format(stats))
+
+        return stats
 
     def _get_metrics(self, client, tags, service_check_tags=None):
         try:
-            raw_stats = client.get_stats()
-
-            assert len(raw_stats) == 1 and len(raw_stats[0]) == 2,\
-                "Malformed response: %s" % raw_stats
-
-            # Access the dict
-            stats = raw_stats[0][1]
+            stats = self._process_response(client.stats())
             for metric in stats:
                 # Check if metric is a gauge or rate
                 if metric in self.GAUGES:
@@ -222,7 +177,7 @@ class Memcache(AgentCheck):
                 self.SERVICE_CHECK, AgentCheck.OK,
                 tags=service_check_tags,
                 message="Server has been up for %s seconds" % uptime)
-        except AssertionError:
+        except BadResponseError:
             raise
 
     def _get_optional_metrics(self, client, tags, options=None):
@@ -233,14 +188,9 @@ class Memcache(AgentCheck):
                     optional_gauges = metrics_args[1]
                     optional_fn = metrics_args[2]
 
-                    raw_stats = client.get_stats(arg)
-
-                    assert len(raw_stats) == 1 and len(raw_stats[0]) == 2,\
-                        "Malformed response: %s" % raw_stats
-
-                    # Access the dict
-                    stats = raw_stats[0][1]
+                    stats = self._process_response(client.stats(arg))
                     prefix = "memcache.{}".format(arg)
+
                     for metric, val in stats.iteritems():
                         # Check if metric is a gauge or rate
                         metric_tags = []
@@ -255,7 +205,7 @@ class Memcache(AgentCheck):
                             our_metric = self.normalize(
                                 "{0}_rate".format(metric.lower()), prefix)
                             self.rate(our_metric, float(val), tags=tags+metric_tags)
-                except AssertionError:
+                except BadResponseError:
                     self.log.warning(
                         "Unable to retrieve optional stats from memcache instance, "
                         "running 'stats %s' they could be empty or bad configuration.", arg
@@ -325,7 +275,7 @@ class Memcache(AgentCheck):
 
         try:
             self.log.debug("Connecting to %s:%s tags:%s", server, port, tags)
-            mc = memcache.Client(["%s:%s" % (server, port)])
+            mc = bmemcached.Client(["%s:%s" % (server, port)])
 
             self._get_metrics(mc, tags, service_check_tags)
             if options:
@@ -333,7 +283,7 @@ class Memcache(AgentCheck):
                 self.OPTIONAL_STATS["items"][2] = Memcache.get_items_stats
                 self.OPTIONAL_STATS["slabs"][2] = Memcache.get_slabs_stats
                 self._get_optional_metrics(mc, tags, options)
-        except AssertionError:
+        except BadResponseError:
             self.service_check(
                 self.SERVICE_CHECK, AgentCheck.CRITICAL,
                 tags=service_check_tags,

--- a/mcache/requirements.in
+++ b/mcache/requirements.in
@@ -1,1 +1,1 @@
-python-memcached==1.53
+python-binary-memcached==0.26.1

--- a/mcache/requirements.txt
+++ b/mcache/requirements.txt
@@ -4,5 +4,9 @@
 #
 #    pip-compile --generate-hashes --output-file requirements.txt requirements.in
 #
-python-memcached==1.53 \
-    --hash=sha256:bcf71371d997bb46a3168a7b63aae66b56cccacc025af9310db4315681ef8868
+python-binary-memcached==0.26.1 \
+    --hash=sha256:e2e535ce1466104a93c0174a1a9217f6dd80d1ceafcc8a4205cbc29c09ae2252
+six==1.11.0 \
+    --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9 \
+    --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb \
+    # via python-binary-memcached

--- a/mcache/tests/common.py
+++ b/mcache/tests/common.py
@@ -6,3 +6,5 @@ import os
 PORT = 11211
 SERVICE_CHECK = 'memcache.can_connect'
 HOST = os.getenv('DOCKER_HOSTNAME', 'localhost')
+USERNAME = 'testuser'
+PASSWORD = 'testpass'

--- a/mcache/tests/docker-compose.yaml
+++ b/mcache/tests/docker-compose.yaml
@@ -2,6 +2,10 @@ version: '3.5'
 
 services:
   memcached:
-    image: memcached
+    image: datadog/docker-library:memcached_SASL
+    environment:
+      USERNAME: testuser
+      PASSWORD: testpass
     ports:
       - "11211:11211"
+    command: memcached -S

--- a/mcache/tests/test_check.py
+++ b/mcache/tests/test_check.py
@@ -8,8 +8,9 @@ import time
 from datadog_checks.mcache import Memcache
 import pytest
 import bmemcached
+from bmemcached.exceptions import MemcachedException
 
-from .common import PORT, SERVICE_CHECK, HOST
+from .common import PORT, SERVICE_CHECK, HOST, USERNAME, PASSWORD
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -110,15 +111,20 @@ def memcached():
     """
     Start a standalone Memcached server.
     """
-    subprocess.check_call(["docker-compose", "-f", os.path.join(HERE, 'docker-compose.yaml'), "up", "-d"])
+    env = os.environ
+    env['PWD'] = HERE
+    compose_file = os.path.join(HERE, 'docker-compose.yaml')
+
+    subprocess.check_call(["docker-compose", "-f", compose_file, "up", "-d"], env=env)
     attempts = 0
     while True:
         if attempts > 10:
             raise Exception("Memcached boot timed out!")
 
-        mc = bmemcached.Client(["{}:{}".format(HOST, PORT)])
-        mc.set("foo", "bar")
-        if not mc.get("foo"):
+        mc = bmemcached.Client(["{}:{}".format(HOST, PORT)], USERNAME, PASSWORD)
+        try:
+            mc.set("foo", "bar")
+        except MemcachedException:
             attempts += 1
             time.sleep(1)
         else:
@@ -133,12 +139,23 @@ def memcached():
 
 @pytest.fixture
 def client():
-    return bmemcached.Client(["{}:{}".format(HOST, PORT)])
+    return bmemcached.Client(["{}:{}".format(HOST, PORT)], USERNAME, PASSWORD)
 
 
 @pytest.fixture
 def check():
     return Memcache('mcache', None, {}, [{}])
+
+
+@pytest.fixture
+def instance():
+    return {
+        'url': "{}".format(HOST),
+        'port': PORT,
+        'tags': ["foo:bar"],
+        'username': USERNAME,
+        'password': PASSWORD,
+    }
 
 
 @pytest.fixture
@@ -175,7 +192,7 @@ def test_service_ko(check, aggregator):
     """
     If the service is down, the service check should be sent accordingly
     """
-    tags = ["host:{}".format(HOST), "port:11211", "foo:bar"]
+    tags = ["host:{}".format(HOST), "port:{}".format(PORT), "foo:bar"]
     with pytest.raises(Exception) as e:
         check.check({'url': "{}".format(HOST), 'port': PORT, 'tags': ["foo:bar"]})
         # FIXME: the check should raise a more precise exception and there should be
@@ -187,54 +204,55 @@ def test_service_ko(check, aggregator):
     assert sc.tags == tags
 
 
-def test_service_ok(check, aggregator, memcached):
+def test_service_ok(check, instance, aggregator, memcached):
     """
     Service is up
     """
-    tags = ["host:{}".format(HOST), "port:11211", "foo:bar"]
-    check.check({'url': "{}".format(HOST), 'port': PORT, 'tags': ["foo:bar"]})
+    tags = ["host:{}".format(HOST), "port:{}".format(PORT), "foo:bar"]
+    check.check(instance)
     assert len(aggregator.service_checks(SERVICE_CHECK)) == 1
     sc = aggregator.service_checks(SERVICE_CHECK)[0]
     assert sc.status == check.OK
     assert sc.tags == tags
 
 
-def test_metrics(client, check, aggregator, memcached):
+def test_metrics(client, check, instance, aggregator, memcached):
     """
     Test all the available metrics: default, options and slabs
     """
     # we need to successfully retrieve a key to produce `get_hit_percent`
-    client.set("foo", "bar")
-    client.get("foo")
+    for _ in range(100):
+        assert client.set("foo", "bar") is True
+        assert client.get("foo") == "bar"
 
-    instance = {
-        'url': "{}".format(HOST),
-        'port': PORT,
+    instance.update({
         'options': {
             'items': True,
             'slabs': True,
         }
-    }
+    })
     check.check(instance)
 
-    expected_tags = ["url:{}:11211".format(HOST)]
+    print(aggregator._metrics)
+
+    expected_tags = ["url:{}:{}".format(HOST, PORT), 'foo:bar']
     for m in GAUGES + RATES + SLABS_AGGREGATES:
         aggregator.assert_metric(m, tags=expected_tags, count=1)
 
-    expected_tags = ["url:{}:11211".format(HOST), "slab:1"]
+    expected_tags += ["slab:1"]
     for m in ITEMS_GAUGES + ITEMS_RATES + SLABS_RATES + SLABS_GAUGES:
         aggregator.assert_metric(m, tags=expected_tags, count=1)
 
     assert aggregator.metrics_asserted_pct == 100.0
 
 
-def test_connections_leaks(check):
+def test_connections_leaks(check, instance):
     """
     This test was ported from the old test suite but the leak might not be a
     problem anymore.
     """
     # Start state, connections should be 0
     assert count_connections(PORT) == 0
-    check.check({'url': "{}".format(HOST), 'port': PORT})
+    check.check(instance)
     # Verify that the count is still 0
     assert count_connections(PORT) == 0

--- a/mcache/tests/test_check.py
+++ b/mcache/tests/test_check.py
@@ -7,7 +7,7 @@ import time
 
 from datadog_checks.mcache import Memcache
 import pytest
-import memcache
+import bmemcached
 
 from .common import PORT, SERVICE_CHECK, HOST
 
@@ -116,7 +116,7 @@ def memcached():
         if attempts > 10:
             raise Exception("Memcached boot timed out!")
 
-        mc = memcache.Client(["{}:{}".format(HOST, PORT)])
+        mc = bmemcached.Client(["{}:{}".format(HOST, PORT)])
         mc.set("foo", "bar")
         if not mc.get("foo"):
             attempts += 1
@@ -133,7 +133,7 @@ def memcached():
 
 @pytest.fixture
 def client():
-    return memcache.Client(["{}:{}".format(HOST, PORT)])
+    return bmemcached.Client(["{}:{}".format(HOST, PORT)])
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

This is a port of this PR: https://github.com/DataDog/dd-agent/pull/2570

### Motivation

Old contribution

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

To support SASL authentication we also need to change the client we use to connect to the service to `python-binary-memcached` which is pure python despite the name

