### PR TITLE
[process] Use` ls /proc/<PID>/fd` alternative to collect open_fd metrics

### DIFF
--- a/process/README.md
+++ b/process/README.md
@@ -39,16 +39,10 @@ To have the check search for processes in a path other than `/proc`, set `procfs
 
 Some process metrics require either running the datadog collector as the same user as the monitored process or privileged access to be retrieved.
 Where the former option is not desired, and to avoid running the datadog collector as `root`, the `try_sudo` option lets the process check try using `sudo` to collect this metric.
-As of now, only the `open_fd` metric on Unix platforms is taking advantage of this setting.
+As of now, only the `open_file_descriptors` metric on Unix platforms is taking advantage of this setting.
 Note: the appropriate sudoers rules have to be configured for this to work, e.g. if packaged as a wheel archive with the datadog agent
 ```
-dd-agent ALL=NOPASSWD: /opt/datadog-agent/embedded/bin/python /opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/process/process.py num_fds *
-dd-agent ALL=NOPASSWD: /opt/datadog-agent/embedded/bin/python /opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/process/process.pyc num_fds *
-```
-Before agent v5.22 and v6.0, integrations were not packaged as wheel archives and the path to the check was a little different:
-```
-dd-agent ALL=NOPASSWD: /opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/checks.d/process.py num_fds *
-dd-agent ALL=NOPASSWD: /opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/checks.d/process.pyc num_fds *
+dd-agent ALL=NOPASSWD: /bin/ls /proc/*/fd/
 ```
 
 See the [example configuration][3] for more details on configuration options.

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -19,13 +19,6 @@ from config import _is_affirmative
 from utils.platform import Platform
 
 
-# Main entry point is meant for checks needing privilege escalation with sudo
-if __name__ == "__main__":
-    if sys.argv[1] == "num_fds":
-        print psutil.Process(int(sys.argv[2])).num_fds()
-    sys.exit(0)
-
-
 DEFAULT_AD_CACHE_DURATION = 120
 DEFAULT_PID_CACHE_DURATION = 120
 
@@ -214,7 +207,7 @@ class ProcessCheck(AgentCheck):
             if method == 'num_fds' and Platform.is_unix() and try_sudo:
                 try:
                     # It is up the agent's packager to grant corresponding sudo policy on unix platforms
-                    result = int(subprocess.check_output(['sudo', sys.executable, __file__, method, str(process.pid)]))
+                    result = int(subprocess.check_output('sudo ls /proc/{}/fd/ | wc -l'.format(process.pid), shell=True))
                 except subprocess.CalledProcessError as e:
                     self.log.exception("running psutil method %s with sudo failed with return code %d", method, e.returncode)
                 except:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

The previous implementation was using sudo to execute python to run the process check in order to retrieve `open_file_descriptors` metric. This solution was only working for Agent5. This PR gives `ls` sudo access to the `/proc/<PID>/fd` directory and can collect `open_fd` metrics.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

Add the following line to your sudoer rules `dd-agent ALL=NOPASSWD: /bin/ls /proc/*/fd/`.

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
