### PR TITLE
Update manifest.json

### DIFF
--- a/cisco_aci/manifest.json
+++ b/cisco_aci/manifest.json
@@ -11,10 +11,9 @@
   ],
   "guid": "8a20f56b-2e25-4a0b-a252-f5187dddeeef",
   "public_title": "Datadog-CiscoACI Integration",
-  "categories":["cisco", "networking"],
+  "categories":["networking"],
   "type": "check",
-  "doc_link": "https://docs.datadoghq.com/integrations/redisdb/",
-  "aliases": ["/integrations/cisco_aci/"],
+  "doc_link": "https://docs.datadoghq.com/integrations/cisco_aci/",
   "is_public": true,
   "has_logo": false
 }


### PR DESCRIPTION
### What does this PR do?

Fixes cisco manifest

### Motivation

wrong link, no cisco category on the doc, no need for an alias.