### PR TITLE
[Active Directory] Update link to conf.yaml.example

### DIFF
--- a/active_directory/CHANGELOG.md
+++ b/active_directory/CHANGELOG.md
@@ -3,6 +3,7 @@
 1.0.1 / Unreleased
 ==================
 * [DOCUMENTATION] Fix broken link to sample configuration file
+* [FIX] Moved conf.yaml to root of folder to ensure it is consistent and shipped with the wheel
 
 1.0.0 / 2017-12-15
 ==================

--- a/active_directory/README.md
+++ b/active_directory/README.md
@@ -13,7 +13,7 @@ Install the `dd-check-active_directory` package manually or with your favorite c
 
 ### Configuration
 
-Edit the `active_directory.yaml` file to collect Active Directory performance data. See the [sample active_directory.yaml](https://github.com/DataDog/integrations-core/blob/master/active_directory/datadog_checks/active_directory/conf.yaml.example) for all available configuration options.
+Edit the `active_directory.yaml` file to collect Active Directory performance data. See the [sample active_directory.yaml](https://github.com/DataDog/integrations-core/blob/master/active_directory/conf.yaml.example) for all available configuration options.
 
 ### Validation
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes a broken link to active directory config sample after PR #1374 moved the conf.yaml.example to the root directory.

### Motivation

The link to the sample configuration was broken on the docs site and in this repo.

### Testing

N/A Documentation Only

### Versioning

- [ X ] Bumped the check version in `manifest.json`
- [ X ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ X ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ X ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

See also: https://github.com/DataDog/documentation/issues/2328

### Additional Notes

N/A
