### PR TITLE
Bumped redisdb version to 1.6.0

### DIFF
--- a/redisdb/CHANGELOG.md
+++ b/redisdb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - redisdb
 
+## 1.6.0 / 2018-06-06
+
+* [Added] Add a config option to disable connection cache. See [#1668](https://github.com/DataDog/integrations-core/pull/1668).
+* [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664](https://github.com/DataDog/integrations-core/pull/1664).
+
 ## 1.5.0 / 2018-05-11
 
 * [FEATURE] Hardcode the 6379 port in the Autodiscovery template. See [#1444][] for more information.

--- a/redisdb/datadog_checks/redisdb/__about__.py
+++ b/redisdb/datadog_checks/redisdb/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -63,7 +63,7 @@ powerdns_recursor==1.0.0
 process==1.3.0
 prometheus==1.0.0
 rabbitmq==1.5.1
-redisdb==1.5.0
+redisdb==1.6.0
 riak==1.2.0
 riakcs==1.1.0
 snmp==1.4.0


### PR DESCRIPTION
### What does this PR do?

Release redis 1.6.0

