### PR TITLE
[Kafka] Producer 0.11.x metrics

### DIFF
--- a/kafka/CHANGELOG.md
+++ b/kafka/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changes
 
 * [FEATURE] Added new Kafka "per topic" metrics. See [#1208][]
+* [FEATURE] Added metrics for Producers 0.11.x See [#1392][]
 
 1.0.2 / 2017-11-21
 ==================
@@ -30,4 +31,5 @@
 [#517]: https://github.com/DataDog/integrations-core/issues/517
 [#863]: https://github.com/DataDog/integrations-core/issues/863
 [#1208]: https://github.com/DataDog/integrations-core/issues/1208
+[#1392]: https://github.com/DataDog/integrations-core/issues/1392
 [@svendx4f]: https://github.com/svendx4f

--- a/kafka/conf.yaml.example
+++ b/kafka/conf.yaml.example
@@ -137,6 +137,76 @@ init_config:
             metric_type: gauge
             alias: kafka.producer.io_wait
 
+    #
+    # Producers (v0.11.x)
+    #
+    - include:
+        domain: 'kafka.producer'
+        bean_regex: 'kafka.producer:type=producer-metrics,client-id=([-.\w]+)'
+        attribute:
+          - waiting-threads:
+              metric_type: gauge
+              alias: kafka.producer.waiting_threads
+          - buffer-total-bytes:
+              metric_type: gauge
+              alias: kafka.producer.buffer_bytes_total
+          - buffer-available-bytes
+              metric_type: gauge
+              alias: kafka.producer.available_buffer_bytes
+          - bufferpool-wait-time
+              metric_type: gauge
+              alias: kafka.producer.bufferpool_wait_time
+          - batch-size-avg
+              metric_type: gauge
+              alias: kafka.producer.batch_size_avg
+          - batch-size-max
+              metric_type: gauge
+              alias: kafka.producer.batch_size_max
+          - compression-rate-avg
+              metric_type: rate
+              alias: kafka.producer.compression_rate_avg
+          - record-queue-time-avg
+              metric_type: gauge
+              alias: kafka.producer.record_queue_time_avg
+          - record-queue-time-max
+              metric_type: gauge
+              alias: kafka.producer.record_queue_time_max
+          - request-latency-avg
+              metric_type: gauge
+              alias: kafka.producer.request_latency_avg
+          - request-latency-max
+              metric_type: gauge
+              alias: kafka.producer.request_latency_max
+          - record-send-rate
+              metric_type: rate
+              alias: kafka.producer.records_sent
+          - records-per-request-avg
+              metric_type: gauge
+              alias: kafka.producer.records_per_request
+          - record-retry-rate
+              metric_type: rate
+              alias: kafka.producer.record_retry_rate
+          - record-error-rate
+              metric_type: rate
+              alias: kafka.producer.record_error_rate
+          - record-size-max
+              metric_type: gauge
+              alias: kafka.producer.record_size_max
+          - record-size-avg
+              metric_type: gauge
+              alias: kafka.producer.record_size_avg
+          - requests-in-flight
+              metric_type: gauge
+              alias: kafka.producer.requests_in_flight
+          - metadata-age
+              metric_type: gauge
+              alias: kafka.producer.metadata_age
+          - produce-throttle-time-max
+              metric_type: gauge
+              alias: kafka.producer.throttle_time_max
+          - produce-throttle-time-avg
+              metric_type: gauge
+              alias: kafka.producer.throttle_time_avg
 
     #
     # Producers: Per Topic Metrics

--- a/kafka/conf.yaml.example
+++ b/kafka/conf.yaml.example
@@ -179,7 +179,7 @@ init_config:
               alias: kafka.producer.request_latency_max
           - record-send-rate
               metric_type: rate
-              alias: kafka.producer.records_sent
+              alias: kafka.producer.records_send_rate
           - records-per-request-avg
               metric_type: gauge
               alias: kafka.producer.records_per_request

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -39,13 +39,23 @@ kafka.producer.batch_size_max,gauge,10,bytes,,The max number of bytes sent per p
 kafka.producer.record_send_rate,gauge,10,record,second,The average number of records sent per second for a topic,1,kafka,rec send
 kafka.producer.record_retry_rate,gauge,10,record,second,The average per-second number of retried record sends for a topic,1,kafka,rec retry
 kafka.producer.record_error_rate,gauge,10,error,second,The average per-second number of retried record sends for a topic,1,kafka,rec error
+kafka.producer.records_per_request,gauge,10,record,,	The average number of records sent per second.,0,kafka,rec per req
+kafka.producer.record_queue_time_avg,gauge,10,milisecond,,The average time in ms record batches spent in the record accumulator.,-1,kafka,avg record queue time
+kafka.producer.record_queue_time_max,gauge,10,milisecond,,The maximum time in ms record batches spent in the record accumulator.,-1,kafka,max record queue time
+kafka.producer.record_size_avg,gauge,10,bytes,,The average record size.,0,kafka,avg record size
+kafka.producer.record_size_max,gauge,10,bytes,,	The maximum record size.,0,kafka,max record size
 kafka.producer.request_rate,gauge,10,request,second,Number of producer requests per second.,1,kafka,prod req
 kafka.producer.response_rate,gauge,10,response,second,Number of producer responses per second.,1,kafka,prod resp
+kafka.producer.requests_in_flight,gauge,10,request,,The current number of in-flight requests awaiting a response.,-1,kafka,req in flight
 kafka.producer.request_latency_avg,gauge,10,millisecond,,Producer average request latency.,-1,kafka,prod req latency avg
-kafka.producer.bytes_out,gauge,10,byte,second,Producer bytes out rate.,1,kafka,prod bytes out
+kafka.producer.request_latency_max,gauge,10,milisecond,,The maximum request latency in ms.,-1,kafka, prod req latency max
+kafka.producer.bytes_out,gauge,10,bytes,second,Producer bytes out rate.,1,kafka,prod bytes out
+kafka.producer.metadata_age,gauge,10,seconds,,The age in seconds of the current producer metadata being used.,-1,kafka,metadata age
 kafka.producer.message_rate,gauge,10,message,second,Producer message rate.,1,kafka,prod msg rate
 kafka.producer.buffer_bytes_total,gauge,10,bytes,,The maximum amount of buffer memory the client can use (whether or not it is currently used).,1,kafka,buffer bytes
 kafka.producer.io_wait,gauge,10,nanosecond,,Producer I/O wait time.,-1,kafka,prod io wait
+kafka.producer.throttle_time_avg,gauge,10,milisecond,,The average time in ms a request was throttled by a broker.,kafka,-1,avg throttle time
+kafka.producer.throttle_time_max,gauge,10,milisecond,,	The maximum time in ms a request was throttled by a broker.,kafka,-1,max throttle time
 kafka.producer.waiting_threads,gauge,10,threads,,The number of user threads blocked waiting for buffer memory to enqueue their records.,-1,kafka,waiting threads
 kafka.consumer.max_lag,gauge,10,offset,,Maximum consumer lag.,-1,kafka,con max lag
 kafka.consumer.fetch_rate,gauge,10,request,,The minimum rate at which the consumer sends fetch requests to a broker.,1,kafka,con min fetch

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -28,9 +28,14 @@ kafka.consumer.delayed_requests,gauge,10,request,,Number of delayed consumer req
 kafka.consumer.expires_per_second,gauge,10,eviction,second,Rate of delayed consumer request expiration.,-1,kafka,con expire rate
 kafka.expires_sec,gauge,10,eviction,second,Rate of delayed producer request expiration.,-1,kafka,expire rate
 kafka.follower.expires_per_second,gauge,10,eviction,second,Rate of request expiration on followers.,-1,kafka,follow expire rate
+kafka.producer.available_buffer_bytes,gauge,10,bytes,,The total amount of buffer memory that is not being used (either unallocated or in the free list),-1,kafka,available buffer bytes
+kafka.producer.batch_size_avg,gauge,10,bytes,,The average number of bytes sent per partition per-request.,0,kafka,avg batch size
+kafka.producer.compression_rate_avg,rate,10,batches,,The average compression rate of record batches.,0,kafka,avg compression rate
+kafka.producer.bufferpool_wait_time,gauge,10,,,The fraction of time an appender waits for space allocation.,-1,kafka,bufferpool wait time
 kafka.producer.compression_rate,gauge,10,records,second,The average compression rate of record batches for a topic,1,kafka,compression rate 
 kafka.producer.delayed_requests,gauge,10,request,,Number of producer requests delayed.,-1,kafka,prod expire rate
 kafka.producer.expires_per_seconds,gauge,10,eviction,second,Rate of producer request expiration.,-1,kafka,prod req expire
+kafka.producer.batch_size_max,gauge,10,bytes,,The max number of bytes sent per partition per-request.,0,kafka,max batch size
 kafka.producer.record_send_rate,gauge,10,record,second,The average number of records sent per second for a topic,1,kafka,rec send
 kafka.producer.record_retry_rate,gauge,10,record,second,The average per-second number of retried record sends for a topic,1,kafka,rec retry
 kafka.producer.record_error_rate,gauge,10,error,second,The average per-second number of retried record sends for a topic,1,kafka,rec error
@@ -39,7 +44,9 @@ kafka.producer.response_rate,gauge,10,response,second,Number of producer respons
 kafka.producer.request_latency_avg,gauge,10,millisecond,,Producer average request latency.,-1,kafka,prod req latency avg
 kafka.producer.bytes_out,gauge,10,byte,second,Producer bytes out rate.,1,kafka,prod bytes out
 kafka.producer.message_rate,gauge,10,message,second,Producer message rate.,1,kafka,prod msg rate
+kafka.producer.buffer_bytes_total,gauge,10,bytes,,The maximum amount of buffer memory the client can use (whether or not it is currently used).,1,kafka,buffer bytes
 kafka.producer.io_wait,gauge,10,nanosecond,,Producer I/O wait time.,-1,kafka,prod io wait
+kafka.producer.waiting_threads,gauge,10,threads,,The number of user threads blocked waiting for buffer memory to enqueue their records.,-1,kafka,waiting threads
 kafka.consumer.max_lag,gauge,10,offset,,Maximum consumer lag.,-1,kafka,con max lag
 kafka.consumer.fetch_rate,gauge,10,request,,The minimum rate at which the consumer sends fetch requests to a broker.,1,kafka,con min fetch
 kafka.consumer.fetch_size_avg,gauge,10,request,,The average number of bytes fetched per request for a specific topic.,1,kafka,con avg fetch size

--- a/kafka/metrics.yaml
+++ b/kafka/metrics.yaml
@@ -110,7 +110,7 @@ jmx_metrics:
               alias: kafka.producer.request_latency_max
           - record-send-rate
               metric_type: rate
-              alias: kafka.producer.records_sent
+              alias: kafka.producer.records_send_rate
           - records-per-request-avg
               metric_type: gauge
               alias: kafka.producer.records_per_request

--- a/kafka/metrics.yaml
+++ b/kafka/metrics.yaml
@@ -71,6 +71,74 @@ jmx_metrics:
             metric_type: gauge
             alias: kafka.producer.io_wait
 
+    - include:
+        domain: 'kafka.producer'
+        bean_regex: 'kafka.producer:type=producer-metrics,client-id=([-.\w]+)'
+        attribute:
+          - waiting-threads:
+              metric_type: gauge
+              alias: kafka.producer.waiting_threads
+          - buffer-total-bytes:
+              metric_type: gauge
+              alias: kafka.producer.buffer_bytes_total
+          - buffer-available-bytes
+              metric_type: gauge
+              alias: kafka.producer.available_buffer_bytes
+          - bufferpool-wait-time
+              metric_type: gauge
+              alias: kafka.producer.bufferpool_wait_time
+          - batch-size-avg
+              metric_type: gauge
+              alias: kafka.producer.batch_size_avg
+          - batch-size-max
+              metric_type: gauge
+              alias: kafka.producer.batch_size_max
+          - compression-rate-avg
+              metric_type: gauge
+              alias: kafka.producer.compression_rate_avg
+          - record-queue-time-avg
+              metric_type: gauge
+              alias: kafka.producer.record_queue_time_avg
+          - record-queue-time-max
+              metric_type: gauge
+              alias: kafka.producer.record_queue_time_max
+          - request-latency-avg
+              metric_type: gauge
+              alias: kafka.producer.request_latency_avg
+          - request-latency-max
+              metric_type: gauge
+              alias: kafka.producer.request_latency_max
+          - record-send-rate
+              metric_type: rate
+              alias: kafka.producer.records_sent
+          - records-per-request-avg
+              metric_type: gauge
+              alias: kafka.producer.records_per_request
+          - record-retry-rate
+              metric_type: rate
+              alias: kafka.producer.record_retry_rate
+          - record-error-rate
+              metric_type: rate
+              alias: kafka.producer.record_error_rate
+          - record-size-max
+              metric_type: gauge
+              alias: kafka.producer.record_size_max
+          - record-size-avg
+              metric_type: gauge
+              alias: kafka.producer.record_size_avg
+          - requests-in-flight
+              metric_type: gauge
+              alias: kafka.producer.requests_in_flight
+          - metadata-age
+              metric_type: gauge
+              alias: kafka.producer.metadata_age
+          - produce-throttle-time-max
+              metric_type: gauge
+              alias: kafka.producer.throttle_time_max
+          - produce-throttle-time-avg
+              metric_type: gauge
+              alias: kafka.producer.throttle_time_avg
+
 
     #
     # Producers: Per Topic Metrics


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Adds in metrics for Kafka Producer 0.11.x Based off of available metrics here - https://kafka.apache.org/0110/documentation.html#producer_monitoring

### Motivation

Customer request. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

Version is already bumped from previous unreleased PR

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [X] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes
