### PR TITLE
Auto detect version to bump a check to when releasing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,9 +45,7 @@ install:
   - ps: (& "$env:PYTHON/Scripts/pip.exe" install -U virtualenv)
   - ps: (& "$env:PYTHON/Scripts/pip.exe" install tox)
   - ps: choco install docker-compose
-  - ps: (& "$env:PYTHON/Scripts/pip.exe" install invoke)
-  - ps: (& "$env:PYTHON/Scripts/pip.exe" install pip-tools)
-  - ps: (& "$env:PYTHON/Scripts/pip.exe" install packaging)
+  - ps: (& "$env:PYTHON/Scripts/pip.exe" install -r requirements-dev.txt)
   - cd datadog_checks_base
   - ps: (& "$env:PYTHON/Scripts/pip.exe" install .)
   - cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,8 +44,9 @@ install:
   - ps: rm $env:PYTHON/lib/site-packages/$env:PYWIN32_INSTALL_DIR/adodbapi/__init__.pyc
   - ps: (& "$env:PYTHON/Scripts/pip.exe" install -U virtualenv)
   - ps: (& "$env:PYTHON/Scripts/pip.exe" install tox)
-  - ps: choco install docker-compose
   - ps: (& "$env:PYTHON/Scripts/pip.exe" install -r requirements-dev.txt)
+  # dd-agent requires an older version of docker-py and our requirements-dev.txt installs the latest
+  - ps: (& "$env:PYTHON/Scripts/pip.exe" install docker-py==1.10.6)
   - cd datadog_checks_base
   - ps: (& "$env:PYTHON/Scripts/pip.exe" install .)
   - cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,8 +45,6 @@ install:
   - ps: (& "$env:PYTHON/Scripts/pip.exe" install -U virtualenv)
   - ps: (& "$env:PYTHON/Scripts/pip.exe" install tox)
   - ps: (& "$env:PYTHON/Scripts/pip.exe" install -r requirements-dev.txt)
-  # dd-agent requires an older version of docker-py and our requirements-dev.txt installs the latest
-  - ps: (& "$env:PYTHON/Scripts/pip.exe" install docker-py==1.10.6)
   - cd datadog_checks_base
   - ps: (& "$env:PYTHON/Scripts/pip.exe" install .)
   - cd ..

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 invoke
 pip-tools
-packaging
 tox
 docker-compose
 twine

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ twine
 cookiecutter
 colorama
 requests
+semver

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 invoke
 pip-tools
 tox
-docker-compose
+docker-compose; sys_platform !='win32'
 twine
 cookiecutter
 colorama

--- a/tasks/changelog.py
+++ b/tasks/changelog.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from six import StringIO
 from invoke import task
 from invoke.exceptions import Exit
-from packaging import version
 import semver
 
 from .constants import ROOT, AGENT_BASED_INTEGRATIONS
@@ -63,8 +62,8 @@ def update_changelog(ctx, target, new_version=None, dry_run=False):
     # sanity check on the version provided
     # The new_version is allowed to be none since we can auto detect it later
     if new_version is not None:
-        p_version = version.parse(new_version)
-        p_current = version.parse(get_version_string(target))
+        p_version = semver.parse(new_version)
+        p_current = semver.parse(get_version_string(target))
         if p_version <= p_current:
             raise Exit("Current version is {}, can't bump to {}".format(p_current, p_version))
         print("Current version of check {}: {}, bumping to: {}".format(target, p_current, p_version))

--- a/tasks/changelog.py
+++ b/tasks/changelog.py
@@ -11,6 +11,7 @@ from six import StringIO
 from invoke import task
 from invoke.exceptions import Exit
 from packaging import version
+import semver
 
 from .constants import ROOT, AGENT_BASED_INTEGRATIONS
 from .utils.common import get_version_string, get_release_tag_string
@@ -27,6 +28,18 @@ CHANGELOG_TYPES = [
     'Removed',
     'Security',
 ]
+CHANGELOG_MAJOR_VERSION = [
+    'Removed',
+    'Changed'
+]
+CHANGELOG_MINOR_VERSION = [
+    'Added',
+    'Deprecated',
+    'Security'
+]
+CHANGELOG_BUGFIX_VERSION = [
+    'Fixed'
+]
 
 ChangelogEntry = namedtuple('ChangelogEntry', 'number, title, url, author, author_url, from_contributor')
 
@@ -35,7 +48,7 @@ ChangelogEntry = namedtuple('ChangelogEntry', 'number, title, url, author, autho
     'target': "The check to compile the changelog for",
     'dry-run': "Runs the task without actually doing anything",
 })
