### PR TITLE
[oracle] enable on windows

### DIFF
--- a/oracle/README.md
+++ b/oracle/README.md
@@ -12,7 +12,7 @@ In order to use the Oracle integration, install the Oracle Instant Client librar
 
 You will need to install the Instant Client Basic and SDK packages.
 
-After you have installed the Instant Client libraries, ensure that the runtime linker can find the libraries. For example, using `'ldconfig`:
+After you have installed the Instant Client libraries, on linux you may have to ensure that the runtime linker can find the libraries. For example, using `'ldconfig`:
 
 ```
 # Put the library location in an ld configuration file.

--- a/oracle/manifest.json
+++ b/oracle/manifest.json
@@ -10,7 +10,7 @@
   "metric_to_check": "oracle.session_count",
   "creates_events": false,
   "support": "contrib",
-  "supported_os": ["linux","mac_os"],
+  "supported_os": ["linux","mac_os", "windows"],
   "version": "1.1.0",
   "guid": "6c4ddc46-2763-4c56-8b71-c838b7f82d7b",
   "public_title": "Datadog-Oracle Integration",


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Enable oracle integration on windows

### Motivation

cx_Oracle is available on windows, once the windows instantclient is available the integration should just work.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

No versioning changes are necessary as we are just enabling it on windows.

### Additional Notes

Anything else we should know when reviewing?
