### PR TITLE
Fix bug and typo in DEFAULT_CLUSTER_NAME for YARN check

### DIFF
--- a/mapreduce/datadog_checks/mapreduce/mapreduce.py
+++ b/mapreduce/datadog_checks/mapreduce/mapreduce.py
@@ -57,7 +57,7 @@ from datadog_checks.config import _is_affirmative
 
 class MapReduceCheck(AgentCheck):
     # Default Settings
-    DEFAULT_CUSTER_NAME = 'default_cluster'
+    DEFAULT_CLUSTER_NAME = 'default_cluster'
 
     # Service Check Names
     YARN_SERVICE_CHECK = 'mapreduce.resource_manager.can_connect'
@@ -143,9 +143,9 @@ class MapReduceCheck(AgentCheck):
         if cluster_name is None:
             self.warning(
                 "The cluster_name must be specified in the instance configuration, "
-                "defaulting to '{}'".format(self.DEFAULT_CUSTER_NAME)
+                "defaulting to '{}'".format(self.DEFAULT_CLUSTER_NAME)
             )
-            cluster_name = self.DEFAULT_CUSTER_NAME
+            cluster_name = self.DEFAULT_CLUSTER_NAME
 
         tags.append('cluster_name:{}'.format(cluster_name))
 

--- a/yarn/datadog_checks/yarn/yarn.py
+++ b/yarn/datadog_checks/yarn/yarn.py
@@ -94,7 +94,7 @@ from datadog_checks.config import _is_affirmative
 # Default settings
 DEFAULT_RM_URI = 'http://localhost:8088'
 DEFAULT_TIMEOUT = 5
-DEFAULT_CUSTER_NAME = 'default_cluster'
+DEFAULT_CLUSTER_NAME = 'default_cluster'
 DEFAULT_COLLECT_APP_METRICS = True
 MAX_DETAILED_QUEUES = 100
 
@@ -250,9 +250,9 @@ class YarnCheck(AgentCheck):
         if cluster_name is None:
             self.warning(
                 "The cluster_name must be specified in the instance configuration, "
-                "defaulting to '{}'".format(self.DEFAULT_CUSTER_NAME)
+                "defaulting to '{}'".format(DEFAULT_CLUSTER_NAME)
             )
-            cluster_name = self.DEFAULT_CUSTER_NAME
+            cluster_name = DEFAULT_CLUSTER_NAME
 
         tags.append('cluster_name:{}'.format(cluster_name))
 


### PR DESCRIPTION
### What does this PR do?
Due to #1684, a bug has been introduced in [`yarn.py`](https://github.com/DataDog/integrations-core/blame/master/yarn/datadog_checks/yarn/yarn.py#L253). Since `DEFAULT_CUSTER_NAME`  is not an attribute of `YarnCheck`, the check fails and metrics are not sent.

I corrected the typo in the meantime.

### Motivation
We noticed metrics were missing and that status error:
```
    yarn (1.3.0)
    ------------
      - instance #0 [ERROR]: "'YarnCheck' object has no attribute 'DEFAULT_CUSTER_NAME'"
      - Collected 0 metrics, 0 events & 0 service checks
```

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

