### PR TITLE
Check will now send data with PUT, DELETE, and PATCH methods--not just POST

### DIFF
--- a/http_check/conf.yaml.example
+++ b/http_check/conf.yaml.example
@@ -7,10 +7,10 @@ instances:
     url: http://some.url.example.com
     timeout: 1
 
-    # The default HTTP method is GET but the (optional) method parameter allows you to change the
-    # HTTP method to POST.
-    # If using the POST method, you can then specify the data to send in the body of the request
-    # with the data parameter.
+    # The default HTTP method is GET but the (optional) method parameter allows you to change the HTTP method used in
+    # the request.
+    # If any one of the POST, PUT, DELETE, or PATCH method is specified, you can choose to send data in the body of the
+    # request with the data parameter.
     # SOAP requests are supported if you use the POST method and supply an XML string as the data parameter.
     #
     # method: get

--- a/http_check/tests/common.py
+++ b/http_check/tests/common.py
@@ -9,202 +9,270 @@ import os
 HERE = os.path.dirname(os.path.abspath(__file__))
 
 CONFIG = {
-    'instances': [{
-        'name': 'conn_error',
-        'url': 'https://thereisnosuchlink.com',
-        'check_certificate_expiration': False,
-        'timeout': 1,
-    }, {
-        'name': 'http_error_status_code',
-        'url': 'http://httpbin.org/404',
-        'check_certificate_expiration': False,
-        'timeout': 1,
-    }, {
-        'name': 'status_code_match',
-        'url': 'http://httpbin.org/404',
-        'http_response_status_code': '4..',
-        'check_certificate_expiration': False,
-        'timeout': 1,
-        'tags': ["foo:bar"]
-    }, {
-        'name': 'cnt_mismatch',
-        'url': 'https://github.com',
-        'timeout': 1,
-        'check_certificate_expiration': False,
-        'content_match': 'thereisnosuchword'
-    }, {
-        'name': 'cnt_match',
-        'url': 'https://github.com',
-        'timeout': 1,
-        'check_certificate_expiration': False,
-        'content_match': '(thereisnosuchword|github)'
-    }, {
-        'name': 'cnt_match_unicode',
-        'url': 'https://ja.wikipedia.org/',
-        'timeout': 1,
-        'check_certificate_expiration': False,
-        'content_match': u'メインページ'
-    }, {
-        'name': 'cnt_mismatch_unicode',
-        'url': 'https://ja.wikipedia.org/',
-        'timeout': 1,
-        'check_certificate_expiration': False,
-        'content_match': u'メインペーー'
-    }, {
-        'name': 'cnt_mismatch_reverse',
-        'url': 'https://github.com',
-        'timeout': 1,
-        'reverse_content_match': True,
-        'check_certificate_expiration': False,
-        'content_match': 'thereisnosuchword'
-    }, {
-        'name': 'cnt_match_reverse',
-        'url': 'https://github.com',
-        'timeout': 1,
-        'reverse_content_match': True,
-        'check_certificate_expiration': False,
-        'content_match': '(thereisnosuchword|github)'
-    }, {
-        'name': 'cnt_mismatch_unicode_reverse',
-        'url': 'https://ja.wikipedia.org/',
-        'timeout': 1,
-        'reverse_content_match': True,
-        'check_certificate_expiration': False,
-        'content_match': u'メインペーー'
-    }, {
-        'name': 'cnt_match_unicode_reverse',
-        'url': 'https://ja.wikipedia.org/',
-        'timeout': 1,
-        'reverse_content_match': True,
-        'check_certificate_expiration': False,
-        'content_match': u'メインページ'
-    }]
+    'instances': [
+        {
+            'name': 'conn_error',
+            'url': 'https://thereisnosuchlink.com',
+            'check_certificate_expiration': False,
+            'timeout': 1,
+        },
+        {
+            'name': 'http_error_status_code',
+            'url': 'http://httpbin.org/404',
+            'check_certificate_expiration': False,
+            'timeout': 1,
+        },
+        {
+            'name': 'status_code_match',
+            'url': 'http://httpbin.org/404',
+            'http_response_status_code': '4..',
+            'check_certificate_expiration': False,
+            'timeout': 1,
+            'tags': ["foo:bar"],
+        },
+        {
+            'name': 'cnt_mismatch',
+            'url': 'https://github.com',
+            'timeout': 1,
+            'check_certificate_expiration': False,
+            'content_match': 'thereisnosuchword',
+        },
+        {
+            'name': 'cnt_match',
+            'url': 'https://github.com',
+            'timeout': 1,
+            'check_certificate_expiration': False,
+            'content_match': '(thereisnosuchword|github)',
+        },
+        {
+            'name': 'cnt_match_unicode',
+            'url': 'https://ja.wikipedia.org/',
+            'timeout': 1,
+            'check_certificate_expiration': False,
+            'content_match': u'メインページ',
+        },
+        {
+            'name': 'cnt_mismatch_unicode',
+            'url': 'https://ja.wikipedia.org/',
+            'timeout': 1,
+            'check_certificate_expiration': False,
+            'content_match': u'メインペーー',
+        },
+        {
+            'name': 'cnt_mismatch_reverse',
+            'url': 'https://github.com',
+            'timeout': 1,
+            'reverse_content_match': True,
+            'check_certificate_expiration': False,
+            'content_match': 'thereisnosuchword',
+        },
+        {
+            'name': 'cnt_match_reverse',
+            'url': 'https://github.com',
+            'timeout': 1,
+            'reverse_content_match': True,
+            'check_certificate_expiration': False,
+            'content_match': '(thereisnosuchword|github)',
+        },
+        {
+            'name': 'cnt_mismatch_unicode_reverse',
+            'url': 'https://ja.wikipedia.org/',
+            'timeout': 1,
+            'reverse_content_match': True,
+            'check_certificate_expiration': False,
+            'content_match': u'メインペーー',
+        },
+        {
+            'name': 'cnt_match_unicode_reverse',
+            'url': 'https://ja.wikipedia.org/',
+            'timeout': 1,
+            'reverse_content_match': True,
+            'check_certificate_expiration': False,
+            'content_match': u'メインページ',
+        },
+    ]
 }
 
 CONFIG_SSL_ONLY = {
-    'instances': [{
-        'name': 'good_cert',
-        'url': 'https://github.com:443',
-        'timeout': 1,
-        'check_certificate_expiration': True,
-        'days_warning': 14,
-        'days_critical': 7
-    }, {
-        'name': 'cert_exp_soon',
-        'url': 'https://google.com',
-        'timeout': 1,
-        'check_certificate_expiration': True,
-        'days_warning': 9999,
-        'days_critical': 7
-    }, {
-        'name': 'cert_critical',
-        'url': 'https://google.com',
-        'timeout': 1,
-        'check_certificate_expiration': True,
-        'days_warning': 9999,
-        'days_critical': 9999
-    }, {
-        'name': 'conn_error',
-        'url': 'https://thereisnosuchlink.com',
-        'timeout': 1,
-        'check_certificate_expiration': True,
-        'days_warning': 14,
-        'days_critical': 7
-    }]
+    'instances': [
+        {
+            'name': 'good_cert',
+            'url': 'https://github.com:443',
+            'timeout': 1,
+            'check_certificate_expiration': True,
+            'days_warning': 14,
+            'days_critical': 7,
+        },
+        {
+            'name': 'cert_exp_soon',
+            'url': 'https://google.com',
+            'timeout': 1,
+            'check_certificate_expiration': True,
+            'days_warning': 9999,
+            'days_critical': 7,
+        },
+        {
+            'name': 'cert_critical',
+            'url': 'https://google.com',
+            'timeout': 1,
+            'check_certificate_expiration': True,
+            'days_warning': 9999,
+            'days_critical': 9999,
+        },
+        {
+            'name': 'conn_error',
+            'url': 'https://thereisnosuchlink.com',
+            'timeout': 1,
+            'check_certificate_expiration': True,
+            'days_warning': 14,
+            'days_critical': 7,
+        },
+    ]
 }
 
 CONFIG_EXPIRED_SSL = {
-    'instances': [{
-        'name': 'expired_cert',
-        'url': 'https://github.com',
-        'timeout': 1,
-        'check_certificate_expiration': True,
-        'days_warning': 14,
-        'days_critical': 7
-    }]
+    'instances': [
+        {
+            'name': 'expired_cert',
+            'url': 'https://github.com',
+            'timeout': 1,
+            'check_certificate_expiration': True,
+            'days_warning': 14,
+            'days_critical': 7,
+        }
+    ]
 }
 
 CONFIG_CUSTOM_NAME = {
-    'instances': [{
-        'name': 'cert_validation_fails',
-        'url': 'https://github.com:443',
-        'timeout': 1,
-        'check_certificate_expiration': True,
-        'days_warning': 14,
-        'days_critical': 7,
-        'ssl_server_name': 'incorrect_name'
-    }, {
-        'name': 'cert_validation_passes',
-        'url': 'https://github.com:443',
-        'timeout': 1,
-        'check_certificate_expiration': True,
-        'days_warning': 14,
-        'days_critical': 7,
-        'ssl_server_name': 'github.com'
-    }]
+    'instances': [
+        {
+            'name': 'cert_validation_fails',
+            'url': 'https://github.com:443',
+            'timeout': 1,
+            'check_certificate_expiration': True,
+            'days_warning': 14,
+            'days_critical': 7,
+            'ssl_server_name': 'incorrect_name',
+        },
+        {
+            'name': 'cert_validation_passes',
+            'url': 'https://github.com:443',
+            'timeout': 1,
+            'check_certificate_expiration': True,
+            'days_warning': 14,
+            'days_critical': 7,
+            'ssl_server_name': 'github.com',
+        },
+    ]
 }
 
 CONFIG_UNORMALIZED_INSTANCE_NAME = {
-    'instances': [{
-        'name': '_need-to__be_normalized-',
-        'url': 'https://github.com',
-        'timeout': 1,
-        'check_certificate_expiration': True,
-        'days_warning': 14,
-        'days_critical': 7
-    }]
+    'instances': [
+        {
+            'name': '_need-to__be_normalized-',
+            'url': 'https://github.com',
+            'timeout': 1,
+            'check_certificate_expiration': True,
+            'days_warning': 14,
+            'days_critical': 7,
+        }
+    ]
 }
 
 CONFIG_DONT_CHECK_EXP = {
-    'instances': [{
-        'name': 'simple_config',
-        'url': 'http://httpbin.org',
-        'check_certificate_expiration': False,
-    }]
+    'instances': [
+        {
+            'name': 'simple_config',
+            'url': 'http://httpbin.org',
+            'check_certificate_expiration': False
+        }
+    ]
 }
 
 CONFIG_HTTP_HEADERS = {
-    'instances': [{
-        'url': 'https://google.com',
-        'name': 'UpService',
-        'timeout': 1,
-        'headers': {"X-Auth-Token": "SOME-AUTH-TOKEN"}
-    }]
+    'instances': [
+        {
+            'url': 'https://google.com',
+            'name': 'UpService',
+            'timeout': 1,
+            'headers': {"X-Auth-Token": "SOME-AUTH-TOKEN"}
+        }
+    ]
 }
 
 CONFIG_HTTP_REDIRECTS = {
-    'instances': [{
-        'name': 'redirect_service',
-        'url': 'http://github.com',
-        'timeout': 1,
-        'http_response_status_code': 301,
-        'allow_redirects': False,
-    }]
+    'instances': [
+        {
+            'name': 'redirect_service',
+            'url': 'http://github.com',
+            'timeout': 1,
+            'http_response_status_code': 301,
+            'allow_redirects': False,
+        }
+    ]
 }
 
 FAKE_CERT = {'notAfter': 'Apr 12 12:00:00 2006 GMT'}
 
