### PR TITLE
Add missing tests to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,8 @@ jobs:
     - stage: test
       env: CHECK=linkerd
     - stage: test
+      env: CHECK=mapreduce
+    - stage: test
       env: CHECK=marathon
     - stage: test
       env: CHECK=mcache
@@ -108,6 +110,10 @@ jobs:
       env: CHECK=nfsstat
     - stage: test
       env: CHECK=nginx
+    - stage: test
+      env: CHECK=ntp
+    - stage: test
+      env: CHECK=openstack
     - stage: test
       env: CHECK=oracle
     - stage: test
@@ -138,6 +144,8 @@ jobs:
       env: CHECK=varnish
     - stage: test
       env: CHECK=vsphere
+    - stage: test
+      env: CHECK=yarn
 before_install:
   - chmod +x .travis/prepare.sh
   - .travis/prepare.sh


### PR DESCRIPTION
### What does this PR do?

This PR adds the missing tests to Travis for mapreduce, ntp, openstack, and yarn.

### Motivation

I didn't add mapreduce or yarn to Travis when I ported them over to pytest. I'm correcting that mistake now!

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes