### PR TITLE
Add a check to count all nodes in a consul cluster

### DIFF
--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changes
 
 * [FEATURE] Hardcode the 8500 port in the Autodiscovery template. See [#1444][] for more information.
+* [FEATURE] Introduce a check at `consul.catalog.total_nodes` as a count of all nodes registered in the cluster
 
 1.3.0 / 2018-01-10
 ==================

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -318,6 +318,8 @@ class ConsulCheck(AgentCheck):
             max_services = instance.get('max_services',
                                         self.init_config.get('max_services', self.MAX_SERVICES))
 
+            self.count_all_nodes(instance, main_tags)
+
             services = self._cull_services_list(services, service_whitelist, max_services)
 
             # {node_id: {"up: 0, "passing": 0, "warning": 0, "critical": 0}
@@ -494,3 +496,9 @@ class ConsulCheck(AgentCheck):
                            latencies[ceili(n * 0.99) - 1], hostname=node_name, tags=main_tags)
                 self.gauge('consul.net.node.latency.max',
                            latencies[-1], hostname=node_name, tags=main_tags)
+    def _get_all_nodes(self, instance):
+        return self.consul_request(instance, 'v1/catalog/nodes')
+
+    def count_all_nodes(self, instance, main_tags):
+        nodes = self._get_all_nodes(instance)
+        self.gauge('consul.catalog.total_nodes', len(nodes), tags=main_tags)

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -496,6 +496,7 @@ class ConsulCheck(AgentCheck):
                            latencies[ceili(n * 0.99) - 1], hostname=node_name, tags=main_tags)
                 self.gauge('consul.net.node.latency.max',
                            latencies[-1], hostname=node_name, tags=main_tags)
+
     def _get_all_nodes(self, instance):
         return self.consul_request(instance, 'v1/catalog/nodes')
 

