### PR TITLE
Increase the timeout in the containers

### DIFF
--- a/mysql/tests/compose/maria.yaml
+++ b/mysql/tests/compose/maria.yaml
@@ -50,7 +50,7 @@ services:
       - ${WAIT_FOR_IT_SCRIPT_PATH}:/usr/local/bin/wait-for-it.sh
     depends_on:
       - "mysql-slave"
-    command: ["wait-for-it.sh", "mysql-master:3306", "-t", "30", "--", "setup_mysql.sh"]
+    command: ["wait-for-it.sh", "mysql-master:3306", "-t", "120", "--", "setup_mysql.sh"]
 
 
 networks:

--- a/mysql/tests/compose/mysql.yaml
+++ b/mysql/tests/compose/mysql.yaml
@@ -22,7 +22,7 @@ services:
       - ${WAIT_FOR_IT_SCRIPT_PATH}:/usr/local/bin/wait-for-it.sh
     networks:
       - network1
-    command: ["wait-for-it.sh", "mysql-master:3306", "-t", "30", "--", "replication-entrypoint.sh", "mysqld"]
+    command: ["wait-for-it.sh", "mysql-master:3306", "-t", "120", "--", "replication-entrypoint.sh", "mysqld"]
     depends_on:
       - "mysql-master"
 
@@ -37,7 +37,7 @@ services:
       - ${WAIT_FOR_IT_SCRIPT_PATH}:/usr/local/bin/wait-for-it.sh
     depends_on:
       - "mysql-slave"
-    command: ["wait-for-it.sh", "mysql-master:3306", "-t", "30", "--", "setup_mysql.sh"]
+    command: ["wait-for-it.sh", "mysql-master:3306", "-t", "120", "--", "setup_mysql.sh"]
 
 
 networks:

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -38,9 +38,8 @@ def wait_for_mysql():
             connected = True
             return True
         except Exception as e:
-            log.debug("exception: {0}".format(e))
+            log.debug("exception: {}".format(e))
             time.sleep(2)
-            pass
 
     return connected
 

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -19,7 +19,7 @@ def wait_for_mysql():
     Wait for the slave to connect to the master
     """
     connected = False
-    for i in xrange(0, 50):
+    for i in xrange(0, 100):
         try:
             pymysql.connect(
                 host=common.HOST,
@@ -38,9 +38,9 @@ def wait_for_mysql():
             connected = True
             return True
         except Exception as e:
-            pass
             log.debug("exception: {0}".format(e))
             time.sleep(2)
+            pass
 
     return connected
 
@@ -70,6 +70,18 @@ def spin_up_mysql():
     subprocess.check_call(args + ["up", "-d"], env=env)
     # wait for the cluster to be up before yielding
     if not wait_for_mysql():
+        containers = [
+            "compose_mysql-master_1",
+            "compose_mysql-slave_1",
+            "compose_mysql-setup_1",
+        ]
+        for container in containers:
+            args = [
+                "docker",
+                "logs",
+                container,
+            ]
+            subprocess.check_call(args, env=env)
         raise Exception("not working")
     yield
     subprocess.check_call(args + ["down"], env=env)

--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -20,7 +20,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt
-    pytest -v -r apP --log-level info
+    pytest -v
 
 [testenv:mysql55]
 deps = {[common]deps}

--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -20,7 +20,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt
-    pytest -v
+    pytest -v -r apP --log-level info
 
 [testenv:mysql55]
 deps = {[common]deps}


### PR DESCRIPTION
### What does this PR do?

The mysql containers have a timeout in their wait scripts. I think the timeout is too low and is causing flakes. Increasing this timeout should resolve at least some of the flakes.

