### PR TITLE
Migrate kubernetes cAdvisor cpu metrics to cores

### DIFF
--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -1,8 +1,8 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-kubernetes.cpu.capacity,gauge,,,,The number of cores in this machine.,0,kubernetes,k8s.cpu.capacity
-kubernetes.cpu.usage.total,gauge,,percent_nano,,The percentage of CPU time used,-1,kubelet,k8s.cpu
-kubernetes.cpu.limits,gauge,,cpu,,The limit of cpu cores set,0,kubelet,k8s.cpu.limits
-kubernetes.cpu.requests,gauge,,cpu,,The requested cpu cores,0,kubelet,k8s.cpu.requests
+kubernetes.cpu.capacity,gauge,,core,,The number of cores in this machine,0,kubelet,k8s.cpu.capacity
+kubernetes.cpu.usage.total,gauge,,nanocore,,The number of cores used,-1,kubelet,k8s.cpu
+kubernetes.cpu.limits,gauge,,core,,The limit of cpu cores set,0,kubelet,k8s.cpu.limits
+kubernetes.cpu.requests,gauge,,core,,The requested cpu cores,0,kubelet,k8s.cpu.requests
 kubernetes.filesystem.usage,gauge,,byte,,The amount of disk used,-1,kubelet,k8s.disk.usage
 kubernetes.filesystem.usage_pct,gauge,,fraction,,The percentage of disk used,-1,kubelet,k8s.disk.used_pct
 kubernetes.memory.capacity,gauge,,byte,,The amount of memory (in bytes) in this machine,0,kubelet,k8s.mem.capacity
@@ -16,4 +16,4 @@ kubernetes.network.rx_errors,gauge,,error,second,The amount of rx errors per sec
 kubernetes.network.tx_bytes,gauge,,byte,second,The amount of bytes per second transmitted,-1,kubelet,k8s.net.tx
 kubernetes.network.tx_dropped,gauge,,packet,second,The amount of tx packets dropped per second,-1,kubelet,k8s.net.tx.drop
 kubernetes.network.tx_errors,gauge,,error,second,The amount of tx errors per second,-1,kubelet,k8s.net.tx.errors
-kubernetes.diskio.io_service_bytes.stats.total,gauge,,byte,,The amount of disk space the container uses.,-1,kubernetes,k8s.disk.total
+kubernetes.diskio.io_service_bytes.stats.total,gauge,,byte,,The amount of disk space the container uses,-1,kubelet,k8s.disk.total

--- a/kubernetes/metadata.csv
+++ b/kubernetes/metadata.csv
@@ -1,8 +1,8 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-kubernetes.cpu.capacity,gauge,,,,The number of cores in this machine.,0,kubernetes,k8s.cpu.capacity
-kubernetes.cpu.usage.total,gauge,,percent_nano,,The percentage of CPU time used,-1,kubernetes,k8s.cpu
-kubernetes.cpu.limits,gauge,,cpu,,The limit of cpu cores set,0,kubernetes,k8s.cpu.limits
-kubernetes.cpu.requests,gauge,,cpu,,The requested cpu cores,0,kubernetes,k8s.cpu.requests
+kubernetes.cpu.capacity,gauge,,core,,The number of cores in this machine,0,kubernetes,k8s.cpu.capacity
+kubernetes.cpu.usage.total,gauge,,nanocore,,The number of cores used,-1,kubernetes,k8s.cpu
+kubernetes.cpu.limits,gauge,,core,,The limit of cpu cores set,0,kubernetes,k8s.cpu.limits
+kubernetes.cpu.requests,gauge,,core,,The requested cpu cores,0,kubernetes,k8s.cpu.requests
 kubernetes.filesystem.usage,gauge,,byte,,The amount of disk used,-1,kubernetes,k8s.disk.usage
 kubernetes.filesystem.usage_pct,gauge,,fraction,,The percentage of disk used,-1,kubernetes,k8s.disk.used_pct
 kubernetes.memory.capacity,gauge,,byte,,The amount of memory (in bytes) in this machine,0,kubernetes,k8s.mem.capacity


### PR DESCRIPTION
### What does this PR do?

This PR migrates the kubernetes cpu related metrics reported by cAdvisor.
Datadog will scale by cores all cpu metrics and allow to graph them together.

This PR impacts both agents.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
