### PR TITLE
make integration public on doc

### DIFF
--- a/ecs_fargate/manifest.json
+++ b/ecs_fargate/manifest.json
@@ -13,7 +13,6 @@
   "category": ["aws","containers","orchestration"],
   "type": "check",
   "doc_link": "https://docs.datadoghq.com/integrations/fargate/",
-  "is_public": false,
-  "private": true,
+  "is_public": true,
   "has_logo": true
 }


### PR DESCRIPTION
### What does this PR do?

Allow Fargate to be displayed on the /integrations page of the DD documentation