### PR TITLE
[http_check] emit a warning if disable_ssl_validation is unset

### DIFF
--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG - http_check
 
+2.0.2 / Unreleased
+==================
+
+### Changes
+
+* [IMPROVEMENT] Emit warning when `disable_ssl_validation` is unset in configuration
+  file. See [#1999][]
+
 2.0.1 / Unreleased
 ==================
 
@@ -88,3 +96,4 @@
 [#905]:https://github.com/DataDog/integrations-core/pull/905
 [#1054]:https://github.com/DataDog/integrations-core/pull/1054
 [#1340]:https://github.com/DataDog/integrations-core/pull/1340
+[#1999]:https://github.com/DataDog/dd-agent/issues/1999

--- a/http_check/conf.yaml.example
+++ b/http_check/conf.yaml.example
@@ -73,8 +73,10 @@ instances:
     # The (optional) disable_ssl_validation will instruct the check
     # to skip the validation of the SSL certificate of the URL being tested.
     # This is useful when checking SSL connections signed with certificates
-    # that are not themselves signed by a public authority.
-    # When true or unset for https URLs, the check logs a warning in the Agent's log file.
+    # that are not themselves signed by a public authority. Even if you are using
+    # HTTPS URLs, you must explicitly set this parameter to false if you want SSL
+    # certificate validation.
+    # When true or unset, the check logs a warning in the Agent's log file.
     # Defaults to true, set to false if you want SSL certificate validation.
     #
     # disable_ssl_validation: true

--- a/http_check/conf.yaml.example
+++ b/http_check/conf.yaml.example
@@ -74,7 +74,7 @@ instances:
     # to skip the validation of the SSL certificate of the URL being tested.
     # This is mostly useful when checking SSL connections signed with
     # certificates that are not themselves signed by a public authority.
-    # When true, the check logs a warning in collector.log
+    # When true or unset, the check logs a warning in the Agent's log file
     # Defaults to true, set to false if you want SSL certificate validation.
     #
     # disable_ssl_validation: true

--- a/http_check/conf.yaml.example
+++ b/http_check/conf.yaml.example
@@ -72,9 +72,9 @@ instances:
 
     # The (optional) disable_ssl_validation will instruct the check
     # to skip the validation of the SSL certificate of the URL being tested.
-    # This is mostly useful when checking SSL connections signed with
-    # certificates that are not themselves signed by a public authority.
-    # When true or unset, the check logs a warning in the Agent's log file
+    # This is useful when checking SSL connections signed with certificates
+    # that are not themselves signed by a public authority.
+    # When true or unset for https URLs, the check logs a warning in the Agent's log file.
     # Defaults to true, set to false if you want SSL certificate validation.
     #
     # disable_ssl_validation: true

--- a/http_check/datadog_checks/http_check/__init__.py
+++ b/http_check/datadog_checks/http_check/__init__.py
@@ -2,6 +2,6 @@ from . import http_check
 
 HTTPCheck = http_check.HTTPCheck
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 __all__ = ['http_check']

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -208,6 +208,11 @@ class HTTPCheck(NetworkCheck):
         instance_ca_certs = instance.get('ca_certs', self.ca_certs)
         weakcipher = _is_affirmative(instance.get('weakciphers', False))
         ignore_ssl_warning = _is_affirmative(instance.get('ignore_ssl_warning', False))
+
+        parsed_uri = urlparse(url)
+        if 'disable_ssl_validation' not in instance and parsed_uri.scheme == 'https' and not ignore_ssl_warning:
+            self.warning('Parameter disable_ssl_validation for {0} is not explicitly set, defaults to true'.format(url))
+
         skip_proxy = _is_affirmative(
             instance.get('skip_proxy', instance.get('no_proxy', False)))
         allow_redirects = _is_affirmative(instance.get('allow_redirects', True))

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -245,9 +245,10 @@ class HTTPCheck(NetworkCheck):
 
             if disable_ssl_validation and parsed_uri.scheme == "https" and not ignore_ssl_warning:
                 if 'disable_ssl_validation' in instance:
-                    self.warning('Parameter disable_ssl_validation for {0} is not explicitly set, defaults to true'.format(addr))
-                else:
                     self.warning("Skipping SSL certificate validation for {0} based on configuration".format(addr))
+                else:
+                    self.warning('Parameter disable_ssl_validation for {0} is not explicitly set, defaults to true'.format(addr))
+
 
             instance_proxy = self.get_instance_proxy(instance, addr)
             self.log.debug("Proxies used for %s - %s", addr, instance_proxy)

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "2.0.1",
+  "version": "2.0.2",
   "guid": "eb133a1f-697c-4143-bad3-10e72541fa9c",
   "public_title": "Datadog-HTTP Check Integration",
   "categories":["web", "network"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Emits a warning when `disable_ssl_validation` is unset for an instance. Also slightly updated the example conf.yaml file.

### Motivation

I was inspired by issue [#1999](https://github.com/DataDog/dd-agent/issues/1999)

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md) is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [x] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Info

Not sure how to make the description for `disable_ssl_validation` more explicit in terms of the danger of not setting the parameter in conf.yaml.example file.