### PR TITLE
[kafka_consumer] Use log module's native string interpolation

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -188,8 +188,8 @@ class KafkaCheck(AgentCheck):
         attempts = 0
         while not client.ready(node_id):
             if attempts > DEFAULT_KAFKA_RETRIES:
-                self.log.error("unable to connect to broker id: {} after {} attempts".format(
-                    node_id, DEFAULT_KAFKA_RETRIES))
+                self.log.error("unable to connect to broker id: %i after %i attempts",
+                               node_id, DEFAULT_KAFKA_RETRIES)
                 break
             attempts = attempts + 1
             delay = (2 ** attempts) + (random.randint(0, 1000) / 1000) * 0.01  # starting at 20 ms


### PR DESCRIPTION
trivial nit: This is considered a best practice for logging