### PR TITLE
Remove tox.ini at the root of the repo

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,0 @@
-[flake8]
-exclude = venv/*,embedded/*,.git/*,*/.tox/*,*/.eggs/*,*/build/*,.eggs/*,.tox/*,build/*
-max-line-length = 700
-ignore = E128,E203,E226,E231,E241,E251,E261,E265,E302,E303,E731,W503,E266,E305,E126,E722


### PR DESCRIPTION
### What does this PR do?

See title

### Motivation

The ini file is there only to provide a config section for flake8 but it's confusing because we don't use tox at the root level. See #1693 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
