### PR TITLE
[tooling] update-changelog task

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -8,6 +8,7 @@ from __future__ import print_function, unicode_literals
 
 from invoke import Collection
 
+# task functions are added to the root namespace automatically
 from .cleanup import cleanup
 from .manifest import manifest
 from .upgrade import upgrade
@@ -16,12 +17,6 @@ from .changelog import update_changelog
 
 # the root namespace
 root = Collection()
-
-# add tasks to the root, without a namespace
-root.add_task(cleanup)
-root.add_task(manifest)
-root.add_task(upgrade)
-root.add_task(test)
 
 root.configure({
     'run': {

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -12,6 +12,7 @@ from .cleanup import cleanup
 from .manifest import manifest
 from .upgrade import upgrade
 from .test import test
+from .changelog import make_changelog
 
 # the root namespace
 root = Collection()

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -12,7 +12,7 @@ from .cleanup import cleanup
 from .manifest import manifest
 from .upgrade import upgrade
 from .test import test
-from .changelog import make_changelog
+from .changelog import update_changelog
 
 # the root namespace
 root = Collection()

--- a/tasks/changelog.py
+++ b/tasks/changelog.py
@@ -1,0 +1,85 @@
+# (C) Datadog, Inc. 2010-2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+from __future__ import print_function, unicode_literals
+import os
+import re
+
+from invoke import task
+from invoke.exceptions import Exit
+
+from .constants import ROOT
+
+
+# match something like `(#1234)` and return `1234` in a group
+PR_REG = re.compile(r'\(\#(\d+)\)')
+
+
+def get_version_string(check_name):
+    """
+    Get the version string for the given check.
+    """
+    about = {}
+    about_path = os.path.join(ROOT, check_name, "datadog_checks", check_name, "__about__.py")
+    with open(about_path) as f:
+        exec(f.read(), about)
+
+    return about.get('__version__')
+
+
+def get_release_tag_string(check_name, version_string):
+    """
+    Compose a string to use for release tags
+    """
+    return '{}-{}'.format(check_name, version_string)
+
+
+def parse_pr_numbers(git_log_lines):
+    """
+    Parse PR numbers from commit messages. At GitHub those have the format:
+
+        `here is the message (#1234)`
+
+    being `1234` the PR number.
+    """
+    prs = []
+    for line in git_log_lines:
+        match = re.search(PR_REG, line)
+        if match:
+            prs.append(match.group(1))
+    return prs
+
+
+@task(help={
+    'target': "The check to compile the changelog for",
+    'dry-run': "Runs the task without actually doing anything",
+})
+def make_changelog(ctx, target, dry_run=False):
+    """
+    Write the changelog for the given check
+
+    Example invocation:
+        inv make-changelog redisdb
+    """
+    # get the current version
+    version_string = get_version_string(target)
+    if not version_string:
+        raise Exit("Unable to get version for check {}".format(target))
+
+    # get the name of the current release tag
+    target_tag = get_release_tag_string(target, version_string)
+
+    print(target, target_tag)
+
+    # get the diff from HEAD
+    target_path = os.path.join(ROOT, target)
+    cmd = 'git log --pretty=%s 6.1.1... {}'.format(target_path)
+    diff_lines = ctx.run(cmd, hide='out').stdout.split('\n')
+
+    # get the PR numbers
+    print(parse_pr_numbers(diff_lines))
+
+
+
+
+

--- a/tasks/changelog.py
+++ b/tasks/changelog.py
@@ -4,15 +4,23 @@
 from __future__ import print_function, unicode_literals
 import os
 import re
+import sys
+import json
+import urllib2
+import StringIO
+from collections import namedtuple
+from datetime import datetime
 
 from invoke import task
 from invoke.exceptions import Exit
 
-from .constants import ROOT
+from .constants import ROOT, GITHUB_API_URL
 
 
 # match something like `(#1234)` and return `1234` in a group
 PR_REG = re.compile(r'\(\#(\d+)\)')
+
+ChangelogEntry = namedtuple('ChangelogEntry', 'number, title, url')
 
 
 def get_version_string(check_name):
@@ -54,32 +62,82 @@ def parse_pr_numbers(git_log_lines):
     'target': "The check to compile the changelog for",
     'dry-run': "Runs the task without actually doing anything",
 })
-def make_changelog(ctx, target, dry_run=False):
+def update_changelog(ctx, target, new_version, dry_run=False):
     """
-    Write the changelog for the given check
+    Update the changelog for the given check with the changes
+    since the current release.
 
     Example invocation:
-        inv make-changelog redisdb
+        inv update-changelog redisdb 3.1.1
     """
     # get the current version
     version_string = get_version_string(target)
     if not version_string:
         raise Exit("Unable to get version for check {}".format(target))
+    print("Current version of check {}: {}".format(target, version_string))
 
     # get the name of the current release tag
     target_tag = get_release_tag_string(target, version_string)
 
-    print(target, target_tag)
-
     # get the diff from HEAD
     target_path = os.path.join(ROOT, target)
-    cmd = 'git log --pretty=%s 6.1.1... {}'.format(target_path)
+    cmd = 'git log --pretty=%s {}... {}'.format(target_tag, target_path)
     diff_lines = ctx.run(cmd, hide='out').stdout.split('\n')
 
-    # get the PR numbers
-    print(parse_pr_numbers(diff_lines))
+    # for each PR get the title, we'll use it to populate the changelog
+    endpoint = GITHUB_API_URL + '/repos/DataDog/integrations-core/pulls/{}'
+    pr_numbers = parse_pr_numbers(diff_lines)
+    print("Found {} PRs merged since tag: {}".format(len(pr_numbers), target_tag))
 
+    entries = []
+    for pr_num in pr_numbers:
+        try:
+            response = urllib2.urlopen(endpoint.format(pr_num))
+        except Exception as e:
+            sys.stderr.write("Unable to fetch info for PR #{}\n: {}".format(pr_num, e))
+            continue
 
+        payload = json.loads(response.read())
+        entry = ChangelogEntry(pr_num, payload.get('title'), payload.get('html_url'))
+        entries.append(entry)
 
+    # store the new changelog in memory
+    output = StringIO.StringIO()
 
+    # the header contains version and date
+    header = "### {} / {}\n".format(new_version, datetime.now().strftime("%Y-%m-%d"))
+    output.write(header)
 
+    # one bullet point for each PR
+    output.write("\n")
+    for entry in entries:
+        output.write("* {}. See [#{}]({}).\n".format(entry.title, entry.number, entry.url))
+    output.write("\n")
+
+    # read the old contents
+    changelog_path = os.path.join(ROOT, target, "CHANGELOG.md")
+    with open(changelog_path, 'r') as f:
+        old = f.readlines()
+
+    # write the new changelog in memory
+    changelog = StringIO.StringIO()
+
+    # preserve the title
+    changelog.write("".join(old[:2]))
+
+    # prepend the new changelog to the old contents
+    # make the command idempotent
+    if header not in old:
+        changelog.write(output.getvalue())
+
+    # append the rest of the old changelog
+    changelog.write("".join(old[2:]))
+
+    # print on the standard out in case of a dry run
+    if dry_run:
+        print(changelog.getvalue())
+        sys.exit(0)
+
+    # overwrite the old changelog
+    with open(changelog_path, 'w') as f:
+        f.write(changelog.getvalue())

--- a/tasks/constants.py
+++ b/tasks/constants.py
@@ -8,6 +8,9 @@ import os
 # the root of the repo
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+# Github API url
+GITHUB_API_URL = 'https://api.github.com'
+
 # Note: these are the names of the folder containing the check
 AGENT_BASED_INTEGRATIONS = [
     'active_directory',


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Adds a new invoke task, `update-changelog` to update the CHANGELOG.md file for a specific check. The command looks at the current version, compute the (expected) corresponding tag and gets the PRs that were merged since then. PR titles will be part of the changelog.

Note that this task makes the assumption that if a check `mycheck` is currently versioned as `1.0.0`, a corresponding tag `mycheck-1.0.0` should be present in the repo. This is not true at the moment but will be fixed in the short/mid term.

### Motivation

Stop asking contributors to update the changelog and do it at release time instead.

### Testing Guidelines

Sorry, no tests, just run it against a guinea pig check.
