### PR TITLE
Update readme with 6.3.0 integration releases list

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Each Datadog Agent release will continue to ship a set of the most up to date st
 | Agent Version | List of Shipped Integration Versions |
 |---------------|--------------------------------------|
 | 6.2.1         | [Link](https://github.com/DataDog/integrations-core/blob/6.2.1/requirements-integration-core.txt) |
-| 6.3.0         | [Link](https://github.com/DataDog/integrations-core/blob/supervisord-1.1.2/requirements-agent-release.txt) |
+| 6.3.0         | [Link](https://github.com/DataDog/integrations-core/blob/ea2dfbf1e8859333af4c8db50553eb72a3b466f9/requirements-agent-release.txt) |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Each Datadog Agent release will continue to ship a set of the most up to date st
 | Agent Version | List of Shipped Integration Versions |
 |---------------|--------------------------------------|
 | 6.2.1         | [Link](https://github.com/DataDog/integrations-core/blob/6.2.1/requirements-integration-core.txt) |
-| 6.3.0         | [Link](https://github.com/DataDog/integrations-core/blob/yarn-1.3.0/requirements-agent-release.txt) |
+| 6.3.0         | [Link](https://github.com/DataDog/integrations-core/blob/supervisord-1.1.2/requirements-agent-release.txt) |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Each Datadog Agent release will continue to ship a set of the most up to date st
 | Agent Version | List of Shipped Integration Versions |
 |---------------|--------------------------------------|
 | 6.2.1         | [Link](https://github.com/DataDog/integrations-core/blob/6.2.1/requirements-integration-core.txt) |
+| 6.3.0         | [Link](https://github.com/DataDog/integrations-core/blob/yarn-1.3.0/requirements-agent-release.txt) |
 
 ## Quick Start
 

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -17,7 +17,7 @@ dns_check==1.1.1
 dotnetclr==1.0.0; sys_platform == 'win32'
 ecs_fargate==1.2.0
 elastic==1.7.0
-envoy==1.2.0
+envoy==1.2.1
 etcd==1.5.0
 exchange_server==1.1.0; sys_platform == 'win32'
 fluentd==1.0.0


### PR DESCRIPTION
### What does this PR do?

Adds the list of integrations that were released with 6.3.0 in the main readme of this repo

### Motivation

Keeping a sane documentation of whats shipped. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

The only integration that is known to be out of sync in the list that is linked in the readme is envoy, which is properly bumped in this check. Going forward things should remain in sync. 