### PR TITLE
Log debug, not warning, for missing /proc/net/dev files

### DIFF
--- a/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py
+++ b/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py
@@ -759,9 +759,9 @@ class DockerDaemon(AgentCheck):
                         m_func(self, "docker.net.bytes_rcvd", long(x[0]), net_tags)
                         m_func(self, "docker.net.bytes_sent", long(x[8]), net_tags)
 
-        except Exception as e:
+        except IOError as e:
             # It is possible that the container got stopped between the API call and now
-            self.warning("Failed to report IO metrics from file {0}. Exception: {1}".format(proc_net_file, e))
+            self.log.debug("Cannot read network interface file, container likely raced to finish : {0}".format(e))
 
     def _invalidate_network_mapping_cache(self, api_events):
         for ev in api_events:


### PR DESCRIPTION
### What does this PR do?

Fixes #1582

### Motivation

Missing `/proc/<pid>/net/dev` files are entirely expected and should not be logged as warnings.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)