### PR TITLE
[kafka_consumer] properly require checks base

### DIFF
--- a/kafka_consumer/setup.py
+++ b/kafka_consumer/setup.py
@@ -50,7 +50,7 @@ setup(
 
     # Run-time dependencies
     install_requires=get_requirements('requirements.in')+[
-        'datadog-checks-base',
+        'datadog_checks_base',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),


### PR DESCRIPTION
### What does this PR do?

It's now `datadog_checks_base`