### PR TITLE
Metric for unallocated bytes

### DIFF
--- a/btrfs/datadog_checks/btrfs/btrfs.py
+++ b/btrfs/datadog_checks/btrfs/btrfs.py
@@ -52,9 +52,16 @@ FLAGS_MAPPER = defaultdict(lambda:  (SINGLE, UNKNOWN), {
 })
 
 BTRFS_IOC_SPACE_INFO = 0xc0109414
+BTRFS_IOC_DEV_INFO = 0xd000941e
+BTRFS_IOC_FS_INFO = 0x8400941f
 
 TWO_LONGS_STRUCT = struct.Struct("=2Q")  # 2 Longs
 THREE_LONGS_STRUCT = struct.Struct("=3Q")  # 3 Longs
+
+# https://github.com/thorvalds/linux/blob/master/include/uapi/linux/btrfs.h#L173
+# https://github.com/thorvalds/linux/blob/master/include/uapi/linux/btrfs.h#L182
+BTRFS_DEV_INFO_STRUCT = struct.Struct("=Q16B381Q1024B")
+BTRFS_FS_INFO_STRUCT = struct.Struct("=2Q16B4I122Q")
 
 
 def sized_array(count):
@@ -82,14 +89,9 @@ class FileDescriptor(object):
 class BTRFS(AgentCheck):
 
     def __init__(self, name, init_config, agentConfig, instances=None):
-        AgentCheck.__init__(
-            self, name, init_config,
-            agentConfig, instances=instances
-        )
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances=instances)
         if instances is not None and len(instances) > 1:
-            raise Exception(
-                "BTRFS check only supports one configured instance."
-            )
+            raise Exception("BTRFS check only supports one configured instance.")
 
     def get_usage(self, mountpoint):
         results = []
@@ -103,25 +105,51 @@ class BTRFS(AgentCheck):
             _, total_spaces = TWO_LONGS_STRUCT.unpack(ret)
 
             # Allocate it
-            buffer_size = (
-                TWO_LONGS_STRUCT.size + total_spaces
-                * THREE_LONGS_STRUCT.size
-            )
+            buffer_size = TWO_LONGS_STRUCT.size + total_spaces * THREE_LONGS_STRUCT.size
 
             data = sized_array(buffer_size)
             TWO_LONGS_STRUCT.pack_into(data, 0, total_spaces, 0)
             fcntl.ioctl(fd, BTRFS_IOC_SPACE_INFO, data)
 
         _, total_spaces = TWO_LONGS_STRUCT.unpack_from(ret, 0)
-        for offset in xrange(TWO_LONGS_STRUCT.size,
-                             buffer_size,
-                             THREE_LONGS_STRUCT.size):
-
+        for offset in xrange(TWO_LONGS_STRUCT.size, buffer_size, THREE_LONGS_STRUCT.size):
             # https://github.com/spotify/linux/blob/master/fs/btrfs/ioctl.h#L40-L44
-            flags, total_bytes, used_bytes =THREE_LONGS_STRUCT.unpack_from(data, offset) # noqa E501
+            flags, total_bytes, used_bytes = THREE_LONGS_STRUCT.unpack_from(data, offset)
             results.append((flags, total_bytes, used_bytes))
 
         return results
+
+    def get_unallocated_space(self, mountpoint):
+        unallocated_bytes = 0
+
+        with FileDescriptor(mountpoint) as fd:
+
+            # Retrieve the fs info to get the number of devices and max device id
+            fs_info = sized_array(BTRFS_FS_INFO_STRUCT.size)
+            fcntl.ioctl(fd, BTRFS_IOC_FS_INFO, fs_info)
+            fs_info = BTRFS_FS_INFO_STRUCT.unpack_from(fs_info, 0)
+            max_id, num_devices = fs_info[0], fs_info[1]
+
+            # Loop through all devices, and sum the number of unallocated bytes on each one
+            for dev_id in xrange(max_id + 1):
+                if num_devices == 0:
+                    break
+                try:
+                    dev_info = sized_array(BTRFS_DEV_INFO_STRUCT.size)
+                    BTRFS_DEV_INFO_STRUCT.pack_into(dev_info, 0, dev_id, *([0] * 1421))
+                    fcntl.ioctl(fd, BTRFS_IOC_DEV_INFO, dev_info)
+                    dev_info = BTRFS_DEV_INFO_STRUCT.unpack_from(dev_info, 0)
+
+                    unallocated_bytes = unallocated_bytes + dev_info[18] - dev_info[17]
+                    num_devices = num_devices - 1
+
+                except IOError as e:
+                    self.log.debug("Cannot get device info for device id %s: %s", dev_id, e)
+
+            if num_devices != 0:
+                # Could not retrieve the info for all the devices, skip the metric
+                return None
+        return unallocated_bytes
 
     def check(self, instance):
         btrfs_devices = {}
