### PR TITLE
fix import of containers.is_excluded, improve logging

### DIFF
--- a/kubelet/datadog_checks/kubelet/cadvisor.py
+++ b/kubelet/datadog_checks/kubelet/cadvisor.py
@@ -9,6 +9,7 @@ Collects metrics from cAdvisor instance
 from fnmatch import fnmatch
 import numbers
 from urlparse import urlparse
+import logging
 
 # 3p
 import requests
@@ -39,6 +40,11 @@ class CadvisorScraper(object):
     class, as it uses its AgentCheck facilities and class members.
     It is not possible to run it standalone.
     """
+    def __init__(self, *args, **kwargs):
+        super(CadvisorScraper, self).__init__(*args, **kwargs)
+
+        # The scraper needs its own logger
+        self.log = logging.getLogger(__name__)
 
     @staticmethod
     def detect_cadvisor(kubelet_url, cadvisor_port):

--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -5,9 +5,12 @@
 from tagger import get_tags
 
 try:
-    from container import is_excluded
+    from containers import is_excluded
 except ImportError:
     # Don't fail on < 6.2
+    import logging
+    logging.info('Agent does not provide filtering logic, disabling container filtering')
+
     def is_excluded(name, image):
         return False
 


### PR DESCRIPTION
### What does this PR do?

Fix the import path of the go filtering logic, add a logline if fallbacking to the stub, to help debuging if that were to happen again

No changelog as it's fixing an unreleased and documented feature