### PR TITLE
Fix update_requirement and requirements-agent-release.txt

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -66,7 +66,7 @@ prometheus==1.0.0
 rabbitmq==1.5.1
 redisdb==1.6.0
 riak==1.3.0
-riak==1.3.0
+riakcs==1.1.0
 snmp==1.4.0
 spark==1.4.0
 sqlserver==1.4.0; sys_platform == 'win32'

--- a/tasks/utils/requirements.py
+++ b/tasks/utils/requirements.py
@@ -49,7 +49,8 @@ def update_requirements(req_file, check, newline):
 
     with open(req_file, 'w') as f:
         for line in lines:
-            if line.startswith(check):
+            check_name = line.split("==")[0]
+            if check_name == check:
                 f.write(newline + '\n')
             else:
                 f.write(line)


### PR DESCRIPTION
### What does this PR do?

The function would not check the entire check name when updating the requirement file, causing some lines to be overwritten if they started the same as another check name (e.g. `riak` and `riakcs`)
This fixes it.

### Motivation

noticed this in https://github.com/DataDog/integrations-core/pull/1700/files#diff-c2695350734a3ecf81601b02048146aaR68

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?