### PR TITLE
Update integration manifest to contain the "creates_events" attribute

### DIFF
--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -1,5 +1,6 @@
 {
   "manifest_version": "1.0.0",
+  "creates_events": "false",
   "name": "Apache",
   "display_name": "Apache",
   "support": "core",

--- a/cassandra/manifest.json
+++ b/cassandra/manifest.json
@@ -1,5 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
+  "creates_events": "false",
   "manifest_version": "1.0.0",
   "name": "cassandra",
   "short_description": "Track cluster performance, capacity, overall health, and much more.",

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -1,5 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
+  "creates_events": "true",
   "manifest_version": "1.0.0",
   "name": "consul",
   "short_description": "Alert on Consul health checks, see service-to-node mappings, and much more.",

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -1,5 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
+  "creates_events": "true",
   "manifest_version": "1.0.0",
   "name": "elastic",
   "short_description": "Monitor overall cluster status down to JVM heap usage and everything in between.",

--- a/iis/manifest.json
+++ b/iis/manifest.json
@@ -1,5 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
+  "creates_events": "false",
   "manifest_version": "1.0.0",
   "name": "iis",
   "short_description": "Track total or per-site metrics and monitor each site's up/down status.",

--- a/kafka/manifest.json
+++ b/kafka/manifest.json
@@ -1,5 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
+  "creates_events": "false",
   "manifest_version": "1.0.0",
   "name": "kafka",
   "short_description": "Collect metrics for producers and consumers, replication, max lag, and more.",

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -1,5 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
+  "creates_events": "true",
   "manifest_version": "1.0.0",
   "name": "mongo",
   "short_description": "Track read/write performance, most-used replicas, collection metrics, and more.",

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -1,5 +1,6 @@
 {
   "manifest_version": "1.0.0",
+  "creates_events": "false",
   "name": "MySQL",
   "display_name": "MySQL",
   "support": "core",

--- a/nginx/manifest.json
+++ b/nginx/manifest.json
@@ -1,4 +1,5 @@
 {
+  "creates_events": "false",
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "name": "nginx",

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -1,5 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
+  "creates_events": "false",
   "manifest_version": "1.0.0",
   "name": "postgres",
   "short_description": "Collect a wealth of database performance and health metrics.",

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -1,5 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
+  "creates_events": "true",
   "manifest_version": "1.0.0",
   "name": "rabbitmq",
   "short_description": "Track queue size, consumer count, unacknowledged messages, and more.",

--- a/redisdb/manifest.json
+++ b/redisdb/manifest.json
@@ -1,5 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
+  "creates_events": "false",
   "manifest_version": "1.0.0",
   "name": "redisdb",
   "short_description": "Track redis performance, memory use, blocked clients, evicted keys, and more.",

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -1,5 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
+  "creates_events": "false",
   "manifest_version": "1.0.0",
   "name": "tomcat",
   "short_description": "Track requests per second, bytes served, cache hits, servlet metrics, and more.",

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -1,5 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
+  "creates_events": "false",
   "manifest_version": "1.0.0",
   "name": "varnish",
   "short_description": "Track client and backend connections, cache misses and evictions, and more.",

--- a/zk/manifest.json
+++ b/zk/manifest.json
@@ -1,5 +1,6 @@
 {
   "maintainer": "help@datadoghq.com",
+  "creates_events": "false",
   "manifest_version": "1.0.0",
   "name": "zk",
   "short_description": "Track client connections and latencies, and know when requests are backing up.",


### PR DESCRIPTION
### What does this PR do?

Update the integration manifest.json to reflect the expected parameter list in order to update the tile with the latest documentation instruction.

### Motivation

We wanted to update the tile and noticed that the `creates_events` attribute was missing.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
