### PR TITLE
add regular expression filter utility

### DIFF
--- a/datadog_checks_base/datadog_checks/utils/common.py
+++ b/datadog_checks_base/datadog_checks/utils/common.py
@@ -11,4 +11,22 @@ def get_docker_hostname():
     return urlparse(os.getenv('DOCKER_HOST', '')).hostname or 'localhost'
 
 
-def pattern_filter(items, patterns)
+def pattern_filter(items, patterns, exclude=False, key=None):
+    if not patterns:
+        return items
+
+    key = key or __return_self
+    matches = {
+        item for pattern in patterns
+        for item in items
+        if re.search(pattern, key(item))
+    }
+
+    if exclude:
+        return [item for item in items if item not in matches]
+    else:
+        return [item for item in items if item in matches]
+
+
+def __return_self(obj):
+    return obj

--- a/datadog_checks_base/datadog_checks/utils/common.py
+++ b/datadog_checks_base/datadog_checks/utils/common.py
@@ -2,9 +2,13 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+import re
 
 from six.moves.urllib.parse import urlparse
 
 
 def get_docker_hostname():
     return urlparse(os.getenv('DOCKER_HOST', '')).hostname or 'localhost'
+
+
+def pattern_filter(items, patterns)

--- a/datadog_checks_base/datadog_checks/utils/common.py
+++ b/datadog_checks_base/datadog_checks/utils/common.py
@@ -32,5 +32,32 @@ def pattern_filter(items, patterns, exclude=False, key=None):
         return [item for item in items if key(item) in matches]
 
 
+def pattern_filter_chain(items, whitelist=None, blacklist=None, key=None):
+    """This filters `items` by a regular expression `whitelist` and/or
+    `blacklist`, with the `whitelist` taking precedence. An optional `key`
+    function can be provided that will be passed each item.
+    """
+    if not (whitelist or blacklist):
+        return items
+
+    key = key or __return_self
+    whitelist = whitelist or []
+    blacklist = blacklist or []
+    whitelisted = set()
+    blacklisted = set()
+
+    for item in items:
+        item_key = key(item)
+        whitelisted.update(item_key for pattern in whitelist if re.search(pattern, item_key))
+        blacklisted.update(item_key for pattern in blacklist if re.search(pattern, item_key))
+
+    if blacklist:
+        # Remove any whitelisted items from the blacklist.
+        blacklisted.difference_update(whitelisted)
+        return [item for item in items if key(item) not in blacklisted]
+    else:
+        return [item for item in items if key(item) in whitelisted]
+
+
 def __return_self(obj):
     return obj

--- a/datadog_checks_base/datadog_checks/utils/common.py
+++ b/datadog_checks_base/datadog_checks/utils/common.py
@@ -12,20 +12,24 @@ def get_docker_hostname():
 
 
 def pattern_filter(items, patterns, exclude=False, key=None):
+    """This filters `items` by regular expression `patterns`. If `exclude`
+    is `True`, treat `patterns` as a blacklist instead. An optional `key`
+    function can be provided that will be passed each item.
+    """
     if not patterns:
         return items
 
     key = key or __return_self
     matches = {
-        item for pattern in patterns
+        key(item) for pattern in patterns
         for item in items
         if re.search(pattern, key(item))
     }
 
     if exclude:
-        return [item for item in items if item not in matches]
+        return [item for item in items if key(item) not in matches]
     else:
-        return [item for item in items if item in matches]
+        return [item for item in items if key(item) in matches]
 
 
 def __return_self(obj):

--- a/datadog_checks_base/datadog_checks/utils/common.py
+++ b/datadog_checks_base/datadog_checks/utils/common.py
@@ -11,31 +11,13 @@ def get_docker_hostname():
     return urlparse(os.getenv('DOCKER_HOST', '')).hostname or 'localhost'
 
 
-def pattern_filter(items, patterns, exclude=False, key=None):
-    """This filters `items` by regular expression `patterns`. If `exclude`
-    is `True`, treat `patterns` as a blacklist instead. An optional `key`
-    function can be provided that will be passed each item.
-    """
-    if not patterns:
-        return items
-
-    key = key or __return_self
-    matches = {
-        key(item) for pattern in patterns
-        for item in items
-        if re.search(pattern, key(item))
-    }
-
-    if exclude:
-        return [item for item in items if key(item) not in matches]
-    else:
-        return [item for item in items if key(item) in matches]
-
-
-def pattern_filter_chain(items, whitelist=None, blacklist=None, key=None):
+def pattern_filter(items, whitelist=None, blacklist=None, key=None):
     """This filters `items` by a regular expression `whitelist` and/or
     `blacklist`, with the `whitelist` taking precedence. An optional `key`
     function can be provided that will be passed each item.
+
+    When you have only one type of list, consider using `pattern_whitelist`
+    or `pattern_blacklist` for increased performance.
     """
     if not (whitelist or blacklist):
         return items
