### PR TITLE
adds build directory to cleanup

### DIFF
--- a/tasks/cleanup.py
+++ b/tasks/cleanup.py
@@ -26,7 +26,8 @@ def cleanup(ctx, dry_run=False):
         ".eggs",
         ".pytest_cache",
         ".tox",
-        "__pycache__"
+        "__pycache__",
+        "build"
     ]
 
     should_delete_directories_globs = [


### PR DESCRIPTION
### What does this PR do?

The build directory is also build detritus. We should remove it in the cleanup task as well. This PR adds it to the directories to cleanup.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
