### PR TITLE
Add support for HTTP authentication

### DIFF
--- a/hdfs_namenode/conf.yaml.example
+++ b/hdfs_namenode/conf.yaml.example
@@ -10,10 +10,17 @@ instances:
   # the property dfs.http.address or dfs.namenode.http-address
   #
   -  hdfs_namenode_jmx_uri: http://localhost:50070
-  # Optional tags to be applied to every emitted metric and service check.
-  #   tags:
-  #      - optional_tag1
-  #      - optional_tag2
+
+  # If your service uses basic HTTP authentication, you can optionally
+  # specify a username and password that will be used in the check.
+  # username: user
+  # password: pass
+
   # Optionally disable SSL validation. Sometimes when using proxies or self-signed certs
   # we'll want to override validation.
   # disable_ssl_validation: false
+
+  # Optional tags to be applied to every emitted metric and service check.
+  # tags:
+  #    - optional:tag1
+  #    - optional:tag2

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 
-'''
+"""
 HDFS NameNode Metrics
 ---------------------
 hdfs.namenode.capacity_total                    Total disk capacity in bytes
@@ -29,7 +29,7 @@ hdfs.namenode.num_stale_data_nodes              Number of stale data nodes
 hdfs.namenode.num_stale_storages                Number of stale storages
 hdfs.namenode.missing_blocks                    Number of missing blocks
 hdfs.namenode.corrupt_blocks                    Number of corrupt blocks
-'''
+"""
 
 # stdlib
 from urlparse import urljoin
@@ -42,116 +42,143 @@ from simplejson import JSONDecodeError
 # Project
 from datadog_checks.checks import AgentCheck
 
-# Service check names
-JMX_SERVICE_CHECK = 'hdfs.namenode.jmx.can_connect'
-
-# URL Paths
-JMX_PATH = 'jmx'
-
-# Namesystem state bean
-HDFS_NAME_SYSTEM_STATE_BEAN = 'Hadoop:service=NameNode,name=FSNamesystemState'
-
-# Namesystem bean
-HDFS_NAME_SYSTEM_BEAN = 'Hadoop:service=NameNode,name=FSNamesystem'
-
-# Metric types
-GAUGE = 'gauge'
-
-# HDFS metrics
-HDFS_NAME_SYSTEM_STATE_METRICS = {
-    'CapacityTotal': ('hdfs.namenode.capacity_total',  GAUGE),
-    'CapacityUsed': ('hdfs.namenode.capacity_used',  GAUGE),
-    'CapacityRemaining': ('hdfs.namenode.capacity_remaining',  GAUGE),
-    'TotalLoad': ('hdfs.namenode.total_load',  GAUGE),
-    'FsLockQueueLength': ('hdfs.namenode.fs_lock_queue_length',  GAUGE),
-    'BlocksTotal': ('hdfs.namenode.blocks_total',  GAUGE),
-    'MaxObjects': ('hdfs.namenode.max_objects',  GAUGE),
-    'FilesTotal': ('hdfs.namenode.files_total',  GAUGE),
-    'PendingReplicationBlocks': ('hdfs.namenode.pending_replication_blocks',  GAUGE),
-    'UnderReplicatedBlocks': ('hdfs.namenode.under_replicated_blocks',  GAUGE),
-    'ScheduledReplicationBlocks': ('hdfs.namenode.scheduled_replication_blocks',  GAUGE),
-    'PendingDeletionBlocks': ('hdfs.namenode.pending_deletion_blocks',  GAUGE),
-    'NumLiveDataNodes': ('hdfs.namenode.num_live_data_nodes',  GAUGE),
-    'NumDeadDataNodes': ('hdfs.namenode.num_dead_data_nodes',  GAUGE),
-    'NumDecomLiveDataNodes': ('hdfs.namenode.num_decom_live_data_nodes',  GAUGE),
-    'NumDecomDeadDataNodes': ('hdfs.namenode.num_decom_dead_data_nodes',  GAUGE),
-    'VolumeFailuresTotal': ('hdfs.namenode.volume_failures_total',  GAUGE),
-    'EstimatedCapacityLostTotal': ('hdfs.namenode.estimated_capacity_lost_total',  GAUGE),
-    'NumDecommissioningDataNodes': ('hdfs.namenode.num_decommissioning_data_nodes',  GAUGE),
-    'NumStaleDataNodes': ('hdfs.namenode.num_stale_data_nodes',  GAUGE),
-    'NumStaleStorages': ('hdfs.namenode.num_stale_storages',  GAUGE),
-}
-
-HDFS_NAME_SYSTEM_METRICS = {
-    'MissingBlocks': ('hdfs.namenode.missing_blocks', GAUGE),
-    'CorruptBlocks': ('hdfs.namenode.corrupt_blocks', GAUGE)
-}
-
 
 class HDFSNameNode(AgentCheck):
+    # Service check names
+    JMX_SERVICE_CHECK = 'hdfs.namenode.jmx.can_connect'
+
+    # URL Paths
+    JMX_PATH = 'jmx'
+
+    # Namesystem state bean
+    HDFS_NAME_SYSTEM_STATE_BEAN = 'Hadoop:service=NameNode,name=FSNamesystemState'
+
+    # Namesystem bean
+    HDFS_NAME_SYSTEM_BEAN = 'Hadoop:service=NameNode,name=FSNamesystem'
+
+    # Metric types
+    GAUGE = 'gauge'
+
+    # HDFS metrics
+    HDFS_NAME_SYSTEM_STATE_METRICS = {
+        'CapacityTotal': ('hdfs.namenode.capacity_total', GAUGE),
+        'CapacityUsed': ('hdfs.namenode.capacity_used', GAUGE),
+        'CapacityRemaining': ('hdfs.namenode.capacity_remaining', GAUGE),
+        'TotalLoad': ('hdfs.namenode.total_load', GAUGE),
+        'FsLockQueueLength': ('hdfs.namenode.fs_lock_queue_length', GAUGE),
+        'BlocksTotal': ('hdfs.namenode.blocks_total', GAUGE),
+        'MaxObjects': ('hdfs.namenode.max_objects', GAUGE),
+        'FilesTotal': ('hdfs.namenode.files_total', GAUGE),
+        'PendingReplicationBlocks': ('hdfs.namenode.pending_replication_blocks', GAUGE),
+        'UnderReplicatedBlocks': ('hdfs.namenode.under_replicated_blocks', GAUGE),
+        'ScheduledReplicationBlocks': ('hdfs.namenode.scheduled_replication_blocks', GAUGE),
+        'PendingDeletionBlocks': ('hdfs.namenode.pending_deletion_blocks', GAUGE),
+        'NumLiveDataNodes': ('hdfs.namenode.num_live_data_nodes', GAUGE),
+        'NumDeadDataNodes': ('hdfs.namenode.num_dead_data_nodes', GAUGE),
+        'NumDecomLiveDataNodes': ('hdfs.namenode.num_decom_live_data_nodes', GAUGE),
+        'NumDecomDeadDataNodes': ('hdfs.namenode.num_decom_dead_data_nodes', GAUGE),
+        'VolumeFailuresTotal': ('hdfs.namenode.volume_failures_total', GAUGE),
+        'EstimatedCapacityLostTotal': ('hdfs.namenode.estimated_capacity_lost_total', GAUGE),
+        'NumDecommissioningDataNodes': ('hdfs.namenode.num_decommissioning_data_nodes', GAUGE),
+        'NumStaleDataNodes': ('hdfs.namenode.num_stale_data_nodes', GAUGE),
+        'NumStaleStorages': ('hdfs.namenode.num_stale_storages', GAUGE),
+    }
+
+    HDFS_NAME_SYSTEM_METRICS = {
+        'MissingBlocks': ('hdfs.namenode.missing_blocks', GAUGE),
+        'CorruptBlocks': ('hdfs.namenode.corrupt_blocks', GAUGE),
+    }
 
     def check(self, instance):
         jmx_address = instance.get('hdfs_namenode_jmx_uri')
-        disable_ssl_validation = instance.get('disable_ssl_validation', False)
-        tags = instance.get('tags', [])
         if jmx_address is None:
-            raise Exception('The JMX URL must be specified in the instance configuration')
+            raise Exception("The JMX URL must be specified in the instance configuration")
 
-        tags.append('namenode_url:' + jmx_address)
+        # Set up tags
+        tags = instance.get("tags", [])
+        tags.append("namenode_url:{}".format(jmx_address))
         tags = list(set(tags))
 
-        # Get metrics from JMX
-        self._hdfs_namenode_metrics(jmx_address, disable_ssl_validation, HDFS_NAME_SYSTEM_STATE_BEAN,
-                                    HDFS_NAME_SYSTEM_STATE_METRICS, tags)
+        # Authenticate our connection to JMX endpoint if required
+        username = instance.get('username')
+        password = instance.get('password')
+        auth = None
+        if username is not None and password is not None:
+            auth = (username, password)
 
-        self._hdfs_namenode_metrics(jmx_address, disable_ssl_validation, HDFS_NAME_SYSTEM_BEAN,
-                                    HDFS_NAME_SYSTEM_METRICS, tags)
+        # Get data from JMX
+        disable_ssl_validation = instance.get('disable_ssl_validation', False)
+        hdfs_system_state_beans = self._get_jmx_data(
+            jmx_address, auth, disable_ssl_validation, self.HDFS_NAME_SYSTEM_STATE_BEAN, tags
+        )
+        hdfs_system_beans = self._get_jmx_data(
+            jmx_address, auth, disable_ssl_validation, self.HDFS_NAME_SYSTEM_BEAN, tags
+        )
 
-        self.service_check(JMX_SERVICE_CHECK, AgentCheck.OK, tags=tags,
-                           message='Connection to %s was successful' % jmx_address)
+        # Process the JMX data and send out metrics
+        if hdfs_system_state_beans:
+            self._hdfs_namenode_metrics(hdfs_system_state_beans, self.HDFS_NAME_SYSTEM_STATE_METRICS, tags)
 
-    def _hdfs_namenode_metrics(self, jmx_uri, disable_ssl_validation, bean_name, metrics, tags):
-        '''
+        if hdfs_system_beans:
+            self._hdfs_namenode_metrics(hdfs_system_beans, self.HDFS_NAME_SYSTEM_METRICS, tags)
+
+        # Send an OK service check
+        self.service_check(
+            self.JMX_SERVICE_CHECK,
+            AgentCheck.OK,
+            tags=tags,
+            message="Connection to {} was successful".format(jmx_address),
+        )
+
+    def _get_jmx_data(self, jmx_address, auth, disable_ssl_validation, bean_name, tags):
+        """
+        Get namenode beans data from JMX endpoint
+        """
+
+        response = self._rest_request_to_json(
+            jmx_address, auth, disable_ssl_validation, self.JMX_PATH, {"qry": bean_name}, tags=tags
+        )
+        beans = response.get("beans", [])
+        return beans
+
+    def _hdfs_namenode_metrics(self, beans, metrics, tags):
+        """
         Get HDFS namenode metrics from JMX
