### PR TITLE
Package `auto_conf.yaml` for appropriate integrations

### DIFF
--- a/apache/setup.py
+++ b/apache/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 # Always prefer setuptools over distutils
 from setuptools import setup
 # To use a consistent encoding
@@ -28,10 +32,11 @@ ABOUT = {}
 with open(path.join(HERE, "datadog_checks", "apache", "__about__.py")) as f:
     exec(f.read(), ABOUT)
 
+
 setup(
     name='datadog-apache',
     version=ABOUT["__version__"],
-    description='The Apache check',
+    description='The Apache Check',
     long_description=long_description,
     keywords='datadog agent apache check',
 
@@ -51,7 +56,7 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'Topic :: System :: Monitoring',
-        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
     ],
@@ -67,6 +72,6 @@ setup(
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package
-    package_data={b'datadog_checks.apache': ['conf.yaml.example']},
+    package_data={b'datadog_checks.apache': ['conf.yaml.example', 'auto_conf.yaml']},
     include_package_data=True,
 )

--- a/consul/setup.py
+++ b/consul/setup.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
 from setuptools import setup
 from codecs import open
 from os import path
@@ -26,7 +27,7 @@ def get_requirements(fpath):
 setup(
     name='datadog-consul',
     version=ABOUT['__version__'],
-    description='The Consul check',
+    description='The Consul Check',
     long_description=long_description,
     keywords='datadog agent consul check',
 
@@ -38,7 +39,7 @@ setup(
     author_email='packages@datadoghq.com',
 
     # License
-    license='MIT',
+    license='BSD',
 
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
@@ -46,7 +47,7 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'Topic :: System :: Monitoring',
-        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
     ],
@@ -60,6 +61,6 @@ setup(
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package
-    package_data={'datadog_checks.consul': ['conf.yaml.example']},
+    package_data={'datadog_checks.consul': ['conf.yaml.example', 'auto_conf.yaml']},
     include_package_data=True,
 )

--- a/couch/setup.py
+++ b/couch/setup.py
@@ -63,6 +63,6 @@ setup(
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package
-    package_data={b'datadog_checks.couch': ['conf.yaml.example', 'autoconf.yaml']},
+    package_data={b'datadog_checks.couch': ['conf.yaml.example', 'auto_conf.yaml']},
     include_package_data=True,
 )

--- a/couchbase/setup.py
+++ b/couchbase/setup.py
@@ -63,6 +63,6 @@ setup(
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package
-    package_data={b'datadog_checks.couchbase': ['conf.yaml.example', 'autoconf.yaml']},
+    package_data={b'datadog_checks.couchbase': ['conf.yaml.example', 'auto_conf.yaml']},
     include_package_data=True,
 )

--- a/elastic/setup.py
+++ b/elastic/setup.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
 from setuptools import setup
 from codecs import open
 from os import path
@@ -22,6 +23,7 @@ def get_requirements(fpath):
 ABOUT = {}
 with open(path.join(HERE, "datadog_checks", "elastic", "__about__.py")) as f:
     exec(f.read(), ABOUT)
+
 
 setup(
     name='datadog-elastic',
@@ -62,6 +64,6 @@ setup(
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package
-    package_data={b'datadog_checks.elastic': ['conf.yaml.example']},
+    package_data={b'datadog_checks.elastic': ['conf.yaml.example', 'auto_conf.yaml']},
     include_package_data=True,
 )

--- a/etcd/setup.py
+++ b/etcd/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 # Always prefer setuptools over distutils
 from setuptools import setup
 # To use a consistent encoding
@@ -47,7 +51,7 @@ version = find_version("datadog_checks", "etcd", "__init__.py")
 setup(
     name='datadog-etcd',
     version=version,
-    description='The Etcd check',
+    description='The Etcd Check',
     long_description=long_description,
     keywords='datadog agent etcd check',
 
@@ -59,7 +63,7 @@ setup(
     author_email='packages@datadoghq.com',
 
     # License
-    license='MIT',
+    license='BSD',
 
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
@@ -67,7 +71,7 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'Topic :: System :: Monitoring',
-        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
     ],
@@ -96,6 +100,6 @@ setup(
     test_suite='nose.collector',
 
     # Extra files to ship with the wheel package
-    package_data={b'datadog_checks.etcd': ['conf.yaml.example']},
+    package_data={b'datadog_checks.etcd': ['conf.yaml.example', 'auto_conf.yaml']},
     include_package_data=True,
 )

--- a/kube_dns/setup.py
+++ b/kube_dns/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 # Always prefer setuptools over distutils
 from setuptools import setup
 # To use a consistent encoding
@@ -66,7 +70,7 @@ if version != manifest_version:
 setup(
     name='datadog-kube_dns',
     version=version,
-    description='The KubeDNS check',
+    description='The KubeDNS Check',
     long_description=long_description,
     keywords='datadog agent kube_dns check',
 
@@ -78,7 +82,7 @@ setup(
     author_email='packages@datadoghq.com',
 
     # License
-    license='MIT',
+    license='BSD',
 
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
@@ -86,7 +90,7 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'Topic :: System :: Monitoring',
-        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
     ],
@@ -115,6 +119,6 @@ setup(
     test_suite='nose.collector',
 
     # Extra files to ship with the wheel package
-    package_data={b'datadog_checks.kube_dns': ['conf.yaml.example']},
+    package_data={b'datadog_checks.kube_dns': ['conf.yaml.example', 'auto_conf.yaml']},
     include_package_data=True,
 )

--- a/kube_proxy/setup.py
+++ b/kube_proxy/setup.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
 from setuptools import setup
 from codecs import open  # To use a consistent encoding
 from os import path
@@ -25,7 +26,7 @@ def get_requirements(fpath):
 setup(
     name='datadog-kube-proxy',
     version=ABOUT["__version__"],
-    description='The kube_proxy check',
+    description='The kube_proxy Check',
     long_description=long_description,
     keywords='datadog agent kube_proxy check',
 
@@ -37,7 +38,7 @@ setup(
     author_email='packages@datadoghq.com',
 
     # License
-    license='New BSD',
+    license='BSD',
 
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
@@ -45,7 +46,7 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'Topic :: System :: Monitoring',
-        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
     ],
@@ -62,6 +63,6 @@ setup(
     tests_require=get_requirements(path.join('tests', 'requirements.txt')),
 
     # Extra files to ship with the wheel package
-    package_data={'datadog_checks.kube_proxy': ['conf.yaml.default']},
+    package_data={'datadog_checks.kube_proxy': ['conf.yaml.default', 'auto_conf.yaml']},
     include_package_data=True,
 )

--- a/kubernetes_state/setup.py
+++ b/kubernetes_state/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 # Always prefer setuptools over distutils
 from setuptools import setup
 # To use a consistent encoding
@@ -66,7 +70,7 @@ if version != manifest_version:
 setup(
     name='datadog-kubernetes_state',
     version=version,
-    description='The Kubernetes State check',
+    description='The Kubernetes State Check',
     long_description=long_description,
     keywords='datadog agent kubernetes_state check',
 
@@ -78,7 +82,7 @@ setup(
     author_email='packages@datadoghq.com',
 
     # License
-    license='MIT',
+    license='BSD',
 
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
@@ -86,7 +90,7 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'Topic :: System :: Monitoring',
-        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
     ],
@@ -115,6 +119,6 @@ setup(
     test_suite='nose.collector',
 
     # Extra files to ship with the wheel package
-    package_data={b'datadog_checks.kubernetes_state': ['conf.yaml.example']},
+    package_data={b'datadog_checks.kubernetes_state': ['conf.yaml.example', 'auto_conf.yaml']},
     include_package_data=True,
 )

--- a/kyototycoon/setup.py
+++ b/kyototycoon/setup.py
@@ -64,6 +64,6 @@ setup(
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package
-    package_data={b'datadog_checks.kyototycoon': ['conf.yaml.example', 'autoconf.yaml']},
+    package_data={b'datadog_checks.kyototycoon': ['conf.yaml.example', 'auto_conf.yaml']},
     include_package_data=True,
 )

--- a/mcache/setup.py
+++ b/mcache/setup.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
 from setuptools import setup
 from codecs import open
 from os import path
@@ -26,7 +27,7 @@ def get_requirements(fpath):
 setup(
     name='datadog-mcache',
     version=ABOUT["__version__"],
-    description='The Memcache check',
+    description='The Memcache Check',
     long_description=long_description,
     keywords='datadog agent Memcache check',
     url='https://github.com/DataDog/integrations-core',
@@ -54,6 +55,6 @@ setup(
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package
-    package_data={'datadog_checks.mcache': ['conf.yaml.example']},
+    package_data={'datadog_checks.mcache': ['conf.yaml.example', 'auto_conf.yaml']},
     include_package_data=True,
 )

--- a/redisdb/setup.py
+++ b/redisdb/setup.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
 from setuptools import setup
 from codecs import open
 from os import path
@@ -26,7 +27,7 @@ def get_requirements(fpath):
 setup(
     name='datadog-redisdb',
     version=ABOUT["__version__"],
-    description='The Redis check',
+    description='The Redis Check',
     long_description=long_description,
     keywords='datadog agent Redis check',
     url='https://github.com/DataDog/integrations-core',
@@ -54,6 +55,6 @@ setup(
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package
-    package_data={'datadog_checks.redisdb': ['conf.yaml.example']},
+    package_data={'datadog_checks.redisdb': ['conf.yaml.example', 'auto_conf.yaml']},
     include_package_data=True,
 )

--- a/riak/setup.py
+++ b/riak/setup.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
 from setuptools import setup
 from codecs import open
 from os import path
@@ -26,7 +27,7 @@ def get_requirements(fpath):
 setup(
     name='datadog-riak',
     version=ABOUT["__version__"],
-    description='The Riak check',
+    description='The Riak Check',
     long_description=long_description,
     keywords='datadog agent riak check',
 
@@ -46,7 +47,7 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'Topic :: System :: Monitoring',
-        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
     ],
@@ -61,6 +62,6 @@ setup(
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package
-    package_data={b'datadog_checks.riak': ['conf.yaml.example']},
+    package_data={b'datadog_checks.riak': ['conf.yaml.example', 'auto_conf.yaml']},
     include_package_data=True,
 )


### PR DESCRIPTION
### What does this PR do?

Adds `auto_conf.yaml` to a few integrations' `setup.py` files. This is because we're shipping the `auto_conf.yaml` file with the wheels package.

### Motivation

We weren't packaging `auto_conf.yaml` files.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes
