### PR TITLE
Removing unnecessary and misleading kube_proxy auto_conf.yaml

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/base_check.py
@@ -92,9 +92,7 @@ class GenericPrometheusCheck(AgentCheck):
             self.get_scraper(instance)
 
     def check(self, instance):
-        endpoint = instance["prometheus_url"]
-        if endpoint is None:
-            endpoint = instance["prometheus_endpoint"]
+        endpoint = instance.get('prometheus_url') or instance.get('prometheus_endpoint')
         if endpoint is None:
             raise CheckException("No endpoint was defined in the prometheus check configuration")
 

--- a/datadog_checks_base/datadog_checks/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/base_check.py
@@ -92,10 +92,7 @@ class GenericPrometheusCheck(AgentCheck):
             self.get_scraper(instance)
 
     def check(self, instance):
-        endpoint = instance.get('prometheus_url') or instance.get('prometheus_endpoint')
-        if endpoint is None:
-            raise CheckException("No endpoint was defined in the prometheus check configuration")
-
+        endpoint = instance["prometheus_url"]
         scraper = self.get_scraper(instance)
         if not scraper.metrics_mapper:
             raise CheckException("You have to collect at least one metric from the endpoint: " + endpoint)

--- a/datadog_checks_base/datadog_checks/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/base_check.py
@@ -93,6 +93,11 @@ class GenericPrometheusCheck(AgentCheck):
 
     def check(self, instance):
         endpoint = instance["prometheus_url"]
+        if endpoint is None:
+            endpoint = instance["prometheus_endpoint"]
+        if endpoint is None:
+            raise CheckException("No endpoint was defined in the prometheus check configuration")
+
         scraper = self.get_scraper(instance)
         if not scraper.metrics_mapper:
             raise CheckException("You have to collect at least one metric from the endpoint: " + endpoint)

--- a/kube_proxy/datadog_checks/kube_proxy/data/auto_conf.yaml
+++ b/kube_proxy/datadog_checks/kube_proxy/data/auto_conf.yaml
@@ -1,7 +1,0 @@
-ad_identifiers:
-  - kube-proxy
-
-init_config:
-
-instances:
-  - prometheus_url: "http://%%host%%:10249/metrics"

--- a/kube_proxy/datadog_checks/kube_proxy/data/auto_conf.yaml
+++ b/kube_proxy/datadog_checks/kube_proxy/data/auto_conf.yaml
@@ -4,4 +4,4 @@ ad_identifiers:
 init_config:
 
 instances:
-  - prometheus_endpoint: "http://%%host%%:10249/metrics"
+  - prometheus_url: "http://%%host%%:10249/metrics"


### PR DESCRIPTION
### What does this PR do?

- Fix kube_proxy endpoint setting in the `autoconf.yaml`: it was set to `prometheus_endpoint` rather than `prometheus_url` and was invalid for use in a GenericPrometheusCheck
- Make `prometheus_endpoint` a valid option in GenericPrometheusCheck, while keeping `prometheus_url` as default

### Motivation

This broke the kube_proxy auto-discovery

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
