### PR TITLE
Bumped version to 1.2.1

### DIFF
--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - mysql
 
+### 1.2.1 / 2018-05-31
+
+* [Fixed] Fix replication data extraction when replication channel is set. See [#1639](https://github.com/DataDog/integrations-core/pull/1639).
+* [Fixed] Fix error while fetching mysql pid from psutil . See [#1620](https://github.com/DataDog/integrations-core/pull/1620).
+
 ## 1.2.0 / 2018-05-11
 
 * [FEATURE] Add custom tag support to service checks.

--- a/mysql/datadog_checks/mysql/__about__.py
+++ b/mysql/datadog_checks/mysql/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"


### PR DESCRIPTION
### What does this PR do?

Bump Mysql to 1.2.1
