### PR TITLE
[prometheus] increase timeout to 10 seconds (6.1.x branch backport)

### DIFF
--- a/datadog-checks-base/datadog_checks/checks/prometheus/mixins.py
+++ b/datadog-checks-base/datadog_checks/checks/prometheus/mixins.py
@@ -469,7 +469,7 @@ class PrometheusScraper(object):
             disable_warnings(InsecureRequestWarning)
             verify = False
         try:
-            response = requests.get(endpoint, headers=headers, stream=True, timeout=1, cert=cert, verify=verify)
+            response = requests.get(endpoint, headers=headers, stream=True, timeout=10, cert=cert, verify=verify)
         except (requests.exceptions.SSLError):
             self.log.error("Invalid SSL settings for requesting {} endpoint".format(endpoint))
             raise


### PR DESCRIPTION
### What does this PR do?

6.1.x introduced a 1 second timeout on all prometheus requests, which breaks collection in the `kubernetes_state` check, see https://github.com/DataDog/integrations-core/issues/1346 for details.

6.2.0 will bring per-integration configurability

PR for the 6.1.x branch, sister PR for master en route (different file path)