### PR TITLE
Drastically increase performance when traversing large directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ stages:
   - name: test
     if: (branch = master) AND (type != pull_request)
 
-script: travis_retry inv test --targets=${CHECK}
+script:
+  - travis_retry inv test --targets=${CHECK}
+  - inv test --targets=${CHECK} --bench || true
 
 # Conditional jobs are currently buggy and verbose.
 #
@@ -39,11 +41,13 @@ jobs:
       script:
        - inv manifest --include-extras
        - inv test --changed-only
+       - inv test --changed-only --bench || true
     - stage: test
       env: CHECK=datadog_checks_base
       script:
         - inv manifest --include-extras
         - travis_retry inv test --targets=${CHECK}
+        - inv test --targets=${CHECK} --bench || true
     - stage: test
       env: CHECK=active_directory
     - stage: test

--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -1,68 +1,64 @@
-# (C) Datadog, Inc. 2013-2017
-# (C) Brett Langdon <brett@blangdon.com> 2013
+# (C) Datadog, Inc. 2018
 # All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
-
-
-# stdlib
+# Licensed under a 3-clause BSD style license (see LICENSE)
 from fnmatch import fnmatch
-from os import stat
 from os.path import abspath, exists, join, relpath
-import time
+from time import time
 
-# 3p
-from scandir import walk
-
-# project
 from datadog_checks.checks import AgentCheck
 from datadog_checks.config import _is_affirmative
+from .traverse import walk
 
 
 class DirectoryCheck(AgentCheck):
-    """This check is for monitoring and reporting metrics on the files for a provided directory
+    """This check is for monitoring and reporting metrics on the files for a provided directory.
 
-    WARNING: the user/group that dd-agent runs as must have access to stat the files in the desired directory
+    WARNING: the user/group that the agent runs as must have access to stat the files in the desired directory
 
     Config options:
-        "directory" - string, the directory to gather stats for. required
-        "name" - string, the name to use when tagging the metrics. defaults to the "directory"
-        "dirtagname" - string, the name of the tag used for the directory. defaults to "name"
-        "filetagname" - string, the name of the tag used for each file. defaults to "filename"
-        "filegauges" - boolean, when true stats will be an individual gauge per file (max. 20 files!) and not a histogram of the whole directory. default False
-        "pattern" - string, the `fnmatch` pattern to use when reading the "directory"'s files. default "*"
-        "recursive" - boolean, when true the stats will recurse into directories. default False
-        "countonly" - boolean, when true the stats will only count the number of files matching the pattern. Useful for very large directories. default False
-        "ignore_missing" - boolean, when true do not raise an exception on missing/inaccessible directories. default False
-    """ # noqa E501
+        `directory` - string, the directory to gather stats for. required
+        `name` - string, the name to use when tagging the metrics. defaults to the `directory`
+        `dirtagname` - string, the name of the tag used for the directory. defaults to `name`
+        `filetagname` - string, the name of the tag used for each file. defaults to `filename`
+        `filegauges` - boolean, when true stats will be an individual gauge per file (max. 20 files!)
+                       and not a histogram of the whole directory. default False
+        `pattern` - string, the `fnmatch` pattern to use when reading the `directory`'s files. default `*`
+        `recursive` - boolean, when true the stats will recurse into directories. default False
+        `countonly` - boolean, when true the stats will only count the number of files matching the pattern.
+                      Useful for very large directories. default False
+        `ignore_missing` - boolean, when true do not raise an exception on missing/inaccessible directories.
+                           default False
+    """
 
     SOURCE_TYPE_NAME = 'system'
 
     def check(self, instance):
-        if "directory" not in instance:
-            raise Exception('DirectoryCheck: missing "directory" in config')
+        try:
+            directory = instance['directory']
+        except KeyError:
+            raise Exception('DirectoryCheck: missing `directory` in config')
 
-        directory = instance["directory"]
         abs_directory = abspath(directory)
-        name = instance.get("name", directory)
-        pattern = instance.get("pattern", "*")
-        recursive = _is_affirmative(instance.get("recursive", False))
-        dirtagname = instance.get("dirtagname", "name")
-        filetagname = instance.get("filetagname", "filename")
-        filegauges = _is_affirmative(instance.get("filegauges", False))
-        countonly = _is_affirmative(instance.get("countonly", False))
-        ignore_missing = _is_affirmative(instance.get("ignore_missing", False))
-        custom_tags = instance.get("tags", [])
+        name = instance.get('name', directory)
+        pattern = instance.get('pattern')
+        recursive = _is_affirmative(instance.get('recursive', False))
+        dirtagname = instance.get('dirtagname', 'name')
+        filetagname = instance.get('filetagname', 'filename')
+        filegauges = _is_affirmative(instance.get('filegauges', False))
+        countonly = _is_affirmative(instance.get('countonly', False))
+        ignore_missing = _is_affirmative(instance.get('ignore_missing', False))
+        custom_tags = instance.get('tags', [])
 
         if not exists(abs_directory):
             if ignore_missing:
-                self.log.info("DirectoryCheck: \
-                              the directory (%s) does not exist. \
-                              Skipping." % abs_directory)
+                self.log.info(
+                    'DirectoryCheck: the directory `{}` does not exist. Skipping.'.format(abs_directory)
+                )
                 return
 
-            raise Exception("DirectoryCheck: \
-                             the directory (%s) does not exist"
-                            % abs_directory)
+            raise Exception(
+                'DirectoryCheck: the directory `{}` does not exist. Skipping.'.format(abs_directory)
+            )
 
         self._get_stats(abs_directory, name, dirtagname,
                         filetagname, filegauges, pattern,
@@ -70,71 +66,86 @@ class DirectoryCheck(AgentCheck):
 
     def _get_stats(self, directory, name, dirtagname, filetagname,
                    filegauges, pattern, recursive, countonly, tags):
-        dirtags = [dirtagname + ":%s" % name] + tags
+        dirtags = ['{}:{}'.format(dirtagname, name)]
+        dirtags.extend(tags)
         directory_bytes = 0
         directory_files = 0
-        for root, dirs, files in walk(directory):
-            for filename in files:
-                filename = join(root, filename)
-                rel_filename = relpath(filename, directory)
-                # Check if the path of the file relative to the directory
-                # matches the pattern. Also check if the absolute path of the
-                # filename matches the pattern, for compatibility with previous
-                # agent verions.
-                if not (fnmatch(filename, pattern) or
-                        fnmatch(rel_filename, pattern)):
-                    continue
 
-                directory_files += 1
+        # If we do not want to recursively search sub-directories only get the root.
+        walker = walk(directory) if recursive else (next(walk(directory)), )
 
-                # We're just looking to count the files, don't stat it as well
+        # Avoid repeated global lookups.
+        get_length = len
+
+        for root, dirs, files in walker:
+            directory_files += get_length(files)
+
+            for file_entry in files:
+                if pattern:
+                    # Check if the path of the file relative to the directory
+                    # matches the pattern. Also check if the absolute path of the
+                    # filename matches the pattern, for compatibility with previous
+                    # agent versions.
+                    filename = join(root, file_entry.name)
+                    if not (
+                        fnmatch(filename, pattern) or
+                        fnmatch(relpath(filename, directory), pattern)
+                    ):
+                        directory_files -= 1
+                        continue
+
+                # We're just looking to count the files.
                 if countonly:
                     continue
 
                 try:
-                    file_stat = stat(filename)
+                    file_stat = file_entry.stat()
 
                 except OSError as ose:
-                    self.warning("DirectoryCheck: could not stat file %s - %s"
-                                 % (filename, ose))
+                    self.warning(
+                        'DirectoryCheck: could not stat file {} - {}'.format(join(root, file_entry.name), ose)
+                    )
                 else:
                     # file specific metrics
                     directory_bytes += file_stat.st_size
                     if filegauges and directory_files <= 20:
-                        filetags = list(dirtags)
-                        filetags.append(filetagname + ":%s" % filename)
+                        filetags = ['{}:{}'.format(filetagname, join(root, file_entry.name))]
+                        filetags.extend(dirtags)
                         self.gauge(
-                            "system.disk.directory.file.bytes",
-                            file_stat.st_size, tags=filetags)
+                            'system.disk.directory.file.bytes',
+                            file_stat.st_size,
+                            tags=filetags
+                        )
                         self.gauge(
-                            "system.disk.directory.file.modified_sec_ago",
-                            time.time() - file_stat.st_mtime, tags=filetags)
+                            'system.disk.directory.file.modified_sec_ago',
+                            time() - file_stat.st_mtime,
+                            tags=filetags
+                        )
                         self.gauge(
-                            "system.disk.directory.file.created_sec_ago",
-                            time.time() - file_stat.st_ctime, tags=filetags)
-                    elif not filegauges:
+                            'system.disk.directory.file.created_sec_ago',
+                            time() - file_stat.st_ctime,
+                            tags=filetags
+                        )
+                    else:
                         self.histogram(
-                            "system.disk.directory.file.bytes",
-                            file_stat.st_size, tags=dirtags)
+                            'system.disk.directory.file.bytes',
+                            file_stat.st_size,
+                            tags=dirtags
+                        )
                         self.histogram(
-                            "system.disk.directory.file.modified_sec_ago",
-                            time.time() - file_stat.st_mtime, tags=dirtags)
+                            'system.disk.directory.file.modified_sec_ago',
+                            time() - file_stat.st_mtime,
+                            tags=dirtags
+                        )
                         self.histogram(
-                            "system.disk.directory.file.created_sec_ago",
-                            time.time() - file_stat.st_ctime, tags=dirtags)
-
-            # os.walk gives us all sub-directories and their files
-            # if we do not want to do this recursively and just want
-            # the top level directory we gave it, then break
-            if not recursive:
-                break
+                            'system.disk.directory.file.created_sec_ago',
+                            time() - file_stat.st_ctime,
+                            tags=dirtags
+                        )
 
         # number of files
-        self.gauge(
-            "system.disk.directory.files",
-            directory_files, tags=dirtags)
+        self.gauge('system.disk.directory.files', directory_files, tags=dirtags)
+
         # total file size
         if not countonly:
-            self.gauge(
-                "system.disk.directory.bytes",
-                directory_bytes, tags=dirtags)
+            self.gauge('system.disk.directory.bytes', directory_bytes, tags=dirtags)

--- a/directory/datadog_checks/directory/traverse.py
+++ b/directory/datadog_checks/directory/traverse.py
@@ -1,0 +1,63 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import platform
+import sys
+from os.path import join
+
+import six
+from scandir import scandir
+
+
+def _walk(top):
+    """Modified version of https://docs.python.org/3/library/os.html#os.scandir
+    that returns https://docs.python.org/3/library/os.html#os.DirEntry for files
+    directly to take advantage of possible cached os.stat calls.
+    """
+    dirs = []
+    nondirs = []
+
+    try:
+        scandir_iter = scandir(top)
+    except OSError:
+        return
+
+    # Avoid repeated global lookups.
+    get_next = next
+
+    while True:
+        try:
+            entry = get_next(scandir_iter)
+        except StopIteration:
+            break
+        except OSError:
+            return
+
+        try:
+            is_dir = entry.is_dir()
+        except OSError:
+            is_dir = False
+
+        if is_dir:
+            dirs.append(entry.name)
+        else:
+            nondirs.append(entry)
+
+    yield top, dirs, nondirs
+
+    for name in dirs:
+        for entry in walk(join(top, name)):
+            yield entry
+
+
+if six.PY3 or platform.system() != 'Windows':
+    walk = _walk
+else:
+    # Fix for broken unicode handling on Windows on Python 2.x, see:
+    # https://github.com/benhoyt/scandir/issues/54
+    file_system_encoding = sys.getfilesystemencoding()
+
+    def walk(top):
+        if isinstance(top, bytes):
+            top = top.decode(file_system_encoding)
+        return _walk(top)

--- a/directory/requirements-dev.txt
+++ b/directory/requirements-dev.txt
@@ -1,1 +1,3 @@
 pytest
+pytest-benchmark
+virtualenv

--- a/directory/tests/requirements.txt
+++ b/directory/tests/requirements.txt
@@ -1,2 +1,0 @@
-mock==2.0.0
-pytest

--- a/directory/tests/test_bench.py
+++ b/directory/tests/test_bench.py
@@ -1,0 +1,23 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import shutil
+import subprocess
+import sys
+import tempfile
+
+from datadog_checks.directory import DirectoryCheck
+
+
+def test_run(benchmark):
+    temp_dir = tempfile.mkdtemp()
+    command = [sys.executable, '-m', 'virtualenv', temp_dir]
+    instance = {'directory': temp_dir, 'recursive': True}
+
+    try:
+        subprocess.call(command)
+        c = DirectoryCheck('directory', None, {}, [instance])
+
+        benchmark(c.check, instance)
+    finally:
+        shutil.rmtree(temp_dir)

