### PR TITLE
[mcache]Add missing options to mcache yaml example

### DIFF
--- a/mcache/conf.yaml.example
+++ b/mcache/conf.yaml.example
@@ -4,6 +4,8 @@ instances:
   - url: localhost  # url used to connect to the memcached instance
   #   socket: /socket/path # if url missing; 'dd-agent' user must have read/write permission
   #   port: 11211 # If this line is not present, port will default to 11211
+  #   username: my_username
+  #   password: my_password
   #   tags:
   #     - optional_tag
 


### PR DESCRIPTION
### What does this PR do?

Add missing options to mcache yaml example

### Motivation

Support case.
