### PR TITLE
Submit `n_purges` metric as rate

### DIFF
--- a/varnish/datadog_checks/varnish/varnish.py
+++ b/varnish/datadog_checks/varnish/varnish.py
@@ -60,6 +60,8 @@ class Varnish(AgentCheck):
                 self.rate(m_name, long(self._current_value), tags=tags)
             elif self._current_type in ("i", "g"):
                 self.gauge(m_name, long(self._current_value), tags=tags)
+                if 'n_purges' in m_name:
+                    self.rate('varnish.n_purgesps', long(self._current_value), tags=tags)
             else:
                 # Unsupported data type, ignore
                 self._reset()
@@ -203,7 +205,6 @@ class Varnish(AgentCheck):
 
         Bitmaps are not supported.
         """
-
         tags = tags or []
         # FIXME: this check is processing an unbounded amount of data
         # we should explicitly list the metrics we want to get from the check
@@ -228,6 +229,8 @@ class Varnish(AgentCheck):
                     self.rate(self.normalize(name, prefix="varnish"), long(value), tags=tags)
                 elif metric["flag"] in ("g", "i"):
                     self.gauge(self.normalize(name, prefix="varnish"), long(value), tags=tags)
+                    if 'n_purges' in self.normalize(name, prefix="varnish"):
+                        self.rate('varnish.n_purgesps', long(value), tags=tags)
         elif varnishstat_format == "text":
             for line in output.split("\n"):
                 self.log.debug("Parsing varnish results: %s" % line)
@@ -242,6 +245,8 @@ class Varnish(AgentCheck):
                     # col 2 matters
                     self.log.debug("Varnish (gauge) %s %d" % (metric_name, int(gauge_val)))
                     self.gauge(metric_name, int(gauge_val), tags=tags)
+                    if 'n_purges' in metric_name:
+                        self.rate('varnish.n_purgesps', float(gauge_val), tags=tags)
                 else:
                     # col 3 has a rate (since restart)
                     self.log.debug("Varnish (rate) %s %d" % (metric_name, int(gauge_val)))

--- a/varnish/metadata.csv
+++ b/varnish/metadata.csv
@@ -340,3 +340,4 @@ varnish.vsm_free,gauge,,byte,,"Free space in the shared memory used to communica
 varnish.vsm_overflow,gauge,,byte,,"Data which does not fit in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish 4.x.",0,varnish,vsm overflow
 varnish.vsm_overflowed,gauge,,byte,second,"Total data which did not fit in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish 4.x.",0,varnish,vsm overflowed
 varnish.vsm_used,gauge,,byte,,"Used space in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish 4.x.",0,varnish,vsm used
+varnish.n_purgesps,rate,,event,,Purges executed. This metric is only provided by varnish 4.x.,0,varnish,n purges

--- a/varnish/tests/common.py
+++ b/varnish/tests/common.py
@@ -63,6 +63,8 @@ COMMON_METRICS = [
     "varnish.LCK.vcl.creat",
     "varnish.LCK.vcl.destroy",
     "varnish.LCK.vcl.locks",
+    "varnish.n_purges",
+    "varnish.n_purgesps",
 ]
 
 VARNISH_DEFAULT_VERSION = "4.1.7"


### PR DESCRIPTION
### What does this PR do?

Addresses the wrong metric type for varnish check mentioned [in issue #2253](https://github.com/DataDog/dd-agent/issues/2253). However, `varnish.uptime` & 'varnish. n_wrk_lqueue` is already resolved. This PR adds the rate alternative for `varnish.n_purges`

The issue 
### Motivation

What inspired you to submit this pull request?

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
