### PR TITLE
[base] when running A6, mirror logging behavior

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/base.py
+++ b/datadog_checks_base/datadog_checks/checks/base.py
@@ -11,7 +11,8 @@ import unicodedata
 
 try:
     import datadog_agent
-    import ..log
+    from ..log import init_logging
+    init_logging()
 except ImportError:
     from ..stubs import datadog_agent
 

--- a/datadog_checks_base/datadog_checks/checks/base.py
+++ b/datadog_checks_base/datadog_checks/checks/base.py
@@ -11,36 +11,7 @@ import unicodedata
 
 try:
     import datadog_agent
-
-    class AgentLogHandler(logging.Handler):
-        """
-        This handler forwards every log to the Go backend allowing python checks to
-        log message within the main agent logging system.
-        """
-
-        def emit(self, record):
-            msg = self.format(record)
-            datadog_agent.log("(%s:%s) | %s" % (record.filename, record.lineno, msg), record.levelno)
-
-
-    def init_logging():
-        """
-        Initialize logging (set up forwarding to Go backend and sane defaults)
-        """
-        # Forward to Go backend
-        rootLogger = logging.getLogger()
-        rootLogger.addHandler(AgentLogHandler())
-        rootLogger.setLevel(_get_py_loglevel(datadog_agent.get_config('log_level')))
-
-        # `requests` (used in a lot of checks) imports `urllib3`, which logs a bunch of stuff at the info level
-        # Therefore, pre-emptively increase the default level of that logger to `WARN`
-        urllib_logger = logging.getLogger("requests.packages.urllib3")
-        urllib_logger.setLevel(logging.WARN)
-        urllib_logger.propagate = True
-
-
-    init_logging()
-
+    import ..log
 except ImportError:
     from ..stubs import datadog_agent
 

--- a/datadog_checks_base/datadog_checks/log.py
+++ b/datadog_checks_base/datadog_checks/log.py
@@ -56,6 +56,3 @@ def init_logging():
     urllib_logger = logging.getLogger("requests.packages.urllib3")
     urllib_logger.setLevel(logging.WARN)
     urllib_logger.propagate = True
-
-
-init_logging()


### PR DESCRIPTION
### What does this PR do?

This maintains the logic of https://github.com/DataDog/datadog-agent/blob/188e0d024e2bdcb7ff8e8323a60b2bfd494e370c/cmd/agent/dist/checks/__init__.py#L25-L52

Ensures this is called https://github.com/DataDog/integrations-core/blob/31f48dc88893fc1e4085e8e382fbbf8c477fd884/datadog_checks_base/datadog_checks/log.py#L61