### PR TITLE
Revert "Merge pull request #1364 from DataDog/massi/mcache-sasl"

### DIFF
--- a/mcache/CHANGELOG.md
+++ b/mcache/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Changes
 
 * [FEATURE] Add custom tag support for service check.
-* [FEATURE] Add support for SASL authentication.
 * [FEATURE] Hardcode the 11211 port in the Autodiscovery template. See [#1444][] for more information.
 
 1.1.0 / 2017-11-21

--- a/mcache/datadog_checks/mcache/mcache.py
+++ b/mcache/datadog_checks/mcache/mcache.py
@@ -1,14 +1,68 @@
 # (C) Datadog, Inc. 2010-2017
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-import bmemcached
-import pkg_resources
+import memcache
 
 from datadog_checks.checks import AgentCheck
 
+# Ref: http://code.sixapart.com/svn/memcached/trunk/server/doc/protocol.txt
+# Name              Type     Meaning
+# ----------------------------------
+# pid               32u      Process id of this server process
+# uptime            32u      Number of seconds this server has been running
+# time              32u      current UNIX time according to the server
+# version           string   Version string of this server
+# pointer_size      32       Default size of pointers on the host OS
+#                            (generally 32 or 64)
+# rusage_user       32u:32u  Accumulated user time for this process
+#                            (seconds:microseconds)
+# rusage_system     32u:32u  Accumulated system time for this process
+#                            (seconds:microseconds)
+# curr_items        32u      Current number of items stored by the server
+# total_items       32u      Total number of items stored by this server
+#                            ever since it started
+# bytes             64u      Current number of bytes used by this server
+#                            to store items
+# curr_connections  32u      Number of open connections
+# total_connections 32u      Total number of connections opened since
+#                            the server started running
+# connection_structures 32u  Number of connection structures allocated
+#                            by the server
+# cmd_get           64u      Cumulative number of retrieval requests
+# cmd_set           64u      Cumulative number of storage requests
+# get_hits          64u      Number of keys that have been requested and
+#                            found present
+# get_misses        64u      Number of items that have been requested
+#                            and not found
+# delete_misses     64u      Number of deletions reqs for missing keys
+# delete_hits       64u      Number of deletion reqs resulting in
+#                            an item being removed.
+# evictions         64u      Number of valid items removed from cache
+#                            to free memory for new items
+# bytes_read        64u      Total number of bytes read by this server
+#                            from network
+# bytes_written     64u      Total number of bytes sent by this server to
+#                            network
+# limit_maxbytes    32u      Number of bytes this server is allowed to
+#                            use for storage.
+# threads           32u      Number of worker threads requested.
+#                            (see doc/threads.txt)
+# listen_disabled_num 32u    How many times the server has reached maxconns
+#                            (see https://code.google.com/p/memcached/wiki/Timeouts)
+#     >>> mc.get_stats()
+# [('127.0.0.1:11211 (1)', {'pid': '2301', 'total_items': '2',
+# 'uptime': '80', 'listen_disabled_num': '0', 'version': '1.2.8',
+# 'limit_maxbytes': '67108864', 'rusage_user': '0.002532',
+# 'bytes_read': '51', 'accepting_conns': '1', 'rusage_system':
+# '0.007445', 'cmd_get': '0', 'curr_connections': '4', 'threads': '2',
+# 'total_connections': '5', 'cmd_set': '2', 'curr_items': '0',
+# 'get_misses': '0', 'cmd_flush': '0', 'evictions': '0', 'bytes': '0',
+# 'connection_structures': '5', 'bytes_written': '25', 'time':
+# '1306364220', 'pointer_size': '64', 'get_hits': '0'})]
 
-class BadResponseError(Exception):
-    pass
+# For Membase it gets worse
+# http://www.couchbase.org/wiki/display/membase/Membase+Statistics
+# https://github.com/membase/ep-engine/blob/master/docs/stats.org
 
 
 class Memcache(AgentCheck):
@@ -109,26 +163,17 @@ class Memcache(AgentCheck):
     SERVICE_CHECK = 'memcache.can_connect'
 
     def get_library_versions(self):
-        return {
-            "memcache": pkg_resources.get_distribution("python-binary-memcached").version
-        }
-
-    def _process_response(self, response):
-        """
-        Examine the response and raise an error is something is off
-        """
-        if len(response) != 1:
-            raise BadResponseError("Malformed response: {}".format(response))
-
-        stats = response.values()[0]
-        if not len(stats):
-            raise BadResponseError("Malformed response for host: {}".format(stats))
-
-        return stats
+        return {"memcache": memcache.__version__}
 
     def _get_metrics(self, client, tags, service_check_tags=None):
         try:
-            stats = self._process_response(client.stats())
+            raw_stats = client.get_stats()
+
+            assert len(raw_stats) == 1 and len(raw_stats[0]) == 2,\
+                "Malformed response: %s" % raw_stats
+
+            # Access the dict
+            stats = raw_stats[0][1]
             for metric in stats:
                 # Check if metric is a gauge or rate
                 if metric in self.GAUGES:
@@ -177,7 +222,7 @@ class Memcache(AgentCheck):
                 self.SERVICE_CHECK, AgentCheck.OK,
                 tags=service_check_tags,
                 message="Server has been up for %s seconds" % uptime)
