### PR TITLE
Update conf.yaml.default

### DIFF
--- a/ntp/conf.yaml.default
+++ b/ntp/conf.yaml.default
@@ -10,8 +10,11 @@ instances:
     # Optional params:
     #
     # host: pool.ntp.org
-    # port: ntp
     # version: 3
+    
+    # Agent v5 only optional params:
+    #
+    # port: ntp
     # timeout: 5
     # tags:
     #   - optional:tag1


### PR DESCRIPTION
### Motivation

It looks like some of these config parameters are no longer used in agent v6: https://github.com/DataDog/datadog-agent/blob/0766c52d9a1e87e8f5bee817224c35a90702ebb4/pkg/collector/corechecks/network/ntp.go#L110

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)