### PR TITLE
[kafka_consumer] Let the client intelligently pick a random node

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -193,14 +193,6 @@ class KafkaCheck(AgentCheck):
 
         return node_id
 
-    def _make_req_async(self, client, request, node_id=None, cb=None):
-        if node_id is None:
-            node_id = self._get_random_node_id(client)
-
-        future = client.send(node_id, request)
-        if cb:
-            future.add_callback(cb, request, node_id, self.current_ts)
-
     def _ensure_ready_node(self, client, node_id):
         if node_id is None:
             raise Exception("node_id is None")

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -37,10 +37,6 @@ class BadKafkaConsumerConfiguration(Exception):
     pass
 
 
-class NoKafkaBrokersAvailable(Exception):
-    pass
-
-
 class KafkaCheck(AgentCheck):
     """
     Check the offsets and lag of Kafka consumers.
@@ -185,14 +181,6 @@ class KafkaCheck(AgentCheck):
 
         return version > self.LAST_ZKONLY_VERSION
 
-    def _get_random_node_id(self, client):
-        brokers = client.cluster.brokers()
-        if not brokers:
-            raise NoKafkaBrokersAvailable('No available brokers.')
-        node_id = random.sample(brokers, 1)[0].nodeId
-
-        return node_id
-
     def _ensure_ready_node(self, client, node_id):
         if node_id is None:
             raise Exception("node_id is None")
@@ -219,7 +207,7 @@ class KafkaCheck(AgentCheck):
 
     def _make_blocking_req(self, client, request, node_id=None):
         if node_id is None:
-            node_id = self._get_random_node_id(client)
+            node_id = client.least_loaded_node()
 
         self._ensure_ready_node(client, node_id)
 


### PR DESCRIPTION
Previously, a node was chosen at random. However, `kafka-python` offers a
built-in method to intelligently pick a node, preferring nodes that are
already connected (lower latency, less error-checking), with the fewest
number of outstanding requests (lower latency), and only if no brokers
are already connected will it fallback to a random node.

Note: This removes a custom exception, however the exception is not
actually needed because _make_blocking_req() calls _ensure_ready_node()
which already doublechecks the node is ready. And _make_req_async()
(which is currently unused and possibly should be outright removed, so it doesn't even really matter) will
hit an error when it triest to call send(). Besides, by the time we get
here, we almost always have working connections to the brokers.