### PR TITLE
[kafka_consumer] context limit is actually 200

### DIFF
--- a/kafka_consumer/conf.yaml.example
+++ b/kafka_consumer/conf.yaml.example
@@ -16,7 +16,7 @@ init_config:
   # Please note that to avoid blindly collecting offsets and lag for an
   # unbounded number of partitions (as could be the case after introducing
   # the self discovery of consumer groups, topics and partitions) the check
-  # will collect at metrics for at most 100 partitions.
+  # will collect at metrics for at most 200 partitions.
 
 
 instances:


### PR DESCRIPTION
https://github.com/DataDog/integrations-core/commit/8718cf1675c358bba7299b8b2e785c410a6c3ca8#diff-4c54f2f13a681969866b36b757f62c8d bumped this to 200 but forgot to update `conf.yaml.example`