### PR TITLE
[Gitlab][skip ci] Specify metrics endpoint for prometheus endpoint in example yaml

### DIFF
--- a/gitlab/conf.yaml.example
+++ b/gitlab/conf.yaml.example
@@ -117,7 +117,7 @@ instances:
   - gitlab_url: http://localhost
 
     # url of the metrics endpoint of prometheus
-    prometheus_endpoint: http://localhost:9090
+    prometheus_endpoint: http://localhost:9090/metrics
     # The histogram buckets can be noisy and generate a lot of tags.
     # send_histograms_buckets controls whether or not you want to pull them.
     #


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Clarifies that the prometheus endpoint should have `/metrics` appended to the end

### Motivation

Gitlab exposes metrics [via a prometheus metrics endpoint](https://docs.gitlab.com/ee/administration/monitoring/prometheus/#gitlab-prometheus-metrics) but if `/metrics` isn't appended to the url in the conf, the check returns an error `Unsupported content-type provided`

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
