### PR TITLE
Make the max custom queries configurable in the yaml file

### DIFF
--- a/mysql/conf.yaml.example
+++ b/mysql/conf.yaml.example
@@ -51,6 +51,7 @@ instances:
     #   cert: /path/to/my/cert.file
     #   ca: /path/to/my/ca.file
 
+    # max_custom_queries: 20 # Optional
     # queries:               # Optional
     #  - # Sample Custom metric
     #    query: SELECT TIMESTAMPDIFF(second,MAX(create_time),NOW()) as last_accessed FROM requests


### PR DESCRIPTION
### What does this PR do?

Makes the max_custom_queries a configurable parameter to update in the yaml file. The default is still 20.

### Motivation

Customer request

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
