### PR TITLE
Reduce log spam on kubernetes tagging

### DIFF
--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -118,6 +118,9 @@ class ContainerFilter(object):
         :param pod_uid: pod UID for static pod detection
         :return: bool
         """
+        if not cid:
+            return True
+
         if cid in self.cache:
             return self.cache[cid]
 

--- a/kubelet/tests/test_common.py
+++ b/kubelet/tests/test_common.py
@@ -38,6 +38,16 @@ def test_container_filter(monkeypatch):
     assert short_cid in filter.containers
     is_excluded.assert_not_called()
 
+    # Test cid == None
+    is_excluded.reset_mock()
+    assert filter.is_excluded(None) is True
+    is_excluded.assert_not_called()
+
+    # Test cid == ""
+    is_excluded.reset_mock()
+    assert filter.is_excluded("") is True
+    is_excluded.assert_not_called()
+
     # Test non-existing container
     is_excluded.reset_mock()
     assert filter.is_excluded("invalid") is True


### PR DESCRIPTION
The `kubelet` check calls the golang tagger to tag metrics. The python glue passed queries with `None` or `""` (empty) cids, causing log spam on the golang side.
Filter these out on the python side

```
2018-06-28 14:22:57 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: uid None not found in pod list
2018-06-28 14:22:57 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-metadata-collector: uid None not found in pod list
```

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
~~- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)~~

### Additional Notes

Anything else we should know when reviewing?
