### PR TITLE
Updating ntp check frequency

### DIFF
--- a/ntp/README.md
+++ b/ntp/README.md
@@ -1,8 +1,8 @@
 # NTP check
-{{< img src="integrations/ntp/ntpgraph.png" alt="NTP Graph" responsive="true" popup="true">}}
+
 ## Overview
 
-The Network Time Protocol (NTP) integration is enabled by default and reports the time offset from an ntp server every 15 minutes. When the local agent's time is more than 15 seconds off from the Datadog service and the other hosts that you are monitoring, you may experience:
+The Network Time Protocol (NTP) integration is enabled by default and reports the time offset from an ntp server every 15-20 seconds. When the local agent's time is more than 15 seconds off from the Datadog service and the other hosts that you are monitoring, you may experience:
 
 * Incorrect alert triggers
 * Metric delays


### PR DESCRIPTION
### What does this PR do?

* Update frequency of ntp check since now  the ntp check now runs at the default check interval (every 15-20 seconds).

* removes outdated screenshots

### Motivation

customer request