### PR TITLE
Add monotonic counts for some metrics

### DIFF
--- a/network/conf.yaml.default
+++ b/network/conf.yaml.default
@@ -20,5 +20,14 @@ instances:
     # For some people, this is fine, but others need more granular data
     # enable this option to get more granular data
     # combine_connection_states: no
+
+    # By default, most metrics are submitted as rates.
+    # However, some metrics like tcp/dup retransmissions and errors are
+    # better handled as counts.
+    # You can choose to enable either or both types of metrics.
+    # Count metrics will have '_count' added to the metric name.
+    # collect_rate_metrics: true
+    # collect_count_metrics: false
+
     # tags:
     #   - optional:tag1

--- a/network/conf.yaml.default
+++ b/network/conf.yaml.default
@@ -25,7 +25,7 @@ instances:
     # However, some metrics like tcp/dup retransmissions and errors are
     # better handled as counts.
     # You can choose to enable either or both types of metrics.
-    # Count metrics will have '_count' added to the metric name.
+    # Count metrics will have '.count' added to the metric name.
     # collect_rate_metrics: true
     # collect_count_metrics: false
 

--- a/network/conf.yaml.default
+++ b/network/conf.yaml.default
@@ -22,7 +22,7 @@ instances:
     # combine_connection_states: no
 
     # By default, most metrics are submitted as rates.
-    # However, some metrics like tcp/dup retransmissions and errors are
+    # However, some metrics like tcp/udp retransmissions and errors are
     # better handled as counts.
     # You can choose to enable either or both types of metrics.
     # Count metrics will have '.count' added to the metric name.

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -236,7 +236,7 @@ class Network(AgentCheck):
         if self._collect_rate_metrics:
             self.rate(metric, value, tags=tags)
         if self._collect_count_metrics:
-            self.monotonic_count('{}_count'.format(metric), value, tags=tags)
+            self.monotonic_count('{}.count'.format(metric), value, tags=tags)
 
     def _submit_devicemetrics(self, iface, vals_by_metric, tags):
         if iface in self._excluded_ifaces or (self._exclude_iface_re and self._exclude_iface_re.match(iface)):

--- a/network/metadata.csv
+++ b/network/metadata.csv
@@ -6,14 +6,21 @@ system.net.packets_in.error,gauge,,error,second,The number of packet receive err
 system.net.packets_out.count,gauge,,packet,second,The number of packets of data transmitted by the interface.,0,system,packets out
 system.net.packets_out.error,gauge,,error,second,The number of packet transmit errors detected by the device driver.,-1,system,pkts out err
 system.net.tcp.in_segs,gauge,,segment,second,The number of TCP segments received.,0,system,segs in
+system.net.tcp.in_segs.count,count,,segment,,Total number of received TCP segments.,0,system,segs in
 system.net.tcp.out_segs,gauge,,segment,second,The number of TCP segments transmitted.,0,system,segs out
+system.net.tcp.out_segs.count,count,,segment,,Total number of transmitted TCP segments.,0,system,segs out
 system.net.tcp.rcv_packs,gauge,,packet,second,The number of TCP packets received.,0,system,pkts rcvd
 system.net.tcp.retrans_packs,gauge,,packet,second,The number of TCP packets retransmitted.,0,system,pkts retrans
 system.net.tcp.retrans_segs,gauge,,segment,second,The number of TCP segments retransmitted.,0,system,segs retrans
+system.net.tcp.retrans_segs.count,count,,segment,,Total number of retransmitted TCP segments.,0,system,segs retrans
 system.net.tcp.sent_packs,gauge,,packet,second,The number of TCP packets transmitted.,0,system,pkts sent
 system.net.tcp.listen_overflows,gauge,,,,The number of times connections have overflowed the accept buffer. Available since Agent v5.14.0.,-1,system,tcp listen overflows
+system.net.tcp.listen_overflows.count,count,,,,Total number of times connections have overflowed the accept buffer.,-1,system,tcp listen overflows
 system.net.tcp.listen_drops,gauge,,,,The number of times connections have dropped out of listen. Available since Agent v5.14.0.,-1,system,tcp listen drops
+system.net.tcp.listen_drops.count,count,,,,Total number of times connections have dropped out of listen.,-1,system,tcp listen drops
 system.net.tcp.backlog_drops,gauge,,packet,,The number of packets dropped because there wasn't room in the TCP backlog. Available since Agent v5.14.0.,-1,system,tcp backlog drops
+system.net.tcp.backlog_drops.count,count,,packet,,Total number of packets dropped because there wasn't room in the TCP backlog.,-1,system,tcp backlog drops
+system.net.tcp.failed_retransmits.count,count,,packet,,Total number of packets that failed to be retransmitted.,-1,system,tcp failed retrans
 system.net.tcp4.closing,gauge,,connection,second,The number of TCP IPv4 closing connections. ,0,system,tcp4 closing
 system.net.tcp4.established,gauge,,connection,second,The number of TCP IPv4 closing connections. ,0,system,tcp4 established
 system.net.tcp4.listening,gauge,,connection,second,The number of TCP IPv4 listening connections. ,0,system,tcp4 listening
