### PR TITLE
fix ensure current branch is not master

### DIFF
--- a/tasks/utils/git.py
+++ b/tasks/utils/git.py
@@ -16,7 +16,7 @@ def get_current_branch(ctx):
     Get the current branch name.
     """
     cmd = "git rev-parse --abbrev-ref HEAD"
-    return ctx.run(cmd, hide='out').stdout
+    return ctx.run(cmd, hide='out').stdout.strip()
 
 
 def parse_pr_numbers(git_log_lines):


### PR DESCRIPTION
### What does this PR do?

Fix `get_current_branch` so that it strips the return value, otherwise newlines chars would make the check `get_current_branch() == 'master'` fail even when one is actually operating on `master`.

### Motivation

Committed stuff to `master` by mistake. Multiple times.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

