### PR TITLE
fixes AttributeError when running on 6.2.1

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -254,11 +254,11 @@ class HTTPCheck(NetworkCheck):
                 else:
                     # Log if we're skipping SSL validation for HTTPS URLs
                     if explicit_validation:
-                        self.debug("Skipping SSL certificate validation for {} based on configuration".format(addr))
+                        self.log.debug("Skipping SSL certificate validation for {} based on configuration".format(addr))
 
                     # Emit a warning if disable_ssl_validation is not explicitly set and we're not ignoring warnings
                     else:
-                        self.warning('Parameter disable_ssl_validation for {} is not explicitly set, '
+                        self.log.warning('Parameter disable_ssl_validation for {} is not explicitly set, '
                                      'defaults to true'.format(addr))
 
 


### PR DESCRIPTION
AttributeError: 'HTTPCheck' object has no attribute 'debug'
AttributeError: 'HTTPCheck' object has no attribute 'warning'

### What does this PR do?

Fixes above http_check errors when running on 6.2.1

### Motivation

client issue

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
Same code works fine in 6.2.0 and previous versions.
I have not tested on 5.x