-def update_changelog(ctx, target, new_version, dry_run=False):
+def update_changelog(ctx, target, new_version=None, dry_run=False):
     """
     Update the changelog for the given check with the changes
     since the current release.
@@ -48,20 +61,27 @@ def update_changelog(ctx, target, new_version, dry_run=False):
         raise Exit("Provided target is not an Agent-based Integration")
 
     # sanity check on the version provided
-    p_version = version.parse(new_version)
-    p_current = version.parse(get_version_string(target))
-    if p_version <= p_current:
-        raise Exit("Current version is {}, can't bump to {}".format(p_current, p_version))
-    print("Current version of check {}: {}, bumping to: {}".format(target, p_current, p_version))
+    # The new_version is allowed to be none since we can auto detect it later
+    if new_version is not None:
+        p_version = version.parse(new_version)
+        p_current = version.parse(get_version_string(target))
+        if p_version <= p_current:
+            raise Exit("Current version is {}, can't bump to {}".format(p_current, p_version))
+        print("Current version of check {}: {}, bumping to: {}".format(target, p_current, p_version))
 
     do_update_changelog(ctx, target, str(p_current), new_version, dry_run)
 
 
-def do_update_changelog(ctx, target, cur_version, new_version, dry_run=False):
+def do_update_changelog(ctx, target, cur_version, new_version=None, dry_run=False):
     """
     Actually perform the operations needed to update the changelog, this
     method is supposed to be used by other tasks and not directly.
     """
+
+    # Store the highest version we need to update:
+    # -1 = No changes for this check, 0 = bugfix, 1 = minor, 2 = major
+    current_highest_version_label = -1
+
     # get the name of the current release tag
     target_tag = get_release_tag_string(target, cur_version)
 
@@ -85,6 +105,8 @@ def do_update_changelog(ctx, target, cur_version, new_version, dry_run=False):
             raise Exit("No valid changelog labels found attached to PR #{}, please add one".format(pr_num))
         elif len(changelog_labels) > 1:
             raise Exit("Multiple changelog labels found attached to PR #{}, please use only one".format(pr_num))
+        current_highest_version_label = update_current_highest_version_label_version(current_highest_version_label, changelog_labels)
+        print(changelog_labels)
 
         changelog_type = changelog_labels[0]
         if changelog_type == CHANGELOG_TYPE_NONE:
@@ -100,6 +122,9 @@ def do_update_changelog(ctx, target, cur_version, new_version, dry_run=False):
                                author, author_url, from_contributor(payload))
 
         entries.append(entry)
+
+    # Determine what the new version should be based on the changelog labels
+    new_version = bump_version(cur_version, current_highest_version_label)
 
     # store the new changelog in memory
     new_entry = StringIO()
@@ -144,3 +169,27 @@ def do_update_changelog(ctx, target, cur_version, new_version, dry_run=False):
     # overwrite the old changelog
     with open(changelog_path, 'w') as f:
         f.write(changelog.getvalue())
+
+    return new_version
+
+def update_current_highest_version_label_version(current_highest_version_label, changelog_label):
+    if changelog_label in CHANGELOG_MAJOR_VERSION:
+        current_highest_version_label = 2
+    elif changelog_label in CHANGELOG_MAJOR_VERSION and current_highest_version_label <= 1:
+        current_highest_version_label = 1
+    elif changelog_label in CHANGELOG_BUGFIX_VERSION and current_highest_version_label <= 0:
+        current_highest_version_label = 0
+
+    return current_highest_version_label
+
+def bump_version(cur_version, version_to_bump):
+    new_version = cur_version
+    print("Bumping version")
+    if version_to_bump == 0:
+        new_version = semver.bump_bugfix(cur_version)
+    elif version_to_bump == 1:
+        new_version = semver.bump_minor(cur_version)
+    elif version_to_bump == 2:
+        new_version = semver.bump_major(cur_version)
+    print("Bumped version")
+    return new_version

--- a/tasks/changelog.py
+++ b/tasks/changelog.py
@@ -104,8 +104,7 @@ def do_update_changelog(ctx, target, cur_version, new_version=None, dry_run=Fals
             raise Exit("No valid changelog labels found attached to PR #{}, please add one".format(pr_num))
         elif len(changelog_labels) > 1:
             raise Exit("Multiple changelog labels found attached to PR #{}, please use only one".format(pr_num))
-        current_highest_version_label = update_current_highest_version_label_version(current_highest_version_label, changelog_labels)
-        print(changelog_labels)
+        current_highest_version_label = update_highest_found_version(current_highest_version_label, changelog_labels[0])
 
         changelog_type = changelog_labels[0]
         if changelog_type == CHANGELOG_TYPE_NONE:
@@ -126,7 +125,7 @@ def do_update_changelog(ctx, target, cur_version, new_version=None, dry_run=Fals
     new_version = bump_version(cur_version, current_highest_version_label)
 
     # Lets exit here if we didn't get any interesting PRs worth releasing for:
-    if current_highest_version_label == -1:
+    if new_version == cur_version:
         raise Exit("No PRs were found with a changelog.")
 
     # store the new changelog in memory
@@ -175,10 +174,10 @@ def do_update_changelog(ctx, target, cur_version, new_version=None, dry_run=Fals
 
     return new_version
 
-def update_current_highest_version_label_version(current_highest_version_label, changelog_label):
+def update_highest_found_version(current_highest_version_label, changelog_label):
     if changelog_label in CHANGELOG_MAJOR_VERSION:
         current_highest_version_label = 2
-    elif changelog_label in CHANGELOG_MAJOR_VERSION and current_highest_version_label <= 1:
+    elif changelog_label in CHANGELOG_MINOR_VERSION and current_highest_version_label <= 1:
         current_highest_version_label = 1
     elif changelog_label in CHANGELOG_BUGFIX_VERSION and current_highest_version_label <= 0:
         current_highest_version_label = 0

--- a/tasks/changelog.py
+++ b/tasks/changelog.py
@@ -126,6 +126,10 @@ def do_update_changelog(ctx, target, cur_version, new_version=None, dry_run=Fals
     # Determine what the new version should be based on the changelog labels
     new_version = bump_version(cur_version, current_highest_version_label)
 
+    # Lets exit here if we didn't get any interesting PRs worth releasing for:
+    if current_highest_version_label == -1:
+        raise Exit("No PRs were found with a changelog.")
+
     # store the new changelog in memory
     new_entry = StringIO()
 
@@ -184,12 +188,10 @@ def update_current_highest_version_label_version(current_highest_version_label, 
 
 def bump_version(cur_version, version_to_bump):
     new_version = cur_version
-    print("Bumping version")
     if version_to_bump == 0:
         new_version = semver.bump_bugfix(cur_version)
     elif version_to_bump == 1:
         new_version = semver.bump_minor(cur_version)
     elif version_to_bump == 2:
         new_version = semver.bump_major(cur_version)
-    print("Bumped version")
     return new_version

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -5,10 +5,10 @@ from __future__ import print_function, unicode_literals
 import os
 import sys
 
-from packaging import version
 from invoke import task
 from invoke.exceptions import Exit
 from colorama import Fore
+import semver
 
 from .constants import AGENT_BASED_INTEGRATIONS, AGENT_V5_ONLY
 from .utils.git import (
@@ -122,10 +122,10 @@ def release_prepare(ctx, target, new_version=None):
 
     # sanity check on the version provided
     cur_version = get_version_string(target)
-    p_current = version.parse(cur_version)
+    p_current = semver.parse(cur_version)
 
     if new_version is not None:
-        p_version = version.parse(new_version)
+        p_version = semver.parse(new_version)
         if p_version <= p_current:
             raise Exit("Current version is {}, can't bump to {}".format(p_current, p_version))
 
@@ -136,7 +136,7 @@ def release_prepare(ctx, target, new_version=None):
 
     if new_version is None:
         new_version = auto_detected_new_ver
-        p_version = version.parse(new_version)
+        p_version = semver.parse(new_version)
 
     # update the version number
     print("Current version of check {}: {}, bumping to: {}".format(target, p_current, p_version))

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -101,7 +101,7 @@ def release_show_pending(ctx, target):
     'target': "The check to release",
     'new_version': "The new version",
 })
-def release_prepare(ctx, target, new_version):
+def release_prepare(ctx, target, new_version=None):
     """
     Perform a set of operations needed to release a single check:
 
