### PR TITLE
[tooling] Add the release task

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ services:
 before_script:
 - docker info
 - apk add --no-cache gcc linux-headers musl-dev python2-dev py-pip postgresql-dev libffi-dev
-- pip install -q docker-compose tox invoke
+- pip install -q docker-compose tox invoke packaging
 
 test:
   script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,6 @@ script:
   - bundle exec rake prep_travis_ci
   - if [ -e $TRAVIS_BUILD_DIR/$TRAVIS_FLAVOR/setup.py ]; then cd $TRAVIS_BUILD_DIR/$TRAVIS_FLAVOR && pip install -r requirements.txt && python setup.py bdist_wheel && pip install . && cd - ; fi
   - bundle exec rake ci:run
-  - bundle exec rake requirements
 # we should clean generated files before we save the cache
 # We don't want to save .pyc files
 # Since clobber only cleans the project directory,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,7 @@ install:
   - ps: choco install docker-compose
   - ps: (& "$env:PYTHON/Scripts/pip.exe" install invoke)
   - ps: (& "$env:PYTHON/Scripts/pip.exe" install pip-tools)
+  - ps: (& "$env:PYTHON/Scripts/pip.exe" install packaging)
   - cd datadog_checks_base
   - ps: (& "$env:PYTHON/Scripts/pip.exe" install .)
   - cd ..

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
 ./datadog_checks_base
-mock==2.0.0
+invoke
+mock
 pytest
 tox
 pip-tools
+packaging

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -14,6 +14,7 @@ from .manifest import manifest
 from .upgrade import upgrade
 from .test import test
 from .changelog import update_changelog
+from .release import release_check
 
 # the root namespace
 root = Collection()

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1,0 +1,99 @@
+# (C) Datadog, Inc. 2010-2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+from __future__ import print_function, unicode_literals
+import os
+
+from packaging import version
+from invoke import task, call
+from invoke.exceptions import Exit
+
+from .constants import AGENT_BASED_INTEGRATIONS, ROOT
+from .utils import get_version_string, get_current_branch, get_release_tag_string
+from .changelog import do_update_changelog
+
+
+def update_version_module(check_name, old_ver, new_ver):
+    """
+    Change the Python code in the __about__.py module so that `__version__`
+    contains the new value.
+    """
+    about_module = os.path.join(check_name, 'datadog_checks', check_name, '__about__.py')
+    with open(about_module, 'r') as f:
+        contents = f.read()
+
+    contents = contents.replace(old_ver, new_ver)
+    with open(about_module, 'w') as f:
+        f.write(contents)
+
+
+def git_commit(ctx, target, message):
+    """
+    Commit the current changes.
+    """
+    target_path = os.path.join(ROOT, target)
+    cmd = 'git add ' + target_path
+    ctx.run(cmd)
+    cmd = 'git commit -m"{}"'.format(message)
+    ctx.run(cmd)
+
+
+def git_tag(ctx, tag_name):
+    """
+    Tag the repo using an annotated tag.
+    """
+    cmd = 'git tag {} -m"{}"'.format(tag_name, tag_name)
+    ctx.run(cmd)
+
+
+@task(help={
+        'target': "The check to release",
+        'new_version': "The new version",
+        'dry-run': "Runs the task without actually doing anything",
+})
+def release_check(ctx, target, new_version, dry_run=False):
+    """
+    Perform a set of operations needed to release a single check:
+
+     * update the version in __about__.py
+     * update the changelog
+     * commit the above changes
+     * tag the repo with a tag in the form `check-name_0_0_1`
+
+    Example invocation:
+        inv release-check redisdb 3.1.1
+    """
+    # sanity check on the target
+    if target not in AGENT_BASED_INTEGRATIONS:
+        raise Exit("Provided target is not an Agent-based Integration")
+
+    # don't run the task on the master branch
+    if get_current_branch(ctx) == 'master':
+        raise Exit("This task will add a commit, you don't want to add it on master directly")
+
+    # sanity check on the version provided
+    p_version = version.parse(new_version)
+    p_current = version.parse(get_version_string(target))
+    if p_version <= p_current:
+        raise Exit("Current version is {}, can't bump to {}".format(p_current, p_version))
+
+    # update the version number
+    print("Current version of check {}: {}, bumping to: {}".format(target, p_current, p_version))
+    cur_version = get_version_string(target)
+    update_version_module(target, cur_version, new_version)
+
+    # update the CHANGELOG
+    print("Updating the changelog")
+    do_update_changelog(ctx, target, cur_version, new_version)
+
+    # commit the changes
+    msg = "Bumped to {}".format(new_version)
+    git_commit(ctx, target, msg)
+
+    # tagging
+    tag = get_release_tag_string(target, new_version)
+    print("Tagging repo with tag: {}".format(tag))
+    git_tag(ctx, tag)
+
+    # done
+    print("All done, remember to open a PR to merge these changes on master")

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -1,0 +1,34 @@
+# (C) Datadog, Inc. 2010-2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+from __future__ import print_function, unicode_literals
+import os
+
+from .constants import ROOT
+
+
+def get_version_string(check_name):
+    """
+    Get the version string for the given check.
+    """
+    about = {}
+    about_path = os.path.join(ROOT, check_name, "datadog_checks", check_name, "__about__.py")
+    with open(about_path) as f:
+        exec(f.read(), about)
+
+    return about.get('__version__')
+
+
+def get_current_branch(ctx):
+    """
+    Get the current branch name.
+    """
+    cmd = "git rev-parse --abbrev-ref HEAD"
+    return ctx.run(cmd, hide='out').stdout
+
+
+def get_release_tag_string(check_name, version_string):
+    """
+    Compose a string to use for release tags
+    """
+    return '{}-{}'.format(check_name, version_string)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Provides an invoke task to group and automate the common operations needed to release a single check:
 
* update the version in __about__.py
* update the changelog
* commit the above changes
* tag the repo with a tag in the form `check-name_0_0_1`

### Motivation

This is intended to be run in preparation of a publish task that would build and upload the wheel on the repo.