@@ -57,6 +39,40 @@ def pattern_filter_chain(items, whitelist=None, blacklist=None, key=None):
         return [item for item in items if key(item) not in blacklisted]
     else:
         return [item for item in items if key(item) in whitelisted]
+
+
+def pattern_whitelist(items, whitelist, key=None):
+    """This filters `items` by a regular expression `whitelist`. An optional
+    `key` function can be provided that will be passed each item.
+    """
+    if not whitelist:
+        return items
+
+    key = key or __return_self
+    matches = {
+        key(item) for pattern in whitelist
+        for item in items
+        if re.search(pattern, key(item))
+    }
+
+    return [item for item in items if key(item) in matches]
+
+
+def pattern_blacklist(items, blacklist, key=None):
+    """This filters `items` by a regular expression `blacklist`. An optional
+    `key` function can be provided that will be passed each item.
+    """
+    if not blacklist:
+        return items
+
+    key = key or __return_self
+    matches = {
+        key(item) for pattern in blacklist
+        for item in items
+        if re.search(pattern, key(item))
+    }
+
+    return [item for item in items if key(item) not in matches]
 
 
 def __return_self(obj):

--- a/datadog_checks_base/tests/test_utils.py
+++ b/datadog_checks_base/tests/test_utils.py
@@ -1,10 +1,24 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.utils.common import pattern_filter
+from datadog_checks.utils.common import pattern_filter, pattern_filter_chain
+
+
+class Item:
+    def __init__(self, name):
+        self.name = name
+
+    def __eq__(self, other):
+        return self.name == other.name
 
 
 class TestPatternFilter:
+    def test_no_items(self):
+        items = []
+        patterns = ['mock']
+
+        assert pattern_filter(items, patterns) == []
+
     def test_no_patterns(self):
         items = ['mock']
         patterns = []
@@ -24,16 +38,49 @@ class TestPatternFilter:
         assert pattern_filter(items, patterns, exclude=True) == ['ghi']
 
     def test_key_function(self):
-        class Item:
-            def __init__(self, name):
-                self.name = name
-
-            def __eq__(self, other):
-                return self.name == other.name
-
         items = [Item('abc'), Item('def'), Item('abcdef'), Item('ghi')]
         patterns = ['abc', 'def']
 
         assert pattern_filter(items, patterns, key=lambda item: item.name) == [
+            Item('abc'), Item('def'), Item('abcdef')
+        ]
+
+
+class TestPatternFilterChain:
+    def test_no_items(self):
+        items = []
+        whitelist = ['mock']
+
+        assert pattern_filter_chain(items, whitelist=whitelist) == []
+
+    def test_no_patterns(self):
+        items = ['mock']
+
+        assert pattern_filter_chain(items) is items
+
+    def test_multiple_matches_whitelist(self):
+        items = ['abc', 'def', 'abcdef', 'ghi']
+        whitelist = ['abc', 'def']
+
+        assert pattern_filter_chain(items, whitelist=whitelist) == ['abc', 'def', 'abcdef']
+
+    def test_multiple_matches_blacklist(self):
+        items = ['abc', 'def', 'abcdef', 'ghi']
+        blacklist = ['abc', 'def']
+
+        assert pattern_filter_chain(items, blacklist=blacklist) == ['ghi']
+
+    def test_whitelist_override(self):
+        items = ['abc', 'def', 'abcdef', 'ghi']
+        whitelist = ['def']
+        blacklist = ['abc', 'def']
+
+        assert pattern_filter_chain(items, whitelist=whitelist, blacklist=blacklist) == ['def', 'abcdef', 'ghi']
+
+    def test_key_function(self):
+        items = [Item('abc'), Item('def'), Item('abcdef'), Item('ghi')]
+        whitelist = ['abc', 'def']
+
+        assert pattern_filter_chain(items, whitelist=whitelist, key=lambda item: item.name) == [
             Item('abc'), Item('def'), Item('abcdef')
         ]

--- a/datadog_checks_base/tests/test_utils.py
+++ b/datadog_checks_base/tests/test_utils.py
@@ -1,9 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.utils.common import (
-    pattern_filter, pattern_whitelist, pattern_blacklist
-)
+from datadog_checks.utils.common import pattern_filter
 
 
 class Item:
