### PR TITLE
Downgrade kafka-python to 1.3.4 to prevent DNS spikes when broker doesn't exist

### DIFF
--- a/kafka_consumer/requirements.in
+++ b/kafka_consumer/requirements.in
@@ -1,2 +1,2 @@
-kafka-python==1.4.2
+kafka-python==1.3.4
 kazoo==2.4.0

--- a/kafka_consumer/requirements.txt
+++ b/kafka_consumer/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --generate-hashes --output-file requirements.txt requirements.in
 #
-kafka-python==1.4.2 \
-    --hash=sha256:6a5c516f540f4b13b78c64a85dd42dc38fe29257e2fae6393fc5daff9106389b \
-    --hash=sha256:b5df584e200da5f814228a308a655c27d9c740ca83442910360c704679640a5f
+kafka-python==1.3.4 \
+    --hash=sha256:2cafc367f06c121fecb43bfd83d6b72423036924a7903a239199671a848d98b3 \
+    --hash=sha256:a84d9635e3a4d5054c342ad6e5b338f9438fbcac810b677a2f6da68a51fb66a8
 kazoo==2.4.0 \
     --hash=sha256:a29fa579812a2c5dd8241eafb8328b8a8673f140903a6102e017129aa223d0c7 \
     --hash=sha256:a7c2d1d7ddb047c936d368e31b08a93bb327ffa46606fe85f550a37ce608c29b


### PR DESCRIPTION
### What does this PR do?

Temporary downgrade `kafka-python` to version 1.3.4

### Motivation

We noticed a huge spike in the number of DNS calls coming from the check when a broker listed on the config file doesn't exist. While this is definitely a misconfiguration problem, we want to investigate the spike, reverting to a known state in the meantime.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
