### PR TITLE
Update win32_event_log default yaml with log instructions

### DIFF
--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -100,3 +100,26 @@ instances:
   #     - Error
   #   tags:
   #     - system
+  
+## Log Section (Available for Agent >=6.0)
+#logs:
+
+    # - type : (mandatory) type of log input source (tcp / udp / file / windows_event)
+    #   port / path /channel: (mandatory) Set port if type is tcp or udp. Set path if type is file and channel if windows_event
+    #   service : (mandatory) name of the service owning the log
+    #   source : (mandatory) attribute that defines which integration is sending the logs
+    #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
+    #   tags: (optional) add tags to each logs collected
+  
+    # - type: windows_event
+    #   channel_path: <CHANNEL_1>
+    #   source: <CHANNEL_1>
+    #   service: myservice
+    #   sourcecategory: windowsevent
+    
+    # - type: windows_event
+    #   channel_path: <CHANNEL_2>
+    #   source: <CHANNEL_2>
+    #   service: myservice
+    #   sourcecategory: windowsevent
+


### PR DESCRIPTION
### What does this PR do?

Update the default yaml with log collection instruction

### Motivation

Forgot to do this when creating the log integration.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
