### PR TITLE
[kafka_consumer] Bump to kafka-python 1.4.3

### DIFF
--- a/kafka_consumer/requirements.in
+++ b/kafka_consumer/requirements.in
@@ -1,2 +1,2 @@
-kafka-python==1.3.4
+kafka-python==1.4.3
 kazoo==2.4.0

--- a/kafka_consumer/requirements.txt
+++ b/kafka_consumer/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --generate-hashes --output-file requirements.txt requirements.in
 #
-kafka-python==1.3.4 \
-    --hash=sha256:2cafc367f06c121fecb43bfd83d6b72423036924a7903a239199671a848d98b3 \
-    --hash=sha256:a84d9635e3a4d5054c342ad6e5b338f9438fbcac810b677a2f6da68a51fb66a8
+kafka-python==1.4.3 \
+    --hash=sha256:078acdcd1fc6eddacc46d437c664998b4cf7613b7e79ced66a460965f2648f88 \
+    --hash=sha256:0b56f286b674dcb331d80c1d39a01a753cc3acc962bee707da5f207db74f0a26
 kazoo==2.4.0 \
     --hash=sha256:a29fa579812a2c5dd8241eafb8328b8a8673f140903a6102e017129aa223d0c7 \
     --hash=sha256:a7c2d1d7ddb047c936d368e31b08a93bb327ffa46606fe85f550a37ce608c29b


### PR DESCRIPTION
This bumps to 1.4.3 which removed the DNS retries when the bootstrap
brokers list contained a failing broker:
https://github.com/dpkp/kafka-python/pull/1507

This should fix the issues observed in https://github.com/DataDog/integrations-core/pull/1592