### PR TITLE
Submit k_state.nodes.by_condition as gauge instead of counter

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -4,7 +4,7 @@
 
 import re
 import time
-from collections import defaultdict
+from collections import defaultdict, Counter
 
 try:
     # Agent5 compatibility layer
@@ -452,6 +452,7 @@ class KubernetesState(PrometheusCheck):
         """ The ready status of a cluster node. v1.0+"""
         base_check_name = self.NAMESPACE + '.node'
         metric_name = self.NAMESPACE + '.nodes.by_condition'
+        by_condition_counter = Counter()
 
         for metric in message.metric:
             self._condition_to_tag_check(metric, base_check_name, self.condition_to_status_positive,
@@ -463,7 +464,10 @@ class KubernetesState(PrometheusCheck):
                 self._label_to_tag("condition", metric.label),
                 self._label_to_tag("status", metric.label)
             ] + self.custom_tags
-            self.count(metric_name, metric.gauge.value, tags)
+            by_condition_counter[tuple(sorted(tags))] += metric.gauge.value
+
+        for tags, count in by_condition_counter.iteritems():
+            self.gauge(metric_name, count, tags=list(tags))
 
     def kube_node_status_ready(self, message, **kwargs):
         """ The ready status of a cluster node (legacy)"""


### PR DESCRIPTION
### What does this PR do?

Because `AgentCheck.count()` will submit the resulting count as a `counter` instead of a `gauge`, this PR moves to an internal use of a [`collections.Counter()`](https://docs.python.org/2/library/collections.html#collections.Counter), to submit node counts as `gauge`.

### Motivation

Ensure the metric type is correct. **Upgrading all agents will be necessary for the correct type to be consistently picked up.**

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
~~- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)~~

### Additional Notes

Anything else we should know when reviewing?
