### PR TITLE
Improve check performance by filtering it's input before parsing

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
@@ -147,6 +147,11 @@ class PrometheusScraperMixin(object):
         # Extra http headers to be sent when polling endpoint
         self.extra_headers = {}
 
+        # List of strings to filter the input text payload on. If any line contains
+        # one of these strings, it will be filtered out before being parsed.
+        # INTERNAL FEATURE, might be removed in future versions
+        self.text_filter_blacklist = []
+
     def parse_metric_family(self, response):
         """
         Parse the MetricFamily from a valid requests.Response object to provide a MetricFamily object (see [0])
@@ -185,12 +190,16 @@ class PrometheusScraperMixin(object):
                 yield message
 
         elif 'text/plain' in response.headers['Content-Type']:
+            input_gen = response.iter_lines(chunk_size=self.REQUESTS_CHUNK_SIZE)
+            if self.text_filter_blacklist:
+                input_gen = self.text_filter_input(input_gen)
+
             messages = defaultdict(list)  # map with the name of the element (before the labels)
             # and the list of occurrences with labels and values
 
             obj_map = {}  # map of the types of each metrics
             obj_help = {}  # help for the metrics
-            for metric in text_fd_to_metric_families(response.iter_lines(chunk_size=self.REQUESTS_CHUNK_SIZE)):
+            for metric in text_fd_to_metric_families(input_gen):
                 metric.name = self.remove_metric_prefix(metric.name)
                 metric_name = "%s_bucket" % metric.name if metric.type == "histogram" else metric.name
                 metric_type = self.type_overrides.get(metric_name, metric.type)
@@ -213,6 +222,23 @@ class PrometheusScraperMixin(object):
         else:
             raise UnknownFormatError('Unsupported content-type provided: {}'.format(
                 response.headers['Content-Type']))
+
+    def text_filter_input(self, input_gen):
+        """
+        Filters out the text input line by line to avoid parsing and processing
+        metrics we know we don't want to process. This only works on `text/plain`
+        payloads, and is an INTERNAL FEATURE implemented for the kubelet check
+        :param input_get: line generator
+        :output: generator of filtered lines
+        """
+        for line in input_gen:
+            filtered = False
+            for item in self.text_filter_blacklist:
+                if item in line:
+                    filtered = True
+                    break
+            if not filtered:
+                yield line
 
     def remove_metric_prefix(self, metric):
         return metric[len(self.prometheus_metrics_prefix):] if metric.startswith(self.prometheus_metrics_prefix) else metric

--- a/datadog_checks_base/tests/test_prometheus.py
+++ b/datadog_checks_base/tests/test_prometheus.py
@@ -561,7 +561,7 @@ def test_filter_sample_on_gauge(p_check):
     # Iter on the generator to get all metrics
     response = MockResponse(text_data, 'text/plain; version=0.0.4')
     check = p_check
-    check.text_filter_blacklist = ["deployment=\"kube-dns\""]
+    check._text_filter_blacklist = ["deployment=\"kube-dns\""]
     metrics = [k for k in check.parse_metric_family(response)]
 
     assert 1 == len(metrics)

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -52,6 +52,9 @@ class CadvisorPrometheusScraper(PrometheusScraper):
             'container_scrape_error'
         ]
 
+        # Filter out system slices to reduce CPU and memory usage of the check
+        self.text_filter_blacklist = ["container_name=\"\""]
+
         # these are filled by container_<metric-name>_usage_<metric-unit>
         # and container_<metric-name>_limit_<metric-unit> reads it to compute <metric-name>usage_pct
         self.fs_usage_bytes = {}

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -53,7 +53,7 @@ class CadvisorPrometheusScraper(PrometheusScraper):
         ]
 
         # Filter out system slices to reduce CPU and memory usage of the check
-        self.text_filter_blacklist = ["container_name=\"\""]
+        self._text_filter_blacklist = ["container_name=\"\""]
 
         # these are filled by container_<metric-name>_usage_<metric-unit>
         # and container_<metric-name>_limit_<metric-unit> reads it to compute <metric-name>usage_pct


### PR DESCRIPTION
### What does this PR do?

The kubelet's `/metrics/cadvisor` payload contains statistics on all cgroups, including system slices that are of no use for the kubelet check.

The `kubelet` check [currently filters these samples by looking of a non-empty `container_name` label](https://github.com/DataDog/integrations-core/blob/7d564809cfcce6e49fc3dada8b96c8fc5af6310a/kubelet/datadog_checks/kubelet/prometheus.py#L60-L98). But this happens after we incurred the parsing, conversion and lookup costs.

On systems running a lot of system slices, this makes the `kubelet` check run in more than 15 seconds and use a lot of memory. One "pathological" host goes up to 40 seconds and > 1 GB memory used. **99,5 %** of the kubelet payload is system slices.

This PR injects a simple text filtering component before the `prometheus_client` parsing logic, to remove these lines before incurring the parsing / conversion / lookup costs. For simplicity and performance, it is implemented as a list of blacklisted strings instead of regexp. If no blacklist is setup, the filtering logic is bypassed completely.

Average `kubelet` check run on this test payload goes **from 47784ms down to  842ms**. These is some CPU overhead to the filtering (with a pre-filtered payload, the check run time is ~500ms), but it is significantly amortised on even a few system slices. More info in this [test notebook](https://app.datadoghq.com/notebook/43512/xvello%20-%20test%20kubelet%20%231869)

On a "regular" host with 15 containers and a dozen system slices, the patch lowers the CPU usage, while keeping the memory usage constant.

We still need to optimise the processing pipeline to handle a large amount of containers, this PR does not address this.

This fix is backported on top of `6.3.2` on the `datadog/agent-dev:xvello-kubelet-input-filter` image (with it's jmx variant too)

### Motivation

Make the `kubelet` check usable on hosts with lots of system slices.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
~~- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)~~

### Additional Notes

Anything else we should know when reviewing?
