### PR TITLE
Update metadata of the cpu metrics from gauges to rates

### DIFF
--- a/ecs_fargate/manifest.json
+++ b/ecs_fargate/manifest.json
@@ -18,7 +18,7 @@
     "orchestration"
   ],
   "type": "check",
-  "doc_link": "https://docs.datadoghq.com/integrations/fargate/",
+  "doc_link": "https://docs.datadoghq.com/integrations/ecs_fargate/",
   "is_public": true,
   "has_logo": true,
   "creates_events": true

--- a/ecs_fargate/metadata.csv
+++ b/ecs_fargate/metadata.csv
@@ -3,8 +3,8 @@ ecs.fargate.io.ops.write,rate,,,,# write operations to the disk,0,fargate,io wri
 ecs.fargate.io.bytes.write,rate,,byte,,# bytes written to the disk,0,fargate,io write
 ecs.fargate.io.ops.read,rate,,,,# read operation on the disk,0,fargate,io read count
 ecs.fargate.io.bytes.read,rate,,byte,,# bytes read on the disk,0,fargate,io read
-ecs.fargate.cpu.user,gauge,,percent,,The percent of time the CPU is under direct control of processes of this container,0,fargate,cpu user
-ecs.fargate.cpu.system,gauge,,percent,,The percent of time the CPU is executing system calls on behalf of processes of this container,0,fargate,cpu system
+ecs.fargate.cpu.user,rate,,percent,,The percent of time the CPU is under direct control of processes of this container,0,fargate,cpu user
+ecs.fargate.cpu.system,rate,,percent,,The percent of time the CPU is executing system calls on behalf of processes of this container,0,fargate,cpu system
 ecs.fargate.cpu.limit,gauge,,percent,,Limit in percent of the CPU usage,0,fargate,cpu limit
 ecs.fargate.mem.cache,gauge,,byte,,# of bytes of page cache memory,0,fargate,mem cache
 ecs.fargate.mem.active_file,gauge,,byte,,# of bytes of file-backed memory on active LRU list,0,fargate,mem active file


### PR DESCRIPTION
### What does this PR do?

The cpu.system and cpu.user are collected as rates but listed as gauges in the metadata.json which overrides the types and leads to wrong values.

### Motivation

Support issue.

### Testing Guidelines

- [ ] Build the image and confirm it fixes the issue.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/ecs_fargate/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

🏆 
