### PR TITLE
Update req.in files with platform specific env markers

### DIFF
--- a/datadog_checks_base/agent_requirements.in
+++ b/datadog_checks_base/agent_requirements.in
@@ -7,7 +7,7 @@ cryptography==2.2.2
 cx_oracle==6.0.1
 dnspython==1.12.0
 enum34==1.1.6
-gearman==2.0.2; sys_platform != 'win32'
+gearman==2.0.2; sys_platform != 'win32' and python_version < '3.0'
 httplib2==0.10.3
 ipaddress==1.0.22
 jaydebeapi==1.1.1
@@ -42,7 +42,7 @@ scandir==1.5
 serpent==1.23; sys_platform == 'win32'
 simplejson==3.6.5
 six==1.11.0
-supervisor==3.3.3
+supervisor==3.3.3; python_version < '3.0'
 testfixtures==4.14.3; sys_platform == 'win32'
 uptime==3.0.1
 uuid==1.30

--- a/datadog_checks_base/agent_requirements.in
+++ b/datadog_checks_base/agent_requirements.in
@@ -1,4 +1,4 @@
-adodbapi==2.6.0.7
+adodbapi==2.6.0.7; sys_platform == 'win32'
 asn1crypto==0.24.0
 beautifulsoup4==4.5.1
 boto==2.46.1
@@ -7,13 +7,13 @@ cryptography==2.2.2
 cx_oracle==6.0.1
 dnspython==1.12.0
 enum34==1.1.6
-gearman==2.0.2
+gearman==2.0.2; sys_platform != 'win32'
 httplib2==0.10.3
 ipaddress==1.0.22
 jaydebeapi==1.1.1
 jpype1==0.6.3
-kafka-python==1.4.3
-kazoo==2.4.0
+kafka-python==1.4.3; sys_platform != 'win32'
+kazoo==2.4.0; sys_platform != 'win32'
 meld3==1.0.2
 ntplib==0.3.3
 paramiko==2.1.5
@@ -28,21 +28,21 @@ pycparser==2.18
 pycryptodomex==3.4.7
 pymongo==3.5.1
 pymysql==0.8.0
-pyodbc==4.0.13
-pyro4==4.36
+pyodbc==4.0.13; sys_platform == 'win32'
+pyro4==4.36; sys_platform == 'win32'
 pysmi==0.2.2
 pysnmp==4.4.3
 pysnmp-mibs==0.1.6
-python-binary-memcached==0.26.1
+python-binary-memcached==0.26.1; sys_platform != 'win32'
 pyvmomi==6.0.0
 redis==2.10.5
 requests==2.19.1
 requests_ntlm==1.1.0
 scandir==1.5
-serpent==1.23
+serpent==1.23; sys_platform == 'win32'
 simplejson==3.6.5
 six==1.11.0
 supervisor==3.3.3
-testfixtures==4.14.3
+testfixtures==4.14.3; sys_platform == 'win32'
 uptime==3.0.1
 uuid==1.30

--- a/gearmand/requirements.in
+++ b/gearmand/requirements.in
@@ -1,1 +1,1 @@
-gearman==2.0.2
+gearman==2.0.2; sys_platform != 'win32'

--- a/gearmand/requirements.in
+++ b/gearmand/requirements.in
@@ -1,1 +1,1 @@
-gearman==2.0.2; sys_platform != 'win32'
+gearman==2.0.2; sys_platform != 'win32' and python_version < '3.0'

--- a/kafka_consumer/requirements.in
+++ b/kafka_consumer/requirements.in
@@ -1,2 +1,2 @@
-kafka-python==1.4.3
-kazoo==2.4.0
+kafka-python==1.4.3; sys_platform != 'win32'
+kazoo==2.4.0; sys_platform != 'win32'

--- a/mcache/requirements.in
+++ b/mcache/requirements.in
@@ -1,1 +1,1 @@
-python-binary-memcached==0.26.1
+python-binary-memcached==0.26.1; sys_platform != 'win32'

--- a/sqlserver/requirements.in
+++ b/sqlserver/requirements.in
@@ -1,5 +1,5 @@
-adodbapi==2.6.0.7
-pyro4==4.36
-testfixtures==4.14.3
-serpent==1.23
-pyodbc==4.0.13
+adodbapi==2.6.0.7; sys_platform == 'win32'
+pyro4==4.36; sys_platform == 'win32'
+testfixtures==4.14.3; sys_platform == 'win32'
+serpent==1.23; sys_platform == 'win32'
+pyodbc==4.0.13; sys_platform == 'win32'

--- a/supervisord/requirements.in
+++ b/supervisord/requirements.in
@@ -1,2 +1,2 @@
-supervisor==3.3.3
+supervisor==3.3.3; python_version < '3.0'
 meld3==1.0.2


### PR DESCRIPTION
### What does this PR do?

Updates individual requirement.in files to include the environment markers for when a dependency is only used for an integration we support on a specific platform. 

Also includes a python version env marker for the two dependencies we have that rely on Python2 and don't yet support Python3

### Motivation

Broader goal to consolidate the static requirements in datadog_checks_base. This should be automated going forward based on the manifest files. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
