### PR TITLE
[ci skip] Bumped tcp_check version to 2.0.1

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -75,7 +75,7 @@ ssh_check==1.2.0
 supervisord==1.1.2
 system_core==1.0.0
 system_swap==1.1.0
-tcp_check==2.0.0
+tcp_check==2.0.1
 teamcity==1.1.0
 tokumx==1.2.0
 twemproxy==1.2.0

--- a/tcp_check/CHANGELOG.md
+++ b/tcp_check/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - tcp_check
 
+## 2.0.1 / 2018-06-20
+
+* [Fixed] Fix error message when TCP check fails. See [#1745](https://github.com/DataDog/integrations-core/pull/1745). Thanks [Siecje](https://github.com/Siecje).
+
 ## 2.0.0 / 2018-03-23
 
 * [DEPRECATION] Remove the `skip_event` option from the check. See [#1054][]

--- a/tcp_check/datadog_checks/tcp_check/__about__.py
+++ b/tcp_check/datadog_checks/tcp_check/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'


### PR DESCRIPTION
### What does this PR do?

See title