### PR TITLE
pushing doc metadata to enforce consistency

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -1,4 +1,7 @@
-# Working with Agent based integrations
+---
+title: Working with Agent based integrations
+kind: documentation
+---
 
 ## Overview
 

--- a/docs/dev/legacy.md
+++ b/docs/dev/legacy.md
@@ -1,7 +1,9 @@
 ---
-title: Legacy development Setup
+title: Legacy
 kind: documentation
 ---
+
+This documentation explains how to create an Agent check for the Datadog Agent v5. Please [refer to the dedicated documentation for creating an Agent check for the Datadog Agent v6 doc][21].
 
 ## Requirements
 
@@ -299,3 +301,4 @@ In our experience building integrations, we've also faced a number of challenges
 [CurrentCategoriesCanBeFoundOnIntegrations]: /integrations
 [ForAnExampleOfTheManifestFile]: https://github.com/DataDog/integrations-core/blob/master/activemq/manifest.json
 [OfficialMysqlContainer]: https://hub.docker.com/_/mysql/
+[21]: https://github.com/DataDog/integrations-core/blob/master/docs/dev/new_check_howto.md

--- a/docs/dev/legacy.md
+++ b/docs/dev/legacy.md
@@ -1,4 +1,7 @@
-# Legacy development Setup
+---
+title: Legacy development Setup
+kind: documentation
+---
 
 ## Requirements
 

--- a/docs/dev/legacy.md
+++ b/docs/dev/legacy.md
@@ -3,7 +3,7 @@ title: Legacy
 kind: documentation
 ---
 
-This documentation explains how to create an Agent check for the Datadog Agent v5. Please [refer to the dedicated documentation for creating an Agent check for the Datadog Agent v6 doc][21].
+This documentation explains how to create an Agent check for the Datadog Agent v5 which has been superceded by agent v6. It is still possible to write checks for v5 however no new integrations for v5 will be considered upstream. To learn more about creating an integrations for agent v6 [refer to the dedicated documentation for creating an Agent check for the Datadog Agent v6][21].
 
 ## Requirements
 

--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -1,6 +1,9 @@
 ---
-title: How to create a new integration
+title: Create a new integration
 kind: documentation
+aliases:
+    - /developers/integrations/integration_sdk/
+    - /developers/integrations/testing/
 ---
 
 To consider an Agent based integration complete, thus ready to be included in the core repository and bundled with the Agent package, a number of requisites have to be met:

--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -1,4 +1,7 @@
-# How to create a new integration
+---
+title: How to create a new integration
+kind: documentation
+---
 
 To consider an Agent based integration complete, thus ready to be included in the core repository and bundled with the Agent package, a number of requisites have to be met:
 

--- a/docs/dev/python.md
+++ b/docs/dev/python.md
@@ -1,5 +1,5 @@
 ---
-title: Setup Python to work on Agent based integrations
+title: Prepare your Python environment for Agent integration development
 kind: documentation
 ---
 

--- a/docs/dev/python.md
+++ b/docs/dev/python.md
@@ -1,4 +1,7 @@
-# Setup Python to work on Agent based integrations
+---
+title: Setup Python to work on Agent based integrations
+kind: documentation
+---
 
 This doc covers all steps to prepare the perfect Python environment to work on Agent based integrations, from installing the interpreter to install and the dependencies needed.
 


### PR DESCRIPTION
### What does this PR do?

Push documentation metadata to documentation files in order to enforce some sort of consistency + allowing for further metadata additions (like aliases for instance) 

### Motivation

a better doc for a better world and also this PR https://github.com/DataDog/documentation/pull/2510
