### PR TITLE
Bumped openstack version to 1.3.0

### DIFF
--- a/openstack/CHANGELOG.md
+++ b/openstack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - openstack
 
+## 1.3.0 / 2018-06-06
+
+* [Added]  Added support for unscoped access, implemented caching mechanism to reduce API calls to Nova. See [#1276](https://github.com/DataDog/integrations-core/pull/1276).
+
 ## 1.2.0 / 2018-05-11
 
 * [FEATURE] Add custom tag support to service check and metrics.

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -52,7 +52,7 @@ nagios==1.1.0
 network==1.5.0
 nfsstat==0.2.0; sys_platform == 'linux2'
 nginx==2.2.0
-openstack==1.2.0
+openstack==1.3.0
 oracle==1.3.0
 pdh_check==1.2.0; sys_platform == 'win32'
 pgbouncer==1.2.0; sys_platform != 'win32'


### PR DESCRIPTION
### What does this PR do?

Release 1.3.0
