### PR TITLE
updated postgres verification script

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -33,8 +33,8 @@ To verify the correct permissions run the following command:
 
 ```
 psql -h localhost -U datadog postgres -c \
-"select * from pg_stat_database LIMIT(1);"
-&& echo -e "\e[0;32mPostgres connection - OK\e[0m" || \
+"select * from pg_stat_database LIMIT(1);" \
+&& echo -e "\e[0;32mPostgres connection - OK\e[0m" \
 || echo -e "\e[0;31mCannot connect to Postgres\e[0m"
 ```
 


### PR DESCRIPTION
### What does this PR do?

Update the bash script to verify Postgres installation in the Postgres readme.

### Motivation

The existing script to verify Postgres installation does not work. The updated one does. Fun fact: I discovered this during my hiring process assignment!

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
