### PR TITLE
Add support client auth for http check cert expiration.

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -379,7 +379,8 @@ class HTTPCheck(NetworkCheck):
             self.gauge('network.http.cant_connect', cant_status, tags=tags_list)
 
         if ssl_expire and parsed_uri.scheme == "https":
-            status, days_left, msg = self.check_cert_expiration(instance, timeout, instance_ca_certs, check_hostname, client_cert, client_key)
+            status, days_left, msg = self.check_cert_expiration(instance, timeout, instance_ca_certs, check_hostname,
+                                                                client_cert, client_key)
 
             tags_list = list(tags)
             tags_list.append('url:{}'.format(addr))
@@ -413,7 +414,8 @@ class HTTPCheck(NetworkCheck):
 
         self.service_check(sc_name, NetworkCheck.STATUS_TO_SERVICE_CHECK[status], tags=tags, message=msg)
 
-    def check_cert_expiration(self, instance, timeout, instance_ca_certs, check_hostname, client_cert=None, client_key=None):
+    def check_cert_expiration(self, instance, timeout, instance_ca_certs, check_hostname,
+                              client_cert=None, client_key=None):
         warning_days = int(instance.get('days_warning', 14))
         critical_days = int(instance.get('days_critical', 7))
         url = instance.get('url')


### PR DESCRIPTION
### What does this PR do?

Make `check_cert_expiration` method use client side certificates like the rest of the check.

### Motivation

When using client side certificates in the check, metric `http.ssl.days_left` always reports `0`.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
