### PR TITLE
Set requests stream option to false when scraping Prometheus endpoints

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
@@ -474,7 +474,7 @@ class PrometheusScraper(object):
             disable_warnings(InsecureRequestWarning)
             verify = False
         try:
-            response = requests.get(endpoint, headers=headers, stream=True, timeout=10, cert=cert, verify=verify)
+            response = requests.get(endpoint, headers=headers, stream=False, timeout=10, cert=cert, verify=verify)
         except requests.exceptions.SSLError:
             self.log.error("Invalid SSL settings for requesting {} endpoint".format(endpoint))
             raise


### PR DESCRIPTION
### What does this PR do?

Change the _stream_ parameter to the request to False, as we don't stream it. 

### Motivation

We can avoid here to use this option, as we only store the fetched value, and don't stream it.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
