### PR TITLE
Print a warning when a PR doesn't have a changelog label attached

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -73,10 +73,16 @@ def print_shippable(ctx, quiet=False):
             try:
                 payload = get_pr(pr_num)
                 changelog_labels = get_changelog_types(payload)
+
+                if not changelog_labels:
+                    msg = Fore.RED + "PR #{} has no changelog label attached, please add one!\n".format(pr_num)
+                    sys.stderr.write(msg)
+                    continue
+
                 if changelog_labels[0] != CHANGELOG_TYPE_NONE:
                     all_no_changelog = False
             except Exception as e:
-                sys.stderr.write("Unable to fetch info for PR #{}\n: {}".format(pr_num, e))
+                sys.stderr.write("Unable to fetch info for PR #{}: {}\n".format(pr_num, e))
                 continue
 
         if pr_numbers and not all_no_changelog:


### PR DESCRIPTION
### What does this PR do?

Stop throwing an `IndexError` when a PR doesn't have a changelog label attached, print a warning instead

### Motivation

`print_shippable` task is too slow now

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

