### PR TITLE
move new-style tests to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,17 @@ env:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
     - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
-    - CHANGED=$(git diff --name-only master...)
 matrix:
   fast_finish: true
   include:
     - if: env(BRANCH) = master OR env(CHANGED) =~ ^datadog_checks_base/
       env:
         - CHECK=datadog_checks_base
+        - CHANGED=$(git diff --name-only master...)
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
       env:
         - CHECK=active_directory
+        - CHANGED=$(git diff --name-only master...)
 before_install:
   - echo $CHECK
   - echo $CHANGED

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,13 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: env(BRANCH) = ofek/travis
+    - if: env(BRANCH) =~ "ofek/travis"
       env:
         - CHECK=datadog_checks_base
-    - if: env(BRANCH) = ofek/travis
+    - if: env(BRANCH) =~ "ofek/travis"
       env:
-        - CHECK=$CHANGED
+        - CHECK=active_directory
 before_install:
-  - echo $CHANGED
-  - echo $CHECK
   - chmod +x .travis/prepare.sh
   - .travis/prepare.sh
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: (env(BRANCH) = ofek/travis) OR (env(CHANGED) =~ ^datadog_checks_base/)
+    - if: (env(BRANCH) = master) OR (env(CHANGED) =~ ^datadog_checks_base/)
       env:
         - CHECK=datadog_checks_base
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: env(BRANCH) = ofek/travis OR env(CHANGED) =~ ^datadog_checks_base/
+    - if: env(BRANCH) =~ ofek/travis OR env(CHANGED) =~ ^datadog_checks_base/
       env:
         - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
         - CHECK=datadog_checks_base

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ jobs:
       script: inv test --changed-only
       env:
         - CHECK=none
-    - stage: test_all
+    - stage: test
       if: (branch = master) AND (type != pull_request)
       script: travis_retry inv test --targets=${CHECK}
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: (env(BRANCH) = ofek/travis)
+    - if: env(BRANCH) = ofek/travis
       env:
         - CHECK=datadog_checks_base
-    - if: (env(BRANCH) = ofek/travis)
+    - if: env(BRANCH) = ofek/travis
       env:
         - CHECK=$CHANGED
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ stages:
   - name: test_changed
     if: type = pull_request
   - name: test
-    if: (branch = master) AND (type != pull_request)
+    if: (branch = master) AND (type = pull_request)
 jobs:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: head_branch =~ "ofek/travis"
+    - if: head_branch = ofek/travis
       env:
         - CHECK=datadog_checks_base
-    - if: head_branch =~ ofek/travis
+    - if: head_branch = ofek/travis
       env:
         - CHECK=active_directory
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: (branch = master) AND (type = pull_request)
+    - if: (branch = master) AND (type = push)
       env:
         - CHECK=datadog_checks_base
-    - if: (branch = master) AND (type = pull_request)
+    - if: (branch = master) AND (type = push)
       env:
         - CHECK=active_directory
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,8 @@ env:
   - CHECK=varnish
   - CHECK=vsphere
 before_install:
-  - chmod +x .travis/install.sh
-  - .travis/install.sh
+  - chmod +x .travis/prepare.sh
+  - .travis/prepare.sh
 install:
   - pip install -U pip setuptools
   - pip install invoke pip-tools packaging tox docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,17 @@ env:
   global:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
-    - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
 matrix:
   fast_finish: true
   include:
     - if: env(BRANCH) = ofek/travis OR env(CHANGED) =~ ^datadog_checks_base/
       env:
+        - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
         - CHECK=datadog_checks_base
         - CHANGED=$(git diff --name-only master...)
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
       env:
+        - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
         - CHECK=active_directory
         - CHANGED=$(git diff --name-only master...)
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ env:
   - CHECK=vsphere
 before_install:
   - chmod +x .travis/prepare.sh
-  - .travis/prepare.sh
+  - sudo .travis/prepare.sh
 install:
   - pip install -U pip setuptools
   - pip install invoke pip-tools packaging tox docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,61 +16,68 @@ env:
   global:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
+env:
+  - CHECK=datadog_checks_base
+  - CHECK=active_directory
+  - CHECK=apache
+  - CHECK=aspdotnet
+  - CHECK=btrfs
+  - CHECK=ceph
+  - CHECK=consul
+  - CHECK=couch
+  - CHECK=couchbase
+  - CHECK=directory
+  - CHECK=disk
+  - CHECK=dotnetclr
+  - CHECK=elastic
+  - CHECK=envoy
+  - CHECK=exchange_server
+  - CHECK=haproxy
+  - CHECK=hdfs_namenode
+  - CHECK=iis
+  - CHECK=istio
+  - CHECK=kafka_consumer
+  - CHECK=kube_proxy
+  - CHECK=kubelet
+  - CHECK=kyototycoon
+  - CHECK=lighttpd
+  - CHECK=linkerd
+  - CHECK=marathon
+  - CHECK=mcache
+  # - CHECK=mysql
+  - CHECK=network
+  - CHECK=nfsstat
+  - CHECK=nginx
+  - CHECK=oracle
+  - CHECK=pdh_check
+  - CHECK=pgbouncer
+  # - CHECK=postgres
+  - CHECK=powerdns_recursor
+  - CHECK=prometheus
+  - CHECK=redisdb
+  - CHECK=riak
+  - CHECK=spark
+  - CHECK=ssh_check
+  - CHECK=squid
+  - CHECK=system_core
+  - CHECK=teamcity
+  - CHECK=varnish
+  - CHECK=vsphere
 jobs:
   fast_finish: true
   include:
     - stage: manifest
       script: inv manifest --include-extras
