### PR TITLE
[pdh] handle error

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/win/winpdh.py
+++ b/datadog_checks_base/datadog_checks/checks/win/winpdh.py
@@ -104,8 +104,11 @@ class WinPDHCounter(object):
             raise AttributeError("No valid counters to report")
 
     def __del__(self):
-        if(self.hq):
+        try:
             win32pdh.CloseQuery(self.hq)
+        except AttributeError:
+            # An error occurred during initialization before a query was opened.
+            pass
 
     def is_single_instance(self):
         return self._is_single_instance

--- a/datadog_checks_base/datadog_checks/checks/win/winpdh.py
+++ b/datadog_checks_base/datadog_checks/checks/win/winpdh.py
@@ -107,7 +107,7 @@ class WinPDHCounter(object):
         try:
             win32pdh.CloseQuery(self.hq)
         except AttributeError:
-            # An error occurred during initialization before a query was opened.
+            # An error occurred during instantiation before a query was opened.
             pass
 
     def is_single_instance(self):


### PR DESCRIPTION
### Motivation

Since `__del__` executes even if `__init__` fails, it was possible that the `hq` instance variable was never initialized.