@@ -52,57 +50,3 @@ class TestPatternFilter:
         assert pattern_filter(items, whitelist=whitelist, key=lambda item: item.name) == [
             Item('abc'), Item('def'), Item('abcdef')
         ]
-
-
-class TestPatternWhitelist:
-    def test_no_items(self):
-        items = []
-        whitelist = ['mock']
-
-        assert pattern_whitelist(items, whitelist) == []
-
-    def test_no_patterns(self):
-        items = ['mock']
-        whitelist = []
-
-        assert pattern_whitelist(items, whitelist) is items
-
-    def test_multiple_matches(self):
-        items = ['abc', 'def', 'abcdef', 'ghi']
-        whitelist = ['abc', 'def']
-
-        assert pattern_whitelist(items, whitelist) == ['abc', 'def', 'abcdef']
-
-    def test_key_function(self):
-        items = [Item('abc'), Item('def'), Item('abcdef'), Item('ghi')]
-        whitelist = ['abc', 'def']
-
-        assert pattern_whitelist(items, whitelist, key=lambda item: item.name) == [
-            Item('abc'), Item('def'), Item('abcdef')
-        ]
-
-
-class TestPatternBlacklist:
-    def test_no_items(self):
-        items = []
-        blacklist = ['mock']
-
-        assert pattern_blacklist(items, blacklist) == []
-
-    def test_no_patterns(self):
-        items = ['mock']
-        blacklist = []
-
-        assert pattern_blacklist(items, blacklist) is items
-
-    def test_multiple_matches(self):
-        items = ['abc', 'def', 'abcdef', 'ghi']
-        blacklist = ['abc', 'def']
-
-        assert pattern_blacklist(items, blacklist) == ['ghi']
-
-    def test_key_function(self):
-        items = [Item('abc'), Item('def'), Item('abcdef'), Item('ghi')]
-        blacklist = ['abc', 'def']
-
-        assert pattern_blacklist(items, blacklist, key=lambda item: item.name) == [Item('ghi')]

--- a/datadog_checks_base/tests/test_utils.py
+++ b/datadog_checks_base/tests/test_utils.py
@@ -1,0 +1,39 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datadog_checks.utils.common import pattern_filter
+
+
+class TestPatternFilter:
+    def test_no_patterns(self):
+        items = ['mock']
+        patterns = []
+
+        assert pattern_filter(items, patterns) is items
+
+    def test_multiple_matches_whitelist(self):
+        items = ['abc', 'def', 'abcdef', 'ghi']
+        patterns = ['abc', 'def']
+
+        assert pattern_filter(items, patterns) == ['abc', 'def', 'abcdef']
+
+    def test_multiple_matches_blacklist(self):
+        items = ['abc', 'def', 'abcdef', 'ghi']
+        patterns = ['abc', 'def']
+
+        assert pattern_filter(items, patterns, exclude=True) == ['ghi']
+
+    def test_key_function(self):
+        class Item:
+            def __init__(self, name):
+                self.name = name
+
+            def __eq__(self, other):
+                return self.name == other.name
+
+        items = [Item('abc'), Item('def'), Item('abcdef'), Item('ghi')]
+        patterns = ['abc', 'def']
+
+        assert pattern_filter(items, patterns, key=lambda item: item.name) == [
+            Item('abc'), Item('def'), Item('abcdef')
+        ]

--- a/datadog_checks_base/tests/test_utils.py
+++ b/datadog_checks_base/tests/test_utils.py
@@ -1,7 +1,9 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.utils.common import pattern_filter, pattern_filter_chain
+from datadog_checks.utils.common import (
+    pattern_filter, pattern_whitelist, pattern_blacklist
+)
 
 
 class Item:
@@ -15,72 +17,92 @@ class Item:
 class TestPatternFilter:
     def test_no_items(self):
         items = []
-        patterns = ['mock']
-
-        assert pattern_filter(items, patterns) == []
-
-    def test_no_patterns(self):
-        items = ['mock']
-        patterns = []
-
-        assert pattern_filter(items, patterns) is items
-
-    def test_multiple_matches_whitelist(self):
-        items = ['abc', 'def', 'abcdef', 'ghi']
-        patterns = ['abc', 'def']
-
-        assert pattern_filter(items, patterns) == ['abc', 'def', 'abcdef']
-
-    def test_multiple_matches_blacklist(self):
-        items = ['abc', 'def', 'abcdef', 'ghi']
-        patterns = ['abc', 'def']
-
-        assert pattern_filter(items, patterns, exclude=True) == ['ghi']
-
-    def test_key_function(self):
-        items = [Item('abc'), Item('def'), Item('abcdef'), Item('ghi')]
-        patterns = ['abc', 'def']
-
-        assert pattern_filter(items, patterns, key=lambda item: item.name) == [
-            Item('abc'), Item('def'), Item('abcdef')
-        ]
-
-
-class TestPatternFilterChain:
-    def test_no_items(self):
-        items = []
         whitelist = ['mock']
 
