### PR TITLE
[http_check] allow users to disable matching hostnames verification in ssl cert verification

### DIFF
--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG - http_check
 
+2.0.2 / Unreleased
+==================
+
+### Changes
+
+* [IMPROVEMENT] Add `check_hostname` option to allow users to disable matching
+  hostnames verification. See [#485][]
+
 2.0.1 / Unreleased
 ==================
 
@@ -88,3 +96,4 @@
 [#905]:https://github.com/DataDog/integrations-core/pull/905
 [#1054]:https://github.com/DataDog/integrations-core/pull/1054
 [#1340]:https://github.com/DataDog/integrations-core/pull/1340
+[#485]:https://github.com/DataDog/integrations-core/issues/485

--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - http_check
 
-2.0.2 / Unreleased
+2.1.2 / Unreleased
 ==================
 
 ### Changes

--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - http_check
 
-2.1.2 / Unreleased
+2.1.0 / Unreleased
 ==================
 
 ### Changes

--- a/http_check/README.md
+++ b/http_check/README.md
@@ -51,6 +51,8 @@ See the [sample http_check.d/conf.yaml][2] for a full list and description of av
 | `ca_certs` | This setting will allow you to override the default certificate path as specified in `init_config` |
 | `check_certificate_expiration` | When `check_certificate_expiration` is enabled, the service check will check the expiration date of the SSL certificate. Note that this will cause the SSL certificate to be validated, regardless of the value of the `disable_ssl_validation` setting. |
 | `days_warning` & `days_critical` | When `check_certificate_expiration` is enabled, these settings will raise a warning or critical alert when the SSL certificate is within the specified number of days from expiration. |
+| `check_hostname` | When `check_certificate_expiration` is enabled, this setting will raise a warning if the hostname on the SSL certificate does not match the host of the given URL. |
+| `ssl_server_name` | When `check_certificate_expiration` is enabled, this setting specifies the hostname of the service to connect to and it also overrides the host to match with if check_hostname is enabled. |
 | `headers` | This parameter allows you to send additional headers with the request. Please see the [example YAML file](https://github.com/DataDog/integrations-core/blob/master/http_check/conf.yaml.example) for additional information and caveats. |
 | `skip_proxy` | If set, the check will bypass proxy settings and attempt to reach the check url directly. This defaults to `false`. |
 | `allow_redirects` | This setting allows the service check to follow HTTP redirects and defaults to `true`.

--- a/http_check/conf.yaml.example
+++ b/http_check/conf.yaml.example
@@ -97,11 +97,15 @@ instances:
     # The SSL certificate will always be validated for this additional
     # service check regardless of the value of disable_ssl_validation.
     # By default, for the expiration check, the Agent validates the SSL certificate
-    # hostname against the host of the provided url. If necessary, you can override
-    # that hostname with ssl_server_name.
+    # hostname against the host of the provided url. If necessary, you can
+    # override the hostname to match with ssl_server_name.
+    # You can also disable the verification check for matching hostnames by explicitly
+    # setting check_hostname to false.
+    #
     # check_certificate_expiration: true
     # days_warning: 14
     # days_critical: 7
+    # check_hostname: true
     # ssl_server_name: hostname
 
     # The (optional) headers parameter allows you to send extra headers
@@ -120,12 +124,12 @@ instances:
     # The (optional) skip_proxy parameter would bypass any proxy settings enabled
     # and attempt to reach the the URL directly.
     # If no proxy is defined at any level, this flag bears no effect.
-    # Defaults to False.
+    # Defaults to false.
     #
     # skip_proxy: false
 
     # The (optional) allow_redirects parameter can enable redirection.
-    # Defaults to True.
+    # Defaults to true.
     #
     # allow_redirects: true
 
@@ -133,9 +137,9 @@ instances:
     # The (optional) include_default_header parameter instructs the check to include the default headers.
     # Default headers can be found at https://github.com/DataDog/dd-agent/blob/5.10.0/util.py#L58-L67
     #
-    # Defaults to True.
+    # Defaults to true.
     #
-    #include_default_headers: false
+    # include_default_headers: false
 
     # tags:
     #   - url:http://alternative.host.example.com

--- a/http_check/conf.yaml.example
+++ b/http_check/conf.yaml.example
@@ -141,7 +141,7 @@ instances:
     #
     # Defaults to true.
     #
-    # include_default_headers: false
+    # include_default_headers: true
 
     # tags:
     #   - url:http://alternative.host.example.com

--- a/http_check/datadog_checks/http_check/__init__.py
+++ b/http_check/datadog_checks/http_check/__init__.py
@@ -2,6 +2,6 @@ from . import http_check
 
 HTTPCheck = http_check.HTTPCheck
 
-__version__ = "2.0.2"
+__version__ = "2.1.2"
 
 __all__ = ['http_check']

--- a/http_check/datadog_checks/http_check/__init__.py
+++ b/http_check/datadog_checks/http_check/__init__.py
@@ -2,6 +2,6 @@ from . import http_check
 
 HTTPCheck = http_check.HTTPCheck
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 __all__ = ['http_check']

--- a/http_check/datadog_checks/http_check/__init__.py
+++ b/http_check/datadog_checks/http_check/__init__.py
@@ -2,6 +2,6 @@ from . import http_check
 
 HTTPCheck = http_check.HTTPCheck
 
-__version__ = "2.1.2"
+__version__ = "2.1.0"
 
 __all__ = ['http_check']

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -427,6 +427,7 @@ class HTTPCheck(NetworkCheck):
             cert = ssl_sock.getpeercert()
 
         except ssl.CertificateError as e:
+            self.log.debug("The hostname on the SSL certificate does not match the given host: %s", e)
             return Status.CRITICAL, 0, '{0}'.format(str(e))
         except Exception as e:
             self.log.debug("Site is down, unable to connect to get cert expiration: %s", e)

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -428,10 +428,10 @@ class HTTPCheck(NetworkCheck):
 
         except ssl.CertificateError as e:
             self.log.debug("The hostname on the SSL certificate does not match the given host: %s", e)
-            return Status.CRITICAL, 0, '{0}'.format(str(e))
+            return Status.CRITICAL, 0, str(e)
         except Exception as e:
             self.log.debug("Site is down, unable to connect to get cert expiration: %s", e)
-            return Status.DOWN, 0, '{0}'.format(str(e))
+            return Status.DOWN, 0, str(e)
 
         exp_date = datetime.strptime(cert['notAfter'], "%b %d %H:%M:%S %Y %Z")
         days_left = exp_date - datetime.utcnow()

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -214,13 +214,8 @@ class HTTPCheck(NetworkCheck):
         allow_redirects = _is_affirmative(instance.get('allow_redirects', True))
 
         return url, username, password, client_cert, client_key, method, data, http_response_status_code, timeout, include_content,\
-<<<<<<< HEAD
-            headers, response_time, content_match, reverse_content_match, tags, ssl, ssl_expire, instance_ca_certs,\
-            weakcipher, check_hostname, ignore_ssl_warning, skip_proxy, allow_redirects
-=======
             headers, response_time, content_match, reverse_content_match, tags, disable_ssl_validation, ssl_expire, instance_ca_certs,\
-            weakcipher, ignore_ssl_warning, skip_proxy, allow_redirects
->>>>>>> master
+            weakcipher, check_hostname, ignore_ssl_warning, skip_proxy, allow_redirects
 
     def _check(self, instance):
         addr, username, password, client_cert, client_key, method, data, http_response_status_code, timeout, include_content, headers,\
@@ -431,9 +426,11 @@ class HTTPCheck(NetworkCheck):
             ssl_sock = context.wrap_socket(sock, server_hostname=server_name)
             cert = ssl_sock.getpeercert()
 
+        except ssl.CertificateError as e:
+            return Status.CRITICAL, 0, '{0}'.format(str(e))
         except Exception as e:
             self.log.debug("Site is down, unable to connect to get cert expiration: %s", e)
-            return Status.DOWN, 0, "%s" % (str(e))
+            return Status.DOWN, 0, '{0}'.format(str(e))
 
         exp_date = datetime.strptime(cert['notAfter'], "%b %d %H:%M:%S %Y %Z")
         days_left = exp_date - datetime.utcnow()

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "2.0.1",
+  "version": "2.0.2",
   "guid": "eb133a1f-697c-4143-bad3-10e72541fa9c",
   "public_title": "Datadog-HTTP Check Integration",
   "categories":["web", "network"],

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "2.0.2",
+  "version": "2.1.2",
   "guid": "eb133a1f-697c-4143-bad3-10e72541fa9c",
   "public_title": "Datadog-HTTP Check Integration",
   "categories":["web", "network"],

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "version": "2.1.2",
+  "version": "2.1.0",
   "guid": "eb133a1f-697c-4143-bad3-10e72541fa9c",
   "public_title": "Datadog-HTTP Check Integration",
   "categories":["web", "network"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Adds the `check_hostname` option to allow users to disable verification of matching the hostname on the ssl cert to the given--or specified--host of the given url.

### Motivation

I was motivated by [issue #485](https://github.com/DataDog/integrations-core/issues/485) to create this PR.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md) is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [x] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

The metadata version changes will need to be merged carefully as there are conflicts with the other branch that touches http_check.