### PR TITLE
Remove gauge timestamp so the check works with agent 6

### DIFF
--- a/cacti/datadog_checks/cacti/cacti.py
+++ b/cacti/datadog_checks/cacti/cacti.py
@@ -167,7 +167,7 @@ class Cacti(AgentCheck):
                     # Save this metric as a gauge
                     val = self._transform_metric(m_name, p[k])
                     self.gauge(m_name, val, hostname=hostname,
-                        device_name=device_name, timestamp=ts, tags=tags)
+                        device_name=device_name, tags=tags)
                     metric_count += 1
                     last_ts = (ts + interval)
 


### PR DESCRIPTION
### What does this PR do?

See title

### Motivation

Runtime error if running the check with agent 6

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
