### PR TITLE
[kafka_consumer] Fix `KafkaCheck` docstring

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -41,7 +41,7 @@ class NoKafkaBrokersAvailable(Exception):
 
 class KafkaCheck(AgentCheck):
     """
-    Check Consumer Lag for Kafka consumers that store their offsets in Zookeeper.
+    Check the offsets and lag of Kafka consumers.
 
     This check also returns broker highwater offsets.
     """


### PR DESCRIPTION
This check fetches consumer offsets from both kafka and zookeeper, and has done so for months.