### PR TITLE
Stale bot changes

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 60
+daysUntilStale: 30
 # Number of days of inactivity before a stale Issue or Pull Request is closed
 daysUntilClose: 1095
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
@@ -9,8 +9,8 @@ exemptLabels:
 staleLabel: stale
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
-  This PR has been automatically marked as stale because it has not had
-  activity in the last 60 days. Note that the PR will not be automatically
+  This issue has been automatically marked as stale because it has not had
+  activity in the last 30 days. Note that the issue will not be automatically
   closed, but this notification will remind us to investigate why there's
   been inactivity. Thank you for participating in the Datadog open source community.
 # Comment to post when removing the stale label. Set to `false` to disable
@@ -18,4 +18,4 @@ unmarkComment: false
 # Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
 closeComment: false
 # Limit to only `issues` or `pulls`
-only: pulls
+# only: pulls


### PR DESCRIPTION
### What does this PR do?

Extends stale detections to issues, reduces inactivity time to 30 days.

### Motivation

Try to better keep track of stale issues and PRs
