### PR TITLE
Fix connection to unix socket for new binary

### DIFF
--- a/mcache/datadog_checks/mcache/mcache.py
+++ b/mcache/datadog_checks/mcache/mcache.py
@@ -265,8 +265,9 @@ class Memcache(AgentCheck):
             raise Exception('Either "url" or "socket" must be configured')
 
         if socket:
-            server = socket
-            connection_server = "{}".format(server)
+            server = 'unix'
+            port = socket
+            connection_server = "{}".format(port)
         else:
             port = int(instance.get('port', self.DEFAULT_PORT))
             connection_server = "{}:{}".format(server, port)

--- a/mcache/datadog_checks/mcache/mcache.py
+++ b/mcache/datadog_checks/mcache/mcache.py
@@ -265,10 +265,11 @@ class Memcache(AgentCheck):
             raise Exception('Either "url" or "socket" must be configured')
 
         if socket:
-            server = 'unix'
-            port = socket
+            server = socket
+            connection_server = "{}".format(server)
         else:
             port = int(instance.get('port', self.DEFAULT_PORT))
+            connection_server = "{}:{}".format(server, port)
         custom_tags = instance.get('tags') or []
 
         mc = None  # client
@@ -277,7 +278,7 @@ class Memcache(AgentCheck):
 
         try:
             self.log.debug("Connecting to %s:%s tags:%s", server, port, tags)
-            mc = bmemcached.Client(["{}:{}".format(server, port)], username, password)
+            mc = bmemcached.Client(connection_server, username, password)
 
             self._get_metrics(mc, tags, service_check_tags)
             if options:

--- a/mcache/datadog_checks/mcache/mcache.py
+++ b/mcache/datadog_checks/mcache/mcache.py
@@ -278,7 +278,7 @@ class Memcache(AgentCheck):
         service_check_tags = ["host:%s" % server, "port:%s" % port] + custom_tags
 
         try:
-            self.log.debug("Connecting to %s:%s tags:%s", server, port, tags)
+            self.log.debug("Connecting to %s, tags:%s", connection_server, tags)
             mc = bmemcached.Client(connection_server, username, password)
 
             self._get_metrics(mc, tags, service_check_tags)


### PR DESCRIPTION
### What does this PR do?

Updates the way we connect to retrieve metrics by removing the "unix" prefix from the socket. Thanks @truthbk for the find!

Tested on a box that exhibited the broken behavior. Also made sure to keep the tagging consistent with what this check has been sending in the past. 

### Motivation

The new binary we are using requires that the 'unix' prefix not be present. If it is, we get an empty response back and the check throws an error. Issue introduced in - https://github.com/DataDog/integrations-core/pull/1364

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

We will look into creating a specific test for this but that requires updating the docker container we are using and some memcache configurations so this will be done at a later time. 