### PR TITLE
Make the stalebot ignore feature requests

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,6 +5,7 @@ daysUntilClose: 1095
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
   - security
+  - kind/feature-request
 # Label to use when marking as stale
 staleLabel: stale
 # Comment to post when marking as stale. Set to `false` to disable


### PR DESCRIPTION
### What does this PR do?

See title

### Motivation

Feature requests have a long ttl so the concept of being "stale" is different.

