### PR TITLE
change default value of AgentCheck.check_id

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/base.py
+++ b/datadog_checks_base/datadog_checks/checks/base.py
@@ -37,7 +37,7 @@ class AgentCheck(object):
         args: `name`, `init_config`, `agentConfig` (deprecated), `instances`
         """
         self.metrics = defaultdict(list)
-        self.check_id = None
+        self.check_id = ''
         self.instances = kwargs.get('instances', [])
         self.name = kwargs.get('name', '')
         self.init_config = kwargs.get('init_config', {})


### PR DESCRIPTION
### Motivation

```
2018-06-03 00:58:39 UTC | ERROR | (datadog_agent.go:133 in LogMessage) | (sqlserver.py:154) | INitialization exception argument 2 must be string, not None
Traceback (most recent call last):
  File "/home/sqlserver/datadog_checks/sqlserver/sqlserver.py", line 132, in __init__
    with self.open_managed_db_connections(instance, None, db_name=self.DEFAULT_DATABASE):
  File "/opt/datadog-agent/embedded/lib/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/home/sqlserver/datadog_checks/sqlserver/sqlserver.py", line 572, in open_managed_db_connections
    self.open_db_connections(instance, db_key, db_name)
  File "/home/sqlserver/datadog_checks/sqlserver/sqlserver.py", line 629, in open_db_connections
    tags=service_check_tags, message=message)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/checks/base.py", line 160, in service_check
    aggregator.submit_service_check(self, self.check_id, ensure_bytes(name), status, tags, hostname, message)
TypeError: argument 2 must be string, not None
```