### PR TITLE
remove A5 compat layer from imports

### DIFF
--- a/gitlab/datadog_checks/gitlab/gitlab.py
+++ b/gitlab/datadog_checks/gitlab/gitlab.py
@@ -8,8 +8,8 @@ import urlparse
 # 3rd party
 import requests
 
-from checks import CheckException
-from checks.prometheus_check import PrometheusCheck
+from datadog_checks.errors import CheckException
+from datadog_checks.checks.prometheus import PrometheusCheck
 from datadog_checks.config import _is_affirmative
 from datadog_checks.utils.headers import headers
 

--- a/gitlab/datadog_checks/gitlab/gitlab.py
+++ b/gitlab/datadog_checks/gitlab/gitlab.py
@@ -8,14 +8,8 @@ import urlparse
 # 3rd party
 import requests
 
-try:
-    # Agent5 compatibility layer
-    from datadog_checks.errors import CheckException
-    from datadog_checks.checks.prometheus import PrometheusCheck
-except ImportError:
-    from checks import CheckException
-    from checks.prometheus_check import PrometheusCheck
-
+from checks import CheckException
+from checks.prometheus_check import PrometheusCheck
 from datadog_checks.config import _is_affirmative
 from datadog_checks.utils.headers import headers
 

--- a/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
@@ -8,14 +8,8 @@ import urlparse
 # 3rd party
 import requests
 
-try:
-    # Agent5 compatibility layer
-    from datadog_checks.errors import CheckException
-    from datadog_checks.checks.prometheus import PrometheusCheck
-except ImportError:
-    from checks import CheckException
-    from checks.prometheus_check import PrometheusCheck
-
+from datadog_checks.errors import CheckException
+from datadog_checks.checks.prometheus import PrometheusCheck
 from datadog_checks.config import _is_affirmative
 from datadog_checks.utils.headers import headers
 

--- a/kube_dns/datadog_checks/kube_dns/kube_dns.py
+++ b/kube_dns/datadog_checks/kube_dns/kube_dns.py
@@ -1,10 +1,10 @@
-try:
-    # Agent5 compatibility layer
-    from datadog_checks.errors import CheckException
-    from datadog_checks.checks.prometheus import PrometheusCheck
-except ImportError:
-    from checks import CheckException
-    from checks.prometheus_check import PrometheusCheck
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from datadog_checks.errors import CheckException
+from datadog_checks.checks.prometheus import PrometheusCheck
+
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'kubedns'
 

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -6,13 +6,8 @@ import re
 import time
 from collections import defaultdict, Counter
 
-try:
-    # Agent5 compatibility layer
-    from datadog_checks.errors import CheckException
-    from datadog_checks.checks.prometheus import PrometheusCheck
-except ImportError:
-    from checks import CheckException
-    from checks.prometheus_check import PrometheusCheck
+from datadog_checks.errors import CheckException
+from datadog_checks.checks.prometheus import PrometheusCheck
 
 
 METRIC_TYPES = ['counter', 'gauge']


### PR DESCRIPTION
### What does this PR do?

Remove the compat imports from:

* gitlab
* gitlab_runner
* kube_dns
* kubernetes_state

Also added a license to kube_dns

### Motivation

The above checks tried to import from checks_base first then went back to the Agent if that failed. We are moving all utilities to the datadog_checks_base so this makes us rely on that. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
