### PR TITLE
[Prometheus] Discard metrics with invalid values

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [BUG] Correctly handle missing counters/strings in PDH checks when possible
 * [BUG] Fix Prometheus Scrapper logger
 * [SANITY] Clean-up export for `PDHBaseCheck` + export `WinPDHCounter`. [#1183][]
+* [IMPROVEMENT] Discard metrics with invalid values
 
 1.2.1 / 2018-03-23
 ==================

--- a/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
@@ -616,5 +616,5 @@ class PrometheusScraper(object):
                 else:
                     self.log.debug("Metric value is not supported for metric {}.count.".format(name))
 
-    def _is_value_valid(val):
+    def _is_value_valid(self, val):
         return not (isnan(val) or isinf(val))


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Ignore metrics with values that are `NaN` or `+/- inf`
### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
