### PR TITLE
Prevent packaging non-existent "autoconf.yaml"

### DIFF
--- a/hdfs_datanode/setup.py
+++ b/hdfs_datanode/setup.py
@@ -63,6 +63,6 @@ setup(
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package
-    package_data={b'datadog_checks.hdfs_datanode': ['conf.yaml.example', 'autoconf.yaml']},
+    package_data={b'datadog_checks.hdfs_datanode': ['conf.yaml.example']},
     include_package_data=True,
 )

--- a/hdfs_namenode/setup.py
+++ b/hdfs_namenode/setup.py
@@ -63,6 +63,6 @@ setup(
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package
-    package_data={b'datadog_checks.hdfs_namenode': ['conf.yaml.example', 'autoconf.yaml']},
+    package_data={b'datadog_checks.hdfs_namenode': ['conf.yaml.example']},
     include_package_data=True,
 )

--- a/http_check/setup.py
+++ b/http_check/setup.py
@@ -63,6 +63,6 @@ setup(
     tests_require=get_requirements('requirements-dev.txt'),
 
     # Extra files to ship with the wheel package
-    package_data={b'datadog_checks.http_check': ['conf.yaml.example', 'autoconf.yaml']},
+    package_data={b'datadog_checks.http_check': ['conf.yaml.example']},
     include_package_data=True,
 )


### PR DESCRIPTION
### What does this PR do?

Certain integrations were packaging up a non-existent autoconf.yaml file, that they shouldn't have been packaging in the first place.

### Motivation

I was inspired by reading the `setup.py` files.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes
