### PR TITLE
Use kubelet credentials in prometheus scrapers

### DIFF
--- a/kubelet/datadog_checks/kubelet/__init__.py
+++ b/kubelet/datadog_checks/kubelet/__init__.py
@@ -1,11 +1,12 @@
 from .kubelet import KubeletCheck
 from .__about__ import __version__
-from .common import ContainerFilter, get_pod_by_uid, is_static_pending_pod
+from .common import ContainerFilter, KubeletCredentials, get_pod_by_uid, is_static_pending_pod
 
 __all__ = [
     'KubeletCheck',
     '__version__',
     'ContainerFilter',
+    'KubeletCredentials',
     'get_pod_by_uid',
     'is_static_pending_pod'
 ]

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -7,7 +7,7 @@ import sys
 
 import mock
 import pytest
-from datadog_checks.kubelet import KubeletCheck
+from datadog_checks.kubelet import KubeletCheck, KubeletCredentials
 from datadog_checks.kubelet.prometheus import CadvisorPrometheusScraper
 from datadog_checks.checks.prometheus import PrometheusScraper
 
@@ -275,7 +275,7 @@ class MockResponse(mock.Mock):
 def test_perform_kubelet_check(monkeypatch):
     check = KubeletCheck('kubelet', None, {}, [{}])
     check.kube_health_url = "http://127.0.0.1:10255/healthz"
-    check.kubelet_conn_info = {}
+    check.kubelet_credentials = KubeletCredentials({})
     monkeypatch.setattr(check, 'service_check', mock.Mock())
 
     instance_tags = ["one:1"]


### PR DESCRIPTION
### What does this PR do?

The credentials were handled in the `KubeletCheck.perform_kubelet_query()` method and propagated to the PrometheusCheck scraper via class members. Now that the scraper is an separate object, the credentials don't propagate anymore.

This PR moves the credentials import / verification logic to a separate `KubeletCredentials` class that is used both for direct `perform_kubelet_query` calls and scraper setup. Unit tests are added to cover this class.

No changelog as the kubelet split was not released yet.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
~~- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)~~
