### PR TITLE
update the AutoDiscovery templates to use hardcoded ports

### DIFF
--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - consul
 
+1.4.0 / Unreleased
+==================
+
+### Changes
+
+* [FEATURE] Hardcode the 8500 port in the Autodiscovery template. See [#1444][] for more information.
+
 1.3.0 / 2018-01-10
 ==================
 

--- a/consul/auto_conf.yaml
+++ b/consul/auto_conf.yaml
@@ -4,7 +4,7 @@ ad_identifiers:
 init_config:
 
 instances:
-  - url: "http://%%host%%:%%port%%"
+  - url: "http://%%host%%:8500"
     catalog_checks: yes
     new_leader_checks: yes
     # service_whitelist:

--- a/consul/datadog_checks/consul/__init__.py
+++ b/consul/datadog_checks/consul/__init__.py
@@ -2,6 +2,6 @@ from . import consul
 
 ConsulCheck = consul.ConsulCheck
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 __all__ = ['consul']

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.3.0",
+  "version": "1.4.0",
   "guid": "ec1e9fac-a339-49a3-b501-60656d2a5671",
   "public_title": "Datadog-Consul Integration",
   "categories":["containers", "orchestration", "configuration & deployment", "notification", "log collection"],

--- a/couch/CHANGELOG.md
+++ b/couch/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - couch
 
+2.5.0 / Unreleased
+==================
+
+### Changes
+
+* [FEATURE] Hardcode the 5984 port in the Autodiscovery template. See [#1444][] for more information.
+
 2.4.0 / 2018-02-13
 ==================
 

--- a/couch/auto_conf.yaml
+++ b/couch/auto_conf.yaml
@@ -4,4 +4,4 @@ ad_identifiers:
 init_config:
 
 instances:
-  - server: http://%%host%%:%%port%%
+  - server: http://%%host%%:5984

--- a/couch/datadog_checks/couch/__init__.py
+++ b/couch/datadog_checks/couch/__init__.py
@@ -2,6 +2,6 @@ from . import couch
 
 CouchDb = couch.CouchDb
 
-__version__ = "2.4.0"
+__version__ = "2.5.0"
 
 __all__ = ['couch']

--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1.1",
   "name": "couch",
   "display_name": "couch",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "support": "core",
   "supported_os": [
     "linux",

--- a/couchbase/CHANGELOG.md
+++ b/couchbase/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - couchbase
 
+1.3.0 / Unreleased
+==================
+
+### Changes
+
+* [FEATURE] Hardcode the 8091 port in the Autodiscovery template. See [#1444][] for more information.
+
 1.2.0 / 2017-11-21
 ==================
 ### Changes

--- a/couchbase/auto_conf.yaml
+++ b/couchbase/auto_conf.yaml
@@ -4,6 +4,6 @@ ad_identifiers:
 init_config:
 
 instances:
-  - server: http://%%host%%:%%port%%
+  - server: http://%%host%%:8091
     user: Administrator
     password: password

--- a/couchbase/datadog_checks/couchbase/__init__.py
+++ b/couchbase/datadog_checks/couchbase/__init__.py
@@ -2,6 +2,6 @@ from . import couchbase
 
 Couchbase = couchbase.Couchbase
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 __all__ = ['couchbase']

--- a/couchbase/manifest.json
+++ b/couchbase/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.2.0",
+  "version": "1.3.0",
   "guid": "ba7ce7de-4fcb-4418-8c90-329baa6a5d59",
   "public_title": "Datadog-CouchBase Integration",
   "categories":["data store"],

--- a/elastic/CHANGELOG.md
+++ b/elastic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - elastic
 
+1.7.0 / Unreleased
+==================
+
+### Changes
+
+* [FEATURE] Hardcode the 9200 port in the Autodiscovery template. See [#1444][] for more information.
+
 1.6.0 / Unreleased
 ==================
 

--- a/elastic/auto_conf.yaml
+++ b/elastic/auto_conf.yaml
@@ -4,4 +4,4 @@ ad_identifiers:
 init_config:
 
 instances:
-  - url: "http://%%host%%:%%port_0%%"
+  - url: "http://%%host%%:9200"

--- a/elastic/datadog_checks/elastic/__init__.py
+++ b/elastic/datadog_checks/elastic/__init__.py
@@ -2,6 +2,6 @@ from . import elastic
 
 ESCheck = elastic.ESCheck
 
-__version__ = "1.6.0"
+__version__ = "1.7.0"
 
 __all__ = ['elastic']

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.6.0",
+  "version": "1.7.0",
   "guid": "d91d91bd-4a8e-4489-bfb1-b119d4cc388a",
   "public_title": "Datadog-ElasticSearch Integration",
   "categories":["data store", "log collection"],

--- a/etcd/CHANGELOG.md
+++ b/etcd/CHANGELOG.md
@@ -1,10 +1,11 @@
 # CHANGELOG - etcd
 
-1.3.1 / Unreleased
+1.4.0 / Unreleased
 ==================
 ### Changes
 
 * [IMPROVEMENT] Get the right metrics depending on the instance state. See [#1348][].
+* [FEATURE] Hardcode the 2379 port in the Autodiscovery template. See [#1444][] for more information.
 
 1.3.0 / 2018-01-10
 ==================

--- a/etcd/auto_conf.yaml
+++ b/etcd/auto_conf.yaml
@@ -4,4 +4,4 @@ ad_identifiers:
 init_config:
 
 instances:
-  - url: "http://%%host%%:%%port_0%%"
+  - url: "http://%%host%%:2379"

--- a/etcd/datadog_checks/etcd/__init__.py
+++ b/etcd/datadog_checks/etcd/__init__.py
@@ -2,6 +2,6 @@ from . import etcd
 
 Etcd = etcd.Etcd
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"
 
 __all__ = ['etcd']

--- a/etcd/manifest.json
+++ b/etcd/manifest.json
@@ -13,6 +13,7 @@
   "public_title": "Datadog-etcd Integration",
   "categories":["orchestration", "containers", "configuration & deployment", "orchestration"],
   "type":"check",
+  "version": "1.4.0",
   "doc_link": "https://docs.datadoghq.com/integrations/etcd/",
   "is_public": true,
   "has_logo": true

--- a/kyototycoon/CHANGELOG.md
+++ b/kyototycoon/CHANGELOG.md
@@ -1,4 +1,12 @@
 # CHANGELOG - kyototycoon
+
+1.3.0 / Unreleased
+==================
+
+### Changes
+
+* [FEATURE] Hardcode the 1978 port in the Autodiscovery template. See [#1444][] for more information.
+
 1.2.0 / 2018-03-23
 ==================
 

--- a/kyototycoon/auto_conf.yaml
+++ b/kyototycoon/auto_conf.yaml
@@ -4,4 +4,4 @@ ad_identifiers:
 init_config:
 
 instances:
-  - report_url: http://%%host%%:%%port%%/rpc/report
+  - report_url: http://%%host%%:1978/rpc/report

--- a/kyototycoon/datadog_checks/kyototycoon/__init__.py
+++ b/kyototycoon/datadog_checks/kyototycoon/__init__.py
@@ -2,6 +2,6 @@ from . import kyototycoon
 
 KyotoTycoonCheck = kyototycoon.KyotoTycoonCheck
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 __all__ = ['kyototycoon']

--- a/kyototycoon/manifest.json
+++ b/kyototycoon/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.2.0",
+  "version": "1.3.0",
   "guid": "2661668b-d804-4c8d-96a7-8019525add8c",
   "public_title": "Datadog-Kyoto Tycoon Integration",
   "categories":["data store"],

--- a/mcache/CHANGELOG.md
+++ b/mcache/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 * [FEATURE] Add custom tag support for service check.
 * [FEATURE] Add support for SASL authentication.
+* [FEATURE] Hardcode the 11211 port in the Autodiscovery template. See [#1444][] for more information.
 
 1.1.0 / 2017-11-21
 ==================

--- a/mcache/auto_conf.yaml
+++ b/mcache/auto_conf.yaml
@@ -5,4 +5,4 @@ init_config:
 
 instances:
   - url: "%%host%%"
-    port: "%%port%%"
+    port: "11211"

--- a/mcache/datadog_checks/mcache/__about__.py
+++ b/mcache/datadog_checks/mcache/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/mcache/manifest.json
+++ b/mcache/manifest.json
@@ -12,6 +12,7 @@
   "public_title": "Datadog-Memcache Integration",
   "categories":["web", "caching"],
   "type":"check",
+  "version": "1.2.0",
   "doc_link": "https://docs.datadoghq.com/integrations/mcache/",
   "is_public": true,
   "has_logo": true,

--- a/redisdb/CHANGELOG.md
+++ b/redisdb/CHANGELOG.md
@@ -1,7 +1,13 @@
 # CHANGELOG - redisdb
 
-1.4.0 / 2018-01-10
+1.5.0 / Unreleased
+==================
+### Changes
 
+* [FEATURE] Hardcode the 6379 port in the Autodiscovery template. See [#1444][] for more information.
+
+1.4.0 / 2018-01-10
+==================
 ### Changes
 
 * [IMPROVEMENT] keys can be expressed as patterns, see [#300][]. Thanks [@aliva][].

--- a/redisdb/auto_conf.yaml
+++ b/redisdb/auto_conf.yaml
@@ -5,4 +5,4 @@ init_config:
 
 instances:
   - host: "%%host%%"
-    port: "%%port%%"
+    port: "6379"

--- a/redisdb/datadog_checks/redisdb/__about__.py
+++ b/redisdb/datadog_checks/redisdb/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"

--- a/redisdb/manifest.json
+++ b/redisdb/manifest.json
@@ -10,7 +10,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.4.0",
+  "version": "1.5.0",
   "guid": "0e2f3ed1-d36b-47a4-b69c-fedb50adf240",
   "max_agent_version": "6.0.0",
   "public_title": "Datadog-RedisDB Integration",

--- a/riak/CHANGELOG.md
+++ b/riak/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - riak
 
+1.2.0 / Unreleased
+==================
+### Changes
+
+* [FEATURE] Hardcode the 8098 port in the Autodiscovery template. See [#1444][] for more information.
+
 1.1.0 / 2017-11-21
 ==================
 ### Changes

--- a/riak/auto_conf.yaml
+++ b/riak/auto_conf.yaml
@@ -4,4 +4,4 @@ ad_identifiers:
 init_config:
 
 instances:
-  - url: http://%%host%%:%%port%%/stats
+  - url: http://%%host%%:8098/stats

--- a/riak/datadog_checks/riak/__about__.py
+++ b/riak/datadog_checks/riak/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/riak/manifest.json
+++ b/riak/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.1.0",
+  "version": "1.2.0",
   "guid": "e1ed642c-8a15-420c-954b-6fb894905956",
   "public_title": "Datadog-Riak Integration",
   "categories":["data store"],


### PR DESCRIPTION
### What does this PR do?

Update all AutoDiscovery templates in `integrations-core` to use the official port, instead of port autodetection. 

Updating the versions and changelogs to give more visibility to the change.

### Motivation

As docker assigns a unique IP to every container / pod, the vast majority of containerised off-the-shelf software runs with their default port, as port collision is a non-issue. The current templates use the `%%port%%` template variable to be able to adapt to different ports, but it comes at a price:

- Our [Fargate integration has no visibility on container ports](https://www.datadoghq.com/blog/monitor-aws-fargate/#monitoring-aws-fargate-containers-with-autodiscovery), which make these default templates un-usable 
- If new ports are added, templates might fail in the future, like [it happened with kube-state-metrics](https://github.com/DataDog/integrations-core/pull/1308/files)
- [Our documentation](https://docs.datadoghq.com/agent/autodiscovery/#supported-template-variables) recommends hardcoding the port number if known, to avoid these woes, but most users use these default templates as a reference
- Possible future port changes would most probably be coupled to a change in the exposition format / endpoint path, requiring an integration update anyway

### Ports used

Software with an official [IANA assigned port number](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt) :

- couch: 5984
- redisdb: 6379
- mcache: 11211
- etcd: 2379 since 2015 / 2.1.0

Software with no assigned IANA port, but stable port for > 1 year:

- consul: 8500 [since 0.1.0](https://github.com/hashicorp/consul/blob/v0.1.0/command/agent/config.go#L156) (IANA: Flight Message Transfer)
- kyototycoon: 1978 [since 2015 at least](https://github.com/alticelabs/kyoto/blob/snapshot-20150102/kyototycoon/ktutil.h#L41) (IANA: UniSQL)
- couchbase: 8091 [since 2.2 at least](https://github.com/couchbase/docker/blob/93ac16cb291fe8c5d1253728ba54e3efb4e0012f/community/couchbase-server/2.2.0/Dockerfile#L59) (IANA: Jam Link Framework)
- elastic: 9200 [since 0.2 at least](https://github.com/elastic/elasticsearch/blob/ab5dae99955d77de5a70024543424f6469591708/config/elasticsearch.yml#L222) (IANA: WAP)
- riak: 8098 [since 0.8 at least](https://github.com/basho/riak/blob/e914438033df5aa46b52ff5b36c8aaab21dd005b/rel/vars.config#L15) (IANA port not registered)

These were already hardcoded:

- apache: 80
- kubernetes-state: 8080
- kube_proxy: 10249
- kube_dns: 10055

### What if I'm using a custom port?

These default templates can be easily overridden by specifying an AD template either in [Docker container labels](https://docs.datadoghq.com/agent/autodiscovery/#template-source-docker-label-annotations) or [Kubernetes pod annotations](https://docs.datadoghq.com/agent/autodiscovery/#template-source-kubernetes-pod-annotations). 


### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [x] If PR impacts documentation, docs team has been notified:  https://github.com/DataDog/documentation/pull/2397

### Additional Notes

Anything else we should know when reviewing?