--- a/consul/metadata.csv
+++ b/consul/metadata.csv
@@ -3,6 +3,7 @@ consul.catalog.nodes_critical,gauge,,node,,Number of nodes with service status `
 consul.catalog.nodes_passing,gauge,,node,,Number of nodes with service status `passing` from those registered,1,consul,nodes pass
 consul.catalog.nodes_up,gauge,,node,,Number of nodes,0,consul,nodes up
 consul.catalog.nodes_warning,gauge,,node,,Number of nodes with service status `warning` from those registered,-1,consul,nodes warn
+consul.catalog.total_nodes,gauge,,node,,Number of nodes registered in the consul cluster,0,consul,total nodes
 consul.catalog.services_critical,gauge,,service,,Total critical services on nodes,-1,consul,svc crit
 consul.catalog.services_passing,gauge,,service,,Total passing services on nodes,1,consul,svc pass
 consul.catalog.services_up,gauge,,service,,Total services registered on nodes,0,consul,svc up

--- a/consul/tests/consul_mocks.py
+++ b/consul/tests/consul_mocks.py
@@ -51,6 +51,7 @@ def _get_consul_mocks():
         '_get_cluster_leader': mock_get_cluster_leader_A,
         '_get_coord_datacenters': mock_get_coord_datacenters,
         '_get_coord_nodes': mock_get_coord_nodes,
+        '_get_all_nodes': mock_get_all_nodes,
     }
 
 
@@ -58,6 +59,27 @@ def _get_random_ip():
     rand_int = int(15 * random.random()) + 10
     return "10.0.2.{0}".format(rand_int)
 
+
+def mock_get_all_nodes(instance):
+    return [{
+	'Address': _get_random_ip(),
+	'CreateIndex': 25010951,
+	'Datacenter': 'dc1',
+	'ID': 'node-1',
+	'Meta': {},
+	'ModifyIndex': 25011022,
+	'Node': 'node-1',
+	'TaggedAddresses': { 'lan': '1.1.1.1', 'wan': '2.2.2.2'}
+    }, {
+	'Address': _get_random_ip(),
+	'CreateIndex': 25010940,
+	'Datacenter': 'dc1',
+	'ID': 'node-2',
+	'Meta': {},
+	'ModifyIndex': 25011010,
+	'Node': 'node-2',
+	'TaggedAddresses': { 'lan': '1.1.1.1', 'wan': '2.2.2.2'}
+    }]
 
 def mock_get_peers_in_cluster(instance):
     return [

--- a/consul/tests/consul_mocks.py
+++ b/consul/tests/consul_mocks.py
@@ -62,24 +62,25 @@ def _get_random_ip():
 
 def mock_get_all_nodes(instance):
     return [{
-	'Address': _get_random_ip(),
-	'CreateIndex': 25010951,
-	'Datacenter': 'dc1',
-	'ID': 'node-1',
-	'Meta': {},
-	'ModifyIndex': 25011022,
-	'Node': 'node-1',
-	'TaggedAddresses': { 'lan': '1.1.1.1', 'wan': '2.2.2.2'}
+        'Address': _get_random_ip(),
+        'CreateIndex': 25010951,
+        'Datacenter': 'dc1',
+        'ID': 'node-1',
+        'Meta': {},
+        'ModifyIndex': 25011022,
+        'Node': 'node-1',
+        'TaggedAddresses': {'lan': '1.1.1.1', 'wan': '2.2.2.2'}
     }, {
-	'Address': _get_random_ip(),
-	'CreateIndex': 25010940,
-	'Datacenter': 'dc1',
-	'ID': 'node-2',
-	'Meta': {},
-	'ModifyIndex': 25011010,
-	'Node': 'node-2',
-	'TaggedAddresses': { 'lan': '1.1.1.1', 'wan': '2.2.2.2'}
+        'Address': _get_random_ip(),
+        'CreateIndex': 25010940,
+        'Datacenter': 'dc1',
+        'ID': 'node-2',
+        'Meta': {},
+        'ModifyIndex': 25011010,
+        'Node': 'node-2',
+        'TaggedAddresses': {'lan': '1.1.1.1', 'wan': '2.2.2.2'}
     }]
+
 
 def mock_get_peers_in_cluster(instance):
     return [

--- a/consul/tests/test_integration.py
+++ b/consul/tests/test_integration.py
@@ -17,6 +17,7 @@ METRICS = [
     'consul.catalog.services_passing',
     'consul.catalog.services_warning',
     'consul.catalog.services_critical',
+    'consul.catalog.total_nodes',
     'consul.net.node.latency.p95',
     'consul.net.node.latency.min',
     'consul.net.node.latency.p25',

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -50,6 +50,15 @@ def test_get_peers_in_cluster(aggregator):
 
     aggregator.assert_metric('consul.peers', value=3, tags=['consul_datacenter:dc1', 'mode:follower'])
 
+def test_count_all_nodes(aggregator):
+    my_mocks = consul_mocks._get_consul_mocks()
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, {})
+    consul_checks['_get_all_nodes'] = consul_mocks.mock_get_all_nodes
+    consul_mocks.mock_check(consul_check, my_mocks)
+    consul_check.check(consul_mocks.MOCK_CONFIG)
+
+    aggregator.assert_metric('consul.catalog.total_nodes', value=2, tags=['consul_datacenter:c1'])
+
 
 def test_get_nodes_with_service_warning(aggregator):
     consul_check = ConsulCheck(common.CHECK_NAME, {}, {})

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -50,6 +50,7 @@ def test_get_peers_in_cluster(aggregator):
 
     aggregator.assert_metric('consul.peers', value=3, tags=['consul_datacenter:dc1', 'mode:follower'])
 
+
 def test_count_all_nodes(aggregator):
     my_mocks = consul_mocks._get_consul_mocks()
     consul_check = ConsulCheck(common.CHECK_NAME, {}, {})

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -53,7 +53,7 @@ def test_get_peers_in_cluster(aggregator):
 def test_count_all_nodes(aggregator):
     my_mocks = consul_mocks._get_consul_mocks()
     consul_check = ConsulCheck(common.CHECK_NAME, {}, {})
-    consul_checks['_get_all_nodes'] = consul_mocks.mock_get_all_nodes
+    my_mocks['_get_all_nodes'] = consul_mocks.mock_get_all_nodes
     consul_mocks.mock_check(consul_check, my_mocks)
     consul_check.check(consul_mocks.MOCK_CONFIG)
 

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -54,11 +54,10 @@ def test_get_peers_in_cluster(aggregator):
 def test_count_all_nodes(aggregator):
     my_mocks = consul_mocks._get_consul_mocks()
     consul_check = ConsulCheck(common.CHECK_NAME, {}, {})
-    my_mocks['_get_all_nodes'] = consul_mocks.mock_get_all_nodes
     consul_mocks.mock_check(consul_check, my_mocks)
     consul_check.check(consul_mocks.MOCK_CONFIG)
 
-    aggregator.assert_metric('consul.catalog.total_nodes', value=2, tags=['consul_datacenter:c1'])
+    aggregator.assert_metric('consul.catalog.total_nodes', value=2, tags=['consul_datacenter:dc1'])
 
 
 def test_get_nodes_with_service_warning(aggregator):


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

This PR adds a `consul.catalog.total_nodes` that is a gauge of how many nodes total have registered in the cluster, with or without a service on them.

### Motivation

The datadog check for consul currently registers a metric called `consul.catalog.nodes_up`. This was rather misleading for us - this check only counts nodes that have been up and have had registered a service, rather than all nodes that have registered themselves in the cluster.

We use consul for a handful of things, and not all of them require registering a service on a machine. This means that `consul.catalog.nodes_up` doesn't match how many nodes we have registered in the consul cluster.


### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [x] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 