### PR TITLE
[ci skip] Bumped php_fpm version to 1.2.0

### DIFF
--- a/php_fpm/CHANGELOG.md
+++ b/php_fpm/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - php_fpm
 
+## 1.2.0 / 2018-07-06
+
+* [Added] Add exponential backoff when status returns 503. See [#1851](https://github.com/DataDog/integrations-core/pull/1851).
+* [Changed] Add data files to the wheel package. See [#1727](https://github.com/DataDog/integrations-core/pull/1727).
+
 ## 1.1.0 / 2018-01-10
 
 * [IMPROVEMENT] Adds a timeout parameter. See #206, thanks @toksvaeth.

--- a/php_fpm/datadog_checks/php_fpm/__about__.py
+++ b/php_fpm/datadog_checks/php_fpm/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -57,7 +57,7 @@ openstack==1.3.0
 oracle==1.3.0
 pdh_check==1.2.0; sys_platform == 'win32'
 pgbouncer==1.2.1; sys_platform != 'win32'
-php_fpm==1.1.0
+php_fpm==1.2.0
 postfix==1.2.1; sys_platform != 'win32'
 postgres==2.1.3
 powerdns_recursor==1.0.0


### PR DESCRIPTION
### What does this PR do?

See title