### PR TITLE
fix task - only git push current tag

### DIFF
--- a/tasks/utils/git.py
+++ b/tasks/utils/git.py
@@ -65,5 +65,5 @@ def git_tag(ctx, tag_name, push=False):
     cmd = 'git tag -a {} -m"{}"'.format(tag_name, tag_name)
     ctx.run(cmd)
     if push:
-        cmd = 'git push --tags'
+        cmd = 'git push origin {}'.format(tag_name)
         ctx.run(cmd)


### PR DESCRIPTION
```
Tagging HEAD with consul-1.5.0                                                       
fatal: HttpRequestException encountered.                                             
   An error occurred while sending the request.                                      
To https://github.com/DataDog/integrations-core.git                                  
 * [new tag]           consul-1.5.0 -> consul-1.5.0                                  
 ! [rejected]          6.2.1 -> 6.2.1 (already exists)                               
 ! [rejected]          mysql-1.2.1 -> mysql-1.2.1 (already exists)                   
error: failed to push some refs to 'https://github.com/DataDog/integrations-core.git'
hint: Updates were rejected because the tag already exists in the remote.            
Encountered a bad command exit code!
```