### PR TITLE
[Doc] Removing image partial

### DIFF
--- a/apache/README.md
+++ b/apache/README.md
@@ -1,5 +1,7 @@
 # Agent Check: Apache Web Server
-{{< img src="integrations/apache/apachegraph.png" alt="apache graph" responsive="true" popup="true">}}
+
+![Apache Graph][12]
+
 ## Overview
 
 The Apache check tracks requests per second, bytes served, number of worker threads, service uptime, and more.
@@ -113,3 +115,4 @@ Returns CRITICAL if the Agent cannot connect to the configured `apache_status_ur
 [9]: https://www.datadoghq.com/blog/monitoring-apache-web-server-performance/
 [10]: https://www.datadoghq.com/blog/collect-apache-performance-metrics/
 [11]: https://www.datadoghq.com/blog/monitor-apache-web-server-datadog/
+[12]: https://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/apache/apachegraph.png

--- a/btrfs/README.md
+++ b/btrfs/README.md
@@ -1,5 +1,7 @@
 # Btrfs Integration
-{{< img src="integrations/btrfs/btrfs_metric.png" alt="btrfs metric" responsive="true" popup="true">}}
+
+![BTRFS metric][8]
+
 ## Overview
 
 Get metrics from Btrfs service in real time to:
@@ -48,3 +50,4 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [5]: https://github.com/DataDog/integrations-core/blob/master/btrfs/metadata.csv
 [6]: http://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/
+[8]: https://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/btrfs/btrfs_metric.png

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -1,5 +1,7 @@
 # Cassandra Integration
-{{< img src="integrations/cassandra/cassandra.png" alt="Cassandra default dashboard" responsive="true" popup="true">}}
+
+![Cassandra default dashboard][1011]
+
 ## Overview
 
 Get metrics from Cassandra service in real time to:
@@ -88,3 +90,4 @@ Need help? Contact [Datadog Support][107].
 [108]: https://www.datadoghq.com/blog/how-to-monitor-cassandra-performance-metrics/
 [109]: https://www.datadoghq.com/blog/how-to-collect-cassandra-metrics/
 [1010]: https://www.datadoghq.com/blog/monitoring-cassandra-with-datadog/
+[1011]: https://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/cassandra/cassandra.png

--- a/ceph/README.md
+++ b/ceph/README.md
@@ -1,5 +1,7 @@
 # Ceph Integration
-{{< img src="integrations/ceph/ceph_graph.png" alt="Ceph Graph" responsive="true" popup="true">}}
+
+![Ceph Graph][7]
+
 ## Overview
 
 Enable the Datadog-Ceph integration to:
@@ -102,3 +104,4 @@ Need help? Contact [Datadog Support][5].
 [4]: https://github.com/DataDog/integrations-core/blob/master/ceph/metadata.csv
 [5]: http://docs.datadoghq.com/help/
 [6]: https://www.datadoghq.com/blog/monitor-ceph-datadog/
+[7]: https://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/ceph/ceph_graph.png

--- a/couch/README.md
+++ b/couch/README.md
@@ -1,5 +1,7 @@
 # CouchDB Integration
-{{< img src="integrations/couchdb/couchdb_graph.png" alt="CouchDb Graph" responsive="true" popup="true">}}
+
+![CouchDB graph][8]
+
 ## Overview
 
 Capture CouchDB data in Datadog to:
@@ -68,3 +70,4 @@ Need help? Contact [Datadog Support][6].
 [5]: https://github.com/DataDog/integrations-core/blob/master/couch/metadata.csv
 [6]: http://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/monitoring-couchdb-with-datadog/
+[8]: https://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/couchdb/couchdb_graph.png

--- a/docker_daemon/README.md
+++ b/docker_daemon/README.md
@@ -1,5 +1,6 @@
 # Docker_daemon Integration
-{{< img src="integrations/docker/docker.png" alt="Docker default dashboard" responsive="true" popup="true">}}
+
+![Docker default dashboard][27]
 
 ## Overview
 
@@ -25,7 +26,7 @@ Whichever you choose, your hosts need to have cgroup memory management enabled f
 4. Add the Agent user to the docker group: `usermod -a -G docker dd-agent`
 5. Create a `docker_daemon.yaml` file by copying [the example file in the agent conf.d directory][5]. If you have a standard install of Docker on your host, there shouldn't be anything you need to change to get the integration to work.
 6. To enable other integrations, use `docker ps` to identify the ports used by the corresponding applications.
-    {{< img src="integrations/docker/integrations-docker-dockerps.png" >}}
+    ![Integration docker docker][28]
 
 **Note:** docker_daemon has replaced the older docker integration.
 
@@ -202,3 +203,5 @@ We've also written several other in-depth blog posts to help you get the most ou
 [24]: https://www.datadoghq.com/blog/monitor-docker-on-aws-ecs/
 [25]: https://www.datadoghq.com/blog/docker-performance-datadog/
 [26]: https://www.datadoghq.com/blog/monitor-docker-datadog/
+[27]: https://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/docker/docker.png
+[28]: https://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/docker/integrations-docker-dockerps.png

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -1,5 +1,6 @@
 # Elasticsearch Integration
-{{< img src="integrations/elasticsearch/elasticsearchgraph.png" alt="Elasticsearch" responsive="true" popup="true">}}
+
+![Elasitc search graph][10]
 
 ## Overview
 
@@ -110,3 +111,4 @@ To get a better idea of how (or why) to integrate your Elasticsearch cluster wit
 [7]: https://docs.datadoghq.com/integrations/faq/elastic-agent-can-t-connect
 [8]: https://docs.datadoghq.com/integrations/faq/why-isn-t-elasticsearch-sending-all-my-metrics/
 [9]: https://www.datadoghq.com/blog/monitor-elasticsearch-performance-metrics/
+[10]: https://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/elasticsearch/elasticsearchgraph.png

--- a/etcd/README.md
+++ b/etcd/README.md
@@ -1,5 +1,7 @@
 # Etcd Integration
-{{< img src="integrations/etcd/etcd_graph.png" alt="Etcd Graph" responsive="true" popup="true">}}
+
+![Etcd graph][8]
+
 ## Overview
 
 Collect etcd metrics to:
@@ -65,3 +67,4 @@ To get a better idea of how (or why) to integrate etcd with Datadog, check out o
 [5]: https://github.com/DataDog/integrations-core/blob/master/etcd/metadata.csv
 [6]: http://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/monitor-etcd-performance/
+[8]: https://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/etcd/etcd_graph.png

--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -1,5 +1,7 @@
 # Fluentd Integration
-{{< img src="integrations/fluentd/snapshot-fluentd.png" alt="Fluentd Dashboard" responsive="true" popup="true">}}
+
+![Fluentd Dashboard][9]
+
 ## Overview
 
 Get metrics from Fluentd to:
@@ -86,3 +88,4 @@ Need help? Contact [Datadog Support][7].
 [6]: https://github.com/DataDog/integrations-core/blob/master/fluentd/metadata.csv
 [7]: http://docs.datadoghq.com/help/
 [8]: https://www.datadoghq.com/blog/monitor-fluentd-datadog/
+[9]: https://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/fluentd/snapshot-fluentd.png

--- a/go_expvar/README.md
+++ b/go_expvar/README.md
@@ -1,5 +1,7 @@
 # Go Expvar Integration
-{{< img src="integrations/goexpvar/go_graph.png" alt="Go Graph" responsive="true" popup="true">}}
+
+![Go graph][11]
+
 ## Overview
 
 Track the memory usage of your Go services and collect metrics instrumented from Go's expvar package.
@@ -77,3 +79,4 @@ Need help? Contact [Datadog Support][9].
 [8]: https://github.com/DataDog/integrations-core/blob/master/go_expvar/metadata.csv
 [9]: http://docs.datadoghq.com/help/
 [10]: https://www.datadoghq.com/blog/instrument-go-apps-expvar-datadog/
+[11]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/goexpvar/go_graph.png

--- a/iis/README.md
+++ b/iis/README.md
@@ -1,5 +1,6 @@
 # IIS Integration
-{{< img src="integrations/iis/iisgraph.png" alt="IIS Graph" responsive="true" popup="true">}}
+
+![IIS Graph][10]
 
 ## Overview
 
@@ -165,3 +166,4 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [7]: https://github.com/DataDog/integrations-core/blob/master/iis/metadata.csv
 [8]: http://docs.datadoghq.com/help/
 [9]: https://www.datadoghq.com/blog/
+[10]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/iis/iisgraph.png

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,5 +1,7 @@
 # Kubernetes Integration
-{{< img src="integrations/kubernetes/k8sdashboard.png" alt="Kubernetes Dashboard" responsive="true" popup="true">}}
+
+![Kubernetes Dashboard][15]
+
 ## Overview
 
 Get metrics from kubernetes service in real time to:
@@ -179,3 +181,4 @@ To get a better idea of how (or why) to integrate your Kubernetes service, check
 [12]: https://www.datadoghq.com/blog/monitoring-kubernetes-era/
 [13]: https://docs.datadoghq.com/agent/faq/how-to-get-more-out-of-your-kubernetes-integration
 [14]: https://docs.datadoghq.com/agent/faq/how-to-report-host-disk-metrics-when-dd-agent-runs-in-a-docker-container
+[15]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/kubernetes/k8sdashboard.png

--- a/lighttpd/README.md
+++ b/lighttpd/README.md
@@ -1,5 +1,7 @@
 # Lighttpd Check
-{{< img src="integrations/lighttpd/lighttpddashboard.png" alt="Lighttpd Dashboard" responsive="true" popup="true">}}
+
+![Lighttpd Dashboard][8]
+
 ## Overview
 
 The Agent's lighttpd check tracks uptime, bytes served, requests per second, response codes, and more.
@@ -61,3 +63,4 @@ To get a better idea of how (or why) to monitor Lighttpd web server metrics with
 [5]: https://github.com/DataDog/integrations-core/blob/master/lighttpd/metadata.csv
 [6]: http://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/monitor-lighttpd-web-server-metrics/
+[8]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/lighttpd/lighttpddashboard.png

--- a/network/README.md
+++ b/network/README.md
@@ -1,5 +1,7 @@
 # Network check
-{{< img src="integrations/network/netdashboard.png" alt="Network Dashboard" responsive="true" popup="true">}}
+
+![Network Dashboard][9]
+
 ## Overview
 
 The network check collects TCP/IP stats from the host operating system.
@@ -63,3 +65,4 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [6]: https://docs.datadoghq.com/integrations/faq/how-to-send-tcp-udp-host-metrics-via-the-datadog-api
 [7]: https://www.datadoghq.com/blog/
 [8]: https://docs.datadoghq.com/monitors/monitor_types/network
+[9]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/network/netdashboard.png

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -1,5 +1,6 @@
 # NGINX check
-{{< img src="integrations/nginx/nginx.jpg" alt="NGINX default dashboard" responsive="true" popup="true">}}
+
+![NGINX default dashboard][14]
 
 ## Overview
 
@@ -222,3 +223,4 @@ Learn more about how to monitor NGINX performance metrics thanks to [our series 
 [11]: https://www.datadoghq.com/blog/how-to-monitor-nginx/
 [12]: https://www.datadoghq.com/blog/how-to-collect-nginx-metrics/index.html
 [13]: https://www.datadoghq.com/blog/how-to-monitor-nginx-with-datadog/index.html
+[14]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/nginx/nginx.jpg

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -1,5 +1,7 @@
 # Openstack Integration
-{{< img src="integrations/openstack/openstack.png" alt="OpenStack default dashboard" responsive="true" popup="true">}}
+
+![OpenStack default dashboard][10]
+
 ## Overview
 
 Get metrics from OpenStack service in real time to:
@@ -127,3 +129,4 @@ See also our blog posts:
 [7]: https://www.datadoghq.com/blog/openstack-monitoring-nova/
 [8]: https://www.datadoghq.com/blog/install-openstack-in-two-commands/
 [9]: https://www.datadoghq.com/blog/openstack-host-aggregates-flavors-availability-zones/
+[10]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/openstack/openstack.png

--- a/php_fpm/README.md
+++ b/php_fpm/README.md
@@ -1,5 +1,7 @@
 # PHP-FPM Check
-{{< img src="integrations/phpfpm/phpfpmoverview.png" alt="PHP overview" responsive="true" popup="true">}}
+
+![PHP overview][8]
+
 ## Overview
 
 The PHP-FPM check monitors the state of your FPM pool and tracks request performance.
@@ -70,3 +72,4 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [5]: https://github.com/DataDog/integrations-core/blob/master/php_fpm/metadata.csv
 [6]: http://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/
+[8]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/phpfpm/phpfpmoverview.png

--- a/postfix/README.md
+++ b/postfix/README.md
@@ -1,5 +1,7 @@
 # Postfix Check
-{{< img src="integrations/postfix/postfixgraph.png" alt="Postfix Graph" responsive="true" popup="true">}}
+
+![Postfix Graph][8]
+
 ## Overview
 
 This check monitors the size of all your Postfix queues.
@@ -105,3 +107,4 @@ Need help? Contact [Datadog Support][6].
 [5]: https://github.com/DataDog/integrations-core/blob/master/postfix/metadata.csv
 [6]: http://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/monitor-postfix-queues/
+[8]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/postfix/postfixgraph.png

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -1,5 +1,6 @@
 # PostgreSQL Integration
-{{< img src="integrations/postgresql/pggraph.png" alt="PostgreSQL Graph" responsive="true" popup="true">}}
+
+![PostgreSQL Graph][24]
 
 ## Overview
 
@@ -217,3 +218,4 @@ You should also check the `/var/log/datadog/collector.log` file for more informa
 [21]: https://www.datadoghq.com/blog/postgresql-monitoring/
 [22]: https://www.datadoghq.com/blog/postgresql-monitoring-tools/
 [23]: https://www.datadoghq.com/blog/collect-postgresql-data-with-datadog/
+[24]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/postgresql/pggraph.png

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -1,5 +1,7 @@
 # RabbitMQ Check
-{{< img src="integrations/rabbitmq/rabbitmqdashboard.png" alt="RabbitMQ Dashboard" responsive="true" popup="true">}}
+
+![RabbitMQ Dashboard][13]
+
 ## Overview
 
 The RabbitMQ check lets you:
@@ -149,3 +151,4 @@ Returns CRITICAL if the Agent cannot connect to rabbitmq to collect metrics, oth
 [10]: https://www.datadoghq.com/blog/rabbitmq-monitoring-tools/
 [11]: https://www.datadoghq.com/blog/monitoring-rabbitmq-performance-with-datadog/
 [12]: https://app.datadoghq.com/account/settings#integrations/rabbitmq
+[13]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/rabbitmq/rabbitmqdashboard.png

--- a/riak/README.md
+++ b/riak/README.md
@@ -1,5 +1,6 @@
 # Riak Check
-{{< img src="integrations/riak/riak_graph.png" alt="Riak Graph" responsive="true" popup="true">}}
+
+![Riak Graph][8]
 
 ## Overview
 
@@ -56,3 +57,4 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [5]: https://github.com/DataDog/integrations-core/blob/master/riak/metadata.csv
 [6]: http://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/
+[8]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/riak/riak_graph.png

--- a/solr/README.md
+++ b/solr/README.md
@@ -1,5 +1,7 @@
 # Solr Check
-{{< img src="integrations/solr/solrgraph.png" alt="Solr Graph" responsive="true" popup="true">}}
+
+![Solr Graph][8]
+
 ## Overview
 
 The Solr check tracks the state and performance of a Solr cluster. It collects metrics like number of documents indexed, cache hits and evictions, average request times, average requests per second, and more.
@@ -272,3 +274,4 @@ You may use the `attribute` filter as follow:
 [5]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [6]: https://github.com/DataDog/integrations-core/blob/master/solr/metadata.csv
 [7]: https://www.datadoghq.com/blog/
+[8]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/solr/solrgraph.png

--- a/spark/README.md
+++ b/spark/README.md
@@ -1,5 +1,7 @@
 # Spark Check
-{{< img src="integrations/spark/sparkgraph.png" alt="spark graph" responsive="true" popup="true">}}
+
+![Spark Graph][10]
+
 ## Overview
 
 The Spark check collects metrics for:
@@ -85,3 +87,4 @@ To get Spark metrics if Spark is set up on AWS EMR, [use bootstrap actions][6] t
 [7]: https://docs.datadoghq.com/agent/
 [8]: https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-connect-master-node-ssh.html
 [9]: https://www.datadoghq.com/blog/monitoring-spark/
+[10]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/spark/sparkgraph.png

--- a/sqlserver/README.md
+++ b/sqlserver/README.md
@@ -1,5 +1,7 @@
 # Microsoft SQL Server Check
-{{< img src="integrations/sql_server/sql_server_graph.png" alt="sql server graph" responsive="true" popup="true">}}
+
+![SQL server Graph][12]
+
 ## Overview
 
 This check lets you track the performance of your SQL Server instances. It collects metrics for number of user connections, rate of SQL compilations, and more.
@@ -86,3 +88,4 @@ Need help? Contact [Datadog Support][6].
 [9]: https://www.datadoghq.com/blog/sql-server-monitoring-tools/
 [10]: https://www.datadoghq.com/blog/sql-server-performance/
 [11]: https://www.datadoghq.com/blog/sql-server-metrics/
+[12]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/sql_server/sql_server_graph.png

--- a/supervisord/README.md
+++ b/supervisord/README.md
@@ -1,5 +1,7 @@
 # Agent Check: Supervisor
-{{< img src="integrations/supervisor/supervisorevent.png" alt="Supervisor Event" responsive="true" popup="true">}}
+
+![Supervisor Event][8]
+
 ## Overview
 
 This check monitors the uptime, status, and number of processes running under supervisord.
@@ -132,3 +134,4 @@ Need help? Contact [Datadog Support][6].
 [5]: https://github.com/DataDog/integrations-core/blob/master/supervisord/metadata.csv
 [6]: http://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/supervisor-monitors-your-processes-datadog-monitors-supervisor/
+[8]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/supervisor/supervisorevent.png

--- a/system_core/README.md
+++ b/system_core/README.md
@@ -1,5 +1,7 @@
 # Agent Check: system cores
-{{< img src="integrations/systemcore/syscoredash.png" alt="System Core" responsive="true" popup="true">}}
+
+![System Core][8]
+
 ## Overview
 
 This check collects the number of CPU cores on a host and CPU times (i.e. system, user, idle, etc).
@@ -55,3 +57,4 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [5]: https://github.com/DataDog/integrations-core/blob/master/system_core/metadata.csv
 [6]: http://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/
+[8]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/systemcore/syscoredash.png

--- a/tcp_check/README.md
+++ b/tcp_check/README.md
@@ -1,5 +1,7 @@
 # Agent Check: TCP connectivity
-{{< img src="integrations/tcpcheck/netgraphs.png" alt="Network Graphs" responsive="true" popup="true">}}
+
+![Network Graph][9]
+
 ## Overview
 
 Monitor TCP connectivity and response time for any host and port.
@@ -71,3 +73,4 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [6]: https://app.datadoghq.com/monitors#/create
 [7]: http://docs.datadoghq.com/help/
 [8]: https://www.datadoghq.com/blog/
+[9]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/tcpcheck/netgraphs.png

--- a/varnish/README.md
+++ b/varnish/README.md
@@ -1,5 +1,6 @@
 # Agent Check: Varnish
-{{< img src="integrations/varnish/varnish.png" alt="Varnish default dashboard" responsive="true" popup="true">}}
+
+![Varnish default dashboard][11]
 
 ## Overview
 
@@ -133,3 +134,4 @@ Need help? Contact [Datadog Support][7].
 [8]: https://www.datadoghq.com/blog/top-varnish-performance-metrics/
 [9]: https://www.datadoghq.com/blog/how-to-collect-varnish-metrics/
 [10]: https://www.datadoghq.com/blog/monitor-varnish-using-datadog/
+[11]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/varnish/varnish.png

--- a/vsphere/README.md
+++ b/vsphere/README.md
@@ -1,5 +1,7 @@
 # Agent Check: VMWare vSphere
-{{< img src="integrations/vmware/vsphere_graph.png" alt="vsphere graph" responsive="true" popup="true">}}
+
+![Vsphere Graph][8]
+
 ## Overview
 
 This check collects resource usage metrics from your vSphere cluster—CPU, disk, memory, and network usage. It also watches your vCenter server for events and emits them to Datadog.
@@ -88,3 +90,4 @@ See our [blog post][7] on monitoring vSphere environments with Datadog.
 [5]: https://github.com/DataDog/integrations-core/blob/master/vsphere/metadata.csv
 [6]: https://docs.datadoghq.com/integrations/faq/can-i-limit-the-number-of-vms-that-are-pulled-in-via-the-vmware-integration
 [7]: https://www.datadoghq.com/blog/unified-vsphere-app-monitoring-datadog/#auto-discovery-across-vm-and-app-layers
+[8]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/vmware/vsphere_graph.png

--- a/wmi_check/README.md
+++ b/wmi_check/README.md
@@ -1,5 +1,7 @@
 # Wmi_check Integration
-{{< img src="integrations/wmi/wmimetric.png" alt="WMI Metric" responsive="true" popup="true">}}
+
+![WMI metric][12]
+
 ## Overview
 
 Get metrics from your Windows applications/servers with Windows Management Instrumentation (WMI) in real time to
@@ -142,3 +144,4 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [9]: https://github.com/DataDog/integrations-core/blob/master/wmi_check/metadata.csv
 [10]: http://docs.datadoghq.com/help/
 [11]: https://www.datadoghq.com/blog/
+[12]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/wmi/wmimetric.png

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -1,5 +1,7 @@
 # Agent Check: Hadoop YARN
-{{< img src="integrations/yarn/yarndashboard.png" alt="Hadoop Yarn" responsive="true" popup="true">}}
+
+![Hadoop Yarn][11]
+
 ## Overview
 
 This check collects metrics from your YARN ResourceManager, including (but not limited to)::
@@ -69,3 +71,4 @@ Need help? Contact [Datadog Support][6].
 [8]: https://www.datadoghq.com/blog/monitor-hadoop-metrics/
 [9]: https://www.datadoghq.com/blog/collecting-hadoop-metrics/
 [10]: https://www.datadoghq.com/blog/monitor-hadoop-metrics-datadog/
+[11]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/yarn/yarndashboard.png

--- a/zk/README.md
+++ b/zk/README.md
@@ -1,5 +1,7 @@
 # Agent Check: Zookeeper
-{{< img src="integrations/zookeeper/zookeepergraph.png" alt="Zookeeper Dashboard" responsive="true" popup="true">}}
+
+![Zookeeper Dashboard][20]
+
 ## Overview
 
 The Zookeeper check tracks client connections and latencies, monitors the number of unprocessed requests, and more.
@@ -145,3 +147,4 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [17]: https://github.com/DataDog/integrations-core/blob/master/zk/metadata.csv
 [18]: http://docs.datadoghq.com/help/
 [19]: https://www.datadoghq.com/blog/
+[20]: http://raw.githubusercontent.com/DataDog/documentation/master/src/images/integrations/zookeeper/zookeepergraph.png


### PR DESCRIPTION
### What does this PR do?

Since the integrations, pipeline is now fixed for in-app automated generation, and the documentation supports non-partial code, let's start the migration of all integrations to the new logic (with logo directly in the repo) 

This is the first PR of a journey that tries to unify our integrations in the app/in the doc/in this repo.

It's removing all partial code that was only used on the doc (all the `{{< img ...`), replacing it with the classic markdown layout for images.

Next step is going to add to each integration of this repo a screenshot of the in-app OOTB Dashboard. 

Then the final step will be to populate each integrations folder with the proper logo.