### PR TITLE
fix idna pin

### DIFF
--- a/datadog_checks_base/requirements.txt
+++ b/datadog_checks_base/requirements.txt
@@ -12,9 +12,9 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
-idna==2.7 \
-    --hash=sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e \
-    --hash=sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16 \
+idna==2.6 \
+    --hash=sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f \
+    --hash=sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4 \
     # via requests
 prometheus-client==0.1.0 \
     --hash=sha256:9f87af37173d0ffeb5542ebba13a4d622edbf334c4dc5f7d95be13cb50777028


### PR DESCRIPTION
### Motivation

```
requests 2.18.4 has requirement idna<2.7,>=2.5, but you'll have idna 2.7 which is incompatible.
datadog-ssh-check 1.2.0 has requirement idna==2.6, but you'll have idna 2.7 which is incompatible.
```