### PR TITLE
Add `docker-compose` and `wait_for_docker_logs` utils

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/__init__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from .docker import get_docker_hostname
-from .utils import chdir, env_vars, run_command, temp_chdir
+from .utils import chdir, env_vars, run_command, temp_chdir, docker_compose, wait_for_docker_logs


### PR DESCRIPTION
### What does this PR do?

Add two utils for common tasks regarding spinning up containers for tests.

### Motivation

Lots of duplication

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?