### PR TITLE
Add project blacklist support for limits metrics

### DIFF
--- a/openstack/conf.yaml.example
+++ b/openstack/conf.yaml.example
@@ -80,6 +80,13 @@ instances:
       # Setting append_tenant_id to true manually adds this suffix for downstream requests
       # append_tenant_id: false
 
+      # Filter the projects that we collect `limit` metrics for. 
+      # Only used when `collect_all_projects` is set to true. 
+      # This only applies to the `limits` metrics. We will still collect metrics about servers under these projects 
+      # projects_blacklist:
+      #   - "server.*"
+      #   - "project_*"
+
       # If you need additional tags to submit with your server metrics. 
       # Please note that server metrics override the host tag and thus do not get
       # the agent-level tags you may have set.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Add the ability to blacklist projects based on regex. Only for `limits` metrics!!

### Motivation

There are cases where projects can exist within keystone with perhaps a UUID or others that may not be important to monitor.

### Additional Notes

This **won't** apply to the servers we collect. We will still pull server stats for the projects in the blacklist.