### PR TITLE
Update MIB instruction for SNMP

### DIFF
--- a/snmp/README.md
+++ b/snmp/README.md
@@ -91,18 +91,59 @@ You can also gather tags based on the indices of your row, in case they are mean
 
 #### Use your own MIB
 
-To use your own MIB with the datadog-agent, you need to convert them to the pysnmp format. This can be done using the ```build-pysnmp-mibs``` script that ships with pysnmp.
+To use your own MIB with the datadog-agent, convert them to the pysnmp format. This can be done using the ```build-pysnmp-mibs``` script that ships with pysnmp, but the `build-pysnmp-mib` script has been made obsolete since pysnmp 4.3 (Reference [here][9]); `mibdump.py` replaces it.
 
-It has a dependency on ```smidump```, from the libsmi2ldbl package so make sure it is installed. Make also sure that you have all the dependencies of your MIB in your mib folder or it won't be able to convert your MIB correctly.
+Since Datadog agent version 5.14, our PySNMP dependency has been upgraded from version 4.25 to 4.3.5 (Reference on our [changelog][8]). Meaning the `build-pysnmp-mib` which shipped with our agent from version 5.13.x and earlier has also been replaced with `mibdump.py`.
+ 
+Finding the location of mibdump.py
 
-##### Run
+```
+# find /opt/datadog-agent/ -type f -name build-pysnmp-mib.py -o -name mibdump.py
+/opt/datadog-agent/bin/mibdump.py
+```
 
-    $ build-pysnmp-mib -o YOUR-MIB.py YOUR-MIB.mib
+Below is the format to use the script:
 
-where YOUR-MIB.mib is the MIB you want to convert.
+```
+/opt/datadog-agent/bin/mibdump.py --mib-source /path/to/mib/files/  --mib-source http://mibs.snmplabs.com/asn1/@mib@ --destination-directory=/path/to/converted/mib/pyfiles/ --destination-format=pysnmp <MIB_FILE_NAME>
+```
 
-Put all your pysnmp mibs into a folder and specify this folder's path in ```snmp.yaml``` file, in the ```init_config``` section.
+Example using the `CISCO-TCP-MIB.my`:
 
+```
+# /opt/datadog-agent/bin/mibdump.py --mib-source /path/to/mib/files/  --mib-source http://mibs.snmplabs.com/asn1/@mib@ --destination-directory=/opt/datadog-agent/pysnmp/custom_mibpy/ --destination-format=pysnmp CISCO-TCP-MIB
+
+ Source MIB repositories: /path/to/mib/files/, http://mibs.snmplabs.com/asn1/@mib@
+ Borrow missing/failed MIBs from: http://mibs.snmplabs.com/pysnmp/notexts/@mib@ 
+ Existing/compiled MIB locations: pysnmp.smi.mibs, pysnmp_mibs 
+ Compiled MIBs destination directory: /opt/datadog-agent/pysnmp/custom_mibpy/ 
+ MIBs excluded from code generation: INET-ADDRESS-MIB, PYSNMP-USM-MIB, RFC-1212, RFC-1215, RFC1065-SMI, RFC1155-SMI, RFC1158-MIB, RFC1213-MIB, SNMP-FRAMEWORK-MIB, SNMP-TARGET-MIB, SNMPv2-CONF, SNMPv2-SMI, SNMPv2-TC, SNMPv2-TM, TRANSPORT-ADDRESS-MIB 
+ MIBs to compile: CISCO-TCP 
+ Destination format: pysnmp 
+ Parser grammar cache directory: not used 
+ Also compile all relevant MIBs: yes 
+ Rebuild MIBs regardless of age: no 
+ Dry run mode: no Create/update MIBs: yes 
+ Byte-compile Python modules: yes (optimization level no) 
+ Ignore compilation errors: no 
+ Generate OID->MIB index: no 
+ Generate texts in MIBs: no 
+ Keep original texts layout: no 
+ Try various file names while searching for MIB module: yes 
+ Created/updated MIBs: CISCO-SMI, CISCO-TCP-MIB (CISCO-TCP) 
+ Pre-compiled MIBs borrowed: 
+ Up to date MIBs: INET-ADDRESS-MIB, SNMPv2-CONF, SNMPv2-SMI, SNMPv2-TC, TCP-MIB 
+ Missing source MIBs: 
+ Ignored MIBs: 
+ Failed MIBs:
+
+
+# ls /opt/datadog-agent/pysnmp/custom_mibpy/
+CISCO-SMI.py CISCO-SMI.pyc CISCO-TCP-MIB.py CISCO-TCP-MIB.pyc
+
+ ```
+
+The Agent with the path looks for the converted MIB Python files by specifying the destination path with mibs_folder: in the [SNMP yaml configuration][10].
 
 ---
 
@@ -145,3 +186,6 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [5]: http://docs.datadoghq.com/help/
 [6]: https://www.datadoghq.com/blog/
 [7]: https://docs.datadoghq.com/integrations/faq/for-snmp-does-datadog-have-a-list-of-commonly-used-compatible-oids
+[8]: https://github.com/DataDog/dd-agent/blob/master/CHANGELOG.md#dependency-changes-3
+[9]: https://stackoverflow.com/questions/35204995/build-pysnmp-mib-convert-cisco-mib-files-to-a-python-fails-on-ubuntu-14-04
+[10]: https://github.com/DataDog/integrations-core/blob/master/snmp/conf.yaml.example#L3


### PR DESCRIPTION
the method for converting mibs was outdated 
But the new method was already documented
https://help.datadoghq.com/hc/en-us/articles/115003480071-Using-your-own-MIB-with-Datadog-agent-v5-14-x-onwards
