### PR TITLE
Adding agent version disclaimer

### DIFF
--- a/agent_metrics/README.md
+++ b/agent_metrics/README.md
@@ -7,6 +7,8 @@ Get metrics from agent_metrics service in real time to:
 * Visualize and monitor agent_metrics states
 * Be notified about agent_metrics failovers and events.
 
+**NOTE**: The Agent Metrics check has been rewritten in Go for Agent v6 to take advantage of the new internal architecture. Hence it is still maintained but **only works with Agents prior to major version 6**.
+
 ## Setup
 ### Installation
 


### PR DESCRIPTION
### What does this PR do?

https://docs.datadoghq.com/integrations/agent_metrics/ should reflect that it only works with Agent 5.

### Motivation

https://github.com/DataDog/datadog-agent/blob/81ea793ee47352ac7e41edbde21731923fe692b9/docs/agent/changes.md#agent-integrations
