### PR TITLE
Add process metrics

### DIFF
--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -243,19 +243,18 @@ class Oracle(AgentCheck):
         if tags is None:
             tags = []
 
-        query = "SELECT PID, {} FROM GV$PROCESS".format(','.join(self.PROCESS_METRICS.keys()))
+        query = "SELECT PROGRAM, {} FROM GV$PROCESS".format(','.join(self.PROCESS_METRICS.keys()))
         with closing(con.cursor()) as cur:
             cur.execute(query)
             for row in cur.fetchall():
 
-                # Oracle process identifier
-                pid = row[0]
-                pid_tag = ['pid:{}'.format(pid)]
+                # Oracle program name
+                program_tag = ['program:{}'.format(row[0])]
 
                 # Get the metrics
                 for i, metric_name in enumerate(self.PROCESS_METRICS.values(), 1):
                     metric_value = row[i]
-                    self.gauge(metric_name, metric_value, tags=tags + pid_tag)
+                    self.gauge(metric_name, metric_value, tags=tags + program_tag)
 
     def _get_tablespace_metrics(self, con, tags):
         if tags is None:

--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -248,9 +248,9 @@ class Oracle(AgentCheck):
             cur.execute(query)
             for row in cur.fetchall():
 
-                # Oracle process identifier for the process
+                # Oracle process identifier
                 pid = row[0]
-                pid_tag = "pid:{}".format(pid)
+                pid_tag = ['pid:{}'.format(pid)]
 
                 # Get the metrics
                 for i, metric_name in enumerate(self.PROCESS_METRICS.values(), 1):

--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -4,6 +4,7 @@
 
 # stdlib
 from contextlib import closing
+from collections import OrderedDict
 
 # 3rd party
 import jaydebeapi as jdb
@@ -53,6 +54,13 @@ class Oracle(AgentCheck):
         'Temp Space Used':                  'oracle.temp_space_used',
     }
 
+    PROCESS_METRICS = OrderedDict([
+        ('PGA_USED_MEM', 'oracle.process.pga_used_memory'),
+        ('PGA_ALLOC_MEM', 'oracle.process.pga_allocated_memory'),
+        ('PGA_FREEABLE_MEM', 'oracle.process.pga_freeable_memory'),
+        ('PGA_MAX_MEM', 'oracle.process.pga_maximum_memory')
+    ])
+
     def check(self, instance):
         self.use_oracle_client = True
         server, user, password, service, jdbc_driver, tags, custom_queries = self._get_config(instance)
@@ -71,6 +79,7 @@ class Oracle(AgentCheck):
 
         with closing(self._get_connection(server, user, password, service, jdbc_driver, tags)) as con:
             self._get_sys_metrics(con, tags)
+            self._get_process_metrics(con, tags)
             self._get_tablespace_metrics(con, tags)
             self._get_custom_metrics(con, custom_queries, tags)
 
@@ -229,6 +238,24 @@ class Oracle(AgentCheck):
                 metric_value = row[1]
                 if metric_name in self.SYS_METRICS:
                     self.gauge(self.SYS_METRICS[metric_name], metric_value, tags=tags)
+
+    def _get_process_metrics(self, con, tags):
+        if tags is None:
+            tags = []
+
+        query = "SELECT PID, {} FROM GV$PROCESS".format(','.join(self.PROCESS_METRICS.keys()))
+        with closing(con.cursor()) as cur:
+            cur.execute(query)
+            for row in cur.fetchall():
+
+                # Oracle process identifier for the process
+                pid = row[0]
+                pid_tag = "pid:{}".format(pid)
+
+                # Get the metrics
+                for i, metric_name in enumerate(self.PROCESS_METRICS.values(), 1):
+                    metric_value = row[i]
+                    self.gauge(metric_name, metric_value, tags=tags + pid_tag)
 
     def _get_tablespace_metrics(self, con, tags):
         if tags is None:

--- a/oracle/metadata.csv
+++ b/oracle/metadata.csv
@@ -21,10 +21,10 @@ oracle.memory_sorts_ratio,gauge,,fraction,,memory sorts ratio,0,oracle_database,
 oracle.database_wait_time_ratio,gauge,,fraction,,memory sorts per second,0,oracle_database,db wait-time ratio
 oracle.session_limit_usage,gauge,,percent,,session limit usage,0,oracle_database,session lim usage %
 oracle.session_count,gauge,,,,session count,0,oracle_database,session count
-oracle.process.pga_used_memory,gauge,,,,PGA memory used by process,0,oracle_database,pga memory used
-oracle.process.pga_allocated_memory,gauge,,,,PGA memory allocated by process,0,oracle_database,pga memory allocated
-oracle.process.pga_freeable_memory,gauge,,,,PGA memory freeable by process,0,oracle_database,pga memory freeable
-oracle.process.pga_maximum_memory,gauge,,,,PGA maximum memory ever allocated by process,0,oracle_database,pga max memory allocated
+oracle.process.pga_used_memory,gauge,,byte,,PGA memory used by process,0,oracle_database,pga memory used
+oracle.process.pga_allocated_memory,gauge,,byte,,PGA memory allocated by process,0,oracle_database,pga memory allocated
+oracle.process.pga_freeable_memory,gauge,,byte,,PGA memory freeable by process,0,oracle_database,pga memory freeable
+oracle.process.pga_maximum_memory,gauge,,byte,,PGA maximum memory ever allocated by process,0,oracle_database,pga max memory allocated
 oracle.temp_space_used,gauge,,byte,,temp space used,0,oracle_database,temp space used
 oracle.tablespace.used,gauge,,byte,,tablespace used,0,oracle_database,tablespace used
 oracle.tablespace.size,gauge,,byte,,tablespace size,0,oracle_database,tablespace size

--- a/oracle/metadata.csv
+++ b/oracle/metadata.csv
@@ -21,6 +21,10 @@ oracle.memory_sorts_ratio,gauge,,fraction,,memory sorts ratio,0,oracle_database,
 oracle.database_wait_time_ratio,gauge,,fraction,,memory sorts per second,0,oracle_database,db wait-time ratio
 oracle.session_limit_usage,gauge,,percent,,session limit usage,0,oracle_database,session lim usage %
 oracle.session_count,gauge,,,,session count,0,oracle_database,session count
+oracle.process.pga_used_memory,gauge,,,,PGA memory used by process,0,oracle_database,pga memory used
+oracle.process.pga_allocated_memory,gauge,,,,PGA memory allocated by process,0,oracle_database,pga memory allocated
+oracle.process.pga_freeable_memory,gauge,,,,PGA memory freeable by process,0,oracle_database,pga memory freeable
+oracle.process.pga_maximum_memory,gauge,,,,PGA maximum memory ever allocated by process,0,oracle_database,pga max memory allocated
 oracle.temp_space_used,gauge,,byte,,temp space used,0,oracle_database,temp space used
 oracle.tablespace.used,gauge,,byte,,tablespace used,0,oracle_database,tablespace used
 oracle.tablespace.size,gauge,,byte,,tablespace size,0,oracle_database,tablespace size

--- a/oracle/tests/test_config.py
+++ b/oracle/tests/test_config.py
@@ -1,0 +1,29 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pytest
+from datadog_checks.oracle import OracleConfigError
+
+
+def test__get_config(check, instance):
+    """
+    Test the _get_config method
+    """
+    server, user, password, service, jdbc_driver, tags, custom_queries = check._get_config(instance)
+    assert user == 'system'
+    assert password == 'oracle'
+    assert service == 'xe'
+    assert jdbc_driver is None
+    assert tags == ['optional:tag1']
+    assert custom_queries == []
+    assert check.server == 'localhost:1521'
+
+
+def test_check_misconfig(check, instance):
+    """
+    Test bad config values
+    """
+    instance['server'] = None
+    with pytest.raises(OracleConfigError):
+        check.check(instance)

--- a/oracle/tests/test_metrics.py
+++ b/oracle/tests/test_metrics.py
@@ -1,0 +1,215 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import mock
+
+
+def test__get_sys_metrics(aggregator, check):
+    query = "SELECT METRIC_NAME, VALUE, BEGIN_TIME FROM GV$SYSMETRIC ORDER BY BEGIN_TIME"
+    con = mock.MagicMock()
+    cur = mock.MagicMock()
+    con.cursor.return_value = cur
+    cur.fetchall.return_value = zip(check.SYS_METRICS.keys(), [0] * len(check.SYS_METRICS.keys()))
+
+    check._get_sys_metrics(con, ["custom_tag"])
+
+    cur.execute.assert_called_with(query)
+    for _, metric in check.SYS_METRICS.items():
+        aggregator.assert_metric(metric, count=1, value=0, tags=["custom_tag"])
+
+
+def test__get_process_metrics(aggregator, check):
+    query = "SELECT PROGRAM, {} FROM GV$PROCESS".format(','.join(check.PROCESS_METRICS.keys()))
+    con = mock.MagicMock()
+    cur = mock.MagicMock()
+    con.cursor.return_value = cur
+    programs = [
+        "PSEUDO",
+        "oracle@localhost.localdomain (PMON)",
+        "oracle@localhost.localdomain (PSP0)",
+        "oracle@localhost.localdomain (VKTM)",
+    ]
+    cur.fetchall.return_value = [[program] + ([0] * len(check.PROCESS_METRICS)) for program in programs]
+
+    check._get_process_metrics(con, ['custom_tag'])
+
+    cur.execute.assert_called_with(query)
+    for i, metric_name in enumerate(check.PROCESS_METRICS.values()):
+        expected_program = programs[i]
+        aggregator.assert_metric(metric_name, count=1, value=0,
+                                 tags=['custom_tag', 'program:{}'.format(expected_program)])
+
+
+def test__get_tablespace_metrics(aggregator, check):
+    query = "SELECT TABLESPACE_NAME, sum(BYTES), sum(MAXBYTES) FROM sys.dba_data_files GROUP BY TABLESPACE_NAME"
+
+    con = mock.MagicMock()
+    cur = mock.MagicMock()
+    cur.fetchall.return_value = [
+        ["offline", None, 100],
+        ["normal", 50, 100],
+        ["full", 100, 100],
+        ["size_0", 1, None]
+    ]
+    con.cursor.return_value = cur
+
+    check._get_tablespace_metrics(con, ["custom_tag"])
+    cur.execute.assert_called_with(query)
+
+    # Offline tablespace
+    tags = ["custom_tag", "tablespace:offline"]
+    aggregator.assert_metric("oracle.tablespace.used", value=0, count=1, tags=tags)
+    aggregator.assert_metric("oracle.tablespace.size", value=100, count=1, tags=tags)
+    aggregator.assert_metric("oracle.tablespace.in_use", value=0, count=1, tags=tags)
+    aggregator.assert_metric("oracle.tablespace.offline", value=1, count=1, tags=tags)
+
+    # Normal tablespace
+    tags = ["custom_tag", "tablespace:normal"]
+    aggregator.assert_metric("oracle.tablespace.used", value=50, count=1, tags=tags)
+    aggregator.assert_metric("oracle.tablespace.size", value=100, count=1, tags=tags)
+    aggregator.assert_metric("oracle.tablespace.in_use", value=50, count=1, tags=tags)
+    aggregator.assert_metric("oracle.tablespace.offline", value=0, count=1, tags=tags)
+
+    # Full tablespace
+    tags = ["custom_tag", "tablespace:full"]
+    aggregator.assert_metric("oracle.tablespace.used", value=100, count=1, tags=tags)
+    aggregator.assert_metric("oracle.tablespace.size", value=100, count=1, tags=tags)
+    aggregator.assert_metric("oracle.tablespace.in_use", value=100, count=1, tags=tags)
+    aggregator.assert_metric("oracle.tablespace.offline", value=0, count=1, tags=tags)
+
+    # Size 0 tablespace
+    tags = ["custom_tag", "tablespace:size_0"]
+    aggregator.assert_metric("oracle.tablespace.used", value=1, count=1, tags=tags)
+    aggregator.assert_metric("oracle.tablespace.size", value=0, count=1, tags=tags)
+    aggregator.assert_metric("oracle.tablespace.in_use", value=100, count=1, tags=tags)
+    aggregator.assert_metric("oracle.tablespace.offline", value=0, count=1, tags=tags)
+
+
+def test__get_custom_metrics_misconfigured(check):
+    log = mock.MagicMock()
+    gauge = mock.MagicMock()
+    con = mock.MagicMock()
+    cursor = mock.MagicMock()
+    cursor.fetchone.return_value = ["foo", "bar"]
+    con.cursor.return_value = cursor
+    check.log = log
+    check.gauge = gauge
+
+    query = {}
+    custom_queries = [query]
+
+    # No metric_prefix
+    check._get_custom_metrics(None, custom_queries, None)
+    log.error.assert_called_once_with('custom query field `metric_prefix` is required')
+    log.reset_mock()
+
+    query["metric_prefix"] = "foo"
+
+    # No query for metric_prefix
+    check._get_custom_metrics(None, custom_queries, None)
+    log.error.assert_called_once_with('custom query field `query` is required for metric_prefix `foo`')
+    log.reset_mock()
+
+    query["query"] = "bar"
+
+    # No columns for metric_prefix
+    check._get_custom_metrics(None, custom_queries, None)
+    log.error.assert_called_once_with('custom query field `columns` is required for metric_prefix `foo`')
+    log.reset_mock()
+
+    query["columns"] = [{}]
+
+    # Wrong number of columns
+    check._get_custom_metrics(con, custom_queries, None)
+    log.error.assert_called_once_with('query result for metric_prefix foo: expected 1 columns, got 2')
+    log.reset_mock()
+
+    col1 = {"name": "baz", "type": "tag"}
+    col2 = {"foo": "bar"}
+    columns = [col1, col2]
+    query["columns"] = columns
+
+    # No name in column
+    check._get_custom_metrics(con, custom_queries, None)
+    log.error.assert_called_once_with('column field `name` is required for metric_prefix `foo`')
+    log.reset_mock()
+
+    del col2["foo"]
+    col2["name"] = "foo"
+
+    # No type in column
+    check._get_custom_metrics(con, custom_queries, None)
+    log.error.assert_called_once_with('column field `type` is required for column `foo` of metric_prefix `foo`')
+    log.reset_mock()
+
+    col2["type"] = "invalid"
+
+    # Invalid type column
+    check._get_custom_metrics(con, custom_queries, None)
+    log.error.assert_called_once_with('invalid submission method `invalid` for column `foo` of metric_prefix `foo`')
+    log.reset_mock()
+
+    col2["type"] = "gauge"
+
+    # Non numeric value
+    check._get_custom_metrics(con, custom_queries, None)
+    log.error.assert_called_once_with('non-numeric value `bar` for metric column `foo` of metric_prefix `foo`')
+
+    # No metric sent if errors
+    gauge.assert_not_called()
+
+
+def test__get_custom_metrics(aggregator, check):
+    con = mock.MagicMock()
+    cursor = mock.MagicMock()
+    cursor.fetchone.side_effect = [
+        ["tag_value1", "1"],
+        [1, 2, "tag_value2"]
+    ]
+    con.cursor.return_value = cursor
+
+    custom_queries = [
+        {
+            "metric_prefix": "oracle.test1",
+            "query": "mocked",
+            "columns": [
+                {
+                    "name": "tag_name",
+                    "type": "tag"
+                },
+                {
+                    "name": "metric",
+                    "type": "gauge"
+                }
+            ],
+            "tags": ["query_tags1"]
+        },
+        {
+            "metric_prefix": "oracle.test2",
+            "query": "mocked",
+            "columns": [
+                {
+                    "name": "rate",
+                    "type": "rate"
+                },
+                {
+                    "name": "gauge",
+                    "type": "gauge"
+                },
+                {
+                    "name": "tag_name",
+                    "type": "tag"
+                }
+            ],
+            "tags": ["query_tags2"]
+        }
+    ]
+
+    check._get_custom_metrics(con, custom_queries, ["custom_tag"])
+    aggregator.assert_metric("oracle.test1.metric", value=1, count=1,
+                             tags=["tag_name:tag_value1", "query_tags1", "custom_tag"])
+    aggregator.assert_metric("oracle.test2.gauge", value=2, count=1, metric_type=aggregator.GAUGE,
+                             tags=["tag_name:tag_value2", "query_tags2", "custom_tag"])
+    aggregator.assert_metric("oracle.test2.rate", value=1, count=1, metric_type=aggregator.RATE,
+                             tags=["tag_name:tag_value2", "query_tags2", "custom_tag"])

