### PR TITLE
Use labels to compile the changelog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,20 @@ Have you fixed a bug or written a new check and want to share it? Many thanks!
 In order to ease/speed up our review, here are some items you can check/improve
 when submitting your PR:
 
-* have a [proper commit history](#commits) (we advise you to rebase if needed).
-* write tests for the code you wrote.
-* make sure that all tests pass locally.
-* summarize your PR with a meaningful title, [see later on this doc](#pull-request-title).
+* Have a [proper commit history](#commits) (we advise you to rebase if needed).
+* Write tests for the code you wrote.
+* Make sure that all tests pass locally.
+* Summarize your PR with a meaningful title, [see later on this doc](#pull-request-title).
+* Add the most suitable changelog label choosing one of the following:
+  * `changelog/Added` for new features.
+  * `changelog/Changed` for changes in existing functionality.
+  * `changelog/Deprecated` for soon-to-be removed features.
+  * `changelog/Removed` for now removed features.
+  * `changelog/Fixed` for any bug fixes.
+  * `changelog/Security` in case of vulnerabilities.
+  * `changelog/no-changelog` in case this PR should not appear in the changelog at all.
+
+See [here](https://keepachangelog.com/en/1.0.0/) for more details about changelogs.
 
 Your pull request must pass all CI tests before we will merge it. If you're seeing
 an error and don't think it's your fault, it may not be! [Join us on Slack][slack]
@@ -38,16 +48,7 @@ checks at once, it makes reviewing harder and the _time-to-release_ longer.
 
 Unless the PR is marked with the proper exclusion label, the title will be used
 to automatically fill the changelog entries. For this reason the title must be
-concise but explanatory and possibly marked with one of the following prefixes:
-
-* `[Added]` for new features.
-* `[Changed]` for changes in existing functionality.
-* `[Deprecated]` for soon-to-be removed features.
-* `[Removed]` for now removed features.
-* `[Fixed]` for any bug fixes.
-* `[Security]` in case of vulnerabilities.
-
-See [here](https://keepachangelog.com/en/1.0.0/) for more details about changelogs.
+concise but explanatory.
 
 ### Commit Messages
 

--- a/tasks/changelog.py
+++ b/tasks/changelog.py
@@ -21,7 +21,16 @@ from .utils import get_version_string, get_release_tag_string
 # match something like `(#1234)` and return `1234` in a group
 PR_REG = re.compile(r'\(\#(\d+)\)')
 
-NO_CHANGELOG_LABEL = 'no-changelog'
+CHANGELOG_LABEL_PREFIX = 'changelog/'
+CHANGELOG_TYPE_NONE = 'no-changelog'
+CHANGELOG_TYPES = [
+    'Added',
+    'Changed',
+    'Deprecated',
+    'Fixed',
+    'Removed',
+    'Security',
+]
 
 ChangelogEntry = namedtuple('ChangelogEntry', 'number, title, url, author, author_url, is_contributor')
 
@@ -103,15 +112,29 @@ def do_update_changelog(ctx, target, cur_version, new_version, dry_run=False):
             continue
 
         payload = json.loads(response.read())
-        if NO_CHANGELOG_LABEL in (l.get('name') for l in payload.get('labels', [])):
+        changelog_labels = []
+        for l in payload.get('labels', []):
+            name = l.get('name')
+            if name.startswith(CHANGELOG_LABEL_PREFIX):
+                # only add the name, e.g. for `changelog/Added` it's just `Added`
+                changelog_labels.append(name.split(CHANGELOG_LABEL_PREFIX)[1])
+
+        if not changelog_labels:
+            raise Exit("No valid changelog labels found attached to PR #{}, please add one".format(pr_num))
+        elif len(changelog_labels) > 1:
+            raise Exit("Multiple changelog labels found attached to PR #{}, please use only one".format(pr_num))
+
+        changelog_type = changelog_labels[0]
+        if changelog_type == CHANGELOG_TYPE_NONE:
             # No changelog entry for this PR
             print("Skipping PR #{} from changelog".format(pr_num))
             continue
 
         author = payload.get('user', {}).get('login')
         author_url = payload.get('user', {}).get('html_url')
+        title = '[{}] {}'.format(changelog_type, payload.get('title'))
 
-        entry = ChangelogEntry(pr_num, payload.get('title'), payload.get('html_url'),
+        entry = ChangelogEntry(pr_num, title, payload.get('html_url'),
                                author, author_url, is_contributor(payload))
 
         entries.append(entry)


### PR DESCRIPTION
### What does this PR do?

Use labels instead of relying solely on the PR title to compose a changelog line that includes the type of the change (new feature, bugfix, etc)

### Motivation

Easier to keep thing on track

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
