### PR TITLE
Document the 'max_services' config option

### DIFF
--- a/consul/conf.yaml.example
+++ b/consul/conf.yaml.example
@@ -54,6 +54,10 @@ instances:
       #   - gunicorn
       #   - redis
 
+      # If you'd rather not maintain a whitelist, you can increase the maximum
+      # number of queried services
+      # max_services: 100
+
       # Additional tags to apply to the metrics, events and service checks
       # You should always specify tags when multiple instances of the check run
       # on the same agent.

--- a/consul/conf.yaml.example
+++ b/consul/conf.yaml.example
@@ -56,7 +56,7 @@ instances:
 
       # If you'd rather not maintain a whitelist, you can increase the maximum
       # number of queried services
-      # max_services: 100
+      # max_services: 50
 
       # Additional tags to apply to the metrics, events and service checks
       # You should always specify tags when multiple instances of the check run


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Documents the `max_services` config option

### Motivation

The `max_services` config option wasn't documented


