### PR TITLE
[ci skip] Bumped sqlserver version to 1.5.0

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -69,7 +69,7 @@ riak==1.3.0
 riakcs==1.1.0
 snmp==1.4.0
 spark==1.4.0
-sqlserver==1.4.0; sys_platform == 'win32'
+sqlserver==1.5.0; sys_platform == 'win32'
 squid==1.0.1
 ssh_check==1.2.0
 supervisord==1.1.2

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - sqlserver
 
+## 1.5.0 / 2018-06-20
+
+* [Added] support object_name metric identifiers. See [#1679](https://github.com/DataDog/integrations-core/pull/1679).
+
 ## 1.4.0 / 2018-05-11
 
 * [FEATURE] Add custom tag support for service checks.

--- a/sqlserver/datadog_checks/sqlserver/__about__.py
+++ b/sqlserver/datadog_checks/sqlserver/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '1.4.0'
+__version__ = '1.5.0'


### PR DESCRIPTION
### What does this PR do?

Release sqlserver 1.5.0

### Motivation

release :allthethings:

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
