### PR TITLE
 Adding db.rollback when transaction fails so we can get metrics from old postgres

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - postgres
 
+2.1.1 / Unreleased
+=================
+### Changes
+
+* [BUGFIX] Adding db rollback when transaction fails in postgres metrics collection. See[#1193][].
+
 2.1.0 / 2018-03-07
 ==================
 ### Changes

--- a/postgres/datadog_checks/postgres/__about__.py
+++ b/postgres/datadog_checks/postgres/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -544,6 +544,7 @@ SELECT s.schemaname,
             results = cursor.fetchall()
         except programming_error as e:
             log_func("Not all metrics may be available: %s" % str(e))
+            db.rollback()
             return None
 
         if not results:

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -1,8 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "0.1.1",
-  "max_agent_version": "6.0.0",
-  "min_agent_version": "5.6.3",
+  "manifest_version": "1.0.0",
   "name": "postgres",
   "short_description": "Collect a wealth of database performance and health metrics.",
   "support": "core",
@@ -12,7 +10,6 @@
     "windows"
   ],
   "package_deps": false,
-  "version": "2.1.0",
   "guid": "e9ca29d5-5b4f-4478-8989-20d89afda0c9",
   "public_title": "Datadog-Postgres SQL Integration",
   "categories":["data store", "log collection"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Continuation of https://github.com/DataDog/integrations-core/pull/1241
