### PR TITLE
Fixing typo in the pod list path used in the kubelet integration 

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -24,7 +24,7 @@ from .prometheus import CadvisorPrometheusScraper
 
 KUBELET_HEALTH_PATH = '/healthz'
 NODE_SPEC_PATH = '/spec'
-POD_LIST_PATH = '/pods/'
+POD_LIST_PATH = '/pods'
 CADVISOR_METRICS_PATH = '/metrics/cadvisor'
 KUBELET_METRICS_PATH = '/metrics'
 


### PR DESCRIPTION
### What does this PR do?

Fixing typo from `/pods/` to `/pods` in `POD_LIST_PATH`

### Motivation

Experiments with the kubelet check showed accesses to path `/pods/?verbose=True` instead of `/pods?verbose=True` when the pod list is retrieved in this request: https://github.com/DataDog/integrations-core/blob/master/kubelet/datadog_checks/kubelet/kubelet.py#L178

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
