### PR TITLE
Add a service_blacklist configuration to ensure certain services never have metrics collected

### DIFF
--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.5.0 / Unreleased
 
 * [FEATURE] Introduce a check at `consul.catalog.total_nodes` as a count of all nodes registered in the cluster
+* [FEATURE] Add a service_blacklist to ensure that certain services will never have metrics logged
 
 ## 1.4.0 / 2018-05-11
 

--- a/consul/conf.yaml.example
+++ b/consul/conf.yaml.example
@@ -57,6 +57,14 @@ instances:
       # If you'd rather not maintain a whitelist, you can increase the maximum
       # number of queried services
       # max_services: 50
+      #
+      # Services to always remove from querying
+      # If you have services you never want to see in results, you can remove
+      # them here.
+      # This takes precedence over both max_services and service_whitelist
+      # service_blacklist:
+      #   - memcached
+      #   - mcrouter
 
       # Additional tags to apply to the metrics, events and service checks
       # You should always specify tags when multiple instances of the check run

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -180,7 +180,7 @@ def test_cull_services_list(aggregator):
     assert len(consul_check._cull_services_list(services, whitelist)) == consul_check.MAX_SERVICES
 
     # Big whitelist with max_services
-    assert len(consul_check._cull_services_list(services, whitelist, max_services)) == max_services
+    assert len(consul_check._cull_services_list(services, whitelist, max_services=max_services)) == max_services
 
     # Whitelist < MAX_SERVICES should spit out the whitelist
     whitelist = ['service_{0}'.format(k) for k in range(consul_check.MAX_SERVICES - 1)]
@@ -188,7 +188,7 @@ def test_cull_services_list(aggregator):
 
     # Whitelist < max_services param should spit out the whitelist
     whitelist = ['service_{0}'.format(k) for k in range(max_services - 1)]
-    assert set(consul_check._cull_services_list(services, whitelist, max_services)) == set(whitelist)
+    assert set(consul_check._cull_services_list(services, whitelist, max_services=max_services)) == set(whitelist)
 
     # No whitelist, still triggers truncation
     whitelist = []
@@ -196,7 +196,7 @@ def test_cull_services_list(aggregator):
 
     # No whitelist with max_services set, also triggers truncation
     whitelist = []
-    assert len(consul_check._cull_services_list(services, whitelist, max_services)) == max_services
+    assert len(consul_check._cull_services_list(services, whitelist, max_services=max_services)) == max_services
 
     # Num. services < MAX_SERVICES should be no-op in absence of whitelist
     num_services = consul_check.MAX_SERVICES - 1
@@ -211,11 +211,16 @@ def test_cull_services_list(aggregator):
     num_services = max_services - 1
     whitelist = []
     services = consul_mocks.mock_get_n_services_in_cluster(num_services)
-    assert len(consul_check._cull_services_list(services, whitelist, max_services)) == num_services
+    assert len(consul_check._cull_services_list(services, whitelist, max_services=max_services)) == num_services
 
     # Num. services < max_services should spit out only the whitelist when one is defined
     whitelist = ['service_1', 'service_2', 'service_3']
-    assert set(consul_check._cull_services_list(services, whitelist, max_services)) == set(whitelist)
+    assert set(consul_check._cull_services_list(services, whitelist, max_services=max_services)) == set(whitelist)
+
+    # blacklist should override whitelist
+    whitelist = ['service_1', 'service_2']
+    blacklist = ['service_1']
+    assert set(consul_check._cull_services_list(services, whitelist, blacklist, max_services)) == set(['service_2'])
 
 
 def test_new_leader_event(aggregator):

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -217,10 +217,11 @@ def test_cull_services_list(aggregator):
     whitelist = ['service_1', 'service_2', 'service_3']
     assert set(consul_check._cull_services_list(services, whitelist, max_services=max_services)) == set(whitelist)
 
-    # blacklist should override whitelist
+    # whitelist should override blacklist
     whitelist = ['service_1', 'service_2']
     blacklist = ['service_1']
-    assert set(consul_check._cull_services_list(services, whitelist, blacklist, max_services)) == set(['service_2'])
+    assert set(consul_check._cull_services_list(services, whitelist, blacklist, max_services)) \
+        == set(['service_1', 'service_2'])
 
 
 def test_new_leader_event(aggregator):


### PR DESCRIPTION
…r have metrics collected.

Closes #1186

<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Addsa service_blacklist configuration to ensure certain services never have metrics collected

### Motivation

I was on a role making consul changes and saw https://github.com/DataDog/integrations-core/issues/1186 so I tackled it



### Versioning
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title