@@ -122,18 +122,26 @@ def release_prepare(ctx, target, new_version):
 
     # sanity check on the version provided
     cur_version = get_version_string(target)
-    p_version = version.parse(new_version)
     p_current = version.parse(cur_version)
-    if p_version <= p_current:
-        raise Exit("Current version is {}, can't bump to {}".format(p_current, p_version))
+
+    if new_version is not None:
+        p_version = version.parse(new_version)
+        if p_version <= p_current:
+            raise Exit("Current version is {}, can't bump to {}".format(p_current, p_version))
+
+
+    # update the CHANGELOG
+    print("Updating the changelog")
+    auto_detected_new_ver = do_update_changelog(ctx, target, cur_version, new_version)
+
+    if new_version is None:
+        new_version = auto_detected_new_ver
+        p_version = version.parse(new_version)
 
     # update the version number
     print("Current version of check {}: {}, bumping to: {}".format(target, p_current, p_version))
     update_version_module(target, cur_version, new_version)
 
-    # update the CHANGELOG
-    print("Updating the changelog")
-    do_update_changelog(ctx, target, cur_version, new_version)
 
     # commit the changes
     msg = "Bumped {} version to {}".format(target, new_version)


### PR DESCRIPTION
### What does this PR do?

Add the ability for the `release_prepare` task to automatically detect the version the check should be bumped to based on the highest severity of the Changelog. 

This still allows for a version to be used to override this, but if none is specified it will attempt to detect the version automagically. 

Also resolves an issue where we would update the changelog even if all the changelogs were "no-changelog". This now exits if all PRs have the no-changelog label. 

Finally, we were individually installing packages in the appveyor config so instead lets just install requirements-dev.txt

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Removed packaging version in favor of semver since it can parse the version and also bump based on semver versioning. 