### PR TITLE
New Agent 6 logic for config doc

### DIFF
--- a/active_directory/README.md
+++ b/active_directory/README.md
@@ -4,16 +4,20 @@
 
 Get metrics from Microsoft Active Directory
 
-* Visualize and monitor Active Directory performance
+The Agent's Active directory check is packaged with the Agent, so simply [install the Agent][4] on your servers.
 
 ## Setup
 ### Installation
 
-Install the `dd-check-active_directory` package manually or with your favorite configuration manager
+The Agent's Active directory check is packaged with the Agent, so simply [install the Agent][4] on your servers.
 
 ### Configuration
 
-Edit the `active_directory.yaml` file to collect Active Directory performance data. See the [sample active_directory.yaml][1] for all available configuration options.
+1. Edit the `active_directory.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your Active Directory performance data.  
+
+    See the [sample active_directory.d/conf.yaml][1] for all available configuration options.
+
+2. [Restart the Agent][7]
 
 ### Validation
 
@@ -29,7 +33,16 @@ The active directory check does not include any event at this time.
 ### Service Checks
 The active directory check does not include any service check at this time.
 
+## Troubleshooting
+Need help? Contact [Datadog Support][5].
+
+## Further Reading
+Learn more about infrastructure monitoring and all our integrations on [our blog][6]
 
 [1]: https://github.com/DataDog/integrations-core/blob/master/active_directory/conf.yaml.example
-[2]: https://help.datadoghq.com/hc/en-us/articles/203764635-Agent-Status-and-Information
+[2]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [3]: https://github.com/DataDog/integrations-core/blob/master/active_directory/metadata.csv
+[4]: https://app.datadoghq.com/account/settings#agent
+[5]: http://docs.datadoghq.com/help/
+[6]: https://www.datadoghq.com/blog/
+[7]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent

--- a/activemq/README.md
+++ b/activemq/README.md
@@ -7,100 +7,98 @@ The ActiveMQ check lets you collect metrics for brokers and queues, producers an
 ## Setup
 ### Installation
 
-The Agent's ActiveMQ check is packaged with the Agent, so simply [install the Agent][1] on your ActiveMQ nodes.
+The Agent's ActiveMQ check is packaged with the Agent, so simply [install the Agent][101] on your ActiveMQ nodes.
 
-The check collects metrics via JMX, so you'll need a JVM on each node so the Agent can fork [jmxfetch][2]. We recommend using an Oracle-provided JVM.
+The check collects metrics via JMX, so you'll need a JVM on each node so the Agent can fork [jmxfetch][102]. We recommend using an Oracle-provided JVM.
 
 ### Configuration
 
-1. **Make sure that [JMX Remote is enabled][3] on your ActiveMQ server.**
-2. Configure the agent to connect to ActiveMQ. Edit `${confd_help('`conf.d/activemq.yaml`')}`. See the [sample activemq.yaml][4] for all available configuration options.
+1. **Make sure that [JMX Remote is enabled][103] on your ActiveMQ server.**
+2. Configure the agent to connect to ActiveMQ. Edit `activemq.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample activemq.d/conf.yaml][104] for all available configuration options.
 
-```
-instances:
-  - host: localhost
-    port: 7199
-    user: username
-    password: password
-    name: activemq_instance
-# List of metrics to be collected by the integration
-# You should not have to modify this.
-init_config:
-  conf:
-    - include:
-      Type: Queue
-      attribute:
-        AverageEnqueueTime:
-          alias: activemq.queue.avg_enqueue_time
-          metric_type: gauge
-        ConsumerCount:
-          alias: activemq.queue.consumer_count
-          metric_type: gauge
-        ProducerCount:
-          alias: activemq.queue.producer_count
-          metric_type: gauge
-        MaxEnqueueTime:
-          alias: activemq.queue.max_enqueue_time
-          metric_type: gauge
-        MinEnqueueTime:
-          alias: activemq.queue.min_enqueue_time
-          metric_type: gauge
-        MemoryPercentUsage:
-          alias: activemq.queue.memory_pct
-          metric_type: gauge
-        QueueSize:
-          alias: activemq.queue.size
-          metric_type: gauge
-        DequeueCount:
-          alias: activemq.queue.dequeue_count
-          metric_type: counter
-        DispatchCount:
-          alias: activemq.queue.dispatch_count
-          metric_type: counter
-        EnqueueCount:
-          alias: activemq.queue.enqueue_count
-          metric_type: counter
-        ExpiredCount:
-          alias: activemq.queue.expired_count
-          type: counter
-        InFlightCount:
-          alias: activemq.queue.in_flight_count
-          metric_type: counter
+    ```yaml
+    instances:
+      - host: localhost
+        port: 7199
+        user: username
+        password: password
+        name: activemq_instance
+    # List of metrics to be collected by the integration
+    # You should not have to modify this.
+    init_config:
+      conf:
+        - include:
+          Type: Queue
+          attribute:
+            AverageEnqueueTime:
+              alias: activemq.queue.avg_enqueue_time
+              metric_type: gauge
+            ConsumerCount:
+              alias: activemq.queue.consumer_count
+              metric_type: gauge
+            ProducerCount:
+              alias: activemq.queue.producer_count
+              metric_type: gauge
+            MaxEnqueueTime:
+              alias: activemq.queue.max_enqueue_time
+              metric_type: gauge
+            MinEnqueueTime:
+              alias: activemq.queue.min_enqueue_time
+              metric_type: gauge
+            MemoryPercentUsage:
+              alias: activemq.queue.memory_pct
+              metric_type: gauge
+            QueueSize:
+              alias: activemq.queue.size
+              metric_type: gauge
+            DequeueCount:
+              alias: activemq.queue.dequeue_count
+              metric_type: counter
+            DispatchCount:
+              alias: activemq.queue.dispatch_count
+              metric_type: counter
+            EnqueueCount:
+              alias: activemq.queue.enqueue_count
+              metric_type: counter
+            ExpiredCount:
+              alias: activemq.queue.expired_count
+              type: counter
+            InFlightCount:
+              alias: activemq.queue.in_flight_count
+              metric_type: counter
 
-    - include:
-      Type: Broker
-      attribute:
-        StorePercentUsage:
-          alias: activemq.broker.store_pct
-          metric_type: gauge
-        TempPercentUsage:
-          alias: activemq.broker.temp_pct
-          metric_type: gauge
-        MemoryPercentUsage:
-          alias: activemq.broker.memory_pct
-          metric_type: gauge
-```
+        - include:
+          Type: Broker
+          attribute:
+            StorePercentUsage:
+              alias: activemq.broker.store_pct
+              metric_type: gauge
+            TempPercentUsage:
+              alias: activemq.broker.temp_pct
+              metric_type: gauge
+            MemoryPercentUsage:
+              alias: activemq.broker.memory_pct
+              metric_type: gauge
+    ```
 
 3. Restart the agent
 
-```bash
-sudo /etc/init.d/datadog-agent restart
+    ```bash
+    sudo /etc/init.d/datadog-agent restart
 
 
-if [ $(sudo supervisorctl status | egrep "datadog-agent.*RUNNING" | wc -l) == 3 ]; \
-then echo -e "\e[0;32mAgent is running\e[0m"; \
-else echo -e "\e[031mAgent is not running\e[0m"; fi
-```
-
-{{< insert-example-links check="none" >}}
+    if [ $(sudo supervisorctl status | egrep "datadog-agent.*RUNNING" | wc -l) == 3 ]; \
+    then echo -e "\e[0;32mAgent is running\e[0m"; \
+    else echo -e "\e[031mAgent is not running\e[0m"; fi
+    ```
 
 ### Validation
 
-[Run the Agent's `status` subcommand][5] and look for `activemq` under the Checks section.
+[Run the Agent's `status` subcommand][105] and look for `activemq` under the Checks section.
 
 ## Data Collected
 ### Metrics
-See [metadata.csv][6] for a list of metrics provided by this integration.
+See [metadata.csv][106] for a list of metrics provided by this integration.
 
 ### Events
 The Activemq check does not include any event at this time.
@@ -111,18 +109,18 @@ The Activemq check does not include any event at this time.
 Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored ActiveMQ instance. Returns `OK` otherwise.
 
 ## Troubleshooting
-Need help? Contact [Datadog Support][7].
+Need help? Contact [Datadog Support][107].
 
 ## Further Reading
 
-* [Monitor ActiveMQ metrics and performance][8]
+* [Monitor ActiveMQ metrics and performance][108]
 
 
-[1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://github.com/DataDog/jmxfetch
-[3]: http://activemq.apache.org/jmx.html
-[4]: https://github.com/DataDog/integrations-core/blob/master/activemq/conf.yaml.example
-[5]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
-[6]: https://github.com/DataDog/integrations-core/blob/master/activemq/metadata.csv
-[7]: http://docs.datadoghq.com/help/
-[8]: https://www.datadoghq.com/blog/monitor-activemq-metrics-performance/
+[101]: https://app.datadoghq.com/account/settings#agent
+[102]: https://github.com/DataDog/jmxfetch
+[103]: http://activemq.apache.org/jmx.html
+[104]: https://github.com/DataDog/integrations-core/blob/master/activemq/conf.yaml.example
+[105]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
+[106]: https://github.com/DataDog/integrations-core/blob/master/activemq/metadata.csv
+[107]: http://docs.datadoghq.com/help/
+[108]: https://www.datadoghq.com/blog/monitor-activemq-metrics-performance/

--- a/activemq_xml/README.md
+++ b/activemq_xml/README.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-Get metrics from activemq_xml service in real time to:
+Get metrics from ActiveMQ XML service in real time to:
 
-* Visualize and monitor activemq_xml states
-* Be notified about activemq_xml failovers and events.
+* Visualize and monitor ActiveMQ XML states
+* Be notified about ActiveMQ XML failovers and events.
 
 ## Setup
 ### Installation
@@ -14,7 +14,11 @@ The Activemq XML check is packaged with the Agent, so simply [install the Agent]
 
 ### Configuration
 
-Edit the `activemq_xml.yaml` file to point to your server and port, set the masters to monitor. See the [sample activemq_xml.yaml][2] for all available configuration options.
+1. Edit the `activemq_xml.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to point to your server and port, set the masters to monitor.  
+
+    See the [sample activemq_xml.d/conf.yaml][2] for all available configuration options.
+
+2. [Restart the Agent][7]
 
 ### Validation
 
@@ -25,10 +29,10 @@ Edit the `activemq_xml.yaml` file to point to your server and port, set the mast
 See [metadata.csv][4] for a list of metrics provided by this integration.
 
 ### Events
-The Activemq_xml check does not include any event at this time.
+The ActiveMQ XML check does not include any event at this time.
 
 ### Service Checks
-The Activemq_xml check does not include any service check at this time.
+The ActiveMQ XML check does not include any service check at this time.
 
 ## Troubleshooting
 Need help? Contact [Datadog Support][5].
@@ -44,3 +48,4 @@ Need help? Contact [Datadog Support][5].
 [4]: https://github.com/DataDog/integrations-core/blob/master/activemq_xml/metadata.csv
 [5]: http://docs.datadoghq.com/help/
 [6]: https://www.datadoghq.com/blog/monitor-activemq-metrics-performance/
+[7]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent

--- a/agent_metrics/README.md
+++ b/agent_metrics/README.md
@@ -14,7 +14,11 @@ The Agent Metrics check is packaged with the Agent, so simply [install the Agent
 
 ### Configuration
 
-Edit the `agent_metrics.yaml` file to point to your server and port, set the masters to monitor. See the [sample agent_metrics.yaml][2] for all available configuration options.
+1. Edit the `agent_metrics.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to point to your server and port, set the masters to monitor.  
+
+    See the [sample agent_metrics.d/conf.yaml][2] for all available configuration options.
+
+2. [Restart the Agent][7]
 
 ### Validation
 
@@ -43,3 +47,4 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [4]: https://github.com/DataDog/integrations-core/blob/master/agent_metrics/metadata.csv
 [5]: http://docs.datadoghq.com/help/
 [6]: https://www.datadoghq.com/blog/
+[7]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent

--- a/apache/README.md
+++ b/apache/README.md
@@ -10,63 +10,65 @@ The Apache check tracks requests per second, bytes served, number of worker thre
 The Apache check is packaged with the Agent. To start gathering your Apache metrics and logs, you need to:
 
 1. [Install the Agent][1] on your Apache servers.
-  
 
 2. Install `mod_status` on your Apache servers and enable `ExtendedStatus`.
 
 ### Configuration
 
-Create a file `apache.yaml` in the Agent's `conf.d` directory.
+1. Edit the `apache.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your Apache [metrics](#metric-collection) and [logs](#log-collection).
+  See the [sample apache.d/conf.yaml][2] for all available configuration options.
+
+2. [Restart the Agent][3]
 
 #### Metric Collection
 
-*  Add this configuration setup to your `apache.yaml` file to start gathering your [Apache Metrics](#metrics):
+1. Add this configuration setup to your `apache.d/conf.yaml` file to start gathering your [Apache Metrics](#metrics):
 
-  ```
-  init_config:
+    ```yaml
+    init_config:
 
-  instances:
-    - apache_status_url: http://example.com/server-status?auto
-  #   apache_user: example_user # if apache_status_url needs HTTP basic auth
-  #   apache_password: example_password
-  #   disable_ssl_validation: true # if you need to disable SSL cert validation, i.e. for self-signed certs
-  ```
-  Change the `apache_status_url` parameter value and configure it for your environment.
-  See the [sample apache.yaml][2] for all available configuration options.
+    instances:
+        apache_status_url: http://example.com/server-status?auto
+    #   apache_user: example_user # if apache_status_url needs HTTP basic auth
+    #   apache_password: example_password
+    #   disable_ssl_validation: true # if you need to disable SSL cert validation, i.e. for self-signed certs
+    ```
+        Change the `apache_status_url` parameter value and configure it for your environment.
+        See the [sample apache.d/conf.yaml][2] for all available configuration options.
 
-*  [Restart the Agent][3].
+2.  [Restart the Agent][3].
 
 #### Log Collection
 
 **Available for Agent >6.0**
 
-* Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
+1. Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
 
-  ```
-  logs_enabled: true
-  ```
+    ```yaml
+    logs_enabled: true
+    ```
 
-* Add this configuration setup to your `apache.yaml` file to start collecting your Apache Logs:
+2. Add this configuration setup to your `apache.yaml` file to start collecting your Apache Logs:
 
-  ```
-    logs:
-        - type: file
-          path: /var/log/apache2/access.log
-          source: apache
-          sourcecategory: http_web_access
-          service: apache
+    ```yaml
+      logs:
+          - type: file
+            path: /var/log/apache2/access.log
+            source: apache
+            sourcecategory: http_web_access
+            service: apache
 
-        - type: file
-          path: /var/log/apache2/error.log
-          source: apache
-          sourcecategory: http_web_access
-          service: apache
-  ```
+          - type: file
+            path: /var/log/apache2/error.log
+            source: apache
+            sourcecategory: http_web_access
+            service: apache
+    ```
 
-  Change the `path` and `service` parameter values and configure them for your environment.
-  See the [sample apache.yaml](https://github.com/DataDog/integrations-core/blob/master/apache/conf.yaml.example) for all available configuration options.
+    Change the `path` and `service` parameter values and configure them for your environment.
+    See the [sample apache.d/conf.yaml][2] for all available configuration options.
 
-* [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent).
+3. [Restart the Agent][3].
 
 **Learn more about log collection [on the log documentation][4]**
 

--- a/aspdotnet/README.md
+++ b/aspdotnet/README.md
@@ -7,18 +7,43 @@ Get metrics from ASP.NET service in real time to:
 * Visualize and monitor ASP.NET states
 * Be notified about ASP.NET failovers and events.
 
-## Installation
+## Setup
+### Installation
 
 The ASP.NET check is packaged with the Agent, so simply [install the Agent][1] on your servers.
 
-## Configuration
+### Configuration
 
-Edit the `aspdotnet.yaml` file to point to your server and port, set the masters to monitor
+1. Edit the `aspdotnet.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your ASP.NET performance data.  
 
-## Validation
+    See the [sample aspdotnet.d/conf.yaml][3] for all available configuration options.
+
+2. [Restart the Agent][5]
+
+### Validation
 
 [Run the Agent's `status` subcommand][2] and look for `aspdotnet` under the Checks section.
+
+## Data Collected
+### Metrics
+The ASP.NET check does not include any metrics at this time.
+
+### Events
+All ASP.NET events and failovers are sent to your [Datadog event stream][4]
+
+### Service Checks
+The ASP.NET check does not include any service check at this time.
+
+## Troubleshooting
+Need help? Contact [Datadog Support][5].
+
+## Further Reading
+Learn more about infrastructure monitoring and all our integrations on [our blog][6]
 
 
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
+[3]: https://github.com/DataDog/integrations-core/blob/master/aspdotnet/conf.yaml.example
+[4]: https://app.datadoghq.com/event/stream
+[5]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
+[6]: https://www.datadoghq.com/blog/

--- a/btrfs/README.md
+++ b/btrfs/README.md
@@ -14,7 +14,9 @@ The Btrfs check is packaged with the Agent, so simply [install the Agent][1] on 
 
 ### Configuration
 
-1. Configure the Agent according to your needs, edit `conf.d/btrfs.yaml`. See the [sample btrfs.yaml][2] for all available configuration options.
+1. Configure the Agent according to your needs, edit `conf.d/btrfs.yaml`. 
+    See the [sample btrfs.yaml][2] for all available configuration options.
+
 2. [Restart the Agent][3]
 
 ### Validation

--- a/cacti/README.md
+++ b/cacti/README.md
@@ -16,14 +16,14 @@ The Cacti check is packaged with the Agent, so simply [install the Agent][1] on 
 
 Create a datadog user with read-only rights to the Cacti database
 
-```
+```shell
 sudo mysql -e "create user 'datadog'@'localhost' identified by '<password>';"
 sudo mysql -e "grant select on cacti.* to 'datadog'@'localhost';"
 ```
 
 Check user and rights
 
-```
+```shell
 mysql -u datadog --password=<password> -e "show status" | \
 grep Uptime && echo -e "\033[0;32mMySQL user - OK\033[0m" || \
 echo -e "\033[0;31mCannot connect to MySQL\033[0m"
@@ -33,10 +33,9 @@ echo -e "\033[0;32mMySQL grant - OK\033[0m" || \
 echo -e "\033[0;31mMissing SELECT grant\033[0m"
 ```
 
-Configure the Agent to connect to MySQL
-Edit conf.d/`cacti.yaml`. See the [sample cacti.yaml][2] for all available configuration options:
+Configure the Agent to connect to MySQL, edit your `cacti.d/conf.yaml` file. See the [sample cacti.d/conf.yaml][2] for all available configuration options:
 
-```
+```yaml
 init_config:
 
 instances:
@@ -53,7 +52,7 @@ instances:
 
 Give the dd-agent user access to the RRD files
 
-```
+```shell
 sudo gpasswd -a dd-agent www-data
 sudo chmod -R g+rx /var/lib/cacti/rra/
 sudo su - dd-agent -c 'if [ -r /var/lib/cacti/rra/ ];

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -10,22 +10,21 @@ Get metrics from cassandra service in real time to:
 ## Setup
 ### Installation
 
-The Cassandra check is packaged with the Agent, so simply [install the Agent][1] on your Cassandra nodes.
+The Cassandra check is packaged with the Agent, so simply [install the Agent][101] on your Cassandra nodes.
 
 We recommend the use of Oracle's JDK for this integration.
 
-This check has a limit of 350 metrics per instance. The number of returned metrics is indicated in the info page. You can specify the metrics you are interested in by editing the configuration below. To learn how to customize the metrics to collect visit the [JMX Checks documentation][2] for more detailed instructions. If you need to monitor more metrics, please send us an email at support@datadoghq.com
+This check has a limit of 350 metrics per instance. The number of returned metrics is indicated in the info page. You can specify the metrics you are interested in by editing the configuration below. To learn how to customize the metrics to collect visit the [JMX Checks documentation][102] for more detailed instructions. If you need to monitor more metrics, please send us an email at support@datadoghq.com
 
 ### Configuration
 
-Create a `cassandra.yaml` file in the Agent's `conf.d` directory.
+Edit the `cassandra.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your Cassandra [metrics](#metric-collection) and [logs](#log-collection).  
+See the [sample cassandra.d/conf.yaml][103] for all available configuration options.
 
 #### Metric Collection
 
-*  The default configuration of your `cassandra.yaml` file activate the collection of your [Cassandra metrics](#metrics).
- See the [sample  cassandra.yaml][3] for all available configuration options.
- 
-2. [Restart the Agent][4].
+The default configuration of your `cassandra.d/conf.yaml` file activate the collection of your [Cassandra metrics](#metrics).  
+See the [sample  cassandra.d/conf.yaml][103] for all available configuration options.
 
 #### Log Collection
 
@@ -33,13 +32,13 @@ Create a `cassandra.yaml` file in the Agent's `conf.d` directory.
 
 * Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-  ```
+  ```yaml
   logs_enabled: true
   ```
 
-* Add this configuration setup to your `cassandra.yaml` file to start collecting your Cassandra logs:
+* Add this configuration setup to your `cassandra.d/conf.yaml` file to start collecting your Cassandra logs:
 
-  ```
+  ```yaml
     logs:
         - type: file
           path: /var/log/cassandra/*.log
@@ -48,18 +47,18 @@ Create a `cassandra.yaml` file in the Agent's `conf.d` directory.
           service: myapplication
   ```
 
-  Change the `path` and `service` parameter values and configure them for your environment.
-See the [sample  cassandra.yaml](https://github.com/DataDog/integrations-core/blob/master/cassandra/conf.yaml.example) for all available configuration options.
+    Change the `path` and `service` parameter values and configure them for your environment.
+    See the [sample  cassandra.d/conf.yaml][103] for all available configuration options.
    
-* [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent).
+* [Restart the Agent][104].
 
 ### Validation
 
-[Run the Agent's `status` subcommand][5] and look for `cassandra` under the Checks section.
+[Run the Agent's `status` subcommand][105] and look for `cassandra` under the Checks section.
 
 ## Data Collected
 ### Metrics
-See [metadata.csv][6] for a list of metrics provided by this integration.
+See [metadata.csv][106] for a list of metrics provided by this integration.
 
 ### Events
 The Cassandra check does not include any event at this time.
@@ -70,22 +69,22 @@ The Cassandra check does not include any event at this time.
 Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Cassandra instance. Returns `OK` otherwise.
 
 ## Troubleshooting
-Need help? Contact [Datadog Support][7].
+Need help? Contact [Datadog Support][107].
 
 ## Further Reading
 
-* [How to monitor Cassandra performance metrics][8]
-* [How to collect Cassandra metrics][9]
-* [Monitoring Cassandra with Datadog][10]
+* [How to monitor Cassandra performance metrics][108]
+* [How to collect Cassandra metrics][109]
+* [Monitoring Cassandra with Datadog][1010]
 
 
-[1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://docs.datadoghq.com/integrations/java/
-[3]: https://github.com/DataDog/integrations-core/blob/master/cassandra/conf.yaml.example
-[4]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
-[5]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
-[6]: https://github.com/DataDog/integrations-core/blob/master/cassandra/metadata.csv
-[7]: http://docs.datadoghq.com/help/
-[8]: https://www.datadoghq.com/blog/how-to-monitor-cassandra-performance-metrics/
-[9]: https://www.datadoghq.com/blog/how-to-collect-cassandra-metrics/
-[10]: https://www.datadoghq.com/blog/monitoring-cassandra-with-datadog/
+[101]: https://app.datadoghq.com/account/settings#agent
+[102]: https://docs.datadoghq.com/integrations/java/
+[103]: https://github.com/DataDog/integrations-core/blob/master/cassandra/conf.yaml.example
+[104]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
+[105]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
+[106]: https://github.com/DataDog/integrations-core/blob/master/cassandra/metadata.csv
+[107]: http://docs.datadoghq.com/help/
+[108]: https://www.datadoghq.com/blog/how-to-monitor-cassandra-performance-metrics/
+[109]: https://www.datadoghq.com/blog/how-to-collect-cassandra-metrics/
+[1010]: https://www.datadoghq.com/blog/monitoring-cassandra-with-datadog/

--- a/cassandra_nodetool/README.md
+++ b/cassandra_nodetool/README.md
@@ -8,13 +8,14 @@ It uses the `nodetool` utility to collect them.
 ## Setup
 ### Installation
 
-The Cassandra nodetool check is packaged with the Agent, so simply [install the Agent][2] on your cassandra nodes.
+The Cassandra Nodetool check is packaged with the Agent, so simply [install the Agent][2] on your Cassandra nodes.
 
 ### Configuration
 
-Create a file `cassandra_nodetool.yaml` in the Agent's `conf.d` directory. See the [sample cassandra_nodetool.yaml][3] for all available configuration options:
+Edit the file `cassandra_nodetool.d/conf.yaml` in the `conf.d/` folder at the root of your Agent's directory.  
+See the [sample cassandra_nodetool.d/conf.yaml][3] for all available configuration options:
 
-```
+```yaml
 init_config:
   # command or path to nodetool (e.g. /usr/bin/nodetool or docker exec container nodetool)
   # can be overwritten on an instance

--- a/ceph/README.md
+++ b/ceph/README.md
@@ -14,10 +14,11 @@ Enable the Datadog-Ceph integration to:
 The Ceph check is packaged with the Agent, so simply [install the Agent][1] on your Ceph servers.
 
 ### Configuration
+ 
+Edit the file `ceph.d/conf.yaml` in the `conf.d/` folder at the root of your Agent's directory.  
+See the [sample ceph.d/conf.yaml][2] for all available configuration options:  
 
-Create a file `ceph.yaml` in the Agent's `conf.d` directory. See the [sample ceph.yaml][2] for all available configuration options:
-
-```
+```yaml
 init_config:
 
 instances:

--- a/consul/README.md
+++ b/consul/README.md
@@ -26,34 +26,35 @@ The Datadog Agent's Consul Check is included in the Agent package, so simply [in
 
 ### Configuration
 
-Create a `consul.yaml` in the Datadog Agent's `conf.d` directory.
+Edit the `consul.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your Consul [metrics](#metric-collection) and [logs](#log-collection).  
+See the [sample consul.d/conf.yaml][2] for all available configuration options.
 
 #### Metric Collection
 
-*  Add this configuration setup to your `consul.yaml` file to start gathering your [Consul Metrics](#metrics):
+1. Add this configuration setup to your `consul.d/conf.yaml` file to start gathering your [Consul Metrics](#metrics):
 
-```
-init_config:
+    ```yaml
+    init_config:
 
-instances:
-    # where the Consul HTTP Server Lives
-    # use 'https' if Consul is configured for SSL
-    - url: http://localhost:8500
-      # again, if Consul is talking SSL
-      # client_cert_file: '/path/to/client.concatenated.pem'
+    instances:
+        # where the Consul HTTP Server Lives
+        # use 'https' if Consul is configured for SSL
+        - url: http://localhost:8500
+          # again, if Consul is talking SSL
+          # client_cert_file: '/path/to/client.concatenated.pem'
 
-      # submit per-service node status and per-node service status?
-      catalog_checks: yes
+          # submit per-service node status and per-node service status?
+          catalog_checks: yes
 
-      # emit leader election events
-      self_leader_check: yes
+          # emit leader election events
+          self_leader_check: yes
 
-      network_latency_checks: yes
-```
+          network_latency_checks: yes
+    ```
 
-See the [sample consul.yaml][2] for all available configuration options.
+    See the [sample consul.d/conf.yaml][2] for all available configuration options.
 
-[Restart the Agent][3] to start sending Consul metrics to Datadog.
+2. [Restart the Agent][3] to start sending Consul metrics to Datadog.
 
 #### Connect Consul Agent to DogStatsD
 
@@ -75,25 +76,25 @@ Reload the Consul Agent to start sending more Consul metrics to DogStatsD.
 
 **Available for Agent >6.0**
 
-* Collecting logs is disabled by default in the Datadog Agent, enable it in `datadog.yaml` with:
+1. Collecting logs is disabled by default in the Datadog Agent, enable it in `datadog.yaml` with:
 
-  ```
-  logs_enabled: true
-  ```
+    ```yaml
+    logs_enabled: true
+    ```
 
-* Add this configuration setup to your `consul.yaml` file to start collecting your Consul Logs:
+2. Add this configuration setup to your `consul.yaml` file to start collecting your Consul Logs:
 
-  ```
-    logs:
-        - type: file
-          path: /var/log/consul_server.log
-          source: consul
-          service: myservice
-  ```
-Change the `path` and `service` parameter values and configure them for your environment.
-  See the [sample consul.yaml](https://github.com/DataDog/integrations-core/blob/master/consul/conf.yaml.example) for all available configuration options.
+    ```yaml
+      logs:
+          - type: file
+            path: /var/log/consul_server.log
+            source: consul
+            service: myservice
+    ```
+    Change the `path` and `service` parameter values and configure them for your environment.
+    See the [sample consul.d/conf.yaml][2] for all available configuration options.
 
-* [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent).
+3. [Restart the Agent][3].
 
 **Learn more about log collection [on the log documentation][4]**
 
@@ -117,7 +118,7 @@ Change the `path` and `service` parameter values and configure them for your env
 
 Use `netstat` to verify that Consul is sending its metrics, too:
 
-```
+```shell
 $ sudo netstat -nup | grep "127.0.0.1:8125.*ESTABLISHED"
 udp        0      0 127.0.0.1:53874         127.0.0.1:8125          ESTABLISHED 23176/consul
 ```

--- a/couch/README.md
+++ b/couch/README.md
@@ -16,24 +16,25 @@ The CouchDB check is packaged with the Agent, so simply [install the Agent][1] o
 
 ### Configuration
 
-Create a file `couch.yaml` in the Agent's `conf.d` directory. See the [sample  couch.yaml][2] for all available configuration options:
+1. Edit the `couch.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your CouchDB performance data.  
+See the [sample couch.d/conf.yaml][2] for all available configuration options.
 
-```
-init_config:
+    ```yaml
+    init_config:
 
-instances:
-  - server: http://localhost:5984 # or wherever your CouchDB is listening
-  #user: <your_username>
-  #password: <your_password>
-  #name: <A node's Erlang name> # Only for CouchDB 2.x
-  #max_nodes_per_check: If no name is specified, the agent will scan all nodes up. As that may be very long, you can limit how many to collect per check. Default: 20
-  #max_dbs_per_check. Maximum number of databases to report on. Default: 50
-  #tags: A list of tags applied to all metrics collected. Tags may be simple strings or key-value pairs. Default: []
-```
+    instances:
+      - server: http://localhost:5984 # or wherever your CouchDB is listening
+      #user: <your_username>
+      #password: <your_password>
+      #name: <A node's Erlang name> # Only for CouchDB 2.x
+      #max_nodes_per_check: If no name is specified, the agent will scan all nodes up. As that may be very long, you can limit how many to collect per check. Default: 20
+      #max_dbs_per_check. Maximum number of databases to report on. Default: 50
+      #tags: A list of tags applied to all metrics collected. Tags may be simple strings or key-value pairs. Default: []
+    ```
 
-Optionally, provide a `db_whitelist` and `db_blacklist` to control which databases the Agent should and should not collect metrics from.
+    Optionally, provide a `db_whitelist` and `db_blacklist` to control which databases the Agent should and should not collect metrics from.
 
-[Restart the Agent][3] to begin sending CouchDB metrics to Datadog.
+2. [Restart the Agent][3] to begin sending CouchDB metrics to Datadog.
 
 ### Validation
 

--- a/couchbase/README.md
+++ b/couchbase/README.md
@@ -19,18 +19,19 @@ The Couchbase check is packaged with the Agent, so simply [install the Agent][1]
 
 ### Configuration
 
-Create a file `couchbase.yaml` in the Agent's `conf.d` directory. See the [sample couchbase.yaml][2] for all available configuration options:
+1. Edit the `couchbase.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your Couchbase performance data.  
+See the [sample couchbase.d/conf.yaml][2] for all available configuration options.
 
-```
-init_config:
+    ```yaml
+    init_config:
 
-instances:
-  - server: http://localhost:8091 # or wherever your Couchbase is listening
-    #user: <your_username>
-    #password: <your_password>
-```
+    instances:
+      - server: http://localhost:8091 # or wherever your Couchbase is listening
+        #user: <your_username>
+        #password: <your_password>
+    ```
 
-[Restart the Agent][3] to begin sending Couchbase metrics to Datadog.
+2. [Restart the Agent][3] to begin sending Couchbase metrics to Datadog.
 
 ### Validation
 

--- a/directory/README.md
+++ b/directory/README.md
@@ -1,5 +1,4 @@
 # Directory Check
-
 ## Overview
 
 Capture metrics from directories and files of your choosing. The Agent will collect:
@@ -16,21 +15,22 @@ The directory check is packaged with the Agent, so simply [install the Agent][1]
 
 ### Configuration
 
-1. Edit your `directory.yaml` file in the Agent's `conf.d` directory. See the [sample directory.yaml][2] for all available configuration options:
+1. Edit the `directory.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting Directory performance data.    
+See the [sample directory.d/conf.yaml][2] for all available configuration options.
 
-```
-init_config:
+    ```yaml
+    init_config:
 
-instances:
-  - directory: "/path/to/directory" # the only required option
-    name: "my_monitored_dir"        # What the Agent will tag this directory's metrics with. Defaults to "directory"
-    pattern: "*.log"                # defaults to "*" (all files)
-    recursive: True                 # default False
-    countonly: False                # set to True to only collect the number of files matching 'pattern'. Useful for very large directories.
-    ignore_missing: False           # set to True to not raise exceptions on missing or inaccessible directories
-```
+    instances:
+      - directory: "/path/to/directory" # the only required option
+        name: "my_monitored_dir"        # What the Agent will tag this directory's metrics with. Defaults to "directory"
+        pattern: "*.log"                # defaults to "*" (all files)
+        recursive: True                 # default False
+        countonly: False                # set to True to only collect the number of files matching 'pattern'. Useful for very large directories.
+        ignore_missing: False           # set to True to not raise exceptions on missing or inaccessible directories
+    ```
 
-Ensure that the user running the Agent process (usually `dd-agent`) has read access to the directories, subdirectories, and files you configure.
+    Ensure that the user running the Agent process (usually `datadog-agent`) has read access to the directories, subdirectories, and files you configure.
 
 2. [Restart the Agent][3].
 

--- a/disk/README.md
+++ b/disk/README.md
@@ -11,7 +11,8 @@ The disk check is packaged with the Agent, so simply [install the Agent][1] anyw
 
 ### Configuration
 
-The disk check is enabled by default, and the Agent will collect metrics on all local partitions. If you want to configure the check with custom options, create a file `disk.yaml` in the Agent's `conf.d` directory. See the [sample disk.yaml][2] for all available configuration options.
+The disk check is enabled by default, and the Agent collects metrics on all local partitions.  
+If you want to configure the check with custom options, Edit the `disk.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample disk.d/conf.yaml][2] for all available configuration options.
 
 ### Validation
 

--- a/dns_check/README.md
+++ b/dns_check/README.md
@@ -7,27 +7,29 @@ Monitor the resolvability of and lookup times for any DNS records using nameserv
 ## Setup
 ### Installation
 
-The DNS check is packaged with the Agent, so simply [install the Agent][1] on any host from which you want to probe your DNS servers. Though many metrics-oriented checks are best run on the same host(s) as the monitored service, you may want to run this status-oriented check from hosts that do not run the monitored DNS services.
+The DNS check is packaged with the Agent, so simply [install the Agent][1] on any host from which you want to probe your DNS servers.  
+Though many metrics-oriented checks are best run on the same host(s) as the monitored service, you may want to run this status-oriented check from hosts that do not run the monitored DNS services.
 
 ### Configuration
 
-Create a file `dns_check.yaml` in the Agent's `conf.d` directory. See the [sample dns_check.yaml][2] for all available configuration options:
+1. Edit the `dns_check.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your Couchbase performance data.  
+    See the [sample dns_check.d/conf.yaml][2] for all available configuration options:
 
-```
-init_config:
+        ```yaml
+        init_config:
 
-instances:
-  - name: Example (com)
-    # nameserver: 8.8.8.8   # The nameserver to query, this must be an IP address
-    hostname: example.com # the record to fetch
-    # record_type: AAAA   # default is A
-  - name: Example (org)
-    hostname: example.org
-```
+        instances:
+          - name: Example (com)
+            # nameserver: 8.8.8.8   # The nameserver to query, this must be an IP address
+            hostname: example.com # the record to fetch
+            # record_type: AAAA   # default is A
+          - name: Example (org)
+            hostname: example.org
+        ```
 
-If you omit the `nameserver` option, the check will use whichever nameserver is configured in local network settings.
+    If you omit the `nameserver` option, the check uses whichever nameserver is configured in local network settings.
 
-[Restart the Agent][3] to begin sending DNS service checks and response times to Datadog.
+2. [Restart the Agent][3] to begin sending DNS service checks and response times to Datadog.
 
 ### Validation
 

--- a/docker_daemon/README.md
+++ b/docker_daemon/README.md
@@ -13,7 +13,7 @@ Configure this Agent check to get metrics from docker_daemon service in real tim
 ## Setup
 ### Installation
 
-To collect Docker metrics about all your containers, you will run **one** Datadog Agent on every host. There are two ways to run the Agent: directly on each host, or within a [docker-dd-agent container][1]. We recommend the latter.
+To collect Docker metrics about all your containers, run **one** Datadog Agent on every host. There are two ways to run the Agent: directly on each host, or within a [docker-dd-agent container][1]. We recommend the latter.  
 
 Whichever you choose, your hosts need to have cgroup memory management enabled for the Docker check to succeed. See the [docker-dd-agent repository][2] for how to enable it.
 

--- a/dotnetclr/README.md
+++ b/dotnetclr/README.md
@@ -13,7 +13,10 @@ The Dotnetclr check is packaged with the Agent, so simply [install the Agent][1]
 
 ## Configuration
 
-Edit the `dotnetclr.yaml` file to point to your server and port, set the masters to monitor
+1. Edit the `dotnetclr.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your dotnetclr performance data.  
+See the [sample dotnetclr.d/conf.yaml][2] for all available configuration options.
+
+2. [Restart the Agent][5]
 
 ## Validation
 
@@ -30,3 +33,4 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [2]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [3]: http://docs.datadoghq.com/help/
 [4]: https://www.datadoghq.com/blog/
+[5]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -8,14 +8,16 @@ Get metrics from all your containers running in ECS Fargate:
 * I/O metrics
 
 ## Setup
-
 ### Installation
 
-Install the `dd-check-ecs_fargate` package manually or with your favorite configuration manager
+The ECS Fargate check is packaged with the Agent, so simply [run the Agent][1] with your containers.
 
 ### Configuration
 
-Edit the `ecs_fargate.yaml` file to point to your server and port, set the masters to monitor
+1. Edit the `ecs_fargate.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your ECS Fargate performance data.  
+See the [sample ecs_fargate.d/conf.yaml][6] for all available configuration options.
+
+2. [Restart the Agent][5]
 
 ### Validation
 
@@ -48,3 +50,5 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [2]: https://github.com/DataDog/integrations-core/blob/master/ecs_fargate/metadata.csv
 [3]: http://docs.datadoghq.com/help/
 [4]: https://www.datadoghq.com/blog/
+[5]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
+[6]: https://github.com/DataDog/integrations-core/blob/master/ecs_fargate/conf.yaml.example

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -14,13 +14,16 @@ The Elasticsearch check is packaged with the Datadog Agent, so simply [install t
 
 ### Configuration
 
-Create a file `elastic.yaml` in the Datadog Agent's `conf.d` directory. 
+1. Edit the `elastic.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your Elasticsearch [metrics](#metric-collection) and [logs](#log-collection).
+  See the [sample elastic.d/conf.yaml][2] for all available configuration options.
+
+2. [Restart the Agent][3]
 
 #### Metric Collection
 
 *  Add this configuration setup to your `elastic.yaml` file to start gathering your [ElasticSearch metrics](#metrics):
 
-```
+```yaml
 init_config:
 
 instances:
@@ -52,7 +55,7 @@ Finally, [Restart the Agent][3] to begin sending Elasticsearch metrics to Datado
 
 * Then add this configuration setup to your `apache.yaml` file to start collecting your Elasticsearch Logs:
 
-  ```
+  ```yaml
     logs:
         - type: file
           path: /var/log/elasticsearch/*.log
@@ -62,9 +65,9 @@ Finally, [Restart the Agent][3] to begin sending Elasticsearch metrics to Datado
 
   Change the `path` and `service` parameter values and configure them for your environment.
   
-  * [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent) to begin sending Elasticsearch logs to Datadog.
+* [Restart the Agent][3] to begin sending Elasticsearch logs to Datadog.
   
-  **Learn more about log collection [on the log documentation][4]**
+**Learn more about log collection [on the log documentation][4]**
   
 ### Validation
 

--- a/envoy/README.md
+++ b/envoy/README.md
@@ -9,17 +9,18 @@ This check collects distributed system observability metrics from [Envoy][1].
 
 The Envoy check is packaged with the Agent, so simply [install the Agent][2] on your server.
 
-If you need the newest version of the Envoy check, install the `dd-check-envoy` package; this package's check overrides the one packaged with the Agent. See the [integrations-core repository README.md for more details][3].
-
 ### Configuration
 
-Create a file `envoy.yaml` in the Datadog Agent's `conf.d` directory. See the [sample envoy.yaml][4] for all available configuration options.
+1. Edit the `envoy.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your Envoy performance data.
+See the [sample envoy.d/conf.yaml][4] for all available configuration options.
 
-Be sure the Datadog Agent can access Envoy's [admin endpoint][5].
+2. Check if the Datadog Agent can access Envoy's [admin endpoint][5].
+
+3. [Restart the Agent][3]
 
 #### via Istio
 
-If you are using Envoy as part of [Istio][6], to access Envoy's [admin endpoint](https://www.envoyproxy.io/docs/envoy/latest/operations/admin) you need to set Istio's [proxyAdminPort][7].
+If you are using Envoy as part of [Istio][6], to access Envoy's [admin endpoint][5] you need to set Istio's [proxyAdminPort][7].
 
 #### Standard
 
@@ -29,7 +30,7 @@ There are 2 ways to setup the `/stats` endpoint:
 
 Here's an example Envoy admin configuration:
 
-```
+```yaml
 admin:
   access_log_path: "/dev/null"
   address:
@@ -42,9 +43,9 @@ admin:
 
 Create a listener/vhost that routes to the admin endpoint (Envoy connecting to itself), but only has a route for `/stats`; all other routes get a static/error response. Additionally, this allows nice integration with L3 filters for auth, for example.
 
-Here's an example config (from [this gist](https://gist.github.com/ofek/6051508cd0dfa98fc6c13153b647c6f8)):
+Here's an example config (from [this gist][13]):
 
-```
+```yaml
 admin:
   access_log_path: /dev/null
   address:
@@ -97,7 +98,8 @@ static_resources:
 ## Data Collected
 ### Metrics
 
-See [metadata.csv][9] for a list of metrics provided by this check.
+See [metadata.csv][9] for a list of metrics provided by this integration.
+
 See [metrics.py][10] for a list of tags sent by each metric.
 
 ### Events
@@ -120,7 +122,7 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 
 [1]: https://www.envoyproxy.io
 [2]: https://app.datadoghq.com/account/settings#agent
-[3]: https://docs.datadoghq.com/agent/faq/install-core-extra/
+[3]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
 [4]: https://github.com/DataDog/integrations-core/blob/master/envoy/conf.yaml.example
 [5]: https://www.envoyproxy.io/docs/envoy/latest/operations/admin
 [6]: https://istio.io
@@ -130,3 +132,4 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [10]: https://github.com/DataDog/integrations-core/blob/master/envoy/datadog_checks/envoy/metrics.py
 [11]: http://docs.datadoghq.com/help/
 [12]: https://www.datadoghq.com/blog/
+[13]: https://gist.github.com/ofek/6051508cd0dfa98fc6c13153b647c6f8

--- a/etcd/README.md
+++ b/etcd/README.md
@@ -15,16 +15,17 @@ The etcd check is packaged with the Agent, so simply [install the Agent][1] on y
 
 ### Configuration
 
-Create a file `etcd.yaml` in the Agent's `conf.d` directory. See the [sample etcd.yaml][2] for all available configuration options:
+1. Edit the `etcd.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your etcd performance data.  
+    See the [sample etcd.d/conf.yaml][2] for all available configuration options.
 
-```
-init_config:
+        ```yaml
+        init_config:
 
-instances:
-  - url: "https://server:port" # API endpoint of your etcd instance
-```
+        instances:
+            - url: "https://server:port" # API endpoint of your etcd instance
+        ```
 
-[Restart the Agent][3] to begin sending etcd metrics to Datadog.
+2. [Restart the Agent][3]
 
 ### Validation
 
@@ -48,8 +49,7 @@ Returns 'Critical' if the Agent cannot collect metrics from your etcd API endpoi
 
 `etcd.healthy`:
 
-Returns 'Critical' if a member node is not healthy. Returns 'Unknown' if the Agent
-can't reach the `/health` endpoint, or if the health status is missing.
+Returns 'Critical' if a member node is not healthy. Returns 'Unknown' if the Agent can't reach the `/health` endpoint, or if the health status is missing.
 
 ## Troubleshooting
 Need help? Contact [Datadog Support][6].

--- a/exchange_server/README.md
+++ b/exchange_server/README.md
@@ -13,7 +13,10 @@ The Exchange check is packaged with the Agent, so simply [install the Agent][1] 
 
 ### Configuration
 
-Edit the `exchange_server.yaml` file to collect Exchange Server performance data. See the [sample exchange_server.yaml][2] for all available configuration options.
+1. Edit the `exchange_server.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your Exchange Server performance data.  
+    See the [sample exchange_server.d/conf.yaml][2] for all available configuration options.
+
+2. [Restart the Agent][5]
 
 ### Validation
 
@@ -34,3 +37,6 @@ The exchange server check does not include any service check at this time.
 [2]: https://github.com/DataDog/integrations-core/blob/master/exchange_server/conf.yaml.example
 [3]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [4]: https://github.com/DataDog/integrations-core/blob/master/exchange_server/metadata.csv
+[5]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
+
+

--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -14,7 +14,8 @@ The Fluentd check is packaged with the Agent, so simply [install the Agent][1] o
 
 ### Configuration
 
-Create a `fluentd.yaml` file in the Agent's `conf.d` directory.
+Edit the `fluentd.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your FluentD [metrics](#metric-collection) and [logs](#log-collection).
+See the [sample fluentd.d/conf.yaml][2] for all available configuration options.
 
 #### Prepare Fluentd
 
@@ -30,22 +31,22 @@ In your fluentd configuration file, add a `monitor_agent` source:
 
 #### Metric Collection
 
- * Add this configuration setup to your `fluentd.yaml` file to start gathering your [Fluentd metrics](#metrics):
+1. Add this configuration setup to your `fluentd.d/conf.yaml` file to start gathering your [Fluentd metrics](#metrics):
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-  - monitor_agent_url: http://localhost:24220/api/plugins.json
-    #tag_by: "type" # defaults to 'plugin_id'
-    #plugin_ids:    # collect metrics only on your chosen plugin_ids (optional)
-    #  - plg1
-    #  - plg2
-```
+    instances:
+      - monitor_agent_url: http://localhost:24220/api/plugins.json
+        #tag_by: "type" # defaults to 'plugin_id'
+        #plugin_ids:    # collect metrics only on your chosen plugin_ids (optional)
+        #  - plg1
+        #  - plg2
+    ```
 
-See the [sample fluentd.yaml][2] for all available configuration options.  
+    See the [sample fluentd.d/conf.yaml][2] for all available configuration options.  
 
-* [Restart the Agent][3] to begin sending Fluentd metrics to Datadog.
+2. [Restart the Agent][3] to begin sending Fluentd metrics to Datadog.
 
 #### Log Collection
 

--- a/gearmand/README.md
+++ b/gearmand/README.md
@@ -15,17 +15,18 @@ The Gearman check is packaged with the Agent, so simply [install the Agent][1] o
 
 ### Configuration
 
-Create a file `gearmand.yaml` in the Agent's `conf.d` directory. See the [sample gearmand.yaml][2] for all available configuration options:
 
-```
-init_config:
+1. Edit the `gearmand.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your Gearman performance data.  
+    See the [sample gearmand.d/conf.yaml][2] for all available configuration options.
+    ```
+    init_config:
 
-instances:
-  - server: localhost
-    port: 4730
-```
+    instances:
+        - server: localhost
+        port: 4730
+    ```
 
-[Restart the Agent][3] to begin sending Gearman metrics to Datadog.
+2. [Restart the Agent][3]
 
 ### Validation
 

--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -12,22 +12,22 @@ more information about Gitlab and its integration with Prometheus
 ## Setup
 ### Installation
 
-The Gitlab check is packaged with the Agent, so simply [install the Agent][1] on your Gitlab servers.
+The Gitlab check is packaged with the Agent, so simply [install the Agent][101] on your Gitlab servers.
 
 ### Configuration
 
-Edit the `gitlab.yaml` file to point to the Gitlab's Prometheus metrics endpoint.
-See the [sample gitlab.yaml][2] for all available configuration options.
+Edit the `gitlab.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to point to the Gitlab's Prometheus metrics endpoint.
+See the [sample gitlab.d/conf.yaml][102] for all available configuration options.
 
-The `allowed_metrics` item in the `init_config` section allows to specify the metrics that should be extracted.
+**Note**: The `allowed_metrics` item in the `init_config` section allows to specify the metrics that should be extracted.
 
 ### Validation
 
-[Run the Agent's `status` subcommand][3] and look for `gitlab` under the Checks section.
+[Run the Agent's `status` subcommand][103] and look for `gitlab` under the Checks section.
 
 ## Data Collected
 ### Metrics
-See [metadata.csv][4] for a list of metrics provided by this integration.
+See [metadata.csv][104] for a list of metrics provided by this integration.
 
 ### Events
 The Gitlab check does not include any event at this time.
@@ -37,15 +37,15 @@ The Gitlab check includes a readiness and a liveness service check.
 Moreover, it provides a service check to ensure that the local Prometheus endpoint is available.
 
 ## Troubleshooting
-Need help? Contact [Datadog Support][5].
+Need help? Contact [Datadog Support][105].
 
 ## Further Reading
-Learn more about infrastructure monitoring and all our integrations on [our blog][6]
+Learn more about infrastructure monitoring and all our integrations on [our blog][106]
 
 
-[1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://github.com/DataDog/integrations-core/blob/master/gitlab/conf.yaml.example
-[3]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
-[4]: https://github.com/DataDog/integrations-core/blob/master/gitlab/metadata.csv
-[5]: http://docs.datadoghq.com/help/
-[6]: https://www.datadoghq.com/blog/
+[101]: https://app.datadoghq.com/account/settings#agent
+[102]: https://github.com/DataDog/integrations-core/blob/master/gitlab/conf.yaml.example
+[103]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
+[104]: https://github.com/DataDog/integrations-core/blob/master/gitlab/metadata.csv
+[105]: http://docs.datadoghq.com/help/
+[106]: https://www.datadoghq.com/blog/

--- a/gitlab_runner/README.md
+++ b/gitlab_runner/README.md
@@ -17,15 +17,12 @@ The Gitlab Runner check is packaged with the Agent, so simply [install the Agent
 
 ### Configuration
 
-Edit the `gitlab_runner.yaml` file to point to the Runner's Prometheus metrics endpoint and to the Gitlab master to have a service check.
-See the [sample gitlab_runner.yaml][2] for all available configuration options.
+Edit the `gitlab_runner.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to point to the Runner's Prometheus metrics endpoint and to the Gitlab master to have a service check.  
+See the [sample gitlab_runner.d/conf.yaml][2] for all available configuration options.
 
-The `allowed_metrics` item in the `init_config` section allows to specify the metrics that should be extracted.
+**Note**: The `allowed_metrics` item in the `init_config` section allows to specify the metrics that should be extracted.
 
-**Remarks:**
-
- - Some metrics should be reported as `rate` (i.e., `ci_runner_errors`)
-
+**Remarks**: Some metrics should be reported as `rate` (i.e., `ci_runner_errors`)
 
 ### Validation
 

--- a/go-metro/README.md
+++ b/go-metro/README.md
@@ -13,21 +13,21 @@ The TCP RTT check—also known as [go-metro][1]—is packaged with the Agent, bu
 
 Debian-based systems should use one of the following:
 
-```
+```bash
 $ sudo apt-get install libcap
 $ sudo apt-get install libcap2-bin
 ```
 
 Redhat-based systems should use one of these:
 
-```
+```bash
 $ sudo yum install libcap
 $ sudo yum install compat-libcap1
 ```
 
 Finally, configure PCAP:
 
-```
+```bash
 $ sudo setcap cap_net_raw+ep /opt/datadog-agent/bin/go-metro
 ```
 
@@ -35,6 +35,7 @@ $ sudo setcap cap_net_raw+ep /opt/datadog-agent/bin/go-metro
 
 Edit the ```go-metro.yaml``` file in your agent's ```conf.d``` directory. See the [sample go-metro.yaml][2] for all available configuration options. The following is an example file that will show the TCP RTT times for app.datadoghq.com and 192.168.0.22:
 
+  ```yaml
     init_config:
       snaplen: 512
       idle_ttl: 300
@@ -43,7 +44,6 @@ Edit the ```go-metro.yaml``` file in your agent's ```conf.d``` directory. See th
       statsd_port: 8125
       log_to_file: true
       log_level: info
-
     instances:
       - interface: eth0
         tags:
@@ -52,27 +52,30 @@ Edit the ```go-metro.yaml``` file in your agent's ```conf.d``` directory. See th
           - 45.33.125.153
         hosts:
           - app.datadoghq.com
+  ```
 
 ### Validation
 
-To validate that the check is running correctly, you should see `system.net.tcp.rtt` metrics showing in the Datadog interface. Also, if you run `sudo /etc/init.d/datadog-agent status`, you should see something similar to the following:
+To validate that the check is running correctly, you should see `system.net.tcp.rtt` metrics showing in the Datadog interface. Also, if you [Run the Agent's `status` subcommand][6], you should see something similar to the following:
 
-    ● datadog-agent.service - "Datadog Agent"
-       Loaded: loaded (/lib/...datadog-agent.service; enabled; vendor preset: enabled)
-       Active: active (running) since Thu 2016-03-31 20:35:27 UTC; 42min ago
-      Process: 10016 ExecStop=/opt/.../supervisorctl -c /etc/dd-....conf shutdown (code=exited, status=0/SUCCESS)
-      Process: 10021 ExecStart=/opt/.../start_agent.sh (code=exited, status=0/SUCCESS)
-     Main PID: 10025 (supervisord)
-       CGroup: /system.slice/datadog-agent.service
-               ├─10025 /opt/datadog-...python /opt/datadog-agent/bin/supervisord -c /etc/dd-agent/supervisor.conf
-               ├─10043 /opt/datadog-...python /opt/datadog-agent/agent/dogstatsd.py --use-local-forwarder
-               ├─10044 /opt/datadog-agent/bin/go-metro -cfg=/etc/dd-agent/conf.d/go-metro.yaml
-               ├─10046 /opt/datadog-.../python /opt/datadog-agent/agent/ddagent.py
-               └─10047 /opt/datadog-.../python /opt/datadog-agent/agent/agent.py foreground --use-local-forwarder
+```
+● datadog-agent.service - "Datadog Agent"
+    Loaded: loaded (/lib/...datadog-agent.service; enabled; vendor preset: enabled)
+    Active: active (running) since Thu 2016-03-31 20:35:27 UTC; 42min ago
+  Process: 10016 ExecStop=/opt/.../supervisorctl -c /etc/dd-....conf shutdown (code=exited, status=0/SUCCESS)
+  Process: 10021 ExecStart=/opt/.../start_agent.sh (code=exited, status=0/SUCCESS)
+  Main PID: 10025 (supervisord)
+    CGroup: /system.slice/datadog-agent.service
+            ├─10025 /opt/datadog-...python /opt/datadog-agent/bin/supervisord -c /etc/dd-agent/supervisor.conf
+            ├─10043 /opt/datadog-...python /opt/datadog-agent/agent/dogstatsd.py --use-local-forwarder
+            ├─10044 /opt/datadog-agent/bin/go-metro -cfg=/etc/dd-agent/conf.d/go-metro.yaml
+            ├─10046 /opt/datadog-.../python /opt/datadog-agent/agent/ddagent.py
+            └─10047 /opt/datadog-.../python /opt/datadog-agent/agent/agent.py foreground --use-local-forwarder
+```
 
 If the TCP RTT check has started you should see something similar to the go-metro line above.
 
-This is a passive check, so unless there are packets actively being sent to the hosts mentioned in the yaml file, the metrics will not be reported.
+**This is a passive check, so unless there are packets actively being sent to the hosts mentioned in the yaml file, the metrics are not reported.**
 
 ## Data Collected
 ### Metrics
@@ -97,3 +100,4 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [3]: https://github.com/DataDog/integrations-core/blob/master/go-metro/metadata.csv
 [4]: http://docs.datadoghq.com/help/
 [5]: https://www.datadoghq.com/blog/
+[6]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information

--- a/go_expvar/README.md
+++ b/go_expvar/README.md
@@ -12,7 +12,6 @@ If you prefer to instrument your Go code using only [dogstats-go][1], you can st
 The Go Expvar check is packaged with the Agent, so simply [install the Agent][2] anywhere you run Go services whose metrics you want to collect.
 
 ### Configuration
-
 #### Prepare your Go service
 
 If your Go service doesn't use the [expvar package][3] already, you'll need to import it (`import "expvar"`). If you don't want to instrument your own metrics with expvar — i.e. you only want to collect your service's memory metrics — import the package using the blank identifier (`import _ "expvar"`).
@@ -21,28 +20,28 @@ If your service doesn't already listen for HTTP requests (via the http package),
 
 #### Connect the Agent
 
-Create a file `go_expvar.yaml` in the Agent's `conf.d` directory. See the [sample go_expvar.yaml][5] for all available configuration options:
+1. Edit the file `go_expvar.d/conf.yaml`, in the `conf.d/` folder at the root of your Agent's directory. See the [sample go_expvar.d/conf.yaml][5] for all available configuration options.
 
-```
-init_config:
+    ```yaml
+    init_config:
 
-instances:
-  - expvar_url: http://localhost:<your_apps_port>
-    # optionally change the top-level namespace for metrics, e.g. my_go_app.memstats.alloc
-    namespace: my_go_app # defaults to go_expvar, e.g. go_expvar.memstats.alloc
-    # optionally define the metrics to collect, e.g. a counter var your service exposes with expvar.NewInt("my_func_counter")
-    metrics:
-      - path: my_func_counter
-        # if you don't want it named my_go_app.my_func_counter
-        #alias: my_go_app.preferred_counter_name
-        type: counter # other valid options: rate, gauge
-        #tags:
-        #  - "tag_name1:tag_value1"
-```
+    instances:
+      - expvar_url: http://localhost:<your_apps_port>
+        # optionally change the top-level namespace for metrics, e.g. my_go_app.memstats.alloc
+        namespace: my_go_app # defaults to go_expvar, e.g. go_expvar.memstats.alloc
+        # optionally define the metrics to collect, e.g. a counter var your service exposes with expvar.NewInt("my_func_counter")
+        metrics:
+          - path: my_func_counter
+            # if you don't want it named my_go_app.my_func_counter
+            #alias: my_go_app.preferred_counter_name
+            type: counter # other valid options: rate, gauge
+            #tags:
+            #  - "tag_name1:tag_value1"
+    ```
 
-If you don't configure a `metrics` list, the Agent will still collect memstat metrics. Use `metrics` to tell the Agent which expvar vars to collect.
+    If you don't configure a `metrics` list, the Agent will still collect memstat metrics. Use `metrics` to tell the Agent which expvar vars to collect.
 
-[Restart the Agent][6] to begin sending memstat and expvar metrics to Datadog.
+2. [Restart the Agent][6] to begin sending memstat and expvar metrics to Datadog.
 
 ### Validation
 

--- a/gunicorn/README.md
+++ b/gunicorn/README.md
@@ -21,19 +21,19 @@ The Gunicorn check requires your Gunicorn app's Python environment to have the [
 ### Configuration
 #### Configure the Datadog Agent
 
-Create a `gunicorn.yaml` in the Datadog Agent's `conf.d` directory. See the [sample gunicorn.yaml][3] for all available configuration options:
+1. Edit the `gunicorn.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory,. See the [sample gunicorn.yaml][3] for all available configuration options:
 
-```
-init_config:
+  ```
+  init_config:
 
-instances:
-  # as set
-  # 1) in your app's config.py (proc_name = <YOUR_APP_NAME>), OR
-  # 2) via CLI (gunicorn --name <YOUR_APP_NAME> your:app)
-  - proc_name: <YOUR_APP_NAME>
-```
+  instances:
+    # as set
+    # 1) in your app's config.py (proc_name = <YOUR_APP_NAME>), OR
+    # 2) via CLI (gunicorn --name <YOUR_APP_NAME> your:app)
+    - proc_name: <YOUR_APP_NAME>
+  ```
 
-[Restart the Agent][4] to begin sending Gunicorn metrics to Datadog.
+2. [Restart the Agent][4] to begin sending Gunicorn metrics to Datadog.
 
 #### Connect Gunicorn to DogStatsD
 

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -20,7 +20,8 @@ The HAProxy check is packaged with the Agent. To start gathering your HAProxy me
 
 ### Configuration
 
-Create a `haproxy.yaml` file in the Agent's `conf.d` directory.
+Edit the `haproxy.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your HAProxy [metrics](#metric-collection) and [logs](#log-collection).
+See the [sample haproxy.d/conf.yaml][4] for all available configuration options.
 
 #### Prepare HAProxy
 
@@ -43,7 +44,7 @@ The Agent collects metrics via a stats endpoint:
 
 #### Metric Collection
 
-*  Add this configuration setup to your `haproxy.yaml` file to start gathering your [Haproxy Metrics](#metrics):
+*  Add this configuration setup to your `haproxy.d/conf.yaml` file to start gathering your [Haproxy Metrics](#metrics):
 
   ```
   init_config:
@@ -67,7 +68,7 @@ The Agent collects metrics via a stats endpoint:
   logs_enabled: true
   ```
 
-* Add this configuration setup to your `haproxy.yaml` file to start collecting your Haproxy Logs:
+* Add this configuration setup to your `haproxy.d/conf.yaml` file to start collecting your Haproxy Logs:
 
   ```
   logs:
@@ -77,7 +78,7 @@ The Agent collects metrics via a stats endpoint:
         source: haproxy
         sourcecategory: http_web_access
   ```
-  Change the `service` parameter value and configure it for your environment. See the [sample haproxy.yaml](https://github.com/DataDog/integrations-core/blob/master/haproxy/conf.yaml.example) for all available configuration options.
+  Change the `service` parameter value and configure it for your environment. See the [sample haproxy.d/conf.yaml](https://github.com/DataDog/integrations-core/blob/master/haproxy/conf.yaml.example) for all available configuration options.
 
 * [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent)
 

--- a/hdfs_datanode/README.md
+++ b/hdfs_datanode/README.md
@@ -9,7 +9,7 @@ Use this check (hdfs_datanode) and its counterpart check (hdfs_namenode), not th
 ## Setup
 ### Installation
 
-The HDFS DataNode check is packaged with the Agent, so simply [install the Agent][1] on your DataNodes.
+The HDFS DataNode check is packaged with the Agent, so simply [install the Agent][101] on your DataNodes.
 
 ### Configuration
 #### Prepare the DataNode
@@ -27,7 +27,7 @@ Restart the DataNode process to enable the JMX interface.
 
 #### Connect the Agent
 
-Create a file `hdfs_datanode.yaml` in the Agent's `conf.d` directory. See the [sample hdfs_datanode.yaml][2] for all available configuration options:
+Edit the `hdfs_datanode.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample hdfs_datanode.d/conf.yaml][102] for all available configuration options:
 
 ```
 init_config:
@@ -36,15 +36,15 @@ instances:
   - hdfs_datanode_jmx_uri: http://localhost:50075
 ```
 
-[Restart the Agent][3] to begin sending DataNode metrics to Datadog.
+[Restart the Agent][103] to begin sending DataNode metrics to Datadog.
 
 ### Validation
 
-[Run the Agent's `status` subcommand][4] and look for `hdfs_datanode` under the Checks section.
+[Run the Agent's `status` subcommand][104] and look for `hdfs_datanode` under the Checks section.
 
 ## Data Collected
 ### Metrics
-See [metadata.csv][5] for a list of metrics provided by this integration.
+See [metadata.csv][105] for a list of metrics provided by this integration.
 
 ### Events
 The HDFS-datanode check does not include any event at this time.
@@ -56,23 +56,23 @@ The HDFS-datanode check does not include any event at this time.
 Returns `Critical` if the Agent cannot connect to the DataNode's JMX interface for any reason (e.g. wrong port provided, timeout, un-parseable JSON response).
 
 ## Troubleshooting
-Need help? Contact [Datadog Support][6].
+Need help? Contact [Datadog Support][106].
 
 ## Further Reading
 
-* [Hadoop architectural overview][7]
-* [How to monitor Hadoop metrics][8]
-* [How to collect Hadoop metrics][9]
-* [How to monitor Hadoop with Datadog][10]
+* [Hadoop architectural overview][107]
+* [How to monitor Hadoop metrics][108]
+* [How to collect Hadoop metrics][109]
+* [How to monitor Hadoop with Datadog][1010]
 
 
-[1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://github.com/DataDog/integrations-core/blob/master/hdfs_datanode/conf.yaml.example
-[3]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
-[4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
-[5]: https://github.com/DataDog/integrations-core/blob/master/hdfs_datanode/metadata.csv
-[6]: http://docs.datadoghq.com/help/
-[7]: https://www.datadoghq.com/blog/hadoop-architecture-overview/
-[8]: https://www.datadoghq.com/blog/monitor-hadoop-metrics/
-[9]: https://www.datadoghq.com/blog/collecting-hadoop-metrics/
-[10]: https://www.datadoghq.com/blog/monitor-hadoop-metrics-datadog/
+[101]: https://app.datadoghq.com/account/settings#agent
+[102]: https://github.com/DataDog/integrations-core/blob/master/hdfs_datanode/conf.yaml.example
+[103]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
+[104]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
+[105]: https://github.com/DataDog/integrations-core/blob/master/hdfs_datanode/metadata.csv
+[106]: http://docs.datadoghq.com/help/
+[107]: https://www.datadoghq.com/blog/hadoop-architecture-overview/
+[108]: https://www.datadoghq.com/blog/monitor-hadoop-metrics/
+[109]: https://www.datadoghq.com/blog/collecting-hadoop-metrics/
+[1010]: https://www.datadoghq.com/blog/monitor-hadoop-metrics-datadog/

--- a/hdfs_namenode/README.md
+++ b/hdfs_namenode/README.md
@@ -27,7 +27,7 @@ Restart the NameNode process to enable the JMX interface.
 
 #### Connect the Agent
 
-Create a file `hdfs_namenode.yaml` in the Agent's `conf.d` directory. See the [sample hdfs_namenode.yaml][2] for all available configuration options:
+Edit the `hdfs_namenode.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample hdfs_namenode.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:

--- a/http_check/README.md
+++ b/http_check/README.md
@@ -11,7 +11,7 @@ The HTTP check is packaged with the Agent, so simply [install the Agent][1] on a
 
 ### Configuration
 
-Create a file `http_check.yaml` in the Agent's `conf.d` directory. See the [sample http_check.yaml][2] for all available configuration options:
+Edit the `http_check.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample http_check.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -31,7 +31,7 @@ instances:
 
 The HTTP check has more configuration options than many checks — many more than are shown above. Most options are opt-in, e.g. the Agent will not check SSL validation unless you configure the requisite options. Notably, the Agent _will_ check for soon-to-expire SSL certificates by default.
 
-See the [sample http_check.yaml](https://github.com/DataDog/integrations-core/blob/master/http_check/conf.yaml.example) for a full list and description of available options, here is a list of them:
+See the [sample http_check.d/conf.yaml][2] for a full list and description of available options, here is a list of them:
 
 | Setting | Description |
 |---|---|
@@ -57,7 +57,7 @@ See the [sample http_check.yaml](https://github.com/DataDog/integrations-core/bl
 | `tags` | A list of arbitrary tags that will be associated with the check. For more information about tags, please see our [Guide to tagging][3] and blog post, [The power of tagged metrics][4] |
 
 
-When you have finished configuring `http_check.yaml`, [restart the Agent][5] to begin sending HTTP service checks and response times to Datadog.
+When you have finished configuring `http_check.d/conf.yaml`, [restart the Agent][5] to begin sending HTTP service checks and response times to Datadog.
 
 ### Validation
 

--- a/iis/README.md
+++ b/iis/README.md
@@ -38,7 +38,7 @@ The IIS check is packaged with the Agent. To start gathering your IIS metrics an
 
 ### Configuration
 
-Create a file `iis.yaml` in the [Agent's `conf.d` directory][2].
+Edit the `iis.d/conf.yaml` file  in the [Agent's `conf.d` directory][2] at the root of your Agent's directory,
 
 #### Prepare IIS
 
@@ -59,7 +59,7 @@ C:/> winmgmt /resyncperf
 
 #### Metric Collection
 
- * Add this configuration setup to your `iis.yaml` file to start gathering your [IIS metrics](#metrics):
+ * Add this configuration setup to your `iis.d/conf.yaml` file to start gathering your [IIS metrics](#metrics):
 
 ```
 init_config:
@@ -75,7 +75,7 @@ To collect metrics on a per-site basis, you *must* use the `sites` option. The A
 
 If you don't configure `sites`, the Agent collects all the same metrics, but their values reflect totals across all sites — `iis.net.num_connections` is the total number of connections on the IIS server; you will not have visibility into per-site metrics.
 
-You can also monitor sites on remote IIS servers. See the [sample iis.conf][3] for relevant configuration options. By default, this check runs against a single instance - the current machine that the Agent is running on. It will check the WMI performance counters for IIS on that machine.
+You can also monitor sites on remote IIS servers. See the [sample iis.d/conf.yaml][3] for relevant configuration options. By default, this check runs against a single instance - the current machine that the Agent is running on. It will check the WMI performance counters for IIS on that machine.
 
 If you want to check other remote machines as well, you can add one instance per host.
 Note: If you also want to check the counters on the current machine, you will haveto create an instance with empty params.
@@ -100,7 +100,7 @@ Here's an example of configuration that would check the current machine and a re
 
 * `is_2008` (Optional) - NOTE: because of a typo in IIS6/7 (typically on W2K8) where perfmon reports TotalBytesTransferred as TotalBytesTransfered, you may have to enable this to grab the IIS metrics in that environment.
 
-* See the [sample iis.yaml](https://github.com/DataDog/integrations-core/blob/master/iis/conf.yaml.example) for all available configuration options.
+* See the [sample iis.yaml][3] for all available configuration options.
 
 * [Restart the Agent][5] to begin sending IIS metrics to Datadog.
 
@@ -114,19 +114,19 @@ Here's an example of configuration that would check the current machine and a re
   logs_enabled: true
   ```
 
-* Add this configuration setup to your `iis.yaml` file to start collecting your IIS Logs:
+* Add this configuration setup to your `iis.d/conf.yaml` file to start collecting your IIS Logs:
 
-```
-logs:
-    
-     - type: file
-       path: C:\inetpub\logs\LogFiles\W3SVC1\u_ex*
-       service: myservice
-       source: iis
-       sourcecategory: http_web_access
-```
+  ```
+  logs:
+       - type: file
+         path: C:\inetpub\logs\LogFiles\W3SVC1\u_ex*
+         service: myservice
+         source: iis
+         sourcecategory: http_web_access
+  ```
+
   Change the `path` and `service` parameter values and configure them for your environment.
-  See the [sample iis.yaml](https://github.com/DataDog/integrations-core/blob/master/iis/conf.yaml.example) for all available configuration options.
+  See the [sample iis.d/conf.yaml][2] for all available configuration options.
   
   * [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent).
 

--- a/istio/README.md
+++ b/istio/README.md
@@ -21,7 +21,7 @@ Istio needs to have the built in [prometheus adapter][2] enabled and the ports e
 
 #### Connect the Agent
 
-Create a basic `istio.yaml` in the Agent's `conf.d` directory to connect it to istio. See the [sample istio.yaml][3] for all available configuration options:
+Edit the `istio.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to connect it to Istio. See the [sample istio.d/conf.yaml][3] for all available configuration options:
 
 ```
 init_config:
@@ -32,7 +32,7 @@ instances:
     send_histograms_buckets: true
 ```
 
-Both endpoints need to be connected to the check for it to work. To learn more about the prometheus adapter, you can read the [istio documentation](https://istio.io/docs/tasks/telemetry/querying-metrics.html#about-the-prometheus-add-on).
+Both endpoints need to be connected to the check for it to work. To learn more about the prometheus adapter, you can read the [istio documentation][2].
 
 ### Validation
 

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -20,13 +20,13 @@ The check collects metrics via JMX, so you'll need a JVM on each kafka node so t
 
 ### Configuration
 
-Create a file `kafka.yaml` in the Datadog Agent's `conf.d` directory.
+Edit the `kafka.d/conf.yaml` file,  in the `conf.d/` folder at the root of your Agent's directory.
 
 #### Metric Collection
 
 **The following instructions are for the Datadog agent >= 5.0. For agents before that, refer to the [older documentation][17].**
 
-Kafka bean names depend on the exact Kafka version you're running. You should always use the example that comes packaged with the Agent as a base since that will be the most up-to-date configuration. Use [this sample conf file][18] as an example, but note that the version there may be for a newer version of the Agent than what you've got installed.
+Kafka bean names depend on the exact Kafka version you're running. You should always use the example that comes packaged with the Agent as a base since that will be the most up-to-date configuration. Use [this sample configuration file][18] as an example, but note that the version there may be for a newer version of the Agent than what you've got installed.
 
 After you've configured `kafka.yaml`, [restart the Agent][19] to begin sending Kafka metrics to Datadog.
 
@@ -60,7 +60,7 @@ Make sure you clone and edit the [integration pipeline][20] if you have a differ
   logs_enabled: true
   ```
 
-* Add this configuration setup to your `kafka.yaml` file to start collecting your Kafka Logs:
+* Add this configuration setup to your `kafka.d/conf.yaml` file to start collecting your Kafka Logs:
 
   ```
   logs:
@@ -76,9 +76,9 @@ Make sure you clone and edit the [integration pipeline][20] if you have a differ
   ```
 
   Change the `path` and `service` parameter values and configure them for your environment.
-  See the [sample kafka.yaml](https://github.com/DataDog/integrations-core/blob/master/kafka/conf.yaml.example) for all available configuration options.
+  See the [sample kafka.d/conf.yaml][18] for all available configuration options.
 
-* [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent). 
+* [Restart the Agent][19]. 
 
 **Learn more about log collection [on the log documentation][21]**
 

--- a/kafka_consumer/README.md
+++ b/kafka_consumer/README.md
@@ -9,19 +9,19 @@ This check fetches the highwater offsets from the Kafka brokers, consumer offset
 ## Setup
 ### Installation
 
-The Agent's Kafka consumer check is packaged with the Agent, so simply [install the Agent][1] on your Kafka nodes.
+The Agent's Kafka consumer check is packaged with the Agent, so simply [install the Agent][101] on your Kafka nodes.
 
 ### Configuration
 
-Create a `kafka_consumer.yaml` file using [this sample conf file][2] as an example. Then restart the Datadog Agent to start sending metrics to Datadog.
+Create a `kafka_consumer.yaml` file using [this sample configuration file][102] as an example. Then [restart the Datadog Agent][108] to start sending metrics to Datadog.
 
 ### Validation
 
-[Run the Agent's `status` subcommand][3] and look for `kafka_consumer` under the Checks section.
+[Run the Agent's `status` subcommand][103] and look for `kafka_consumer` under the Checks section.
 
 ## Data Collected
 ### Metrics
-See [metadata.csv][4] for a list of metrics provided by this check.
+See [metadata.csv][104] for a list of metrics provided by this check.
 
 ### Events
 
@@ -49,15 +49,16 @@ Specify the specific partition of your environment for your topic in your kafka_
 
 ## Further Reading
 
-* [Monitoring Kafka performance metrics][5]
-* [Collecting Kafka performance metrics][6]
-* [Monitoring Kafka with Datadog][7]
+* [Monitoring Kafka performance metrics][105]
+* [Collecting Kafka performance metrics][106]
+* [Monitoring Kafka with Datadog][107]
 
 
-[1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://github.com/DataDog/integrations-core/blob/master/kafka_consumer/conf.yaml.example
-[3]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
-[4]: https://github.com/DataDog/integrations-core/blob/master/kafka_consumer/metadata.csv
-[5]: https://www.datadoghq.com/blog/monitoring-kafka-performance-metrics/
-[6]: https://www.datadoghq.com/blog/collecting-kafka-performance-metrics/
-[7]: https://www.datadoghq.com/blog/monitor-kafka-with-datadog/
+[101]: https://app.datadoghq.com/account/settings#agent
+[102]: https://github.com/DataDog/integrations-core/blob/master/kafka_consumer/conf.yaml.example
+[103]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
+[104]: https://github.com/DataDog/integrations-core/blob/master/kafka_consumer/metadata.csv
+[105]: https://www.datadoghq.com/blog/monitoring-kafka-performance-metrics/
+[106]: https://www.datadoghq.com/blog/collecting-kafka-performance-metrics/
+[107]: https://www.datadoghq.com/blog/monitor-kafka-with-datadog/
+[108]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent

--- a/kong/README.md
+++ b/kong/README.md
@@ -11,22 +11,22 @@ The Kong check is packaged with the Agent, so simply [install the Agent][1] on y
 
 ### Configuration
 
-Create a `kong.yaml` in the Datadog Agent's `conf.d` directory. See the [sample kong.yaml][2] for all available configuration options:
+1. Edit the `kong.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample kong.d/conf.yaml][2] for all available configuration options:
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-# Each instance needs a `kong_status_url`. Tags are optional.
--   kong_status_url: http://example.com:8001/status/
-    tags:
-    - instance:foo
-#-   kong_status_url: http://example2.com:8001/status/
-#    tags:
-#    - instance:bar
-```
+    instances:
+    # Each instance needs a `kong_status_url`. Tags are optional.
+    -   kong_status_url: http://example.com:8001/status/
+        tags:
+        - instance:foo
+    #-   kong_status_url: http://example2.com:8001/status/
+    #    tags:
+    #    - instance:bar
+    ```
 
-[Restart the Agent][3] to begin sending Kong metrics to Datadog.
+2. [Restart the Agent][3] to begin sending Kong metrics to Datadog.
 
 ### Validation
 

--- a/kube_dns/README.md
+++ b/kube_dns/README.md
@@ -17,7 +17,7 @@ The Kube-dns check is packaged with the Agent, so simply [install the Agent][1] 
 
 ### Configuration
 
-Edit the `kube_dns.yaml` file to point to your server and port, set the masters to monitor. See the [sample kube_dns.yaml][2] for all available configuration options.
+Edit the `kube_dns.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to point to your server and port, set the masters to monitor. See the [sample kube_dns.d/conf.yaml][2] for all available configuration options.
 
 #### Using with service discovery
 

--- a/kube_proxy/README.md
+++ b/kube_proxy/README.md
@@ -10,11 +10,11 @@ Get metrics from kube_proxy service in real time to:
 ## Configuration
 
 The integration relies on the `--metrics-bind-address` option of the kube-proxy, by default it's bound to `127.0.0.1:10249`.
-You can either start the agent on the host network if the kube-proxy is also on the host network (default) or start the kube-proxy with the `--metrics-bind-address=0.0.0.0:10249`
+Either start the agent on the host network if the kube-proxy is also on the host network (default) or start the kube-proxy with the `--metrics-bind-address=0.0.0.0:10249`
 
-Edit the `kube_proxy.yaml` file to point to your server and port, set the masters to monitor
+Edit the `kube_proxy.d/conf.yaml` file to point to your server and port, set the masters to monitor
 
-⚠️ If you edit the namespace & metrics name, or add any other metric they will be considered as custom
+⚠️ If you edit the namespace & metrics name, or add any other metric they are considered as custom
 
 Please contribute to the integration if you want to add a relevant metric.
 

--- a/kubelet/README.md
+++ b/kubelet/README.md
@@ -9,11 +9,11 @@ This integration gets container metrics from kubelet
 
 ## Installation
 
-Install the `dd-check-kubelet` package manually or with your favorite configuration manager
+The Kubelet check is packaged with the Agent, so simply [install the Agent][3] on your servers.
 
 ## Configuration
 
-Edit the `kubelet.yaml` file to point to your server and port, set tags to send along with metrics.
+Edit the `kubelet.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to point to your server and port, set tags to send along with metrics.
 
 ## Validation
 
@@ -51,3 +51,4 @@ The check will still be able to collect:
 
 [1]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [2]: https://docs.openshift.org/3.7/install_config/master_node_configuration.html#node-configuration-files
+[3]: https://app.datadoghq.com/account/settings#agent

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -84,7 +84,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-In your `kubernetes.yaml` file you will see the [leader_lease_duration][7] parameter. It's the duration for which a leader stays elected. **It should be > 30 seconds**.
+In your `kubernetes.d/conf.yaml` file you will see the [leader_lease_duration][7] parameter. It's the duration for which a leader stays elected. **It should be > 30 seconds**.
 The longer it is, the less hard your agent hits the apiserver with requests, but it also means that if the leader dies (and under certain conditions) there can be an event blackout until the lease expires and a new leader takes over.
 
 ### Validation

--- a/kubernetes_state/README.md
+++ b/kubernetes_state/README.md
@@ -14,7 +14,7 @@ The Kubernetes-Sate check is packaged with the Agent, so simply [install the Age
 
 ### Configuration
 
-Edit the `kubernetes_state.yaml` file to point to your server and port, set the masters to monitor. See the [sample kubernetes_state.yaml][2] for all available configuration options.
+Edit the `kubernetes_state.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to point to your server and port, set the masters to monitor. See the [sample kubernetes_state.d/conf.yaml][2] for all available configuration options.
 
 ### Validation
 

--- a/kyototycoon/README.md
+++ b/kyototycoon/README.md
@@ -11,24 +11,26 @@ The KyotoTycoon check is packaged with the Agent, so simply [install the Agent][
 
 ### Configuration
 
-Create a file `kyototycoon.yaml` in the Agent's `conf.d` directory. See the [sample kyototycoon.yaml][2] for all available configuration options:
+1. Edit the `kyototycoon.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample kyototycoon.d/conf.yaml][2] for all available configuration options:
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-#  Each instance needs a report URL.
-#  name, and optionally tags keys. The report URL should
-#  be a URL to the Kyoto Tycoon "report" RPC endpoint.
-#
-#  Complete example:
-#
-- report_url: http://localhost:1978/rpc/report
-#   name: my_kyoto_instance
-#   tags:
-#     foo: bar
-#     baz: bat
-```
+    instances:
+    #  Each instance needs a report URL.
+    #  name, and optionally tags keys. The report URL should
+    #  be a URL to the Kyoto Tycoon "report" RPC endpoint.
+    #
+    #  Complete example:
+    #
+    - report_url: http://localhost:1978/rpc/report
+    #   name: my_kyoto_instance
+    #   tags:
+    #     foo: bar
+    #     baz: bat
+    ```
+
+2. [Restart the Agent][7] to begin sending Kong metrics to Datadog.
 
 ### Validation
 
@@ -61,3 +63,4 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [4]: https://github.com/DataDog/integrations-core/blob/master/kyototycoon/metadata.csv
 [5]: http://docs.datadoghq.com/help/
 [6]: https://www.datadoghq.com/blog/
+[7]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent

--- a/lighttpd/README.md
+++ b/lighttpd/README.md
@@ -9,23 +9,23 @@ The Agent's lighttpd check tracks uptime, bytes served, requests per second, res
 
 The lighttpd check is packaged with the Agent, so simply [install the Agent][1] on your lighttpd servers.
 
-You'll also need to install `mod_status` on your Lighttpd servers.
+In addition, install `mod_status` on your Lighttpd servers.
 
 ### Configuration
 
-Create a file `lighttpd.yaml` in the Agent's `conf.d` directory. See the [sample lighttpd.yaml][2] for all available configuration options:
+1. Edit the  `lighttpd.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample lighttpd.d/conf.yaml][2] for all available configuration options:
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-# Each instance needs a lighttpd_status_url. Tags are optional.
-  - lighttpd_status_url: http://example.com/server-status?auto
-#   tags:
-#     - instance:foo
-```
+    instances:
+    # Each instance needs a lighttpd_status_url. Tags are optional.
+      - lighttpd_status_url: http://example.com/server-status?auto
+    #   tags:
+    #     - instance:foo
+    ```
 
-[Restart the Agent][3] to begin sending lighttpd metrics to Datadog.
+2. [Restart the Agent][3] to begin sending lighttpd metrics to Datadog.
 
 ### Validation
 

--- a/linkerd/README.md
+++ b/linkerd/README.md
@@ -9,12 +9,10 @@ This check collects distributed system observability metrics from [Linkerd][1].
 
 The Linkerd check is packaged with the Agent, so simply [install the Agent][2] on your server.
 
-If you need the newest version of the Linkerd check, install the `dd-check-linkerd` package; this package's check overrides the one packaged with the Agent. See the [integrations-core repository README.md for more details][3].
-
 ### Configuration
 
-Edit the `linkerd.yaml` file located in your configuration directory.
-See [sample linkerd.yaml][4] for all available configuration options.
+Edit the `linkerd.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory.
+See [sample linkerd.d/conf.yaml][4] for all available configuration options.
 
 ### Validation
 
@@ -37,7 +35,7 @@ curl <linkerd_prometheus_endpoint>
 Where `linkerd_prometheus_endpoint` is the linkerd prometheus endpoint (you should use the same value as the `prometheus_url` config key in your `linkerd.yaml`)
 
 If you need to use a metric that is not provided by default, you can add an entry to `linkerd.yaml`.
-Simply follow the examples present in the [default configuration](https://github.com/DataDog/integrations-core/blob/master/linkerd/conf.yaml.example).
+Simply follow the examples present in the [default configuration][4].
 
 ### Service Checks
 

--- a/linux_proc_extras/README.md
+++ b/linux_proc_extras/README.md
@@ -13,7 +13,7 @@ The Linux_proc_extras check is packaged with the Agent, so simply [install the A
 
 ### Configuration
 
-Create a `linux_proc_extras.yaml` file in the Datadog Agent's `conf.d` directory. See the [sample linux_proc_extras.yaml][2] for all available configuration options.
+Edit the `linux_proc_extras.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample linux_proc_extras.d/conf.yaml][2] for all available configuration options.
 
 ### Validation
 

--- a/mapreduce/README.md
+++ b/mapreduce/README.md
@@ -14,7 +14,7 @@ The Mapreduce check is packaged with the Agent, so simply [install the Agent][1]
 
 ### Configuration
 
-Edit the `mapreduce.yaml` file to point to your server and port, set the masters to monitor. See the [sample mapreduce.yaml][2] for all available configuration options.
+Edit the `mapreduce.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory to point to your server and port, set the masters to monitor. See the [sample mapreduce.d/conf.yaml][2] for all available configuration options.
 
 ### Validation
 

--- a/marathon/README.md
+++ b/marathon/README.md
@@ -14,21 +14,21 @@ The Marathon check is packaged with the Agent, so simply [install the Agent][1] 
 
 ### Configuration
 
-Create a file `marathon.yaml` in the Agent's `conf.d` directory. See the [sample marathon.yaml][2] for all available configuration options:
+1. Edit the `marathon.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample marathon.d/conf.yaml][2] for all available configuration options:
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-  - url: https://<server>:<port> # the API endpoint of your Marathon master; required
-#   acs_url: https://<server>:<port> # if your Marathon master requires ACS auth
-    user: <username> # the user for marathon API or ACS token authentication
-    password: <password> # the password for marathon API or ACS token authentication
-```
+    instances:
+      - url: https://<server>:<port> # the API endpoint of your Marathon master; required
+    #   acs_url: https://<server>:<port> # if your Marathon master requires ACS auth
+        user: <username> # the user for marathon API or ACS token authentication
+        password: <password> # the password for marathon API or ACS token authentication
+    ```
 
-The function of `user` and `password` depends on whether or not you configure `acs_url`; If you do, the Agent uses them to request an authentication token from ACS, which it then uses to authenticate to the Marathon API. Otherwise, the Agent uses `user` and `password` to directly authenticate to the Marathon API.
+    The function of `user` and `password` depends on whether or not you configure `acs_url`; If you do, the Agent uses them to request an authentication token from ACS, which it then uses to authenticate to the Marathon API. Otherwise, the Agent uses `user` and `password` to directly authenticate to the Marathon API.
 
-[Restart the Agent][3] to begin sending Marathon metrics to Datadog.
+2. [Restart the Agent][3] to begin sending Marathon metrics to Datadog.
 
 ### Validation
 

--- a/mcache/README.md
+++ b/mcache/README.md
@@ -11,23 +11,23 @@ The memcache check is packaged with the Agent, so simply [install the Agent][1] 
 
 ### Configuration
 
-Create a file `mcache.yaml` in the Agent's `conf.d` directory.See the [sample mcache.yaml][2] for all available configuration options:
+1. Edit the `mcache.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample mcache.d/conf.yaml][2] for all available configuration options:
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-  - url: localhost  # url used to connect to the memcached instance
-    port: 11212 # optional; default is 11211
-#    socket: /path/to/memcache/socket # alternative to url/port; 'dd-agent' user must have read/write permission
-    options:
-      items: false # set to true to collect items stats
-      slabs: false # set to true to collect slabs stats
-#    tags:
-#    - optional_tag
-```
+    instances:
+      - url: localhost  # url used to connect to the memcached instance
+        port: 11212 # optional; default is 11211
+    #    socket: /path/to/memcache/socket # alternative to url/port; 'dd-agent' user must have read/write permission
+        options:
+          items: false # set to true to collect items stats
+          slabs: false # set to true to collect slabs stats
+    #    tags:
+    #    - optional_tag
+    ```
 
-[Restart the Agent][3] to begin sending memcache metrics to Datadog.
+2. [Restart the Agent][3] to begin sending memcache metrics to Datadog.
 
 ### Validation
 
@@ -38,7 +38,7 @@ instances:
 
 See [metadata.csv][5] for a list of metrics provided by this check.
 
-The check only collects `memcache.slabs.*` metrics if you set `options.slabs: true` in `mcache.yaml`. Likewise, it only collects `memcache.items.*` metrics if you set `options.items: true`.
+The check only collects `memcache.slabs.*` metrics if you set `options.slabs: true` in `mcache.d/conf.yaml`. Likewise, it only collects `memcache.items.*` metrics if you set `options.items: true`.
 
 
 ### Events

--- a/mesos_master/README.md
+++ b/mesos_master/README.md
@@ -30,9 +30,9 @@ Substitute your Datadog API key and Mesos Master's API URL into the command abov
 
 ### Configuration
 
-If you passed the correct Master URL when starting datadog-agent, the Agent is already using a default `mesos_master.d/conf.yaml` to collect metrics from your masters; you don't need to configure anything else. See the [sample mesos_master.d/conf.yaml][1] for all available configuration options.
+If you passed the correct Master URL when starting datadog-agent, the Agent is already using a default `mesos_master.d/conf.yaml` to collect metrics from your masters; you don't need to configure anything else. See the [sample mesos_master.d/conf.yaml][101] for all available configuration options.
 
-Unless your masters' API uses a self-signed certificate. In that case, set `disable_ssl_validation: true` in `mesos_master.yaml`.
+Unless your masters' API uses a self-signed certificate. In that case, set `disable_ssl_validation: true` in `mesos_master.d/conf.yaml`.
 
 ### Validation
 
@@ -41,7 +41,7 @@ In the Datadog app, search for `mesos.cluster` in the Metrics Explorer.
 ## Data Collected
 ### Metrics
 
-See [metadata.csv][2] for a list of metrics provided by this integration.
+See [metadata.csv][102] for a list of metrics provided by this integration.
 
 ### Events
 The Mesos-master check does not include any event at this time.
@@ -53,14 +53,14 @@ The Mesos-master check does not include any event at this time.
 Returns CRITICAL if the Agent cannot connect to the Mesos Master API to collect metrics, otherwise OK.
 
 ## Troubleshooting
-Need help? Contact [Datadog Support][3].
+Need help? Contact [Datadog Support][103].
 
 ## Further Reading
 
-* [Installing Datadog on Mesos with DC/OS][4]
+* [Installing Datadog on Mesos with DC/OS][104]
 
 
-[1]: https://github.com/DataDog/integrations-core/blob/master/mesos_master/conf.yaml.example
-[2]: https://github.com/DataDog/integrations-core/blob/master/mesos_master/metadata.csv
-[3]: http://docs.datadoghq.com/help/
-[4]: https://www.datadoghq.com/blog/deploy-datadog-dcos/
+[101]: https://github.com/DataDog/integrations-core/blob/master/mesos_master/conf.yaml.example
+[102]: https://github.com/DataDog/integrations-core/blob/master/mesos_master/metadata.csv
+[103]: http://docs.datadoghq.com/help/
+[104]: https://www.datadoghq.com/blog/deploy-datadog-dcos/

--- a/mesos_slave/README.md
+++ b/mesos_slave/README.md
@@ -28,7 +28,7 @@ Follow the instructions in our [blog post][1] to install the Datadog Agent on ea
 
 #### Marathon
 
-If you are not using DC/OS, then use either the Marathon web UI or post to the API URL the following JSON to define the Datadog Agent application. You will need to change <YOUR_DATADOG_API_KEY> with your API Key and the number of instances with the number of slave nodes on your cluster. You may also need to update the docker image used to more recent tag. You can find the latest [on Docker Hub][2]
+If you are not using DC/OS, then use either the Marathon web UI or post to the API URL the following JSON to define the Datadog Agent application. You will need to change `<YOUR_DATADOG_API_KEY>` with your API Key and the number of instances with the number of slave nodes on your cluster. You may also need to update the docker image used to more recent tag. You can find the latest [on Docker Hub][2]
 
 ```json
 {
@@ -89,7 +89,7 @@ Unless you want to configure a custom `mesos_slave.d/conf.yaml`—perhaps you ne
 Under the Services tab in the DC/OS web UI you should see the Datadog Agent shown. In the Datadog app, search for `mesos.slave` in the Metrics Explorer.
 
 #### Marathon
-If you are not using DC/OS, then datadog-agent will be in the list of running applications with a healthy status. In the Datadog app, search for mesos.slave in the Metrics Explorer.
+If you are not using DC/OS, then datadog-agent is in the list of running applications with a healthy status. In the Datadog app, search for `mesos.slave` in the Metrics Explorer.
 
 ## Data Collected
 ### Metrics
@@ -126,7 +126,7 @@ Need help? Contact [Datadog Support][4].
 
 ## Further Reading
 
-* [Installing Datadog on Mesos with DC/OS](https://www.datadoghq.com/blog/deploy-datadog-dcos/)
+* [Installing Datadog on Mesos with DC/OS][1]
 
 
 [1]: https://www.datadoghq.com/blog/deploy-datadog-dcos/

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -14,7 +14,7 @@ The MongoDB check is packaged with the Agent, so simply [install the Agent][1] o
 
 ### Configuration
 
-Create a `mongodb.yaml` file in the Agent's `conf.d` directory.
+Edit the `mongodb.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your MongoDB [metrics](#metric-collection) and [logs](#log-collection).  See the [sample mongo.yaml][2] for all available configuration options.
 
 #### Prepare MongoDB
 
@@ -42,7 +42,7 @@ db.createUser({
 
 #### Metric Collection
 
-* Add this configuration setup to your `mongodb.yaml` file to start gathering your [MongoDB Metrics](#metrics). See the [sample mongo.yaml][2] for all available configuration options:
+* Add this configuration setup to your `mongodb.d/conf.yaml` file to start gathering your [MongoDB Metrics](#metrics). See the [sample mongo.d/conf.yaml][2] for all available configuration options:
 
   ```
   init_config:
@@ -54,7 +54,7 @@ db.createUser({
         - tcmalloc
         - top
   ```
-  See the [sample mongodb.yaml](https://github.com/DataDog/integrations-core/blob/master/mongo/conf.yaml.example) for all available configuration options
+  See the [sample mongodb.yaml][2] for all available configuration options
 
 * [Restart the Agent][3] to start sending MongoDB metrics to Datadog.
 
@@ -68,7 +68,7 @@ db.createUser({
   logs_enabled: true
   ```
 
-* Add this configuration setup to your `mongodb.yaml` file to start collecting your MongoDB Logs:
+* Add this configuration setup to your `mongodb.d/conf.yaml` file to start collecting your MongoDB Logs:
 
   ```
   logs:
@@ -78,9 +78,9 @@ db.createUser({
         source: mongodb
   ```
   Change the `service` and `path` parameter values and configure them for your environment.
-  See the [sample mongodb.yaml](https://github.com/DataDog/integrations-core/blob/master/mongo/conf.yaml.example) for all available configuration options
+  See the [sample mongodb.yaml][2] for all available configuration options
 
-* [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent)
+* [Restart the Agent][3].
 
 **Learn more about log collection [on the log documentation][4]**
 

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -18,7 +18,8 @@ The MySQL check is included in the Datadog Agent package, so simply [install the
 
 ### Configuration
 
-Create a `mysql.yaml` file in the Agent's `conf.d` directory to connect it to the MySQL server.
+Edit the `mysql.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's directory, to connect it to the MySQL server and start collecting your MySQL [metrics](#metric-collection) and [logs](#log-collection).
+See the [sample mysql.d/conf.yaml][16] for all available configuration options.
 
 #### Prepare MySQL
 
@@ -70,7 +71,7 @@ Query OK, 0 rows affected (0.00 sec)
 
 #### Metric Collection
 
-* Add this configuration setup to your `mysql.yaml` file to start gathering your [MySQL metrics](#metrics):
+* Add this configuration setup to your `mysql.d/conf.yaml` file to start gathering your [MySQL metrics](#metrics):
 
   ```
   init_config:
@@ -141,7 +142,7 @@ The `datadog` user should be set up in the MySQL integration configuration as `h
     logs_enabled: true
     ```
 
-3. Add this configuration setup to your `mysql.yaml` file to start collecting your MySQL logs:
+3. Add this configuration setup to your `mysql.d/conf.yaml` file to start collecting your MySQL logs:
 
     ```
     logs:
@@ -168,9 +169,9 @@ The `datadog` user should be set up in the MySQL integration configuration as `h
           #     name: new_log_start_with_date
           #     pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
     ```
-    See our [sample mysql.yaml](https://github.com/Datadog/integrations-core/blob/master/mysql/conf.yaml.example) for all available configuration options, including those for custom metrics.
+    See our [sample mysql.yaml][16] for all available configuration options, including those for custom metrics.
 
-4. [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent).
+4. [Restart the Agent][17].
 
 **Learn more about log collection [on the log documentation][18]**
 

--- a/nagios/README.md
+++ b/nagios/README.md
@@ -17,7 +17,7 @@ The Nagios check is packaged with the Agent, so simply [install the Agent][1] on
 
 ### Configuration
 
-Create a file `nagios.yaml` in the Agent's `conf.d` directory. See the [sample nagios.yaml][2] for all available configuration options:
+Edit the `nagios.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample nagios.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:

--- a/network/README.md
+++ b/network/README.md
@@ -11,22 +11,22 @@ The network check is packaged with the Agent, so simply [install the Agent][1] o
 
 ### Configuration
 
-The Agent enables the network check by default, but if you want to configure the check yourself, create a file `network.yaml` in the Agent's `conf.d` directory. See the [sample network.yaml][2] for all available configuration options:
+1. The Agent enables the network check by default, but if you want to configure the check yourself, edit file `network.d/conf.yaml`, in the `conf.d/` folder at the root of your Agent's directory. See the [sample network.d/conf.yaml][2] for all available configuration options:
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-  # Network check only supports one configured instance
-  - collect_connection_state: false # set to true to collect TCP connection state metrics, e.g. SYN_SENT, ESTABLISHED
-    excluded_interfaces: # the check will collect metrics on all other interfaces
-      - lo
-      - lo0
-# ignore any network interface matching the given regex:
-#   excluded_interface_re: eth1.*
-```
+    instances:
+      # Network check only supports one configured instance
+      - collect_connection_state: false # set to true to collect TCP connection state metrics, e.g. SYN_SENT, ESTABLISHED
+        excluded_interfaces: # the check will collect metrics on all other interfaces
+          - lo
+          - lo0
+    # ignore any network interface matching the given regex:
+    #   excluded_interface_re: eth1.*
+    ```
 
-[Restart the Agent][3] to effect any configuration changes.
+2. [Restart the Agent][3] to effect any configuration changes.
 
 ### Validation
 

--- a/nfsstat/README.md
+++ b/nfsstat/README.md
@@ -11,7 +11,7 @@ The NFSstat check is packaged with the Agent, so simply [install the Agent][2] o
 
 ### Configuration
 
-Edit the `nfsstat.yaml` file to point to your nfsiostat binary script, or use the one included with the binary installer. See the [sample nfsstat.yaml][3] for all available configuration options.
+Edit the `nfsstat.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to point to your nfsiostat binary script, or use the one included with the binary installer. See the [sample nfsstat.d/conf.yaml][3] for all available configuration options.
 
 ### Validation
 
@@ -22,10 +22,10 @@ Edit the `nfsstat.yaml` file to point to your nfsiostat binary script, or use th
 See [metadata.csv][5] for a list of metrics provided by this check.
 
 ### Events
-The nfststat check does not include any event at this time.
+The Nfststat check does not include any event at this time.
 
 ### Service Checks
-The nfsstat check does not include any service check at this time.
+The Nfsstat check does not include any service check at this time.
 
 ## Troubleshooting
 Need help? Contact [Datadog Support][6].

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -15,8 +15,6 @@ For users of NGINX Plus, the commercial version of NGINX, the Agent can collect 
 * Caches (size, hits, misses, etc)
 * SSL (handshakes, failed handshakes, etc)
 
-And many more.
-
 ## Setup
 ### Installation
 
@@ -43,7 +41,8 @@ If the command output does not include `http_stub_status_module`, you must insta
 
 ### Configuration
 
-Create a `nginx.yaml` file in the Agent's `conf.d` directory.
+Edit the `nginx.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory to start collecting your NGINX [metrics](#metric-collection) and [logs](#log-collection).
+See the [sample nginx.d/conf.yaml][5] for all available configuration options.
 
 #### Prepare NGINX
 
@@ -81,7 +80,7 @@ Reload NGINX to enable the status endpoint. (There's no need for a full restart)
 
 #### Metric Collection
 
-* Add this configuration setup to your `nginx.yaml` file to start gathering your [NGINX metrics](#metrics):
+* Add this configuration setup to your `nginx.d/conf.yaml` file to start gathering your [NGINX metrics](#metrics):
 
   ```
   init_config:
@@ -92,7 +91,7 @@ Reload NGINX to enable the status endpoint. (There's no need for a full restart)
     # user: <USER>
     # password: <PASSWORD>
   ```
-  See the [sample nginx.yaml][5] for all available configuration options.
+  See the [sample nginx.d/conf.yaml][5] for all available configuration options.
 
 * [Restart the Agent][6] to start sending NGINX metrics to Datadog.
 
@@ -106,7 +105,7 @@ Reload NGINX to enable the status endpoint. (There's no need for a full restart)
   logs_enabled: true
   ```
 
-*  Add this configuration setup to your `nginx.yaml` file to start collecting your NGINX Logs:
+*  Add this configuration setup to your `nginx.d/conf.yaml` file to start collecting your NGINX Logs:
 
   ```
   logs:
@@ -123,9 +122,9 @@ Reload NGINX to enable the status endpoint. (There's no need for a full restart)
       sourcecategory: http_web_access
   ```
   Change the `service` and `path` parameter values and configure them for your environment.
-  See the [sample nginx.yaml](https://github.com/DataDog/integrations-core/blob/master/nginx/conf.yaml.example) for all available configuration options.
+  See the [sample nginx.d/conf.yaml][5] for all available configuration options.
 
-* [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent)
+* [Restart the Agent][6]
 
 **Learn more about log collection [on the log documentation][7]**
 
@@ -138,7 +137,7 @@ Reload NGINX to enable the status endpoint. (There's no need for a full restart)
 
 See [metadata.csv][9] for a full list of provided metrics by this integration.
 
-Not all metrics shown are available to users of open source NGINX. Compare the module reference for [stub status](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html) (open source NGINX) and [http status](http://nginx.org/en/docs/http/ngx_http_status_module.html) (NGINX Plus) to understand which metrics are provided by each module.
+Not all metrics shown are available to users of open source NGINX. Compare the module reference for [stub status][2] (open source NGINX) and [http status][3] (NGINX Plus) to understand which metrics are provided by each module.
 
 A few open-source NGINX metrics are named differently in NGINX Plus; they refer to the exact same metric, though:
 

--- a/ntp/README.md
+++ b/ntp/README.md
@@ -21,7 +21,7 @@ The NTP check is packaged with the Agent, so simply [install the Agent][1] on yo
 
 ### Configuration
 
-The Agent enables the NTP check by default, but if you want to configure the check yourself, create a file `ntp.yaml` in the Agent's `conf.d` directory. See the [sample ntp.yaml][2] for all available configuration options:
+The Agent enables the NTP check by default, but if you want to configure the check yourself, edit the file `ntp.d/conf.yaml` in the `conf.d/` folder at the root of your Agent's directory. See the [sample ntp.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -18,15 +18,15 @@ To capture OpenStack metrics you need to [install the Agent][1] on your hosts ru
 
 1. First configure a Datadog role and user with your identity server
 
-
-        openstack role create datadog_monitoring
-        openstack user create datadog \
-            --password my_password \
-            --project my_project_name
-        openstack role add datadog_monitoring \
-            --project my_project_name \
-            --user datadog
-
+```
+openstack role create datadog_monitoring
+openstack user create datadog \
+    --password my_password \
+    --project my_project_name
+openstack role add datadog_monitoring \
+    --project my_project_name \
+    --user datadog
+```
 
 2. Update your policy.json files to grant the needed permissions.
 ```role:datadog_monitoring``` requires access to the following operations:
@@ -71,7 +71,7 @@ To capture OpenStack metrics you need to [install the Agent][1] on your hosts ru
 You may need to restart your Keystone, Neutron and Nova API services to ensure that the policy changes take.
 
 
-3. Configure the Datadog Agent to connect to your Keystone server, and specify individual projects to monitor. Edit `openstack.yaml`. You can find a sample configuration in the conf.d directory in your agent install. See the [sample openstack.yaml][2] for all available configuration options.
+3. Configure the Datadog Agent to connect to your Keystone server, and specify individual projects to monitor. Edit the `openstack.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's directory. See the [sample openstack.d/conf.yaml][2] for all available configuration options.
 
 4. [Restart the Agent][3]
 

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -59,7 +59,7 @@ ALTER SESSION SET "_ORACLE_SCRIPT"=true;
 
 ### Configuration
 
-Edit the `oracle.yaml` file to point to your server and port, set the masters to monitor. See the [sample oracle.yaml][4] for all available configuration options.
+Edit the `oracle.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory to point to your server and port, set the masters to monitor. See the [sample oracle.d/conf.yaml][4] for all available configuration options.
 
 Configuration Options:
 

--- a/pdh_check/README.md
+++ b/pdh_check/README.md
@@ -13,7 +13,7 @@ The PDH check is packaged with the Agent, so simply [install the Agent][1] on yo
 
 ### Configuration
 
-Edit the `pdh_check.yaml` file to collect Windows performance data. See the [sample pdh_check.yaml][2] for all available configuration options.
+Edit the `pdh_check.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory to collect Windows performance data. See the [sample pdh_check.d/conf.yaml][2] for all available configuration options.
 
 ### Validation
 

--- a/pgbouncer/README.md
+++ b/pgbouncer/README.md
@@ -11,7 +11,7 @@ The PgBouncer check is packaged with the Agent, so simply [install the Agent][1]
 
 ### Configuration
 
-Create a file `pgbouncer.yaml` in the Agent's `conf.d` directory. See the [sample pgbouncer.yaml][2] for all available configuration options:
+Edit the `pgbouncer.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample pgbouncer.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:

--- a/php_fpm/README.md
+++ b/php_fpm/README.md
@@ -11,7 +11,7 @@ The PHP-FPM check is packaged with the Agent, so simply [install the Agent][1] o
 
 ### Configuration
 
-Create a file `php_fpm.yaml` in the Agent's `conf.d` directory. See the [sample php_fpm.yaml][2] for all available configuration options:
+Edit the `php_fpm.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample php_fpm.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -35,6 +35,7 @@ Configuration Options:
 * `user` (Optional) - Used if you have set basic authentication on the status and ping pages
 * `password` (Optional) - Used if you have set basic authentication on the status and ping pages
 * `http_host` (Optional) - If your FPM pool is only accessible via a specific HTTP vhost, specify it here
+
 [Restart the Agent][3] to start sending PHP-FPM metrics to Datadog.
 
 ### Validation
@@ -47,7 +48,7 @@ Configuration Options:
 See [metadata.csv][5] for a list of metrics provided by this check.
 
 ### Events
-The php-fpm check does not include any event at this time.
+The PHP-FPM check does not include any event at this time.
 
 ### Service Checks
 

--- a/postfix/README.md
+++ b/postfix/README.md
@@ -17,7 +17,7 @@ Optionally, you can configure the agent to use a built in `postqueue -p` command
 **WARNING**: Using `postqueue` to monitor the mail queues will not report a count of messages for the `incoming` queue.
 
 ### Using sudo
-Create a file `postfix.yaml` in the Agent's `conf.d` directory. See the [sample postfix.yaml][2] for all available configuration options:
+Edit the file `postfix.d/conf.yaml`, in the `conf.d/` folder at the root of your Agent's directory. See the [sample postfix.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -44,8 +44,9 @@ dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/incoming -type 
 dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/active -type f
 dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/deferred -type f
 ```
+
 ### Using postqueue
-Create a file `postfix.yaml` in the Agent's `conf.d` directory:
+Edit the `postfix.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory:
 
 ```
 init_config:
@@ -60,21 +61,18 @@ instances:
 #     - optional_tag
 #     - optional_tag0
 ```
-For each `config_directory` in `instances`, the Agent forks a `postqueue -c` for
-the Postfix configuration directory.
+For each `config_directory` in `instances`, the Agent forks a `postqueue -c` for the Postfix configuration directory.
 
-Postfix has internal access controls that limit activities on the mail queue. By default,
-Postfix allows `anyone` to view the queue. On production systems where the Postfix installation
-may be configured with stricter access controls, you may need to grant the dd-agent user access to view
-the mail queue.
+Postfix has internal access controls that limit activities on the mail queue. By default, Postfix allows `anyone` to view the queue. On production systems where the Postfix installation may be configured with stricter access controls, you may need to grant the dd-agent user access to view the mail queue.
 
-    postconf -e "authorized_mailq_users = dd-agent"
-
+```
+postconf -e "authorized_mailq_users = dd-agent"
+```
 http://www.postfix.org/postqueue.1.html
-
-            authorized_mailq_users (static:anyone)
-                List of users who are authorized to view the queue.
-
+```
+authorized_mailq_users (static:anyone)
+```
+List of users who are authorized to view the queue.
 
 [Restart the Agent][3] to start sending Postfix metrics to Datadog.
 

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -13,11 +13,10 @@ Get metrics from PostgreSQL service in real time to:
 ### Installation
 
 The PostgreSQL check is packaged with the Agent. To start gathering your PostgreSQL metrics and logs, [install the Agent][13].
-If you need the newest version of the check, install the `dd-check-postgres` package manually or with your favorite configuration manager.
 
 ### Configuration
 
-Create a `postgres.yaml` file in the Agent's `conf.d` directory.
+Edit the `postgres.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory to start collecting your PostgreSQL [metrics](#metric-collection) and [logs](#log-collection). See the [sample postgres.d/conf.yaml][14] for all available configuration options. 
 
 #### Prepare Postgres
 
@@ -43,7 +42,7 @@ When it prompts for a password, enter the one used in the first command.
 
 #### Metric Collection
 
-* Edit the `postgres.yaml` file to point to your server and port, set the masters to monitor. See the [sample postgres.yaml][14] for all available configuration options. Configuration Options:
+* Edit the `postgres.d/conf.yaml` file to point to your server and port, set the masters to monitor. See the [sample postgres.d/conf.yaml][14] for all available configuration options. Configuration Options:
 
   * **`username`** (Optional) - The user account used to collect metrics, set in the [Installation section above](#installation)
   * **`password`** (Optional) - The password for the user account.
@@ -90,7 +89,7 @@ PostgreSQL default logging is to stderr and logs do not include detailed informa
   logs_enabled: true
   ```
 
-*  Add this configuration setup to your `postgres.yaml` file to start collecting your PostgreSQL logs:
+*  Add this configuration setup to your `postgres.d/conf.yaml` file to start collecting your PostgreSQL logs:
 
   ```
   logs:
@@ -106,9 +105,9 @@ PostgreSQL default logging is to stderr and logs do not include detailed informa
         #    name: new_log_start_with_date
   ```
   Change the `service` and `path` parameter values and configure them for your environment.
-  See the [sample postgres.yaml](https://github.com/DataDog/integrations-core/blob/master/postgres/conf.yaml.example) for all available configuration options.
+  See the [sample postgres.d/conf.yaml][14] for all available configuration options.
 
-* [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent).
+* [Restart the Agent][15].
 
 **Learn more about log collection [on the log documentation][16]**
 ### Validation
@@ -189,7 +188,7 @@ custom_metrics:
 
 ##### Debugging
 
-[Run the Agent's `status` subcommand](https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information) and look for `postgres` under the Checks section:
+[Run the Agent's `status` subcommand][17] and look for `postgres` under the Checks section:
 
 ```
 postgres

--- a/powerdns_recursor/README.md
+++ b/powerdns_recursor/README.md
@@ -38,19 +38,19 @@ Restart the recursor to enable the statistics API.
 
 #### Connect the Agent
 
-Create a file `powerdns_recursor.yaml` in the Agent's `conf.d` directory. See the [sample powerdns_recursor.yaml][2] for all available configuration options:
+1. Edit the `powerdns_recursor.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample powerdns_recursor.d/conf.yaml][2] for all available configuration options:
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-  - host: 127.0.0.1
-    port: 8082
-    api_key: changeme
-    version: 4 # omit this line if you're running pdns_recursor version 3.x
-```
+    instances:
+      - host: 127.0.0.1
+        port: 8082
+        api_key: changeme
+        version: 4 # omit this line if you're running pdns_recursor version 3.x
+    ```
 
-[Restart the Agent][3] to begin sending PowerDNS Recursor metrics to Datadog.
+2. [Restart the Agent][3] to begin sending PowerDNS Recursor metrics to Datadog.
 
 ### Validation
 

--- a/process/README.md
+++ b/process/README.md
@@ -16,7 +16,7 @@ The process check is packaged with the Agent, so simply [install the Agent][2] a
 
 Unlike many checks, the process check doesn't monitor anything useful by default; you must tell it which processes you want to monitor, and how.
 
-While there's no standard default check configuration, here's an example `process.yaml` that monitors ssh/sshd processes. See the [sample process.yaml][3] for all available configuration options:
+While there's no standard default check configuration, here's an example `process.d/conf.yaml` that monitors ssh/sshd processes. See the [sample process.d/conf.yaml][3] for all available configuration options:
 
 ```
 init_config:
@@ -37,7 +37,7 @@ You can also configure the check to find any process by exact PID (`pid`) or pid
 
 To have the check search for processes in a path other than `/proc`, set `procfs_path: <your_proc_path>` in `datadog.conf`, NOT in `process.yaml` (its use has been deprecated there). Set this to `/host/proc` if you're running the Agent from a Docker container (i.e. [docker-dd-agent](https://github.com/DataDog/docker-dd-agent)) and want to monitor processes running on the server hosting your containers. You DON'T need to set this to monitor processes running _in_ your containers; the [Docker check][5] monitors those.  
 
-See the [example configuration](https://github.com/DataDog/integrations-core/blob/master/process/conf.yaml.example) for more details on configuration options.  
+See the [example configuration][3] for more details on configuration options.  
 
 [Restart the Agent][6] to start sending process metrics and service checks to Datadog.
 

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -8,7 +8,7 @@ Extract custom metrics from any prometheus endpoints.
 
 ## Configuration
 
-Edit the `prometheus.yaml` file to add your different prometheus instances you want to retrieve metrics from.
+Edit the `prometheus.d/conf.yaml` file to add your different prometheus instances you want to retrieve metrics from.
 
 Each instance is at least composed of:
 
@@ -18,7 +18,7 @@ Each instance is at least composed of:
 simply add it to the list `- metric_name` or renaming it like `- metric_name: renamed`.
 It's also possible to use a `*` wildcard such as `- metric*` that would fetch all matching metrics (to use with caution as it can potentially send a lot of custom metrics)
 
-There is also a couple of more advanced settings (ssl, labels joining, custom tags,...) that are documented in the [example configuration](conf.yaml.example)
+There is also a couple of more advanced settings (ssl, labels joining, custom tags,...) that are documented in the [example configuration][2]
 
 If you are monitoring an off-the-shelf software and you think it would deserve an official integration, have a look at `kube-proxy` for an example, and don't hesitate to contribute.
 
@@ -28,3 +28,4 @@ If you are monitoring an off-the-shelf software and you think it would deserve a
 
 
 [1]: https://docs.datadoghq.com/agent/faq/agent-status-and-information/
+[2]: https://docs.datadoghq.com/agent/prometheus/

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -16,7 +16,7 @@ The RabbitMQ check is packaged with the Agent, so simply [install the Agent][1] 
 
 ### Configuration
 
-Create a `rabbitmq.yaml` file in the Agent's `conf.d` directory.
+Edit the `rabbitmq.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory to start collecting your RabbitMQ [metrics](#metric-collection) and [logs](#log-collection). See the [sample rabbitmq.yaml][3] for all available configuration options.
 
 #### Prepare RabbitMQ
 
@@ -24,7 +24,7 @@ Enable the RabbitMQ management plugin. See [RabbitMQ's documentation][2] to enab
 
 #### Metric Collection
 
-* Add this configuration setup to your `rabbitmq.yaml` file to start gathering your [RabbitMQ metrics](#metrics):
+* Add this configuration setup to your `rabbitmq.d/conf.yaml` file to start gathering your [RabbitMQ metrics](#metrics):
 
 ```
 init_config:
@@ -57,7 +57,7 @@ Configuration Options
 * `queues` or `queues_regexes` - **optional** - Use the `queues` or `queues_regexes` parameters to specify the queues you'd like to collect metrics on (up to 200 queues). If you have less than 200 queues, you don't have to set this parameter, the metrics will be collected on all the queues by. default. If you have set up vhosts, set the queue names as `vhost_name/queue_name`. If you have `tag_families` enabled, the first captured group in the regex will be used as the queue_family tag.  See the link to the example YAML below for more.
 * `vhosts` - **optional** - By default a list of all vhosts is fetched and each one will be checked using the aliveness API. If you prefer only certain vhosts to be monitored, list the vhosts you care about.
 
- See the [sample rabbitmq.yaml](https://github.com/DataDog/integrations-core/blob/master/rabbitmq/conf.yaml.example) for all available configuration options.
+ See the [sample rabbitmq.d/conf.yaml][3] for all available configuration options.
 * [Restart the Agent][5] to begin sending RabbitMQ metrics, events, and service checks to Datadog.
 
 #### Log Collection
@@ -77,7 +77,7 @@ log.file = rabbit.log
     logs_enabled: true
     ```
     
-3. Add this configuration setup to your `rabbitmq.yaml` file to start collecting your RabbitMQ logs:
+3. Add this configuration setup to your `rabbitmq.d/conf.yaml` file to start collecting your RabbitMQ logs:
 
 ```
 logs:
@@ -92,9 +92,9 @@ logs:
           pattern: =
 ```
 
-See the [sample rabbitmq.yaml](https://github.com/DataDog/integrations-core/blob/master/rabbitmq/conf.yaml.example) for all available configuration options.
+See the [sample rabbitmq.yaml][3] for all available configuration options.
 
-4. [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent).
+4. [Restart the Agent][5].
 
 ### Validation
 
@@ -111,7 +111,7 @@ The Agent tags `rabbitmq.queue.*` metrics by queue name, and `rabbitmq.node.*` m
 
 For performance reasons, the RabbitMQ check self-limits the number of queues and nodes it will collect metrics for. If and when the check nears this limit, it emits a warning-level event to your event stream.
 
-See the [example check configuration](https://github.com/DataDog/integrations-core/blob/master/rabbitmq/conf.yaml.example) for details about these limits.
+See the [example check configuration][3] for details about these limits.
 
 ### Service Checks
 

--- a/redisdb/README.md
+++ b/redisdb/README.md
@@ -12,11 +12,12 @@ The Redis check is packaged with the Agent, so simply [install the Agent][1] on 
 
 ### Configuration
 
-Create a `redisdb.yaml` in the Datadog Agent's `conf.d` directory.
+Edit the `redisdb.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory to start collecting your Redis [metrics](#metric-collection) and [logs](#log-collection).
+See the [sample redis.d/conf.yaml][2] for all available configuration options.
 
 #### Metric Collection
 
-Add this configuration setup to your `redisdb.yaml` file to start gathering your [Redis metrics](#metrics):
+Add this configuration setup to your `redisdb.d/conf.yaml` file to start gathering your [Redis metrics](#metrics):
 
 ```
 init_config:
@@ -39,7 +40,7 @@ Configuration Options:
         set the value here. Warning: It may impact the performance of your Redis instance
 * `command_stats` - (Optional) - Collect INFO COMMANDSTATS output as metrics.
 
-See the [sample redisdb.yaml][2] for all available configuration options.
+See the [sample redisdb.d/conf.yaml][2] for all available configuration options.
 
 [Restart the Agent][3] to begin sending Redis metrics to Datadog.
 
@@ -53,7 +54,7 @@ See the [sample redisdb.yaml][2] for all available configuration options.
   logs_enabled: true
   ```
 
-* Add this configuration setup to your `redisdb.yaml` file to start collecting your Redis Logs:
+* Add this configuration setup to your `redisdb.d/conf.yaml` file to start collecting your Redis Logs:
 
   ```
     logs:
@@ -65,9 +66,9 @@ See the [sample redisdb.yaml][2] for all available configuration options.
   ```
 
   Change the `path` and `service` parameter values and configure them for your environment.
-  See the [sample redisdb.yaml](https://github.com/DataDog/integrations-core/blob/master/redisdb/conf.yaml.example) for all available configuration options.
+  See the [sample redisdb.yaml][2] for all available configuration options.
 
-* [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent) to begin sending Redis logs to Datadog.
+* [Restart the Agent][3] to begin sending Redis logs to Datadog.
 
 ### Validation
 

--- a/riak/README.md
+++ b/riak/README.md
@@ -12,16 +12,16 @@ The Riak check is packaged with the Agent, so simply [install the Agent][1] on y
 
 ### Configuration
 
-Create a file `riak.yaml` in the Agent's `conf.d` directory. See the [sample riak.yaml][2] for all available configuration options:
+1. Edit the `riak.d/conf.yaml` file, . See the [sample riak.yaml][2] for all available configuration options:
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-  - url: http://127.0.0.1:8098/stats # or whatever your stats endpoint is
-```
+    instances:
+      - url: http://127.0.0.1:8098/stats # or whatever your stats endpoint is
+    ```
 
-[Restart the Agent][3] to start sending Riak metrics to Datadog.
+2. [Restart the Agent][3] to start sending Riak metrics to Datadog.
 
 ### Validation
 

--- a/riakcs/README.md
+++ b/riakcs/README.md
@@ -14,21 +14,21 @@ The RiakCS check is packaged with the Agent, so simply [install the Agent][1] on
 
 ### Configuration
 
-Create a file `riakcs.yaml` in the Agent's `conf.d` directory. See the [sample riakcs.yaml][2] for all available configuration options:
+1. Edit the `riakcs.yamld/conf.` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample riakcs.d/conf.yaml][2] for all available configuration options:
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-  - host: localhost
-    port: 8080
-    access_id: <YOUR_ACCESS_KEY>
-    access_secret: <YOUR_ACCESS_SECRET>
-#   is_secure: true # set to false if your endpoint doesn't use SSL
-#   s3_root: s3.amazonaws.com #
-```
+    instances:
+      - host: localhost
+        port: 8080
+        access_id: <YOUR_ACCESS_KEY>
+        access_secret: <YOUR_ACCESS_SECRET>
+    #   is_secure: true # set to false if your endpoint doesn't use SSL
+    #   s3_root: s3.amazonaws.com #
+    ```
 
-[Restart the Agent][3] to start sending RiakCS metrics to Datadog.
+2. [Restart the Agent][3] to start sending RiakCS metrics to Datadog.
 
 ### Validation
 

--- a/snmp/README.md
+++ b/snmp/README.md
@@ -13,7 +13,7 @@ The SNMP check is packaged with the Agent, so simply [install the Agent][1] on a
 
 The SNMP check doesn't collect anything by default; you have to tell it specifically what to collect.
 
-Here's an example `snmp.yaml`. See the [sample snmp.yaml][2] for all available configuration options:
+Here's an example of `snmp.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's directory. See the [sample snmp.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:

--- a/solr/README.md
+++ b/solr/README.md
@@ -13,7 +13,7 @@ This check is JMX-based, so you'll need to enable JMX Remote on your Tomcat serv
 
 ### Configuration
 
-Create a file `solr.yaml` in the Agent's `conf.d` directory. See the [sample solr.yaml][3] for all available configuration options:
+Edit the `solr.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample solr.d/conf.yaml][3] for all available configuration options:
 
 ```
 instances:
@@ -92,7 +92,7 @@ init_config:
           metric_type: gauge
 ```
 
-Again, see the [JMX Check documentation](http://docs.datadoghq.com/integrations/java/) for a list of configuration options usable by all JMX-based checks. The page also describes how the Agent tags JMX metrics.
+Again, see the [JMX Check documentation][2] for a list of configuration options usable by all JMX-based checks. The page also describes how the Agent tags JMX metrics.
 
 [Restart the Agent][4] to start sending Solr metrics to Datadog.
 
@@ -159,8 +159,8 @@ In that case you can specify an alias for the metric that will become the metric
 
 In that case:
 
-  * The metric type will be a gauge
-  * The metric name will be jmx.\[DOMAIN_NAME].\[ATTRIBUTE_NAME]
+  * The metric type is a gauge
+  * The metric name is `jmx.\[DOMAIN_NAME].\[ATTRIBUTE_NAME]`
 
 Here is another filtering example:
 

--- a/spark/README.md
+++ b/spark/README.md
@@ -20,29 +20,29 @@ The Spark check is packaged with the Agent, so simply [install the Agent][1] on 
 
 ### Configuration
 
-Create a file `spark.yaml` in the Agent's `conf.d` directory. See the [sample spark.yaml][2] for all available configuration options:
+1. Edit the `spark.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory. See the [sample spark.d/conf.yaml][2] for all available configuration options:
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-  - spark_url: http://localhost:8088 # Spark master web UI
-#   spark_url: http://<Mesos_master>:5050 # Mesos master web UI
-#   spark_url: http://<YARN_ResourceManager_address>:8088 # YARN ResourceManager address
+    instances:
+      - spark_url: http://localhost:8088 # Spark master web UI
+    #   spark_url: http://<Mesos_master>:5050 # Mesos master web UI
+    #   spark_url: http://<YARN_ResourceManager_address>:8088 # YARN ResourceManager address
 
-    spark_cluster_mode: spark_standalone_mode # default is spark_yarn_mode
-#   spark_cluster_mode: spark_mesos_mode
-#   spark_cluster_mode: spark_yarn_mode
+        spark_cluster_mode: spark_standalone_mode # default is spark_yarn_mode
+    #   spark_cluster_mode: spark_mesos_mode
+    #   spark_cluster_mode: spark_yarn_mode
 
-    cluster_name: <CLUSTER_NAME> # required; adds a tag 'cluster_name:<CLUSTER_NAME>' to all metrics
+        cluster_name: <CLUSTER_NAME> # required; adds a tag 'cluster_name:<CLUSTER_NAME>' to all metrics
 
-#   spark_pre_20_mode: true   # if you use Standalone Spark < v2.0
-#   spark_proxy_enabled: true # if you have enabled the spark UI proxy
-```
+    #   spark_pre_20_mode: true   # if you use Standalone Spark < v2.0
+    #   spark_proxy_enabled: true # if you have enabled the spark UI proxy
+    ```
 
-Set `spark_url` and `spark_cluster_mode` according to how you're running Spark.
+    Set `spark_url` and `spark_cluster_mode` according to how you're running Spark.
 
-[Restart the Agent][3] to start sending Spark metrics to Datadog.
+2. [Restart the Agent][3] to start sending Spark metrics to Datadog.
 
 ### Validation
 

--- a/sqlserver/README.md
+++ b/sqlserver/README.md
@@ -18,27 +18,27 @@ Make sure that your SQL Server instance supports SQL Server authentication by en
 
 1. Create a read-only user to connect to your server:
 
-```
-CREATE LOGIN datadog WITH PASSWORD = 'YOUR_PASSWORD';
-CREATE USER datadog FOR LOGIN datadog;
-GRANT SELECT on sys.dm_os_performance_counters to datadog;
-GRANT VIEW SERVER STATE to datadog;
-```
+    ```
+    CREATE LOGIN datadog WITH PASSWORD = 'YOUR_PASSWORD';
+    CREATE USER datadog FOR LOGIN datadog;
+    GRANT SELECT on sys.dm_os_performance_counters to datadog;
+    GRANT VIEW SERVER STATE to datadog;
+    ```
 
-2. Create a file `sqlserver.yaml` in the Agent's `conf.d` directory. See the [sample sqlserver.yaml][2] for all available configuration options:
+2. Create a file `sqlserver.d/conf.yaml`, in the `conf.d/` folder at the root of your Agent's directory. See the [sample sqlserver.d/conf.yaml][2] for all available configuration options:
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-  - host: <SQL_HOST>,<SQL_PORT>
-    username: <SQL_ADMIN_USER>
-    password: <SQL_ADMIN_PASSWORD>
-    connector: odbc # alternative is 'adodbapi'
-    driver: SQL Server
-```
+    instances:
+      - host: <SQL_HOST>,<SQL_PORT>
+        username: <SQL_ADMIN_USER>
+        password: <SQL_ADMIN_PASSWORD>
+        connector: odbc # alternative is 'adodbapi'
+        driver: SQL Server
+    ```
 
-See the [example check configuration](https://github.com/DataDog/integrations-core/blob/master/sqlserver/conf.yaml.example) for a comprehensive description of all options, including how to use custom queries to create your own metrics.
+    See the [example check configuration][2] for a comprehensive description of all options, including how to use custom queries to create your own metrics.
 
 3. [Restart the Agent][3] to start sending SQL Server metrics to Datadog.
 

--- a/squid/README.md
+++ b/squid/README.md
@@ -12,21 +12,21 @@ The Agent's Squid integration is packaged with the Agent, so simply [install the
 
 ## Configuration
 
-Create a file `squid.yaml` in the Agent's `conf.d` directory. See the [sample squid.yaml][2] for all available configuration options:
+1. Edit the `squid.d/conf.yaml`, in the `conf.d/` folder at the root of your Agent's directory. See the [sample squid.d/conf.yaml][2] for all available configuration options:
 
-```yaml
-init_config:
+    ```yaml
+    init_config:
 
-instances:
-  # A list of squid instances identified by their name
+    instances:
+      # A list of squid instances identified by their name
 
-  - name: my_squid
-  #   host: localhost  # The hostname or ip address of the squid server. Default to 'localhost'
-  #   port: 3128  # The port where the squid server is listening. Default to 3128
-  #   tags: ['custom:tag']  # A list of tags that you wish to send with your squid metrics
-```
+      - name: my_squid
+      #   host: localhost  # The hostname or ip address of the squid server. Default to 'localhost'
+      #   port: 3128  # The port where the squid server is listening. Default to 3128
+      #   tags: ['custom:tag']  # A list of tags that you wish to send with your squid metrics
+    ```
 
-Restart the Agent to start sending metrics and service checks to Datadog.
+2. [Restart the Agent][10] to start sending metrics and service checks to Datadog.
 
 ## Validation
 
@@ -77,3 +77,4 @@ Reach out to our team and other Datadog users on [Slack][9].
 [7]: https://app.datadoghq.com/event/stream
 [8]: mailto:support@datadoghq.com
 [9]: http://chat.datadoghq.com/
+[10]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent

--- a/ssh_check/README.md
+++ b/ssh_check/README.md
@@ -11,23 +11,23 @@ The SSH/SFTP check is packaged with the Agent, so simply [install the Agent][1] 
 
 ### Configuration
 
-Create a file `ssh_check.yaml` in the Agent's `conf.d` directory. See the [sample ssh_check.yaml][2] for all available configuration options:
+1. Edit the `ssh_check.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's directory. See the [sample ssh_check.d/conf.yaml][2] for all available configuration options:
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-  - host: <SOME_REMOTE_HOST>  # required
-    username: <SOME_USERNAME> # required
-    password: <SOME_PASSWORD> # or use private_key_file
-#   private_key_file: <PATH_TO_PRIVATE_KEY>
-#   private_key_type:         # rsa or ecdsa; default is rsa
-#   port: 22                  # default is port 22
-#   sftp_check: False         # set False to disable SFTP check; default is True
-#   add_missing_keys: True    # default is False
-```
+    instances:
+      - host: <SOME_REMOTE_HOST>  # required
+        username: <SOME_USERNAME> # required
+        password: <SOME_PASSWORD> # or use private_key_file
+    #   private_key_file: <PATH_TO_PRIVATE_KEY>
+    #   private_key_type:         # rsa or ecdsa; default is rsa
+    #   port: 22                  # default is port 22
+    #   sftp_check: False         # set False to disable SFTP check; default is True
+    #   add_missing_keys: True    # default is False
+    ```
 
-[Restart the Agent][3] to start sending SSH/SFTP metrics and service checks to Datadog.
+2. [Restart the Agent][3] to start sending SSH/SFTP metrics and service checks to Datadog.
 
 ### Validation
 

--- a/statsd/README.md
+++ b/statsd/README.md
@@ -13,24 +13,24 @@ The StatsD check is packaged with the Agent, so simply [install the Agent][1] on
 
 ### Configuration
 
-Create a file `statsd.yaml` in the Agent's `conf.d` directory. See the [sample statsd.yaml][2] for all available configuration options:
+1. Edit the `statsd.d/conf.yaml` in the `conf.d/` folder at the root of your Agent's directory. See the [sample statsd.d/conf.yaml][2] for all available configuration options:
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-  - host: localhost
-    port: 8126 # or wherever your statsd listens
-```
+    instances:
+      - host: localhost
+        port: 8126 # or wherever your statsd listens
+    ```
 
-Configuration Options
+    Configuration Options
 
-* `host` (Optional) - Host to be checked. This will be included as a tag: `host:<host>`. Defaults to `localhost`.
-* `port` (Optional) - Port to be checked. This will be included as a tag: `port:<port>`. Defaults to `8126`.
-* `timeout` (Optional) - Timeout for the check. Defaults to 10 seconds.
-* `tags` (Optional) - Tags to be assigned to the metric.
+    - `host` (Optional) - Host to be checked. This will be included as a tag: `host:<host>`. Defaults to `localhost`.
+    - `port` (Optional) - Port to be checked. This will be included as a tag: `port:<port>`. Defaults to `8126`.
+    - `timeout` (Optional) - Timeout for the check. Defaults to 10 seconds.
+    - `tags` (Optional) - Tags to be assigned to the metric.
 
-[Restart the Agent][3] to start sending StatsD metrics and service checks to Datadog.
+2. [Restart the Agent][3] to start sending StatsD metrics and service checks to Datadog.
 
 ### Validation
 

--- a/supervisord/README.md
+++ b/supervisord/README.md
@@ -13,6 +13,7 @@ The Supervisor check is packaged with the Agent, so simply [install the Agent][1
 #### Prepare supervisord
 
 The Agent can collect data from Supervisor via HTTP server or UNIX socket. The Agent collects the same data no matter which collection method you configure.
+
 ##### HTTP server
 
 Add a block like this to supervisor's main configuration file (e.g. `/etc/supervisor.conf`):
@@ -45,7 +46,7 @@ Reload supervisord.
 
 #### Connect the Agent
 
-Create a file `supervisord.yaml` in the Agent's `conf.d` directory. See the [sample supervisord.yaml][2] for all available configuration options:
+Edit the `supervisord.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's directory. See the [sample supervisord.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -74,7 +75,7 @@ Configuration Options
 * `server_check` (Optional) - Defaults to true. Service check for connection to supervisord server.
 * `socket` (Optional) - If using supervisorctl to communicate with supervisor, a socket is needed.
 
-See the [example check configuration](https://github.com/DataDog/integrations-core/blob/master/supervisord/conf.yaml.example) for comprehensive descriptions of other check options.
+See the [example check configuration][2] for comprehensive descriptions of other check options.
 
 [Restart the Agent][3] to start sending Supervisor metrics to Datadog.
 

--- a/system_core/README.md
+++ b/system_core/README.md
@@ -11,18 +11,18 @@ The system_core check is packaged with the Agent, so simply [install the Agent][
 
 ### Configuration
 
-Create a file `system_core.yaml` in the Agent's `conf.d` directory. See the [sample system_core.yaml][2] for all available configuration options:
+1. Edit the `system_core.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's directory. See the [sample system_core.d/conf.yaml][2] for all available configuration options:
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-  - foo: bar
-```
+    instances:
+      - foo: bar
+    ```
 
-The Agent just needs one item in `instances` in order to enable the check. The content of the item doesn't matter.
+    The Agent just needs one item in `instances` in order to enable the check. The content of the item doesn't matter.
 
-[Restart the Agent][3] to enable the check.
+2. [Restart the Agent][3] to enable the check.
 
 ### Validation
 

--- a/system_swap/README.md
+++ b/system_swap/README.md
@@ -11,16 +11,16 @@ The system swap check is packaged with the Agent, so simply [install the Agent][
 
 ### Configuration
 
-Create a blank Agent check configuration file called `system_swap.yaml` in the Agent's `conf.d` directory. See the [sample system_swap.yaml][2] for all available configuration options:
+1. Edit the `system_swap.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's directory. See the [sample system_swap.d/conf.yaml][2] for all available configuration options:
 
-```
-# This check takes no initial configuration
-init_config:
+    ```
+    # This check takes no initial configuration
+    init_config:
 
-instances: [{}]
-```
+    instances: [{}]
+    ```
 
-[Restart the Agent][3] to start collecting swap metrics.
+2. [Restart the Agent][3] to start collecting swap metrics.
 
 ### Validation
 

--- a/tcp_check/README.md
+++ b/tcp_check/README.md
@@ -11,7 +11,7 @@ The TCP check is packaged with the Agent, so simply [install the Agent][1] on an
 
 ### Configuration
 
-Create a file `tcp_check.yaml` in the Agent's `conf.d` directory. See the [sample tcp_check.yaml][2] for all available configuration options:
+Edit the `tcp_check.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's directory. See the [sample tcp_check.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:

--- a/teamcity/README.md
+++ b/teamcity/README.md
@@ -16,7 +16,7 @@ The Teamcity check is packaged with the Agent, so simply [install the Agent][1] 
 
 Follow [Teamcity's documentation][2] to enable Guest Login.
 
-Create a file `teamcity.yaml` in the Agent's `conf.d` directory. See the [sample teamcity.yaml][3] for all available configuration options:
+Edit the `teamcity.d/conf.yaml` in the `conf.d/` folder at the root of your Agent's directory. See the [sample teamcity.d/conf.yaml][3] for all available configuration options:
 
 ```
 init_config:

--- a/tokumx/README.md
+++ b/tokumx/README.md
@@ -50,16 +50,16 @@ For more details about creating and managing users in MongoDB, refer to [the Mon
 
 #### Connect the Agent
 
-Create a file `tokumx.yaml` in the Agent's `conf.d` directory. See the [sample tokumx.yaml][3] for all available configuration options:
+1. Edit the `tokumx.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's directory. See the [sample tokumx.d/conf.yaml][3] for all available configuration options:
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-  - server: mongodb://datadog:<UNIQUEPASSWORD>@localhost:27017
-```
+    instances:
+      - server: mongodb://datadog:<UNIQUEPASSWORD>@localhost:27017
+    ```
 
-[Restart the Agent][4] to start sending TokuMX metrics to Datadog.
+2. [Restart the Agent][4] to start sending TokuMX metrics to Datadog.
 
 ### Validation
 

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -19,7 +19,10 @@ This check is JMX-based, so you'll need to enable JMX Remote on your Tomcat serv
 
 ### Configuration
 
-Create a file `tomcat.yaml` in the Agent's `conf.d` directory. 
+1. Edit the `tomcat.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your Tomcat [metrics](#metric-collection) and [logs](#log-collection).
+  See the [sample tomcat.d/conf.yaml][17] for all available configuration options.
+
+2. [Restart the Agent][16]
 
 #### Metric Collection
 
@@ -165,8 +168,8 @@ In that case you can specify an alias for the metric that will become the metric
 
 In that case:
 
-  * The metric type will be a gauge
-  * The metric name will be jmx.\[DOMAIN_NAME].\[ATTRIBUTE_NAME]
+  * The metric type is a gauge
+  * The metric name is `jmx.\[DOMAIN_NAME].\[ATTRIBUTE_NAME]`
 
 Here is another filtering example:
 
@@ -271,7 +274,7 @@ Make sure you clone and edit the [integration pipeline][19] if you have a differ
   logs_enabled: true
   ```
 
-* Add this configuration setup to your `tomcat.yaml` file to start collecting your Tomcat Logs:
+* Add this configuration setup to your `tomcat.d/conf.yaml` file to start collecting your Tomcat Logs:
 
   ```
   logs:
@@ -287,8 +290,8 @@ Make sure you clone and edit the [integration pipeline][19] if you have a differ
   ```
 
   Change the `path` and `service` parameter values and configure them for your environment.
-    see the [sample tomcat.yaml](https://github.com/DataDog/integrations-core/blob/master/tomcat/conf.yaml.example) for all available configuration options.
-    * [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent). 
+    see the [sample tomcat.yaml][17] for all available configuration options.
+    * [Restart the Agent][16]. 
 
 ### Validation
 

--- a/twemproxy/README.md
+++ b/twemproxy/README.md
@@ -11,17 +11,17 @@ The Agent's twemproxy check is packaged with the Agent, so simply [install the A
 
 ### Configuration
 
-Create a file `twemproxy.yaml` in the Agent's `conf.d` directory. See the [sample twemproxy.yaml][2] for all available configuration options:
+1. Edit the `twemproxy.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's directory. See the [sample twemproxy.d/conf.yaml][2] for all available configuration options:
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-    - host: localhost
-      port: 2222 # change if your twemproxy doesn't use the default stats monitoring port
-```
+    instances:
+        - host: localhost
+          port: 2222 # change if your twemproxy doesn't use the default stats monitoring port
+    ```
 
-[Restart the Agent][3] to begin sending twemproxy metrics to Datadog.
+2. [Restart the Agent][3] to begin sending twemproxy metrics to Datadog.
 
 ### Validation
 

--- a/varnish/README.md
+++ b/varnish/README.md
@@ -19,7 +19,10 @@ The Varnish check is packaged with the Agent, so simply [install the Agent][1] o
 
 ### Configuration
 
-Create a `varnish.yaml` file in the Agent's `conf.d` directory
+1. Edit the `varnish.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your Varnish [metrics](#metric-collection) and [logs](#log-collection).
+  See the [sample varnish.d/conf.yaml][2] for all available configuration options.
+
+2. [Restart the Agent][3]
 
 #### Prepare Varnish
 
@@ -27,7 +30,7 @@ If you're running Varnish 4.1+, add the dd-agent system user to the Varnish grou
 
 #### Metric Collection
 
-* Add this configuration setup to your `varnish.yaml` file to start gathering your [Varnish metrics](#metrics):
+* Add this configuration setup to your `varnish.d/conf.yaml` file to start gathering your [Varnish metrics](#metrics):
 
   ```
   init_config:
@@ -77,7 +80,7 @@ DAEMON_OPTS="$DAEMON_OPTS -c -a -F '${LOG_FORMAT}'"
   logs_enabled: true
   ```
 
-* Add this configuration setup to your `varnish.yaml` file to start collecting your Varnish logs:
+* Add this configuration setup to your `varnish.d/conf.yaml` file to start collecting your Varnish logs:
 
   ```
   logs:
@@ -88,9 +91,9 @@ DAEMON_OPTS="$DAEMON_OPTS -c -a -F '${LOG_FORMAT}'"
       service: varnish
   ```
   Change the `path` and `service` parameter value and configure them for your environment.
-  See the [sample varnish.yaml](https://github.com/DataDog/integrations-core/blob/master/varnish/conf.yaml.example) for all available configuration options.
+  See the [sample varnish.yaml][2] for all available configuration options.
 
-* [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent).
+* [Restart the Agent][3].
 
 **Learn more about log collection [on the log documentation][4]**
 

--- a/vsphere/README.md
+++ b/vsphere/README.md
@@ -13,7 +13,7 @@ The vSphere check is packaged with the Agent, so simply [install the Agent][1] o
 
 In the Administration section of vCenter, add a read-only user called datadog-readonly.
 
-Then, create a file `vsphere.yaml` in the Datadog Agent's `conf.d` directory. See the [sample vsphere.yaml][2] for all available configuration options:
+Then, edit the `vsphere.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's directory. See the [sample vsphere.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:

--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -11,7 +11,7 @@ The Windows Event Log check is packaged with the Agent, so simply [install the A
 
 ### Configuration
 
-Create a file `win32_event_log.yaml` in the Agent's `conf.d` directory. See the [sample win32_event_log.yaml][2] for all available configuration options:
+Edit the `win32_event_log.d/conf.yaml` in the `conf.d/` folder at the root of your Agent's directory. See the [sample win32_event_log.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -20,7 +20,7 @@ instances:
   - host: localhost
 ```
 
-This minimal file will capture all events from localhost, but you can configure the check to only collect certain kinds of events. See the [example check configuration](https://github.com/DataDog/integrations-core/blob/master/win32_event_log/conf.yaml.example) for a comprehensive list and description of options that allow you to do that.
+This minimal file will capture all events from localhost, but you can configure the check to only collect certain kinds of events. See the [example check configuration][2] for a comprehensive list and description of options that allow you to do that.
 
 [Restart the Agent][3] to start sending Windows events to Datadog.
 

--- a/windows_service/README.md
+++ b/windows_service/README.md
@@ -11,7 +11,7 @@ The Windows Service check is packaged with the Agent, so simply [install the Age
 
 ### Configuration
 
-Create a file `windows_service.yaml` in the Agent's `conf.d` directory. See the [sample windows_service.yaml][2] for all available configuration options:
+Edit the `windows_service.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's directory. See the [sample windows_service.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:

--- a/wmi_check/README.md
+++ b/wmi_check/README.md
@@ -92,15 +92,15 @@ See [MSDN][7] for more information.
 
 `constant_tags` optionally lets you tag each metric with a set of fixed values.
 
-`tag_queries` optionally lets you specify a list of queries, to tag metrics with a target class property. Each item in the list is a set of \[link source property, target class, link target class property, target property] where:
+`tag_queries` optionally lets you specify a list of queries, to tag metrics with a target class property. Each item in the list is a set of `[link source property, target class, link target class property, target property]` where:
 
-- 'link source property' contains the link value
+- `link source property` contains the link value
 
-- 'target class' is the class to link to
+- `target class` is the class to link to
 
-- 'link target class property' is the target class property to link to
+- `link target class property` is the target class property to link to
 
-- 'target property' contains the value to tag with
+- `target property` contains the value to tag with
 
 It translates to a WMI query:
 

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -14,23 +14,22 @@ And more.
 
 The YARN check is packaged with the Agent, so simply [install the Agent][1] on your YARN ResourceManager.
 
-
 ### Configuration
 
-Create a file `yarn.yaml` in the Agent's `conf.d` directory. See the [sample yarn.yaml][2] for all available configuration options.:
+1. Edit the `yarn.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's directory.
 
-```
-init_config:
+    ```
+    init_config:
 
-instances:
-  - resourcemanager_uri: http://localhost:8088 # or whatever your resource manager listens
-    cluster_name: MyCluster # used to tag metrics, i.e. 'cluster_name:MyCluster'; default is 'default_cluster'
-    collect_app_metrics: true
-```
+    instances:
+      - resourcemanager_uri: http://localhost:8088 # or whatever your resource manager listens
+        cluster_name: MyCluster # used to tag metrics, i.e. 'cluster_name:MyCluster'; default is 'default_cluster'
+        collect_app_metrics: true
+    ```
 
-See the [example check configuration](https://github.com/DataDog/integrations-core/blob/master/yarn/conf.yaml.example) for a comprehensive list and description of all check options.
+    See the [example check configuration][2] for a comprehensive list and description of all check options.
 
-[Restart the Agent][3] to start sending YARN metrics to Datadog.
+2. [Restart the Agent][3] to start sending YARN metrics to Datadog.
 
 ### Validation
 

--- a/zk/README.md
+++ b/zk/README.md
@@ -11,7 +11,10 @@ The Zookeeper check is packaged with the Agent, so simply [install the Agent][13
 
 ### Configuration
 
-Create a file `zk.yaml` in the Agent's `conf.d` directory.
+1. Edit the `zk.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's directory, to start collecting your Zookeeper [metrics](#metric-collection) and [logs](#log-collection).
+  See the [sample zk.d/conf.yaml][14] for all available configuration options.
+
+2. [Restart the Agent][15]
 
 #### Metric Collection
 
@@ -75,9 +78,9 @@ Make sure you clone and edit the integration pipeline if you have a different fo
       #    pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
   ```
 
-* See the [sample zk.yaml](https://github.com/DataDog/integrations-core/blob/master/zk/conf.yaml.example) for all available configuration options.
+* See the [sample zk.yaml][14] for all available configuration options.
 
-* [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent) to start sending Zookeeper Logs to Datadog.
+* [Restart the Agent][15] to start sending Zookeeper Logs to Datadog.
 
 ### Validation
 


### PR DESCRIPTION
### What does this PR do?

* Update all configuration file paths to match new agent 6 logic. 
* Normalise the configuration section of alldoc pages
* Fix indentation issue
* New sentence to introduce metrics and logs collection by the agent.
* Since some files are merged during doc build, this PR fix the footnote link incrementation
* Code highlighting 

### Motivation

It's confusing right now with Agent 5 and 6 logic, let's migrate everything to agent 6, since it's better faster stronger.