--- a/oracle/tests/test_oracle.py
+++ b/oracle/tests/test_oracle.py
@@ -5,306 +5,73 @@
 import mock
 import pytest
 import cx_Oracle
-from datadog_checks.oracle import OracleConfigError
 
 
-class TestConfig:
-    def test__get_config(self, check, instance):
-        """
-        Test the _get_config method
-        """
-        server, user, password, service, jdbc_driver, tags, custom_queries = check._get_config(instance)
-        assert user == 'system'
-        assert password == 'oracle'
-        assert service == 'xe'
-        assert jdbc_driver is None
-        assert tags == ['optional:tag1']
-        assert custom_queries == []
-        assert check.server == 'localhost:1521'
-
-    def test_check_misconfig(self, check, instance):
-        """
-        Test bad config values
-        """
-        instance['server'] = None
-        with pytest.raises(OracleConfigError):
-            check.check(instance)
+def test_client_fallback(check, instance):
+    """
+    Test the client fallback logic
+    """
+    check._get_connection = mock.MagicMock()
+    with mock.patch('datadog_checks.oracle.oracle.cx_Oracle') as cx:
+        check.check(instance)
+        assert check.use_oracle_client is True
+        cx.DatabaseError = cx_Oracle.DatabaseError
+        cx.clientversion.side_effect = cx_Oracle.DatabaseError
+        check.check(instance)
+        assert check.use_oracle_client is False
 
 
-class TestClientFallback:
-    def test_client_fallback(self, check, instance):
-        """
-        Test the client fallback logic
-        """
-        check._get_connection = mock.MagicMock()
-        with mock.patch('datadog_checks.oracle.oracle.cx_Oracle') as cx:
-            check.check(instance)
-            assert check.use_oracle_client is True
-            cx.DatabaseError = cx_Oracle.DatabaseError
-            cx.clientversion.side_effect = cx_Oracle.DatabaseError
-            check.check(instance)
-            assert check.use_oracle_client is False
+def test__get_connection_instant_client(check, instance):
+    """
+    Test the _get_connection method using the instant client
+    """
+    check.use_oracle_client = True
+    server, user, password, service, jdbc_driver, tags, _ = check._get_config(instance)
+    con = mock.MagicMock()
+    service_check = mock.MagicMock()
+    check.service_check = service_check
+    expected_tags = ['server:localhost:1521', 'optional:tag1']
+    with mock.patch('datadog_checks.oracle.oracle.cx_Oracle') as cx:
+        cx.connect.return_value = con
+        ret = check._get_connection(server, user, password, service, jdbc_driver, tags)
+        assert ret == con
+        assert check.service_check_tags == expected_tags
+        cx.connect.assert_called_with('system/oracle@//localhost:1521/xe')
+        service_check.assert_called_with(check.SERVICE_CHECK_NAME, check.OK, tags=expected_tags)
 
 
-class TestConnection:
-    def test__get_connection_instant_client(self, check, instance):
-        """
-        Test the _get_connection method using the instant client
-        """
-        check.use_oracle_client = True
-        server, user, password, service, jdbc_driver, tags, _ = check._get_config(instance)
-        con = mock.MagicMock()
-        service_check = mock.MagicMock()
-        check.service_check = service_check
-        expected_tags = ['server:localhost:1521', 'optional:tag1']
-        with mock.patch('datadog_checks.oracle.oracle.cx_Oracle') as cx:
-            cx.connect.return_value = con
-            ret = check._get_connection(server, user, password, service, jdbc_driver, tags)
-            assert ret == con
-            assert check.service_check_tags == expected_tags
-            cx.connect.assert_called_with('system/oracle@//localhost:1521/xe')
-            service_check.assert_called_with(check.SERVICE_CHECK_NAME, check.OK, tags=expected_tags)
-
-    def test__get_connection_jdbc(self, check, instance):
-        """
-        Test the _get_connection method using the JDBC client
-        """
-        check.use_oracle_client = False
-        server, user, password, service, jdbc_driver, tags, _ = check._get_config(instance)
-        con = mock.MagicMock()
-        service_check = mock.MagicMock()
-        check.service_check = service_check
-        expected_tags = ['server:localhost:1521', 'optional:tag1']
-        with mock.patch('datadog_checks.oracle.oracle.cx_Oracle'):
-            with mock.patch('datadog_checks.oracle.oracle.jdb') as jdb:
-                with mock.patch('datadog_checks.oracle.oracle.jpype') as jpype:
-                    jpype.isJVMStarted.return_value = False
-                    jdb.connect.return_value = con
-                    ret = check._get_connection(server, user, password, service, jdbc_driver, tags)
-                    assert ret == con
-                    assert check.service_check_tags == expected_tags
-                    jdb.connect.assert_called_with('oracle.jdbc.OracleDriver', 'jdbc:oracle:thin:@//localhost:1521/xe',
-                                                   ['system', 'oracle'], None)
-                    service_check.assert_called_with(check.SERVICE_CHECK_NAME, check.OK, tags=expected_tags)
-
-    def test__get_connection_failure(self, check, instance):
-        """
-        Test the right service check is sent upon _get_connection failures
-        """
-        check.use_oracle_client = True
-        expected_tags = ['server:localhost:1521', 'optional:tag1']
-        service_check = mock.MagicMock()
-        check.service_check = service_check
-        server, user, password, service, jdbc_driver, tags, _ = check._get_config(instance)
-        with pytest.raises(Exception):
-            check._get_connection(server, user, password, service, jdbc_driver, tags)
-        service_check.assert_called_with(check.SERVICE_CHECK_NAME, check.CRITICAL, tags=expected_tags)
+def test__get_connection_jdbc(check, instance):
+    """
+    Test the _get_connection method using the JDBC client
+    """
+    check.use_oracle_client = False
+    server, user, password, service, jdbc_driver, tags, _ = check._get_config(instance)
+    con = mock.MagicMock()
+    service_check = mock.MagicMock()
+    check.service_check = service_check
+    expected_tags = ['server:localhost:1521', 'optional:tag1']
+    with mock.patch('datadog_checks.oracle.oracle.cx_Oracle'):
+        with mock.patch('datadog_checks.oracle.oracle.jdb') as jdb:
+            with mock.patch('datadog_checks.oracle.oracle.jpype') as jpype:
+                jpype.isJVMStarted.return_value = False
+                jdb.connect.return_value = con
+                ret = check._get_connection(server, user, password, service, jdbc_driver, tags)
+                assert ret == con
+                assert check.service_check_tags == expected_tags
+                jdb.connect.assert_called_with('oracle.jdbc.OracleDriver', 'jdbc:oracle:thin:@//localhost:1521/xe',
+                                               ['system', 'oracle'], None)
+                service_check.assert_called_with(check.SERVICE_CHECK_NAME, check.OK, tags=expected_tags)
 
 
-class TestCustomMetrics:
-    def test__get_custom_metrics_misconfigured(self, check):
-        log = mock.MagicMock()
-        gauge = mock.MagicMock()
-        con = mock.MagicMock()
-        cursor = mock.MagicMock()
-        cursor.fetchone.return_value = ["foo", "bar"]
-        con.cursor.return_value = cursor
-        check.log = log
-        check.gauge = gauge
-
-        query = {}
-        custom_queries = [query]
-
-        # No metric_prefix
-        check._get_custom_metrics(None, custom_queries, None)
-        log.error.assert_called_once_with('custom query field `metric_prefix` is required')
-        log.reset_mock()
-
-        query["metric_prefix"] = "foo"
-
-        # No query for metric_prefix
-        check._get_custom_metrics(None, custom_queries, None)
-        log.error.assert_called_once_with('custom query field `query` is required for metric_prefix `foo`')
-        log.reset_mock()
-
-        query["query"] = "bar"
-
-        # No columns for metric_prefix
-        check._get_custom_metrics(None, custom_queries, None)
-        log.error.assert_called_once_with('custom query field `columns` is required for metric_prefix `foo`')
-        log.reset_mock()
-
-        query["columns"] = [{}]
-
-        # Wrong number of columns
-        check._get_custom_metrics(con, custom_queries, None)
-        log.error.assert_called_once_with('query result for metric_prefix foo: expected 1 columns, got 2')
-        log.reset_mock()
-
-        col1 = {"name": "baz", "type": "tag"}
-        col2 = {"foo": "bar"}
-        columns = [col1, col2]
-        query["columns"] = columns
-
-        # No name in column
-        check._get_custom_metrics(con, custom_queries, None)
-        log.error.assert_called_once_with('column field `name` is required for metric_prefix `foo`')
-        log.reset_mock()
-
-        del col2["foo"]
-        col2["name"] = "foo"
-
-        # No type in column
-        check._get_custom_metrics(con, custom_queries, None)
-        log.error.assert_called_once_with('column field `type` is required for column `foo` of metric_prefix `foo`')
-        log.reset_mock()
-
-        col2["type"] = "invalid"
-
-        # Invalid type column
-        check._get_custom_metrics(con, custom_queries, None)
-        log.error.assert_called_once_with('invalid submission method `invalid` for column `foo` of metric_prefix `foo`')
-        log.reset_mock()
-
-        col2["type"] = "gauge"
-
-        # Non numeric value
-        check._get_custom_metrics(con, custom_queries, None)
-        log.error.assert_called_once_with('non-numeric value `bar` for metric column `foo` of metric_prefix `foo`')
-
-        # No metric sent if errors
-        gauge.assert_not_called()
-
-    def test__get_custom_metrics(self, aggregator, check):
-        con = mock.MagicMock()
-        cursor = mock.MagicMock()
-        cursor.fetchone.side_effect = [
-            ["tag_value1", "1"],
-            [1, 2, "tag_value2"]
-        ]
-        con.cursor.return_value = cursor
-
-        custom_queries = [
-            {
-                "metric_prefix": "oracle.test1",
-                "query": "mocked",
-                "columns": [
-                    {
-                        "name": "tag_name",
-                        "type": "tag"
-                    },
-                    {
-                        "name": "metric",
-                        "type": "gauge"
-                    }
-                ],
-                "tags": ["query_tags1"]
-            },
-            {
-                "metric_prefix": "oracle.test2",
-                "query": "mocked",
-                "columns": [
-                    {
-                        "name": "rate",
-                        "type": "rate"
-                    },
-                    {
-                        "name": "gauge",
-                        "type": "gauge"
-                    },
-                    {
-                        "name": "tag_name",
-                        "type": "tag"
-                    }
-                ],
-                "tags": ["query_tags2"]
-            }
-        ]
-
-        check._get_custom_metrics(con, custom_queries, ["custom_tag"])
-        aggregator.assert_metric("oracle.test1.metric", value=1, count=1,
-                                 tags=["tag_name:tag_value1", "query_tags1", "custom_tag"])
-        aggregator.assert_metric("oracle.test2.gauge", value=2, count=1, metric_type=aggregator.GAUGE,
-                                 tags=["tag_name:tag_value2", "query_tags2", "custom_tag"])
-        aggregator.assert_metric("oracle.test2.rate", value=1, count=1, metric_type=aggregator.RATE,
-                                 tags=["tag_name:tag_value2", "query_tags2", "custom_tag"])
-
-
-class TestMetrics:
-    def test__get_sys_metrics(self, aggregator, check):
-        query = "SELECT METRIC_NAME, VALUE, BEGIN_TIME FROM GV$SYSMETRIC ORDER BY BEGIN_TIME"
-        con = mock.MagicMock()
-        cur = mock.MagicMock()
-        con.cursor.return_value = cur
-        cur.fetchall.return_value = zip(check.SYS_METRICS.keys(), [0] * len(check.SYS_METRICS.keys()))
-
-        check._get_sys_metrics(con, ["custom_tag"])
-
-        cur.execute.assert_called_with(query)
-        for _, metric in check.SYS_METRICS.items():
-            aggregator.assert_metric(metric, count=1, value=0, tags=["custom_tag"])
-
-    def test__get_process_metrics(self, aggregator, check):
-        query = "SELECT PROGRAM, {} FROM GV$PROCESS".format(','.join(check.PROCESS_METRICS.keys()))
-        con = mock.MagicMock()
-        cur = mock.MagicMock()
-        con.cursor.return_value = cur
-        programs = [
-            "PSEUDO",
-            "oracle@localhost.localdomain (PMON)",
-            "oracle@localhost.localdomain (PSP0)",
-            "oracle@localhost.localdomain (VKTM)",
-        ]
-        cur.fetchall.return_value = [[program] + ([0] * len(check.PROCESS_METRICS)) for program in programs]
-
-        check._get_process_metrics(con, ['custom_tag'])
-
-        cur.execute.assert_called_with(query)
-        for i, metric_name in enumerate(check.PROCESS_METRICS.values()):
-            expected_program = programs[i]
-            aggregator.assert_metric(metric_name, count=1, value=0,
-                                     tags=['custom_tag', 'program:{}'.format(expected_program)])
-
-    def test__get_tablespace_metrics(self, aggregator, check):
-        query = "SELECT TABLESPACE_NAME, sum(BYTES), sum(MAXBYTES) FROM sys.dba_data_files GROUP BY TABLESPACE_NAME"
-
-        con = mock.MagicMock()
-        cur = mock.MagicMock()
-        cur.fetchall.return_value = [
-            ["offline", None, 100],
-            ["normal", 50, 100],
-            ["full", 100, 100],
-            ["size_0", 1, None]
-        ]
-        con.cursor.return_value = cur
-
-        check._get_tablespace_metrics(con, ["custom_tag"])
-        cur.execute.assert_called_with(query)
-
-        # Offline tablespace
-        tags = ["custom_tag", "tablespace:offline"]
-        aggregator.assert_metric("oracle.tablespace.used", value=0, count=1, tags=tags)
-        aggregator.assert_metric("oracle.tablespace.size", value=100, count=1, tags=tags)
-        aggregator.assert_metric("oracle.tablespace.in_use", value=0, count=1, tags=tags)
-        aggregator.assert_metric("oracle.tablespace.offline", value=1, count=1, tags=tags)
-
-        # Normal tablespace
-        tags = ["custom_tag", "tablespace:normal"]
-        aggregator.assert_metric("oracle.tablespace.used", value=50, count=1, tags=tags)
-        aggregator.assert_metric("oracle.tablespace.size", value=100, count=1, tags=tags)
-        aggregator.assert_metric("oracle.tablespace.in_use", value=50, count=1, tags=tags)
-        aggregator.assert_metric("oracle.tablespace.offline", value=0, count=1, tags=tags)
-
-        # Full tablespace
-        tags = ["custom_tag", "tablespace:full"]
-        aggregator.assert_metric("oracle.tablespace.used", value=100, count=1, tags=tags)
-        aggregator.assert_metric("oracle.tablespace.size", value=100, count=1, tags=tags)
-        aggregator.assert_metric("oracle.tablespace.in_use", value=100, count=1, tags=tags)
-        aggregator.assert_metric("oracle.tablespace.offline", value=0, count=1, tags=tags)
-
-        # Size 0 tablespace
-        tags = ["custom_tag", "tablespace:size_0"]
-        aggregator.assert_metric("oracle.tablespace.used", value=1, count=1, tags=tags)
-        aggregator.assert_metric("oracle.tablespace.size", value=0, count=1, tags=tags)
-        aggregator.assert_metric("oracle.tablespace.in_use", value=100, count=1, tags=tags)
-        aggregator.assert_metric("oracle.tablespace.offline", value=0, count=1, tags=tags)
+def test__get_connection_failure(check, instance):
+    """
+    Test the right service check is sent upon _get_connection failures
+    """
+    check.use_oracle_client = True
+    expected_tags = ['server:localhost:1521', 'optional:tag1']
+    service_check = mock.MagicMock()
+    check.service_check = service_check
+    server, user, password, service, jdbc_driver, tags, _ = check._get_config(instance)
+    with pytest.raises(Exception):
+        check._get_connection(server, user, password, service, jdbc_driver, tags)
+    service_check.assert_called_with(check.SERVICE_CHECK_NAME, check.CRITICAL, tags=expected_tags)