-        except BadResponseError:
+        except AssertionError:
             raise
 
     def _get_optional_metrics(self, client, tags, options=None):
@@ -188,9 +233,14 @@ class Memcache(AgentCheck):
                     optional_gauges = metrics_args[1]
                     optional_fn = metrics_args[2]
 
-                    stats = self._process_response(client.stats(arg))
-                    prefix = "memcache.{}".format(arg)
+                    raw_stats = client.get_stats(arg)
 
+                    assert len(raw_stats) == 1 and len(raw_stats[0]) == 2,\
+                        "Malformed response: %s" % raw_stats
+
+                    # Access the dict
+                    stats = raw_stats[0][1]
+                    prefix = "memcache.{}".format(arg)
                     for metric, val in stats.iteritems():
                         # Check if metric is a gauge or rate
                         metric_tags = []
@@ -205,7 +255,7 @@ class Memcache(AgentCheck):
                             our_metric = self.normalize(
                                 "{0}_rate".format(metric.lower()), prefix)
                             self.rate(our_metric, float(val), tags=tags+metric_tags)
-                except BadResponseError:
+                except AssertionError:
                     self.log.warning(
                         "Unable to retrieve optional stats from memcache instance, "
                         "running 'stats %s' they could be empty or bad configuration.", arg
@@ -258,8 +308,6 @@ class Memcache(AgentCheck):
         socket = instance.get('socket')
         server = instance.get('url')
         options = instance.get('options', {})
-        username = instance.get('username')
-        password = instance.get('password')
 
         if not server and not socket:
             raise Exception('Either "url" or "socket" must be configured')
@@ -277,7 +325,7 @@ class Memcache(AgentCheck):
 
         try:
             self.log.debug("Connecting to %s:%s tags:%s", server, port, tags)
-            mc = bmemcached.Client(["{}:{}".format(server, port)], username, password)
+            mc = memcache.Client(["%s:%s" % (server, port)])
 
             self._get_metrics(mc, tags, service_check_tags)
             if options:
@@ -285,14 +333,14 @@ class Memcache(AgentCheck):
                 self.OPTIONAL_STATS["items"][2] = Memcache.get_items_stats
                 self.OPTIONAL_STATS["slabs"][2] = Memcache.get_slabs_stats
                 self._get_optional_metrics(mc, tags, options)
-        except BadResponseError as e:
+        except AssertionError:
             self.service_check(
                 self.SERVICE_CHECK, AgentCheck.CRITICAL,
                 tags=service_check_tags,
                 message="Unable to fetch stats from server")
             raise Exception(
-                "Unable to retrieve stats from memcache instance: {}:{}."
-                "Please check your configuration. ({})".format(server, port, e))
+                "Unable to retrieve stats from memcache instance: {0}:{1}."
+                "Please check your configuration".format(server, port))
 
         if mc is not None:
             mc.disconnect_all()

--- a/mcache/requirements.in
+++ b/mcache/requirements.in
@@ -1,1 +1,1 @@
-python-binary-memcached==0.26.1
+python-memcached==1.53

--- a/mcache/requirements.txt
+++ b/mcache/requirements.txt
@@ -4,9 +4,5 @@
 #
 #    pip-compile --generate-hashes --output-file requirements.txt requirements.in
 #
-python-binary-memcached==0.26.1 \
-    --hash=sha256:e2e535ce1466104a93c0174a1a9217f6dd80d1ceafcc8a4205cbc29c09ae2252
-six==1.11.0 \
-    --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9 \
-    --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb \
-    # via python-binary-memcached
+python-memcached==1.53 \
+    --hash=sha256:bcf71371d997bb46a3168a7b63aae66b56cccacc025af9310db4315681ef8868

--- a/mcache/tests/common.py
+++ b/mcache/tests/common.py
@@ -6,5 +6,3 @@ import os
 PORT = 11211
 SERVICE_CHECK = 'memcache.can_connect'
 HOST = os.getenv('DOCKER_HOSTNAME', 'localhost')
-USERNAME = 'testuser'
-PASSWORD = 'testpass'

--- a/mcache/tests/docker-compose.yaml
+++ b/mcache/tests/docker-compose.yaml
@@ -2,10 +2,6 @@ version: '3.5'
 
 services:
   memcached:
-    image: datadog/docker-library:memcached_SASL
-    environment:
-      USERNAME: testuser
-      PASSWORD: testpass
+    image: memcached
     ports:
       - "11211:11211"
-    command: memcached -S


### PR DESCRIPTION
This reverts commit 41cb69cc391a05d9647b9e60279f1e827f4026a7, reversing
changes made to 09dae880e153bf831e8ece51376bfe6701151a3d.

<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Reverts SASL support for memcached, there's an issue when connecting through unix socket that needs further investigation.
