### PR TITLE
Convert port to a string before calling get_subprocess_output

### DIFF
--- a/cassandra_nodetool/datadog_checks/cassandra_nodetool/cassandra_nodetool.py
+++ b/cassandra_nodetool/datadog_checks/cassandra_nodetool/cassandra_nodetool.py
@@ -58,7 +58,7 @@ class CassandraNodetoolCheck(AgentCheck):
 
         for keyspace in keyspaces:
             # Build the nodetool command
-            cmd = nodetool_cmd + ['-h', host, '-p', port]
+            cmd = nodetool_cmd + ['-h', host, '-p', str(port)]
             if username and password:
                 cmd += ['-u', username, '-pw', password]
             cmd += ['status', '--', keyspace]

--- a/cassandra_nodetool/test/test_cassandra_nodetool.py
+++ b/cassandra_nodetool/test/test_cassandra_nodetool.py
@@ -58,6 +58,16 @@ class TestCassandraNodetoolCheck(AgentCheckTest):
         self.assertServiceCheckOK('cassandra.nodetool.node_up', count=4)
         self.assertServiceCheckCritical('cassandra.nodetool.node_up', count=1)
 
+
+        # test port config
+        config_with_port = self.config.copy()
+        config_with_port['instances'][0]['port'] = 7199
+        self.run_check(config_with_port)
+
+        self.assertEquals(mock_output.call_args[0][0],
+                          ['docker', 'exec', CASSANDRA_CONTAINER_NAME, 'nodetool', '-h', 'localhost', '-p',
+                          '7199', '-u', 'controlRole', '-pw', 'QED', 'status', '--', 'test'])
+
     @attr(requires='cassandra_nodetool')
     def test_integration(self):
         self.run_check(self.config)


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where the `cassandra_nodetool` check breaks subtly when using a custom port by ensuring that the port is always treated as a string.

### Motivation

The default config example suggests that a custom port can be provided unquoted in the YAML. However, the port is passed to `get_subprocess_output` without being converted to a string fist. This results in the underlying call to `execv` complaining about types.

### Review checklist

- [ ] PR has a meaningful title or PR has the `documentation/no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has
      been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
