### PR TITLE
Send prometheus counter as monotonic count by default on generic check

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -3,6 +3,7 @@
 1.2.2 / Unreleased
 ==================
 
+* [FEATURE] The generic Prometheus check will now send counter as monotonic counter.
 * [BUG] Prometheus requests can use an insecure option
 * [BUG] Correctly handle missing counters/strings in PDH checks when possible
 * [BUG] Fix Prometheus Scrapper logger

--- a/datadog_checks_base/datadog_checks/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/base_check.py
@@ -35,6 +35,18 @@ class Scraper(PrometheusScraper):
         _tags = self._metric_tags(metric_name, val, metric, custom_tags, hostname)
         self.check.gauge('{}.{}'.format(self.NAMESPACE, metric_name), val, _tags, hostname=hostname)
 
+    def _submit_monotonic_count(self, metric_name, val, metric, custom_tags=None, hostname=None):
+        """
+        Submit a metric as a monotonic count, additional tags provided will be added to
+        the ones from the label provided via the metrics object.
+
+        `custom_tags` is an array of 'tag:value' that will be added to the
+        metric when sending the gauge to Datadog.
+        """
+
+        _tags = self._metric_tags(metric_name, val, metric, custom_tags, hostname)
+        self.check.monotonic_count('{}.{}'.format(self.NAMESPACE, metric_name), val, _tags, hostname=hostname)
+
     def _metric_tags(self, metric_name, val, metric, custom_tags=None, hostname=None):
         _tags = []
         if custom_tags is not None:
@@ -82,6 +94,7 @@ class GenericPrometheusCheck(AgentCheck):
         scraper.process(
             endpoint,
             send_histograms_buckets=instance.get('send_histograms_buckets', True),
+            send_monotonic_counter=instance.get('send_monotonic_counter', True),
             instance=instance,
             ignore_unmapped=True
         )

--- a/datadog_checks_base/datadog_checks/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/base_check.py
@@ -41,7 +41,7 @@ class Scraper(PrometheusScraper):
         the ones from the label provided via the metrics object.
 
         `custom_tags` is an array of 'tag:value' that will be added to the
-        metric when sending the gauge to Datadog.
+        metric when sending the monotonic count to Datadog.
         """
 
         _tags = self._metric_tags(metric_name, val, metric, custom_tags, hostname)

--- a/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
@@ -412,13 +412,14 @@ class PrometheusScraper(object):
         self.join_labels(message)
 
         send_histograms_buckets = kwargs.get('send_histograms_buckets', True)
+        send_monotonic_counter = kwargs.get('send_monotonic_counter', False)
         custom_tags = kwargs.get('custom_tags')
         ignore_unmapped = kwargs.get('ignore_unmapped', False)
 
         try:
             if not self._dry_run:
                 try:
-                    self._submit(self.metrics_mapper[message.name], message, send_histograms_buckets, custom_tags)
+                    self._submit(self.metrics_mapper[message.name], message, send_histograms_buckets, send_monotonic_counter, custom_tags)
                 except KeyError:
                     if not ignore_unmapped:
                         # call magic method (non-generic check)
@@ -430,7 +431,7 @@ class PrometheusScraper(object):
                         # try matching wildcard (generic check)
                         for wildcard in self._metrics_wildcards:
                             if fnmatchcase(message.name, wildcard):
-                                self._submit(message.name, message, send_histograms_buckets, custom_tags)
+                                self._submit(message.name, message, send_histograms_buckets, send_monotonic_counter, custom_tags)
 
         except AttributeError as err:
             self.log.debug("Unable to handle metric: {} - error: {}".format(message.name, err))
@@ -504,7 +505,7 @@ class PrometheusScraper(object):
                 )
             raise
 
-    def _submit(self, metric_name, message, send_histograms_buckets=True, custom_tags=None, hostname=None):
+    def _submit(self, metric_name, message, send_histograms_buckets=True, send_monotonic_counter=False, custom_tags=None, hostname=None):
         """
         For each metric in the message, report it as a gauge with all labels as tags
         except if a labels dict is passed, in which case keys are label names we'll extract
