### PR TITLE
[nginx] log warning, not exception, when trying to collect stream metrics

### DIFF
--- a/nginx/CHANGELOG.md
+++ b/nginx/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.2.0 / Unreleased
 
 * [FEATURE] Add support for VTS module. See [#1295](https://github.com/DataDog/integrations-core/pull/1295). Thanks [mattjbray](https://github.com/mattjbray)
+* [IMPROVEMENT] Log a warning instead of an exception when trying to collect stream metrics but stream may not be configured.
 
 ## 2.1.0 / 2018-05-11
 

--- a/nginx/datadog_checks/nginx/__about__.py
+++ b/nginx/datadog_checks/nginx/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '2.0.0'
+__version__ = '2.1.0'

--- a/nginx/datadog_checks/nginx/__about__.py
+++ b/nginx/datadog_checks/nginx/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '2.1.0'
+__version__ = '2.2.0'

--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -287,9 +287,9 @@ class Nginx(AgentCheck):
 
     @classmethod
     def _flatten_json(cls, metric_base, val, tags):
-        ''' Recursively flattens the nginx json object. Returns the following:
-            [(metric_name, value, tags)]
-        '''
+        """
+        Recursively flattens the nginx json object. Returns the following: [(metric_name, value, tags)]
+        """
         output = []
 
         if isinstance(val, dict):

--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -232,7 +232,11 @@ class Nginx(AgentCheck):
             r = self._perform_request(instance, url, ssl_validation, auth)
             payload = self._nest_payload(nest, r.json())
         except Exception as e:
-            self.log.exception("Error querying %s metrics at %s: %s", endpoint, url, e)
+            if endpoint == "stream/server_zones" or endpoint == "stream/upstreams":
+                self.log.warning("Stream may not be initialized. "
+                                 "Error querying {} metrics at {}: {}".format(endpoint, url, e))
+            else:
+                self.log.exception("Error querying {} metrics at {}: {}".format(endpoint, url, e))
 
         return payload
 


### PR DESCRIPTION
### What does this PR do?

This PR will cause a warning to be logged instead if an error occurs when trying to collect stream metrics.

### Motivation

Streams are not configured by default in NGINX which causes exceptions to be logged when trying to collect stream metrics. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md) is available in our contribution guidelines.

### Versioning

- [x] Bumped the check version in `manifest.json`
- [x] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [x] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [x] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

We may instead want to allow the user to choose whether or not they want:

1. no log message if stream isn't up
2. warning when check fails (what this PR does)
3. exception when check fails (originally how it was)
