### PR TITLE
Adding note for gitlab url CE

### DIFF
--- a/gitlab/conf.yaml.example
+++ b/gitlab/conf.yaml.example
@@ -114,6 +114,8 @@ init_config:
 
 instances:
     # Master URL to probe for service health status
+    # If you are using gitlab CE and not EE, use this url with
+    # the authorization token: http://localhost/?token=<TOKEN>
   - gitlab_url: http://localhost
 
     # url of the metrics endpoint of prometheus


### PR DESCRIPTION
A customer using the CE edition of gitlab, and not the EE, reached out to notify us that gitlab CE requires a token to be passed.
