### PR TITLE
No moar snmp until it's flaky

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,8 @@ env:
     - TRAVIS_FLAVOR=php_fpm FLAVOR_VERSION=5.5
     - TRAVIS_FLAVOR=rabbitmq FLAVOR_VERSION=3.5.0
     - TRAVIS_FLAVOR=rabbitmq FLAVOR_VERSION=3.6.0
-    - TRAVIS_FLAVOR=snmp
+    # this is just too flaky to stay here, suspending while we find a fix
+    # - TRAVIS_FLAVOR=snmp
     - TRAVIS_FLAVOR=solr FLAVOR_VERSION=6.2
     - TRAVIS_FLAVOR=sqlserver FLAVOR_VERSION=2017-GA
     - TRAVIS_FLAVOR=statsd


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Avoid running SNMP integration tests while they're so flaky
