### PR TITLE
Fix name of ssl options in example file

### DIFF
--- a/prometheus/conf.yaml.example
+++ b/prometheus/conf.yaml.example
@@ -72,12 +72,12 @@ instances:
   #
   # Can either be only the path to the certificate and thus you should specify the private key
   # or it can be the path to a file containing both the certificate & the private key
-  # self.ssl_cert: "/path/to/cert"
+  # ssl_cert: "/path/to/cert"
   #
   # Needed if the certificate does not include the private key
   #
   # /!\ The private key to your local certificate must be unencrypted.
-  # self.ssl_private_key: "/path/to/key"
+  # ssl_private_key: "/path/to/key"
   #
   # The path to the trusted CA used for generating custom certificates
-  # self.ssl_ca_cert: "/path/to/cacert"
+  # ssl_ca_cert: "/path/to/cacert"


### PR DESCRIPTION
### What does this PR do?

Fixes name of ssl options in example file.

### Motivation

Accurate documentation.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x]  N/A Feature or bugfix has tests
- [x] Git history is clean
- [x]  N/A If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
