### PR TITLE
[kafka_consumer] Simplify version handling

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -45,7 +45,6 @@ class KafkaCheck(AgentCheck):
     """
 
     SOURCE_TYPE_NAME = 'kafka'
-    LAST_ZKONLY_VERSION = (0, 8, 1, 1)
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances=instances)
@@ -98,13 +97,19 @@ class KafkaCheck(AgentCheck):
 
         cli = self._get_kafka_client(instance)
         cli._maybe_refresh_metadata()
-        kafka_version = self._get_kafka_version(cli)
+
         if get_kafka_consumer_offsets:
             # For now, consumer groups are mandatory if not using ZK
             if not zk_hosts_ports and not consumer_groups:
                 raise BadKafkaConsumerConfiguration('Invalid configuration - if you\'re not collecting '
                                                     'offsets from ZK you _must_ specify consumer groups')
-            if self._kafka_compatible(kafka_version):
+            # kafka-python automatically probes the cluster for broker version
+            # and then stores it. Note that this returns the first version
+            # found, so in a mixed-version cluster this will be a
+            # non-deterministic result.
+            #
+            # Kafka 0.8.2 added support for storing consumer offsets in Kafka.
+            if cli.config.get('api_version') >= (0, 8, 2):
                 kafka_consumer_offsets, topics = self._get_kafka_consumer_offsets(instance, consumer_groups)
 
         if not topics:
@@ -174,13 +179,6 @@ class KafkaCheck(AgentCheck):
 
         return self.kafka_clients[instance_key]
 
-    def _kafka_compatible(self, version):
-        if not version:
-            self.log.debug("Unable to determine compatibility.")
-            return False
-
-        return version > self.LAST_ZKONLY_VERSION
-
     def _ensure_ready_node(self, client, node_id):
         if node_id is None:
             raise Exception("node_id is None")
@@ -217,17 +215,6 @@ class KafkaCheck(AgentCheck):
         response = future.value
 
         return response
-
-    def _get_kafka_version(self, client, node_id=None):
-        if node_id is not None:
-            return client.check_version(node_id=node_id)
-
-        for broker in client.cluster.brokers():
-            version = client.check_version(node_id=broker.nodeId)
-            if version:
-                return version
-
-        return None
 
     def _get_group_coordinator(self, client, group):
         request = GroupCoordinatorRequest[0](group)
@@ -478,8 +465,6 @@ class KafkaCheck(AgentCheck):
         return consumer_offsets, topics
 
     def _get_consumer_offsets(self, client, consumer_group, topic_partitions, coord_id=None):
-        # version = client.check_version(coord_id)
-
         tps = defaultdict(set)
         for topic, partitions in topic_partitions.iteritems():
             if len(partitions) == 0:
@@ -493,9 +478,10 @@ class KafkaCheck(AgentCheck):
             broker_ids = [b.nodeId for b in client.cluster.brokers()]
 
         for broker_id in broker_ids:
-            offset_request = self._get_consumer_offset_request(client)
-
-            request = offset_request(consumer_group, list(tps.iteritems()))
+            # Kafka protocol uses OffsetFetchRequests to retrieve consumer offsets:
+            # https://kafka.apache.org/protocol#The_Messages_OffsetFetch
+            # https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-OffsetFetchRequest
+            request = OffsetFetchRequest[1](consumer_group, list(tps.iteritems()))
             response = self._make_blocking_req(client, request, node_id=broker_id)
             for (topic, partition_offsets) in response.topics:
                 for partition, offset, _, error_code in partition_offsets:
@@ -504,15 +490,6 @@ class KafkaCheck(AgentCheck):
                     consumer_offsets[(topic, partition)] = offset
 
         return consumer_offsets
-
-    def _get_consumer_offset_request(self, client):
-        version = client.config.get('api_version')
-        request_idx = 1
-
-        if version < (0, 8, 2):
-            request_idx = 0
-
-        return OffsetFetchRequest[request_idx]
 
     def _should_zk(self, zk_hosts_ports, interval, kafka_collect=False):
         if not kafka_collect or not interval:


### PR DESCRIPTION
Problems:
 - Version checking was inconsistent and not exactly DRY.
 - An attempt was made to separate version checking from feature
   flagging, but the name _kafka_compatible() is misleading because its
   purpose is really to feature flag whether to check kafka for consumer
   offsets. In addition to a minimium broker version required, there's
   also a feature flag in the yaml config. So that abstraction could be
   clarified.
 - kafka-python already handles version checking, no need to
   explicitly do that. All we need to do is check the result that
   kafka-python stored.
 - the method that picked the OffsetFetchRequest version never hit the
   version 0 because it was buried under the verification that the
   broker was >= (0, 8, 2). Since this added confusion rather than
   clarity, I removed it.
 - in the future, there will be multiple features that are require
   various broker versions, for example checking for time-based offsets.
   So the long term solution will probably be a map plus clearer feature
   flags that are then combined to flip on/off various features of the
   check.

   I'm still working on exactly how the logic will flow for
   these new features, and that will make it more clear the best way to
   handle enabling/disabling features based on a combo of flags plus
   a consistent mappping of minimum required broker version for each
   feature.

   So for now I just simplified the code to make it more
   straightforward and readable.

Lastly, this also fixes a very minor bug where if someone built the latest version of the kafka 0.8.1 branch, then it would be above `0.8.1.1` so this check would treat it as supporting kafka-based storage of consumer offsets... the fix is to check for `>= (0, 8, 2)` rather than `> (0, 8, 1, 1)`.