-    - stage: test_all
-      if: (branch = master) AND (type = pull_request)
-      script: travis_retry inv test --targets=${CHECK}
       env:
-        - CHECK=datadog_checks_base
-        - CHECK=active_directory
-        - CHECK=apache
-        - CHECK=aspdotnet
-        - CHECK=btrfs
-        - CHECK=ceph
-        - CHECK=consul
-        - CHECK=couch
-        - CHECK=couchbase
-        - CHECK=directory
-        - CHECK=disk
-        - CHECK=dotnetclr
-        - CHECK=elastic
-        - CHECK=envoy
-        - CHECK=exchange_server
-        - CHECK=haproxy
-        - CHECK=hdfs_namenode
-        - CHECK=iis
-        - CHECK=istio
-        - CHECK=kafka_consumer
-        - CHECK=kube_proxy
-        - CHECK=kubelet
-        - CHECK=kyototycoon
-        - CHECK=lighttpd
-        - CHECK=linkerd
-        - CHECK=marathon
-        - CHECK=mcache
-        # - CHECK=mysql
-        - CHECK=network
-        - CHECK=nfsstat
-        - CHECK=nginx
-        - CHECK=oracle
-        - CHECK=pdh_check
-        - CHECK=pgbouncer
-        # - CHECK=postgres
-        - CHECK=powerdns_recursor
-        - CHECK=prometheus
-        - CHECK=redisdb
-        - CHECK=riak
-        - CHECK=spark
-        - CHECK=ssh_check
-        - CHECK=squid
-        - CHECK=system_core
-        - CHECK=teamcity
-        - CHECK=varnish
-        - CHECK=vsphere
+        - CHECK=none
+    - stage: test_changed
+      if: type = pull_request
+      script: inv test --changed-only
+      env:
+        - CHECK=none
+    - stage: test_all
+      if: (branch = master) AND (type != pull_request)
+      script: travis_retry inv test --targets=${CHECK}
 before_install:
   - chmod +x .travis/prepare.sh
   - .travis/prepare.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: (env(BRANCH) = master)
+    - if: (env(BRANCH) = ofek/travis)
       env:
         - CHECK=datadog_checks_base
-    - if: branch = master
+    - if: (env(BRANCH) = ofek/travis)
       env:
         - CHECK=$CHANGED
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: (env(BRANCH) = master) OR (env(CHANGED) =~ ^datadog_checks_base/)
+    - if: (env(BRANCH) = master)
       env:
         - CHECK=datadog_checks_base
-    - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
+    - if: branch = master
       env:
         - CHECK=$CHANGED
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: env(BRANCH) =~ ofek/travis OR env(CHANGED) =~ ^datadog_checks_base/
+    - if: (env(BRANCH) =~ ofek/travis) OR (env(CHANGED) =~ ^datadog_checks_base/)
       env:
         - CHECK=datadog_checks_base
         - CHANGED=$(git diff --name-only master...)

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,13 @@ env:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
     - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
-    - CHANGED=$(git diff --name-only master...)
 matrix:
   fast_finish: true
   include:
     - if: env(BRANCH) =~ "ofek/travis"
       env:
         - CHECK=datadog_checks_base
-    - if: env(BRANCH) =~ "ofek/travis"
+    - if: env(BRANCH) =~ ofek/travis
       env:
         - CHECK=active_directory
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ env:
   - CHECK=vsphere
 before_install:
   - chmod +x .travis/prepare.sh
-  - sudo .travis/prepare.sh
+  - .travis/prepare.sh
 install:
   - pip install -U pip setuptools
   - pip install invoke pip-tools packaging tox docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,12 @@ jobs:
   include:
     - stage: manifest
       script: inv manifest --include-extras
+      env:
+        - CHECK=none
     - stage: test_changed
       script: inv test --changed-only
+      env:
+        - CHECK=none
     - stage: test_all
       script: travis_retry inv test --targets=${CHECK}
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
   include:
     - if: env(CHANGED) =~ "e"
       env:
-        - CHANGED=$(git diff --name-only master...)
+        - CHANGED="$(git diff --name-only master...)"
         - CHECK=datadog_checks_base
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,59 +12,17 @@ git:
 branches:
   only:
     - master
-matrix:
-  fast_finish: true
 env:
   global:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
