### PR TITLE
kubernetes_state: plumb more container waiting reasons

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -16,7 +16,7 @@ except ImportError:
 
 
 METRIC_TYPES = ['counter', 'gauge']
-WHITELISTED_WAITING_REASONS = ['ErrImagePull']
+WHITELISTED_WAITING_REASONS = ['ErrImagePull', 'ImagePullBackoff', 'CrashLoopBackoff']
 WHITELISTED_TERMINATED_REASONS = ['OOMKilled', 'ContainerCannotRun', 'Error']
 
 

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -428,6 +428,8 @@ kube_pod_container_status_waiting_reason{container="hello",namespace="default",p
 kube_pod_container_status_waiting_reason{container="kube-addon-manager",namespace="kube-system",pod="kube-addon-manager-minikube",reason="ContainerCreating"} 0
 kube_pod_container_status_waiting_reason{container="kube-addon-manager",namespace="kube-system",pod="kube-addon-manager-minikube",reason="ErrImagePull"} 0
 kube_pod_container_status_waiting_reason{container="kube-state-metrics",namespace="default",pod="jaundiced-numbat-kube-state-metrics-b7fbc487d-4phhj",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{container="kube-state-metrics",namespace="default",pod="jaundiced-numbat-kube-state-metrics-b7fbc487d-4phhj",reason="CrashLoopBackoff"} 1
+kube_pod_container_status_waiting_reason{container="kube-state-metrics",namespace="default",pod="jaundiced-numbat-kube-state-metrics-b7fbc487d-4phhj",reason="ImagePullBackoff"} 1
 kube_pod_container_status_waiting_reason{container="kube-state-metrics",namespace="default",pod="jaundiced-numbat-kube-state-metrics-b7fbc487d-4phhj",reason="ErrImagePull"} 0
 kube_pod_container_status_waiting_reason{container="kubedns",namespace="kube-system",pod="kube-dns-1326421443-hj4hx",reason="ContainerCreating"} 0
 kube_pod_container_status_waiting_reason{container="kubedns",namespace="kube-system",pod="kube-dns-1326421443-hj4hx",reason="ErrImagePull"} 0

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -81,6 +81,11 @@ TAGS = {
         'condition:MemoryPressure', 'condition:DiskPressure',
         'condition:OutOfDisk', 'condition:Ready',
         'status:true', 'status:false', 'status:unknown',
+    ],
+    NAMESPACE + '.container.status_report.count.waiting': [
+        'reason:CrashLoopBackoff',
+        'reason:ErrImagePull',
+        'reason:ImagePullBackoff'
     ]
 }
 


### PR DESCRIPTION
We'd like to create monitors that fire when containers are stuck waiting
for various reasons. Two particular reasons, ImagePullBackoff and
CrashLoopBackoff, can be used to detect bad or broken deployments. These
have been plumbed as of kube-state-metric 1.3 but are not currently
whitelisted in the DataDog agent integration. The tests have also been
update with fixture data.

Signed-off-by: Stephen Day <stephen.day@getcruise.com>