### PR TITLE
Allow users to specify scheme in server URLs

### DIFF
--- a/teamcity/conf.yaml.example
+++ b/teamcity/conf.yaml.example
@@ -28,11 +28,12 @@ instances:
     # rather than just that a successful build happened
     # is_deployment: true
 
+    # Optional, this allows you to connect to your server through HTTPS. Defaults to False.
+    # use_https: false
+
     # Optional, this turns off ssl certificate validation. Defaults to True.
-    # ssl_validation: false
+    # ssl_validation: true
 
     # Optional, any additional tags you'd like to add to the event
     # tags:
     #   - test
-
-

--- a/teamcity/conf.yaml.example
+++ b/teamcity/conf.yaml.example
@@ -10,8 +10,8 @@ instances:
     # Specify the server name of your teamcity instance here
     # Guest authentication must be on if you want the check to be able to get data
     # When using the optional basic_http_authentication use
-    # server: user:password@teamcity.mycompany.com
-    server: teamcity.mycompany.com
+    # server: http://user:password@teamcity.mycompany.com
+    server: http://teamcity.mycompany.com
 
     # This is the internal build ID of the build configuration you wish to track.
     # You can find it labelled as "Build configuration ID" when editing the configuration in question.
@@ -27,9 +27,6 @@ instances:
     # Optional, this changes the event message slightly to specify that TeamCity was used to deploy something
     # rather than just that a successful build happened
     # is_deployment: true
-
-    # Optional, this allows you to connect to your server through HTTPS. Defaults to False.
-    # use_https: false
 
     # Optional, this turns off ssl certificate validation. Defaults to True.
     # ssl_validation: true

--- a/teamcity/datadog_checks/teamcity/teamcity.py
+++ b/teamcity/datadog_checks/teamcity/teamcity.py
@@ -18,17 +18,13 @@ class TeamCityCheck(AgentCheck):
     HEADERS = {"Accept": "application/json"}
     DEFAULT_TIMEOUT = 10
 
-    # E
     NEW_BUILD_URL = (
-        "{server}/guestAuth/app/rest/builds/"
-        + "?locator=buildType:{build_conf},sinceBuild:id:{since_build},status:SUCCESS"
+        "{server}/guestAuth/app/rest/builds/?locator=buildType:{build_conf},sinceBuild:id:{since_build},status:SUCCESS"
     )
-    LAST_BUILD_URL = "{server}/guestAuth/app/rest/builds/" + "?locator=buildType:{build_conf},count:1"
+    LAST_BUILD_URL = "{server}/guestAuth/app/rest/builds/?locator=buildType:{build_conf},count:1"
 
-    # HTTP Authenticated Endpoints
     NEW_BUILD_URL_AUTHENTICATED = (
-        "{server}/httpAuth/app/rest/builds/"
-        + "?locator=buildType:{build_conf},sinceBuild:id:{since_build},status:SUCCESS"
+        "{server}/httpAuth/app/rest/builds/?locator=buildType:{build_conf},sinceBuild:id:{since_build},status:SUCCESS"
     )
     LAST_BUILD_URL_AUTHENTICATED = "{server}/httpAuth/app/rest/builds/?locator=buildType:{build_conf},count:1"
 

--- a/teamcity/tests/test_teamcity.py
+++ b/teamcity/tests/test_teamcity.py
@@ -9,20 +9,17 @@ import pytest
 # project
 from datadog_checks.teamcity import TeamCityCheck
 
-CHECK_NAME = 'nfsstat'
-
-INIT_CONFIG = {}
-INSTANCES = [
-    {
+CONFIG = {
+    'instances': [{
         'name': 'One test build',
         'server': 'localhost:8111',
         'build_configuration': 'TestProject_TestBuild',
         'host_affected': 'buildhost42.dtdg.co',
         'basic_http_authentication': False,
         'is_deployment': False,
-        'tags': ['one:tag', 'one:test']
-    }
-]
+        'tags': ['one:tag', 'one:test'],
+    }]
+}
 
 
 @pytest.fixture
@@ -30,6 +27,35 @@ def aggregator():
     from datadog_checks.stubs import aggregator
     aggregator.reset()
     return aggregator
+
+
+def test_build_event(aggregator):
+    teamcity = TeamCityCheck('teamcity', {}, {})
+
+    with patch('requests.get', get_mock_first_build):
+        teamcity.check(CONFIG['instances'][0])
+
+    assert len(aggregator.metric_names) == 0
+    assert len(aggregator.events) == 0
+    aggregator.reset()
+
+    with patch('requests.get', get_mock_one_more_build):
+        teamcity.check(CONFIG['instances'][0])
+
+    events = aggregator.events
+    assert len(events) == 1
+    assert events[0]['msg_title'] == "Build for One test build successful"
+    assert events[0]['msg_text'] == "Build Number: 2\nDeployed To: buildhost42.dtdg.co\n\nMore Info: " + \
+                                    "http://localhost:8111/viewLog.html?buildId=2&buildTypeId=TestProject_TestBuild"
+    assert events[0]['tags'] == ['build', 'one:tag', 'one:test']
+    assert events[0]['host'] == "buildhost42.dtdg.co"
+    aggregator.reset()
+
+    # One more check should not create any more events
+    with patch('requests.get', get_mock_one_more_build):
+        teamcity.check(CONFIG['instances'][0])
+
+    assert len(aggregator.events) == 0
 
 
 def get_mock_first_build(url, *args, **kwargs):
@@ -91,36 +117,3 @@ def get_mock_one_more_build(url, *args, **kwargs):
 
     mock_resp.json.return_value = json
     return mock_resp
-
-
-def test_build_event(aggregator):
-    agent_config = {
-        'version': '0.1',
-        'api_key': 'toto'
-    }
-    check = TeamCityCheck('teamcity', {}, agent_config, INSTANCES)
-
-    with patch('requests.get', get_mock_first_build):
-        check.check(check.instances[0])
-
-    assert len(aggregator.metric_names) == 0
-    assert len(aggregator.events) == 0
-    aggregator.reset()
-
-    with patch('requests.get', get_mock_one_more_build):
-        check.check(check.instances[0])
-
-    events = aggregator.events
-    assert len(events) == 1
-    assert events[0]['msg_title'] == "Build for One test build successful"
-    assert events[0]['msg_text'] == "Build Number: 2\nDeployed To: buildhost42.dtdg.co\n\nMore Info: " + \
-                                    "http://localhost:8111/viewLog.html?buildId=2&buildTypeId=TestProject_TestBuild"
-    assert events[0]['tags'] == ['build', 'one:tag', 'one:test']
-    assert events[0]['host'] == "buildhost42.dtdg.co"
-    aggregator.reset()
-
-    # One more check should not create any more events
-    with patch('requests.get', get_mock_one_more_build):
-        check.check(check.instances[0])
-
-    assert len(aggregator.events) == 0

--- a/teamcity/tests/test_teamcity.py
+++ b/teamcity/tests/test_teamcity.py
@@ -1,6 +1,6 @@
-# (C) Datadog, Inc. 2010-2017
+# (C) Datadog, Inc. 2018
 # All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
+# Licensed under a 3-clause BSD style license (see LICENSE)
 
 # 3p
 from mock import MagicMock, patch
@@ -29,6 +29,7 @@ def aggregator():
     return aggregator
 
 
+@pytest.mark.integration
 def test_build_event(aggregator):
     teamcity = TeamCityCheck('teamcity', {}, {})
 

