### PR TITLE
[docs] remove frontmatter params from eks

### DIFF
--- a/amazon_eks/README.md
+++ b/amazon_eks/README.md
@@ -1,23 +1,3 @@
----
-display_name: Amazon EKS
-doc_link: https://docs.datadoghq.com/integrations/amazon_eks/
-has_logo: true
-integration_title: Amazon EKS
-is_public: true
-kind: integration
-name: amazon_eks
-public_title: Datadog-Amazon EKS Integration
-categories:
-- aws
-- containers
-- orchestration
-further_reading:
-- link: "graphing/infrastructure/livecontainers"
-  text: List and explore all containers in your EKS cluster
-- link: "graphing/infrastructure/process"
-  text: Understand what is going on at any level of your system
----
-
 ![EKS Dashboard](https://raw.githubusercontent.com/DataDog/integrations-core/a30e284214e465844d18b7ac06c7c2b1dab8b43a/amazon_eks/images/eks_screenboard.png)
 
 ## Overview

--- a/amazon_eks/README.md
+++ b/amazon_eks/README.md
@@ -18,4 +18,5 @@ along with integrations for any other AWS services you're running with EKS (e.g.
 
 ## Further Reading
 
-{{< partial name="whats-next/whats-next.html" >}}
+Learn more about infrastructure monitoring and all our integrations on [our blog](https://www.datadoghq.com/blog/)
+


### PR DESCRIPTION
### What does this PR do?

This PR fixes content issues in the readme file which is effecting the docs site. This PR is removing the partial call and removing the frontmatter params at the top as both are not needed.

Without them removed we see  these params doubled up in the content. 
See https://docs.datadoghq.com/integrations/amazon_eks/ for the issues.

### Motivation

The integration page https://docs.datadoghq.com/integrations/amazon_eks/ has text that shouldn't be appearing

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