-env:
-  - CHECK=datadog_checks_base
-  - CHECK=active_directory
-  - CHECK=apache
-  - CHECK=aspdotnet
-  - CHECK=btrfs
-  - CHECK=ceph
-  - CHECK=consul
-  - CHECK=couch
-  - CHECK=couchbase
-  - CHECK=directory
-  - CHECK=disk
-  - CHECK=dotnetclr
-  - CHECK=elastic
-  - CHECK=envoy
-  - CHECK=exchange_server
-  - CHECK=haproxy
-  - CHECK=hdfs_namenode
-  - CHECK=iis
-  - CHECK=istio
-  - CHECK=kafka_consumer
-  - CHECK=kube_proxy
-  - CHECK=kubelet
-  - CHECK=kyototycoon
-  - CHECK=lighttpd
-  - CHECK=linkerd
-  - CHECK=marathon
-  - CHECK=mcache
-  # - CHECK=mysql
-  - CHECK=network
-  - CHECK=nfsstat
-  - CHECK=nginx
-  - CHECK=oracle
-  - CHECK=pdh_check
-  - CHECK=pgbouncer
-  # - CHECK=postgres
-  - CHECK=powerdns_recursor
-  - CHECK=prometheus
-  - CHECK=redisdb
-  - CHECK=riak
-  - CHECK=spark
-  - CHECK=ssh_check
-  - CHECK=squid
-  - CHECK=system_core
-  - CHECK=teamcity
-  - CHECK=varnish
-  - CHECK=vsphere
+    - CHANGED=$(git diff --name-only master...)
+matrix:
+  fast_finish: true
+  include:
+    - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
+      env:
+        - CHECK=datadog_checks_base
 before_install:
   - chmod +x .travis/prepare.sh
   - .travis/prepare.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: head_branch = ofek/travis
+    - if: (branch = master) AND (head_branch = ofek/travis)
       env:
         - CHECK=datadog_checks_base
-    - if: head_branch = ofek/travis
+    - if: (branch = master) AND (head_branch = ofek/travis)
       env:
         - CHECK=active_directory
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: env(CHANGED) =~ datadog_checks_base
+    - if: env(CHANGED) =~ "e"
       env:
         - CHECK=datadog_checks_base
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,15 @@ env:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
     - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
+    - CHANGED=$(git diff --name-only master...)
 matrix:
   fast_finish: true
   include:
-    - if: env(CHANGED) =~ ^datadog_checks_base
+    - if: env(CHANGED) =~ datadog_checks_base
       env:
-        - CHANGED=datadog_checks_base
         - CHECK=datadog_checks_base
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
       env:
-        - CHANGED=$(git diff --name-only master...)
         - CHECK=active_directory
 before_install:
   - chmod +x .travis/prepare.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,21 +17,17 @@ env:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
     - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
+    - CHANGED=$(git diff --name-only master...)
 matrix:
   fast_finish: true
   include:
-    - if: (env(BRANCH) =~ ofek/travis) OR (env(CHANGED) =~ ^datadog_checks_base/)
+    - if: (env(BRANCH) = master) OR (env(CHANGED) =~ ^datadog_checks_base/)
       env:
         - CHECK=datadog_checks_base
-        - CHANGED=$(git diff --name-only master...)
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
       env:
         - CHECK=active_directory
-        - CHANGED=$(git diff --name-only master...)
 before_install:
-  - echo $CHECK
-  - echo $CHANGED
-  - echo $BRANCH
   - chmod +x .travis/prepare.sh
   - .travis/prepare.sh
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,20 +17,21 @@ env:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
 stages:
-  - name: manifest
   - name: test_changed
     if: type = pull_request
   - name: test
-    if: (branch = master) AND (type = pull_request)
+    if: (branch = master) AND (type != pull_request)
 jobs:
   fast_finish: true
   include:
-    - stage: manifest
-      script: inv manifest --include-extras
     - stage: test_changed
-      script: inv test --changed-only
+      script:
+       - inv manifest --include-extras
+       - inv test --changed-only
     - stage: test
-      script: travis_retry inv test --targets=${CHECK}
+      script:
+        - inv manifest --include-extras
+        - travis_retry inv test --targets=${CHECK}
       env: CHECK=datadog_checks_base
     - stage: test
       script: travis_retry inv test --targets=${CHECK}
@@ -41,7 +42,132 @@ jobs:
     - stage: test
       script: travis_retry inv test --targets=${CHECK}
       env: CHECK=aspdotnet
-        - CHECK=btrfs
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=btrfs
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=ceph
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=consul
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=couch
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=couchbase
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=directory
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=disk
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=dotnetclr
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=elastic
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=envoy
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=exchange_server
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=haproxy
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=hdfs_namenode
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=iis
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=istio
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=kafka_consumer
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=kube_proxy
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=kubelet
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=kyototycoon
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=lighttpd
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=linkerd
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=marathon
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=mcache
+    # - stage: test
+    #   script: travis_retry inv test --targets=${CHECK}
+    #   env: CHECK=mysql
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=network
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=nfsstat
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=nginx
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=oracle
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=pdh_check
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=pgbouncer
+    # - stage: test
+    #   script: travis_retry inv test --targets=${CHECK}
+    #   env: CHECK=postgres
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=powerdns_recursor
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=prometheus
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=redisdb
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=riak
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=spark
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=ssh_check
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=squid
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=system_core
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=teamcity
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=varnish
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=vsphere
 before_install:
   - chmod +x .travis/prepare.sh
   - .travis/prepare.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: branch = master
+    - if: branch = mock
       env:
         - CHECK=datadog_checks_base
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: (branch = master) AND (head_branch = ofek/travis)
+    - if: (branch = master) AND (type = pull_request)
       env:
         - CHECK=datadog_checks_base
-    - if: (branch = master) AND (head_branch = ofek/travis)
+    - if: (branch = master) AND (type = pull_request)
       env:
         - CHECK=active_directory
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,24 +16,74 @@ env:
   global:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
-matrix:
+stages:
+  - manifest
+  - test_changed
+    if: type = pull_request
+  - test_all
+    if: (branch = master) AND (type != pull_request)
+jobs:
   fast_finish: true
   include:
-    - if: (branch = master) AND (type = push)
+    - stage: manifest
+      script: inv manifest --include-extras
+    - stage: test_changed
+      script: inv test --changed-only
+    - stage: test_all
+      script: travis_retry inv test --targets=${CHECK}
       env:
         - CHECK=datadog_checks_base
-    - if: (branch = master) AND (type = push)
-      env:
         - CHECK=active_directory
+        - CHECK=apache
+        - CHECK=aspdotnet
+        - CHECK=btrfs
+        - CHECK=ceph
+        - CHECK=consul
+        - CHECK=couch
+        - CHECK=couchbase
+        - CHECK=directory
+        - CHECK=disk
+        - CHECK=dotnetclr
+        - CHECK=elastic
+        - CHECK=envoy
+        - CHECK=exchange_server
+        - CHECK=haproxy
+        - CHECK=hdfs_namenode
+        - CHECK=iis
+        - CHECK=istio
+        - CHECK=kafka_consumer
+        - CHECK=kube_proxy
+        - CHECK=kubelet
+        - CHECK=kyototycoon
+        - CHECK=lighttpd
+        - CHECK=linkerd
+        - CHECK=marathon
+        - CHECK=mcache
+        # - CHECK=mysql
+        - CHECK=network
+        - CHECK=nfsstat
+        - CHECK=nginx
+        - CHECK=oracle
+        - CHECK=pdh_check
+        - CHECK=pgbouncer
+        # - CHECK=postgres
+        - CHECK=powerdns_recursor
+        - CHECK=prometheus
+        - CHECK=redisdb
+        - CHECK=riak
+        - CHECK=spark
+        - CHECK=ssh_check
+        - CHECK=squid
+        - CHECK=system_core
+        - CHECK=teamcity
+        - CHECK=varnish
+        - CHECK=vsphere
 before_install:
   - chmod +x .travis/prepare.sh
   - .travis/prepare.sh
 install:
   - pip install -U pip setuptools
   - pip install invoke pip-tools packaging tox docker-compose
-script:
-  - if [[ $CHECK == "datadog_checks_base" ]]; then inv manifest --include-extras; fi
-  - travis_retry inv test --targets=${CHECK}
 # we should clean generated files before we save the cache
 # We don't want to save .pyc files, so we'll use find and -delete
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: env(BRANCH) = master OR env(CHANGED) =~ ^datadog_checks_base/
+    - if: env(BRANCH) = ofek/travis OR env(CHANGED) =~ ^datadog_checks_base/
       env:
         - CHECK=datadog_checks_base
         - CHANGED=$(git diff --name-only master...)

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,9 @@ env:
   - CHECK=vsphere
 before_install:
   - sudo service postgresql stop
+  - sudo service memcached stop
   - while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done
+  - while sudo lsof -Pi :11211 -sTCP:LISTEN -t; do sleep 1; done
 install:
   - pip install -U pip setuptools
   - pip install invoke pip-tools packaging tox docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,13 @@ env:
   global:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
-    - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
 matrix:
   fast_finish: true
   include:
-    - if: env(BRANCH) =~ "ofek/travis"
+    - if: head_branch =~ "ofek/travis"
       env:
         - CHECK=datadog_checks_base
-    - if: env(BRANCH) =~ ofek/travis
+    - if: head_branch =~ ofek/travis
       env:
         - CHECK=active_directory
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,15 @@ env:
   global:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
+
 stages:
   - name: test_changed
     if: type = pull_request
   - name: test
     if: (branch = master) AND (type = pull_request)
+
 script: travis_retry inv test --targets=${CHECK}
+
 jobs:
   fast_finish: true
   include:
@@ -30,10 +33,10 @@ jobs:
        - inv manifest --include-extras
        - inv test --changed-only
     - stage: test
+      env: CHECK=datadog_checks_base
       script:
         - inv manifest --include-extras
         - travis_retry inv test --targets=${CHECK}
-      env: CHECK=datadog_checks_base
     - stage: test
       env: CHECK=active_directory
     - stage: test
@@ -44,6 +47,86 @@ jobs:
       env: CHECK=btrfs
     - stage: test
       env: CHECK=ceph
+    - stage: test
+      env: CHECK=consul
+    - stage: test
+      env: CHECK=couch
+    - stage: test
+      env: CHECK=couchbase
+    - stage: test
+      env: CHECK=directory
+    - stage: test
+      env: CHECK=disk
+    - stage: test
+      env: CHECK=dotnetclr
+    - stage: test
+      env: CHECK=elastic
+    - stage: test
+      env: CHECK=envoy
+    - stage: test
+      env: CHECK=exchange_server
+    - stage: test
+      env: CHECK=haproxy
+    - stage: test
+      env: CHECK=hdfs_namenode
+    - stage: test
+      env: CHECK=iis
+    - stage: test
+      env: CHECK=istio
+    - stage: test
+      env: CHECK=kafka_consumer
+    - stage: test
+      env: CHECK=kube_proxy
+    - stage: test
+      env: CHECK=kubelet
+    - stage: test
+      env: CHECK=kyototycoon
+    - stage: test
+      env: CHECK=lighttpd
+    - stage: test
+      env: CHECK=linkerd
+    - stage: test
+      env: CHECK=marathon
+    - stage: test
+      env: CHECK=mcache
+    # - stage: test
+    #   env: CHECK=mysql
+    - stage: test
+      env: CHECK=network
+    - stage: test
+      env: CHECK=nfsstat
+    - stage: test
+      env: CHECK=nginx
+    - stage: test
+      env: CHECK=oracle
+    - stage: test
+      env: CHECK=pdh_check
+    - stage: test
+      env: CHECK=pgbouncer
+    # - stage: test
+    #   env: CHECK=postgres
+    - stage: test
+      env: CHECK=powerdns_recursor
+    - stage: test
+      env: CHECK=prometheus
+    - stage: test
+      env: CHECK=redisdb
+    - stage: test
+      env: CHECK=riak
+    - stage: test
+      env: CHECK=spark
+    - stage: test
+      env: CHECK=ssh_check
+    - stage: test
+      env: CHECK=squid
+    - stage: test
+      env: CHECK=system_core
+    - stage: test
+      env: CHECK=teamcity
+    - stage: test
+      env: CHECK=varnish
+    - stage: test
+      env: CHECK=vsphere
 before_install:
   - chmod +x .travis/prepare.sh
   - .travis/prepare.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
+    - if: branch = master OR env(CHANGED) =~ ^datadog_checks_base/
       env:
         - CHECK=datadog_checks_base
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: branch = mock
+    - if: branch = master OR env(CHANGED) =~ ^datadog_checks_base/
       env:
         - CHECK=datadog_checks_base
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
@@ -29,6 +29,7 @@ matrix:
 before_install:
   - echo $CHECK
   - echo $CHANGED
+  - echo ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
   - chmod +x .travis/prepare.sh
   - .travis/prepare.sh
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: branch = master OR env(CHANGED) =~ ^datadog_checks_base/
+    - if: branch = master
       env:
         - CHECK=datadog_checks_base
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,68 +16,32 @@ env:
   global:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
-env:
-  - CHECK=datadog_checks_base
-  - CHECK=active_directory
-  - CHECK=apache
-  - CHECK=aspdotnet
-  - CHECK=btrfs
-  - CHECK=ceph
-  - CHECK=consul
-  - CHECK=couch
-  - CHECK=couchbase
-  - CHECK=directory
-  - CHECK=disk
-  - CHECK=dotnetclr
-  - CHECK=elastic
-  - CHECK=envoy
-  - CHECK=exchange_server
-  - CHECK=haproxy
-  - CHECK=hdfs_namenode
-  - CHECK=iis
-  - CHECK=istio
-  - CHECK=kafka_consumer
-  - CHECK=kube_proxy
-  - CHECK=kubelet
-  - CHECK=kyototycoon
-  - CHECK=lighttpd
-  - CHECK=linkerd
-  - CHECK=marathon
-  - CHECK=mcache
-  # - CHECK=mysql
-  - CHECK=network
-  - CHECK=nfsstat
-  - CHECK=nginx
-  - CHECK=oracle
-  - CHECK=pdh_check
-  - CHECK=pgbouncer
-  # - CHECK=postgres
-  - CHECK=powerdns_recursor
-  - CHECK=prometheus
-  - CHECK=redisdb
-  - CHECK=riak
-  - CHECK=spark
-  - CHECK=ssh_check
-  - CHECK=squid
-  - CHECK=system_core
-  - CHECK=teamcity
-  - CHECK=varnish
-  - CHECK=vsphere
+stages:
+  - name: manifest
+  - name: test_changed
+    if: type = pull_request
+  - name: test
+    if: (branch = master) AND (type != pull_request)
 jobs:
   fast_finish: true
   include:
     - stage: manifest
       script: inv manifest --include-extras