-        assert pattern_filter_chain(items, whitelist=whitelist) == []
+        assert pattern_filter(items, whitelist=whitelist) == []
 
     def test_no_patterns(self):
         items = ['mock']
 
-        assert pattern_filter_chain(items) is items
+        assert pattern_filter(items) is items
 
     def test_multiple_matches_whitelist(self):
         items = ['abc', 'def', 'abcdef', 'ghi']
         whitelist = ['abc', 'def']
 
-        assert pattern_filter_chain(items, whitelist=whitelist) == ['abc', 'def', 'abcdef']
+        assert pattern_filter(items, whitelist=whitelist) == ['abc', 'def', 'abcdef']
 
     def test_multiple_matches_blacklist(self):
         items = ['abc', 'def', 'abcdef', 'ghi']
         blacklist = ['abc', 'def']
 
-        assert pattern_filter_chain(items, blacklist=blacklist) == ['ghi']
+        assert pattern_filter(items, blacklist=blacklist) == ['ghi']
 
     def test_whitelist_override(self):
         items = ['abc', 'def', 'abcdef', 'ghi']
         whitelist = ['def']
         blacklist = ['abc', 'def']
 
-        assert pattern_filter_chain(items, whitelist=whitelist, blacklist=blacklist) == ['def', 'abcdef', 'ghi']
+        assert pattern_filter(items, whitelist=whitelist, blacklist=blacklist) == ['def', 'abcdef', 'ghi']
 
     def test_key_function(self):
         items = [Item('abc'), Item('def'), Item('abcdef'), Item('ghi')]
         whitelist = ['abc', 'def']
 
-        assert pattern_filter_chain(items, whitelist=whitelist, key=lambda item: item.name) == [
+        assert pattern_filter(items, whitelist=whitelist, key=lambda item: item.name) == [
             Item('abc'), Item('def'), Item('abcdef')
         ]
+
+
+class TestPatternWhitelist:
+    def test_no_items(self):
+        items = []
+        whitelist = ['mock']
+
+        assert pattern_whitelist(items, whitelist) == []
+
+    def test_no_patterns(self):
+        items = ['mock']
+        whitelist = []
+
+        assert pattern_whitelist(items, whitelist) is items
+
+    def test_multiple_matches(self):
+        items = ['abc', 'def', 'abcdef', 'ghi']
+        whitelist = ['abc', 'def']
+
+        assert pattern_whitelist(items, whitelist) == ['abc', 'def', 'abcdef']
+
+    def test_key_function(self):
+        items = [Item('abc'), Item('def'), Item('abcdef'), Item('ghi')]
+        whitelist = ['abc', 'def']
+
+        assert pattern_whitelist(items, whitelist, key=lambda item: item.name) == [
+            Item('abc'), Item('def'), Item('abcdef')
+        ]
+
+
+class TestPatternBlacklist:
+    def test_no_items(self):
+        items = []
+        blacklist = ['mock']
+
+        assert pattern_blacklist(items, blacklist) == []
+
+    def test_no_patterns(self):
+        items = ['mock']
+        blacklist = []
+
+        assert pattern_blacklist(items, blacklist) is items
+
+    def test_multiple_matches(self):
+        items = ['abc', 'def', 'abcdef', 'ghi']
+        blacklist = ['abc', 'def']
+
+        assert pattern_blacklist(items, blacklist) == ['ghi']
+
+    def test_key_function(self):
+        items = [Item('abc'), Item('def'), Item('abcdef'), Item('ghi')]
+        blacklist = ['abc', 'def']
+
+        assert pattern_blacklist(items, blacklist, key=lambda item: item.name) == [Item('ghi')]


### PR DESCRIPTION
### What does this PR do?

This adds a core utility to filter `items` by a regular expression `whitelist` and/or `blacklist`, with the `whitelist` taking precedence. An optional `key` function can be provided that will be passed each item.

### Motivation

Many integrations need this functionality and the logic is non-trivial.