--- a/directory/tox.ini
+++ b/directory/tox.ini
@@ -4,22 +4,28 @@ basepython = py27
 envlist =
     directory
     flake8
+    bench
 
 [testenv]
-platform = linux2|darwin|win32
-
-[testenv:directory]
+platform = linux|darwin|win32
 deps =
     ../datadog_checks_base
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt
-    pytest .
+    pytest -v --benchmark-skip
+
+[testenv:directory]
 
 [testenv:flake8]
 skip_install = true
 deps = flake8
 commands = flake8 .
+
+[testenv:bench]
+commands =
+    pip install --require-hashes -r requirements.txt
+    pytest --benchmark-only --benchmark-cprofile=tottime
 
 [flake8]
 exclude = .eggs,.tox

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -28,7 +28,7 @@ def files_changed(ctx):
     return [f for f in changed_files if f]
 
 
-def run_tox(ctx, target, bench, dry_run):
+def run_tox(ctx, target, bench, every, dry_run):
     """
     Run tox on the folders contained in `targets`
     """
@@ -37,18 +37,23 @@ def run_tox(ctx, target, bench, dry_run):
             sys.stdout.write("\nRunning tox in '{}'...\n".format(target))
             sys.stdout.write("Ok.\n")
         else:
-            env_list = ctx.run('tox --listenvs', hide='out').stdout
-            env_list = [e.strip() for e in env_list.splitlines()]
-
-            if bench:
-                benches = [e for e in env_list if e.startswith('bench')]
-                # Don't print anything if there are no benchmarks
-                if benches:
-                    ctx.run('tox -e {}'.format(','.join(benches)))
-            else:
+            if every:
                 sys.stdout.write('\nRunning tox in `{}`...\n'.format(target))
-                ctx.run('tox -e {}'.format(','.join(e for e in env_list if not e.startswith('bench'))))
+                ctx.run('tox')
                 sys.stdout.write('Ok.\n')
+            else:
+                env_list = ctx.run('tox --listenvs', hide='out').stdout
+                env_list = [e.strip() for e in env_list.splitlines()]
+
+                if bench:
+                    benches = [e for e in env_list if e.startswith('bench')]
+                    # Don't print anything if there are no benchmarks
+                    if benches:
+                        ctx.run('tox -e {}'.format(','.join(benches)))
+                else:
+                    sys.stdout.write('\nRunning tox in `{}`...\n'.format(target))
+                    ctx.run('tox -e {}'.format(','.join(e for e in env_list if not e.startswith('bench'))))
+                    sys.stdout.write('Ok.\n')
 
 
 def check_requirements(ctx, target, dry_run, changed_files):
@@ -91,9 +96,10 @@ def check_requirements(ctx, target, dry_run, changed_files):
     'targets': "Comma separated names of the checks that will be tested",
     'changed-only': "Whether to only test checks that were changed in a PR",
     'bench': "Runs any benchmarks",
+    'every': "Runs every kind of test",
     'dry-run': "Runs the task without actually doing anything",
 })
-def test(ctx, targets=None, changed_only=False, bench=False, dry_run=False):
+def test(ctx, targets=None, changed_only=False, bench=False, every=False, dry_run=False):
     """
     Run the tests for Agent-based checks
 
@@ -129,4 +135,4 @@ def test(ctx, targets=None, changed_only=False, bench=False, dry_run=False):
         if not bench:
             check_requirements(ctx, target, dry_run, changed_files)
         # run the tests for each target with tox
-        run_tox(ctx, target, bench, dry_run)
+        run_tox(ctx, target, bench, every, dry_run)


### PR DESCRIPTION
### What does this PR do?

Uses an optimized recursive directory walker, and other minor perf-related changes.

### Motivation

Customer report: Large directories (200 GiB+) with many files (10s of thousands) will lock up the agent (including other checks).

### Notes

Before: https://travis-ci.org/DataDog/integrations-core/builds/394857200#L646
After: https://travis-ci.org/DataDog/integrations-core/builds/394857766#L646

Due to the unreliable nature of Travis, it only shows a 2x increase, locally however it was 5-7x faster. Now the next slowest thing is our tag normalization, which is being addressed here https://github.com/DataDog/integrations-core/pull/1653.