### PR TITLE
Collect consumer groups by default

### DIFF
--- a/kafka_consumer/conf.yaml.example
+++ b/kafka_consumer/conf.yaml.example
@@ -49,6 +49,8 @@ instances:
     # ssl_keyfile: /path/to/key/file
     # ssl_password: password1
 
+    # Set monitor_unlisted_consumer_groups and kafka_consumer_offsets to True
+    # to collect consumer groups stored in Kafka (only for versions >0.9)
     # kafka_consumer_offsets: false
     consumer_groups:
       my_consumer:  # consumer group name

--- a/kafka_consumer/conf.yaml.example
+++ b/kafka_consumer/conf.yaml.example
@@ -29,8 +29,6 @@ instances:
   # If you wish to only collect consumer offsets from kafka, because
   # you're using the new style consumers, you can comment out all
   # zk_* configuration elements below.
-  # Please note that unlisted consumer groups are not supported at
-  # the moment when zookeeper consumer offset collection is disabled.
   - kafka_connect_str:
       - localhost:9092
       - another_kafka_broker:9092

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -82,7 +82,8 @@ class KafkaCheck(AgentCheck):
 
         # If monitor_unlisted_consumer_groups is True, fetch all groups stored in ZK
         consumer_groups = None
-        if instance.get('monitor_unlisted_consumer_groups', False):
+        monitor_unlisted = instance.get('monitor_unlisted_consumer_groups', False)
+        if monitor_unlisted:
             consumer_groups = None
         elif 'consumer_groups' in instance:
             consumer_groups = instance.get('consumer_groups')
@@ -107,7 +108,8 @@ class KafkaCheck(AgentCheck):
 
         if get_kafka_consumer_offsets:
             # If not using ZK, get consumer groups from Kafka (only for versions after 0.9)
-            if not zk_hosts_ports and not consumer_groups and cli.config.get('api_version') >= (0, 9):
+            if not zk_hosts_ports and not consumer_groups and\
+                cli.config.get('api_version') >= (0, 9) and monitor_unlisted:
                 consumer_groups = self._get_kafka_consumer_groups(cli, kafka_conn_str)
                 self._validate_explicit_consumer_groups(consumer_groups)
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -107,7 +107,7 @@ class KafkaCheck(AgentCheck):
 
         if get_kafka_consumer_offsets:
             # If not using ZK, get consumer groups from Kafka (only for versions after 0.9)
-            if not zk_hosts_ports and not consumer_groups and cli.config.get('api_version') >= (0, 9, 0):
+            if not zk_hosts_ports and not consumer_groups and cli.config.get('api_version') >= (0, 9):
                 consumer_groups = self._get_kafka_consumer_groups(cli, kafka_conn_str)
                 self._validate_explicit_consumer_groups(consumer_groups)
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -109,7 +109,7 @@ class KafkaCheck(AgentCheck):
         if get_kafka_consumer_offsets:
             # If not using ZK, get consumer groups from Kafka (only for versions after 0.9)
             if not zk_hosts_ports and not consumer_groups and\
-                cli.config.get('api_version') >= (0, 9) and monitor_unlisted:
+                    cli.config.get('api_version') >= (0, 9) and monitor_unlisted:
                 consumer_groups = self._get_kafka_consumer_groups(cli, kafka_conn_str)
                 self._validate_explicit_consumer_groups(consumer_groups)
 

--- a/kafka_consumer/tests/conftest.py
+++ b/kafka_consumer/tests/conftest.py
@@ -238,3 +238,12 @@ def kafka_instance():
             }
         }
     }
+
+
+@pytest.fixture
+def kafka_only_instance():
+    return {
+        'kafka_connect_str': KAFKA_CONNECT_STR,
+        'kafka_consumer_offsets': True,
+        'tags': ['optional:tag1']
+    }

--- a/kafka_consumer/tests/conftest.py
+++ b/kafka_consumer/tests/conftest.py
@@ -245,5 +245,6 @@ def kafka_only_instance():
     return {
         'kafka_connect_str': KAFKA_CONNECT_STR,
         'kafka_consumer_offsets': True,
-        'tags': ['optional:tag1']
+        'tags': ['optional:tag1'],
+        'monitor_unlisted_consumer_groups': True
     }

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -51,3 +51,31 @@ def test_check_kafka(kafka_cluster, kafka_producer, kafka_consumer, kafka_instan
 
     # let's reassert for the __consumer_offsets - multiple partitions
     aggregator.assert_metric('kafka.broker_offset', at_least=1)
+
+
+@pytest.mark.kafka
+def test_check_kafka_default_groups(kafka_cluster, kafka_producer, kafka_consumer, kafka_only_instance, aggregator):
+    """
+    Test kafka check with default consumer groups
+    """
+    if not is_supported(['kafka']):
+        pytest.skip("kafka consumer offsets not supported in current environment")
+
+    if not kafka_producer.is_alive():
+        kafka_producer.start()
+        time.sleep(5)
+
+    if not kafka_consumer.is_alive():
+        kafka_consumer.start()
+        time.sleep(5)
+
+    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, {})
+    kafka_consumer_check.check(kafka_only_instance)
+
+    for mname in BROKER_METRICS:
+        aggregator.assert_metric(mname, at_least=1)
+    for mname in CONSUMER_METRICS:
+        aggregator.assert_metric(mname, at_least=1)
+
+    # let's reassert for the __consumer_offsets - multiple partitions
+    aggregator.assert_metric('kafka.broker_offset', at_least=1)


### PR DESCRIPTION
### What does this PR do?

For Kafka versions >0.9, consumer offsets are stored directly in Kafka. If there are no manually configured consumer groups, and `kafka_consumer_offsets` is set to `true` in `conf.yaml`, we will collect consumer groups, topics, and partitions from kafka. 

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
