### PR TITLE
Add comment about support for cursor metrics

### DIFF
--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -98,10 +98,10 @@ class MongoDb(AgentCheck):
         "mem.mappedWithJournal": GAUGE,
         "mem.resident": GAUGE,
         "mem.virtual": GAUGE,
-        "metrics.cursor.open.noTimeout": GAUGE,
-        "metrics.cursor.open.pinned": GAUGE,
-        "metrics.cursor.open.total": GAUGE,
-        "metrics.cursor.timedOut": RATE,
+        "metrics.cursor.open.noTimeout": GAUGE,    # >= 2.6
+        "metrics.cursor.open.pinned": GAUGE,       # >= 2.6
+        "metrics.cursor.open.total": GAUGE,        # >= 2.6
+        "metrics.cursor.timedOut": RATE,           # >= 2.6
         "metrics.document.deleted": RATE,
         "metrics.document.inserted": RATE,
         "metrics.document.returned": RATE,

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -70,8 +70,8 @@ class MongoDb(AgentCheck):
         "connections.available": GAUGE,
         "connections.current": GAUGE,
         "connections.totalCreated": GAUGE,
-        "cursors.timedOut": GAUGE,
-        "cursors.totalOpen": GAUGE,
+        "cursors.timedOut": GAUGE,                   # < 2.6
+        "cursors.totalOpen": GAUGE,                  # < 2.6
         "extra_info.heap_usage_bytes": RATE,
         "extra_info.page_faults": RATE,
         "fsyncLocked": GAUGE,


### PR DESCRIPTION
### What does this PR do?

Adds comments on cursor metrics to note support depending on mongo version

### Motivation

In Mongo v2.4 and before, the format for the [cursors metrics](https://docs.mongodb.com/v2.4/reference/command/serverStatus/#cursors) were `cursors.totalOpen` and `cursors.timedOut`. This was [changed in v 2.6 ](https://docs.mongodb.com/manual/reference/command/serverStatus/#serverstatus.metrics.cursor)

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
