### PR TITLE
Properly use skip_proxy for instance configuration

### DIFF
--- a/datadog_checks_base/tests/test_proxy.py
+++ b/datadog_checks_base/tests/test_proxy.py
@@ -20,7 +20,14 @@ def test_use_proxy():
         check = AgentCheck()
         assert check.get_instance_proxy({}, 'endpoint1') == PROXY_SETTINGS
 
+
 def test_skip_proxy():
     with mock.patch('datadog_checks.checks.AgentCheck._get_requests_proxy', return_value=PROXY_SETTINGS):
         check = AgentCheck()
         assert check.get_instance_proxy({'skip_proxy': True}, 'endpoint2') == NO_PROXY_SETTINGS
+
+
+def test_deprecated_no_proxy():
+    with mock.patch('datadog_checks.checks.AgentCheck._get_requests_proxy', return_value=PROXY_SETTINGS):
+        check = AgentCheck()
+        assert check.get_instance_proxy({'no_proxy': True}, 'endpoint2') == NO_PROXY_SETTINGS

--- a/datadog_checks_base/tests/test_proxy.py
+++ b/datadog_checks_base/tests/test_proxy.py
@@ -6,8 +6,8 @@ import mock
 from datadog_checks.checks import AgentCheck
 
 PROXY_SETTINGS = {
-    "http": 'nffjn',
-    "https": 'Noniergui3rngne',
+    "http": 'http(s)://user:password@proxy_for_http:port',
+    "https": 'http(s)://user:password@proxy_for_https:port',
     "no": None
 }
 
@@ -18,16 +18,16 @@ NO_PROXY_SETTINGS = {
 def test_use_proxy():
     with mock.patch('datadog_checks.checks.AgentCheck._get_requests_proxy', return_value=PROXY_SETTINGS):
         check = AgentCheck()
-        assert check.get_instance_proxy({}, 'endpoint1') == PROXY_SETTINGS
+        assert check.get_instance_proxy({}, 'uri1/health') == PROXY_SETTINGS
 
 
 def test_skip_proxy():
     with mock.patch('datadog_checks.checks.AgentCheck._get_requests_proxy', return_value=PROXY_SETTINGS):
         check = AgentCheck()
-        assert check.get_instance_proxy({'skip_proxy': True}, 'endpoint2') == NO_PROXY_SETTINGS
+        assert check.get_instance_proxy({'skip_proxy': True}, 'uri/health') == NO_PROXY_SETTINGS
 
 
 def test_deprecated_no_proxy():
     with mock.patch('datadog_checks.checks.AgentCheck._get_requests_proxy', return_value=PROXY_SETTINGS):
         check = AgentCheck()
-        assert check.get_instance_proxy({'no_proxy': True}, 'endpoint2') == NO_PROXY_SETTINGS
+        assert check.get_instance_proxy({'no_proxy': True}, 'uri/health') == NO_PROXY_SETTINGS

--- a/datadog_checks_base/tests/test_proxy.py
+++ b/datadog_checks_base/tests/test_proxy.py
@@ -1,0 +1,26 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import mock
+
+from datadog_checks.checks import AgentCheck
+
+PROXY_SETTINGS = {
+    "http": 'nffjn',
+    "https": 'Noniergui3rngne',
+    "no": None
+}
+
+NO_PROXY_SETTINGS = {
+    "no": None
+}
+
+def test_use_proxy():
+    with mock.patch('datadog_checks.checks.AgentCheck._get_requests_proxy', return_value=PROXY_SETTINGS):
+        check = AgentCheck()
+        assert check.get_instance_proxy({}, 'endpoint1') == PROXY_SETTINGS
+
+def test_skip_proxy():
+    with mock.patch('datadog_checks.checks.AgentCheck._get_requests_proxy', return_value=PROXY_SETTINGS):
+        check = AgentCheck()
+        assert check.get_instance_proxy({'skip_proxy': True}, 'endpoint2') == NO_PROXY_SETTINGS


### PR DESCRIPTION
### What does this PR do?

Mirrors:
https://github.com/DataDog/dd-agent/blob/2fb88e5b4cbcad950b377ad55bbb4a52ebd4c085/checks/__init__.py#L392
https://github.com/DataDog/datadog-agent/blob/5e22bb6aae27576ed3f7c36f4c7574e487c34348/cmd/agent/dist/checks/__init__.py#L130

### Motivation

`no_proxy` is deprecated