### PR TITLE
Add support for HTTP authentication

### DIFF
--- a/hdfs_datanode/conf.yaml.example
+++ b/hdfs_datanode/conf.yaml.example
@@ -11,8 +11,16 @@ instances:
   #
   - hdfs_datanode_jmx_uri: http://localhost:50075
 
+  # If your service uses basic HTTP authentication, you can optionally
+  # specify a username and password that will be used in the check.
+  # username: user
+  # password: pass
+
   # Optionally disable SSL validation. Sometimes when using proxies or self-signed certs
   # we'll want to override validation.
   # disable_ssl_validation: false
+
+  # Optional tags to be applied to every emitted metric and service check.
   # tags:
   #   - optional:tags1
+  #   - optional:tags2

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/hdfs_datanode.py
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/hdfs_datanode.py
@@ -29,91 +29,102 @@ from simplejson import JSONDecodeError
 # Project
 from datadog_checks.checks import AgentCheck
 
-# Service check names
-JMX_SERVICE_CHECK = 'hdfs.datanode.jmx.can_connect'
-
-# URL Paths
-JMX_PATH = 'jmx'
-
-# Metric types
-GAUGE = 'gauge'
-
-# HDFS bean name
-HDFS_DATANODE_BEAN_NAME = 'Hadoop:service=DataNode,name=FSDatasetState*'
-
-# HDFS metrics
-HDFS_METRICS = {
-    'Remaining': ('hdfs.datanode.dfs_remaining',  GAUGE),
-    'Capacity': ('hdfs.datanode.dfs_capacity', GAUGE),
-    'DfsUsed': ('hdfs.datanode.dfs_used', GAUGE),
-    'CacheCapacity': ('hdfs.datanode.cache_capacity', GAUGE),
-    'CacheUsed': ('hdfs.datanode.cache_used', GAUGE),
-    'NumFailedVolumes': ('hdfs.datanode.num_failed_volumes', GAUGE),
-    'LastVolumeFailureDate': ('hdfs.datanode.last_volume_failure_date', GAUGE),
-    'EstimatedCapacityLostTotal': ('hdfs.datanode.estimated_capacity_lost_total', GAUGE),
-    'NumBlocksCached': ('hdfs.datanode.num_blocks_cached', GAUGE),
-    'NumBlocksFailedToCache': ('hdfs.datanode.num_blocks_failed_to_cache', GAUGE),
-    'NumBlocksFailedToUnCache': ('hdfs.datanode.num_blocks_failed_to_uncache', GAUGE)
-}
-
 
 class HDFSDataNode(AgentCheck):
+
+    # Service check names
+    JMX_SERVICE_CHECK = 'hdfs.datanode.jmx.can_connect'
+
+    # URL Paths
+    JMX_PATH = 'jmx'
+
+    # Metric types
+    GAUGE = 'gauge'
+
+    # HDFS bean name
+    HDFS_DATANODE_BEAN_NAME = 'Hadoop:service=DataNode,name=FSDatasetState*'
+
+    # HDFS metrics
+    HDFS_METRICS = {
+        'Remaining': ('hdfs.datanode.dfs_remaining', GAUGE),
+        'Capacity': ('hdfs.datanode.dfs_capacity', GAUGE),
+        'DfsUsed': ('hdfs.datanode.dfs_used', GAUGE),
+        'CacheCapacity': ('hdfs.datanode.cache_capacity', GAUGE),
+        'CacheUsed': ('hdfs.datanode.cache_used', GAUGE),
+        'NumFailedVolumes': ('hdfs.datanode.num_failed_volumes', GAUGE),
+        'LastVolumeFailureDate': ('hdfs.datanode.last_volume_failure_date', GAUGE),
+        'EstimatedCapacityLostTotal': ('hdfs.datanode.estimated_capacity_lost_total', GAUGE),
+        'NumBlocksCached': ('hdfs.datanode.num_blocks_cached', GAUGE),
+        'NumBlocksFailedToCache': ('hdfs.datanode.num_blocks_failed_to_cache', GAUGE),
+        'NumBlocksFailedToUnCache': ('hdfs.datanode.num_blocks_failed_to_uncache', GAUGE),
+    }
 
     def check(self, instance):
         jmx_address = instance.get('hdfs_datanode_jmx_uri')
 
         if jmx_address is None:
-            raise Exception('The JMX URL must be specified in the instance configuration')
+            raise Exception("The JMX URL must be specified in the instance configuration")
 
