### PR TITLE
[mysql] fix slave_running service check bug

### DIFF
--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [FEATURE] Add custom tag support to service checks.
+* [BUGFIX] reports slave_service check as `CRITICAL` if `Slave_running` global variable is OFF.
 
 1.1.3 / 2018-03-23
 ==================


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Customer is using MySQL version `5.6.30` which uses the deprecated `slave_running` status variable (https://dev.mysql.com/doc/refman/5.7/en/replication-administration-status.html). The `mysql.replication.slave_running` service check reports `OK` when at least one slave is connected but `Slave_running` reports `OFF`. This PR adds ensures that if `Slave_running: OFF`, the status sent will be `CRITICAL`

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
