### PR TITLE
Add an option to disable hostname override

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
@@ -19,7 +19,11 @@ instances:
     #    label_to_match: deployment
     #    labels_to_get:
     #      - label_addonmanager_kubernetes_io_mode
-    
+    # By default the hostname for metrics containing the node label will be
+    # overriden by the value of the label, this can be deactivated (all metrics
+    # will be attached to the host running KSM)
+    # hostname_override: true
+
     # You can also specify here custom tags to be added to all metrics reported by this integration
     #  tags:
     #    - optional_tag1

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -170,7 +170,9 @@ class KubernetesState(PrometheusCheck):
         # We do not support more than one instance of kube-state-metrics
         extra_labels = instances[0].get("label_joins", {})
         self.label_joins.update(extra_labels)
-        self.label_to_hostname = 'node'
+        hostname_override = instances[0].get('hostname_override', True)
+        if hostname_override:
+            self.label_to_hostname = 'node'
 
     def check(self, instance):
         endpoint = instance.get('kube_state_url')

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -178,7 +178,7 @@ def resourcequota_was_collected(aggregator):
     return False
 
 
-def test__update_kube_state_metrics(aggregator, instance, check):
+def test_update_kube_state_metrics(aggregator, instance, check):
     # run check twice to have pod/node mapping
     for _ in range(2):
         check.check(instance)
@@ -223,7 +223,7 @@ def test__update_kube_state_metrics(aggregator, instance, check):
     # assert resourcequota_was_collected(aggregator)
 
 
-def test__update_kube_state_metrics_v040(aggregator, instance, check):
+def test_update_kube_state_metrics_v040(aggregator, instance, check):
     # run check twice to have pod/node mapping
     for _ in range(2):
         check.check(instance)
@@ -239,7 +239,7 @@ def test__update_kube_state_metrics_v040(aggregator, instance, check):
     # assert resourcequota_was_collected(aggregator)
 
 
-def test__join_custom_labels(aggregator, instance, check):
+def test_join_custom_labels(aggregator, instance, check):
     instance['label_joins'] = {
         'kube_deployment_labels': {
             'label_to_match': 'deployment',
@@ -257,8 +257,14 @@ def test__join_custom_labels(aggregator, instance, check):
     for metric in METRICS:
         aggregator.assert_metric(metric, hostname=HOSTNAMES.get(metric, None))
         for tag in JOINED_METRICS.get(metric, []):
-            print aggregator.metrics(metric)
-            print tag
             aggregator.assert_metric_has_tag(metric, tag)
         if metric not in ZERO_METRICS:
             assert_not_all_zeroes(aggregator, metric)
+
+
+def test_disabling_hostname_override(instance):
+    check = KubernetesState(CHECK_NAME, {}, {}, [instance])
+    assert check.label_to_hostname == "node"
+    instance["hostname_override"] = False
+    check = KubernetesState(CHECK_NAME, {}, {}, [instance])
+    assert check.label_to_hostname is None


### PR DESCRIPTION
### What does this PR do?

Add an option to disable hostname override

### Motivation

In EC2 environnement EKS is reporting ec2 internal as node label, this might conflicts in some setup with several cluster where the IP could be the same.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