--- a/oracle/tests/test_oracle.py
+++ b/oracle/tests/test_oracle.py
@@ -1,288 +1,302 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
 import mock
 import pytest
 import cx_Oracle
 from datadog_checks.oracle import OracleConfigError
 
 
-def test__get_config(check, instance):
-    """
-    Test the _get_config method
-    """
-    server, user, password, service, jdbc_driver, tags, custom_queries = check._get_config(instance)
-    assert user == 'system'
-    assert password == 'oracle'
-    assert service == 'xe'
-    assert jdbc_driver is None
-    assert tags == ['optional:tag1']
-    assert custom_queries == []
-    assert check.server == 'localhost:1521'
+class TestConfig:
+    def test__get_config(self, check, instance):
+        """
+        Test the _get_config method
+        """
+        server, user, password, service, jdbc_driver, tags, custom_queries = check._get_config(instance)
+        assert user == 'system'
+        assert password == 'oracle'
+        assert service == 'xe'
+        assert jdbc_driver is None
+        assert tags == ['optional:tag1']
+        assert custom_queries == []
+        assert check.server == 'localhost:1521'
+
+    def test_check_misconfig(self, check, instance):
+        """
+        Test bad config values
+        """
+        instance['server'] = None
+        with pytest.raises(OracleConfigError):
+            check.check(instance)
 
 
-def test_check_misconfig(check, instance):
-    """
-    Test bad config values
-    """
-    instance['server'] = None
-    with pytest.raises(OracleConfigError):
-        check.check(instance)
+class TestClientFallback:
+    def test_client_fallback(self, check, instance):
+        """
+        Test the client fallback logic
+        """
+        check._get_connection = mock.MagicMock()
+        with mock.patch('datadog_checks.oracle.oracle.cx_Oracle') as cx:
+            check.check(instance)
+            assert check.use_oracle_client is True
+            cx.DatabaseError = cx_Oracle.DatabaseError
+            cx.clientversion.side_effect = cx_Oracle.DatabaseError
+            check.check(instance)
+            assert check.use_oracle_client is False
 
 
-def test_client_fallback(check, instance):
-    """
-    Test the client fallback logic
-    """
-    check._get_connection = mock.MagicMock()
-    with mock.patch('datadog_checks.oracle.oracle.cx_Oracle') as cx:
-        check.check(instance)
-        assert check.use_oracle_client is True
-        cx.DatabaseError = cx_Oracle.DatabaseError
-        cx.clientversion.side_effect = cx_Oracle.DatabaseError
-        check.check(instance)
-        assert check.use_oracle_client is False
+class TestConnection:
+    def test__get_connection_instant_client(self, check, instance):
+        """
+        Test the _get_connection method using the instant client
+        """
+        check.use_oracle_client = True
+        server, user, password, service, jdbc_driver, tags, _ = check._get_config(instance)
+        con = mock.MagicMock()
+        service_check = mock.MagicMock()
+        check.service_check = service_check
+        expected_tags = ['server:localhost:1521', 'optional:tag1']
+        with mock.patch('datadog_checks.oracle.oracle.cx_Oracle') as cx:
+            cx.connect.return_value = con
+            ret = check._get_connection(server, user, password, service, jdbc_driver, tags)
+            assert ret == con
+            assert check.service_check_tags == expected_tags
+            cx.connect.assert_called_with('system/oracle@//localhost:1521/xe')
+            service_check.assert_called_with(check.SERVICE_CHECK_NAME, check.OK, tags=expected_tags)
+
+    def test__get_connection_jdbc(self, check, instance):
+        """
+        Test the _get_connection method using the JDBC client
+        """
+        check.use_oracle_client = False
+        server, user, password, service, jdbc_driver, tags, _ = check._get_config(instance)
+        con = mock.MagicMock()
+        service_check = mock.MagicMock()
+        check.service_check = service_check
+        expected_tags = ['server:localhost:1521', 'optional:tag1']
+        with mock.patch('datadog_checks.oracle.oracle.cx_Oracle'):
+            with mock.patch('datadog_checks.oracle.oracle.jdb') as jdb:
+                with mock.patch('datadog_checks.oracle.oracle.jpype') as jpype:
+                    jpype.isJVMStarted.return_value = False
+                    jdb.connect.return_value = con
+                    ret = check._get_connection(server, user, password, service, jdbc_driver, tags)
+                    assert ret == con
+                    assert check.service_check_tags == expected_tags
+                    jdb.connect.assert_called_with('oracle.jdbc.OracleDriver', 'jdbc:oracle:thin:@//localhost:1521/xe',
+                                                   ['system', 'oracle'], None)
+                    service_check.assert_called_with(check.SERVICE_CHECK_NAME, check.OK, tags=expected_tags)
+
+    def test__get_connection_failure(self, check, instance):
+        """
+        Test the right service check is sent upon _get_connection failures
+        """
+        check.use_oracle_client = True
+        expected_tags = ['server:localhost:1521', 'optional:tag1']
+        service_check = mock.MagicMock()
+        check.service_check = service_check
+        server, user, password, service, jdbc_driver, tags, _ = check._get_config(instance)
+        with pytest.raises(Exception):
+            check._get_connection(server, user, password, service, jdbc_driver, tags)
+        service_check.assert_called_with(check.SERVICE_CHECK_NAME, check.CRITICAL, tags=expected_tags)
 
 
-def test__get_connection_instant_client(check, instance):
-    """
-    Test the _get_connection method using the instant client
-    """
-    check.use_oracle_client = True
-    server, user, password, service, jdbc_driver, tags, _ = check._get_config(instance)
-    con = mock.MagicMock()
-    service_check = mock.MagicMock()
-    check.service_check = service_check
-    expected_tags = ['server:localhost:1521', 'optional:tag1']
-    with mock.patch('datadog_checks.oracle.oracle.cx_Oracle') as cx:
-        cx.connect.return_value = con
-        ret = check._get_connection(server, user, password, service, jdbc_driver, tags)
-        assert ret == con
-        assert check.service_check_tags == expected_tags
-        cx.connect.assert_called_with('system/oracle@//localhost:1521/xe')
-        service_check.assert_called_with(check.SERVICE_CHECK_NAME, check.OK, tags=expected_tags)
+class TestCustomMetrics:
+    def test__get_custom_metrics_misconfigured(self, check):
+        log = mock.MagicMock()
+        gauge = mock.MagicMock()
+        con = mock.MagicMock()
+        cursor = mock.MagicMock()
+        cursor.fetchone.return_value = ["foo", "bar"]
+        con.cursor.return_value = cursor
+        check.log = log
+        check.gauge = gauge
+
+        query = {}
+        custom_queries = [query]
+
+        # No metric_prefix
+        check._get_custom_metrics(None, custom_queries, None)
+        log.error.assert_called_once_with('custom query field `metric_prefix` is required')
+        log.reset_mock()
+
+        query["metric_prefix"] = "foo"
+
+        # No query for metric_prefix
+        check._get_custom_metrics(None, custom_queries, None)
+        log.error.assert_called_once_with('custom query field `query` is required for metric_prefix `foo`')
+        log.reset_mock()
+
+        query["query"] = "bar"
+
+        # No columns for metric_prefix
+        check._get_custom_metrics(None, custom_queries, None)
+        log.error.assert_called_once_with('custom query field `columns` is required for metric_prefix `foo`')
+        log.reset_mock()
+
+        query["columns"] = [{}]
+
+        # Wrong number of columns
+        check._get_custom_metrics(con, custom_queries, None)
+        log.error.assert_called_once_with('query result for metric_prefix foo: expected 1 columns, got 2')
+        log.reset_mock()
+
+        col1 = {"name": "baz", "type": "tag"}
+        col2 = {"foo": "bar"}
+        columns = [col1, col2]
+        query["columns"] = columns
+
+        # No name in column
+        check._get_custom_metrics(con, custom_queries, None)
+        log.error.assert_called_once_with('column field `name` is required for metric_prefix `foo`')
+        log.reset_mock()
+
+        del col2["foo"]
+        col2["name"] = "foo"
+
+        # No type in column
+        check._get_custom_metrics(con, custom_queries, None)
+        log.error.assert_called_once_with('column field `type` is required for column `foo` of metric_prefix `foo`')
+        log.reset_mock()
+
+        col2["type"] = "invalid"
+
+        # Invalid type column
+        check._get_custom_metrics(con, custom_queries, None)
+        log.error.assert_called_once_with('invalid submission method `invalid` for column `foo` of metric_prefix `foo`')
+        log.reset_mock()
+
+        col2["type"] = "gauge"
+
+        # Non numeric value
+        check._get_custom_metrics(con, custom_queries, None)
+        log.error.assert_called_once_with('non-numeric value `bar` for metric column `foo` of metric_prefix `foo`')
+
+        # No metric sent if errors
+        gauge.assert_not_called()
+
+    def test__get_custom_metrics(self, aggregator, check):
+        con = mock.MagicMock()
+        cursor = mock.MagicMock()
+        cursor.fetchone.side_effect = [
+            ["tag_value1", "1"],
+            [1, 2, "tag_value2"]
+        ]
+        con.cursor.return_value = cursor
+
+        custom_queries = [
+            {
+                "metric_prefix": "oracle.test1",
+                "query": "mocked",
+                "columns": [
+                    {
+                        "name": "tag_name",
+                        "type": "tag"
+                    },
+                    {
+                        "name": "metric",
+                        "type": "gauge"
+                    }
+                ],
+                "tags": ["query_tags1"]
+            },
+            {
+                "metric_prefix": "oracle.test2",
+                "query": "mocked",
+                "columns": [
+                    {
+                        "name": "rate",
+                        "type": "rate"
+                    },
+                    {
+                        "name": "gauge",
+                        "type": "gauge"
+                    },
+                    {
+                        "name": "tag_name",
+                        "type": "tag"
+                    }
+                ],
+                "tags": ["query_tags2"]
+            }
+        ]
+
+        check._get_custom_metrics(con, custom_queries, ["custom_tag"])
+        aggregator.assert_metric("oracle.test1.metric", value=1, count=1,
+                                 tags=["tag_name:tag_value1", "query_tags1", "custom_tag"])
+        aggregator.assert_metric("oracle.test2.gauge", value=2, count=1, metric_type=aggregator.GAUGE,
+                                 tags=["tag_name:tag_value2", "query_tags2", "custom_tag"])
+        aggregator.assert_metric("oracle.test2.rate", value=1, count=1, metric_type=aggregator.RATE,
+                                 tags=["tag_name:tag_value2", "query_tags2", "custom_tag"])
 
 
-def test__get_connection_jdbc(check, instance):
-    """
-    Test the _get_connection method using the JDBC client
-    """
-    check.use_oracle_client = False
-    server, user, password, service, jdbc_driver, tags, _ = check._get_config(instance)
-    con = mock.MagicMock()
-    service_check = mock.MagicMock()
-    check.service_check = service_check
-    expected_tags = ['server:localhost:1521', 'optional:tag1']
-    with mock.patch('datadog_checks.oracle.oracle.cx_Oracle'):
-        with mock.patch('datadog_checks.oracle.oracle.jdb') as jdb:
-            with mock.patch('datadog_checks.oracle.oracle.jpype') as jpype:
-                jpype.isJVMStarted.return_value = False
-                jdb.connect.return_value = con
-                ret = check._get_connection(server, user, password, service, jdbc_driver, tags)
-                assert ret == con
-                assert check.service_check_tags == expected_tags
-                jdb.connect.assert_called_with('oracle.jdbc.OracleDriver', 'jdbc:oracle:thin:@//localhost:1521/xe',
-                                               ['system', 'oracle'], None)
-                service_check.assert_called_with(check.SERVICE_CHECK_NAME, check.OK, tags=expected_tags)
+class TestMetrics:
+    def test__get_sys_metrics(self, aggregator, check):
+        query = "SELECT METRIC_NAME, VALUE, BEGIN_TIME FROM GV$SYSMETRIC ORDER BY BEGIN_TIME"
+        con = mock.MagicMock()
+        cur = mock.MagicMock()
+        con.cursor.return_value = cur
+        cur.fetchall.return_value = zip(check.SYS_METRICS.keys(), [0] * len(check.SYS_METRICS.keys()))
 
+        check._get_sys_metrics(con, ["custom_tag"])
 
-def test__get_connection_failure(check, instance):
-    """
-    Test the right service check is sent upon _get_connection failures
-    """
-    check.use_oracle_client = True
-    expected_tags = ['server:localhost:1521', 'optional:tag1']
-    service_check = mock.MagicMock()
-    check.service_check = service_check
-    server, user, password, service, jdbc_driver, tags, _ = check._get_config(instance)
-    with pytest.raises(Exception):
-        check._get_connection(server, user, password, service, jdbc_driver, tags)
-    service_check.assert_called_with(check.SERVICE_CHECK_NAME, check.CRITICAL, tags=expected_tags)
+        cur.execute.assert_called_with(query)
+        for _, metric in check.SYS_METRICS.items():
+            aggregator.assert_metric(metric, count=1, value=0, tags=["custom_tag"])
 
+    def test__get_process_metrics(self, aggregator, check):
+        query = "SELECT PID, {} FROM GV$PROCESS".format(','.join(check.PROCESS_METRICS.keys()))
+        con = mock.MagicMock()
+        cur = mock.MagicMock()
+        con.cursor.return_value = cur
+        cur.fetchall.return_value = [[pid] + ([0] * len(check.PROCESS_METRICS)) for pid in range(10)]
 
