### PR TITLE
Makes the Cisco Check more resilient

### DIFF
--- a/cisco_aci/datadog_checks/cisco_aci/api.py
+++ b/cisco_aci/datadog_checks/cisco_aci/api.py
@@ -5,6 +5,8 @@
 import random
 from requests import Request, Session
 
+from .exceptions import APIConnectionException, APIParsingException
+
 
 class SessionWrapper:
     def __init__(self, aci_url, session, apic_cookie, verify=None, timeout=None, log=None):
@@ -32,15 +34,15 @@ class SessionWrapper:
             response.raise_for_status()
         except Exception as e:
             self.log.warning("Error making request: {}".format(e))
-            raise
+            raise APIConnectionException("Error making request: {}".format(e))
         try:
             if raw_response:
                 return response
             else:
                 return response.json()
         except Exception as e:
-            self.log.warning("Exception in json parsing, returning nothing: {}".format(e))
-            raise
+            self.log.warning("Exception in json parsing: {}".format(e))
+            raise APIParsingException("Exception in json parsing: {}".format(e))
 
 
 class Api:

--- a/cisco_aci/datadog_checks/cisco_aci/api.py
+++ b/cisco_aci/datadog_checks/cisco_aci/api.py
@@ -5,7 +5,7 @@
 import random
 from requests import Request, Session
 
-from .exceptions import APIConnectionException, APIParsingException
+from . import exceptions
 
 
 class SessionWrapper:
@@ -34,7 +34,7 @@ class SessionWrapper:
             response.raise_for_status()
         except Exception as e:
             self.log.warning("Error making request: {}".format(e))
-            raise APIConnectionException("Error making request: {}".format(e))
+            raise exceptions.APIConnectionException("Error making request: {}".format(e))
         try:
             if raw_response:
                 return response
@@ -42,7 +42,7 @@ class SessionWrapper:
                 return response.json()
         except Exception as e:
             self.log.warning("Exception in json parsing: {}".format(e))
-            raise APIParsingException("Exception in json parsing: {}".format(e))
+            raise exceptions.APIParsingException("Exception in json parsing: {}".format(e))
 
 
 class Api:

--- a/cisco_aci/datadog_checks/cisco_aci/capacity.py
+++ b/cisco_aci/datadog_checks/cisco_aci/capacity.py
@@ -4,6 +4,7 @@
 
 from . import metrics as aci_metrics
 from . import helpers
+from .exceptions import APIConnectionException, APIParsingException
 
 
 class Capacity:
@@ -24,10 +25,26 @@ class Capacity:
 
     def collect(self):
         self.log.info("collecting capacity data")
-        self.get_contexts()
-        self.get_apic_capacity_limits()
-        self.get_apic_capacity_metrics()
-        self.get_eqpt_capacity()
+        try:
+            self.get_contexts()
+        except APIConnectionException, APIParsingException:
+            # all should fail independently
+            pass
+        try:
+            self.get_apic_capacity_limits()
+        except APIConnectionException, APIParsingException:
+            # all should fail independently
+            pass
+        try:
+            self.get_apic_capacity_metrics()
+        except APIConnectionException, APIParsingException:
+            # all should fail independently
+            pass
+        try:
+            self.get_eqpt_capacity()
+        except APIConnectionException, APIParsingException:
+            # all should fail independently
+            pass
         self.log.info("finished collecting capacity data")
 
     def get_eqpt_capacity(self):

--- a/cisco_aci/datadog_checks/cisco_aci/capacity.py
+++ b/cisco_aci/datadog_checks/cisco_aci/capacity.py
@@ -4,7 +4,7 @@
 
 from . import metrics as aci_metrics
 from . import helpers
-from .exceptions import APIConnectionException, APIParsingException
+from . import exceptions
 
 
 class Capacity:
@@ -27,22 +27,22 @@ class Capacity:
         self.log.info("collecting capacity data")
         try:
             self.get_contexts()
-        except APIConnectionException, APIParsingException:
+        except exceptions.APIConnectionException, exceptions.APIParsingException:
             # all should fail independently
             pass
         try:
             self.get_apic_capacity_limits()
-        except APIConnectionException, APIParsingException:
+        except exceptions.APIConnectionException, exceptions.APIParsingException:
             # all should fail independently
             pass
         try:
             self.get_apic_capacity_metrics()
-        except APIConnectionException, APIParsingException:
+        except exceptions.APIConnectionException, exceptions.APIParsingException:
             # all should fail independently
             pass
         try:
             self.get_eqpt_capacity()
-        except APIConnectionException, APIParsingException:
+        except exceptions.APIConnectionException, exceptions.APIParsingException:
             # all should fail independently
             pass
         self.log.info("finished collecting capacity data")

--- a/cisco_aci/datadog_checks/cisco_aci/exceptions.py
+++ b/cisco_aci/datadog_checks/cisco_aci/exceptions.py
@@ -1,0 +1,12 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+class APIException(Exception):
+    pass
+
+class APIConnectionException(APIException):
+    pass
+
+class APIParsingException(APIException):
+    pass

--- a/cisco_aci/datadog_checks/cisco_aci/exceptions.py
+++ b/cisco_aci/datadog_checks/cisco_aci/exceptions.py
@@ -2,11 +2,14 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+
 class APIException(Exception):
     pass
 
+
 class APIConnectionException(APIException):
     pass
+
 
 class APIParsingException(APIException):
     pass

--- a/cisco_aci/datadog_checks/cisco_aci/fabric.py
+++ b/cisco_aci/datadog_checks/cisco_aci/fabric.py
@@ -4,6 +4,7 @@
 
 from . import metrics as aci_metrics
 from . import helpers
+from .exceptions import APIConnectionException, APIParsingException
 
 
 class Fabric:

--- a/cisco_aci/datadog_checks/cisco_aci/fabric.py
+++ b/cisco_aci/datadog_checks/cisco_aci/fabric.py
@@ -4,7 +4,7 @@
 
 from . import metrics as aci_metrics
 from . import helpers
-from .exceptions import APIConnectionException, APIParsingException
+from . import exceptions
 
 
 class Fabric:
@@ -45,7 +45,7 @@ class Fabric:
             try:
                 stats = self.api.get_pod_stats(pod_id)
                 self.submit_fabric_metric(stats, tags, 'fabricPod')
-            except APIConnectionException, APIParsingException:
+            except exceptions.APIConnectionException, exceptions.APIParsingException:
                 pass
             self.log.info("finished processing pod {}".format(pod_attrs['id']))
 
@@ -68,14 +68,14 @@ class Fabric:
             self.log.info("processing node {} on pod {}".format(node_id, pod_id))
             try:
                 self.submit_process_metric(n, tags + self.check_tags + user_tags, hostname=hostname)
-            except APIConnectionException, APIParsingException:
+            except exceptions.APIConnectionException, exceptions.APIParsingException:
                 pass
             if node_attrs['role'] != "controller":
                 try:
                     stats = self.api.get_node_stats(pod_id, node_id)
                     self.submit_fabric_metric(stats, tags, 'fabricNode', hostname=hostname)
                     self.process_eth(node_attrs)
-                except APIConnectionException, APIParsingException:
+                except exceptions.APIConnectionException, exceptions.APIParsingException:
                     pass
             self.log.info("finished processing node {}".format(node_id))
 
@@ -85,7 +85,7 @@ class Fabric:
         pod_id = helpers.get_pod_from_dn(node['dn'])
         try:
             eth_list = self.api.get_eth_list(pod_id, node['id'])
-        except APIConnectionException, APIParsingException:
+        except exceptions.APIConnectionException, exceptions.APIParsingException:
             pass
         for e in eth_list:
             eth_attrs = helpers.get_attributes(e)
@@ -94,7 +94,7 @@ class Fabric:
             try:
                 stats = self.api.get_eth_stats(pod_id, node['id'], eth_id)
                 self.submit_fabric_metric(stats, tags, 'l1PhysIf', hostname=hostname)
-            except APIConnectionException, APIParsingException:
+            except exceptions.APIConnectionException, exceptions.APIParsingException:
                 pass
         self.log.info("finished processing ethernet ports for {}".format(node['id']))
 

--- a/cisco_aci/datadog_checks/cisco_aci/tags.py
+++ b/cisco_aci/datadog_checks/cisco_aci/tags.py
@@ -7,6 +7,7 @@ import re
 from datadog_checks.utils.containers import hash_mutable
 
 from . import helpers
+from .exceptions import APIConnectionException, APIParsingException
 
 
 class CiscoTags:

--- a/cisco_aci/datadog_checks/cisco_aci/tags.py
+++ b/cisco_aci/datadog_checks/cisco_aci/tags.py
@@ -7,7 +7,7 @@ import re
 from datadog_checks.utils.containers import hash_mutable
 
 from . import helpers
-from .exceptions import APIConnectionException, APIParsingException
+from . import exceptions
 
 
 class CiscoTags:
@@ -66,7 +66,7 @@ class CiscoTags:
                     if encap:
                         endpoint_meta.append("encap:" + encap)
                     # adding application tags
-        except APIConnectionException, APIParsingException:
+        except exceptions.APIConnectionException, exceptions.APIParsingException:
             # the exception will already be logged, just pass it over here
             pass
         endpoint_meta += application_meta
@@ -102,7 +102,7 @@ class CiscoTags:
                         self.tenant_farbic_mapper[tenant_fabric_key].extend(application_meta)
 
                     self.tenant_farbic_mapper[tenant_fabric_key] = list(set(self.tenant_farbic_mapper[tenant_fabric_key]))
-            except APIConnectionException, APIParsingException:
+            except exceptions.APIConnectionException, exceptions.APIParsingException:
                 # the exception will already be logged, just pass it over here
                 pass
 

--- a/cisco_aci/datadog_checks/cisco_aci/tags.py
+++ b/cisco_aci/datadog_checks/cisco_aci/tags.py
@@ -47,23 +47,27 @@ class CiscoTags:
             if app:
                 app_name = app.group(1)
                 application_meta.append("application:" + app_name)
-        # adding meta tags
-        meta = self.api.get_epg_meta(tenant_name, app_name, epg_name)
         endpoint_meta = []
-        if len(meta) > 0:
-            meta = meta[0]
-            meta_attrs = meta.get('fvCEp', {}).get('attributes')
-            if meta_attrs:
-                ip = meta_attrs.get('ip')
-                if ip:
-                    endpoint_meta.append("ip:" + ip)
-                mac = meta_attrs.get('mac')
-                if mac:
-                    endpoint_meta.append("mac:" + mac)
-                encap = meta_attrs.get('encap')
-                if encap:
-                    endpoint_meta.append("encap:" + encap)
-                # adding application tags
+        # adding meta tags
+        try:
+            meta = self.api.get_epg_meta(tenant_name, app_name, epg_name)
+            if len(meta) > 0:
+                meta = meta[0]
+                meta_attrs = meta.get('fvCEp', {}).get('attributes')
+                if meta_attrs:
+                    ip = meta_attrs.get('ip')
+                    if ip:
+                        endpoint_meta.append("ip:" + ip)
+                    mac = meta_attrs.get('mac')
+                    if mac:
+                        endpoint_meta.append("mac:" + mac)
+                    encap = meta_attrs.get('encap')
+                    if encap:
+                        endpoint_meta.append("encap:" + encap)
+                    # adding application tags
+        except APIConnectionException, APIParsingException:
+            # the exception will already be logged, just pass it over here
+            pass
         endpoint_meta += application_meta
 
         context_hash = hash_mutable(endpoint_meta)
@@ -71,31 +75,35 @@ class CiscoTags:
         if self.tenant_tags.get(context_hash):
             eth_meta = self.tenant_tags.get(context_hash)
         else:
