### PR TITLE
Changing dead link in the main page README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ with all the checks from this repository, so to get started using them, you can
 simply [install the Agent][8] for your operating
 system.
 
-General documentation about the project can be [found here](docs/index.md)
+General documentation about the project can be [found here](docs/README.md)
 
 ## Integrations as Python wheels
 


### PR DESCRIPTION
### What does this PR do?

Changing a deadlink in the integration-core README pointing to documentation.

### Motivation

Previous link pointed to a file (`docs/index.md`) deleted by https://github.com/DataDog/integrations-core/pull/1359
Now pointing to `docs/README.md`, or maybe we can directly point it to `docs/` ?

