### PR TITLE
Fix prom cadvisor metrics handling

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
@@ -423,7 +423,7 @@ class PrometheusScraperMixin(object):
                 except KeyError:
                     if not ignore_unmapped:
                         # call magic method (non-generic check)
-                        handler = getattr(self, message.name)
+                        handler = getattr(self, message.name)  # Lookup will throw AttributeError if not found
                         try:
                             handler(message, **kwargs)
                         except Exception as err:

--- a/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
@@ -423,7 +423,11 @@ class PrometheusScraperMixin(object):
                 except KeyError:
                     if not ignore_unmapped:
                         # call magic method (non-generic check)
-                        getattr(self, message.name)(message, **kwargs)
+                        handler = getattr(self, message.name)
+                        try:
+                            handler(message, **kwargs)
+                        except Exception as err:
+                            self.log.warning("Error handling metric: {} - error: {}".format(message.name, err))
                     else:
                         # build the wildcard list if first pass
                         if self._metrics_wildcards is None:

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -180,6 +180,10 @@ class CadvisorPrometheusScraper(PrometheusScraper):
 
         super(CadvisorPrometheusScraper, self).process(endpoint, **kwargs)
 
+        # Free up memory
+        self.pod_list = None
+        self.container_filter = None
+
     def _process_container_rate(self, metric_name, message):
         """Takes a simple metric about a container, reports it as a rate."""
         if message.type >= len(METRIC_TYPES):

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -24,6 +24,7 @@ class CadvisorPrometheusScraper(PrometheusScraper):
         super(CadvisorPrometheusScraper, self).__init__(check)
 
         self.NAMESPACE = 'kubernetes'
+        self.instance_tags = []
 
         self.ignore_metrics = [
             'container_cpu_cfs_periods_total',


### PR DESCRIPTION
### What does this PR do?

- fix handling of cadvisor prometheus metrics (add `self.instance_tags` to `CadvisorPrometheusScraper`, lost in class split)
- add a log warning when a metric handling method throws an exception. They were silently ignored, which made the investigation longer
- de-reference podlist and filter after `CadvisorPrometheusScraper` runs, to release memory

No changelog as the changes triggering the bug are not released yet.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
~~- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)~~