-        '''
-        response = self._rest_request_to_json(jmx_uri, disable_ssl_validation, JMX_PATH,
-                                              query_params={'qry': bean_name}, tags=tags)
+        """
+        bean = next(iter(beans))
+        bean_name = bean.get('name')
 
-        beans = response.get('beans', [])
+        if bean_name != bean_name:
+            raise Exception("Unexpected bean name {}".format(bean_name))
 
-        if beans:
+        for metric, (metric_name, metric_type) in metrics.iteritems():
+            metric_value = bean.get(metric)
 
-            bean = next(iter(beans))
-            bean_name = bean.get('name')
+            if metric_value is not None:
+                self._set_metric(metric_name, metric_type, metric_value, tags)
 
-            if bean_name != bean_name:
-                raise Exception("Unexpected bean name {0}".format(bean_name))
-
-            for metric, (metric_name, metric_type) in metrics.iteritems():
-                metric_value = bean.get(metric)
-
-                if metric_value is not None:
-                    self._set_metric(metric_name, metric_type, metric_value, tags)
-
-            if 'CapacityUsed' in bean and 'CapacityTotal' in bean:
-                self._set_metric('hdfs.namenode.capacity_in_use', GAUGE,
-                                 float(bean['CapacityUsed']) / float(bean['CapacityTotal']), tags)
+        if 'CapacityUsed' in bean and 'CapacityTotal' in bean:
+            self._set_metric(
+                'hdfs.namenode.capacity_in_use',
+                self.GAUGE,
+                float(bean['CapacityUsed']) / float(bean['CapacityTotal']),
+                tags,
+            )
 
     def _set_metric(self, metric_name, metric_type, value, tags=None):
-        '''
+        """
         Set a metric
-        '''
-        if metric_type == GAUGE:
+        """
+        if metric_type == self.GAUGE:
             self.gauge(metric_name, value, tags=tags)
         else:
-            self.log.error('Metric type "%s" unknown' % (metric_type))
+            self.log.error('Metric type "{}" unknown'.format(metric_type))
 
-    def _rest_request_to_json(self, address, disable_ssl_validation, object_path, query_params, tags=None):
-        '''
+    def _rest_request_to_json(self, address, auth, disable_ssl_validation, object_path, query_params, tags=None):
+        """
         Query the given URL and return the JSON response
-        '''
+        """
         response_json = None
-
         url = address
 
         if object_path:
@@ -159,44 +186,49 @@ class HDFSNameNode(AgentCheck):
 
         # Add query_params as arguments
         if query_params:
-            query = '&'.join(['{0}={1}'.format(key, value) for key, value in query_params.iteritems()])
+            query = '&'.join(['{}={}'.format(key, value) for key, value in query_params.iteritems()])
             url = urljoin(url, '?' + query)
 
-        self.log.debug('Attempting to connect to "%s"' % url)
+        self.log.debug('Attempting to connect to "{}"'.format(url))
 
         try:
-            response = requests.get(url, timeout=self.default_integration_http_timeout,
-                                    verify=not disable_ssl_validation)
+            response = requests.get(
+                url, auth=auth, timeout=self.default_integration_http_timeout, verify=not disable_ssl_validation
+            )
             response.raise_for_status()
             response_json = response.json()
 
         except Timeout as e:
-            self.service_check(JMX_SERVICE_CHECK, AgentCheck.CRITICAL, tags=tags,
-                               message="Request timeout: {}, {}".format(url, e))
+            self.service_check(
+                self.JMX_SERVICE_CHECK, AgentCheck.CRITICAL, tags=tags, message="Request timeout: {}, {}".format(url, e)
+            )
             raise
 
-        except (HTTPError,
-                InvalidURL,
-                ConnectionError) as e:
-            self.service_check(JMX_SERVICE_CHECK, AgentCheck.CRITICAL, tags=tags,
-                               message="Request failed: {}, {}".format(url, e))
+        except (HTTPError, InvalidURL, ConnectionError) as e:
+            self.service_check(
+                self.JMX_SERVICE_CHECK, AgentCheck.CRITICAL, tags=tags, message="Request failed: {}, {}".format(url, e)
+            )
             raise
 
         except JSONDecodeError as e:
-            self.service_check(JMX_SERVICE_CHECK, AgentCheck.CRITICAL, tags=tags,
-                               message='JSON Parse failed: {}, {}'.format(url, e))
+            self.service_check(
+                self.JMX_SERVICE_CHECK,
+                AgentCheck.CRITICAL,
+                tags=tags,
+                message='JSON Parse failed: {}, {}'.format(url, e),
+            )
             raise
 
         except ValueError as e:
-            self.service_check(JMX_SERVICE_CHECK, AgentCheck.CRITICAL, tags=tags, message=str(e))
+            self.service_check(self.JMX_SERVICE_CHECK, AgentCheck.CRITICAL, tags=tags, message=str(e))
             raise
 
         return response_json
 
     def _join_url_dir(self, url, *args):
-        '''
+        """
         Join a URL with multiple directories