-        disable_ssl_validation = instance.get('disable_ssl_validation', False)
-        custom_tags = instance.get('tags', [])
-
-        # Get metrics from JMX
-        self._hdfs_datanode_metrics(jmx_address, disable_ssl_validation, custom_tags)
-
-    def _hdfs_datanode_metrics(self, jmx_uri, disable_ssl_validation, tags):
-        """
-        Get HDFS data node metrics from JMX
-        """
-        response = self._rest_request_to_json(jmx_uri, disable_ssl_validation, JMX_PATH, tags,
-                                              query_params={'qry': HDFS_DATANODE_BEAN_NAME})
-
-        beans = response.get('beans', [])
-
-        tags.append('datanode_url:{}'.format(jmx_uri))
+        # Set up tags
+        tags = instance.get('tags', [])
+        tags.append("datanode_url:{}".format(jmx_address))
         tags = list(set(tags))
 
-        if beans:
+        # Authenticate our connection to JMX endpoint if required
+        username = instance.get('username')
+        password = instance.get('password')
+        auth = None
+        if username is not None and password is not None:
+            auth = (username, password)
 
-            # Only get the first bean
-            bean = next(iter(beans))
-            bean_name = bean.get('name')
+        disable_ssl_validation = instance.get('disable_ssl_validation', False)
 
-            self.log.debug('Bean name retrieved: {}'.format(bean_name))
+        # Get data from JMX
+        hdfs_datanode_beans = self._get_jmx_data(jmx_address, auth, disable_ssl_validation, tags)
 
-            for metric, (metric_name, metric_type) in HDFS_METRICS.iteritems():
-                metric_value = bean.get(metric)
-                if metric_value is not None:
-                    self._set_metric(metric_name, metric_type, metric_value, tags)
+        # Process the JMX data and send out metrics
+        if hdfs_datanode_beans:
+            self._hdfs_datanode_metrics(hdfs_datanode_beans, tags)
+
+    def _get_jmx_data(self, jmx_address, auth, disable_ssl_validation, tags):
+        """
+        Get namenode beans data from JMX endpoint
+        """
+        response = self._rest_request_to_json(
+            jmx_address, auth, disable_ssl_validation, self.JMX_PATH, {'qry': self.HDFS_DATANODE_BEAN_NAME}, tags=tags
+        )
+        beans = response.get('beans', [])
+        return beans
+
+    def _hdfs_datanode_metrics(self, beans, tags):
+        """
+        Process HDFS Datanode metrics from given beans
+        """
+        # Only get the first bean
+        bean = next(iter(beans))
+        bean_name = bean.get('name')
+
+        self.log.debug("Bean name retrieved: {}".format(bean_name))
+
+        for metric, (metric_name, metric_type) in self.HDFS_METRICS.iteritems():
+            metric_value = bean.get(metric)
+            if metric_value is not None:
+                self._set_metric(metric_name, metric_type, metric_value, tags)
 
     def _set_metric(self, metric_name, metric_type, value, tags=None):
         """
         Set a metric
         """
-        if metric_type == GAUGE:
+        if metric_type == self.GAUGE:
             self.gauge(metric_name, value, tags=tags)
         else:
             self.log.error('Metric type "{}" unknown'.format(metric_type))
 
-    def _rest_request_to_json(self, address, disable_ssl_validation, object_path, tags, query_params):
+    def _rest_request_to_json(self, address, auth, disable_ssl_validation, object_path, query_params, tags):
         """
         Query the given URL and return the JSON response
         """
         response_json = None
-
-        service_check_tags = ['datanode_url:{}'.format(address)]
-        service_check_tags.extend(tags)
-        service_check_tags = list(set(service_check_tags))
 
         url = address
 
@@ -128,33 +139,41 @@ class HDFSDataNode(AgentCheck):
         self.log.debug('Attempting to connect to "{}"'.format(url))
 
         try:
-            response = requests.get(url, timeout=self.default_integration_http_timeout,
-                                    verify=not disable_ssl_validation)
+            response = requests.get(
+                url, auth=auth, timeout=self.default_integration_http_timeout, verify=not disable_ssl_validation
+            )
             response.raise_for_status()
             response_json = response.json()
 
         except Timeout as e:
-            self.service_check(JMX_SERVICE_CHECK, AgentCheck.CRITICAL, tags=service_check_tags,
-                               message="Request timeout: {}, {}".format(url, e))
+            self.service_check(
+                self.JMX_SERVICE_CHECK, AgentCheck.CRITICAL, tags=tags, message="Request timeout: {}, {}".format(url, e)
+            )
             raise
 
         except (HTTPError, InvalidURL, ConnectionError) as e:
-            self.service_check(JMX_SERVICE_CHECK, AgentCheck.CRITICAL, tags=service_check_tags,
-                               message="Request failed: {}, {}".format(url, e))
+            self.service_check(
+                self.JMX_SERVICE_CHECK, AgentCheck.CRITICAL, tags=tags, message="Request failed: {}, {}".format(url, e)
+            )
             raise
 
         except JSONDecodeError as e:
-            self.service_check(JMX_SERVICE_CHECK, AgentCheck.CRITICAL, tags=service_check_tags,
-                               message='JSON Parse failed: {}, {}'.format(url, e))
+            self.service_check(
+                self.JMX_SERVICE_CHECK,
+                AgentCheck.CRITICAL,
+                tags=tags,
+                message="JSON Parse failed: {}, {}".format(url, e),
+            )
             raise
 
         except ValueError as e:
