### PR TITLE
Update RBAC role to allow watch on events

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -45,7 +45,7 @@ rules:
     - "namespaces"  #
     - "events"      # Cluster events + kube_service cache invalidation
     - "services"    # kube_service tag
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources:
     - "configmaps"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Add `watch` RBAC permission.

### Motivation

Without this the api server check complains that `cannot watch events at the cluster scope`.

### Additional Notes

I'm not sure if I should be using this RBAC config or this one: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/rbac/clusterrole.yaml. The docs here: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/ point to that one but it doesn't contain the `nonResourceURLs` section, nor the `datadog-leader-election` configmap permissons.