### PR TITLE
Add integration requirements file

### DIFF
--- a/requirements-integration-core.txt
+++ b/requirements-integration-core.txt
@@ -1,0 +1,86 @@
+active_directory==1.1.0; sys_platform == 'win32'
+activemq_xml==1.0.0
+apache==1.2.0
+aspdotnet==0.1.2; sys_platform == 'win32'
+btrfs==1.1.0; sys_platform != 'win32'
+cacti==1.1.0; sys_platform != 'win32'
+cassandra_nodetool==0.1.1
+ceph==1.3.0; sys_platform != 'win32'
+consul==1.4.0
+couch==2.5.0
+couchbase==1.3.0
+datadog_checks_base==1.2.2
+directory==1.2.0
+disk==1.2.0
+dns_check==1.1.0
+dotnetclr==1.0.0; sys_platform == 'win32'
+ecs_fargate==1.2.0
+elastic==1.6.0
+envoy==1.1.0
+etcd==1.4.0
+exchange_server==1.1.0; sys_platform == 'win32'
+fluentd==1.0.0
+gearmand==1.1.0; sys_platform != 'win32'
+gitlab==1.1.0
+gitlab_runner==1.1.0
+go_expvar==1.0.3
+gunicorn==1.2.0; sys_platform != 'win32'
+haproxy==1.3.0
+hdfs_datanode==1.2.0; sys_platform != 'win32'
+hdfs_namenode==1.2.1; sys_platform != 'win32'
+http_check==2.1.0
+iis==2.1.0; sys_platform == 'win32'
+istio==1.0.0
+kafka_consumer==1.4.0; sys_platform != 'win32'
+kong==1.2.0
+kube_dns==1.3.0
+kube_proxy==1.0.0
+kubelet==1.2.0; sys_platform == 'linux2'
+kubernetes_state==2.5.0; sys_platform != 'win32'
+kyototycoon==1.3.0
+lighttpd==1.2.0
+linkerd==1.0.0
+linux_proc_extras==1.0.0; sys_platform == 'linux'
+mapreduce==1.2.0
+marathon==1.3.0; sys_platform != 'win32'
+mcache==1.2.0; sys_platform != 'win32'
+mesos_master==1.2.0; sys_platform != 'win32'
+mesos_slave==1.2.0; sys_platform != 'win32'
+mongo==1.5.4
+mysql==1.2.0
+nagios==1.1.0
+network==1.5.0
+nfsstat==0.2.0; sys_platform == 'linux2'
+nginx==2.2.0
+openstack==1.2.0
+oracle==1.3.0
+pdh_check==1.2.0; sys_platform == 'win32'
+pgbouncer==1.2.0; sys_platform != 'win32'
+php_fpm==1.1.0
+postfix==1.1.0; sys_platform != 'win32'
+postgres==2.1.1
+powerdns_recursor==1.0.0
+process==1.3.0
+prometheus==1.0.0
+rabbitmq==1.5.1
+redisdb==1.5.0
+riak==1.2.0
+riakcs==1.1.0
+snmp==1.4.0
+spark==1.2.0
+sqlserver==1.4.0; sys_platform == 'win32'
+squid==1.0.0
+ssh_check==1.2.0
+system_core==1.0.0
+system_swap==1.1.0
+tcp_check==2.0.0
+teamcity==1.0.0
+tokumx==1.2.0
+twemproxy==1.2.0
+varnish==1.2.0
+vsphere==2.1.0
+win32_event_log==1.1.1; sys_platform == 'win32'
+win32_service==1.2.0; sys_platform == 'win32'
+wmi_check==1.1.1; sys_platform == 'win32'
+yarn==1.2.0
+zk==1.2.0; sys_platform != 'win32'


### PR DESCRIPTION
### What does this PR do?

Add an integration core requirements file to the root of this repo. This should align at the 6.2.0 Agent release. 

Currently this file will only be used for documentation purposes, its not used as part of the build process. This will be updated and available in the git tag corresponding to each agent release so users and we can keep better track of which versions ship with each Agent release

Taken from this PR in datadog-agent - https://github.com/DataDog/datadog-agent/pull/1701/files

### Motivation

Provide better clarity for what versions of each integration is bundled with each Agent release. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