-        '''
+        """
 
         for path in args:
             url = url.rstrip('/') + '/'

--- a/hdfs_namenode/tests/common.py
+++ b/hdfs_namenode/tests/common.py
@@ -16,12 +16,31 @@ NAME_SYSTEM_STATE_URL = NAMENODE_JMX_URI + '?qry=Hadoop:service=NameNode,name=FS
 # Namesystem url
 NAME_SYSTEM_URL = NAMENODE_JMX_URI + '?qry=Hadoop:service=NameNode,name=FSNamesystem'
 
+CUSTOM_TAGS = ["cluster_name:hdfs_dev", "instance:level_tags"]
+
+# Authentication Parameters
+TEST_USERNAME = 'Picard'
+TEST_PASSWORD = 'NCC-1701'
+
 HDFS_NAMENODE_CONFIG = {
-    'instances': [{
-        'hdfs_namenode_jmx_uri': NAMENODE_URI,
-        'tags': ['cluster_name:hdfs_dev', 'cluster_name:hdfs_dev', 'instance:level_tags'],
-        }]
-    }
+    'instances': [
+        {
+            'hdfs_namenode_jmx_uri': NAMENODE_URI,
+            'tags': list(CUSTOM_TAGS)
+        }
+    ]
+}
+
+HDFS_NAMENODE_AUTH_CONFIG = {
+    'instances': [
+        {
+            'hdfs_namenode_jmx_uri': NAMENODE_URI,
+            'tags': list(CUSTOM_TAGS),
+            'username': TEST_USERNAME,
+            'password': TEST_PASSWORD,
+        }
+    ]
+}
 
 HDFS_NAMESYSTEM_STATE_METRICS_VALUES = {
     'hdfs.namenode.capacity_total': 41167421440,
@@ -56,8 +75,4 @@ HDFS_NAMESYSTEM_MUTUAL_METRICS_VALUES = {
     'hdfs.namenode.capacity_in_use': None
 }
 
-HDFS_NAMESYSTEM_METRIC_TAGS = [
-    'namenode_url:' + NAMENODE_URI,
-    'cluster_name:hdfs_dev',
-    'instance:level_tags',
-]
+HDFS_NAMESYSTEM_METRIC_TAGS = ['namenode_url:' + NAMENODE_URI]

--- a/hdfs_namenode/tests/test_hdfs_namenode.py
+++ b/hdfs_namenode/tests/test_hdfs_namenode.py
@@ -5,8 +5,8 @@
 from datadog_checks.hdfs_namenode import HDFSNameNode
 
 from .common import (
-    HDFS_NAMENODE_CONFIG, HDFS_NAMESYSTEM_METRIC_TAGS, HDFS_NAMESYSTEM_METRICS_VALUES,
-    HDFS_NAMESYSTEM_STATE_METRICS_VALUES, HDFS_NAMESYSTEM_MUTUAL_METRICS_VALUES
+    HDFS_NAMENODE_CONFIG, HDFS_NAMENODE_AUTH_CONFIG, CUSTOM_TAGS, HDFS_NAMESYSTEM_METRIC_TAGS,
+    HDFS_NAMESYSTEM_METRICS_VALUES, HDFS_NAMESYSTEM_STATE_METRICS_VALUES, HDFS_NAMESYSTEM_MUTUAL_METRICS_VALUES
 )
 
 
@@ -16,13 +16,28 @@ def test_check(aggregator, mocked_request):
     # Run the check once
     hdfs_namenode.check(HDFS_NAMENODE_CONFIG['instances'][0])
 
+    aggregator.assert_service_check(
+        HDFSNameNode.JMX_SERVICE_CHECK, HDFSNameNode.OK, tags=HDFS_NAMESYSTEM_METRIC_TAGS + CUSTOM_TAGS, count=1
+    )
+
     for metric, value in HDFS_NAMESYSTEM_STATE_METRICS_VALUES.iteritems():
-        aggregator.assert_metric(metric, value=value, tags=HDFS_NAMESYSTEM_METRIC_TAGS, count=1)
+        aggregator.assert_metric(metric, value=value, tags=HDFS_NAMESYSTEM_METRIC_TAGS + CUSTOM_TAGS, count=1)
 
     for metric, value in HDFS_NAMESYSTEM_METRICS_VALUES.iteritems():
-        aggregator.assert_metric(metric, value=value, tags=HDFS_NAMESYSTEM_METRIC_TAGS, count=1)
+        aggregator.assert_metric(metric, value=value, tags=HDFS_NAMESYSTEM_METRIC_TAGS + CUSTOM_TAGS, count=1)
 
     for metric, value in HDFS_NAMESYSTEM_MUTUAL_METRICS_VALUES.iteritems():
-        aggregator.assert_metric(metric, value=value, tags=HDFS_NAMESYSTEM_METRIC_TAGS, count=2)
+        aggregator.assert_metric(metric, value=value, tags=HDFS_NAMESYSTEM_METRIC_TAGS + CUSTOM_TAGS, count=2)
 
     aggregator.assert_all_metrics_covered()
+
+
+def test_auth(aggregator, mocked_auth_request):
+    hdfs_namenode = HDFSNameNode('hdfs_namenode', {}, {})
+
+    # Run the check once
+    hdfs_namenode.check(HDFS_NAMENODE_AUTH_CONFIG['instances'][0])
+
+    aggregator.assert_service_check(
+        HDFSNameNode.JMX_SERVICE_CHECK, HDFSNameNode.OK, tags=HDFS_NAMESYSTEM_METRIC_TAGS + CUSTOM_TAGS, count=1
+    )


### PR DESCRIPTION
### What does this PR do?

This PR adds support for HTTP authentication for `hdfs_namenode`.

### Motivation

Fixes issue where users protect endpoints with authentication.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes