### PR TITLE
Add a config option to disable connection cache

### DIFF
--- a/redisdb/conf.yaml.example
+++ b/redisdb/conf.yaml.example
@@ -57,7 +57,12 @@ instances:
 
     # Collect INFO COMMANDSTATS output as metrics.
     # command_stats: False
- 
+
+    # Disable connections cache.
+    # The check attempts to reuse the same Redis connections at every collection
+    # cycle, this behaviour can be disabled to prevent stale connections.
+    # disable_connection_cache: False
+
 ## Log Section (Available for Agent >=6.0)
 
 #logs:
@@ -68,11 +73,11 @@ instances:
     #   source : (mandatory) attribute that defines which integration is sending the logs
     #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
     #   tags: (optional) add tags to each logs collected
-    
+
     # - type: file
     #   path: /var/log/redis_6379.log
     #   source: redis
     #   sourcecategory: database
     #   service: myapplication
-       
+
 

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -8,7 +8,7 @@ import time
 import redis
 
 from datadog_checks.checks import AgentCheck
-
+from datadog_checks.config import is_affirmative
 
 DEFAULT_MAX_SLOW_ENTRIES = 128
 MAX_SLOW_ENTRIES_KEY = "slowlog-max-len"
@@ -120,20 +120,23 @@ class Redis(AgentCheck):
             return (instance.get('host'), instance.get('port'), instance.get('db'))
 
     def _get_conn(self, instance):
+        no_cache = is_affirmative(instance.get('disable_connection_cache', False))
         key = self._generate_instance_key(instance)
-        if key not in self.connections:
-            try:
 
+        if no_cache or key not in self.connections:
+            try:
                 # Only send useful parameters to the redis client constructor
-                list_params = ['host', 'port', 'db', 'password', 'socket_timeout',
-                               'connection_pool', 'charset', 'errors', 'unix_socket_path', 'ssl',
-                               'ssl_certfile', 'ssl_keyfile', 'ssl_ca_certs', 'ssl_cert_reqs']
+                list_params = [
+                    'host', 'port', 'db', 'password', 'socket_timeout',
+                    'connection_pool', 'charset', 'errors', 'unix_socket_path', 'ssl',
+                    'ssl_certfile', 'ssl_keyfile', 'ssl_ca_certs', 'ssl_cert_reqs'
+                ]
 
                 # Set a default timeout (in seconds) if no timeout is specified in the instance config
                 instance['socket_timeout'] = instance.get('socket_timeout', 5)
-
                 connection_params = dict((k, instance[k]) for k in list_params if k in instance)
-
+                # If caching is disabled, we overwrite the dictionary value so the old connection
+                # will be closed as soon as the corresponding Python object gets garbage collected
                 self.connections[key] = redis.Redis(**connection_params)
 
             except TypeError:

--- a/redisdb/tests/test_unit.py
+++ b/redisdb/tests/test_unit.py
@@ -10,3 +10,25 @@ def test_init():
     check = Redis('redisdb', {}, {}, None)
     assert check.connections == {}
     assert len(check.last_timestamp_seen) == 0
+
+
+def test__get_conn():
+    check = Redis('redisdb', {}, {}, None)
+    instance = {}
+
+    # create a connection
+    check._get_conn(instance)
+    key1, conn1 = next(check.connections.iteritems())
+
+    # assert connection is cached
+    check._get_conn(instance)
+    key2, conn2 = next(check.connections.iteritems())
+    assert key2 == key1
+    assert conn2 == conn1
+
+    # disable cache and assert connection has changed
+    instance['disable_connection_cache'] = True
+    check._get_conn(instance)
+    key2, conn2 = next(check.connections.iteritems())
+    assert key2 == key1
+    assert conn2 != conn1


### PR DESCRIPTION
### What does this PR do?

Adds an option to disable Redis connection cache across collection cycles.

### Motivation

#1657 

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

A specific test was added to avoid regressions.
