### PR TITLE
Skip tests for documentation-only changes

### DIFF
--- a/tasks/constants.py
+++ b/tasks/constants.py
@@ -75,8 +75,8 @@ AGENT_V5_ONLY = [
 ]
 
 # If a file changes in a PR with any of these file extensiosn, a test will run against the check containing the file
-TESTABLE_FILE_EXTENSIONS = [
+TESTABLE_FILE_EXTENSIONS = (
     '.py',
     '.ini',
     '.txt',
-]
+)

--- a/tasks/constants.py
+++ b/tasks/constants.py
@@ -73,3 +73,11 @@ AGENT_V5_ONLY = [
     'kubernetes',
     'ntp',
 ]
+
+# If a file changes in a PR with any of these file extensiosn, a test will run against the check containing the file
+FILE_EXTENSIONS_TO_TEST = [
+    '.py',
+    '.rake',
+    '.ini',
+    '.txt',
+]

--- a/tasks/constants.py
+++ b/tasks/constants.py
@@ -75,9 +75,8 @@ AGENT_V5_ONLY = [
 ]
 
 # If a file changes in a PR with any of these file extensiosn, a test will run against the check containing the file
-FILE_EXTENSIONS_TO_TEST = [
+TESTABLE_FILE_EXTENSIONS = [
     '.py',
-    '.rake',
     '.ini',
     '.txt',
 ]

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -15,14 +15,14 @@ def testable_files(files):
     """
     Given a list of files, return the files that have an extension listed in FILE_EXTENSIONS_TO_TEST
     """
-    return [f for f in files if f.endswith(tuple(TESTABLE_FILE_EXTENSIONS))]
+    return [f for f in files if f.endswith(TESTABLE_FILE_EXTENSIONS)]
 
 
 def files_changed(ctx):
     """
     Return the list of file changed in the current branch compared to `master`
     """
-    changed_files = ctx.run('git diff --name-only master...', hide='out').stdout.split('\n')
+    changed_files = ctx.run('git diff --name-only master...', hide='out').stdout.splitlines()
 
     # Remove empty lines
     return [f for f in changed_files if f]

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -8,14 +8,26 @@ import sys
 from invoke import task
 from invoke.exceptions import Exit
 
-from .constants import AGENT_BASED_INTEGRATIONS, ROOT
+from .constants import AGENT_BASED_INTEGRATIONS, ROOT, FILE_EXTENSIONS_TO_TEST
+
+
+def files_requiring_tests(files):
+    """
+    Given a list of files, return the files that have an extension listed in FILE_EXTENSIONS_TO_TEST
+    """
+    files_to_test = []
+    for file in files:
+        if file and file.endswith(tuple(FILE_EXTENSIONS_TO_TEST)):
+            files_to_test.append(file)
+
+    return files_to_test
 
 
 def files_changed(ctx):
     """
     Return the list of file changed in the current branch compared to `master`
     """
-    return ctx.run('git diff --name-only master...', hide='out').stdout
+    return ctx.run('git diff --name-only master...', hide='out').stdout.split('\n')
 
 
 def run_tox(ctx, target, bench, dry_run):
@@ -95,14 +107,20 @@ def test(ctx, targets=None, changed_only=False, bench=False, dry_run=False):
     elif isinstance(targets, basestring):
         targets = [t for t in targets.split(',') if t in AGENT_BASED_INTEGRATIONS]
 
-    # get the list of the files that changed compared to `master`
+    # determine the integrations we need to test based on the changed files
     changed_files = []
     if changed_only:
-        changed_files = files_changed(ctx).split('\n')
+        # get the list of the files that changed compared to `master`
+        changed_files = files_changed(ctx)
+
+        # get the list of files that can change the implementation of a check
+        implementation_changing_files = files_requiring_tests(changed_files)
+
+        # get the integrations associated with changed files
         changed_checks = set()
-        for line in changed_files:
-            if line:
-                changed_checks.add(line.split('/')[0])
+        for line in implementation_changing_files:
+            changed_checks.add(line.split('/')[0])
+
         targets = list(set(targets) & changed_checks)
 
     if bench:


### PR DESCRIPTION
### What does this PR do?

This PR adds the ability to skip tests for PRs that don't touch files with an `.py`, `.ini`, or `.txt` extension.

### Motivation

To save computing power! 🌳♻️ 🌱 

Bonus: faster tests (thereby reducing the number of concurrent jobs).

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Comments welcome on the best approach to doing this, other ideas include using regex to have more control over figuring out which files are "implementation-changing files" 🙇 

Also, comments welcome on variable names/function names; `implementation_changing_files` doesn't quite roll off the tongue.
