### PR TITLE
[oracle] fix for DB with offline tablespace (#1402)

### DIFF
--- a/oracle/CHANGELOG.md
+++ b/oracle/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - oracle
 
-1.1.1 / Unreleased
+1.2.0 / Unreleased
 ==================
 
 ### Changes

--- a/oracle/CHANGELOG.md
+++ b/oracle/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG - oracle
 
+1.1.1 / Unreleased
+==================
+
+### Changes
+
+* [FEATURE] adds metric `oracle.tablespace.offline`. See #1402
+* [BUGFIX] fix for DB with offline tablespace. See #1402
+
 1.1.0 / Unreleased
 ==================
 

--- a/oracle/datadog_checks/oracle/__init__.py
+++ b/oracle/datadog_checks/oracle/__init__.py
@@ -2,6 +2,6 @@ from . import oracle
 
 Oracle = oracle.Oracle
 
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 
 __all__ = ['oracle']

--- a/oracle/datadog_checks/oracle/__init__.py
+++ b/oracle/datadog_checks/oracle/__init__.py
@@ -2,6 +2,6 @@ from . import oracle
 
 Oracle = oracle.Oracle
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 __all__ = ['oracle']

--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -115,8 +115,17 @@ class Oracle(AgentCheck):
         cur.execute(query)
         for row in cur:
             tablespace_tag = 'tablespace:%s' % row[0]
-            used = float(row[1])
-            size = float(row[2])
+            if row[1] is None:
+                # mark tablespace as offline if sum(BYTES) is null
+                offline = True
+                used = 0
+            else:
+                offline = False
+                used = float(row[1])
+            if row[2] is None:
+                size = 0
+            else:
+                size = float(row[2])
             if (used >= size):
                 in_use = 100
             elif (used == 0) or (size == 0):
@@ -127,3 +136,4 @@ class Oracle(AgentCheck):
             self.gauge('oracle.tablespace.used', used, tags=tags + [tablespace_tag])
             self.gauge('oracle.tablespace.size', size, tags=tags + [tablespace_tag])
             self.gauge('oracle.tablespace.in_use', in_use, tags=tags + [tablespace_tag])
+            self.gauge('oracle.tablespace.offline', offline, tags=tags + [tablespace_tag])

--- a/oracle/manifest.json
+++ b/oracle/manifest.json
@@ -11,7 +11,7 @@
   "creates_events": false,
   "support": "contrib",
   "supported_os": ["linux","mac_os", "windows"],
-  "version": "1.1.0",
+  "version": "1.1.1",
   "guid": "6c4ddc46-2763-4c56-8b71-c838b7f82d7b",
   "public_title": "Datadog-Oracle Integration",
   "categories":["data store"],

--- a/oracle/manifest.json
+++ b/oracle/manifest.json
@@ -11,7 +11,7 @@
   "creates_events": false,
   "support": "contrib",
   "supported_os": ["linux","mac_os", "windows"],
-  "version": "1.1.1",
+  "version": "1.2.0",
   "guid": "6c4ddc46-2763-4c56-8b71-c838b7f82d7b",
   "public_title": "Datadog-Oracle Integration",
   "categories":["data store"],

--- a/oracle/metadata.csv
+++ b/oracle/metadata.csv
@@ -25,3 +25,4 @@ oracle.temp_space_used,gauge,,bytes,,temp space used,0,oracle,temp space used
 oracle.tablespace.used,gauge,,bytes,,tablespace used,0,oracle,tablespace used
 oracle.tablespace.size,gauge,,bytes,,tablespace size,0,oracle,tablespace size
 oracle.tablespace.in_use,gauge,,fraction,,tablespace in-use,0,oracle,tablespace in-use
+oracle.tablespace.offline,gauge,,boolean,,tablespace offline,0,oracle,tablespace offline

--- a/oracle/test/ci/resources/DropTest.sql
+++ b/oracle/test/ci/resources/DropTest.sql
@@ -28,6 +28,13 @@ begin
         execute immediate 'drop user ' || r.username || ' cascade';
     end loop;
 
+    for t in
+            ( select tablespace_name
+              from dba_tablespaces
+              where tablespace_name in ('OFFLINE_TABLESPACE')
+            ) loop
+        execute immediate 'drop tablespace ' || t.tablespace_name ||
+            ' including contents and datafiles';
+    end loop;
 end;
 /
-

--- a/oracle/test/ci/resources/SetupTest.sql
+++ b/oracle/test/ci/resources/SetupTest.sql
@@ -883,3 +883,18 @@ create or replace package body &main_user..pkg_TestRecords as
 end;
 /
 
+-- create offline tablespace
+declare
+    t_FilePath dba_data_files.file_name%TYPE;
+begin
+    select substr(file_name, 1, instr(file_name, '/', -1)) into t_FilePath
+        from dba_data_files do where upper(tablespace_name) = 'SYSTEM'
+        and file_id in (select min(file_id) from dba_data_files di
+            where do.tablespace_name = di.tablespace_name);
+
+    -- create offline tablespace
+    execute immediate 'create tablespace OFFLINE_TABLESPACE datafile ''' ||
+        t_FilePath || 'offline_tablespace.dbf'' size 10m autoextend off';
+    execute immediate 'alter tablespace OFFLINE_TABLESPACE offline';
+end;
+/

--- a/oracle/test/test_oracle.py
+++ b/oracle/test/test_oracle.py
@@ -43,6 +43,7 @@ METRICS = [
     'oracle.tablespace.used',
     'oracle.tablespace.size',
     'oracle.tablespace.in_use',
+    'oracle.tablespace.offline',
     'oracle.buffer_cachehit_ratio',
     'oracle.cursor_cachehit_ratio',
     'oracle.library_cachehit_ratio',


### PR DESCRIPTION
### What does this PR do?

Fixes #1402 and adds metric `oracle.tablespace.offline`.

### Motivation

I encountered #1402 on a Datadog-monitored testbed system with an Oracle DB that had a tablespace taken offline for test purposes.  In this situation the current `oracle` integration stops partway through metric gathering, with a relatively cryptic `TypeError`.  I thought it would be useful to catch that situation and provide a metric so administrators can create a monitor to alert when a tablespace is offline.

### Testing Guidelines

Run the following in Oracle to create an offline tablespace (replace `<datapath>` with the location of datafiles for your testbed):
```
create tablespace offline_tablespace datafile '<datapath>/offline_tablespace.dbf' size 10m autoextend off;
alter tablespace offline_tablespace offline;
```

Before this change the `oracle` integration will fail with the error seen in #1402.  After the change is added the `oracle` integration completes successfully, and a new `oracle.tablespace.offline` metric should be available.

### Versioning

- [X] Bumped the check version in `manifest.json`
- [X] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [X] Updated `CHANGELOG.md`.
- [X] Opened documentation issue [2348](https://github.com/DataDog/documentation/issues/2348)

### Additional Notes

I haven't had any luck getting `rake` to work on OSX, so unfortunately I haven't been able to run `rake lint` against these changes (more of a DBA than a dev/DevOps/CI guy, sorry!).  I have manually tested this change by copying `oracle.py` to the cluster where I first encountered #1402, and successfully tested a monitor that alerts when the number of offline tablespaces exceeds a threshold:
```
sum:oracle.tablespace.offline{*} by {tablespace}
```
I made the metric value boolean since a tablespace is either online or offline, but it can still be aggregated with `sum` (0 for online, 1 for offline).

The new blocks added in `DropTest.sql` and `SetupTest.sql` were also manually tested on the same system.