### PR TITLE
[ci skip] Bumped datadog_checks_base version to 1.4.0

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG - datadog_checks
 
+## 1.4.0 / 2018-07-18
+
+* [Fixed] fix packaging of agent requirements. See [#1911](https://github.com/DataDog/integrations-core/pull/1911).
+* [Fixed] Properly use skip_proxy for instance configuration. See [#1880](https://github.com/DataDog/integrations-core/pull/1880).
+* [Fixed] Sync WMI utils from dd-agent to datadog-checks-base. See [#1897](https://github.com/DataDog/integrations-core/pull/1897).
+* [Fixed] Improve check performance by filtering it's input before parsing. See [#1875](https://github.com/DataDog/integrations-core/pull/1875).
+* [Changed] Bump prometheus client library to 0.3.0. See [#1866](https://github.com/DataDog/integrations-core/pull/1866).
+* [Added] Make HTTP request timeout configurable in prometheus checks. See [#1790](https://github.com/DataDog/integrations-core/pull/1790).
+
 ## 1.3.2 / 2018-06-15
 
 * [Changed] Bump requests to 2.19.1. See [#1743](https://github.com/DataDog/integrations-core/pull/1743).

--- a/datadog_checks_base/datadog_checks/__about__.py
+++ b/datadog_checks_base/datadog_checks/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "1.3.2"
+__version__ = "1.4.0"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -10,7 +10,7 @@ cisco_aci==1.1.0
 consul==1.5.0
 couch==2.6.0
 couchbase==1.5.0
-datadog_checks_base==1.3.2
+datadog_checks_base==1.4.0
 directory==1.2.0
 disk==1.2.0
 dns_check==1.1.1


### PR DESCRIPTION
### What does this PR do?

release datadog-checks-base 1.4.0

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
