### PR TITLE
Add channel tag to replica metrics

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -541,6 +541,7 @@ class MySql(AgentCheck):
             replication_channel = options.get('replication_channel')
             if replication_channel:
                 self.service_check_tags.append("channel:{0}".format(replication_channel))
+                tags = tags.append("channel:{0}".format(replication_channel))
             results.update(self._get_replica_stats(db, is_mariadb, replication_channel))
             nonblocking = _is_affirmative(options.get('replication_non_blocking_status', False))
             results.update(self._get_slave_status(db, above_560, nonblocking))

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -541,7 +541,7 @@ class MySql(AgentCheck):
             replication_channel = options.get('replication_channel')
             if replication_channel:
                 self.service_check_tags.append("channel:{0}".format(replication_channel))
-                tags = tags.append("channel:{0}".format(replication_channel))
+                tags.append("channel:{0}".format(replication_channel))
             results.update(self._get_replica_stats(db, is_mariadb, replication_channel))
             nonblocking = _is_affirmative(options.get('replication_non_blocking_status', False))
             results.update(self._get_slave_status(db, above_560, nonblocking))


### PR DESCRIPTION
### What does this PR do?

Adds the `channel` tag to `mysql.replication.slave_running` metric to match the service check tags, for consistency.

### Motivation

Customer reached out noticing that this tag was missing.  This was spurred on by a [recent update to the code](https://github.com/DataDog/integrations-core/pull/1639) that addressed an issue when including a replication channel in the mysql check.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes


