### PR TITLE
[docs] Rewrite Integration development docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ python project. The new structure should help keep a more sane and modular codeb
 To help with the transition, please take a look at the following map to understand
 where everything falls into place in the new approach.
 
-| FORMER LOCATION | NEW LOCATION |
-| --------------- | ------------ |
-| `{integration}/check.py` | `{integration}/datadog_checks/{integration}/*.py` |
-| `{integration}/test_check.py` | `{integration}/tests/*.py` |
-| n/a | `{integration}/setup.py` |
+| FORMER LOCATION               | NEW LOCATION                                      |
+| ---------------               | ------------                                      |
+| `{integration}/check.py`      | `{integration}/datadog_checks/{integration}/*.py` |
+| `{integration}/test_check.py` | `{integration}/tests/*.py`                        |
+| n/a                           | `{integration}/setup.py`                          |
 
 ## A note about installing
 
@@ -42,10 +42,10 @@ Each Datadog Agent release will continue to ship a set of the most up to date st
 
 **Note** The release process is currently in flux as we move toward the ability to ship wheels independently of Agent releases. Due to this, the Changelog may show a version and release that isn't yet available to download. Please check the below table to see which Integration versions are shipped with your Agent install.
 
-| Agent Version | List of Shipped Integration Versions |
-|---------------|--------------------------------------|
-| 6.2.1         | [Link][15] |
-| 6.3.0         | [Link][16] |
+| Agent Version   | List of Shipped Integration Versions   |
+| --------------- | -------------------------------------- |
+| 6.2.1           | [Link][15]                             |
+| 6.3.0           | [Link][16]                             |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ where everything falls into place in the new approach.
 
 | FORMER LOCATION | NEW LOCATION |
 | --------------- | ------------ |
-| {integration}/check.py | {integration}/datadog_checks/{integration}/*.py |
-| {integration}/test_check.py | {integration}/tests/*.py |
-| n/a | {integration}/setup.py |
+| `{integration}/check.py` | `{integration}/datadog_checks/{integration}/*.py` |
+| `{integration}/test_check.py` | `{integration}/tests/*.py` |
+| n/a | `{integration}/setup.py` |
 
 ## A note about installing
 
@@ -44,8 +44,8 @@ Each Datadog Agent release will continue to ship a set of the most up to date st
 
 | Agent Version | List of Shipped Integration Versions |
 |---------------|--------------------------------------|
-| 6.2.1         | [Link](https://github.com/DataDog/integrations-core/blob/6.2.1/requirements-integration-core.txt) |
-| 6.3.0         | [Link](https://github.com/DataDog/integrations-core/blob/ea2dfbf1e8859333af4c8db50553eb72a3b466f9/requirements-agent-release.txt) |
+| 6.2.1         | [Link][15] |
+| 6.3.0         | [Link][16] |
 
 ## Quick Start
 
@@ -77,3 +77,5 @@ and [knowledge base][12]. You can also visit our
 [12]: https://help.datadoghq.com/hc/en-us
 [13]: https://docs.datadoghq.com/help/
 [14]: https://github.com/DataDog/integrations-core/blob/master/tasks/constants.py#L15
+[15]: https://github.com/DataDog/integrations-core/blob/6.2.1/requirements-integration-core.txt
+[16]: https://github.com/DataDog/integrations-core/blob/ea2dfbf1e8859333af4c8db50553eb72a3b466f9/requirements-agent-release.txt

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -5,75 +5,27 @@ kind: documentation
 
 ## Why create an Integration?
 
-While we do have guides to submit [custom metrics][1] via our [API][2] and [code instrumentation][3], it's possible you might want to see a certain source become an integration available in the [official core repository][4] and bundled into the Agent package.
+[Custom Checks][11] are great for occasional reporting, or in cases where the data source is either unique or very limited. For more general use-cases — such as application frameworks, open source projects, or commonly-used software — it makes sense to write an Integration.
 
-Overall, the largest deciding factor in what integrations we build is what our clients request. There are two ways to propose an integration:
+Metrics reported from accepted Integrations are not counted as custom metrics, and therefore don’t impact your custom metric allocation. (Integrations that emit potentially unlimited metrics may still be considered custom.) Ensuring native support for Datadog reduces friction to adoption, and incentivizes people to use your product, service, or project. Also, being featured within the Datadog ecosystem is a great avenue for added visibility.
 
-* [Reach out to support@datadoghq.com][5] and tell us what metrics you would like to see from a given source.
-* Implement the integration yourself and submit the code to the [official extras repository][6].
+### What’s the process?
+The initial goal is to generate some code that collects the desired metrics in a reliable way, and to ensure that the general Integration framework is in place. Start by writing the basic functionality as a custom Check, then fill in the framework details from the [Create an Integration documentation][10].
 
-## Development basics
+Next, open a pull request against the [integrations-extras repository][6]. This signals to Datadog that you’re ready to start reviewing code together. Don’t worry if you have questions about tests, Datadog internals, or other topics — the Integrations team is ready to help, and the pull request is a good place to go over those concerns. Be sure to take advantage of the [Community Office Hours][12] as well!
 
-The remainder of this document introduces you to the base knowledge and setup required to start working on your own Integration. If you're comfortable with this content already, move on to the [technical specifics of Integration development][10] directly - otherwise, read on.
+Once the Integration has been validated (functionality, framework compliance, and general code quality) it will be merged into Extras. Once there, it becomes part of the Datadog ecosystem. Congratulations!
 
-### Prerequisites
+### What are your responsibilities?
 
-* Python 2.7, see [this page][7] for more details.
+Going forward, you — as the author of the code — are now the active maintainer of the Integration. You’re responsible for maintaining the code and ensuring the Integration’s functionality. There is no specific time commitment, but we do ask that you only agree to become a maintainer if you feel that you can take care of the code for the foreseeable future. Datadog extends support on a best-effort basis for Extras, so you won’t be on your own!
 
-### Quickstart
+## Let's get started!
 
-The project comes with a requirements file usable by `pip` to install all the dependencies needed to work with any Check. From the root of the repo, run:
-
-```
-pip install -r requirements-dev.txt
-```
-
-You must install the dependencies of a specific Check in order to work with it. The easiest way to iterate during development is by installing the wheel itself in editable mode. Consider the `disk` Check as an example:
-
-```
-cd disk && pip install -e .
-```
-
-Verify that everything is working as expected:
-
-```
-python -c"from datadog_checks.disk import Disk"
-```
-
-If the command exits without errors, you're good to go!
-
-### Testing
-
-Use `tox` to run the test suite for a given Check:
-
-```
-cd {integration} && tox
-```
-
-If you updated the test requirements for a check, run `tox --recreate` for your changes to become effective.
-
-### Building
-
-`setup.py` provides the setuptools setup script that helps us package and build the wheel. To learn more about Python packaging, take a look at [the official python documentation][9]
-
-Once your `setup.py` is ready, create a wheel:
-
-```
-  cd {integration}
-  python setup.py bdist_wheel
-```
-
-## Writing your own
-
-Now that you're comfortable with the basics, move on to the [technical specifics of Integration development][10].
+All of the details—including prerequisites, code examples, and more—are in the [Create a new Integration][10] documentation.
 
 [1]: https://docs.datadoghq.com/developers/metrics/
-[2]: https://docs.datadoghq.com/api/
-[3]: https://docs.datadoghq.com/developers/libraries/
-[4]: https://github.com/DataDog/integrations-core
-[5]: https://docs.datadoghq.com/help/
 [6]: https://github.com/DataDog/integrations-extras
-[7]: https://github.com/DataDog/integrations-core/blob/master/docs/dev/python.md
-[8]: https://docs.pytest.org/en/latest/
-[9]: https://packaging.python.org/tutorials/distributing-packages/
 [10]: https://github.com/DataDog/integrations-core/blob/master/docs/dev/new_check_howto.md 
+[11]: https://docs.datadoghq.com/developers/agent_checks/
+[12]: https://docs.datadoghq.com/developers/office_hours/

--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -21,7 +21,7 @@ These requirements are used during the code review process as a checklist. This 
 
 Python 2.7 needs to be available on your system. It is strongly recommended to create and activate a [Python virtual environment][5] in order to isolate the development environment. See the [Python Environment documentation][6] for more information.
 
-You'll also need [cookiecutter][1] to generate a template, and `docker-compose` in order to run the test harness. 
+You'll also need `docker-compose` in order to run the test harness. 
 
 ## Setup
 
@@ -336,3 +336,4 @@ python setup.py bdist_wheel
 [5]: https://virtualenv.pypa.io/en/stable/
 [6]: https://github.com/DataDog/integrations-core/blob/master/docs/dev/python.md
 [7]: https://github.com/DataDog/integrations-extras
+[9]: https://packaging.python.org/tutorials/distributing-packages/

--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -21,11 +21,11 @@ These requirements are used during the code review process as a checklist. This 
 
 Python 2.7 needs to be available on your system. It is strongly recommended to create and activate a [Python virtual environment][5] in order to isolate the development environment. See the [Python Environment documentation][6] for more information.
 
-You'll also need `docker-compose` in order to run the test harness. 
+You'll also need [cookiecutter][1] to generate a template, and `docker-compose` in order to run the test harness. 
 
 ## Setup
 
-Clone the [integrations extras repository][IntegrationsExtrasRepository] and point your shell at the root:
+Clone the [integrations extras repository][7] and point your shell at the root:
 
 ```
 git clone https://github.com/DataDog/integrations-extras.git && cd integrations-extras
@@ -318,6 +318,16 @@ Our check sends a Service Check though, so we need to add it to the `service_che
 ]
 ```
 
+### Building
+
+`setup.py` provides the setuptools setup script that helps us package and build the wheel. To learn more about Python packaging, take a look at [the official python documentation][9]
+
+Once your `setup.py` is ready, create a wheel:
+
+```
+cd {integration}
+python setup.py bdist_wheel
+```
 
 [1]: https://github.com/audreyr/cookiecutter
 [2]: https://github.com/DataDog/datadog-agent/blob/6.2.x/docs/dev/checks/python/check_api.md
@@ -325,4 +335,4 @@ Our check sends a Service Check though, so we need to add it to the `service_che
 [4]: https://tox.readthedocs.io/en/latest/
 [5]: https://virtualenv.pypa.io/en/stable/
 [6]: https://github.com/DataDog/integrations-core/blob/master/docs/dev/python.md
-[IntegrationsExtrasRepository]: https://github.com/DataDog/integrations-extras
+[7]: https://github.com/DataDog/integrations-extras


### PR DESCRIPTION
### What does this PR do?

This is a complete rewrite of the README which comprises the introduction to Integration development. The "Quickstart" has been removed since the information there is effectively duplicated in `new_check_howto.md`, with the notable exception of the "Building" section, which has been moved in its entirety.

### Motivation

The goal here is to make the benefits and responsibilities of developing an Integration more clear, especially as represented within the Datadog documentation proper.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

This also touches the root README - just some minor formatting adjustments though.