### PR TITLE
Update stored proc yaml example for driver info

### DIFF
--- a/sqlserver/conf.yaml.example
+++ b/sqlserver/conf.yaml.example
@@ -67,6 +67,7 @@ init_config:
 
     # As well as capturing from the DMV you can also capture from a custom proc
     # Please note this feature will produce a number of custom metrics that might affect your billing
+    # This feature is also only available when using the adodbapi driver (set by default)
     # To use this feature, specify in your instance the procedure to execute : 
     # stored_procedure: ProcedureToExecute
     #


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Clarifies that the stored proc functionality won't work with the pyodbc driver. (adodbapi is the default)

### Motivation

Pyodbc [doesn't implement](https://github.com/mkleehammer/pyodbc/wiki/Calling-Stored-Procedures) the `callproc` method so using stored procedures when that implementation is chosen in the conf.yaml won't work.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
