### PR TITLE
Allow the updating of JMX based checks via invoke

### DIFF
--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -676,7 +676,6 @@ class Network(AgentCheck):
         Gather metrics about connections states and interfaces counters
         using psutil facilities
         """
-        # import pdb; pdb.set_trace()
         custom_tags = instance.get('tags', [])
         if self._collect_cx_state:
             self._cx_state_psutil(tags=custom_tags)

--- a/tasks/constants.py
+++ b/tasks/constants.py
@@ -73,3 +73,13 @@ AGENT_V5_ONLY = [
     'kubernetes',
     'ntp',
 ]
+
+JMX_INTEGRATIONS = [
+   'activemq',
+    'activemq_58',
+    'cassandra',
+    'jmx',
+    'solr',
+    'tomcat',
+    'kafka',
+]

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -10,7 +10,7 @@ from invoke import task
 from invoke.exceptions import Exit
 from colorama import Fore
 
-from .constants import AGENT_BASED_INTEGRATIONS, AGENT_V5_ONLY, ROOT, AGENT_REQ_FILE
+from .constants import AGENT_BASED_INTEGRATIONS, AGENT_V5_ONLY, ROOT, AGENT_REQ_FILE, JMX_INTEGRATIONS
 from .utils.git import (
     get_current_branch, parse_pr_numbers, get_diff, git_tag, git_commit
 )
@@ -57,7 +57,7 @@ def print_shippable(ctx, quiet=False):
     """
     Print all the checks that can be released.
     """
-    for target in AGENT_BASED_INTEGRATIONS:
+    for target in AGENT_BASED_INTEGRATIONS + JMX_INTEGRATIONS:
         # get the name of the current release tag
         cur_version = get_version_string(target)
         target_tag = get_release_tag_string(target, cur_version)
@@ -85,7 +85,7 @@ def release_show_pending(ctx, target):
         inv release-show-pending mysql
     """
     # sanity check on the target
-    if target not in AGENT_BASED_INTEGRATIONS:
+    if target not in AGENT_BASED_INTEGRATIONS and target not in JMX_INTEGRATIONS:
         raise Exit("Provided target is not an Agent-based Integration")
 
     # get the name of the current release tag
@@ -128,6 +128,7 @@ def release_prepare(ctx, target, new_version):
     Perform a set of operations needed to release a single check:
 
      * update the version in __about__.py
+     * For JMX Integrations, update the version in manifest.json instead
      * update the changelog
      * update the AGENT_REQ_FILE file
      * commit the above changes
@@ -136,7 +137,7 @@ def release_prepare(ctx, target, new_version):
         inv release-prepare redisdb 3.1.1
     """
     # sanity check on the target
-    if target not in AGENT_BASED_INTEGRATIONS:
+    if target not in AGENT_BASED_INTEGRATIONS and target not in JMX_INTEGRATIONS:
         raise Exit("Provided target is not an Agent-based Integration")
 
     # don't run the task on the master branch
@@ -180,7 +181,7 @@ def release_upload(ctx, target, dry_run=False):
     Release to PyPI a specific check as it is on the repo HEAD
     """
     # sanity check on the target
-    if target not in AGENT_BASED_INTEGRATIONS:
+    if target not in AGENT_BASED_INTEGRATIONS and target not in JMX_INTEGRATIONS:
         raise Exit("Provided target is not an Agent-based Integration")
 
     # retrieve credentials

--- a/tasks/utils/common.py
+++ b/tasks/utils/common.py
@@ -5,12 +5,14 @@ from __future__ import print_function, unicode_literals
 import os
 import json
 
-from ..constants import ROOT
+from ..constants import ROOT, JMX_INTEGRATIONS
 
 
 def get_version_file(check_name):
     if check_name in ('datadog_checks_base', 'datadog_checks_test_helper'):
         return os.path.join(ROOT, check_name, "datadog_checks", "__about__.py")
+    elif check_name in JMX_INTEGRATIONS:
+        return os.path.join(ROOT, check_name, "manifest.json")
     else:
         return os.path.join(ROOT, check_name, "datadog_checks", check_name, "__about__.py")
 
@@ -20,10 +22,13 @@ def get_version_string(check_name):
     Get the version string for the given check.
     """
     about = {}
-    with open(get_version_file(check_name)) as f:
-        exec(f.read(), about)
-
-    return about.get('__version__')
+    if check_name in JMX_INTEGRATIONS:
+        manifest_content = load_manifest(check_name)
+        return manifest_content.get('version')
+    else:
+        with open(get_version_file(check_name)) as f:
+            exec(f.read(), about)
+        return about.get('__version__')
 
 
 def get_release_tag_string(check_name, version_string):


### PR DESCRIPTION
### What does this PR do?

Modifies the release invoke tasks to allow for the release of JMX based integrations. 

### Motivation

We have a handful of JMX based checks that contain no python code but are versioned when the yaml files changes. These will not have an __about__.py file but still have their version defined in manifest.json

This allows us to use the release tasks to "release" a new version of these integrations by updating the changelog and bumping the version in the manifest file. 

This may ultimately apply to any integrations that don't have python code but are versioned. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
