### PR TITLE
Include consul_datacenter tag in service checks

### DIFF
--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 1.4.0 / 2018-05-11
 
 * [FEATURE] Hardcode the 8500 port in the Autodiscovery template. See [#1444][] for more information.
+* [FEATURE] Include consul_datacenter tag in service checks
 
 ## 1.3.0 / 2018-01-10
 

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -269,7 +269,7 @@ class ConsulCheck(AgentCheck):
         else:
             self.gauge("consul.peers", len(peers), tags=main_tags + ["mode:leader"])
 
-        service_check_tags = ['consul_url:{0}'.format(instance.get('url'))]
+        service_check_tags = main_tags + ['consul_url:{0}'.format(instance.get('url'))]
         perform_catalog_checks = instance.get('catalog_checks',
                                               self.init_config.get('catalog_checks'))
         perform_network_latency_checks = instance.get('network_latency_checks',

--- a/consul/tests/test_integration.py
+++ b/consul/tests/test_integration.py
@@ -65,7 +65,10 @@ def test_integration(aggregator, consul_cluster):
     aggregator.assert_metric('consul.peers', value=3)
 
     aggregator.assert_service_check('consul.check')
-    aggregator.assert_service_check('consul.up')
+    aggregator.assert_service_check('consul.up', tags=[
+        'consul_datacenter:dc1',
+        'consul_url:{}'.format(common.URL)
+    ])
 
 
 @pytest.mark.integration


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Includes the `consul_datacenter` tag in service checks.

### Motivation

We have an alert set up for the service check `consul.up`, individual by host. We had a network event which segmented off a node, triggering a leader election. Consul recovered in a few minutes, but the alert never resolved.

Looks like this was because the service check never fired on that host again, because it was no longer the leader: https://github.com/DataDog/integrations-core/blob/master/consul/datadog_checks/consul/consul.py#L264

When we went in to configure a new group alert fo service checks by consul_datacenter, rather than individually by host, we realized that tag hadn't been set on the service checks.

### Versioning
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.

