### PR TITLE
Add Active Module Log integration documentation

### DIFF
--- a/active_directory/README.md
+++ b/active_directory/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Get metrics from Microsoft Active Directory to visualize and monitor its performances.
+Get metrics and logs from Microsoft Active Directory to visualize and monitor its performances.
 
 ## Setup
 
@@ -14,9 +14,39 @@ The Agent's Active Directory check is included in the [Datadog Agent][4] package
 
 1. Edit the `active_directory.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Active Directory performance data.
 
-    See the [sample active_directory.d/conf.yaml][1] for all available configuration options.
+#### Metric collection
+
+The default setup should already collect metrics for the localhost.
+See the [sample active_directory.d/conf.yaml][1] for all available configuration options.
 
 2. [Restart the Agent][7]
+
+#### Log Collection
+
+**Available for Agent >6.0**
+
+1. Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
+
+    ```yaml
+    logs_enabled: true
+    ```
+
+2. Add this configuration block to your `active_directory.d/conf.yaml` file to start collecting your Active Directory Logs:
+
+    ```yaml
+      logs:
+          - type: file
+            path: /path/to/my/directory/file.log
+            source: ruby
+            service: <MY_SERVICE>
+    ```
+
+    Change the `path` and `service` parameter values and configure them for your environment.
+    See the [sample active_directory.d/conf.yaml][1] for all available configuration options.
+
+3. This integration is intended for the [Active Directory Module for Ruby][8]. If you are not using the Ruby module, change the below source value to `active_directory` and configure the `path` for your environment.
+
+4. [Restart the Agent][7].
 
 ### Validation
 
@@ -46,3 +76,4 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [5]: http://docs.datadoghq.com/help/
 [6]: https://www.datadoghq.com/blog/
 [7]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
+[8]: https://www.rubydoc.info/gems/activedirectory/0.9.3

--- a/active_directory/datadog_checks/active_directory/data/conf.yaml.example
+++ b/active_directory/datadog_checks/active_directory/data/conf.yaml.example
@@ -18,3 +18,18 @@ instances:
   #   
   #   additional_metrics:
   #     - ['NTDS', none, 'DS % Writes from LDAP', active_directory.ds.writes_from_ldap, gauge]
+
+## Log Section (Available for Agent >=6.0)
+#logs:
+
+    # - type : (mandatory) type of log input source (tcp / udp / file / windows_event)
+    #   port / path /channel: (mandatory) Set port if type is tcp or udp. Set path if type is file and channel if windows_event
+    #   service : (mandatory) name of the service owning the log
+    #   source : (mandatory) attribute that defines which integration is sending the logs
+    #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
+    #   tags: (optional) add tags to each logs collected
+    
+    # - type: file
+    #   path: /path/to/active_directory/file.log
+    #   source: ruby
+    #   service: <MY_SERVICE>

--- a/active_directory/manifest.json
+++ b/active_directory/manifest.json
@@ -10,7 +10,8 @@
   "guid": "ba667ff3-cf6a-458c-aa4b-1172f33de562",
   "public_title": "Datadog-Active Directory Integration",
   "categories": [
-    "os & system"
+    "os & system",
+    "log collection"
   ],
   "doc_link": "https://docs.datadoghq.com/integrations/active_directory/",
   "is_public": true,


### PR DESCRIPTION
### What does this PR do?

Update the Active directory integration to contain Log collection instruction.

### Motivation

The ruby integration has been improved to take the Active Directory module into account.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
