### PR TITLE
Adding documentation of agent check flags for Elasticsearch

### DIFF
--- a/elastic/README.md
+++ b/elastic/README.md
@@ -29,8 +29,9 @@ init_config:
 instances:
   - url: http://localhost:9200 # or wherever your cluster API is listening
     cluster_stats: false # set true ONLY if you're not running the check on each cluster node
-    pshard_stats: true
-    pending_task_stats: true
+    pshard_stats: true # the agent sends primary shard metrics
+    index_stats: true # the agent sends index level metrics
+    pending_task_stats: true # the agent sends cluster-wide pending task metrics
 ```
 
 **Note**:
@@ -74,6 +75,13 @@ Finally, [Restart the Agent][3] to begin sending Elasticsearch metrics to Datado
 [Run the Agent's `status` subcommand][5] and look for `elastic` under the Checks section.
 
 ## Data Collected
+
+By default, not all of the following metrics are sent by the Agent. To send all metrics, configure flags in `elastic.yaml` as shown above.
+
+* `pshard_states` sends **elasticsearch.primaries.\*** and **elasticsearch.indices.count** metrics
+* `index_stats` sends **elasticsearch.index.\*** metrics
+* `pending_task_stats` sends **elasticsearch.pending_\*** metrics
+
 ### Metrics
 
 See [metadata.csv][6] for a list of metrics provided by this integration.


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?
By default, not all metrics are sent by the Agent (appears to be for optimization of performance, though the ticket says that performance is "probably not an issue") and three flags must be configured in order to send all metrics. These flags are now doumented.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
