### PR TITLE
Add `pod:` tags to kubernetes_state status reason metrics

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -395,6 +395,7 @@ class KubernetesState(PrometheusCheck):
             skip_metric = False
             for label in metric.label:
                 if label.name == "reason":
+                    # Filtering according to the reason here is paramount to limit cardinality
                     if label.value.lower() in whitelisted_status_reasons:
                         tags.append(self._format_tag(label.name, label.value))
                     else:

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -409,10 +409,12 @@ class KubernetesState(PrometheusCheck):
                 self.count(metric_name, metric.gauge.value, tags + self.custom_tags)
 
     def kube_pod_container_status_waiting_reason(self, message, **kwargs):
-        self._submit_metric_kube_pod_container_status_reason(message, '.container.status_report.count.waiting', WHITELISTED_WAITING_REASONS)
+        self._submit_metric_kube_pod_container_status_reason(message, '.container.status_report.count.waiting',
+                                                             WHITELISTED_WAITING_REASONS)
 
     def kube_pod_container_status_terminated_reason(self, message, **kwargs):
-        self._submit_metric_kube_pod_container_status_reason(message, '.container.status_report.count.terminated', WHITELISTED_TERMINATED_REASONS)
+        self._submit_metric_kube_pod_container_status_reason(message, '.container.status_report.count.terminated',
+                                                             WHITELISTED_TERMINATED_REASONS)
 
     def kube_cronjob_next_schedule_time(self, message, **kwargs):
         """ Time until the next schedule """

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -403,6 +403,8 @@ class KubernetesState(PrometheusCheck):
                     tags.append(self._format_tag("kube_container_name", label.value))
                 elif label.name == "namespace":
                     tags.append(self._format_tag(label.name, label.value))
+                elif label.name == "pod":
+                    tags.append(self._format_tag(label.name, label.value))
             if not skip_metric:
                 self.count(metric_name, metric.gauge.value, tags + self.custom_tags)
 
@@ -420,6 +422,8 @@ class KubernetesState(PrometheusCheck):
                 elif label.name == "container":
                     tags.append(self._format_tag("kube_container_name", label.value))
                 elif label.name == "namespace":
+                    tags.append(self._format_tag(label.name, label.value))
+                elif label.name == "pod":
                     tags.append(self._format_tag(label.name, label.value))
             if not skip_metric:
                 self.count(metric_name, metric.gauge.value, tags + self.custom_tags)

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -388,14 +388,14 @@ class KubernetesState(PrometheusCheck):
         for tags, count in status_phase_counter.iteritems():
             self.gauge(metric_name, count, tags=list(tags))
 
-    def kube_pod_container_status_waiting_reason(self, message, **kwargs):
-        metric_name = self.NAMESPACE + '.container.status_report.count.waiting'
+    def _submit_metric_kube_pod_container_status_reason(self, message, metric_suffix, whitelisted_status_reasons):
+        metric_name = self.NAMESPACE + metric_suffix
         for metric in message.metric:
             tags = []
             skip_metric = False
             for label in metric.label:
                 if label.name == "reason":
-                    if label.value.lower() in WHITELISTED_WAITING_REASONS:
+                    if label.value.lower() in whitelisted_status_reasons:
                         tags.append(self._format_tag(label.name, label.value))
                     else:
                         skip_metric = True
@@ -408,25 +408,11 @@ class KubernetesState(PrometheusCheck):
             if not skip_metric:
                 self.count(metric_name, metric.gauge.value, tags + self.custom_tags)
 
+    def kube_pod_container_status_waiting_reason(self, message, **kwargs):
+        self._submit_metric_kube_pod_container_status_reason(message, '.container.status_report.count.waiting', WHITELISTED_WAITING_REASONS)
+
     def kube_pod_container_status_terminated_reason(self, message, **kwargs):
-        metric_name = self.NAMESPACE + '.container.status_report.count.terminated'
-        for metric in message.metric:
-            tags = []
-            skip_metric = False
-            for label in metric.label:
-                if label.name == "reason":
-                    if label.value.lower() in WHITELISTED_TERMINATED_REASONS:
-                        tags.append(self._format_tag(label.name, label.value))
-                    else:
-                        skip_metric = True
-                elif label.name == "container":
-                    tags.append(self._format_tag("kube_container_name", label.value))
-                elif label.name == "namespace":
-                    tags.append(self._format_tag(label.name, label.value))
-                elif label.name == "pod":
-                    tags.append(self._format_tag(label.name, label.value))
-            if not skip_metric:
-                self.count(metric_name, metric.gauge.value, tags + self.custom_tags)
+        self._submit_metric_kube_pod_container_status_reason(message, '.container.status_report.count.terminated', WHITELISTED_TERMINATED_REASONS)
 
     def kube_cronjob_next_schedule_time(self, message, **kwargs):
         """ Time until the next schedule """

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -55,9 +55,9 @@ METRICS = [
     NAMESPACE + '.container.ready',
     NAMESPACE + '.container.running',
     NAMESPACE + '.container.terminated',
-    NAMESPACE + '.container.status_report.count.terminated',
     NAMESPACE + '.container.waiting',
     NAMESPACE + '.container.status_report.count.waiting',
+    NAMESPACE + '.container.status_report.count.terminated',
     NAMESPACE + '.container.restarts',
     NAMESPACE + '.container.cpu_requested',
     NAMESPACE + '.container.memory_requested',
@@ -98,7 +98,12 @@ TAGS = {
         'reason:CrashLoopBackoff',
         'reason:CrashLoopBackOff',
         'reason:ErrImagePull',
-        'reason:ImagePullBackoff'
+        'reason:ImagePullBackoff',
+        'pod:kube-dns-1326421443-hj4hx',
+        'pod:hello-1509998340-k4f8q'
+    ],
+    NAMESPACE + '.container.status_report.count.terminated': [
+        'pod:pod2',
     ],
     NAMESPACE + '.persistentvolumeclaim.request_storage': [
         'storageclass:manual'


### PR DESCRIPTION
### What does this PR do?

Adding pod tags to `kube_pod_container_status_waiting_reason` and `kube_pod_container_status_terminated_reason` metrics 

### Motivation

Github issue https://github.com/DataDog/integrations-core/issues/1418
### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