-            # adding eth and node tags
-            eth_list = self.api.get_eth_list_for_epg(tenant_name, app_name, epg_name)
-            for eth in eth_list:
-                eth_attrs = eth.get('fvRsCEpToPathEp', {}).get('attributes', {})
-                port = re.search('/pathep-\[(.+?)\]', eth_attrs.get('tDn', ''))
-                if not port:
-                    continue
-                eth_tag = 'port:' + port.group(1)
-                if eth_tag not in eth_meta:
-                    eth_meta.append(eth_tag)
-                node = re.search('/paths-(.+?)/', eth_attrs.get('tDn', ''))
-                if not node:
-                    continue
-                eth_node = 'node_id:' + node.group(1)
-                if eth_node not in eth_meta:
-                    eth_meta.append(eth_node)
-                # populating the map for eth-app mapping
+            try:
+                # adding eth and node tags
+                eth_list = self.api.get_eth_list_for_epg(tenant_name, app_name, epg_name)
+                for eth in eth_list:
+                    eth_attrs = eth.get('fvRsCEpToPathEp', {}).get('attributes', {})
+                    port = re.search('/pathep-\[(.+?)\]', eth_attrs.get('tDn', ''))
+                    if not port:
+                        continue
+                    eth_tag = 'port:' + port.group(1)
+                    if eth_tag not in eth_meta:
+                        eth_meta.append(eth_tag)
+                    node = re.search('/paths-(.+?)/', eth_attrs.get('tDn', ''))
+                    if not node:
+                        continue
+                    eth_node = 'node_id:' + node.group(1)
+                    if eth_node not in eth_meta:
+                        eth_meta.append(eth_node)
+                    # populating the map for eth-app mapping
 
-                tenant_fabric_key = node.group(1) + ":" + port.group(1)
-                if tenant_fabric_key not in self.tenant_farbic_mapper:
-                    self.tenant_farbic_mapper[tenant_fabric_key] = application_meta
-                else:
-                    self.tenant_farbic_mapper[tenant_fabric_key].extend(application_meta)
+                    tenant_fabric_key = node.group(1) + ":" + port.group(1)
+                    if tenant_fabric_key not in self.tenant_farbic_mapper:
+                        self.tenant_farbic_mapper[tenant_fabric_key] = application_meta
+                    else:
+                        self.tenant_farbic_mapper[tenant_fabric_key].extend(application_meta)
 
-                self.tenant_farbic_mapper[tenant_fabric_key] = list(set(self.tenant_farbic_mapper[tenant_fabric_key]))
+                    self.tenant_farbic_mapper[tenant_fabric_key] = list(set(self.tenant_farbic_mapper[tenant_fabric_key]))
+            except APIConnectionException, APIParsingException:
+                # the exception will already be logged, just pass it over here
+                pass
 
         tags = tags + endpoint_meta + eth_meta
         if len(eth_meta) > 0:

--- a/cisco_aci/datadog_checks/cisco_aci/tenant.py
+++ b/cisco_aci/datadog_checks/cisco_aci/tenant.py
@@ -7,7 +7,7 @@ import time
 import datetime
 
 from . import helpers
-from .exceptions import APIConnectionException, APIParsingException
+from . import exceptions
 
 
 class Tenant:
@@ -50,14 +50,14 @@ class Tenant:
                         list_epgs = self.api.get_epgs(t, app_name)
                         self.log.info("collecting %s endpoint groups from %s" % (len(list_epgs), app_name))
                         self.submit_epg_data(t, app_name, list_epgs)
-                    except APIConnectionException, APIParsingException:
+                    except exceptions.APIConnectionException, exceptions.APIParsingException:
                         pass
-            except APIConnectionException, APIParsingException:
+            except exceptions.APIConnectionException, exceptions.APIParsingException:
                 pass
             self.submit_ten_data(t)
             try:
                 self.collect_events(t)