-      env:
-        - CHECK=none
     - stage: test_changed
-      if: type = pull_request
       script: inv test --changed-only
-      env:
-        - CHECK=none
     - stage: test
-      if: (branch = master) AND (type != pull_request)
       script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=datadog_checks_base
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=active_directory
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=apache
+    - stage: test
+      script: travis_retry inv test --targets=${CHECK}
+      env: CHECK=aspdotnet
+        - CHECK=btrfs
 before_install:
   - chmod +x .travis/prepare.sh
   - .travis/prepare.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,12 @@ env:
   global:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
+    - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
     - CHANGED=$(git diff --name-only master...)
 matrix:
   fast_finish: true
   include:
-    - if: branch = master OR env(CHANGED) =~ ^datadog_checks_base/
+    - if: env(BRANCH) = master OR env(CHANGED) =~ ^datadog_checks_base/
       env:
         - CHECK=datadog_checks_base
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
@@ -29,7 +30,7 @@ matrix:
 before_install:
   - echo $CHECK
   - echo $CHANGED
-  - echo ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
+  - echo $BRANCH
   - chmod +x .travis/prepare.sh
   - .travis/prepare.sh
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,8 @@ jobs:
   include:
     - stage: manifest
       script: inv manifest --include-extras
-    - stage: test_changed
-      if: type = pull_request
-      script: inv test --changed-only
     - stage: test_all
-      if: (branch = master) AND (type != pull_request)
+      if: (branch = master) AND (type = pull_request)
       script: travis_retry inv test --targets=${CHECK}
       env:
         - CHECK=datadog_checks_base

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,13 @@ stages:
 
 script: travis_retry inv test --targets=${CHECK}
 
+# Conditional jobs are currently buggy and verbose.
+#
+# https://github.com/travis-ci/beta-features/issues/28
+# https://github.com/travis-ci/beta-features/issues/40
+# https://github.com/travis-ci/travis-ci/issues/8295
+# https://github.com/travis-ci/travis-conditions/pull/1
+# https://github.com/travis-ci/travis-ci/issues/6652
 jobs:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,16 @@ env:
   global:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
+    - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
 matrix:
   fast_finish: true
   include:
     - if: env(BRANCH) =~ ofek/travis OR env(CHANGED) =~ ^datadog_checks_base/
       env:
-        - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
         - CHECK=datadog_checks_base
         - CHANGED=$(git diff --name-only master...)
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
       env:
-        - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
         - CHECK=active_directory
         - CHANGED=$(git diff --name-only master...)
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ stages:
   - name: test_changed
     if: type = pull_request
   - name: test
-    if: (branch = master) AND (type = pull_request)
+    if: (branch = master) AND (type != pull_request)
 
 script: travis_retry inv test --targets=${CHECK}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ stages:
     if: type = pull_request
   - name: test
     if: (branch = master) AND (type = pull_request)
-    script: travis_retry inv test --targets=${CHECK}
+script: travis_retry inv test --targets=${CHECK}
 jobs:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,12 @@ matrix:
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
       env:
         - CHECK=datadog_checks_base
+    - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
+      env:
+        - CHECK=active_directory
 before_install:
+  - echo $CHECK
+  - echo $CHANGED
   - chmod +x .travis/prepare.sh
   - .travis/prepare.sh
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ stages:
     if: type = pull_request
   - name: test
     if: (branch = master) AND (type = pull_request)
+    script: travis_retry inv test --targets=${CHECK}
 jobs:
   fast_finish: true
   include:
@@ -34,140 +35,15 @@ jobs:
         - travis_retry inv test --targets=${CHECK}
       env: CHECK=datadog_checks_base
     - stage: test
-      script: travis_retry inv test --targets=${CHECK}
       env: CHECK=active_directory
     - stage: test
-      script: travis_retry inv test --targets=${CHECK}
       env: CHECK=apache
     - stage: test
-      script: travis_retry inv test --targets=${CHECK}
       env: CHECK=aspdotnet
     - stage: test
-      script: travis_retry inv test --targets=${CHECK}
       env: CHECK=btrfs
     - stage: test
-      script: travis_retry inv test --targets=${CHECK}
       env: CHECK=ceph
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=consul
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=couch
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=couchbase
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=directory
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=disk
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=dotnetclr
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=elastic
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=envoy
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=exchange_server
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=haproxy
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=hdfs_namenode
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=iis
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=istio
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=kafka_consumer
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=kube_proxy
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=kubelet
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=kyototycoon
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=lighttpd
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=linkerd
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=marathon
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=mcache
-    # - stage: test
-    #   script: travis_retry inv test --targets=${CHECK}
-    #   env: CHECK=mysql
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=network
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=nfsstat
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=nginx
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=oracle
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=pdh_check
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=pgbouncer
-    # - stage: test
-    #   script: travis_retry inv test --targets=${CHECK}
-    #   env: CHECK=postgres
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=powerdns_recursor
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=prometheus
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=redisdb
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=riak
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=spark
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=ssh_check
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=squid
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=system_core
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=teamcity
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=varnish
-    - stage: test
-      script: travis_retry inv test --targets=${CHECK}
-      env: CHECK=vsphere
 before_install:
   - chmod +x .travis/prepare.sh
   - .travis/prepare.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,6 @@ env:
   global:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
-stages:
-  - manifest
-  - test_changed
-    if: type = pull_request
-  - test_all
-    if: (branch = master) AND (type != pull_request)
 jobs:
   fast_finish: true
   include:
@@ -30,10 +24,12 @@ jobs:
       env:
         - CHECK=none
     - stage: test_changed
+      if: type = pull_request
       script: inv test --changed-only
       env:
         - CHECK=none
     - stage: test_all
+      if: (branch = master) AND (type != pull_request)
       script: travis_retry inv test --targets=${CHECK}
       env:
         - CHECK=datadog_checks_base

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,16 @@ env:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
     - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
-    - CHANGED=$(git diff --name-only master...)
 matrix:
   fast_finish: true
   include:
     - if: env(CHANGED) =~ ^datadog_checks_base/
       env:
+        - CHANGED=$(git diff --name-only master...)
         - CHECK=datadog_checks_base
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
       env:
+        - CHANGED=$(git diff --name-only master...)
         - CHECK=active_directory
 before_install:
   - chmod +x .travis/prepare.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,14 +46,14 @@ env:
   - CHECK=linkerd
   - CHECK=marathon
   - CHECK=mcache
-  - CHECK=mysql
+  # - CHECK=mysql
   - CHECK=network
   - CHECK=nfsstat
   - CHECK=nginx
   - CHECK=oracle
   - CHECK=pdh_check
   - CHECK=pgbouncer
-  - CHECK=postgres
+  # - CHECK=postgres
   - CHECK=powerdns_recursor
   - CHECK=prometheus
   - CHECK=redisdb
@@ -66,10 +66,8 @@ env:
   - CHECK=varnish
   - CHECK=vsphere
 before_install:
-  - sudo service postgresql stop
-  - sudo service memcached stop
-  - while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done
-  - while sudo lsof -Pi :11211 -sTCP:LISTEN -t; do sleep 1; done
+  - chmod +x .travis/install.sh
+  - .travis/install.sh
 install:
   - pip install -U pip setuptools
   - pip install invoke pip-tools packaging tox docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ stages:
   - name: test_changed
     if: type = pull_request
   - name: test
-    if: (branch = master) AND (type != pull_request)
+    if: (branch = master) AND (type = pull_request)
 jobs:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,9 @@ jobs:
   include:
     - stage: manifest
       script: inv manifest --include-extras
-      env:
-        - CHECK=none
     - stage: test_changed
       if: type = pull_request
       script: inv test --changed-only
-      env:
-        - CHECK=none
     - stage: test_all
       if: (branch = master) AND (type != pull_request)
       script: travis_retry inv test --targets=${CHECK}

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: (env(BRANCH) = master) OR (env(CHANGED) =~ ^datadog_checks_base/)
+    - if: env(CHANGED) =~ ^datadog_checks_base/
       env:
         - CHECK=datadog_checks_base
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,19 @@ env:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
     - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
+    - CHANGED=$(git diff --name-only master...)
 matrix:
   fast_finish: true
   include:
-    - if: env(CHANGED) =~ "e"
+    - if: (env(BRANCH) = ofek/travis) OR (env(CHANGED) =~ ^datadog_checks_base/)
       env:
-        - CHANGED="$(git diff --name-only master...)"
         - CHECK=datadog_checks_base
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
       env:
-        - CHANGED=$(git diff --name-only master...)
-        - CHECK=active_directory
+        - CHECK=$CHANGED
 before_install:
+  - echo $CHANGED
+  - echo $CHECK
   - chmod +x .travis/prepare.sh
   - .travis/prepare.sh
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,16 @@ env:
     - SKIP_CLEANUP=true
     - PIP_CACHE=$HOME/.cache/pip
     - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
-    - CHANGED=$(git diff --name-only master...)
 matrix:
   fast_finish: true
   include:
     - if: env(CHANGED) =~ "e"
       env:
+        - CHANGED=$(git diff --name-only master...)
         - CHECK=datadog_checks_base
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
       env:
+        - CHANGED=$(git diff --name-only master...)
         - CHECK=active_directory
 before_install:
   - chmod +x .travis/prepare.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ env:
 matrix:
   fast_finish: true
   include:
-    - if: env(CHANGED) =~ ^datadog_checks_base/
+    - if: env(CHANGED) =~ ^datadog_checks_base
       env:
-        - CHANGED=$(git diff --name-only master...)
+        - CHANGED=datadog_checks_base
         - CHECK=datadog_checks_base
     - if: branch = master OR env(CHANGED) =~ "^${CHECK}/"
       env:

--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -4,12 +4,12 @@ set -ex
 
 case $CHECK in
     couchbase|mcache)
-        sudo service postgresql stop
-        while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done
-        ;;
-    pgbouncer|postgres)
         sudo service memcached stop
         while sudo lsof -Pi :11211 -sTCP:LISTEN -t; do sleep 1; done
+        ;;
+    pgbouncer|postgres)
+        sudo service postgresql stop
+        while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done
         ;;
 esac
 

--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-case "${CHECK}" in
+set -ex
+
+case $CHECK in
     couchbase|mcache)
         sudo service postgresql stop
         while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done
@@ -10,3 +12,5 @@ case "${CHECK}" in
         while sudo lsof -Pi :11211 -sTCP:LISTEN -t; do sleep 1; done
         ;;
 esac
+
+set +ex

--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -3,12 +3,12 @@
 set -ex
 
 # Stop any services that bind to ports we need.
-if [[ "$CHECK" =~ "^$|couchbase|mcache" ]]; then
+if [[ "$CHECK" =~ ^$|couchbase|mcache ]]; then
     sudo service memcached stop
     while sudo lsof -Pi :11211 -sTCP:LISTEN -t; do sleep 1; done
 fi
 
-if [[ "$CHECK" =~ "^$|pgbouncer|postgres" ]]; then
+if [[ "$CHECK" =~ ^$|pgbouncer|postgres ]]; then
     sudo service postgresql stop
     while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done
 fi

--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -2,6 +2,7 @@
 
 set -ex
 
+# Stop any services that bind to ports we need.
 case $CHECK in
     couchbase|mcache)
         sudo service memcached stop

--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -8,7 +8,7 @@ case $CHECK in
         sudo service memcached stop
         while sudo lsof -Pi :11211 -sTCP:LISTEN -t; do sleep 1; done
         ;;
-    pgbouncer|postgres|)
+    pgbouncer|postgres|"")
         sudo service postgresql stop
         while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done
         ;;

--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -4,7 +4,7 @@ set -ex
 
 # Stop any services that bind to ports we need.
 case $CHECK in
-    couchbase|mcache|)
+    couchbase|mcache|"")
         sudo service memcached stop
         while sudo lsof -Pi :11211 -sTCP:LISTEN -t; do sleep 1; done
         ;;

--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -3,15 +3,14 @@
 set -ex
 
 # Stop any services that bind to ports we need.
-case $CHECK in
-    couchbase|mcache|"")
-        sudo service memcached stop
-        while sudo lsof -Pi :11211 -sTCP:LISTEN -t; do sleep 1; done
-        ;;
-    pgbouncer|postgres|"")
-        sudo service postgresql stop
-        while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done
-        ;;
-esac
+if [[ "$CHECK" =~ "^$|couchbase|mcache" ]]; then
+    sudo service memcached stop
+    while sudo lsof -Pi :11211 -sTCP:LISTEN -t; do sleep 1; done
+fi
+
+if [[ "$CHECK" =~ "^$|pgbouncer|postgres" ]]; then
+    sudo service postgresql stop
+    while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done
+fi
 
 set +ex

--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -4,11 +4,11 @@ set -ex
 
 # Stop any services that bind to ports we need.
 case $CHECK in
-    couchbase|mcache)
+    couchbase|mcache|)
         sudo service memcached stop
         while sudo lsof -Pi :11211 -sTCP:LISTEN -t; do sleep 1; done
         ;;
-    pgbouncer|postgres)
+    pgbouncer|postgres|)
         sudo service postgresql stop
         while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done
         ;;

--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+case "${CHECK}" in
+    couchbase|mcache)
+        sudo service postgresql stop
+        while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done
+        ;;
+    pgbouncer|postgres)
+        sudo service memcached stop
+        while sudo lsof -Pi :11211 -sTCP:LISTEN -t; do sleep 1; done
+        ;;
+esac

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -32,7 +32,7 @@ def postgres_standalone():
     # waiting for PG to start
     attempts = 0
     while True:
-        if attempts > 90:
+        if attempts > 10:
             subprocess.check_call(args + ["down"], env=env)
             raise Exception("PostgreSQL boot timed out!")
 


### PR DESCRIPTION
### Motivation

1. Concurrent jobs
2. Due to the increased speed from `1`, we can test everything on merges instead of `--changed-only`, allowing us to notice when things break
3. Pull requests from forks can now trigger tests

### Notes

- We're skipping `postgres` and `mysql` until their tests get fixed.
- It appears we broke our Travis config file in https://github.com/DataDog/integrations-core/pull/1540 so we're actually not even running a matrix anymore. This fixes that.