@@ -520,7 +521,13 @@ class PrometheusScraper(object):
         if message.type < len(self.METRIC_TYPES):
             for metric in message.metric:
                 custom_hostname = self._get_hostname(hostname, metric)
-                if message.type == 4:
+                if message.type == 0:
+                    val = getattr(metric, self.METRIC_TYPES[message.type]).value
+                    if send_monotonic_counter:
+                        self._submit_monotonic_count(metric_name, val, metric, custom_tags, custom_hostname)
+                    else:
+                        self._submit_gauge(metric_name, val, metric, custom_tags, custom_hostname)
+                elif message.type == 4:
                     self._submit_gauges_from_histogram(metric_name, metric, send_histograms_buckets, custom_tags, custom_hostname)
                 elif message.type == 2:
                     self._submit_gauges_from_summary(metric_name, metric, custom_tags, custom_hostname)

--- a/datadog_checks_base/datadog_checks/checks/prometheus/prometheus_base.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/prometheus_base.py
@@ -49,7 +49,7 @@ class PrometheusCheck(PrometheusScraper, AgentCheck):
         the ones from the label provided via the metrics object.
 
         `custom_tags` is an array of 'tag:value' that will be added to the
-        metric when sending the gauge to Datadog.
+        metric when sending the monotonic count to Datadog.
         """
 
         _tags = self._metric_tags(metric_name, val, metric, custom_tags, hostname)

--- a/datadog_checks_base/datadog_checks/checks/prometheus/prometheus_base.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/prometheus_base.py
@@ -43,6 +43,18 @@ class PrometheusCheck(PrometheusScraper, AgentCheck):
         _tags = self._metric_tags(metric_name, val, metric, custom_tags, hostname)
         self.rate('{}.{}'.format(self.NAMESPACE, metric_name), val, _tags, hostname=hostname)
 
+    def _submit_monotonic_count(self, metric_name, val, metric, custom_tags=None, hostname=None):
+        """
+        Submit a metric as a monotonic count, additional tags provided will be added to
+        the ones from the label provided via the metrics object.
+
+        `custom_tags` is an array of 'tag:value' that will be added to the
+        metric when sending the gauge to Datadog.
+        """
+
+        _tags = self._metric_tags(metric_name, val, metric, custom_tags, hostname)
+        self.monotonic_count('{}.{}'.format(self.NAMESPACE, metric_name), val, _tags, hostname=hostname)
+
 
     def _submit_gauge(self, metric_name, val, metric, custom_tags=None, hostname=None):
         """

