### PR TITLE
Add Couchbase health and cluster membership service checks and alerts

### DIFF
--- a/couchbase/README.md
+++ b/couchbase/README.md
@@ -47,13 +47,24 @@ instances:
 See [metadata.csv](https://github.com/DataDog/integrations-core/blob/master/couchbase/metadata.csv) for a list of metrics provided by this integration.
 
 ### Events
-The Couchbase check does not include any events at this time.
+
+The Couchbase check emits an event to Datadog each time the cluster rebalances.
 
 ### Service Checks
 
-`couchbase.can_connect`:
+- `couchbase.can_connect`:
 
 Returns `Critical` if the Agent cannot connect to Couchbase to collect metrics.
+
+- `couchbase.by_node.cluster_membership`:
+
+Returns `Critical` if the node failed over.
+Returns `Warning` if the node is added to the cluster but is waiting for a rebalance.
+Returns `Ok` otherwise.
+
+- `couchbase.by_node.health_status`:
+
+Returns `Critical` if the node is unhealthy. Returns `Ok` otherwise.
 
 ## Troubleshooting
 Need help? Contact [Datadog Support](http://docs.datadoghq.com/help/).

--- a/couchbase/datadog_checks/couchbase/couchbase.py
+++ b/couchbase/datadog_checks/couchbase/couchbase.py
@@ -4,7 +4,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 # stdlib
+import time
 import re
+from collections import defaultdict
 
 # 3rd party
 import requests
@@ -12,6 +14,7 @@ import requests
 # project
 from datadog_checks.checks import AgentCheck
 from datadog_checks.utils.headers import headers
+from datadog_checks.utils.containers import hash_mutable
 
 # Constants
 COUCHBASE_STATS_PATH = '/pools/default'
@@ -20,10 +23,31 @@ DEFAULT_TIMEOUT = 10
 
 
 class Couchbase(AgentCheck):
-    """Extracts stats from Couchbase via its REST API
+    """
+    Extracts stats from Couchbase via its REST API
     http://docs.couchbase.com/couchbase-manual-2.0/#using-the-rest-api
     """
+
+    # Service Checks
     SERVICE_CHECK_NAME = 'couchbase.can_connect'
+    NODE_CLUSTER_SERVICE_CHECK_NAME = 'couchbase.by_node.cluster_membership'
+    NODE_HEALTH_SERVICE_CHECK_NAME = 'couchbase.by_node.health'
+
+    NODE_MEMBERSHIP_TRANSLATION = {
+        'active': AgentCheck.OK,
+        'inactiveAdded': AgentCheck.WARNING,
+        'activeFailed': AgentCheck.CRITICAL,
+        None: AgentCheck.UNKNOWN
+    }
+
+    NODE_HEALTH_TRANSLATION = {
+        'healthy': AgentCheck.OK,
+        'warmup': AgentCheck.OK,
+        'unhealthy': AgentCheck.CRITICAL,
+        None: AgentCheck.UNKNOWN
+    }
+    # Events
+    SOURCE_TYPE_NAME = 'couchbase'
 
     # Selected metrics to send amongst all the bucket stats, after name normalization
     BUCKET_STATS = set([
@@ -232,32 +256,49 @@ class Couchbase(AgentCheck):
 
     seconds_value_pattern = re.compile('(\d+(\.\d+)?)(\D+)')
 
-    def _create_metrics(self, data, tags=None):
+    class CouchbaseInstanceState(object):
+        def __init__(self):
+            self.previous_status = None
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+
+        # Keep track of all instances
+        self._instance_states = defaultdict(lambda: self.CouchbaseInstanceState())
+
+    def _create_metrics(self, data, instance_state, server, tags=None):
+        # Get storage metrics
         storage_totals = data['stats']['storageTotals']
         for key, storage_type in storage_totals.items():
             for metric_name, val in storage_type.items():
                 if val is not None:
-                    metric_name = '.'.join(['couchbase', key, self.camel_case_to_joined_lower(metric_name)])
+                    metric_name = 'couchbase.{}.{}'.format(key, self.camel_case_to_joined_lower(metric_name))
                     self.gauge(metric_name, val, tags=tags)
 
+        # Get bucket metrics
         for bucket_name, bucket_stats in data['buckets'].items():
+            metric_tags = list(tags)
+            metric_tags.extend(('bucket:{}'.format(bucket_name), 'device_name:{}'.format(bucket_name)))
             for metric_name, val in bucket_stats.items():
                 if val is not None:
                     norm_metric_name = self.camel_case_to_joined_lower(metric_name)
                     if norm_metric_name in self.BUCKET_STATS:
-                        full_metric_name = '.'.join(['couchbase', 'by_bucket', norm_metric_name])
-                        metric_tags = list(tags)
-                        metric_tags.append('bucket:%s' % bucket_name)
-                        self.gauge(full_metric_name, val[0], tags=metric_tags, device_name=bucket_name)
+                        full_metric_name = 'couchbase.by_bucket.{}'.format(norm_metric_name)
+                        self.gauge(full_metric_name, val[0], tags=metric_tags)
 
+        # Get node metrics
         for node_name, node_stats in data['nodes'].items():
+            metric_tags = list(tags)
+            metric_tags.extend(('node:{}'.format(node_name), 'device_name:{}'.format(node_name)))
             for metric_name, val in node_stats['interestingStats'].items():
                 if val is not None:
-                    metric_name = '.'.join(['couchbase', 'by_node', self.camel_case_to_joined_lower(metric_name)])
-                    metric_tags = list(tags)
-                    metric_tags.append('node:%s' % node_name)
-                    self.gauge(metric_name, val, tags=metric_tags, device_name=node_name)
+                    metric_name = 'couchbase.by_node.{}'.format(self.camel_case_to_joined_lower(metric_name))
+                    self.gauge(metric_name, val, tags=metric_tags)
 
+            # Get cluster health data
+            self._process_cluster_health_data(node_name, node_stats, tags)
+
+        # Get query metrics
         for metric_name, val in data['query'].items():
             if val is not None:
                 norm_metric_name = self.camel_case_to_joined_lower(metric_name)
@@ -266,13 +307,89 @@ class Couchbase(AgentCheck):
                     if isinstance(val, basestring):
                         val = self.extract_seconds_value(val)
 
-                    full_metric_name = '.'.join(['couchbase', 'query',
-                                                self.camel_case_to_joined_lower(norm_metric_name)])
+                    full_metric_name = 'couchbase.query.{}'.format(self.camel_case_to_joined_lower(norm_metric_name))
                     self.gauge(full_metric_name, val, tags=tags)
 
+        # Get tasks, we currently only care about 'rebalance' tasks
+        rebalance_status, rebalance_msg = data['tasks'].get('rebalance', (None, None))
+
+        # Only fire an event when the state has changed
+        if rebalance_status is not None and instance_state.previous_status != rebalance_status:
+            rebalance_event = None
+
+            # If we get an error, we create an error event with the msg we receive
+            if rebalance_status == 'error':
+                msg_title = 'Encountered an error while rebalancing'
+                msg = rebalance_msg
+
+                rebalance_event = self._create_event('error', msg_title, msg, server, tags=tags)
+
+            # We only want to fire a 'completion' of a rebalance so make sure we're not firing an event on first run
+            elif rebalance_status == 'notRunning' and instance_state.previous_status is not None:
+                msg_title = 'Stopped rebalancing'
+                msg = 'stopped rebalancing.'
+                rebalance_event = self._create_event('info', msg_title, msg, server, tags=tags)
+
+            # If a rebalance task is running, fire an event. This will also fire an event if a rebalance task was
+            #   already running when the check first runs.
+            elif rebalance_status == 'gracefulFailover':
+                msg_title = 'Failing over gracefully'
+                msg = 'is failing over gracefully.'
+                rebalance_event = self._create_event('info', msg_title, msg, server, tags=tags)
+            elif rebalance_status == 'rebalance':
+                msg_title = 'Rebalancing'
+                msg = 'is rebalancing.'
+                rebalance_event = self._create_event('info', msg_title, msg, server, tags=tags)
+
+            # Send the event
+            if rebalance_event is not None:
+                self.event(rebalance_event)
+
+            # Update the status of this instance
+            instance_state.previous_status = rebalance_status
+
+    def _process_cluster_health_data(self, node_name, node_stats, tags):
+        """
+        Process and send cluster health data (i.e. cluster membership status and node health
+        """
+
+        # Tags for service check
+        cluster_health_tags = list(tags) + ['node:{}'.format(node_name), 'device_name:{}'.format(node_name)]
+
+        # Get the membership status of the node
+        cluster_membership = node_stats.get('clusterMembership', None)
+        membership_status = self.NODE_MEMBERSHIP_TRANSLATION.get(cluster_membership, AgentCheck.UNKNOWN)
+        self.service_check(self.NODE_CLUSTER_SERVICE_CHECK_NAME, membership_status, tags=cluster_health_tags)
+
+        # Get the health status of the node
+        health = node_stats.get('status', None)
+        health_status = self.NODE_HEALTH_TRANSLATION.get(health, AgentCheck.UNKNOWN)
+        self.service_check(self.NODE_HEALTH_SERVICE_CHECK_NAME, health_status, tags=cluster_health_tags)
+
+    def _create_event(self, alert_type, msg_title, msg, server, tags=None):
+        """
+        Create an event object
+        """
+        msg_title = 'Couchbase {}: {}'.format(server, msg_title)
+        msg = 'Couchbase instance {} {}'.format(server, msg)
+
+        return {
+            'timestamp': int(time.time()),
+            'event_type': 'couchbase_rebalance',
+            'msg_text': msg,
+            'msg_title': msg_title,
+            'alert_type': alert_type,
+            'source_type_name': self.SOURCE_TYPE_NAME,
+            'aggregation_key': server,
+            'tags': tags
+        }
+
     def _get_stats(self, url, instance):
-        """ Hit a given URL and return the parsed json. """
-        self.log.debug('Fetching Couchbase stats at url: %s' % url)
+        """
+        Hit a given URL and return the parsed json.
+        """
+
+        self.log.debug('Fetching Couchbase stats at url: {}'.format(url))
 
         timeout = float(instance.get('timeout', DEFAULT_TIMEOUT))
 
@@ -285,6 +402,8 @@ class Couchbase(AgentCheck):
         return r.json()
 
     def check(self, instance):
+        instance_state = self._instance_states[hash_mutable(instance)]
+
         server = instance.get('server', None)
         if server is None:
             raise Exception("The server must be specified")
@@ -295,9 +414,9 @@ class Couchbase(AgentCheck):
             tags = []
         else:
             tags = list(set(tags))
-        tags.append('instance:%s' % server)
+        tags.append('instance:{}'.format(server))
         data = self.get_data(server, instance)
-        self._create_metrics(data, tags=list(set(tags)))
+        self._create_metrics(data, instance_state, server, tags=list(set(tags)))
 
     def get_data(self, server, instance):
         # The dictionary to be returned.
@@ -306,10 +425,11 @@ class Couchbase(AgentCheck):
             'buckets': {},
             'nodes': {},
             'query': {},
+            'tasks': {}
         }
 
         # build couchbase stats entry point
-        url = '%s%s' % (server, COUCHBASE_STATS_PATH)
+        url = '{}{}'.format(server, COUCHBASE_STATS_PATH)
 
         # Fetch initial stats and capture a service check based on response.
         service_check_tags = instance.get('tags', [])
@@ -317,12 +437,12 @@ class Couchbase(AgentCheck):
             service_check_tags = []
         else:
             service_check_tags = list(set(service_check_tags))
-        service_check_tags.append('instance:%s' % server)
+        service_check_tags.append('instance:{}'.format(server))
         try:
             overall_stats = self._get_stats(url, instance)
             # No overall stats? bail out now
             if overall_stats is None:
-                raise Exception("No data returned from couchbase endpoint: %s" % url)
+                raise Exception("No data returned from couchbase endpoint: {}".format(url))
         except requests.exceptions.HTTPError as e:
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
                                tags=service_check_tags, message=str(e.message))
@@ -345,7 +465,7 @@ class Couchbase(AgentCheck):
         # Next, get all buckets .
         endpoint = overall_stats['buckets']['uri']
 
-        url = '%s%s' % (server, endpoint)
+        url = '{}{}'.format(server, endpoint)
         buckets = self._get_stats(url, instance)
 
         if buckets is not None:
@@ -354,12 +474,12 @@ class Couchbase(AgentCheck):
 
                 # Fetch URI for the stats bucket
                 endpoint = bucket['stats']['uri']
-                url = '%s%s' % (server, endpoint)
+                url = '{}{}'.format(server, endpoint)
 
                 try:
                     bucket_stats = self._get_stats(url, instance)
                 except requests.exceptions.HTTPError:
-                    url_backup = '%s/pools/nodes/buckets/%s/stats' % (server, bucket_name)
+                    url_backup = '{}/pools/nodes/buckets/{}/stats'.format(server, bucket_name)
                     bucket_stats = self._get_stats(url_backup, instance)
 
                 bucket_samples = bucket_stats['op']['samples']
@@ -370,13 +490,41 @@ class Couchbase(AgentCheck):
         query_monitoring_url = instance.get('query_monitoring_url', None)
         if query_monitoring_url is not None:
             try:
-                url = '%s%s' % (query_monitoring_url, COUCHBASE_VITALS_PATH)
+                url = '{}{}'.format(query_monitoring_url, COUCHBASE_VITALS_PATH)
                 query = self._get_stats(url, instance)
                 if query is not None:
                     couchbase['query'] = query
             except requests.exceptions.HTTPError:
-                self.log.error("Error accessing the endpoint %s, make sure you're running at least "
-                               "couchbase 4.5 to collect the query monitoring metrics", url)
+                self.log.error("Error accessing the endpoint {}, make sure you're running at least "
+                               "couchbase 4.5 to collect the query monitoring metrics".format(url))
+
+        # Next, get all the tasks
+        tasks_url = '{}{}/tasks'.format(server, COUCHBASE_STATS_PATH)
+        try:
+            tasks = self._get_stats(tasks_url, instance)
+            for task in tasks:
+                task_type = task['type']
+
+                # We only care about rebalance statuses
+                if task_type != 'rebalance':
+                    continue
+
+                # Format the status so it's easier to understand
+                if 'errorMessage' in task:
+                    couchbase['tasks'][task_type] = ('error', task['errorMessage'])
+                elif task['status'] == 'notRunning':
+                    couchbase['tasks'][task_type] = (task['status'], None)
+
+                # If the status is 'running', we want to differentiate between a regular rebalance and a graceful
+                #   failover rebalance, so we use the subtype
+                elif task['status'] == 'running':
+                    couchbase['tasks'][task_type] = (task['subtype'], None)
+
+                # Should only be 1 rebalance
+                break
+
+        except requests.exceptions.HTTPError:
+            self.log.error("Error accessing the endpoint {}".format(url))
 
         return couchbase
 

--- a/couchbase/datadog_checks/couchbase/couchbase.py
+++ b/couchbase/datadog_checks/couchbase/couchbase.py
@@ -37,7 +37,7 @@ class Couchbase(AgentCheck):
         'active': AgentCheck.OK,
         'inactiveAdded': AgentCheck.WARNING,
         'activeFailed': AgentCheck.CRITICAL,
-        None: AgentCheck.UNKNOWN
+        None: AgentCheck.UNKNOWN,
     }
 
     NODE_HEALTH_TRANSLATION = {
@@ -46,6 +46,7 @@ class Couchbase(AgentCheck):
         'unhealthy': AgentCheck.CRITICAL,
         None: AgentCheck.UNKNOWN
     }
+
     # Events
     SOURCE_TYPE_NAME = 'couchbase'
 
@@ -278,22 +279,22 @@ class Couchbase(AgentCheck):
         # Get bucket metrics
         for bucket_name, bucket_stats in data['buckets'].items():
             metric_tags = list(tags)
-            metric_tags.extend(('bucket:{}'.format(bucket_name), 'device_name:{}'.format(bucket_name)))
+            metric_tags.append('bucket:{}'.format(bucket_name))
             for metric_name, val in bucket_stats.items():
                 if val is not None:
                     norm_metric_name = self.camel_case_to_joined_lower(metric_name)
                     if norm_metric_name in self.BUCKET_STATS:
                         full_metric_name = 'couchbase.by_bucket.{}'.format(norm_metric_name)
-                        self.gauge(full_metric_name, val[0], tags=metric_tags)
+                        self.gauge(full_metric_name, val[0], tags=metric_tags, device_name=bucket_name)
 
         # Get node metrics
         for node_name, node_stats in data['nodes'].items():
             metric_tags = list(tags)
-            metric_tags.extend(('node:{}'.format(node_name), 'device_name:{}'.format(node_name)))
+            metric_tags.append('node:{}'.format(node_name))
             for metric_name, val in node_stats['interestingStats'].items():
                 if val is not None:
                     metric_name = 'couchbase.by_node.{}'.format(self.camel_case_to_joined_lower(metric_name))
-                    self.gauge(metric_name, val, tags=metric_tags)
+                    self.gauge(metric_name, val, tags=metric_tags, device_name=node_name)
 
             # Get cluster health data
             self._process_cluster_health_data(node_name, node_stats, tags)
@@ -354,7 +355,7 @@ class Couchbase(AgentCheck):
         """
 
         # Tags for service check
-        cluster_health_tags = list(tags) + ['node:{}'.format(node_name), 'device_name:{}'.format(node_name)]
+        cluster_health_tags = list(tags) + ['node:{}'.format(node_name)]
 
         # Get the membership status of the node
         cluster_membership = node_stats.get('clusterMembership', None)

--- a/couchbase/service_checks.json
+++ b/couchbase/service_checks.json
@@ -7,5 +7,23 @@
         "groups": ["host"],
         "name": "Can Connect",
         "description": "Returns status after pinging your Couchbase instance. Additional information about response status at the time of collection is included in the check message."
+    },
+    {
+        "agent_version": "6.2.1",
+        "integration":"couchbase",
+        "check": "couchbase.by_node.cluster_membership",
+        "statuses": ["ok", "critical"],
+        "groups": ["node"],
+        "name": "Node Cluster Membership",
+        "description": "Returns `CRITICAL` if the node is failed over. Returns `WARNING` if the node is added to the cluster but is waiting for a rebalance to activate. Returns `OK` otherwise."
+    },
+    {
+        "agent_version": "6.2.1",
+        "integration":"couchbase",
+        "check": "couchbase.by_node.health_status",
+        "statuses": ["ok", "critical"],
+        "groups": ["node"],
+        "name": "Node Health Status",
+        "description": "Returns `CRITICAL` if the node is unhealthy. Returns `OK` otherwise."
     }
 ]

--- a/couchbase/service_checks.json
+++ b/couchbase/service_checks.json
@@ -12,7 +12,7 @@
         "agent_version": "6.2.1",
         "integration":"couchbase",
         "check": "couchbase.by_node.cluster_membership",
-        "statuses": ["ok", "critical"],
+        "statuses": ["ok", "warning", "critical"],
         "groups": ["node"],
         "name": "Node Cluster Membership",
         "description": "Returns `CRITICAL` if the node is failed over. Returns `WARNING` if the node is added to the cluster but is waiting for a rebalance to activate. Returns `OK` otherwise."

--- a/couchbase/tests/common.py
+++ b/couchbase/tests/common.py
@@ -22,6 +22,27 @@ USER = 'Administrator'
 PASSWORD = 'password'
 
 # Tags and common bucket name
-TAGS = ['optional:tag1']
-CHECK_TAGS = TAGS + ['instance:http://{}:{}'.format(HOST, PORT)]
+CUSTOM_TAGS = ['optional:tag1']
+CHECK_TAGS = CUSTOM_TAGS + ['instance:http://{}:{}'.format(HOST, PORT)]
 BUCKET_NAME = 'cb_bucket'
+
+CONFIG = {
+    'instances': [{
+        'server': URL,
+        'user': USER,
+        'password': PASSWORD,
+        'timeout': 0.5,
+        'tags': list(CUSTOM_TAGS),
+    }]
+}
+
+CONFIG_QUERY = {
+    'instances': [{
+        'server': URL,
+        'user': USER,
+        'password': PASSWORD,
+        'timeout': 0.5,
+        'tags': list(CUSTOM_TAGS),
+        'query_monitoring_url': SYSTEM_VITALS_URL,
+    }]
+}

--- a/couchbase/tests/conftest.py
+++ b/couchbase/tests/conftest.py
@@ -9,12 +9,13 @@ from time import sleep
 import pytest
 import requests
 
-from .common import HERE, PORT, SYSTEM_VITALS_URL, URL, TAGS, BUCKET_NAME, USER, PASSWORD, CB_CONTAINER_NAME
+from .common import HERE, PORT, URL, BUCKET_NAME, USER, PASSWORD, CB_CONTAINER_NAME
 
 
 @pytest.fixture
 def aggregator():
     from datadog_checks.stubs import aggregator
+
     aggregator.reset()
     return aggregator
 
@@ -65,29 +66,6 @@ def couchbase_container_ip(couchbase_service):
     Modular fixture that depends on couchbase being initialized
     """
     return get_container_ip(CB_CONTAINER_NAME)
-
-
-@pytest.fixture
-def couchbase_config():
-    return {
-        'server': URL,
-        'user': USER,
-        'password': PASSWORD,
-        'timeout': 0.5,
-        'tags': TAGS
-    }
-
-
-@pytest.fixture
-def couchbase_query_config():
-    return {
-        'server': URL,
-        'user': USER,
-        'password': PASSWORD,
-        'timeout': 0.5,
-        'tags': TAGS,
-        'query_monitoring_url': SYSTEM_VITALS_URL
-    }
 
 
 def get_container_ip(container_id_or_name):

--- a/couchbase/tests/test_couchbase.py
+++ b/couchbase/tests/test_couchbase.py
@@ -10,14 +10,21 @@ from .common import CHECK_TAGS, BUCKET_NAME, PORT
 
 
 @pytest.mark.integration
-def test_service_check(aggregator, couchbase_service, couchbase_config):
+def test_service_check(aggregator, couchbase_container_ip, couchbase_config):
     """
     Assert the OK service check
     """
     couchbase = Couchbase('couchbase', {}, {})
     couchbase.check(couchbase_config)
 
+    NODE_HOST = '{}:{}'.format(couchbase_container_ip, PORT)
+    NODE_TAGS = ['device_name:{}'.format(NODE_HOST), 'node:{}'.format(NODE_HOST)]
+
     aggregator.assert_service_check(Couchbase.SERVICE_CHECK_NAME, tags=CHECK_TAGS, status=Couchbase.OK, count=1)
+    aggregator.assert_service_check(Couchbase.NODE_CLUSTER_SERVICE_CHECK_NAME, tags=CHECK_TAGS + NODE_TAGS,
+                                    status=Couchbase.OK, count=1)
+    aggregator.assert_service_check(Couchbase.NODE_HEALTH_SERVICE_CHECK_NAME, tags=CHECK_TAGS + NODE_TAGS,
+                                    status=Couchbase.OK, count=1)
 
 
 @pytest.mark.integration
@@ -58,11 +65,7 @@ def assert_basic_couchbase_metrics(aggregator, couchbase_container_ip):
     #  Because some metrics are deprecated, we can just see if we get an arbitrary number
     #  of bucket metrics. If there are more than that number, we assume that we're getting
     #  all the bucket metrics we should be getting
-
-    for m in aggregator._metrics.items():
-        print(str(m))
-
-    BUCKET_TAGS = ['device:{}'.format(BUCKET_NAME), 'bucket:{}'.format(BUCKET_NAME)]
+    BUCKET_TAGS = ['device_name:{}'.format(BUCKET_NAME), 'bucket:{}'.format(BUCKET_NAME)]
     bucket_metric_count = 0
     for bucket_metric in aggregator.metric_names:
         if bucket_metric.find('couchbase.by_bucket.') == 0:
@@ -73,7 +76,7 @@ def assert_basic_couchbase_metrics(aggregator, couchbase_container_ip):
 
     # Assert 'couchbase.by_node.' metrics
     NODE_HOST = '{}:{}'.format(couchbase_container_ip, PORT)
-    NODE_TAGS = ['device:{}'.format(NODE_HOST), 'node:{}'.format(NODE_HOST)]
+    NODE_TAGS = ['device_name:{}'.format(NODE_HOST), 'node:{}'.format(NODE_HOST)]
     NODE_STATS = [
         'curr_items',
         'curr_items_tot',

--- a/couchbase/tox.ini
+++ b/couchbase/tox.ini
@@ -8,24 +8,19 @@ envlist =
 
 [testenv]
 platform = linux|darwin|win32
+deps =
+    ../datadog_checks_base
+    -rrequirements-dev.txt
 passenv =
     DOCKER*
     COMPOSE*
 
-[common]
-deps =
-    ../datadog_checks_base
-    -rrequirements-dev.txt
+[testenv:couchbase]
 commands =
     pip install --require-hashes -r requirements.txt
     pytest -m"integration" -v
 
-[testenv:couchbase]
-deps = {[common]deps}
-commands = {[common]commands}
-
 [testenv:unit]
-deps = {[common]deps}
 commands =
     pip install --require-hashes -r requirements.txt
     pytest -m"not integration" -v


### PR DESCRIPTION
### What does this PR do?

Adds service checks and events relating to cluster membership and node health to Couchbase check.

### Motivation

Users would like to collect additional information (i.e. cluster membership and node health) from Couchbase.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

~Will first need to merge #1612, because we need to register Couchbase as an integration that emits events.~ Ready to go!