-def test__get_custom_metrics_misconfigured(check):
-    log = mock.MagicMock()
-    gauge = mock.MagicMock()
-    con = mock.MagicMock()
-    cursor = mock.MagicMock()
-    cursor.fetchone.return_value = ["foo", "bar"]
-    con.cursor.return_value = cursor
-    check.log = log
-    check.gauge = gauge
+        check._get_process_metrics(con, ['custom_tag'])
 
-    query = {}
-    custom_queries = [query]
+        cur.execute.assert_called_with(query)
+        for i, metric_name in enumerate(check.PROCESS_METRICS.values()):
+            aggregator.assert_metric(metric_name, count=1, value=0, tags=['custom_tag', 'pid:{}'.format(i)])
 
-    # No metric_prefix
-    check._get_custom_metrics(None, custom_queries, None)
-    log.error.assert_called_once_with('custom query field `metric_prefix` is required')
-    log.reset_mock()
+    def test__get_tablespace_metrics(self, aggregator, check):
+        query = "SELECT TABLESPACE_NAME, sum(BYTES), sum(MAXBYTES) FROM sys.dba_data_files GROUP BY TABLESPACE_NAME"
 
-    query["metric_prefix"] = "foo"
+        con = mock.MagicMock()
+        cur = mock.MagicMock()
+        cur.fetchall.return_value = [
+            ["offline", None, 100],
+            ["normal", 50, 100],
+            ["full", 100, 100],
+            ["size_0", 1, None]
+        ]
+        con.cursor.return_value = cur
 