--- a/datadog_checks_base/tests/test_prometheus.py
+++ b/datadog_checks_base/tests/test_prometheus.py
@@ -257,6 +257,17 @@ def test_process_send_histograms_buckets(bin_data, mocked_prometheus_check, ref_
     check.process_metric.assert_called_with(ref_gauge, instance=None, send_histograms_buckets=False)
 
 
+def test_process_send_monotonic_counter(bin_data, mocked_prometheus_check, ref_gauge):
+    """ Checks that the send_monotonic_counter parameter is passed along """
+    endpoint = "http://fake.endpoint:10055/metrics"
+    check = mocked_prometheus_check
+    check.poll = mock.MagicMock(
+        return_value=MockResponse(bin_data, protobuf_content_type))
+    check.process_metric = mock.MagicMock()
+    check.process(endpoint, send_monotonic_counter=False, instance=None)
+    check.poll.assert_called_with(endpoint)
+    check.process_metric.assert_called_with(ref_gauge, instance=None, send_monotonic_counter=False)
+
 def test_process_instance_with_tags(bin_data, mocked_prometheus_check, ref_gauge):
     """ Checks that an instances with tags passes them as custom tag """
     endpoint = "http://fake.endpoint:10055/metrics"

--- a/prometheus/conf.yaml.example
+++ b/prometheus/conf.yaml.example
@@ -59,6 +59,10 @@ instances:
   #
   #   send_histograms_buckets: True
 
+  #   To send counters as monotonic counter
+  #
+  #   send_monotonic_counter: True
+
   #   List of label to be excluded
   #
   #   exclude_labels:

--- a/prometheus/tests/test_prometheus.py
+++ b/prometheus/tests/test_prometheus.py
@@ -6,7 +6,7 @@ import pytest
 import mock
 
 # 3p
-from prometheus_client import generate_latest, CollectorRegistry, Gauge
+from prometheus_client import generate_latest, CollectorRegistry, Gauge, Counter
 
 # project
 from datadog_checks.prometheus import PrometheusCheck
@@ -16,9 +16,11 @@ instance = {
     'namespace': 'prometheus',
     'metrics': [
         {'metric1': 'renamed.metric1'},
-        'metric2'
+        'metric2',
+        'counter1'
     ],
-    'send_histograms_buckets': True
+    'send_histograms_buckets': True,
+    'send_monotonic_counter': True
 }
 
 # Constants
@@ -39,6 +41,8 @@ def poll_mock():
     g1.labels(matched_label="foobar", node="host1", flavor="test").set(99.9)
     g2 = Gauge('metric2', 'memory usage', ['matched_label', 'node', 'timestamp'], registry=registry)
     g2.labels(matched_label="foobar", node="host2", timestamp="123").set(12.2)
+    c1 = Counter('counter1', 'hits', ['node'], registry=registry)
+    c1.labels(node="host2").inc(42)
 
     poll_mock = mock.patch(
         'requests.get',
@@ -58,8 +62,9 @@ def test_prometheus_check(aggregator, poll_mock):
 
     c = PrometheusCheck('prometheus', None, {}, [instance])
     c.check(instance)
-    aggregator.assert_metric(CHECK_NAME + '.renamed.metric1', tags=['node:host1', 'flavor:test', 'matched_label:foobar'])
-    aggregator.assert_metric(CHECK_NAME + '.metric2', tags=['timestamp:123', 'node:host2', 'matched_label:foobar'])
+    aggregator.assert_metric(CHECK_NAME + '.renamed.metric1', tags=['node:host1', 'flavor:test', 'matched_label:foobar'], metric_type=aggregator.GAUGE)
+    aggregator.assert_metric(CHECK_NAME + '.metric2', tags=['timestamp:123', 'node:host2', 'matched_label:foobar'], metric_type=aggregator.GAUGE)
+    aggregator.assert_metric(CHECK_NAME + '.counter1', tags=['node:host2'], metric_type=aggregator.MONOTONIC_COUNT)
     assert aggregator.metrics_asserted_pct == 100.0
 
 def test_prometheus_wildcard(aggregator, poll_mock):
@@ -71,8 +76,8 @@ def test_prometheus_wildcard(aggregator, poll_mock):
 
     c = PrometheusCheck('prometheus', None, {}, [instance_wildcard])
     c.check(instance)
-    aggregator.assert_metric(CHECK_NAME + '.metric1', tags=['node:host1', 'flavor:test', 'matched_label:foobar'])
-    aggregator.assert_metric(CHECK_NAME + '.metric2', tags=['timestamp:123', 'node:host2', 'matched_label:foobar'])
+    aggregator.assert_metric(CHECK_NAME + '.metric1', tags=['node:host1', 'flavor:test', 'matched_label:foobar'], metric_type=aggregator.GAUGE)
+    aggregator.assert_metric(CHECK_NAME + '.metric2', tags=['timestamp:123', 'node:host2', 'matched_label:foobar'], metric_type=aggregator.GAUGE)
     assert aggregator.metrics_asserted_pct == 100.0
 
 def test_prometheus_default_instance(aggregator, poll_mock):
@@ -93,8 +98,8 @@ def test_prometheus_default_instance(aggregator, poll_mock):
     c.check({
         'prometheus_url': 'http://custom:1337/metrics',
     })
-    aggregator.assert_metric(CHECK_NAME + '.renamed.metric1', tags=['node:host1', 'flavor:test', 'matched_label:foobar'])
-    aggregator.assert_metric(CHECK_NAME + '.metric2', tags=['timestamp:123', 'node:host2', 'matched_label:foobar'])
+    aggregator.assert_metric(CHECK_NAME + '.renamed.metric1', tags=['node:host1', 'flavor:test', 'matched_label:foobar'], metric_type=aggregator.GAUGE)
+    aggregator.assert_metric(CHECK_NAME + '.metric2', tags=['timestamp:123', 'node:host2', 'matched_label:foobar'], metric_type=aggregator.GAUGE)
     assert aggregator.metrics_asserted_pct == 100.0
 
 def test_prometheus_mixed_instance(aggregator, poll_mock):
@@ -142,6 +147,6 @@ def test_prometheus_mixed_instance(aggregator, poll_mock):
             'label_to_hostname':'node',
             'tags': ['extra:foo']
         })
