### PR TITLE
Add command to create Trello test cards from Agent release diffs

### DIFF
--- a/datadog_checks_dev/README.md
+++ b/datadog_checks_dev/README.md
@@ -16,40 +16,41 @@ and is available on Linux, macOS, and Windows, and supports Python 2.7/3.5+ and 
 **Table of Contents**
 
 - [Management](#management)
-  * [Installation](#installation)
-  * [Usage](#usage)
-    + [Clean](#clean)
-    + [Config](#config)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [Clean](#clean)
+    - [Config](#config)
       - [Find](#find)
       - [Restore](#restore)
       - [Set](#set)
       - [Show](#show)
       - [Update](#update)
-    + [Dep](#dep)
+    - [Dep](#dep)
       - [Freeze](#freeze)
       - [Pin](#pin)
       - [Resolve](#resolve)
       - [Verify](#verify)
-    + [Manifest](#manifest)
+    - [Manifest](#manifest)
       - [Set](#set-1)
       - [Verify](#verify-1)
-    + [Release](#release)
+    - [Release](#release)
       - [Changelog](#changelog)
       - [Freeze](#freeze-1)
       - [Make](#make)
       - [Show](#show-1)
-        * [Changes](#changes)
-        * [Ready](#ready)
+        - [Changes](#changes)
+        - [Ready](#ready)
       - [Tag](#tag)
+      - [Testable](#testable)
       - [Upload](#upload)
-    + [Test](#test)
+    - [Test](#test)
 - [Development](#development)
-  * [Installation](#installation-1)
-  * [Usage](#usage-1)
-    + [Fixtures](#fixtures)
+  - [Installation](#installation-1)
+  - [Usage](#usage-1)
+    - [Fixtures](#fixtures)
       - [Aggregator](#aggregator)
       - [Mocker](#mocker)
-    + [Utilities](#utilities)
+    - [Utilities](#utilities)
       - [Subprocess commands](#subprocess-commands)
       - [Temporary directories](#temporary-directories)
 
@@ -347,6 +348,7 @@ Commands:
   make       Release a single check
   show       Show release information
   tag        Tag the git repo with the current release of a check
+  testable   Create a Trello card for each change that needs to be tested
   upload     Build and upload a check to PyPI
 ```
 
@@ -461,6 +463,35 @@ Options:
   --push / --no-push
   -n, --dry-run
   -h, --help          Show this message and exit.
+```
+
+##### Testable
+
+```console
+$ ddev release testable -h
+Usage: ddev release testable [OPTIONS]
+
+  Create a Trello card for each change that needs to be tested for the next
+  release. Run via `ddev -x release testable` to force the use of the
+  current directory.
+
+  To avoid GitHub's public API rate limits, you need to set
+  `github.user`/`github.token` in your config file or use the
+  `DD_GITHUB_USER`/`DD_GITHUB_TOKEN` environment variables.
+
+  To use Trello:
+  1. Go to `https://trello.com/app-key` and copy your API key.
+  2. Run `ddev config set trello.key` and paste your API key.
+  3. Go to `https://trello.com/1/authorize?key=key&name=name&scope=read,write&expiration=never&response_type=token`,
+     where `key` is your API key and `name` is the name to give your token, e.g. ReleaseTestingYourName.
+     Authorize access and copy your token.
+  4. Run `ddev config set trello.token` and paste your token.
+
+Options:
+  --start TEXT   The PR number or commit hash to start at
+  --since TEXT   The version of the Agent to compare
+  -n, --dry-run  Only show the changes
+  -h, --help     Show this message and exit.
 ```
 
 ##### Upload

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -7,6 +7,7 @@ import click
 
 from .utils import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_waiting
 from ..constants import TESTABLE_FILE_EXTENSIONS, get_root
+from ..git import files_changed
 from ..utils import get_testable_checks
 from ...subprocess import run_command
 from ...utils import chdir
@@ -17,18 +18,6 @@ def testable_files(files):
     Given a list of files, return the files that have an extension listed in FILE_EXTENSIONS_TO_TEST
     """
     return [f for f in files if f.endswith(TESTABLE_FILE_EXTENSIONS)]
-
-
-def files_changed():
-    """
-    Return the list of file changed in the current branch compared to `master`
-    """
-    with chdir(get_root()):
-        result = run_command('git diff --name-only master...', capture='out')
-    changed_files = result.stdout.splitlines()
-
-    # Remove empty lines
-    return [f for f in changed_files if f]
 
 
 @click.command(

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/utils.py
@@ -3,6 +3,15 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import sys
 
+try:
+    from textwrap import indent as indent_text
+except ImportError:
+    def indent_text(text, prefix):
+        return ''.join(
+            (prefix + line if line.strip() else line)
+            for line in text.splitlines(True)
+        )
+
 import click
 
 CONTEXT_SETTINGS = {
@@ -14,23 +23,33 @@ UNKNOWN_OPTIONS = {
 }
 
 
-def echo_info(text, nl=True, err=False):
+def echo_info(text, nl=True, err=False, indent=None):
+    if indent:
+        text = indent_text(text, indent)
     click.secho(text, bold=True, nl=nl, err=err)
 
 
-def echo_success(text, nl=True, err=False):
+def echo_success(text, nl=True, err=False, indent=None):
+    if indent:
+        text = indent_text(text, indent)
     click.secho(text, fg='cyan', bold=True, nl=nl, err=err)
 
 
-def echo_failure(text, nl=True, err=False):
+def echo_failure(text, nl=True, err=False, indent=None):
+    if indent:
+        text = indent_text(text, indent)
     click.secho(text, fg='red', bold=True, nl=nl, err=err)
 
 
-def echo_warning(text, nl=True, err=False):
+def echo_warning(text, nl=True, err=False, indent=None):
+    if indent:
+        text = indent_text(text, indent)
     click.secho(text, fg='yellow', bold=True, nl=nl, err=err)
 
 
-def echo_waiting(text, nl=True, err=False):
+def echo_waiting(text, nl=True, err=False, indent=None):
+    if indent:
+        text = indent_text(text, indent)
     click.secho(text, fg='magenta', bold=True, nl=nl, err=err)
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/config.py
@@ -19,6 +19,8 @@ CONFIG_FILE = os.path.join(APP_DIR, 'config.toml')
 SECRET_KEYS = {
     'github.token',
     'pypi.pass',
+    'trello.key',
+    'trello.token',
 }
 
 DEFAULT_CONFIG = OrderedDict([
@@ -31,6 +33,10 @@ DEFAULT_CONFIG = OrderedDict([
     ('pypi', OrderedDict((
         ('user', ''),
         ('pass', ''),
+    ))),
+    ('trello', OrderedDict((
+        ('key', ''),
+        ('token', ''),
     ))),
 ])
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/github.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/github.py
@@ -45,6 +45,17 @@ def get_pr(pr_num, config=None):
     return response.json()
 
 
+def get_pr_from_hash(commit_hash, repo, config=None):
+    response = requests.get(
+        'https://api.github.com/search/issues?q=sha:{}+repo:DataDog/{}'.format(
+            commit_hash, repo
+        ),
+        auth=get_auth_info(config)
+    )
+    response.raise_for_status()
+    return response.json()
+
+
 def from_contributor(pr_payload):
     """
     If the PR comes from a fork, we can safely assumed it's from an

--- a/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
@@ -1,0 +1,48 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import requests
+
+
+class TrelloClient:
+    API_URL = 'https://api.trello.com'
+    CREATE_ENDPOINT = API_URL + '/1/cards'
+
+    def __init__(self, config):
+        self.auth = {
+            'key': config['trello']['key'] or None,
+            'token': config['trello']['token'] or None,
+        }
+        self.team_list_map = {
+            'Integrations': '5ae1e3e2c81fff836d00497e',
+            'Containers': '5ae1cab495edd80852396c71',
+            'Agent': '5ae1e3d62a5167779e65e87d',
+        }
+
+    def create_card(self, team, name, body):
+        rate_limited = False
+        error = None
+        response = None
+
+        params = {
+            'idList': self.team_list_map[team],
+            'name': name,
+            'desc': body,
+        }
+        params.update(self.auth)
+
+        try:
+            response = requests.post(self.CREATE_ENDPOINT, params=params)
+        except Exception as e:
+            error = str(e)
+        else:
+            try:
+                response.raise_for_status()
+            except Exception as e:
+                error = str(e)
+
+        # Rate limit
+        if response:
+            rate_limited = response.status_code == 429
+
+        return rate_limited, error, response

--- a/datadog_checks_dev/datadog_checks/dev/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/utils.py
@@ -80,6 +80,18 @@ def create_file(fname):
         os.utime(fname, None)
 
 
+def ensure_bytes(s):
+    if not isinstance(s, bytes):
+        s = s.encode('utf-8')
+    return s
+
+
+def ensure_unicode(s):
+    if isinstance(s, bytes):
+        s = s.decode('utf-8')
+    return s
+
+
 def download_file(url, fname):
     req = urlopen(url)
     with open(fname, 'wb') as f:


### PR DESCRIPTION
### Motivation

The 100% manual way is tedious and error-prone.

### Additional Notes

In the future we may also want this to randomly assign team members and provide recommendations based on issue labels and any `CODEOWNERS` file too.

![ddev release testable](https://user-images.githubusercontent.com/9677399/43121585-404133fe-8eec-11e8-8af1-95c319c3cde8.PNG)
