### PR TITLE
Fix function metrics tagging issue for no-args functions

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -292,14 +292,14 @@ WITH overloaded_funcs AS (
  HAVING COUNT(*) > 1
 )
 SELECT s.schemaname,
-       CASE WHEN o.funcname is null THEN p.proname
-            else p.proname || '_' || array_to_string(p.proargnames, '_')
+       CASE WHEN o.funcname IS NULL OR p.proargnames IS NULL THEN p.proname
+            ELSE p.proname || '_' || array_to_string(p.proargnames, '_')
         END funcname,
         %s
   FROM pg_proc p
   JOIN pg_stat_user_functions s
     ON p.oid = s.funcid
-  LEFT join overloaded_funcs o
+  LEFT JOIN overloaded_funcs o
     ON o.funcname = s.funcname;
 """,
         'relation': False


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?
This PR aims to fix an issue with tagging of postgres functions.
In case there is many schemas in a database and each has its own copy
of the same function **without arguments** tagging does no work properly.
Tag: "function:<fname>"  is assigned "None" value for such functions.

This happens because in Postgres any valid string concatenation with NULL gives NULL, not an empty string as it was assumed.

### Motivation

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.


### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

This includes SQL query fix only which is enough for it.
