### PR TITLE
[mcache] Bring back SASL support

### DIFF
--- a/mcache/CHANGELOG.md
+++ b/mcache/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changes
 
 * [FEATURE] Add custom tag support for service check.
+* [FEATURE] Add support for SASL authentication.
 * [FEATURE] Hardcode the 11211 port in the Autodiscovery template. See [#1444][] for more information.
 
 1.1.0 / 2017-11-21

--- a/mcache/requirements.in
+++ b/mcache/requirements.in
@@ -1,1 +1,1 @@
-python-memcached==1.53
+python-binary-memcached==0.26.1

--- a/mcache/requirements.txt
+++ b/mcache/requirements.txt
@@ -4,5 +4,9 @@
 #
 #    pip-compile --generate-hashes --output-file requirements.txt requirements.in
 #
-python-memcached==1.53 \
-    --hash=sha256:bcf71371d997bb46a3168a7b63aae66b56cccacc025af9310db4315681ef8868
+python-binary-memcached==0.26.1 \
+    --hash=sha256:e2e535ce1466104a93c0174a1a9217f6dd80d1ceafcc8a4205cbc29c09ae2252
+six==1.11.0 \
+    --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9 \
+    --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb \
+    # via python-binary-memcached

--- a/mcache/tests/common.py
+++ b/mcache/tests/common.py
@@ -6,3 +6,5 @@ import os
 PORT = 11211
 SERVICE_CHECK = 'memcache.can_connect'
 HOST = os.getenv('DOCKER_HOSTNAME', 'localhost')
+USERNAME = 'testuser'
+PASSWORD = 'testpass'

--- a/mcache/tests/docker-compose.yaml
+++ b/mcache/tests/docker-compose.yaml
@@ -2,6 +2,10 @@ version: '3.5'
 
 services:
   memcached:
-    image: memcached
+    image: datadog/docker-library:memcached_SASL
+    environment:
+      USERNAME: testuser
+      PASSWORD: testpass
     ports:
       - "11211:11211"
+    command: memcached -S


### PR DESCRIPTION
This reverts commit df81618854ab752c9c9865e20c915bca6ae9893c, reversing
changes made to edafd819212af6bee23e0fae5bd3721ab758f707.

<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Had to revert SASL support for Agent 6.2 release due to an issue still under investigation, this PR brings it back.