-    # No query for metric_prefix
-    check._get_custom_metrics(None, custom_queries, None)
-    log.error.assert_called_once_with('custom query field `query` is required for metric_prefix `foo`')
-    log.reset_mock()
+        check._get_tablespace_metrics(con, ["custom_tag"])
+        cur.execute.assert_called_with(query)
 
-    query["query"] = "bar"
+        # Offline tablespace
+        tags = ["custom_tag", "tablespace:offline"]
+        aggregator.assert_metric("oracle.tablespace.used", value=0, count=1, tags=tags)
+        aggregator.assert_metric("oracle.tablespace.size", value=100, count=1, tags=tags)
+        aggregator.assert_metric("oracle.tablespace.in_use", value=0, count=1, tags=tags)
+        aggregator.assert_metric("oracle.tablespace.offline", value=1, count=1, tags=tags)
 
-    # No columns for metric_prefix
-    check._get_custom_metrics(None, custom_queries, None)
-    log.error.assert_called_once_with('custom query field `columns` is required for metric_prefix `foo`')
-    log.reset_mock()
+        # Normal tablespace
+        tags = ["custom_tag", "tablespace:normal"]
+        aggregator.assert_metric("oracle.tablespace.used", value=50, count=1, tags=tags)
+        aggregator.assert_metric("oracle.tablespace.size", value=100, count=1, tags=tags)
+        aggregator.assert_metric("oracle.tablespace.in_use", value=50, count=1, tags=tags)
+        aggregator.assert_metric("oracle.tablespace.offline", value=0, count=1, tags=tags)
 
-    query["columns"] = [{}]
+        # Full tablespace
+        tags = ["custom_tag", "tablespace:full"]
+        aggregator.assert_metric("oracle.tablespace.used", value=100, count=1, tags=tags)
+        aggregator.assert_metric("oracle.tablespace.size", value=100, count=1, tags=tags)
+        aggregator.assert_metric("oracle.tablespace.in_use", value=100, count=1, tags=tags)
+        aggregator.assert_metric("oracle.tablespace.offline", value=0, count=1, tags=tags)
 
