### PR TITLE
[kubelet] add container filtering + instance tags to prometheus metrics

### DIFF
--- a/kubelet/CHANGELOG.md
+++ b/kubelet/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [FEATURE] Add instance tags to all metrics. Improve the coverage of the check. See [#1377][]
 * [FEATURE] Reports nanocores instead of cores. See [#1361][]
 * [FEATURE] Allow to disable prometheus metric collection. See [#1423][]
+* [FEATURE] Container metrics now respect the container filtering rules. Requires Agent 6.2+. See [#1442][]
 
 1.1.0 / 2018-03-23
 ==================

--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -88,7 +88,9 @@ class ContainerFilter(object):
         self.static_pod_uids = set()
         self.cache = {}
 
-        for pod in podlist.get('items'):
+        pods = podlist.get('items') or []
+
+        for pod in pods:
             # FIXME we are forced to do that because the Kubelet PodList isn't updated
             # for static pods, see https://github.com/kubernetes/kubernetes/pull/59948
             if is_static_pending_pod(pod):

--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -73,11 +73,28 @@ def is_static_pending_pod(pod):
 
 
 class ContainerFilter(object):
+    """
+    Queries the podlist and the agent6's filtering logic to determine whether to
+    send metrics for a given container.
+    Results and podlist are cached between calls to avoid the repeated python-go switching
+    cost (filter called once per prometheus metric), hence the ContainerFilter object MUST
+    be re-created at every check run.
+
+    Containers that are part of a static pod are not filtered, as we cannot curently
+    reliably determine their image name to pass to the filtering logic.
+    """
     def __init__(self, podlist):
         self.containers = {}
+        self.static_pod_uids = set()
+        self.cache = {}
 
         for pod in podlist.get('items'):
-            for ctr in pod['status'].get('containerStatuses', []):
+            # FIXME we are forced to do that because the Kubelet PodList isn't updated
+            # for static pods, see https://github.com/kubernetes/kubernetes/pull/59948
+            if is_static_pending_pod(pod):
+                self.static_pod_uids.add(pod.get("metadata", {}).get("uid"))
+
+            for ctr in pod.get('status', {}).get('containerStatuses', []):
                 cid = ctr.get('containerID')
                 if not cid:
                     continue
@@ -88,19 +105,34 @@ class ContainerFilter(object):
                     short_cid = cid.split("://", 1)[-1]
                     self.containers[short_cid] = ctr
 
-    def is_excluded(self, cid):
+    def is_excluded(self, cid, pod_uid=None):
         """
         Queries the agent6 container filter interface. It retrieves container
         name + image from the podlist, so static pod filtering is not supported.
+
+        Result is cached between calls to avoid the python-go switching cost for
+        prometheus metrics (will be called once per metric)
         :param cid: container id
+        :param pod_uid: pod UID for static pod detection
         :return: bool
         """
+        if cid in self.cache:
+            return self.cache[cid]
+
+        if pod_uid and pod_uid in self.static_pod_uids:
+            self.cache[cid] = False
+            return False
+
         if cid not in self.containers:
             # Filter out metrics not coming from a container (system slices)
+            self.cache[cid] = True
             return True
         ctr = self.containers[cid]
         if not ("name" in ctr and "image" in ctr):
             # Filter out invalid containers
+            self.cache[cid] = True
             return True
 
-        return is_excluded(ctr.get("name"), ctr.get("image"))
+        excluded = is_excluded(ctr.get("name"), ctr.get("image"))
+        self.cache[cid] = excluded
+        return excluded


### PR DESCRIPTION
### What does this PR do?

- Add container filter queries before submitting prometheus and limit/request metrics
- Move static pod handling to the `ContainerFilter` class (check was done by the cadvisor logic itself)
- Add a caching layer to the `ContainerFilter` class: cadvisor logic did one query per container per run, prometheus logic does one query per metric line. With this, baseline CPU usage is the same as `master`
- Add instance tags to prom metrics, add testing to make sure all metrics (podlist/cadvisor/prom) are tagged
- Dereference the `ContainerFilter` after check run to reduce memory footprint

### Testing Guidelines

`datadog/agent-dev:xvello-prom-filter` image

### Versioning

~~- [ ] Bumped the check version in `manifest.json`~~
~~- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`~~

- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

~~- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new)~~
