### PR TITLE
Add support for HTTP authentication

### DIFF
--- a/spark/conf.yaml.example
+++ b/spark/conf.yaml.example
@@ -22,6 +22,9 @@ instances:
   # The use of `resourcemanager_uri` has been deprecated, but is still functional.
   - spark_url: http://localhost:8088
 
+    # A Required friendly name for the cluster.
+    # cluster_name: MySparkCluster
+
     # To enable monitoring of a Standalone Spark cluster, the spark cluster
     # mode must be set. Uncomment the cluster mode that applies.
     # spark_cluster_mode: spark_yarn_mode
@@ -43,13 +46,15 @@ instances:
     # If you have enabled the spark UI proxy, you may set this to `true`
     # spark_proxy_enabled: false
 
-    # A Required friendly name for the cluster.
-    # cluster_name: MySparkCluster
-
     # Optional tags to be applied to every emitted metric.
     # tags:
     #   - key:value
     #   - instance:production
+
+    # If your service uses basic HTTP authentication, you can optionally
+    # specify a username and password that will be used in the check.
+    # username: user
+    # password: pass
 
     # SSL configuration.
     # ssl_verify: false

--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -637,9 +637,6 @@ def test_mesos(aggregator):
         c = SparkCheck('spark', None, {}, [MESOS_CONFIG])
         c.check(MESOS_CONFIG)
 
