### PR TITLE
[kubelet] Fix SSL when specifying certificates files

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
@@ -467,6 +467,8 @@ class PrometheusScraper(object):
             cert = self.ssl_cert
             if isinstance(self.ssl_private_key, basestring):
                 cert = (self.ssl_cert, self.ssl_private_key)
+        elif isinstance(self.ssl_cert, tuple):
+            cert = self.ssl_cert
         verify = True
         if isinstance(self.ssl_ca_cert, basestring):
             verify = self.ssl_ca_cert
@@ -475,10 +477,10 @@ class PrometheusScraper(object):
             verify = False
         try:
             response = requests.get(endpoint, headers=headers, stream=True, timeout=10, cert=cert, verify=verify)
-        except (requests.exceptions.SSLError):
+        except requests.exceptions.SSLError:
             self.log.error("Invalid SSL settings for requesting {} endpoint".format(endpoint))
             raise
-        except (IOError):
+        except IOError:
             if self.health_service_check:
                 self._submit_service_check(
                     "{}{}".format(self.NAMESPACE, ".prometheus.health"),

--- a/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
@@ -467,8 +467,6 @@ class PrometheusScraper(object):
             cert = self.ssl_cert
             if isinstance(self.ssl_private_key, basestring):
                 cert = (self.ssl_cert, self.ssl_private_key)
-        elif isinstance(self.ssl_cert, tuple):
-            cert = self.ssl_cert
         verify = True
         if isinstance(self.ssl_ca_cert, basestring):
             verify = self.ssl_ca_cert

--- a/kubelet/CHANGELOG.md
+++ b/kubelet/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [FEATURE] Allow to disable prometheus metric collection. See [#1423][]
 * [FEATURE] Container metrics now respect the container filtering rules. Requires Agent 6.2+. See [#1442][]
 * [BUGFIX] Fix submission of CPU metrics on multi-threaded containers. See [#1489][]
-* [BUGFIX] Fix SSL when using the insecure options but still providing certificates
+* [BUGFIX] Fix SSL when specifying certificates files
 
 1.1.0 / 2018-03-23
 ==================

--- a/kubelet/CHANGELOG.md
+++ b/kubelet/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [FEATURE] Allow to disable prometheus metric collection. See [#1423][]
 * [FEATURE] Container metrics now respect the container filtering rules. Requires Agent 6.2+. See [#1442][]
 * [BUGFIX] Fix submission of CPU metrics on multi-threaded containers. See [#1489][]
+* [BUGFIX] Fix SSL when using the insecure options but still providing certificates
 
 1.1.0 / 2018-03-23
 ==================

--- a/kubelet/CHANGELOG.md
+++ b/kubelet/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [FEATURE] Allow to disable prometheus metric collection. See [#1423][]
 * [FEATURE] Container metrics now respect the container filtering rules. Requires Agent 6.2+. See [#1442][]
 * [BUGFIX] Fix submission of CPU metrics on multi-threaded containers. See [#1489][]
-* [BUGFIX] Fix SSL when specifying certificates files
+* [BUGFIX] Fix SSL when specifying certificate files
 
 1.1.0 / 2018-03-23
 ==================

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -163,7 +163,9 @@ class KubeletCheck(PrometheusCheck, CadvisorScraper):
         if not cert[0] or not cert[1]:
             cert = None
         else:
-            self.ssl_cert = cert  # prometheus check setting
+            # prometheus check setting
+            self.ssl_cert = cert[0]
+            self.ssl_private_key = cert[1]
 
         if self.kubelet_conn_info.get('verify_tls') == 'false':
             verify = False

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -163,7 +163,7 @@ class KubeletCheck(PrometheusCheck, CadvisorScraper):
         if not cert[0] or not cert[1]:
             cert = None
         else:
-            # prometheus check setting
+            # prometheus check settings
             self.ssl_cert = cert[0]
             self.ssl_private_key = cert[1]
 


### PR DESCRIPTION
### What does this PR do?

Support a setup with the insecure options but still provide certificates.
Currently with this stack trace occuring:
```
2018-05-02 23:18:40 UTC | ERROR | (runner.go:276 in work) | Error running check kubelet: [{"message": "401 Client Error: Unauthorized for url: https://192.168.128.156:10250/metrics/cadvisor", "traceback": "Traceback (most recent call last):\n  File \"/opt/datadog-agent/bin/agent/dist/checks/__init__.py\", line 332, in run\n    self.check(copy.deepcopy(self.instances[0]))\n  File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/kubelet/kubelet.py\", line 151, in check\n    self.process(self.metrics_url, send_histograms_buckets=send_buckets, instance=instance)\n  File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/checks/prometheus/mixins.py\", line 356, in process\n    for metric in self.scrape_metrics(endpoint):\n  File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/checks/prometheus/mixins.py\", line 320, in scrape_metrics\n    response = self.poll(endpoint)\n  File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/checks/prometheus/mixins.py\", line 492, in poll\n    response.raise_for_status()\n  File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/requests/models.py\", line 935, in raise_for_status\n    raise HTTPError(http_error_msg, response=self)\nHTTPError: 401 Client Error: Unauthorized for url: https://192.168.128.156:10250/metrics/cadvisor\n"}]
```

### Motivation

Setup where using self signed certificate without providing the certificate authority.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
