### PR TITLE
Remove test to check requirements sync

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -31,32 +31,6 @@ def files_changed():
     return [f for f in changed_files if f]
 
 
-def check_requirements(check):
-    """
-    Assert the output of pip-compile is the same as the contents of
-    `requirements.txt` for the given check
-    """
-    check_dir = os.path.join(get_root(), check)
-    if not dir_exists(check_dir):
-        abort('Unable to find folder `{}`'.format(check_dir))
-
-    # Check the files are there
-    req_in = os.path.join(check_dir, 'requirements.in')
-    req_txt = os.path.join(check_dir, 'requirements.txt')
-    if not (file_exists(req_in) and file_exists(req_txt)):
-        abort('Target folder `{}` must contain `requirements.in` and `requirements.txt`.'.format(check_dir))
-
-    # Get the output of pip-compile
-    with chdir(check_dir):
-        out_lines = run_command('pip-compile -n --generate-hashes', capture=True).stdout.splitlines()
-
-    # Read the contents of `requirements.txt`
-    if read_file(req_txt).splitlines() != out_lines:
-        abort('`requirements.in` and `requirements.txt` are out of sync, please run pip-compile and try again.')
-
-    echo_success('Requirements are in sync!')
-
-
 @click.command(
     context_settings=CONTEXT_SETTINGS,
     short_help='Run tests'
@@ -91,12 +65,6 @@ def test(checks, bench, every):
         return
 
     for check in checks:
-        # check requirements.in and requirements.txt are in sync
-        if not bench and check != 'datadog_checks_dev':
-            echo_waiting('Verifying requirements are in sync for `{}`...'.format(check))
-            check_requirements(check)
-            click.echo()
-
         with chdir(os.path.join(root, check)):
             if every:
                 wait_text = 'Running tests for `{}`'.format(check)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -9,7 +9,7 @@ from .utils import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_waitin
 from ..constants import TESTABLE_FILE_EXTENSIONS, get_root
 from ..utils import get_testable_checks
 from ...subprocess import run_command
-from ...utils import chdir, dir_exists, file_exists, read_file
+from ...utils import chdir
 
 
 def testable_files(files):


### PR DESCRIPTION
### What does this PR do?

Stop testing that the requirements are in sync between requirement.txt and requirement.in 

### Motivation

Moving to the static environment we no longer need these. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
