### PR TITLE
[SNMP] improve error handling for undefined metrics, when device cannot be connected to 

### DIFF
--- a/snmp/CHANGELOG.md
+++ b/snmp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - snmp
 
+1.3.2 / Unreleased
+==================
+
+### Changes
+
+* [IMPROVEMENT] Enhance error handling when metrics aren't defined or device cannot be reached. See [#1406][]
+
 1.3.1 / 2018-02-13
 ==================
 
@@ -40,3 +47,4 @@
 [#426]: https://github.com/DataDog/integrations-core/issues/426
 [#723]: https://github.com/DataDog/integrations-core/issues/723
 [#1041]: https://github.com/DataDog/integrations-core/issues/1041
+[#1406]: https://github.com/DataDog/integrations-core/issues/1406

--- a/snmp/CHANGELOG.md
+++ b/snmp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - snmp
 
-1.3.2 / Unreleased
+1.4.0 / Unreleased
 ==================
 
 ### Changes

--- a/snmp/datadog_checks/snmp/__init__.py
+++ b/snmp/datadog_checks/snmp/__init__.py
@@ -2,6 +2,6 @@ from . import snmp
 
 SnmpCheck = snmp.SnmpCheck
 
-__version__ = "1.3.2"
+__version__ = "1.4.0"
 
 __all__ = ['snmp']

--- a/snmp/datadog_checks/snmp/__init__.py
+++ b/snmp/datadog_checks/snmp/__init__.py
@@ -2,6 +2,6 @@ from . import snmp
 
 SnmpCheck = snmp.SnmpCheck
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 __all__ = ['snmp']

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -301,7 +301,13 @@ class SnmpCheck(NetworkCheck):
                         message = "{0} for instance {1}".format(error_status.prettyPrint(),
                                                                 instance["ip_address"])
                         instance["service_check_error"] = message
-                        self.warning(message)
+                        
+                        # submit CRITICAL service check if we can't connect to device
+                        if 'unknownUserName' in message:
+                            instance["service_check_severity"] = Status.CRITICAL
+                            self.log.error(message)
+                        else:    
+                            self.warning(message)
 
                     for table_row in var_binds_table:
                         complete_results.extend(table_row)

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -341,6 +341,9 @@ class SnmpCheck(NetworkCheck):
 
         cmd_generator, ip_address, tags, metrics, timeout, retries, enforce_constraints = self._load_conf(instance)
 
+        if len(metrics) < 1:
+            raise Exception('Metrics list must contain at least one metric')
+
         tags += ['snmp_device:{0}'.format(ip_address)]
 
         table_oids = []

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -301,12 +301,12 @@ class SnmpCheck(NetworkCheck):
                         message = "{0} for instance {1}".format(error_status.prettyPrint(),
                                                                 instance["ip_address"])
                         instance["service_check_error"] = message
-                        
+
                         # submit CRITICAL service check if we can't connect to device
                         if 'unknownUserName' in message:
                             instance["service_check_severity"] = Status.CRITICAL
                             self.log.error(message)
-                        else:    
+                        else:
                             self.warning(message)
 
                     for table_row in var_binds_table:

--- a/snmp/manifest.json
+++ b/snmp/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.3.1",
+  "version": "1.3.2",
   "guid": "080bb566-d1c8-428c-9d85-71cc2cdf393c",
   "public_title": "Datadog-SNMP Integration",
   "categories":["monitoring", "notification", "network"],

--- a/snmp/manifest.json
+++ b/snmp/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.3.2",
+  "version": "1.4.0",
   "guid": "080bb566-d1c8-428c-9d85-71cc2cdf393c",
   "public_title": "Datadog-SNMP Integration",
   "categories":["monitoring", "notification", "network"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Adds error handling for two cases. 1) When metrics aren't defined in the yaml config file and 2) when we can't connect to a device due to an `unknownUserName`. When metrics aren't defined, the check now raises an exception. When `unknownUserName` is detected as part of the error status when polling a device, a `CRITICAL` service check is submitted an the error is logged.

### Motivation

Customer requested enhanced error handling in these two cases

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
