### PR TITLE
Fix parsing of requirements file so that `dnspython` is listed as a req

### DIFF
--- a/dns_check/setup.py
+++ b/dns_check/setup.py
@@ -9,26 +9,36 @@ import re
 
 here = path.abspath(path.dirname(__file__))
 
+def parse_req_line(line):
+    line = line.strip()
+    if not line or line.startswith('--hash') or line[0] == '#':
+        return None
+    req = line.rpartition('#')
+    if len(req[1]) == 0:
+        line = req[2].strip()
+    else:
+        line = req[1].strip()
+
+    if '--hash=' in line:
+        line = line[:line.find('--hash=')].strip()
+    if ';' in line:
+        line = line[:line.find(';')].strip()
+    if '\\' in line:
+        line = line[:line.find('\\')].strip()
+
+    return line
+
 # get the long description from the readme file
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
+# Parse requirements
 runtime_reqs = ['datadog_checks_base']
 with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
     for line in f.readlines():
-        line = line.strip()
-        if not line or line.startswith('--hash') or line[0] == '#':
-            continue
-        req = line.rpartition('#')
-        if not len(req[1]):
-            if '--hash=' in req[2]:
-                tokens = req[2].split()
-                if len(tokens) > 1:
-                    runtime_reqs.append(tokens[0])
-            elif ';' in req[2]:
-                runtime_reqs.append(req[2])
-        else:
-            runtime_reqs.append(req[0])
+        req = parse_req_line(line)
+        if req:
+            runtime_reqs.append(req)
 
 def read(*parts):
     with open(path.join(here, *parts), 'r') as fp:


### PR DESCRIPTION
### What does this PR do?

Fixes the parsing of the `requirements.txt` file in `setup.py`. Bug introduced in https://github.com/DataDog/integrations-core/pull/1353 originally because the parsing fix in https://github.com/DataDog/integrations-core/pull/1010 wasn't applied to this integration's `setup.py`.

### Motivation

Currently the `dns_check`'s wheel doesn't declare `dnspython` as a dependency, as a result we don't ship `dnspython` with the Agent 6 since `6.2.0`.

Note: Agent `5.24.0` still ships `dnspython` (with a different version), but only because it's a subdependency of a python package (`python-etcd`) required by the core Agent5.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
~- [ ] Feature or bugfix has tests~
- [x] Git history is clean
~- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)~

### Additional Notes

This simply applies the fix in #1010 to the `dns_check` integration. Since this integration hasn't been migrated to the new `pytest` framework yet I didn't make any additional change (like pulling the reqs from `requirements.in` instead).
