### PR TITLE
fix tomcat auto_conf.yaml

### DIFF
--- a/tomcat/auto_conf.yaml
+++ b/tomcat/auto_conf.yaml
@@ -2,8 +2,8 @@ ad_identifiers:
   - tomcat
 
 init_config:
-  - is_jmx: true
-    collect_default_metrics: true
+  is_jmx: true
+  collect_default_metrics: true
 
 instances:
   - url: "%%host%%"

--- a/tomcat/auto_conf.yaml
+++ b/tomcat/auto_conf.yaml
@@ -6,5 +6,5 @@ init_config:
   collect_default_metrics: true
 
 instances:
-  - url: "%%host%%"
+  - host: "%%host%%"
     port: "9012"


### PR DESCRIPTION
### What does this PR do?

- `init_config` should not be an array but a dictionary.
-  [`url` should be `host` ](https://github.com/DataDog/integrations-core/blob/7bcaafbad17ea57f68a7b06020469d6f9eb40116/tomcat/conf.yaml.example#L2)

### Motivation

Working on jmx and stumbled on this.