-            self.service_check(JMX_SERVICE_CHECK, AgentCheck.CRITICAL, tags=service_check_tags, message=str(e))
+            self.service_check(self.JMX_SERVICE_CHECK, AgentCheck.CRITICAL, tags=tags, message=str(e))
             raise
 
         else:
-            self.service_check(JMX_SERVICE_CHECK, AgentCheck.OK, tags=service_check_tags,
-                               message='Connection to {} was successful'.format(url))
+            self.service_check(
+                self.JMX_SERVICE_CHECK, AgentCheck.OK, tags=tags, message="Connection to {} was successful".format(url)
+            )
 
         return response_json
 

--- a/hdfs_datanode/tests/common.py
+++ b/hdfs_datanode/tests/common.py
@@ -8,11 +8,29 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 
 DATANODE_URI = 'http://localhost:50070/'
 
+CUSTOM_TAGS = ['optional:tag1']
+
+TEST_USERNAME = 'AzureDiamond'
+TEST_PASSWORD = 'hunter2'
+
 HDFS_DATANODE_CONFIG = {
-    'instances': [{
-        'hdfs_datanode_jmx_uri': DATANODE_URI,
-        'tags': ['optional:tag1']
-    }]
+    'instances': [
+        {
+            'hdfs_datanode_jmx_uri': DATANODE_URI,
+            'tags': list(CUSTOM_TAGS)
+        }
+    ]
+}
+
+HDFS_DATANODE_AUTH_CONFIG = {
+    'instances': [
+        {
+            'hdfs_datanode_jmx_uri': DATANODE_URI,
+            'tags': list(CUSTOM_TAGS),
+            'username': TEST_USERNAME,
+            'password': TEST_PASSWORD,
+        }
+    ]
 }
 
 HDFS_DATANODE_METRICS_VALUES = {
@@ -31,5 +49,4 @@ HDFS_DATANODE_METRICS_VALUES = {
 
 HDFS_DATANODE_METRIC_TAGS = [
     'datanode_url:{}'.format(DATANODE_URI),
-    'optional:tag1'
 ]

--- a/hdfs_datanode/tests/test_hdfs_datanode.py
+++ b/hdfs_datanode/tests/test_hdfs_datanode.py
@@ -4,19 +4,44 @@
 
 from datadog_checks.hdfs_datanode import HDFSDataNode
 
-from .common import HDFS_DATANODE_CONFIG, HDFS_DATANODE_METRICS_VALUES, HDFS_DATANODE_METRIC_TAGS
+from .common import (
+    CUSTOM_TAGS, HDFS_DATANODE_CONFIG, HDFS_DATANODE_AUTH_CONFIG, HDFS_DATANODE_METRICS_VALUES,
+    HDFS_DATANODE_METRIC_TAGS
+)
 
 
-def test_check(aggregator):
+def test_check(aggregator, mocked_request):
     """
     Test that we get all the metrics we're supposed to get
     """
 
     hdfs_datanode = HDFSDataNode('hdfs_datanode', {}, {})
 
+    # Run the check once
     hdfs_datanode.check(HDFS_DATANODE_CONFIG['instances'][0])
 
+    # Make sure the service is up
+    aggregator.assert_service_check(
+        HDFSDataNode.JMX_SERVICE_CHECK, status=HDFSDataNode.OK, tags=HDFS_DATANODE_METRIC_TAGS + CUSTOM_TAGS, count=1
+    )
+
     for metric, value in HDFS_DATANODE_METRICS_VALUES.iteritems():
-        aggregator.assert_metric(metric, value=value, tags=HDFS_DATANODE_METRIC_TAGS, count=1)
+        aggregator.assert_metric(metric, value=value, tags=HDFS_DATANODE_METRIC_TAGS + CUSTOM_TAGS, count=1)
 
     aggregator.assert_all_metrics_covered()
+
+
+def test_auth(aggregator, mocked_auth_request):
+    """
+    Test that we can connect to the endpoint when we authenticate
+    """
+
+    hdfs_datanode = HDFSDataNode('hdfs_datanode', {}, {})
+
+    # Run the check once
+    hdfs_datanode.check(HDFS_DATANODE_AUTH_CONFIG['instances'][0])
+
+    # Make sure the service is up
+    aggregator.assert_service_check(
+        HDFSDataNode.JMX_SERVICE_CHECK, status=HDFSDataNode.OK, tags=HDFS_DATANODE_METRIC_TAGS + CUSTOM_TAGS, count=1
+    )


### PR DESCRIPTION
### What does this PR do?

This PR adds support for HTTP authentication for `hdfs_datanode`.

### Motivation

Fixes issue where users protect endpoints with authentication.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes
