### PR TITLE
[docs] Add detailed inline docs on get_subprocess_output function

### DIFF
--- a/datadog_checks_base/datadog_checks/utils/subprocess_output.py
+++ b/datadog_checks_base/datadog_checks/utils/subprocess_output.py
@@ -24,6 +24,17 @@ def get_subprocess_output(command, log, raise_on_empty_output=True):
     """
     Run the given subprocess command and return its output. Raise an Exception
     if an error occurs.
+
+    :param command: The command to run. Using a list of strings is recommended. The command
+                    will be run in a subprocess without using a shell, as such shell features like
+                    shell pipes, wildcard expansion, environment variable expansion, etc., are
+                    not supported.
+    :type command: list(str) or str
+    :param logging.Logger log: The log object to use
+    :param bool raise_on_empty_output: Whether to raise a SubprocessOutputEmptyError exception when
+                                       the subprocess doesn't output anything to its stdout.
+    :returns: The stdout contents, stderr contents and status code of the command
+    :rtype: tuple(str, str, int)
     """
 
     cmd_args = []


### PR DESCRIPTION
### What does this PR do?

Adds detailed inline docs on `get_subprocess_output` function.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
~Feature or bugfix has tests~
- [x] Git history is clean
~If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)~

### Additional Notes

Followed sphinx syntax documented here: http://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#info-field-lists