### PR TITLE
Added contributing instructions, cleaned up PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,43 +1,16 @@
-<!--
-
-This issue queue is primarily intended for tracking features, bugs and work items associated with
-the Datadog Agent open-source project.
-
-Prior to submitting an issue please review the following:
-
-- [ ] [Troubleshooting](https://datadog.zendesk.com/hc/en-us/sections/200766955-Troubleshooting) section of our [Knowledge base](https://datadog.zendesk.com/hc/en-us).
-- [ ] Contact our [support](http://docs.datadoghq.com/help/) and [send them your logs](https://github.com/DataDog/dd-agent/wiki/Send-logs-to-support).
-- [ ] Finally, you can open a Github issue respecting this [title convention](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md#commits-titles) (it helps us triage).
-
-If you are reporting a new issue, make sure that we do not have any duplicates
-already open. You can ensure this by searching the issue list for this
-repository. If there is a duplicate, please close your issue and add a comment
-to the existing issue instead.
-
-If you suspect your issue is a bug, please edit your issue description to
-include the BUG REPORT INFORMATION shown below.
-
----------------------------------------------------
-BUG REPORT INFORMATION
----------------------------------------------------
-Use the commands below to provide key information from your environment:
-You do NOT have to include this information if this is a FEATURE REQUEST
--->
 
 **Output of the [info page](https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information)**
 
-```
+```text
 (paste your output here)
 ```
 
 **Additional environment details (Operating System, Cloud provider, etc):**
 
-
 **Steps to reproduce the issue:**
 1.
 2.
 3.
-
 
 **Describe the results you received:**
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,3 @@
-<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
-if you have not yet done so.* -->
-
 ### What does this PR do?
 
 A brief description of the change being made with this pull request.
@@ -14,13 +11,13 @@ What inspired you to submit this pull request?
 An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
 is available in our contribution guidelines.
 
-### Versioning
+### Review checklist
 
-- [ ] Bumped the check version in `manifest.json`
-- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
-- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
-  for the new section.
-- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 
+- [ ] PR has a meaningful title or PR has the `documentation/no-changelog` label attached
+- [ ] Feature or bugfix has tests
+- [ ] Git history is clean
+- [ ] If PR impacts documentation, docs team has been notified or an issue has
+      been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
 
 ### Additional Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to Datadog Agent
+
+First of all, thanks for contributing!
+
+This document provides some basic guidelines for contributing to this repository.
+To propose improvements, feel free to submit a PR.
+
+## Submitting issues
+
+* If you think you've found an issue, please search the [Troubleshooting][troubleshooting]
+  section of our [Knowledge base][kb] to see if it's known.
+* If you can't find anything useful, please contact our [support][support] and
+  [send them your logs][flare].
+* Finally, you can open a Github issue.
+
+## Pull Requests
+
+Have you fixed a bug or written a new check and want to share it? Many thanks!
+
+In order to ease/speed up our review, here are some items you can check/improve
+when submitting your PR:
+
+* have a [proper commit history](#commits) (we advise you to rebase if needed).
+* write tests for the code you wrote.
+* make sure that all tests pass locally.
+* summarize your PR with an explanatory title and a message describing your
+  changes, cross-referencing any related bugs/PRs. **Please note PR title will
+  be used to compile the CHANGELOG file, so it has to be concise but explanatory**.
+
+Your pull request must pass all CI tests before we will merge it. If you're seeing
+an error and don't think it's your fault, it may not be! [Join us on Slack][slack]
+or send  us an email, and together we'll get it sorted out.
+
+### Keep it small, focused
+
+Avoid changing too many things at once. For instance if you're fixing two different
+checks at once, it makes reviewing harder and the _time-to-release_ longer.
+
+### Commit Messages
+
+Please don't be this person: `git commit -m "Fixed stuff"`. Take a moment to
+write meaningful commit messages.
+
+The commit message should describe the reason for the change and give extra details
+that will allow someone later on to understand in 5 seconds the thing you've been
+working on for a day.
+
+If your commit is only shipping documentation changes or example files, and is a
+complete no-op for the test suite, please prepend the commit message with the
+string `[skip ci]` to skip the build and test and give that slot to someone else
+who does need it.
+
+### Squash your commits
+
+Please rebase your changes on `master` and squash your commits whenever possible,
+it keeps history cleaner and it's easier to revert things. It also makes developers
+happier!
+
+## Integrations Extras
+
+For new integrations, please open a pull request in the [integrations-extras][extras] repo.
+
+[troubleshooting]: https://datadog.zendesk.com/hc/en-us/sections/200766955-Troubleshooting
+[kb]: https://datadog.zendesk.com/hc/en-us
+[support]: http://docs.datadoghq.com/help/
+[flare]: https://docs.datadoghq.com/agent/troubleshooting/#send-a-flare
+[extras]: https://github.com/DataDog/integrations-extras
+[slack]: http://datadoghq.slack.com


### PR DESCRIPTION
### What does this PR do?

Removed stale links to contributing guides from the Github templates. Add a brand new CONTRIBUTING.md file heavily based on the one from `datadog-agent`.
