### PR TITLE
remove pytest-runner from setup_requires

### DIFF
--- a/active_directory/setup.py
+++ b/active_directory/setup.py
@@ -61,7 +61,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner'],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/apache/setup.py
+++ b/apache/setup.py
@@ -64,7 +64,6 @@ setup(
         'datadog_checks_base',
     ],
 
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/aspdotnet/setup.py
+++ b/aspdotnet/setup.py
@@ -60,7 +60,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner'],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/btrfs/setup.py
+++ b/btrfs/setup.py
@@ -56,7 +56,6 @@ setup(
     install_requires=get_requirements('requirements.in') + [
         'datadog_checks_base',
     ],
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/ceph/setup.py
+++ b/ceph/setup.py
@@ -58,7 +58,6 @@ setup(
         "datadog_checks_base"
     ],
 
-    setup_requires=["pytest_runner"],
 
     # Testing setup and dependencies
     tests_require=get_requirements("requirements-dev.txt"),

--- a/consul/setup.py
+++ b/consul/setup.py
@@ -57,7 +57,6 @@ setup(
     install_requires=get_requirements('requirements.in')+[
         'datadog_checks_base',
     ],
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/couch/setup.py
+++ b/couch/setup.py
@@ -60,7 +60,6 @@ setup(
     install_requires=get_requirements('requirements.in') + [
         'datadog_checks_base',
     ],
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/couchbase/setup.py
+++ b/couchbase/setup.py
@@ -60,7 +60,6 @@ setup(
     install_requires=get_requirements('requirements.in') + [
         'datadog_checks_base',
     ],
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/datadog_checks_base/setup.py
+++ b/datadog_checks_base/setup.py
@@ -51,6 +51,5 @@ setup(
 
     install_requires=get_requirements('requirements.in'),
 
-    setup_requires=['pytest-runner', ],
     tests_require=['pytest<4', ],
 )

--- a/datadog_checks_tests_helper/setup.py
+++ b/datadog_checks_tests_helper/setup.py
@@ -52,6 +52,5 @@ setup(
     include_package_data=True,
     install_requires=get_requirements('requirements.in'),
 
-    #setup_requires=['pytest-runner', ],
     tests_require=['pytest<4', ],
 )

--- a/directory/setup.py
+++ b/directory/setup.py
@@ -63,7 +63,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/disk/setup.py
+++ b/disk/setup.py
@@ -69,7 +69,6 @@ setup(
     },
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements(path.join('tests', 'requirements.txt')),
 
     # Extra files to ship with the wheel package

--- a/dotnetclr/setup.py
+++ b/dotnetclr/setup.py
@@ -61,7 +61,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner'],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/elastic/setup.py
+++ b/elastic/setup.py
@@ -59,7 +59,6 @@ setup(
         'datadog_checks_base',
     ],
 
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/envoy/setup.py
+++ b/envoy/setup.py
@@ -60,7 +60,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner'],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/exchange_server/setup.py
+++ b/exchange_server/setup.py
@@ -60,7 +60,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner'],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/haproxy/setup.py
+++ b/haproxy/setup.py
@@ -59,7 +59,6 @@ setup(
         'datadog_checks_base',
     ],
 
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/iis/setup.py
+++ b/iis/setup.py
@@ -60,7 +60,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner'],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/istio/setup.py
+++ b/istio/setup.py
@@ -60,7 +60,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements(path.join('tests', 'requirements.txt')),
 
     # Extra files to ship with the wheel package

--- a/kafka_consumer/setup.py
+++ b/kafka_consumer/setup.py
@@ -52,7 +52,6 @@ setup(
     install_requires=get_requirements('requirements.in')+[
         'datadog_checks_base',
     ],
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/kube_proxy/setup.py
+++ b/kube_proxy/setup.py
@@ -59,7 +59,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner',],
     tests_require=get_requirements(path.join('tests', 'requirements.txt')),
 
     # Extra files to ship with the wheel package

--- a/kubelet/setup.py
+++ b/kubelet/setup.py
@@ -60,7 +60,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements(path.join('tests', 'requirements.txt')),
 
     # Extra files to ship with the wheel package

--- a/kyototycoon/setup.py
+++ b/kyototycoon/setup.py
@@ -61,7 +61,6 @@ setup(
     install_requires=get_requirements('requirements.in') + [
         'datadog_checks_base',
     ],
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/lighttpd/setup.py
+++ b/lighttpd/setup.py
@@ -51,7 +51,6 @@ setup(
     install_requires=get_requirements('requirements.in')+[
         'datadog_checks_base',
     ],
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/linkerd/setup.py
+++ b/linkerd/setup.py
@@ -67,7 +67,6 @@ setup(
     },
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner',],
     tests_require=get_requirements(path.join('tests', 'requirements.txt')),
 
     # Extra files to ship with the wheel package

--- a/mcache/setup.py
+++ b/mcache/setup.py
@@ -51,7 +51,6 @@ setup(
     install_requires=get_requirements('requirements.in')+[
         'datadog_checks_base',
     ],
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/mysql/setup.py
+++ b/mysql/setup.py
@@ -58,7 +58,6 @@ setup(
     install_requires=get_requirements('requirements.in')+[
         'datadog_checks_base',
     ],
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/network/setup.py
+++ b/network/setup.py
@@ -58,7 +58,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/nfsstat/setup.py
+++ b/nfsstat/setup.py
@@ -60,7 +60,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner'],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/nginx/setup.py
+++ b/nginx/setup.py
@@ -61,7 +61,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner'],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/pdh_check/setup.py
+++ b/pdh_check/setup.py
@@ -62,7 +62,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner'],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/postgres/setup.py
+++ b/postgres/setup.py
@@ -53,7 +53,6 @@ setup(
     install_requires=get_requirements('requirements.in')+[
         'datadog_checks_base',
     ],
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/powerdns_recursor/setup.py
+++ b/powerdns_recursor/setup.py
@@ -61,7 +61,6 @@ setup(
         'datadog_checks_base',
     ],
 
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/prometheus/setup.py
+++ b/prometheus/setup.py
@@ -59,7 +59,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner',],
     tests_require=get_requirements(path.join('tests', 'requirements.txt')),
 
     # Extra files to ship with the wheel package

--- a/redisdb/setup.py
+++ b/redisdb/setup.py
@@ -51,7 +51,6 @@ setup(
     install_requires=get_requirements('requirements.in')+[
         'datadog_checks_base',
     ],
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/riak/setup.py
+++ b/riak/setup.py
@@ -58,7 +58,6 @@ setup(
     install_requires=get_requirements('requirements.in')+[
         'datadog_checks_base',
     ],
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/spark/setup.py
+++ b/spark/setup.py
@@ -60,7 +60,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner'],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/ssh_check/setup.py
+++ b/ssh_check/setup.py
@@ -60,7 +60,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner'],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/system_core/setup.py
+++ b/system_core/setup.py
@@ -60,7 +60,6 @@ setup(
     ],
 
     # Testing setup and dependencies
-    setup_requires=['pytest-runner'],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/teamcity/setup.py
+++ b/teamcity/setup.py
@@ -51,7 +51,6 @@ setup(
     install_requires=get_requirements('requirements.in')+[
         'datadog_checks_base',
     ],
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package

--- a/varnish/setup.py
+++ b/varnish/setup.py
@@ -60,7 +60,6 @@ setup(
         "datadog_checks_base",
     ],
 
-    setup_requires=["pytest-runner"],
     # Testing setup and dependencies
     tests_require=get_requirements("requirements-dev.txt"),
 

--- a/vsphere/setup.py
+++ b/vsphere/setup.py
@@ -51,7 +51,6 @@ setup(
     install_requires=get_requirements('requirements.in')+[
         'datadog_checks_base',
     ],
-    setup_requires=['pytest-runner', ],
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package


### PR DESCRIPTION
### Motivation

New PyPI requires HTTPS which `easy_install` doesn't support, thus breaking the developer installation of our integrations on many systems (including our A6 Gitlab). We've also never used `pytest-runner`.

https://bugzilla.redhat.com/show_bug.cgi?id=1510444
