### PR TITLE
Fix bug parsing squid metrics

### DIFF
--- a/squid/datadog_checks/squid/squid.py
+++ b/squid/datadog_checks/squid/squid.py
@@ -94,7 +94,7 @@ class SquidCheck(AgentCheck):
             raise
 
         # Each line is a counter in the form 'counter_name = value'
-        raw_counters = res.text.split("\n")
+        raw_counters = res.text.strip().split("\n")
         counters = {}
         for line in raw_counters:
             counter, value = self.parse_counter(line)


### PR DESCRIPTION
### What does this PR do?

Fix bug parsing squid metrics.

Squid can return a trailing newline at the end of its metrics. Prior to
this change the trailing newline would be treated as a metric line, and
an error would be raised attempting to parse the line due to a missing
`=` character. This strips the trailing newline from the metrics before
they're parsed line by line.

### Motivation

I noticed we weren't receiving metrics from the agent's squid integration. Upon inspecting the logs I found:

```
(datadog_agent.go:133 in LogMessage) | (squid.py:130) | Error parsing counter with line : need more than 1 value to unpack
```

Running the change in this PR has restored our squid metrics.
