### PR TITLE
Add table to root README for versions of each integration per Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ to idiomatic Python package delivery.
 Agent releases starting from version 5.21 bundle the latest wheels for any
 integration, but at the moment you can't upgrade or downgrade between releases.
 
+Each Datadog Agent release will continue to ship a set of the most up to date stable integrations available. The `requirements-integration-core.txt` file at the root of this repo is the best place to check what Integration version is shipped with each Agent. 
+
+**Note** The release process is currently in flux as we move toward the ability to ship wheels independently of Agent releases. Due to this, the Changelog may show a version and release that isn't yet available to download. Please check the below table to see which Integration versions are shipped with your Agent install. 
+
+| Agent Version | List of Shipped Integration Versions                                                      |   |   |   |
+|---------------|-------------------------------------------------------------------------------------------|---|---|---|
+| 6.2.1         | https://github.com/DataDog/integrations-core/blob/6.2.1/requirements-integration-core.txt | 
+
 ## Quick Start
 
 Working with integrations is easy, the main page of the [development docs](docs/dev/README.md)

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ Each Datadog Agent release will continue to ship a set of the most up to date st
 
 **Note** The release process is currently in flux as we move toward the ability to ship wheels independently of Agent releases. Due to this, the Changelog may show a version and release that isn't yet available to download. Please check the below table to see which Integration versions are shipped with your Agent install. 
 
-| Agent Version | List of Shipped Integration Versions                                                      |   |   |   |
-|---------------|-------------------------------------------------------------------------------------------|---|---|---|
-| 6.2.1         | https://github.com/DataDog/integrations-core/blob/6.2.1/requirements-integration-core.txt | 
+
+| Agent Version | List of Shipped Integration Versions                                                      |
+|---------------|-------------------------------------------------------------------------------------------|
+| 6.2.1         | https://github.com/DataDog/integrations-core/blob/6.2.1/requirements-integration-core.txt |
 
 ## Quick Start
 


### PR DESCRIPTION

### What does this PR do?

Adds a mini table at the root's README that lists the Agent version and the list of integrations available with that version.

Also adds a note that the changelogs are a bit in flux as we test out and finalize the release process

### Motivation

Keep docs up to date 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