--- a/teamcity/tests/test_unit.py
+++ b/teamcity/tests/test_unit.py
@@ -1,0 +1,44 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+# project
+from datadog_checks.teamcity import TeamCityCheck
+
+# A path regularly used in the TeamCity Check
+COMMON_PATH = "guestAuth/app/rest/builds/?locator=buildType:TestProject_TestBuild,sinceBuild:id:1,status:SUCCESS"
+
+# These values are acceptable URLs
+TEAMCITY_SERVER_VALUES = {
+
+    # Regular URLs
+    "localhost:8111/httpAuth": "http://localhost:8111/httpAuth",
+    "localhost:8111/{}".format(COMMON_PATH): "http://localhost:8111/{}".format(COMMON_PATH),
+    "http.com:8111/{}".format(COMMON_PATH): "http://http.com:8111/{}".format(COMMON_PATH),
+    "http://localhost:8111/some_extra_url_with_http://": "http://localhost:8111/some_extra_url_with_http://",
+    "https://localhost:8111/correct_url_https://": "https://localhost:8111/correct_url_https://",
+    "https://localhost:8111/{}".format(COMMON_PATH): "https://localhost:8111/{}".format(COMMON_PATH),
+    "http://http.com:8111/{}".format(COMMON_PATH): "http://http.com:8111/{}".format(COMMON_PATH),
+
+    # <user>:<password>@teamcity.company.com
+    "user:password@localhost:8111/http://_and_https://": "http://user:password@localhost:8111/http://_and_https://",
+    "user:password@localhost:8111/{}".format(COMMON_PATH):
+        "http://user:password@localhost:8111/{}".format(COMMON_PATH),
+    "http://user:password@localhost:8111/{}".format(COMMON_PATH):
+        "http://user:password@localhost:8111/{}".format(COMMON_PATH),
+    "https://user:password@localhost:8111/{}".format(COMMON_PATH):
+        "https://user:password@localhost:8111/{}".format(COMMON_PATH),
+}
+
+
+def test_server_normalization():
+    """
+    Make sure server URLs are being normalized correctly
+    """
+
+    teamcity = TeamCityCheck("teamcity", {}, {})
+
+    for server, expected_server in TEAMCITY_SERVER_VALUES.iteritems():
+        normalized_server = teamcity._normalize_server_url(server)
+
+        assert expected_server == normalized_server

--- a/teamcity/tox.ini
+++ b/teamcity/tox.ini
@@ -8,20 +8,16 @@ envlist =
 
 [testenv]
 platform = linux|darwin|win32
-
-[common]
 deps =
     ../datadog_checks_base
     -rrequirements-dev.txt
 
 [testenv:teamcity]
-deps = {[common]deps}
 commands =
     pip install --require-hashes -r requirements.txt
     pytest -m"integration" -v
 
 [testenv:unit]
-deps = {[common]deps}
 commands =
     pip install --require-hashes -r requirements.txt
     pytest -m"not integration" -v

--- a/teamcity/tox.ini
+++ b/teamcity/tox.ini
@@ -14,7 +14,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt
-    pytest
+    pytest -v
 
 [testenv:flake8]
 skip_install = true

--- a/teamcity/tox.ini
+++ b/teamcity/tox.ini
@@ -2,19 +2,29 @@
 minversion = 2.0
 basepython = py27
 envlist =
+    unit
     teamcity
     flake8
 
 [testenv]
 platform = linux|darwin|win32
 
-[testenv:teamcity]
+[common]
 deps =
     ../datadog_checks_base
     -rrequirements-dev.txt
+
+[testenv:teamcity]
+deps = {[common]deps}
 commands =
     pip install --require-hashes -r requirements.txt
-    pytest -v
+    pytest -m"integration" -v
+
+[testenv:unit]
+deps = {[common]deps}
+commands =
+    pip install --require-hashes -r requirements.txt
+    pytest -m"not integration" -v
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
### What does this PR do?

Allows users to specify server URLs starting with `http://` or `https://`. Check will fall back to `http://` if scheme is not specified.

### Motivation

See issue #1162.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes
