### PR TITLE
[Active Directory] Fix broken link to conf sample

### DIFF
--- a/active_directory/CHANGELOG.md
+++ b/active_directory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - active_directory
 
+1.0.1 / Unreleased
+==================
+* [DOCUMENTATION] Fix broken link to sample configuration file
+
 1.0.0 / 2017-12-15
 ==================
 

--- a/active_directory/README.md
+++ b/active_directory/README.md
@@ -13,7 +13,7 @@ Install the `dd-check-active_directory` package manually or with your favorite c
 
 ### Configuration
 
-Edit the `active_directory.yaml` file to collect Active Directory performance data. See the [sample active_directory.yaml](https://github.com/DataDog/integrations-core/blob/master/active_directory/conf.yaml.example) for all available configuration options.
+Edit the `active_directory.yaml` file to collect Active Directory performance data. See the [sample active_directory.yaml](https://github.com/DataDog/integrations-core/blob/master/active_directory/datadog_checks/active_directory/conf.yaml.example) for all available configuration options.
 
 ### Validation
 

--- a/active_directory/datadog_checks/active_directory/__init__.py
+++ b/active_directory/datadog_checks/active_directory/__init__.py
@@ -2,6 +2,6 @@ from . import active_directory
 
 ActiveDirectory = active_directory.ActiveDirectory
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 __all__ = ['active_directory']

--- a/active_directory/manifest.json
+++ b/active_directory/manifest.json
@@ -9,7 +9,7 @@
   "supported_os": [
     "windows"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "guid": "ba667ff3-cf6a-458c-aa4b-1172f33de562",
   "public_title": "Datadog-Active Directory Integration",
   "categories":["os & system"],


### PR DESCRIPTION
### What does this PR do?

This PR fixes a broken link to active directory config sample

### Motivation

The link to the sample configuration was broken on the docs site and in this repo.

### Testing

N/A Documentation Only

### Versioning

- [ X ] Bumped the check version in `manifest.json`
- [ X ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ X ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ X ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

See also: https://github.com/DataDog/documentation/issues/2328


### Additional Notes

N/A