@@ -22,9 +29,16 @@ system.net.tcp6.closing,gauge,,connection,second,The number of TCP IPv6 closing 
 system.net.tcp6.established,gauge,,connection,second,The number of TCP IPv6 closing connections. ,0,system,tcp6 established
 system.net.tcp6.listening,gauge,,connection,second,The number of TCP IPv6 listening connections. ,0,system,tcp6 listening
 system.net.tcp6.opening,gauge,,connection,second,The number of TCP IPv6 opening connections. ,0,system,tcp6 opening
-system.net.udp.in_datagrams,gauge,,datagram,second,"The rate of UDP datagrams delivered to UDP users.",0,system,udp in datagrams
-system.net.udp.in_errors,gauge,,datagram,second,"The rate of received UDP datagrams that could not be delivered for reasons other than the lack of an application at the destination port.",-1,system,udp in errors
-system.net.udp.no_ports,gauge,,datagram,second,"The rate of received UDP datagrams for which there was no application at the destination port.",-1,system,udp no_ports
-system.net.udp.out_datagrams,gauge,,datagram,second,"The rate of UDP datagrams sent from this entity.",0,system,udp out datagrams
+system.net.udp.in_datagrams,gauge,,datagram,second,The rate of UDP datagrams delivered to UDP users.,0,system,udp in datagrams
+system.net.udp.in_datagrams.count,count,,datagram,,Total number of UDP datagrams delivered to UDP users.,0,system,udp in datagrams
+system.net.udp.in_errors,gauge,,datagram,second,The rate of received UDP datagrams that could not be delivered for reasons other than the lack of an application at the destination port.,-1,system,udp in errors
+system.net.udp.in_errors.count,count,,datagram,,Total number of received UDP datagrams that could not be delivered for reasons other than the lack of an application at the destination port.,-1,system,udp in errors
+system.net.udp.no_ports,gauge,,datagram,second,The rate of received UDP datagrams for which there was no application at the destination port.,-1,system,udp no_ports
+system.net.udp.no_ports.count,count,,datagram,,Total number of received UDP datagrams for which there was no application at the destination port.,-1,system,udp no_ports
+system.net.udp.out_datagrams,gauge,,datagram,second,The rate of UDP datagrams sent from this entity.,0,system,udp out datagrams
+system.net.udp.out_datagrams.count,count,,datagram,,Total number of UDP datagrams sent from this entity.,0,system,udp out datagrams
 system.net.udp.rcv_buf_errors,gauge,,error,second,The rate of UDP datagrams lost because there was no room in the receive buffer.,-1,system,udp rcv buf errs
+system.net.udp.rcv_buf_errors.count,count,,error,,Total number of UDP datagrams lost because there was no room in the receive buffer.,-1,system,udp rcv buf errs
 system.net.udp.snd_buf_errors,gauge,,error,second,The rate of UDP datagrams lost because there was no room in the send buffer.,-1,system,udp snd buf errs
+system.net.udp.snd_buf_errors.count,count,,error,,Total number of UDP datagrams lost because there was no room in the send buffer.,-1,system,udp snd buf errs
+system.net.udp.in_csum_errors.count,count,,error,,Total number of UDP datagrams that failed checksum verification.,-1,system,udp in csum errors


### PR DESCRIPTION
### What does this PR do?

Add monotonic counts for tcp segments and udp datagrams. This allows more
precise counting of incoming and outgoing segments and datagrams for a given
time period.

The following metrics are affected:
- system.net.tcp.retrans_segs
- system.net.tcp.in_segs
- system.net.tcp.out_segs
- system.net.udp.in_datagrams
- system.net.udp.no_ports
- system.net.udp.in_errors
- system.net.udp.out_datagrams
- system.net.udp.rcv_buf_errors
- system.net.udp.snd_buf_errors
- system.net.tcp.retrans_packs
- system.net.tcp.sent_packs
- system.net.tcp.rcv_packs

For backwards compatibility, the new metrics are suffixed with `.count`.

I've also added the ability to enable/disable rate-based and count-based metrics per the discussion in DataDog/dd-agent#2630

### Motivation

This fixes DataDog/dd-agent#2630. It allows graphing and alerting on the precise number of segments, datagrams, or errors in a set time period.

### Review checklist

- [ ] PR has a meaningful title or PR has the `documentation/no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has
      been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

It may be useful to warn if users accidentally disable both types of metrics, but I wasn't sure if that was necessary.

I also did not add counts for the `bytes_rcvd`, `bytes_sent`, `packets_in`, and `packets_out` metric. Counts could be useful, but rates seem more appropriate. Also, the naming of `packets_in.count` doesn't help.

I've also been debating switching the suffix to `.count` instead of `_count`, as it seems more appropriate.

Finally, I was not sure if I need to update `metadata.csv`. 