-        for m in aggregator._service_checks.items():
-            print(m)
-
         # Check the running job metrics
         for metric, value in SPARK_JOB_RUNNING_METRIC_VALUES.iteritems():
             aggregator.assert_metric(

--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -50,6 +50,11 @@ YARN_SERVICE_CHECK = 'spark.resource_manager.can_connect'
 MESOS_SERVICE_CHECK = 'spark.mesos_master.can_connect'
 STANDALONE_SERVICE_CHECK = 'spark.standalone_master.can_connect'
 
+TEST_USERNAME = 'admin'
+TEST_PASSWORD = 'password'
+
+CUSTOM_TAGS = ['optional:tag1']
+
 
 def join_url_dir(url, *args):
     '''
@@ -168,6 +173,17 @@ def yarn_requests_get_mock(*args, **kwargs):
         with open(os.path.join(FIXTURE_DIR, 'rdd_metrics'), 'r') as f:
             body = f.read()
             return MockResponse(body, 200)
+
+
+def yarn_requests_auth_mock(*args, **kwargs):
+    # Make sure we're passing in authentication
+    assert 'auth' in kwargs, "Error, missing authentication"
+
+    # Make sure we've got the correct username and password
+    assert kwargs['auth'] == (TEST_USERNAME, TEST_PASSWORD), "Incorrect username or password"
+
+    # Return mocked request.get(...)
+    return yarn_requests_get_mock(*args, **kwargs)
 
 
 def mesos_requests_get_mock(*args, **kwargs):
@@ -342,14 +358,23 @@ YARN_CONFIG = {
     'spark_url': 'http://localhost:8088',
     'cluster_name': CLUSTER_NAME,
     'spark_cluster_mode': 'spark_yarn_mode',
-    'tags': ['optional:tag1']
+    'tags': list(CUSTOM_TAGS),
+}
+
+YARN_AUTH_CONFIG = {
+    'spark_url': 'http://localhost:8088',
+    'cluster_name': CLUSTER_NAME,
+    'spark_cluster_mode': 'spark_yarn_mode',
+    'tags': list(CUSTOM_TAGS),
+    'username': TEST_USERNAME,
+    'password': TEST_PASSWORD,
 }
 
 MESOS_CONFIG = {
     'spark_url': 'http://localhost:5050',
     'cluster_name': CLUSTER_NAME,
     'spark_cluster_mode': 'spark_mesos_mode',
-    'tags': ['instance:mytag']
+    'tags': list(CUSTOM_TAGS),
 }
 
 MESOS_FILTERED_CONFIG = {
@@ -531,60 +556,78 @@ def test_yarn(aggregator):
         for metric, value in SPARK_JOB_RUNNING_METRIC_VALUES.iteritems():
             aggregator.assert_metric(
                 metric,
-                tags=SPARK_JOB_RUNNING_METRIC_TAGS + ['optional:tag1'], value=value)
+                tags=SPARK_JOB_RUNNING_METRIC_TAGS + CUSTOM_TAGS, value=value)
 
         # Check the succeeded job metrics
         for metric, value in SPARK_JOB_SUCCEEDED_METRIC_VALUES.iteritems():
             aggregator.assert_metric(
                 metric,
                 value=value,
-                tags=SPARK_JOB_SUCCEEDED_METRIC_TAGS + ['optional:tag1'])
+                tags=SPARK_JOB_SUCCEEDED_METRIC_TAGS + CUSTOM_TAGS)
 
         # Check the running stage metrics
         for metric, value in SPARK_STAGE_RUNNING_METRIC_VALUES.iteritems():
             aggregator.assert_metric(
                 metric,
                 value=value,
-                tags=SPARK_STAGE_RUNNING_METRIC_TAGS + ['optional:tag1'])
+                tags=SPARK_STAGE_RUNNING_METRIC_TAGS + CUSTOM_TAGS)
 
         # Check the complete stage metrics
         for metric, value in SPARK_STAGE_COMPLETE_METRIC_VALUES.iteritems():
             aggregator.assert_metric(
                 metric,
                 value=value,
-                tags=SPARK_STAGE_COMPLETE_METRIC_TAGS + ['optional:tag1'])
+                tags=SPARK_STAGE_COMPLETE_METRIC_TAGS + CUSTOM_TAGS)
 
         # Check the driver metrics
         for metric, value in SPARK_DRIVER_METRIC_VALUES.iteritems():
             aggregator.assert_metric(
                 metric,
                 value=value,
-                tags=SPARK_METRIC_TAGS + ['optional:tag1'])
+                tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
 
         # Check the executor metrics
         for metric, value in SPARK_EXECUTOR_METRIC_VALUES.iteritems():
             aggregator.assert_metric(
                 metric,
                 value=value,
-                tags=SPARK_METRIC_TAGS + ['optional:tag1'])
+                tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
 
         # Check the RDD metrics
         for metric, value in SPARK_RDD_METRIC_VALUES.iteritems():
             aggregator.assert_metric(
                 metric,
                 value=value,
-                tags=SPARK_METRIC_TAGS + ['optional:tag1'])
+                tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
+
+        tags = ['url:http://localhost:8088', 'cluster_name:SparkCluster'] + CUSTOM_TAGS
+        tags.sort()
 
         for sc in aggregator.service_checks(YARN_SERVICE_CHECK):
             assert sc.status == SparkCheck.OK
-            tags = ['url:http://localhost:8088', 'cluster_name:SparkCluster', 'optional:tag1']
-            tags.sort()
             sc.tags.sort()
             assert sc.tags == tags
         for sc in aggregator.service_checks(SPARK_SERVICE_CHECK):
             assert sc.status == SparkCheck.OK
-            tags = ['url:http://localhost:8088', 'cluster_name:SparkCluster', 'optional:tag1']
-            tags.sort()
+            sc.tags.sort()
+            assert sc.tags == tags
+
+
+def test_auth_yarn(aggregator):
+    with mock.patch('requests.get', yarn_requests_auth_mock):
+        c = SparkCheck('spark', None, {}, [YARN_AUTH_CONFIG])
+        c.check(YARN_AUTH_CONFIG)
+
+        tags = ['url:http://localhost:8088', 'cluster_name:SparkCluster'] + CUSTOM_TAGS
+        tags.sort()
+
+        for sc in aggregator.service_checks(YARN_SERVICE_CHECK):
+            assert sc.status == SparkCheck.OK
+            sc.tags.sort()
+            assert sc.tags == tags
+
+        for sc in aggregator.service_checks(SPARK_SERVICE_CHECK):
+            assert sc.status == SparkCheck.OK
             sc.tags.sort()
             assert sc.tags == tags
 
@@ -594,66 +637,69 @@ def test_mesos(aggregator):
         c = SparkCheck('spark', None, {}, [MESOS_CONFIG])
         c.check(MESOS_CONFIG)
 
+        for m in aggregator._service_checks.items():
+            print(m)
+
         # Check the running job metrics
         for metric, value in SPARK_JOB_RUNNING_METRIC_VALUES.iteritems():
             aggregator.assert_metric(
                 metric,
                 value=value,
-                tags=SPARK_JOB_RUNNING_METRIC_TAGS + ['instance:mytag'])
+                tags=SPARK_JOB_RUNNING_METRIC_TAGS + CUSTOM_TAGS)
 
         # Check the succeeded job metrics
         for metric, value in SPARK_JOB_SUCCEEDED_METRIC_VALUES.iteritems():
             aggregator.assert_metric(
                 metric,
                 value=value,
-                tags=SPARK_JOB_SUCCEEDED_METRIC_TAGS + ['instance:mytag'])
+                tags=SPARK_JOB_SUCCEEDED_METRIC_TAGS + CUSTOM_TAGS)
 
         # Check the running stage metrics
         for metric, value in SPARK_STAGE_RUNNING_METRIC_VALUES.iteritems():
             aggregator.assert_metric(
                 metric,
                 value=value,
-                tags=SPARK_STAGE_RUNNING_METRIC_TAGS + ['instance:mytag'])
+                tags=SPARK_STAGE_RUNNING_METRIC_TAGS + CUSTOM_TAGS)
 
         # Check the complete stage metrics
         for metric, value in SPARK_STAGE_COMPLETE_METRIC_VALUES.iteritems():
             aggregator.assert_metric(
                 metric,
                 value=value,
-                tags=SPARK_STAGE_COMPLETE_METRIC_TAGS + ['instance:mytag'])
+                tags=SPARK_STAGE_COMPLETE_METRIC_TAGS + CUSTOM_TAGS)
 
         # Check the driver metrics
         for metric, value in SPARK_DRIVER_METRIC_VALUES.iteritems():
             aggregator.assert_metric(
                 metric,
                 value=value,
-                tags=SPARK_METRIC_TAGS + ['instance:mytag'])
+                tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
 
         # Check the executor metrics
         for metric, value in SPARK_EXECUTOR_METRIC_VALUES.iteritems():
             aggregator.assert_metric(
                 metric,
                 value=value,
-                tags=SPARK_METRIC_TAGS + ['instance:mytag'])
+                tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
 
         # Check the RDD metrics
         for metric, value in SPARK_RDD_METRIC_VALUES.iteritems():
             aggregator.assert_metric(
                 metric,
                 value=value,
-                tags=SPARK_METRIC_TAGS + ['instance:mytag'])
+                tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
 
         # Check the service tests
 
         for sc in aggregator.service_checks(MESOS_SERVICE_CHECK):
             assert sc.status == SparkCheck.OK
-            tags = ['url:http://localhost:5050', 'cluster_name:SparkCluster', 'instance:mytag']
+            tags = ['url:http://localhost:5050', 'cluster_name:SparkCluster'] + CUSTOM_TAGS
             tags.sort()
             sc.tags.sort()
             assert sc.tags == tags
         for sc in aggregator.service_checks(SPARK_SERVICE_CHECK):
             assert sc.status == SparkCheck.OK
-            tags = ['url:http://localhost:4040', 'cluster_name:SparkCluster', 'instance:mytag']
+            tags = ['url:http://localhost:4040', 'cluster_name:SparkCluster'] + CUSTOM_TAGS
             tags.sort()
             sc.tags.sort()
             assert sc.tags == tags

--- a/spark/tox.ini
+++ b/spark/tox.ini
@@ -1,18 +1,18 @@
 [tox]
 minversion = 2.0
 basepython = py27
-envlist = unit, flake8
+envlist = spark, flake8
 
 [testenv]
 platform = linux|darwin|win32
 
-[testenv:unit]
+[testenv:spark]
 deps =
     ../datadog_checks_base
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt
-    pytest
+    pytest -v
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
### What does this PR do?

This PR adds support for HTTP authentication for `spark`. 

### Motivation

Fixes issue where users protect endpoints with authentication.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes