### PR TITLE
[checks_base/subprocess_output] Fix imports for Agent 5 & 6 compat

### DIFF
--- a/datadog_checks_base/datadog_checks/stubs/_util.py
+++ b/datadog_checks_base/datadog_checks/stubs/_util.py
@@ -3,5 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 
+class SubprocessOutputEmptyError(Exception):
+    pass
+
 def subprocess_output(*args, **kwargs):
     pass

--- a/datadog_checks_base/datadog_checks/utils/subprocess_output.py
+++ b/datadog_checks_base/datadog_checks/utils/subprocess_output.py
@@ -4,20 +4,21 @@
 import logging
 
 try:
-    # Agent5
-    from utils.subprocess_output import get_subprocess_output as subprocess_output
+    # Agent6
+    from _util import get_subprocess_output as subprocess_output
+    from _util import SubprocessOutputEmptyError  # noqa
 except ImportError:
     try:
-        # Agent6
-        from _util import get_subprocess_output as subprocess_output
+        # Agent5 (these paths may also exist in Agent6, so import them only if Agent6-specific ones aren't found)
+        from utils.subprocess_output import subprocess_output
+        from utils.subprocess_output import SubprocessOutputEmptyError  # noqa
     except ImportError:
         # No agent
         from ..stubs._util import subprocess_output
+        from ..stubs._util import SubprocessOutputEmptyError  # noqa
 
 log = logging.getLogger(__name__)
 
-class SubprocessOutputEmptyError(Exception):
-    pass
 
 def get_subprocess_output(command, log, raise_on_empty_output=True):
     """


### PR DESCRIPTION
### What does this PR do?

Fixes `subprocess_output`-related imports for Agent 5 & 6 compat.

1. Import A6-specific paths first
2. Import the correct methods (i.e. those that only expect 2 args, `command` and `raise_on_empty_output`)
3. Fix `SubprocessOutputEmptyError` definition (since it's thrown from  the imported modules, it needs to be imported from them too, otherwise code doing `from datadog_checks.utils.subprocess_output import SubprocessOutputEmptyError` won't import the exception class that's actually thrown)

Requires related change on `dd-agent`: https://github.com/DataDog/dd-agent/pull/3723

### Motivation

`network` check is currently broken on A6 because of this.

### Versioning

_doesn't apply_

### Additional notes

Relevant related files on A5 & 6: 
* A6: https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/dist/utils/subprocess_output.py
* A5: https://github.com/DataDog/dd-agent/blob/master/utils/subprocess_output.py