-    # Wrong number of columns
-    check._get_custom_metrics(con, custom_queries, None)
-    log.error.assert_called_once_with('query result for metric_prefix foo: expected 1 columns, got 2')
-    log.reset_mock()
-
-    col1 = {"name": "baz", "type": "tag"}
-    col2 = {"foo": "bar"}
-    columns = [col1, col2]
-    query["columns"] = columns
-
-    # No name in column
-    check._get_custom_metrics(con, custom_queries, None)
-    log.error.assert_called_once_with('column field `name` is required for metric_prefix `foo`')
-    log.reset_mock()
-
-    del col2["foo"]
-    col2["name"] = "foo"
-
-    # No type in column
-    check._get_custom_metrics(con, custom_queries, None)
-    log.error.assert_called_once_with('column field `type` is required for column `foo` of metric_prefix `foo`')
-    log.reset_mock()
-
-    col2["type"] = "invalid"
-
-    # Invalid type column
-    check._get_custom_metrics(con, custom_queries, None)
-    log.error.assert_called_once_with('invalid submission method `invalid` for column `foo` of metric_prefix `foo`')
-    log.reset_mock()
-
-    col2["type"] = "gauge"
-
-    # Non numeric value
-    check._get_custom_metrics(con, custom_queries, None)
-    log.error.assert_called_once_with('non-numeric value `bar` for metric column `foo` of metric_prefix `foo`')
-
-    # No metric sent if errors
-    gauge.assert_not_called()
-
-
-def test__get_custom_metrics(aggregator, check):
-    con = mock.MagicMock()
-    cursor = mock.MagicMock()
-    cursor.fetchone.side_effect = [
-        ["tag_value1", "1"],
-        [1, 2, "tag_value2"]
-    ]
-    con.cursor.return_value = cursor
-
-    custom_queries = [
-        {
-            "metric_prefix": "oracle.test1",
-            "query": "mocked",
-            "columns": [
-                {
-                    "name": "tag_name",
-                    "type": "tag"
-                },
-                {
-                    "name": "metric",
-                    "type": "gauge"
-                }
-            ],
-            "tags": ["query_tags1"]
-        },
-        {
-            "metric_prefix": "oracle.test2",
-            "query": "mocked",
-            "columns": [
-                {
-                    "name": "rate",
-                    "type": "rate"
-                },
-                {
-                    "name": "gauge",
-                    "type": "gauge"
-                },
-                {
-                    "name": "tag_name",
-                    "type": "tag"
-                }
-            ],
-            "tags": ["query_tags2"]
-        }
-    ]
-
-    check._get_custom_metrics(con, custom_queries, ["custom_tag"])
-    aggregator.assert_metric("oracle.test1.metric", value=1, count=1,
-                             tags=["tag_name:tag_value1", "query_tags1", "custom_tag"])
-    aggregator.assert_metric("oracle.test2.gauge", value=2, count=1, metric_type=aggregator.GAUGE,
-                             tags=["tag_name:tag_value2", "query_tags2", "custom_tag"])
-    aggregator.assert_metric("oracle.test2.rate", value=1, count=1, metric_type=aggregator.RATE,
-                             tags=["tag_name:tag_value2", "query_tags2", "custom_tag"])
-
-
-def test__get_sys_metrics(aggregator, check):
-    query = "SELECT METRIC_NAME, VALUE, BEGIN_TIME FROM GV$SYSMETRIC ORDER BY BEGIN_TIME"
-    con = mock.MagicMock()
-    cur = mock.MagicMock()
-    con.cursor.return_value = cur
-    cur.fetchall.return_value = zip(check.SYS_METRICS.keys(), [0] * len(check.SYS_METRICS.keys()))
-
-    check._get_sys_metrics(con, ["custom_tag"])
-
-    cur.execute.assert_called_with(query)
-    for _, metric in check.SYS_METRICS.items():
-        aggregator.assert_metric(metric, count=1, value=0, tags=["custom_tag"])
-
-
-def test__get_tablespace_metrics(aggregator, check):
-    query = "SELECT TABLESPACE_NAME, sum(BYTES), sum(MAXBYTES) FROM sys.dba_data_files GROUP BY TABLESPACE_NAME"
-
-    con = mock.MagicMock()
-    cur = mock.MagicMock()
-    cur.fetchall.return_value = [
-        ["offline", None, 100],
-        ["normal", 50, 100],
-        ["full", 100, 100],
-        ["size_0", 1, None]
-    ]
-    con.cursor.return_value = cur
-
-    check._get_tablespace_metrics(con, ["custom_tag"])
-    cur.execute.assert_called_with(query)
-
-    # Offline tablespace
-    tags = ["custom_tag", "tablespace:offline"]
-    aggregator.assert_metric("oracle.tablespace.used", value=0, count=1, tags=tags)
-    aggregator.assert_metric("oracle.tablespace.size", value=100, count=1, tags=tags)
-    aggregator.assert_metric("oracle.tablespace.in_use", value=0, count=1, tags=tags)
-    aggregator.assert_metric("oracle.tablespace.offline", value=1, count=1, tags=tags)
-
-    # Normal tablespace
-    tags = ["custom_tag", "tablespace:normal"]
-    aggregator.assert_metric("oracle.tablespace.used", value=50, count=1, tags=tags)
-    aggregator.assert_metric("oracle.tablespace.size", value=100, count=1, tags=tags)
-    aggregator.assert_metric("oracle.tablespace.in_use", value=50, count=1, tags=tags)
-    aggregator.assert_metric("oracle.tablespace.offline", value=0, count=1, tags=tags)
-
-    # Full tablespace
-    tags = ["custom_tag", "tablespace:full"]
-    aggregator.assert_metric("oracle.tablespace.used", value=100, count=1, tags=tags)
-    aggregator.assert_metric("oracle.tablespace.size", value=100, count=1, tags=tags)
-    aggregator.assert_metric("oracle.tablespace.in_use", value=100, count=1, tags=tags)
-    aggregator.assert_metric("oracle.tablespace.offline", value=0, count=1, tags=tags)
-
-    # Size 0 tablespace
-    tags = ["custom_tag", "tablespace:size_0"]
-    aggregator.assert_metric("oracle.tablespace.used", value=1, count=1, tags=tags)
-    aggregator.assert_metric("oracle.tablespace.size", value=0, count=1, tags=tags)
-    aggregator.assert_metric("oracle.tablespace.in_use", value=100, count=1, tags=tags)
-    aggregator.assert_metric("oracle.tablespace.offline", value=0, count=1, tags=tags)
+        # Size 0 tablespace
+        tags = ["custom_tag", "tablespace:size_0"]
+        aggregator.assert_metric("oracle.tablespace.used", value=1, count=1, tags=tags)
+        aggregator.assert_metric("oracle.tablespace.size", value=0, count=1, tags=tags)
+        aggregator.assert_metric("oracle.tablespace.in_use", value=100, count=1, tags=tags)
+        aggregator.assert_metric("oracle.tablespace.offline", value=0, count=1, tags=tags)


### PR DESCRIPTION
### What does this PR do?

Adds metrics from the `V$PROCESS` table on Oracle DB.
 
### Motivation

Feature Request.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

The majority of the diff comes from me adding classes for the tests to better group them, the relevant test function is `test__get_process_metrics`.