@@ -129,8 +157,7 @@ class BTRFS(AgentCheck):
         custom_tags = instance.get('tags', [])
 
         for p in psutil.disk_partitions():
-            if (p.fstype == 'btrfs' and p.device not in btrfs_devices
-                    and p.device not in excluded_devices):
+            if p.fstype == 'btrfs' and p.device not in btrfs_devices and p.device not in excluded_devices:
                 btrfs_devices[p.device] = p.mountpoint
 
         if len(btrfs_devices) == 0:
@@ -140,27 +167,26 @@ class BTRFS(AgentCheck):
             for flags, total_bytes, used_bytes in self.get_usage(mountpoint):
                 replication_type, usage_type = FLAGS_MAPPER[flags]
                 tags = [
-                    'usage_type:{0}'.format(usage_type),
-                    'replication_type:{0}'.format(replication_type),
+                    'usage_type:{}'.format(usage_type),
+                    'replication_type:{}'.format(replication_type),
+                    "device:{}".format(device)
                 ]
                 tags.extend(custom_tags)
 
                 free = total_bytes - used_bytes
                 usage = float(used_bytes) / float(total_bytes)
 
-                self.gauge(
-                    'system.disk.btrfs.total', total_bytes,
-                    tags=tags, device_name=device
-                )
-                self.gauge(
-                    'system.disk.btrfs.used', used_bytes,
-                    tags=tags, device_name=device
-                )
-                self.gauge(
-                    'system.disk.btrfs.free',
-                    free, tags=tags, device_name=device
-                )
-                self.gauge(
-                    'system.disk.btrfs.usage',
-                    usage, tags=tags, device_name=device
+                self.gauge('system.disk.btrfs.total', total_bytes, tags=tags)
+                self.gauge('system.disk.btrfs.used', used_bytes, tags=tags)
+                self.gauge('system.disk.btrfs.free', free, tags=tags)
+                self.gauge('system.disk.btrfs.usage', usage, tags=tags)
+
+            unallocated_bytes = self.get_unallocated_space(mountpoint)
+            if unallocated_bytes is not None:
+                tags = ["device:{}".format(device)] + custom_tags
+                self.gauge("system.disk.btrfs.unallocated", unallocated_bytes, tags=tags)
+            else:
+                self.log.debug(
+                    "Could not retrieve the number of unallocated bytes for all devices,"
+                    " skipping metric for mountpoint {}".format(mountpoint)
                 )

--- a/btrfs/metadata.csv
+++ b/btrfs/metadata.csv
@@ -3,3 +3,4 @@ system.disk.btrfs.total,gauge,,byte,,The total amount of space on a device,0,btr
 system.disk.btrfs.used,gauge,,byte,,The used space on a device,-1,btrfs,btrfs disk used
 system.disk.btrfs.free,gauge,,byte,,The free space on a device,1,btrfs,btrfs disk free
 system.disk.btrfs.usage,gauge,,fraction,,The amount of space used on a device as a fraction of the total,-1,btrfs,btrfs disk usage
+system.disk.btrfs.unallocated,gauge,,byte,,The amount of unallocated space on a device,0,btrfs,btrfs unallocated


### PR DESCRIPTION
### What does this PR do?

- Add a new metric for unallocated bytes per device

### Motivation

Fixes #768 

### Testing Guidelines

Manually tested with vagrant box: https://github.com/akanto/vagrant/tree/master/vagrant-btrfs-centos7

### Review checklist

- [ ] PR has a meaningful title or PR has the `documentation/no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has
      been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?