### PR TITLE
[checks-base] Fix logger in prom scraper

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [BUG] Prometheus requests can use an insecure option
 * [BUG] Correctly handle missing counters/strings in PDH checks when possible
+* [BUG] Fix Prometheus Scrapper logger
 
 ## 1.2.1 / 2018-03-23
 

--- a/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from fnmatch import fnmatchcase
+import logging
 import requests
 from urllib3 import disable_warnings
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
@@ -39,6 +40,9 @@ class PrometheusScraper(object):
 
     def __init__(self, *args, **kwargs):
         super(PrometheusScraper, self).__init__(*args, **kwargs)
+
+        # The scraper needs its own logger
+        self.log = logging.getLogger(__name__)
 
         # message.type is the index in this array
         # see: https://github.com/prometheus/client_model/blob/master/ruby/lib/prometheus/client/model/metrics.pb.rb

--- a/kubelet/CHANGELOG.md
+++ b/kubelet/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - kubelet
 
-Unreleased
+1.2.0 / Unreleased
 ==================
 
 ### Changes
@@ -8,7 +8,7 @@ Unreleased
 * [FEATURE] Reports nanocores instead of cores.
 
 
-1.1.0/ 2018-03-23
+1.1.0 / 2018-03-23
 ==================
 
 ### Changes


### PR DESCRIPTION
### What does this PR do?

Add a logger to the prometheus scrapper

### Motivation

Fix `Error running check prometheus: [{"message": "'Scraper' object has no attribute 'log'"}]` (reported by @j-vizcaino)

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
