### PR TITLE
Remove docker-compose dep in requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@ invoke
 pip-tools
 packaging
 tox
-docker-compose
 twine
 cookiecutter
 colorama


### PR DESCRIPTION
### What does this PR do?

Fixing the following issue:
```
pip install -r requirements-dev.txt` `docker-compose 1.21.2 has requirement requests!=2.11.0,!=2.12.2,!=2.18.0,<2.19,>=2.6.1, but you'll have requests 2.19.1 which is incompatible.
```
We decided to remove the docker-compose dependency because:
1. It's not used by all checks
2. We have documentation about how docker-compose should be installed, see https://github.com/DataDog/integrations-core/blob/master/docs/dev/new_check_howto.md#prerequisites

### Motivation
See above

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes
