### PR TITLE
[Fixed] Couchbase integration was not working during server set up

### DIFF
--- a/couchbase/datadog_checks/couchbase/couchbase.py
+++ b/couchbase/datadog_checks/couchbase/couchbase.py
@@ -399,6 +399,12 @@ class Couchbase(AgentCheck):
 
     # Takes a string with a time and a unit (e.g '3.45ms') and returns the value in seconds
     def extract_seconds_value(self, value):
+
+        # When couchbase is set up, most of values are equal to 0 and are exposed as "0" and not "0s"
+        # This statement is preventing values to be searched by the pattern (and break things)
+        if value == '0':
+            return 0
+
         match = self.seconds_value_pattern.search(value)
 
         val, unit = match.group(1, 3)

--- a/couchbase/datadog_checks/couchbase/couchbase.py
+++ b/couchbase/datadog_checks/couchbase/couchbase.py
@@ -260,11 +260,12 @@ class Couchbase(AgentCheck):
 
         for metric_name, val in data['query'].items():
             if val is not None:
-                # for query times, the unit is part of the value, we need to extract it
-                if isinstance(val, basestring):
-                    val = self.extract_seconds_value(val)
                 norm_metric_name = self.camel_case_to_joined_lower(metric_name)
                 if norm_metric_name in self.QUERY_STATS:
+                    # for query times, the unit is part of the value, we need to extract it
+                    if isinstance(val, basestring):
+                        val = self.extract_seconds_value(val)
+
                     full_metric_name = '.'.join(['couchbase', 'query',
                                                 self.camel_case_to_joined_lower(norm_metric_name)])
                     self.gauge(full_metric_name, val, tags=tags)

--- a/couchbase/tests/test_unit.py
+++ b/couchbase/tests/test_unit.py
@@ -35,6 +35,7 @@ def test_extract_seconds_value():
         '12ms': .012,
         '700.5us': .0007005,
         u'733.364\u00c2s': .000733364,
+        '0': 0,
     }
 
     for test_input, expected_output in EXTRACT_SECONDS_TEST_PAIRS.items():


### PR DESCRIPTION
### What does this PR do?

Fix the integration that would crash at the beginning of Couchbase usage, mostly during the set up or while there is no data inside the Couchbase database.

### Motivation

When couchbase was just set up, it was returning an unexpected value.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
