### PR TITLE
[SNMP] Fix metric length checking

### DIFF
--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -347,7 +347,7 @@ class SnmpCheck(NetworkCheck):
 
         cmd_generator, ip_address, tags, metrics, timeout, retries, enforce_constraints = self._load_conf(instance)
 
-        if len(metrics) < 1:
+        if not metrics:
             raise Exception('Metrics list must contain at least one metric')
 
         tags += ['snmp_device:{0}'.format(ip_address)]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Check if the `metrics` field exists, not its length. 

### Motivation

If there is nothing there, its actually None so checking its length just throws an exception.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

Resolves issue in unreleased check.

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
