### PR TITLE
Fix Link with for now doc organisation on logs

### DIFF
--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -81,7 +81,7 @@ Need help? Contact [Datadog Support][7].
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: https://github.com/DataDog/integrations-core/blob/master/fluentd/conf.yaml.example
 [3]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
-[4]: https://docs.datadoghq.com/logs/faq/how-to-send-logs-to-datadog-via-external-log-shippers/#fluentd
+[4]: https://docs.datadoghq.com/logs/log_collection/fluentd/
 [5]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [6]: https://github.com/DataDog/integrations-core/blob/master/fluentd/metadata.csv
 [7]: http://docs.datadoghq.com/help/


### PR DESCRIPTION
### What does this PR do?

Fix the link to the Fluentd installation instruction

### Motivation

Doc organisation was changed and link not updated.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