-            except APIConnectionException, APIParsingException:
+            except exceptions.APIConnectionException, exceptions.APIParsingException:
                 pass
 
     def submit_app_data(self, tenant, app):
@@ -86,7 +86,7 @@ class Tenant:
             stats = self.api.get_tenant_stats(tenant)
             tags = self.tagger.get_tags(tenant, 'tenant')
             self.submit_raw_obj(stats, tags, 'tenant')
-        except APIConnectionException, APIParsingException:
+        except exceptions.APIConnectionException, exceptions.APIParsingException:
             pass
 
     def submit_raw_obj(self, raw_stats, tags, obj_type):

--- a/cisco_aci/datadog_checks/cisco_aci/tenant.py
+++ b/cisco_aci/datadog_checks/cisco_aci/tenant.py
@@ -39,16 +39,25 @@ class Tenant:
         self.log.info("collecting from %s tenants" % len(tenants))
         # check if tenant exist before proceeding.
         for t in tenants:
-            list_apps = self.api.get_apps(t)
-            self.log.info("collecting %s apps from %s" % (len(list_apps), t))
-            for app in list_apps:
-                self.submit_app_data(t, app)
-                app_name = app.get('fvAp', {}).get('attributes', {}).get('name')
-                list_epgs = self.api.get_epgs(t, app_name)
-                self.log.info("collecting %s endpoint groups from %s" % (len(list_epgs), app_name))
-                self.submit_epg_data(t, app_name, list_epgs)
+            try:
+                list_apps = self.api.get_apps(t)
+                self.log.info("collecting %s apps from %s" % (len(list_apps), t))
+                for app in list_apps:
+                    self.submit_app_data(t, app)
+                    app_name = app.get('fvAp', {}).get('attributes', {}).get('name')
+                    try:
+                        list_epgs = self.api.get_epgs(t, app_name)
+                        self.log.info("collecting %s endpoint groups from %s" % (len(list_epgs), app_name))
+                        self.submit_epg_data(t, app_name, list_epgs)
+                    except APIConnectionException, APIParsingException:
+                        pass
+            except APIConnectionException, APIParsingException:
+                pass
             self.submit_ten_data(t)
-            self.collect_events(t)
+            try:
+                self.collect_events(t)
+            except APIConnectionException, APIParsingException:
+                pass
 
     def submit_app_data(self, tenant, app):
         a = app.get('fvAp', {})
@@ -72,9 +81,12 @@ class Tenant:
             self.submit_raw_obj(stats, tags, 'endpoint_group')
 
     def submit_ten_data(self, tenant):
-        stats = self.api.get_tenant_stats(tenant)
-        tags = self.tagger.get_tags(tenant, 'tenant')
-        self.submit_raw_obj(stats, tags, 'tenant')
+        try:
+            stats = self.api.get_tenant_stats(tenant)
+            tags = self.tagger.get_tags(tenant, 'tenant')
+            self.submit_raw_obj(stats, tags, 'tenant')
+        except APIConnectionException, APIParsingException:
+            pass
 
     def submit_raw_obj(self, raw_stats, tags, obj_type):
         for s in raw_stats:

--- a/cisco_aci/datadog_checks/cisco_aci/tenant.py
+++ b/cisco_aci/datadog_checks/cisco_aci/tenant.py
@@ -7,6 +7,7 @@ import time
 import datetime
 
 from . import helpers
+from .exceptions import APIConnectionException, APIParsingException
 
 
 class Tenant:


### PR DESCRIPTION
### What does this PR do?

The Cisco Check should try to collect everything, even if some types of failures occur that shouldn't stop it from running. 

Network errors and access errors should be ignored, because that could mean that a switch has been cycled out or something. Also sometimes switches can be a part of the APIC without actually being monitored or managed by the apic, and it will fail on some of the collection requests.

### Motivation

Found some failures, it shouldn't stop halfway.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

We might want to add service checks to some of these requests. I am not sure which ones, I'm gonna add them in a followup PR.