-    aggregator.assert_metric(CHECK_NAME + '.renamed.metric1', hostname="host1", tags=['node:host1', 'flavor:test', 'matched_label:foobar', 'timestamp:123', 'extra:foo'])
-    aggregator.assert_metric(CHECK_NAME + '.metric2', hostname="host2", tags=['timestamp:123', 'node:host2', 'matched_label:foobar', 'timestamp:123', 'extra:foo'])
+    aggregator.assert_metric(CHECK_NAME + '.renamed.metric1', hostname="host1", tags=['node:host1', 'flavor:test', 'matched_label:foobar', 'timestamp:123', 'extra:foo'], metric_type=aggregator.GAUGE)
+    aggregator.assert_metric(CHECK_NAME + '.metric2', hostname="host2", tags=['timestamp:123', 'node:host2', 'matched_label:foobar', 'timestamp:123', 'extra:foo'], metric_type=aggregator.GAUGE)
     assert aggregator.metrics_asserted_pct == 100.0

--- a/prometheus/tests/test_prometheus.py
+++ b/prometheus/tests/test_prometheus.py
@@ -67,6 +67,19 @@ def test_prometheus_check(aggregator, poll_mock):
     aggregator.assert_metric(CHECK_NAME + '.counter1', tags=['node:host2'], metric_type=aggregator.MONOTONIC_COUNT)
     assert aggregator.metrics_asserted_pct == 100.0
 
+def test_prometheus_check_counter_gauge(aggregator, poll_mock):
+    """
+    Testing prometheus check.
+    """
+
+    instance["send_monotonic_counter"] = False
+    c = PrometheusCheck('prometheus', None, {}, [instance])
+    c.check(instance)
+    aggregator.assert_metric(CHECK_NAME + '.renamed.metric1', tags=['node:host1', 'flavor:test', 'matched_label:foobar'], metric_type=aggregator.GAUGE)
+    aggregator.assert_metric(CHECK_NAME + '.metric2', tags=['timestamp:123', 'node:host2', 'matched_label:foobar'], metric_type=aggregator.GAUGE)
+    aggregator.assert_metric(CHECK_NAME + '.counter1', tags=['node:host2'], metric_type=aggregator.GAUGE)
+    assert aggregator.metrics_asserted_pct == 100.0
+
 def test_prometheus_wildcard(aggregator, poll_mock):
     instance_wildcard = {
         'prometheus_url': 'http://localhost:10249/metrics',


### PR DESCRIPTION
### What does this PR do?

Send `counter` prometheus type as `monotonic_count` by default on the generic check.

This will impact all checks using `GenericPrometheusCheck` class

### Motivation

Monotonic count is better fit thang gauge for the counter type (see #1303 for more context)

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
