### PR TITLE
Removing logging cat to leave only log collection

### DIFF
--- a/fluentd/manifest.json
+++ b/fluentd/manifest.json
@@ -12,7 +12,6 @@
   "guid": "68100352-b993-43e6-9dc8-5ecd498e160b",
   "public_title": "Datadog-FluentD Integration",
   "categories": [
-    "logging",
     "log collection"
   ],
   "type": "check",


### PR DESCRIPTION
### What does this PR do?

Removes the `logging` category and leaves only the `log collection` one

### Motivation

Better consistency for integrations categorization