### PR TITLE
kubelet: remove dummy option from config example

### DIFF
--- a/kubelet/conf.yaml.example
+++ b/kubelet/conf.yaml.example
@@ -1,8 +1,7 @@
 init_config:
 
 instances:
-  - enabled: true
-    ###
+  - ###
     ### Common additional tags for all metrics from this check
     ###
     #


### PR DESCRIPTION
Remove the misleading dummy `enable` field, and comment out everything.

The resulting file works OK with agent6 and passes http://www.yamllint.com/ , even when uncommenting one option.