### PR TITLE
[kafka_consumer] Bump kafka-python to 1.4.2

### DIFF
--- a/kafka_consumer/requirements.in
+++ b/kafka_consumer/requirements.in
@@ -1,3 +1,3 @@
-kafka-python==1.3.4
+kafka-python==1.4.2
 kazoo==2.4.0
 six==1.11.0


### PR DESCRIPTION
Picks up some bugfixes and a few new wire formats.