### PR TITLE
[kafka_consumer] Use >= 0 rather than >-1 for consistency

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -336,7 +336,7 @@ class KafkaCheck(AgentCheck):
         for topic, partitions in topics_to_fetch.iteritems():
             for partition in partitions:
                 partition_leader = cli.cluster.leader_for_partition(TopicPartition(topic, partition))
-                if partition_leader is not None and partition_leader > -1:
+                if partition_leader is not None and partition_leader >= 0:
                     leader_tp[partition_leader][topic].update([partition])
 
         max_offsets = 1


### PR DESCRIPTION
Valid Kafka broker IDs start at 0.

Logically `> -1` is equvalent to `>= 0`. However, the latter is less confusing to someone familiar with Kafka broker IDs.

Additionally, line 265 uses `>= 0`, so use that here as well for consistency.