### PR TITLE
fix categories in manifests

### DIFF
--- a/cisco_aci/manifest.json
+++ b/cisco_aci/manifest.json
@@ -14,7 +14,7 @@
   ],
   "guid": "8a20f56b-2e25-4a0b-a252-f5187dddeeef",
   "public_title": "Datadog-CiscoACI Integration",
-  "categories":["networking"],
+  "categories":["network"],
   "type": "check",
   "doc_link": "https://docs.datadoghq.com/integrations/cisco_aci/",
   "is_public": true,

--- a/gitlab/manifest.json
+++ b/gitlab/manifest.json
@@ -12,8 +12,9 @@
   ],
   "public_title": "Datadog-Gitlab Integration",
   "categories": [
-    "web",
-    "network"
+    "collaboration",
+    "source control",
+    "issue tracking"
   ],
   "doc_link": "https://docs.datadoghq.com/integrations/gitlab/",
   "is_public": true,

--- a/gitlab_runner/manifest.json
+++ b/gitlab_runner/manifest.json
@@ -12,8 +12,9 @@
   ],
   "public_title": "Datadog-Gitlab Runners Integration",
   "categories": [
-    "web",
-    "network"
+    "collaboration",
+    "source control",
+    "issue tracking"
   ],
   "doc_link": "https://docs.datadoghq.com/integrations/gitlab_runner/",
   "is_public": true,


### PR DESCRIPTION
### What does this PR do?

Fix categories in manifest for the docs site

### Motivation

Noticed issue by chance

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
