### PR TITLE
Correcting duplicate metric name

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -126,7 +126,7 @@ SELECT mode,
         'metrics': {
             'seq_scan': ('postgresql.seq_scans', RATE),
             'seq_tup_read': ('postgresql.seq_rows_read', RATE),
-            'idx_scan': ('postgresql.index_scans', RATE),
+            'idx_scan': ('postgresql.index_rel_scans', RATE),
             'idx_tup_fetch': ('postgresql.index_rows_fetched', RATE),
             'n_tup_ins': ('postgresql.rows_inserted', RATE),
             'n_tup_upd': ('postgresql.rows_updated', RATE),

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -123,6 +123,11 @@ SELECT mode,
             ('relname', 'table'),
             ('schemaname', 'schema'),
         ],
+        # this field contains old metrics that need to be deprecated. For now
+        # we keep sending them.
+        'deprecated_metrics': {
+            'idx_scan': ('postgresql.index_scans', RATE),
+        },
         'metrics': {
             'seq_scan': ('postgresql.seq_scans', RATE),
             'seq_tup_read': ('postgresql.seq_rows_read', RATE),
@@ -594,6 +599,11 @@ SELECT s.schemaname,
             # metric-map is: (dd_name, "rate"|"gauge")
             # shift the results since the first columns will be the "descriptors"
             values = zip([scope['metrics'][c] for c in cols], row[len(desc):])
+            # keep sending the deprecated metrics if any
+            deprecated_values = zip([scope.get('deprecated_metrics', {}).get(c) for c in cols], row[len(desc):])
+            for metric_map, value in deprecated_values:
+                if metric_map is not None:
+                    values.append((metric_map, value))
 
             # To submit simply call the function for each value v
             # v[0] == (metric_name, submit_function)

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -27,6 +27,7 @@ postgresql.locks,gauge,,lock,,The number of locks active for this database.,0,po
 postgresql.seq_scans,gauge,,,,The number of sequential scans initiated on this table.,0,postgres,seq scans
 postgresql.seq_rows_read,gauge,,row,second,The number of live rows fetched by sequential scans.,0,postgres,seq rows rd
 postgresql.index_scans,gauge,,,,The number of index scans initiated on this table.,0,postgres,idx scans
+postgresql.index_rel_scans,gauge,,,,The number of index scans initiated on this table tagged by relation name.,0,postgres,idx scans
 postgresql.index_rows_fetched,gauge,,row,second,The number of live rows fetched by index scans.,0,postgres,idx rows fetch
 postgresql.rows_hot_updated,gauge,,row,second,"The number of rows HOT updated, meaning no separate index update was needed.",0,postgres,rows hot updated
 postgresql.live_rows,gauge,,row,,The estimated number of live rows.,0,postgres,live rows

--- a/postgres/tests/compose/resources/02_load_data.sh
+++ b/postgres/tests/compose/resources/02_load_data.sh
@@ -4,6 +4,7 @@ set -e
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" datadog_test <<-EOSQL
     CREATE TABLE persons (personid SERIAL, lastname VARCHAR(255), firstname VARCHAR(255), address VARCHAR(255), city VARCHAR(255));
     INSERT INTO persons (lastname, firstname, address, city) VALUES ('Cavaille', 'Leo', 'Midtown', 'New York'), ('Someveryveryveryveryveryveryveryveryveryverylongname', 'something', 'Avenue des Champs Elysees', 'Beautiful city of lights');
+    CREATE INDEX person_lastname ON persons (lastname);
     SELECT * FROM persons;
     SELECT * FROM persons;
     SELECT * FROM persons;

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -31,7 +31,8 @@ RELATION_SIZE_METRICS = [
 ]
 
 RELATION_INDEX_METRICS = [
-    'postgresql.index_scans',
+    'postgresql.index_scans',  # deprecated
+    'postgresql.index_rel_scans',
     'postgresql.index_rows_fetched',
     'postgresql.index_blocks_read',
     'postgresql.index_blocks_hit',
@@ -58,7 +59,7 @@ def test_relations_metrics(aggregator, postgres_standalone, pg_instance):
 
     # 'persons' db don't have any indexes
     for name in RELATION_INDEX_METRICS:
-        aggregator.assert_metric(name, count=0, tags=expected_tags)
+        aggregator.assert_metric(name, count=1, tags=expected_tags)
 
     for name in RELATION_SIZE_METRICS:
         aggregator.assert_metric(name, count=1, tags=expected_size_tags)


### PR DESCRIPTION
### What does this PR do?

Correcting duplicate metric name: postgresql.index_scans
This metric name have been set for both REL_METRICS and IDX_METRICS.
So, I'd suggest renaming postgresql.index_rel_scans metric for REL_METRICS.

More explanation about the issue retrieved by the customer: 
I prepared a dashboard showing the issue with duplicate index metric names: [see card]
The first graph, “by index, table”, shows postgresql.index_scans values by index and table, the second one by table. There is a value with “index: N/A” on the first graph which is actually a sum of all index scans of each table. I’d like to remove “index: N/A” from the graph. And I can’t say what does show the second graph: average value of sum of index scans per table and of each of index or something else. I’d like to get postgresql.index_scans by table only (from REL_METRICS, not with “index” tag from IDX_METRICS).

### Motivation

Correcting duplicate metric name: postgresql.index_scans
A new name should be defined to prevent confusion and incorrect data in graph.