-CONFIG_POST_METHOD = {
-    'instances': [{
-        'name': 'post_method',
-        'url': 'http://httpbin.org/post',
-        'timeout': 1,
-        'method': 'post',
-        'data': {
-            'foo': 'bar',
-            'baz': ['qux', 'quux']
-        }
-    }]
-}
-
-CONFIG_POST_SOAP = {
-    'instances': [{
-        'name': 'post_soap',
-        'url': 'http://httpbin.org/post',
-        'timeout': 1,
-        'method': 'post',
-        'data': '<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"'
-                'xmlns:m="http://www.example.org/stocks"><soap:Header></soap:Header><soap:Body><m:GetStockPrice>'
-                '<m:StockName>EXAMPLE</m:StockName></m:GetStockPrice></soap:Body></soap:Envelope>'
-    }]
+CONFIG_DATA_METHOD = {
+    'instances': [
+        {
+            'name': 'post_json',
+            'url': 'http://httpbin.org/post',
+            'timeout': 1,
+            'method': 'post',
+            'data': {'foo': 'bar', 'baz': ['qux', 'quux']},
+        },
+        {
+            'name': 'post_str',
+            'url': 'http://httpbin.org/post',
+            'timeout': 1,
+            'method': 'post',
+            'data': '<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"'
+                    'xmlns:m="http://www.example.org/stocks"><soap:Header></soap:Header><soap:Body><m:GetStockPrice>'
+                    '<m:StockName>EXAMPLE</m:StockName></m:GetStockPrice></soap:Body></soap:Envelope>',
+        },
+        {
+            'name': 'put_json',
+            'url': 'http://httpbin.org/put',
+            'timeout': 1,
+            'method': 'put',
+            'data': {'foo': 'bar', 'baz': ['qux', 'quux']},
+        },
+        {
+            'name': 'put_str',
+            'url': 'http://httpbin.org/put',
+            'timeout': 1,
+            'method': 'put',
+            'data': 'Lorem ipsum',
+        },
+        {
+            'name': 'patch_json',
+            'url': 'http://httpbin.org/patch',
+            'timeout': 1,
+            'method': 'patch',
+            'data': {'foo': 'bar', 'baz': ['qux', 'quux']},
+        },
+        {
+            'name': 'patch_str',
+            'url': 'http://httpbin.org/patch',
+            'timeout': 1,
+            'method': 'patch',
+            'data': 'Lorem ipsum',
+        },
+        {
+            'name': 'delete_json',
+            'url': 'http://httpbin.org/delete',
+            'timeout': 1,
+            'method': 'delete',
+            'data': {'foo': 'bar', 'baz': ['qux', 'quux']},
+        },
+        {
+            'name': 'delete_str',
+            'url': 'http://httpbin.org/delete',
+            'timeout': 1,
+            'method': 'delete',
+            'data': 'Lorem ipsum',
+        },
+    ]
 }

--- a/http_check/tests/test_http_check.py
+++ b/http_check/tests/test_http_check.py
@@ -10,8 +10,8 @@ import mock
 from datadog_checks.http_check import HTTPCheck
 from datadog_checks.utils.headers import headers as agent_headers
 from .common import (
-    FAKE_CERT, CONFIG, CONFIG_HTTP_HEADERS, CONFIG_SSL_ONLY, CONFIG_EXPIRED_SSL, CONFIG_CUSTOM_NAME, CONFIG_POST_METHOD,
-    CONFIG_HTTP_REDIRECTS, CONFIG_UNORMALIZED_INSTANCE_NAME, CONFIG_POST_SOAP, CONFIG_DONT_CHECK_EXP
+    FAKE_CERT, CONFIG, CONFIG_HTTP_HEADERS, CONFIG_SSL_ONLY, CONFIG_EXPIRED_SSL, CONFIG_CUSTOM_NAME, CONFIG_DATA_METHOD,
+    CONFIG_HTTP_REDIRECTS, CONFIG_UNORMALIZED_INSTANCE_NAME, CONFIG_DONT_CHECK_EXP
 )
 
 
@@ -185,11 +185,10 @@ def test_dont_check_expiration(aggregator, http_check):
     aggregator.assert_service_check(HTTPCheck.SC_SSL_CERT, tags=url_tag + instance_tag, count=0)
 
 
-def test_post_method(aggregator, http_check):
+def test_data_methods(aggregator, http_check):
 
     # Run the check once for both POST configs
-    POST_CONFIGS = CONFIG_POST_METHOD['instances'] + CONFIG_POST_SOAP['instances']
-    for instance in POST_CONFIGS:
+    for instance in CONFIG_DATA_METHOD['instances']:
         http_check.check(instance)
 
         url_tag = ['url:{}'.format(instance.get('url'))]


### PR DESCRIPTION
### What does this PR do?

This PR allows users to send data with requests made with the PUT, DELETE, and PATCH methods--not just POST.

### Motivation

See #1631.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

The diff for `common.py` is large because I ran a formatter. The only real change in that file is the creation of the last object in that file.