### PR TITLE
[kubelet] Allow user to disable both cadvisor and prometheus

### DIFF
--- a/kubelet/CHANGELOG.md
+++ b/kubelet/CHANGELOG.md
@@ -8,7 +8,7 @@
 * [FEATURE] Collect metrics directly from cadvisor, for kubenetes version older than 1.7.6. See [#1339][]
 * [FEATURE] Add instance tags to all metrics. Improve the coverage of the check. See [#1377][]
 * [FEATURE] Reports nanocores instead of cores. See [#1361][]
-
+* [FEATURE] Allow to disable prometheus metric collection. See [#1423][]
 
 1.1.0 / 2018-03-23
 ==================

--- a/kubelet/README.md
+++ b/kubelet/README.md
@@ -34,6 +34,8 @@ The kubelet check can run in two modes:
 - the default prometheus mode is compatible with Kubernetes version 1.7.6 or superior
 - the cAdvisor mode (enabled by setting the `cadvisor_port` option) should be compatible with versions 1.3 and up. Consistent tagging and filtering requires at least version 6.2 of the Agent.
 
+## OpenShift <3.7 support
+
 The cAdvisor 4194 port is disabled by default on OpenShift. To enable it, you need to add
 the following lines to your [node-config file](https://docs.openshift.org/3.7/install_config/master_node_configuration.html#node-configuration-files):
 
@@ -41,3 +43,15 @@ the following lines to your [node-config file](https://docs.openshift.org/3.7/in
 kubeletArguments:
   cadvisor-port: ["4194"]
 ```
+
+If you cannot open the port, you can disable both sources of container metric collection, by setting:
+
+- `cadvisor_port` to `0`
+- `metrics_endpoint` to `""`
+
+The check will still be able to collect:
+
+- kubelet health service checks
+- pod running/stopped metrics
+- pod limits and requests
+- node capacity metrics

--- a/kubelet/conf.yaml.example
+++ b/kubelet/conf.yaml.example
@@ -15,6 +15,8 @@ instances:
     ###
     #
     # url of the kubelet metrics endpoint
+    # Pass an empty string, or set the cadvisor_port option to disable
+    # prometheus metrics collection
     # metrics_endpoint: http://10.8.0.1:10255/metrics/cadvisor
     #
     # The histogram buckets can be noisy and generate a lot of tags.

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -111,7 +111,7 @@ class KubeletCheck(PrometheusCheck, CadvisorScraper):
             raise CheckException("Unable to find metrics_endpoint in config "
                                  "file or detect the kubelet URL automatically.")
 
-        self.metrics_url = instance.get('metrics_endpoint') or urljoin(endpoint, CADVISOR_METRICS_PATH)
+        self.metrics_url = instance.get('metrics_endpoint', urljoin(endpoint, CADVISOR_METRICS_PATH))
         self.kube_health_url = urljoin(endpoint, KUBELET_HEALTH_PATH)
         self.node_spec_url = urljoin(endpoint, NODE_SPEC_PATH)
         self.pod_list_url = urljoin(endpoint, POD_LIST_PATH)
@@ -147,7 +147,7 @@ class KubeletCheck(PrometheusCheck, CadvisorScraper):
 
         if self.cadvisor_legacy_url:  # Legacy cAdvisor
             self.process_cadvisor(instance, self.cadvisor_legacy_url, self.pod_list, self.container_filter)
-        else:  # Prometheus
+        elif self.metrics_url:  # Prometheus
             self.process(self.metrics_url, send_histograms_buckets=send_buckets, instance=instance)
 
         # Free up memory


### PR DESCRIPTION
### What does this PR do?

Allow user to disable both cadvisor and prometheus modes
### Motivation

OShift < 3.7 default setup has neither prometheus not cadvisor port available
Covered by unit tests
