### PR TITLE
Remove explicit notice of testing with pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,6 @@ To run the testsuite for a given check you can either use `tox`, like:
 cd {integration} && tox
 ```
 
-or invoke [Pytest][9] directly:
-
-```shell
-cd {integration} && py.test
-```
-
 **Note:** only a subset of the checks can be tested like this. Porting all the
 checks to Pytest is a work in progress. There is an [updated list][14] of the
 checks supporting the new testing approach, for checks that are not listed there


### PR DESCRIPTION
### What does this PR do?

Removes the command about testing via py.test directly from the README. 

### Motivation

There are a number of integrations where we store the environment variables required to spin up docker compose. Running through pytest directly will cause those tests to fail when attempting to run `docker-compose up` The better/recommended scenario is to run tests via invoke or tox. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Doesn't need to go in the Changelog. 