### PR TITLE
updates README typo

### DIFF
--- a/http_check/README.md
+++ b/http_check/README.md
@@ -24,7 +24,7 @@ instances:
     # check_certificate_expiration: true # default is true
     # days_warning: 28                   # default 14
     # days_critical: 14                  # default 7
-    # timeout: 3                         # in seconds. Default is 1.
+    # timeout: 3                         # in seconds. Default is 10.
   - name: Example website (staging)
     url: http://staging.example.com/
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

default timeout for HTTP CHECK is 10 seconds, but the documentation say default timeout in 1 second.  Updated to fix this typo

### Motivation

What inspired you to submit this pull request?

A customer spotted the typo when comparing the code base to the documentation

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
