### PR TITLE
Fix error message when TCP check fails

### DIFF
--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -53,7 +53,7 @@ class TCPCheck(NetworkCheck):
                 addr = socket.gethostbyname(url)
                 socket_type = socket.AF_INET
             except Exception:
-                msg = "URL: %s is not a correct IPv4, IPv6 or hostname" % url
+                msg = "URL: {} is not a correct IPv4, IPv6 or hostname".format(url)
                 raise BadConfException(msg)
 
         return addr, port, custom_tags, socket_type, timeout, response_time

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -53,7 +53,8 @@ class TCPCheck(NetworkCheck):
                 addr = socket.gethostbyname(url)
                 socket_type = socket.AF_INET
             except Exception:
-                raise BadConfException("URL: %s is not a correct IPv4, IPv6 or hostname" % addr)
+                msg = "URL: %s is not a correct IPv4, IPv6 or hostname" % url
+                raise BadConfException(msg)
 
         return addr, port, custom_tags, socket_type, timeout, response_time
 


### PR DESCRIPTION
### What does this PR do?

Shows an error message instead of a traceback.

### Motivation

I was getting a traceback because `addr` was not defined.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
