### PR TITLE
Clarify that we only check the ssl validation by default on one code …

### DIFF
--- a/http_check/README.md
+++ b/http_check/README.md
@@ -47,7 +47,7 @@ See the [sample http_check.d/conf.yaml][2] for a full list and description of av
 | `http_response_status_code` | A string or Python regular expression for an HTTP status code. This check will report DOWN for any status code that does not match. This defaults to 1xx, 2xx and 3xx HTTP status codes. For example: `401` or `4\d\d`.|
 | `include_content` | When set to `true`, the check will include the first 200 characters of the HTTP response body in notifications. The default value is `false`. |
 | `collect_response_time` | By default, the check will collect the response time (in seconds) as the metric `network.http.response_time`. To disable, set this value to `false`. |
-| `disable_ssl_validation` | This setting will skip SSL certificate validation and is enabled by default. If you require SSL certificate validation, set this to `false`. |
+| `disable_ssl_validation` | This setting will skip SSL certificate validation and is enabled by default. If you require SSL certificate validation, set this to `false`. This option is only used when gathering the response time/aliveness from the specified endpoint. Note this setting doesn't apply to the `check_certificate_expiration` option. |
 | `ignore_ssl_warning` | When SSL certificate validation is enabled (see setting above), this setting will allow you to disable security warnings. |
 | `ca_certs` | This setting will allow you to override the default certificate path as specified in `init_config` |
 | `check_certificate_expiration` | When `check_certificate_expiration` is enabled, the service check will check the expiration date of the SSL certificate. Note that this will cause the SSL certificate to be validated, regardless of the value of the `disable_ssl_validation` setting. |


### PR DESCRIPTION
…path

### What does this PR do?

This makes it clearer that there are two code paths in the HTTP Check:
1) Check the aliveness of the endpoint and get response time
2) Get the number of days left for the certificate on the endpoint

We have an option to disable SSL validation for `1`, but that config option doesn't apply to `2`, we _always_ validate the certificate when getting the days left metric. 

### Motivation

Some users have the option to get the days left on the certificate and are confused when they see the log line about SSL Validation being skipped when the check hits the endpoint for case `2`

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
