### PR TITLE
adding link to agent directory KB

### DIFF
--- a/active_directory/README.md
+++ b/active_directory/README.md
@@ -12,7 +12,7 @@ The Agent's Active Directory check is included in the [Datadog Agent][4] package
 
 ### Configuration
 
-1. Edit the `active_directory.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Active Directory performance data.
+1. Edit the `active_directory.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][9] to start collecting your Active Directory performance data.
 
 #### Metric collection
 
@@ -73,3 +73,4 @@ Need help? Contact [Datadog Support][5].
 [5]: https://docs.datadoghq.com/help/
 [7]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
 [8]: https://www.rubydoc.info/gems/activedirectory/0.9.3
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/activemq/README.md
+++ b/activemq/README.md
@@ -16,7 +16,7 @@ The check collects metrics via JMX, so you need a JVM on each node so the Agent 
 ### Configuration
 
 1. **Make sure that [JMX Remote is enabled][103] on your ActiveMQ server.**
-2. Configure the agent to connect to ActiveMQ. Edit `activemq.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample activemq.d/conf.yaml][104] for all available configuration options.
+2. Configure the agent to connect to ActiveMQ. Edit `activemq.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][111]. See the [sample activemq.d/conf.yaml][104] for all available configuration options.
 
       ```yaml
       instances:
@@ -118,3 +118,4 @@ Need help? Contact [Datadog Support][107].
 [108]: https://www.datadoghq.com/blog/monitor-activemq-metrics-performance/
 [109]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
 [110]: https://raw.githubusercontent.com/DataDog/dd-agent/5.10.1/conf.d/activemq.yaml.example
+[111]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/activemq_xml/README.md
+++ b/activemq_xml/README.md
@@ -14,7 +14,7 @@ The Activemq XML check is included in the [Datadog Agent][1] package, so you don
 
 ### Configuration
 
-1. Edit the `activemq_xml.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory, to point to your server and port, set the masters to monitor.
+1. Edit the `activemq_xml.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][9], to point to your server and port, set the masters to monitor.
 
     See the [sample activemq_xml.d/conf.yaml][2] for all available configuration options.
 
@@ -50,3 +50,4 @@ Need help? Contact [Datadog Support][5].
 [6]: https://www.datadoghq.com/blog/monitor-activemq-metrics-performance/
 [7]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
 [8]: https://github.com/DataDog/integrations-core/blob/master/docs/index.md
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/agent_metrics/README.md
+++ b/agent_metrics/README.md
@@ -16,7 +16,7 @@ The Agent Metrics check is included in the [Datadog Agent][1] package, so you do
 
 ### Configuration
 
-1. Edit the `agent_metrics.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory, to point to your server and port, set the masters to monitor.
+1. Edit the `agent_metrics.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][8], to point to your server and port, set the masters to monitor.
 
     See the [sample agent_metrics.d/conf.yaml][2] for all available configuration options.
 
@@ -45,3 +45,4 @@ Need help? Contact [Datadog Support][5].
 [4]: https://github.com/DataDog/integrations-core/blob/master/agent_metrics/metadata.csv
 [5]: https://docs.datadoghq.com/help/
 [7]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
+[8]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/apache/README.md
+++ b/apache/README.md
@@ -17,7 +17,7 @@ The Apache check is packaged with the Agent. To start gathering your Apache metr
 
 ### Configuration
 
-1. Edit the `apache.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Apache [metrics](#metric-collection) and [logs](#log-collection).
+1. Edit the `apache.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][13] to start collecting your Apache [metrics](#metric-collection) and [logs](#log-collection).
   See the [sample apache.d/conf.yaml][2] for all available configuration options.
 
 2. [Restart the Agent][3]
@@ -116,3 +116,4 @@ Returns CRITICAL if the Agent cannot connect to the configured `apache_status_ur
 [10]: https://www.datadoghq.com/blog/collect-apache-performance-metrics/
 [11]: https://www.datadoghq.com/blog/monitor-apache-web-server-datadog/
 [12]: https://raw.githubusercontent.com/DataDog/integrations-core/master/apache/images/apache_dashboard.png
+[13]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/aspdotnet/README.md
+++ b/aspdotnet/README.md
@@ -14,7 +14,7 @@ The ASP.NET check is included in the [Datadog Agent][1] package, so you don't ne
 
 ### Configuration
 
-1. Edit the `aspdotnet.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your ASP.NET performance data.
+1. Edit the `aspdotnet.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][6] to start collecting your ASP.NET performance data.
 
     See the [sample aspdotnet.d/conf.yaml][3] for all available configuration options.
 
@@ -42,3 +42,4 @@ Need help? Contact [Datadog Support][5].
 [3]: https://github.com/DataDog/integrations-core/blob/master/aspdotnet/datadog_checks/aspdotnet/data/conf.yaml.example
 [4]: https://app.datadoghq.com/event/stream
 [5]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
+[6]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/btrfs/README.md
+++ b/btrfs/README.md
@@ -16,7 +16,7 @@ The Btrfs check is included in the [Datadog Agent][4] package, so you don't need
 
 ### Configuration
 
-1. Configure the Agent according to your needs, edit the `btrfs.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory.
+1. Configure the Agent according to your needs, edit the `btrfs.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][9].
     See the [sample btrfs.d/conf.yaml][2] for all available configuration options.
 
 2. [Restart the Agent][3]
@@ -45,3 +45,4 @@ Need help? Contact [Datadog Support][6].
 [5]: https://github.com/DataDog/integrations-core/blob/master/btrfs/metadata.csv
 [6]: https://docs.datadoghq.com/help/
 [8]: https://raw.githubusercontent.com/DataDog/integrations-core/master/btrfs/images/btrfs_metric.png
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -20,7 +20,7 @@ This check has a limit of 350 metrics per instance. The number of returned metri
 
 ### Configuration
 
-Edit the `cassandra.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Cassandra [metrics](#metric-collection) and [logs](#log-collection).
+Edit the `cassandra.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][1012] to start collecting your Cassandra [metrics](#metric-collection) and [logs](#log-collection).
 See the [sample cassandra.d/conf.yaml][103] for all available configuration options.
 
 #### Metric Collection
@@ -91,3 +91,4 @@ Need help? Contact [Datadog Support][107].
 [109]: https://www.datadoghq.com/blog/how-to-collect-cassandra-metrics/
 [1010]: https://www.datadoghq.com/blog/monitoring-cassandra-with-datadog/
 [1011]: https://raw.githubusercontent.com/DataDog/integrations-core/master/cassandra/images/cassandra_dashboard.png
+[1012]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/cassandra_nodetool/README.md
+++ b/cassandra_nodetool/README.md
@@ -14,7 +14,7 @@ The Cassandra Nodetool check is included in the [Datadog Agent][2] package, so y
 
 ### Configuration
 
-Edit the file `cassandra_nodetool.d/conf.yaml` in the `conf.d/` folder at the root of your Agent's configuration directory.
+Edit the file `cassandra_nodetool.d/conf.yaml` in the `conf.d/` folder at the root of your [Agent's configuration directory][11].
 See the [sample cassandra_nodetool.d/conf.yaml][3] for all available configuration options:
 
 ```yaml
@@ -79,3 +79,4 @@ Need help? Contact [Datadog Support][6].
 [8]: https://www.datadoghq.com/blog/how-to-collect-cassandra-metrics/
 [9]: https://www.datadoghq.com/blog/monitoring-cassandra-with-datadog/
 [10]: https://raw.githubusercontent.com/DataDog/integrations-core/master/cassandra_nodetool/images/cassandra_dashboard.png
+[11]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/ceph/README.md
+++ b/ceph/README.md
@@ -17,7 +17,7 @@ The Ceph check is included in the [Datadog Agent][1] package, so you don't need 
 
 ### Configuration
 
-Edit the file `ceph.d/conf.yaml` in the `conf.d/` folder at the root of your Agent's configuration directory.
+Edit the file `ceph.d/conf.yaml` in the `conf.d/` folder at the root of your [Agent's configuration directory][8].
 See the [sample ceph.d/conf.yaml][2] for all available configuration options:
 
 ```yaml
@@ -105,3 +105,4 @@ Need help? Contact [Datadog Support][5].
 [5]: https://docs.datadoghq.com/help/
 [6]: https://www.datadoghq.com/blog/monitor-ceph-datadog/
 [7]: https://raw.githubusercontent.com/DataDog/integrations-core/master/ceph/images/ceph_dashboard.png
+[8]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/cisco_aci/README.md
+++ b/cisco_aci/README.md
@@ -15,7 +15,7 @@ The Cisco ACI check is packaged with the Agent, so simply [install the Agent][1]
 
 ### Configuration
 
-1. Edit the `cisco_aci.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory.
+1. Edit the `cisco_aci.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][7].
     See the [sample cisco_aci.d/conf.yaml][2] for all available configuration options:
 
     ```yaml
@@ -64,3 +64,4 @@ Need help? Contact [Datadog Support][6].
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [5]: https://github.com/DataDog/integrations-core/blob/master/cisco_aci/metadata.csv
 [6]: https://docs.datadoghq.com/help/
+[7]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/consul/README.md
+++ b/consul/README.md
@@ -28,7 +28,7 @@ The Datadog Agent's Consul check is included in the [Datadog Agent][4] package, 
 
 ### Configuration
 
-Edit the `consul.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Consul [metrics](#metric-collection) and [logs](#log-collection).
+Edit the `consul.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][13] to start collecting your Consul [metrics](#metric-collection) and [logs](#log-collection).
 See the [sample consul.d/conf.yaml][2] for all available configuration options.
 
 #### Metric Collection
@@ -170,3 +170,4 @@ Need help? Contact [Datadog Support][9].
 [10]: https://www.datadoghq.com/blog/monitor-consul-health-and-performance-with-datadog
 [11]: https://engineering.datadoghq.com/consul-at-datadog/
 [12]: https://raw.githubusercontent.com/DataDog/integrations-core/master/consul/images/consul-dash.png
+[13]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/couch/README.md
+++ b/couch/README.md
@@ -18,7 +18,7 @@ The CouchDB check is included in the [Datadog Agent][1] package, so you don't ne
 
 ### Configuration
 
-1. Edit the `couch.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your CouchDB performance data.
+1. Edit the `couch.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][9] to start collecting your CouchDB performance data.
   See the [sample couch.d/conf.yaml][2] for all available configuration options.
 
       ```yaml
@@ -71,3 +71,4 @@ Need help? Contact [Datadog Support][6].
 [6]: https://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/monitoring-couchdb-with-datadog/
 [8]: https://raw.githubusercontent.com/DataDog/integrations-core/master/couch/images/couchdb_dashboard.png
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/couchbase/README.md
+++ b/couchbase/README.md
@@ -22,7 +22,7 @@ The Couchbase check is included in the [Datadog Agent][2] package, so you don't 
 
 ### Configuration
 
-1. Edit the `couchbase.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Couchbase performance data.  
+1. Edit the `couchbase.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][10] to start collecting your Couchbase performance data.  
 	See the [sample couchbase.d/conf.yaml][3] for all available configuration options.
 
 ```
@@ -82,3 +82,4 @@ Need help? Contact [Datadog Support][7].
 [6]: https://github.com/DataDog/integrations-core/blob/master/couchbase/metadata.csv
 [7]: https://docs.datadoghq.com/help/
 [9]: https://www.datadoghq.com/blog/monitoring-couchbase-performance-datadog/
+[10]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/directory/README.md
+++ b/directory/README.md
@@ -15,7 +15,7 @@ The directory check is included in the [Datadog Agent][1] package, so you don't 
 
 ### Configuration
 
-1. Edit the `directory.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting Directory performance data.
+1. Edit the `directory.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][7] to start collecting Directory performance data.
   See the [sample directory.d/conf.yaml][2] for all available configuration options.
 
     ```yaml
@@ -58,3 +58,4 @@ Need help? Contact [Datadog Support][6].
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [5]: https://github.com/DataDog/integrations-core/blob/master/directory/metadata.csv
 [6]: https://docs.datadoghq.com/help/
+[7]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/disk/README.md
+++ b/disk/README.md
@@ -12,7 +12,7 @@ The disk check is included in the [Datadog Agent][1] package, so you don't need 
 ### Configuration
 
 The disk check is enabled by default, and the Agent collects metrics on all local partitions.
-If you want to configure the check with custom options, Edit the `disk.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample disk.d/conf.yaml][2] for all available configuration options.
+If you want to configure the check with custom options, Edit the `disk.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][6]. See the [sample disk.d/conf.yaml][2] for all available configuration options.
 
 ### Validation
 
@@ -37,3 +37,4 @@ Need help? Contact [Datadog Support][5].
 [3]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [4]: https://github.com/DataDog/integrations-core/blob/master/disk/metadata.csv
 [5]: https://docs.datadoghq.com/help/
+[6]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/dns_check/README.md
+++ b/dns_check/README.md
@@ -14,7 +14,7 @@ Though many metrics-oriented checks are best run on the same host(s) as the moni
 
 ### Configuration
 
-1. Edit the `dns_check.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Couchbase performance data.
+1. Edit the `dns_check.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][7] to start collecting your Couchbase performance data.
     See the [sample dns_check.d/conf.yaml][2] for all available configuration options:
 
     ```yaml
@@ -67,3 +67,4 @@ Need help? Contact [Datadog Support][6].
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [5]: https://github.com/DataDog/integrations-core/blob/master/dns_check/metadata.csv
 [6]: https://docs.datadoghq.com/help/
+[7]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/dotnetclr/README.md
+++ b/dotnetclr/README.md
@@ -13,7 +13,7 @@ The Dotnetclr check is included in the [Datadog Agent][1] package, so you don't 
 
 ## Configuration
 
-1. Edit the `dotnetclr.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your dotnetclr performance data.
+1. Edit the `dotnetclr.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][6] to start collecting your dotnetclr performance data.
     See the [sample dotnetclr.d/conf.yaml][2] for all available configuration options.
 
 2. [Restart the Agent][5]
@@ -29,3 +29,4 @@ Need help? Contact [Datadog Support][3].
 [2]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [3]: https://docs.datadoghq.com/help/
 [5]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
+[6]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -14,7 +14,7 @@ The ECS Fargate check is packaged with the Agent, [run the Agent][1] with your c
 
 ### Configuration
 
-1. Edit the `ecs_fargate.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your ECS Fargate performance data.
+1. Edit the `ecs_fargate.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][7] to start collecting your ECS Fargate performance data.
     See the [sample ecs_fargate.d/conf.yaml][6] for all available configuration options.
 
 2. [Restart the Agent][5]
@@ -52,3 +52,4 @@ Need help? Contact [Datadog Support][3].
 [4]: https://www.datadoghq.com/blog/monitor-aws-fargate/
 [5]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
 [6]: https://github.com/DataDog/integrations-core/blob/master/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
+[7]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -15,7 +15,7 @@ The Elasticsearch check is included in the [Datadog Agent][1] package, so you do
 
 ### Configuration
 
-1. Edit the `elastic.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Elasticsearch [metrics](#metric-collection) and [logs](#log-collection).
+1. Edit the `elastic.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][11] to start collecting your Elasticsearch [metrics](#metric-collection) and [logs](#log-collection).
   See the [sample elastic.d/conf.yaml][2] for all available configuration options.
 
 2. [Restart the Agent][3]
@@ -120,3 +120,4 @@ To get a better idea of how (or why) to integrate your Elasticsearch cluster wit
 [8]: https://docs.datadoghq.com/integrations/faq/why-isn-t-elasticsearch-sending-all-my-metrics/
 [9]: https://www.datadoghq.com/blog/monitor-elasticsearch-performance-metrics/
 [10]: https://raw.githubusercontent.com/DataDog/integrations-core/master/elastic/images/elasticsearch-dash.png
+[11]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/envoy/README.md
+++ b/envoy/README.md
@@ -11,7 +11,7 @@ The Envoy check is included in the [Datadog Agent][2] package, so you don't need
 
 ### Configuration
 
-1. Edit the `envoy.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Envoy performance data.
+1. Edit the `envoy.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][14] to start collecting your Envoy performance data.
   See the [sample envoy.d/conf.yaml][4] for all available configuration options.
 
 2. Check if the Datadog Agent can access Envoy's [admin endpoint][5].
@@ -129,3 +129,4 @@ Need help? Contact [Datadog Support][11].
 [10]: https://github.com/DataDog/integrations-core/blob/master/envoy/datadog_checks/envoy/metrics.py
 [11]: https://docs.datadoghq.com/help/
 [13]: https://gist.github.com/ofek/6051508cd0dfa98fc6c13153b647c6f8
+[14]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/etcd/README.md
+++ b/etcd/README.md
@@ -17,7 +17,7 @@ The etcd check is included in the [Datadog Agent][1] package, so you don't need 
 
 ### Configuration
 
-1. Edit the `etcd.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your etcd performance data.
+1. Edit the `etcd.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][9] to start collecting your etcd performance data.
     See the [sample etcd.d/conf.yaml][2] for all available configuration options.
 
     ```yaml
@@ -68,3 +68,4 @@ To get a better idea of how (or why) to integrate etcd with Datadog, check out o
 [6]: https://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/monitor-etcd-performance/
 [8]: https://raw.githubusercontent.com/DataDog/integrations-core/master/etcd/images/etcd_dashboard.png
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/exchange_server/README.md
+++ b/exchange_server/README.md
@@ -13,7 +13,7 @@ The Exchange check is included in the [Datadog Agent][1] package, so you don't n
 
 ### Configuration
 
-1. Edit the `exchange_server.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Exchange Server performance data.  
+1. Edit the `exchange_server.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][6] to start collecting your Exchange Server performance data.  
   ```yaml
   init_config:
 
@@ -63,3 +63,4 @@ The Exchange server check does not include any service checks at this time.
 [3]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [4]: https://github.com/DataDog/integrations-core/blob/master/exchange_server/metadata.csv
 [5]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
+[6]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -16,7 +16,7 @@ The Fluentd check is included in the [Datadog Agent][1] package, so you don't ne
 
 ### Configuration
 
-Edit the `fluentd.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your FluentD [metrics](#metric-collection) and [logs](#log-collection).
+Edit the `fluentd.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][18] to start collecting your FluentD [metrics](#metric-collection) and [logs](#log-collection).
 See the [sample fluentd.d/conf.yaml][2] for all available configuration options.
 
 #### Prepare Fluentd
@@ -150,3 +150,4 @@ Need help? Contact [Datadog Support][7].
 [15]: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/
 [16]: https://docs.datadoghq.com/integrations/#cat-log-collection
 [17]: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter
+[18]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/gearmand/README.md
+++ b/gearmand/README.md
@@ -16,7 +16,7 @@ The Gearman check is included in the [Datadog Agent][1] package, so you don't ne
 ### Configuration
 
 
-1. Edit the `gearmand.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Gearman performance data.
+1. Edit the `gearmand.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][7] to start collecting your Gearman performance data.
     See the [sample gearmand.d/conf.yaml][2] for all available configuration options.
     ```yaml
     init_config:
@@ -55,3 +55,4 @@ Need help? Contact [Datadog Support][6].
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [5]: https://github.com/DataDog/integrations-core/blob/master/gearmand/metadata.csv
 [6]: https://docs.datadoghq.com/help/
+[7]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -15,7 +15,7 @@ The Gitlab check is included in the [Datadog Agent][101] package, so you don't n
 
 ### Configuration
 
-Edit the `gitlab.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory, to point to the Gitlab's Prometheus metrics endpoint.
+Edit the `gitlab.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][108], to point to the Gitlab's Prometheus metrics endpoint.
 See the [sample gitlab.d/conf.yaml][102] for all available configuration options.
 
 **Note**: The `allowed_metrics` item in the `init_config` section allows to specify the metrics that should be extracted.
@@ -44,3 +44,4 @@ Need help? Contact [Datadog Support][105].
 [104]: https://github.com/DataDog/integrations-core/blob/master/gitlab/metadata.csv
 [105]: https://docs.datadoghq.com/help/
 [107]: https://docs.gitlab.com/ee/administration/monitoring/prometheus/
+[108]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/gitlab_runner/README.md
+++ b/gitlab_runner/README.md
@@ -17,7 +17,7 @@ The Gitlab Runner check is included in the [Datadog Agent][1] package, so you do
 
 ### Configuration
 
-Edit the `gitlab_runner.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory, to point to the Runner's Prometheus metrics endpoint and to the Gitlab master to have a service check.
+Edit the `gitlab_runner.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][8], to point to the Runner's Prometheus metrics endpoint and to the Gitlab master to have a service check.
 See the [sample gitlab_runner.d/conf.yaml][2] for all available configuration options.
 
 **Note**: The `allowed_metrics` item in the `init_config` section allows to specify the metrics that should be extracted.
@@ -48,3 +48,4 @@ Need help? Contact [Datadog Support][5].
 [4]: https://github.com/DataDog/integrations-core/blob/master/gitlab_runner/metadata.csv
 [5]: https://docs.datadoghq.com/help/
 [7]: https://docs.gitlab.com/runner/monitoring/README.html
+[8]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/go_expvar/README.md
+++ b/go_expvar/README.md
@@ -22,7 +22,7 @@ If your service doesn't already listen for HTTP requests (via the http package),
 
 #### Connect the Agent
 
-1. Edit the file `go_expvar.d/conf.yaml`, in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample go_expvar.d/conf.yaml][5] for all available configuration options.
+1. Edit the file `go_expvar.d/conf.yaml`, in the `conf.d/` folder at the root of your [Agent's configuration directory][12]. See the [sample go_expvar.d/conf.yaml][5] for all available configuration options.
 
     ```yaml
         init_config:
@@ -80,3 +80,4 @@ Need help? Contact [Datadog Support][9].
 [9]: https://docs.datadoghq.com/help/
 [10]: https://www.datadoghq.com/blog/instrument-go-apps-expvar-datadog/
 [11]: https://raw.githubusercontent.com/DataDog/integrations-core/master/go_expvar/images/go_graph.png
+[12]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/gunicorn/README.md
+++ b/gunicorn/README.md
@@ -23,7 +23,7 @@ The Gunicorn check requires your Gunicorn app's Python environment to have the [
 
 ### Configuration
 
-Edit the `gunicorn.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your GUNICORN [metrics](#metric-collection) and [logs](#log-collection).
+Edit the `gunicorn.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][13] to start collecting your GUNICORN [metrics](#metric-collection) and [logs](#log-collection).
 See the [sample gunicorn.yaml][3] for all available configuration options.
 
 #### Metric Collection
@@ -165,3 +165,4 @@ To get a better idea of how (or why) to integrate your Gunicorn apps with Datado
 [10]: https://docs.gunicorn.org/en/stable/settings.html#accesslog
 [11]: https://docs.gunicorn.org/en/stable/settings.html#errorlog
 [12]: https://raw.githubusercontent.com/DataDog/integrations-core/master/gunicorn/images/gunicorn-dash.png
+[13]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -21,7 +21,7 @@ The HAProxy check is packaged with the Agent. To start gathering your HAProxy me
 
 ### Configuration
 
-Edit the `haproxy.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your HAProxy [metrics](#metric-collection) and [logs](#log-collection).
+Edit the `haproxy.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][18] to start collecting your HAProxy [metrics](#metric-collection) and [logs](#log-collection).
 See the [sample haproxy.d/conf.yaml][6] for all available configuration options.
 
 #### Prepare HAProxy
@@ -127,3 +127,4 @@ Need help? Contact [Datadog Support][14].
 [15]: https://www.datadoghq.com/blog/monitoring-haproxy-performance-metrics/
 [16]: https://www.datadoghq.com/blog/how-to-collect-haproxy-metrics/
 [17]: https://www.datadoghq.com/blog/monitor-haproxy-with-datadog/
+[18]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/hdfs_datanode/README.md
+++ b/hdfs_datanode/README.md
@@ -29,7 +29,7 @@ Restart the DataNode process to enable the JMX interface.
 
 #### Connect the Agent
 
-Edit the `hdfs_datanode.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample hdfs_datanode.d/conf.yaml][102] for all available configuration options:
+Edit the `hdfs_datanode.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][1012]. See the [sample hdfs_datanode.d/conf.yaml][102] for all available configuration options:
 
 ```
 init_config:
@@ -79,3 +79,4 @@ Need help? Contact [Datadog Support][106].
 [109]: https://www.datadoghq.com/blog/collecting-hadoop-metrics/
 [1010]: https://www.datadoghq.com/blog/monitor-hadoop-metrics-datadog/
 [1011]: https://raw.githubusercontent.com/DataDog/integrations-core/master/hdfs_datanode/images/hadoop_dashboard.png
+[1012]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/hdfs_namenode/README.md
+++ b/hdfs_namenode/README.md
@@ -29,7 +29,7 @@ Restart the NameNode process to enable the JMX interface.
 
 #### Connect the Agent
 
-Edit the `hdfs_namenode.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample hdfs_namenode.d/conf.yaml][2] for all available configuration options:
+Edit the `hdfs_namenode.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][12]. See the [sample hdfs_namenode.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -80,3 +80,4 @@ Need help? Contact [Datadog Support][6].
 [9]: https://www.datadoghq.com/blog/collecting-hadoop-metrics/
 [10]: https://www.datadoghq.com/blog/monitor-hadoop-metrics-datadog/
 [11]: https://raw.githubusercontent.com/DataDog/integrations-core/master/hdfs_datanode/images/hadoop_dashboard.png
+[12]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/http_check/README.md
+++ b/http_check/README.md
@@ -12,7 +12,7 @@ The HTTP check is included in the [Datadog Agent][1] package, so you don't need 
 
 ### Configuration
 
-Edit the `http_check.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample http_check.d/conf.yaml][2] for all available configuration options:
+Edit the `http_check.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][10]. See the [sample http_check.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -116,3 +116,4 @@ Need help? Contact [Datadog Support][9].
 [7]: https://github.com/DataDog/integrations-core/blob/master/http_check/metadata.csv
 [8]: https://app.datadoghq.com/monitors#/create
 [9]: https://docs.datadoghq.com/help/
+[10]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/iis/README.md
+++ b/iis/README.md
@@ -39,7 +39,7 @@ The IIS check is packaged with the Agent. To start gathering your IIS metrics an
 
 ### Configuration
 
-Edit the `iis.d/conf.yaml` file  in the [Agent's `conf.d` directory][2] at the root of your Agent's configuration directory,
+Edit the `iis.d/conf.yaml` file  in the [Agent's `conf.d` directory][2] at the root of your [Agent's configuration directory][11],
 
 #### Prepare IIS
 
@@ -162,3 +162,4 @@ Need help? Contact [Datadog Support][8].
 [7]: https://github.com/DataDog/integrations-core/blob/master/iis/metadata.csv
 [8]: https://docs.datadoghq.com/help/
 [10]: https://raw.githubusercontent.com/DataDog/integrations-core/master/iis/images/iisgraph.png
+[11]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/istio/README.md
+++ b/istio/README.md
@@ -22,7 +22,7 @@ Istio needs to have the built in [prometheus adapter][2] enabled and the ports e
 
 #### Connect the Agent
 
-Edit the `istio.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory, to connect it to Istio. See the [sample istio.d/conf.yaml][3] for all available configuration options:
+Edit the `istio.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][8], to connect it to Istio. See the [sample istio.d/conf.yaml][3] for all available configuration options:
 
 ```
 init_config:
@@ -61,3 +61,4 @@ Need help? Contact [Datadog Support][7].
 [5]: https://docs.datadoghq.com/agent/faq/agent-status-and-information/
 [6]: https://github.com/DataDog/integrations-core/blob/master/istio/metadata.csv
 [7]: https://docs.datadoghq.com/help/
+[8]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -22,7 +22,7 @@ The check collects metrics via JMX, so you'll need a JVM on each kafka node so t
 
 ### Configuration
 
-Edit the `kafka.d/conf.yaml` file,  in the `conf.d/` folder at the root of your Agent's configuration directory.
+Edit the `kafka.d/conf.yaml` file,  in the `conf.d/` folder at the root of your [Agent's configuration directory][31].
 
 #### Metric Collection
 
@@ -132,3 +132,4 @@ Returns `OK` otherwise.
 [28]: https://www.datadoghq.com/blog/collecting-kafka-performance-metrics/
 [29]: https://www.datadoghq.com/blog/monitor-kafka-with-datadog/
 [30]: https://raw.githubusercontent.com/DataDog/integrations-core/master/kafka/images/kafka_dashboard.png
+[31]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/kong/README.md
+++ b/kong/README.md
@@ -11,7 +11,7 @@ The Kong check is included in the [Datadog Agent][1] package, so you don't need 
 
 ### Configuration
 
-1. Edit the `kong.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory.
+1. Edit the `kong.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][8].
     See the [sample kong.d/conf.yaml][2] for all available configuration options:
     ```yaml
     init_config:
@@ -61,3 +61,4 @@ Need help? Contact [Datadog Support][6].
 [5]: https://github.com/DataDog/integrations-core/blob/master/kong/metadata.csv
 [6]: https://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/monitor-kong-datadog/
+[8]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/kube_dns/README.md
+++ b/kube_dns/README.md
@@ -17,7 +17,7 @@ The Kube-dns check is included in the [Datadog Agent][1] package, so you don't n
 
 ### Configuration
 
-Edit the `kube_dns.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory, to point to your server and port, set the masters to monitor. See the [sample kube_dns.d/conf.yaml][2] for all available configuration options.
+Edit the `kube_dns.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][6], to point to your server and port, set the masters to monitor. See the [sample kube_dns.d/conf.yaml][2] for all available configuration options.
 
 #### Using with service discovery
 
@@ -66,3 +66,4 @@ Need help? Contact [Datadog Support][5].
 [3]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [4]: https://github.com/DataDog/integrations-core/blob/master/kube_dns/metadata.csv
 [5]: https://docs.datadoghq.com/help/
+[6]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/kubelet/README.md
+++ b/kubelet/README.md
@@ -13,7 +13,7 @@ The Kubelet check is included in the [Datadog Agent][3] package, so you don't ne
 
 ## Configuration
 
-Edit the `kubelet.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory, to point to your server and port, set tags to send along with metrics.
+Edit the `kubelet.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4], to point to your server and port, set tags to send along with metrics.
 
 ## Validation
 
@@ -52,3 +52,4 @@ The check will still be able to collect:
 [1]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [2]: https://docs.openshift.org/3.7/install_config/master_node_configuration.html#node-configuration-files
 [3]: https://app.datadoghq.com/account/settings#agent
+[4]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/kubernetes_state/README.md
+++ b/kubernetes_state/README.md
@@ -14,7 +14,7 @@ The Kubernetes-Sate check is included in the [Datadog Agent][1] package, so you 
 
 ### Configuration
 
-Edit the `kubernetes_state.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory, to point to your server and port, set the masters to monitor. See the [sample kubernetes_state.d/conf.yaml][2] for all available configuration options.
+Edit the `kubernetes_state.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][6], to point to your server and port, set the masters to monitor. See the [sample kubernetes_state.d/conf.yaml][2] for all available configuration options.
 
 ### Validation
 
@@ -65,3 +65,4 @@ Need help? Contact [Datadog Support][5].
 [3]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [4]: https://github.com/DataDog/integrations-core/blob/master/kubernetes_state/metadata.csv
 [5]: https://docs.datadoghq.com/help/
+[6]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/kyototycoon/README.md
+++ b/kyototycoon/README.md
@@ -11,7 +11,7 @@ The KyotoTycoon check is included in the [Datadog Agent][1] package, so you don'
 
 ### Configuration
 
-1. Edit the `kyototycoon.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory.
+1. Edit the `kyototycoon.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][8].
     See the [sample kyototycoon.d/conf.yaml][2] for all available configuration options:
 
     ```yaml
@@ -61,3 +61,4 @@ Need help? Contact [Datadog Support][5].
 [4]: https://github.com/DataDog/integrations-core/blob/master/kyototycoon/metadata.csv
 [5]: https://docs.datadoghq.com/help/
 [7]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
+[8]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/lighttpd/README.md
+++ b/lighttpd/README.md
@@ -15,7 +15,7 @@ In addition, install `mod_status` on your Lighttpd servers.
 
 ### Configuration
 
-1. Edit the  `lighttpd.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory.
+1. Edit the  `lighttpd.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][9].
 	See the [sample lighttpd.d/conf.yaml][2] for all available configuration options:
 
     ```yaml
@@ -64,3 +64,4 @@ To get a better idea of how (or why) to monitor Lighttpd web server metrics with
 [6]: https://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/monitor-lighttpd-web-server-metrics/
 [8]: https://raw.githubusercontent.com/DataDog/integrations-core/master/lighttpd/images/lighttpddashboard.png
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/linkerd/README.md
+++ b/linkerd/README.md
@@ -12,7 +12,7 @@ The Linkerd check is included in the [Datadog Agent][2] package, so you don't ne
 
 ### Configuration
 
-Edit the `linkerd.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory.
+Edit the `linkerd.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][9].
 See [sample linkerd.d/conf.yaml][3] for all available configuration options.
 
 ### Validation
@@ -56,3 +56,4 @@ Need help? Contact [Datadog Support][8].
 [6]: https://twitter.github.io/finagle/guide/Metrics.html
 [7]: https://gist.githubusercontent.com/arbll/2f63a5375a4d6d5acface6ca8a51e2ab/raw/bc35ed4f0f4bac7e2643a6009f45f9068f4c1d12/gistfile1.txt
 [8]: https://docs.datadoghq.com/help/
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/linux_proc_extras/README.md
+++ b/linux_proc_extras/README.md
@@ -13,7 +13,7 @@ The Linux_proc_extras check is included in the [Datadog Agent][1] package, so yo
 
 ### Configuration
 
-Edit the `linux_proc_extras.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample linux_proc_extras.d/conf.yaml][2] for all available configuration options.
+Edit the `linux_proc_extras.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][5]. See the [sample linux_proc_extras.d/conf.yaml][2] for all available configuration options.
 
 ### Validation
 
@@ -37,3 +37,4 @@ Need help? Contact [Datadog Support][4].
 [2]: https://github.com/DataDog/integrations-core/blob/master/linux_proc_extras/datadog_checks/linux_proc_extras/data/conf.yaml.example
 [3]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [4]: https://docs.datadoghq.com/help/
+[5]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/mapreduce/README.md
+++ b/mapreduce/README.md
@@ -16,7 +16,7 @@ The Mapreduce check is included in the [Datadog Agent][1] package, so you don't 
 
 ### Configuration
 
-Edit the `mapreduce.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to point to your server and port, set the masters to monitor. See the [sample mapreduce.d/conf.yaml][2] for all available configuration options.
+Edit the `mapreduce.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][11] to point to your server and port, set the masters to monitor. See the [sample mapreduce.d/conf.yaml][2] for all available configuration options.
 
 ### Validation
 
@@ -61,3 +61,4 @@ Need help? Contact [Datadog Support][5].
 [8]: https://www.datadoghq.com/blog/collecting-hadoop-metrics/
 [9]: https://www.datadoghq.com/blog/monitor-hadoop-metrics-datadog/
 [10]: https://raw.githubusercontent.com/DataDog/integrations-core/master/mapreduce/images/mapreduce_dashboard.png
+[11]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/marathon/README.md
+++ b/marathon/README.md
@@ -14,7 +14,7 @@ The Marathon check is included in the [Datadog Agent][1] package, so you don't n
 
 ### Configuration
 
-1. Edit the `marathon.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory.
+1. Edit the `marathon.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][7].
     See the [sample marathon.d/conf.yaml][2] for all available configuration options:
 
     ```yaml
@@ -57,3 +57,4 @@ Need help? Contact [Datadog Support][6].
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [5]: https://github.com/DataDog/integrations-core/blob/master/marathon/metadata.csv
 [6]: https://docs.datadoghq.com/help/
+[7]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/mcache/README.md
+++ b/mcache/README.md
@@ -11,7 +11,7 @@ The memcache check is included in the [Datadog Agent][1] package, so you don't n
 
 ### Configuration
 
-1. Edit the `mcache.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory.
+1. Edit the `mcache.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][10].
   See the [sample mcache.d/conf.yaml][2] for all available configuration options:
 
     ```yaml
@@ -70,3 +70,4 @@ Need help? Contact [Datadog Support][6].
 [7]: https://www.datadoghq.com/blog/speed-up-web-applications-memcached/
 [8]: https://www.datadoghq.com/blog/instrument-memcached-performance-metrics-dogstatsd/
 [9]: https://www.datadoghq.com/blog/monitoring-elasticache-performance-metrics-with-redis-or-memcached/
+[10]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -16,7 +16,7 @@ The MongoDB check is included in the [Datadog Agent][1] package, so you don't ne
 
 ### Configuration
 
-Edit the `mongo.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your MongoDB [metrics](#metric-collection) and [logs](#log-collection).  See the [sample mongo.yaml][2] for all available configuration options.
+Edit the `mongo.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][12] to start collecting your MongoDB [metrics](#metric-collection) and [logs](#log-collection).  See the [sample mongo.yaml][2] for all available configuration options.
 
 #### Prepare MongoDB
 
@@ -149,3 +149,4 @@ Read our series of blog posts about collecting metrics from MongoDB with Datadog
 [9]: https://www.datadoghq.com/blog/monitoring-mongodb-performance-metrics-wiredtiger/
 [10]: https://www.datadoghq.com/blog/monitoring-mongodb-performance-metrics-mmap/
 [11]: https://raw.githubusercontent.com/DataDog/integrations-core/master/mongo/images/mongo_dashboard.png
+[12]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -21,7 +21,7 @@ The MySQL check is included in the [Datadog Agent][13] package, so you don't nee
 
 ### Configuration
 
-Edit `conf.d/mysql.d/conf.yaml` in the root of your Agent's configuration directory in order to connect the Agent to your MySQL server. You will begin collecting your MySQL [metrics](#metric-collection) and [logs](#log-collection) right away. See the [sample configuration file][16] for all available configuration options.
+Edit `conf.d/mysql.d/conf.yaml` in the root of your [Agent's configuration directory][31] in order to connect the Agent to your MySQL server. You will begin collecting your MySQL [metrics](#metric-collection) and [logs](#log-collection) right away. See the [sample configuration file][16] for all available configuration options.
 
 #### Prepare MySQL
 
@@ -378,3 +378,4 @@ Read our [series of blog posts][29] about monitoring MySQL with Datadog.
 [28]: https://docs.datadoghq.com/integrations/faq/database-user-lacks-privileges
 [29]: https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics/
 [30]: https://raw.githubusercontent.com/DataDog/integrations-core/master/mysql/images/mysql-dash-dd.png
+[31]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/nagios/README.md
+++ b/nagios/README.md
@@ -13,7 +13,7 @@ The Nagios check is included in the [Datadog Agent][1] package, so you don't nee
 
 ### Configuration
 
-Edit the `nagios.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample nagios.d/conf.yaml][2] for all available configuration options:
+Edit the `nagios.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][7]. See the [sample nagios.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -76,3 +76,4 @@ Need help? Contact [Datadog Support][5].
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [5]: https://docs.datadoghq.com/help/
 [6]: https://www.datadoghq.com/blog/nagios-monitoring/
+[7]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/network/README.md
+++ b/network/README.md
@@ -13,7 +13,7 @@ The network check is included in the [Datadog Agent][1] package, so you don't ne
 
 ### Configuration
 
-1. The Agent enables the network check by default, but if you want to configure the check yourself, edit file `network.d/conf.yaml`, in the `conf.d/` folder at the root of your Agent's configuration directory.
+1. The Agent enables the network check by default, but if you want to configure the check yourself, edit file `network.d/conf.yaml`, in the `conf.d/` folder at the root of your [Agent's configuration directory][10].
   See the [sample network.d/conf.yaml][2] for all available configuration options:
 
     ```yaml
@@ -62,3 +62,4 @@ The Network check does not include any service checks at this time.
 [6]: https://docs.datadoghq.com/integrations/faq/how-to-send-tcp-udp-host-metrics-via-the-datadog-api
 [8]: https://docs.datadoghq.com/monitors/monitor_types/network
 [9]: https://raw.githubusercontent.com/DataDog/integrations-core/master/network/images/netdashboard.png
+[10]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/nfsstat/README.md
+++ b/nfsstat/README.md
@@ -11,7 +11,7 @@ The NFSstat check is included in the [Datadog Agent][2] package, so you don't ne
 
 ### Configuration
 
-Edit the `nfsstat.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory, to point to your nfsiostat binary script, or use the one included with the binary installer. See the [sample nfsstat.d/conf.yaml][3] for all available configuration options.
+Edit the `nfsstat.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][9], to point to your nfsiostat binary script, or use the one included with the binary installer. See the [sample nfsstat.d/conf.yaml][3] for all available configuration options.
 
 ### Validation
 
@@ -42,3 +42,4 @@ Need help? Contact [Datadog Support][6].
 [5]: https://github.com/DataDog/integrations-core/blob/master/nfsstat/metadata.csv
 [6]: https://docs.datadoghq.com/help/
 [8]: https://docs.datadoghq.com/monitors/monitor_types/network
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -43,7 +43,7 @@ If the command output does not include `http_stub_status_module`, you must insta
 
 ### Configuration
 
-Edit the `nginx.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your NGINX [metrics](#metric-collection) and [logs](#log-collection).
+Edit the `nginx.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][15] to start collecting your NGINX [metrics](#metric-collection) and [logs](#log-collection).
 See the [sample nginx.d/conf.yaml][5] for all available configuration options.
 
 #### Prepare NGINX
@@ -224,3 +224,4 @@ Learn more about how to monitor NGINX performance metrics thanks to [our series 
 [12]: https://www.datadoghq.com/blog/how-to-collect-nginx-metrics/index.html
 [13]: https://www.datadoghq.com/blog/how-to-monitor-nginx-with-datadog/index.html
 [14]: https://raw.githubusercontent.com/DataDog/integrations-core/master/nginx/images/nginx_dashboard.png
+[15]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/ntp/README.md
+++ b/ntp/README.md
@@ -21,7 +21,7 @@ The NTP check is included in the [Datadog Agent][1] package, so you don't need t
 
 ### Configuration
 
-The Agent enables the NTP check by default, but if you want to configure the check yourself, edit the file `ntp.d/conf.yaml` in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample ntp.d/conf.yaml][2] for all available configuration options:
+The Agent enables the NTP check by default, but if you want to configure the check yourself, edit the file `ntp.d/conf.yaml` in the `conf.d/` folder at the root of your [Agent's configuration directory][7]. See the [sample ntp.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -69,3 +69,4 @@ Need help? Contact [Datadog Support][6].
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [5]: https://github.com/DataDog/integrations-core/blob/master/ntp/metadata.csv
 [6]: https://docs.datadoghq.com/help/
+[7]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -72,7 +72,7 @@ To capture OpenStack metrics you need to [install the Agent][1] on your hosts ru
 
 You may need to restart your Keystone, Neutron and Nova API services to ensure that the policy changes take.
 
-3. Configure the Datadog Agent to connect to your Keystone server, and specify individual projects to monitor. Edit the `openstack.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample openstack.d/conf.yaml][2] for all available configuration options.
+3. Configure the Datadog Agent to connect to your Keystone server, and specify individual projects to monitor. Edit the `openstack.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][11]. See the [sample openstack.d/conf.yaml][2] for all available configuration options.
 
 4. [Restart the Agent][3]
 
@@ -130,3 +130,4 @@ See also our blog posts:
 [8]: https://www.datadoghq.com/blog/install-openstack-in-two-commands/
 [9]: https://www.datadoghq.com/blog/openstack-host-aggregates-flavors-availability-zones/
 [10]: https://raw.githubusercontent.com/DataDog/integrations-core/master/openstack/images/openstack_dashboard.png
+[11]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -72,7 +72,7 @@ ALTER SESSION SET "_ORACLE_SCRIPT"=true;
 
 ### Configuration
 
-Edit the `oracle.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to point to your server and port, set the masters to monitor. See the [sample oracle.d/conf.yaml][2] for all available configuration options.
+Edit the `oracle.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][10] to point to your server and port, set the masters to monitor. See the [sample oracle.d/conf.yaml][2] for all available configuration options.
 
 Configuration Options:
 
@@ -109,3 +109,4 @@ Need help? Contact [Datadog Support][8].
 [7]: https://github.com/DataDog/integrations-core/blob/master/oracle/metadata.csv
 [8]: https://docs.datadoghq.com/help/
 [9]: https://raw.githubusercontent.com/DataDog/integrations-core/master/oracle/images/oracle_dashboard.png
+[10]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/pdh_check/README.md
+++ b/pdh_check/README.md
@@ -13,7 +13,7 @@ The PDH check is included in the [Datadog Agent][1] package, so you don't need t
 
 ### Configuration
 
-Edit the `pdh_check.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to collect Windows performance data. See the [sample pdh_check.d/conf.yaml][2] for all available configuration options.
+Edit the `pdh_check.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][5] to collect Windows performance data. See the [sample pdh_check.d/conf.yaml][2] for all available configuration options.
 
 ### Validation
 
@@ -34,3 +34,4 @@ The PDH check does not include any service checks at this time.
 [2]: https://github.com/DataDog/integrations-core/blob/master/pdh_check/datadog_checks/pdh_check/data/conf.yaml.example
 [3]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [4]: https://github.com/DataDog/integrations-core/blob/master/pdh_check/metadata.csv
+[5]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/pgbouncer/README.md
+++ b/pgbouncer/README.md
@@ -11,7 +11,7 @@ The PgBouncer check is included in the [Datadog Agent][1] package, so you don't 
 
 ### Configuration
 
-Edit the `pgbouncer.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample pgbouncer.d/conf.yaml][2] for all available configuration options:
+Edit the `pgbouncer.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][7]. See the [sample pgbouncer.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -70,3 +70,4 @@ Need help? Contact [Datadog Support][6].
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [5]: https://github.com/DataDog/integrations-core/blob/master/pgbouncer/metadata.csv
 [6]: https://docs.datadoghq.com/help/
+[7]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/php_fpm/README.md
+++ b/php_fpm/README.md
@@ -13,7 +13,7 @@ The PHP-FPM check is included in the [Datadog Agent][1] package, so you don't ne
 
 ### Configuration
 
-Edit the `php_fpm.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample php_fpm.d/conf.yaml][2] for all available configuration options:
+Edit the `php_fpm.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][9]. See the [sample php_fpm.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -68,3 +68,4 @@ Need help? Contact [Datadog Support][6].
 [5]: https://github.com/DataDog/integrations-core/blob/master/php_fpm/metadata.csv
 [6]: https://docs.datadoghq.com/help/
 [8]: https://raw.githubusercontent.com/DataDog/integrations-core/master/php_fpm/images/phpfpmoverview.png
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/postfix/README.md
+++ b/postfix/README.md
@@ -19,7 +19,7 @@ Optionally, you can configure the agent to use a built in `postqueue -p` command
 **WARNING**: Using `postqueue` to monitor the mail queues will not report a count of messages for the `incoming` queue.
 
 ### Using sudo
-Edit the file `postfix.d/conf.yaml`, in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample postfix.d/conf.yaml][2] for all available configuration options:
+Edit the file `postfix.d/conf.yaml`, in the `conf.d/` folder at the root of your [Agent's configuration directory][9]. See the [sample postfix.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -48,7 +48,7 @@ dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/deferred -type 
 ```
 
 ### Using postqueue
-Edit the `postfix.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory:
+Edit the `postfix.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][9]:
 
 ```
 init_config:
@@ -108,3 +108,4 @@ Need help? Contact [Datadog Support][6].
 [6]: https://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/monitor-postfix-queues/
 [8]: https://raw.githubusercontent.com/DataDog/integrations-core/master/postfix/images/postfixgraph.png
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -17,7 +17,7 @@ The PostgreSQL check is packaged with the Agent. To start gathering your Postgre
 
 ### Configuration
 
-Edit the `postgres.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your PostgreSQL [metrics](#metric-collection) and [logs](#log-collection). See the [sample postgres.d/conf.yaml][14] for all available configuration options.
+Edit the `postgres.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][25] to start collecting your PostgreSQL [metrics](#metric-collection) and [logs](#log-collection). See the [sample postgres.d/conf.yaml][14] for all available configuration options.
 
 #### Prepare Postgres
 
@@ -221,3 +221,4 @@ You should also check the `/var/log/datadog/collector.log` file for more informa
 [22]: https://www.datadoghq.com/blog/postgresql-monitoring-tools/
 [23]: https://www.datadoghq.com/blog/collect-postgresql-data-with-datadog/
 [24]: https://raw.githubusercontent.com/DataDog/integrations-core/master/postgres/images/postgresql_dashboard.png
+[25]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/powerdns_recursor/README.md
+++ b/powerdns_recursor/README.md
@@ -38,7 +38,7 @@ Restart the recursor to enable the statistics API.
 
 #### Connect the Agent
 
-1. Edit the `powerdns_recursor.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory.
+1. Edit the `powerdns_recursor.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][7].
 	See the [sample powerdns_recursor.d/conf.yaml][2] for all available configuration options:
 
     ```yaml
@@ -78,3 +78,4 @@ Need help? Contact [Datadog Support][6].
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [5]: https://github.com/DataDog/integrations-core/blob/master/powerdns_recursor/metadata.csv
 [6]: https://docs.datadoghq.com/help/
+[7]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -18,7 +18,7 @@ The RabbitMQ check is included in the [Datadog Agent][1] package, so you don't n
 
 ### Configuration
 
-Edit the `rabbitmq.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your RabbitMQ [metrics](#metric-collection) and [logs](#log-collection). See the [sample rabbitmq.yaml][3] for all available configuration options.
+Edit the `rabbitmq.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][14] to start collecting your RabbitMQ [metrics](#metric-collection) and [logs](#log-collection). See the [sample rabbitmq.yaml][3] for all available configuration options.
 
 #### Prepare RabbitMQ
 
@@ -154,3 +154,4 @@ Returns CRITICAL if the Agent cannot connect to rabbitmq to collect metrics, oth
 [11]: https://www.datadoghq.com/blog/monitoring-rabbitmq-performance-with-datadog/
 [12]: https://app.datadoghq.com/account/settings#integrations/rabbitmq
 [13]: https://raw.githubusercontent.com/DataDog/integrations-core/master/rabbitmq/images/rabbitmq_dashboard.png
+[14]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/redisdb/README.md
+++ b/redisdb/README.md
@@ -12,7 +12,7 @@ The Redis check is included in the [Datadog Agent][1] package, so you don't need
 
 ### Configuration
 
-Edit the `redisdb.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Redis [metrics](#metric-collection) and [logs](#log-collection).
+Edit the `redisdb.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][9] to start collecting your Redis [metrics](#metric-collection) and [logs](#log-collection).
 See the [sample redis.d/conf.yaml][2] for all available configuration options.
 
 #### Metric Collection
@@ -231,3 +231,4 @@ Read our [series of blog posts][8] about how to monitor your Redis servers with 
 [6]: https://docs.datadoghq.com/integrations/faq/redis-integration-error-unknown-command-config
 [7]: https://docs.datadoghq.com/developers/integrations/
 [8]: https://www.datadoghq.com/blog/how-to-monitor-redis-performance-metrics/
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/riak/README.md
+++ b/riak/README.md
@@ -13,7 +13,7 @@ The Riak check is included in the [Datadog Agent][1] package, so you don't need 
 
 ### Configuration
 
-1. Edit the `riak.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory.
+1. Edit the `riak.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][9].
 	See the [sample riak.yaml][2] for all available configuration options:
 
     ```yaml
@@ -53,3 +53,4 @@ Need help? Contact [Datadog Support][6].
 [5]: https://github.com/DataDog/integrations-core/blob/master/riak/metadata.csv
 [6]: https://docs.datadoghq.com/help/
 [8]: https://raw.githubusercontent.com/DataDog/integrations-core/master/riak/images/riak_graph.png
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/riakcs/README.md
+++ b/riakcs/README.md
@@ -16,7 +16,7 @@ The RiakCS check is included in the [Datadog Agent][1] package, so you don't nee
 
 ### Configuration
 
-1. Edit the `riakcs.yamld/conf.` file, in the `conf.d/` folder at the root of your Agent's configuration directory.
+1. Edit the `riakcs.yamld/conf.` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][9].
     See the [sample riakcs.d/conf.yaml][2] for all available configuration options:
 
     ```yaml
@@ -66,3 +66,4 @@ To get a better idea of how (or why) to monitor Riak CS performance and availabi
 [6]: https://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/monitor-riak-cs-performance-and-availability/
 [8]: https://raw.githubusercontent.com/DataDog/integrations-core/master/riakcs/images/riakcs_dashboard.png
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/snmp/README.md
+++ b/snmp/README.md
@@ -13,7 +13,7 @@ The SNMP check is included in the [Datadog Agent][1] package, so you don't need 
 
 The SNMP check doesn't collect anything by default; you have to tell it specifically what to collect.
 
-Here's an example of `snmp.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample snmp.d/conf.yaml][2] for all available configuration options:
+Here's an example of `snmp.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][11]. See the [sample snmp.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -184,3 +184,4 @@ Need help? Contact [Datadog Support][5].
 [8]: https://github.com/DataDog/dd-agent/blob/master/CHANGELOG.md#dependency-changes-3
 [9]: https://stackoverflow.com/questions/35204995/build-pysnmp-mib-convert-cisco-mib-files-to-a-python-fails-on-ubuntu-14-04
 [10]: https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/conf.yaml.example#L3
+[11]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/solr/README.md
+++ b/solr/README.md
@@ -15,7 +15,7 @@ This check is JMX-based, so you'll need to enable JMX Remote on your Tomcat serv
 
 ### Configuration
 
-Edit the `solr.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample solr.d/conf.yaml][3] for all available configuration options:
+Edit the `solr.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][9]. See the [sample solr.d/conf.yaml][3] for all available configuration options:
 
 ```
 instances:
@@ -270,3 +270,4 @@ You may use the `attribute` filter as follow:
 [5]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [6]: https://github.com/DataDog/integrations-core/blob/master/solr/metadata.csv
 [8]: https://raw.githubusercontent.com/DataDog/integrations-core/master/solr/images/solrgraph.png
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/spark/README.md
+++ b/spark/README.md
@@ -22,7 +22,7 @@ The Spark check is included in the [Datadog Agent][1] package, so you don't need
 
 ### Configuration
 
-1. Edit the `spark.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory.
+1. Edit the `spark.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][11].
     See the [sample spark.d/conf.yaml][2] for all available configuration options:
 
     ```yaml
@@ -88,3 +88,4 @@ To get Spark metrics if Spark is set up on AWS EMR, [use bootstrap actions][6] t
 [8]: https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-connect-master-node-ssh.html
 [9]: https://www.datadoghq.com/blog/monitoring-spark/
 [10]: https://raw.githubusercontent.com/DataDog/integrations-core/master/spark/images/sparkgraph.png
+[11]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/sqlserver/README.md
+++ b/sqlserver/README.md
@@ -27,7 +27,7 @@ Make sure that your SQL Server instance supports SQL Server authentication by en
         GRANT VIEW SERVER STATE to datadog;
     ```
 
-2. Create a file `sqlserver.d/conf.yaml`, in the `conf.d/` folder at the root of your Agent's configuration directory.
+2. Create a file `sqlserver.d/conf.yaml`, in the `conf.d/` folder at the root of your [Agent's configuration directory][13].
     See the [sample sqlserver.d/conf.yaml][2] for all available configuration options:
 
     ```yaml
@@ -89,3 +89,4 @@ Need help? Contact [Datadog Support][6].
 [10]: https://www.datadoghq.com/blog/sql-server-performance/
 [11]: https://www.datadoghq.com/blog/sql-server-metrics/
 [12]: https://raw.githubusercontent.com/DataDog/integrations-core/master/sqlserver/images/sqlserver_dashboard.png
+[13]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/squid/README.md
+++ b/squid/README.md
@@ -12,7 +12,7 @@ The Agent's Squid check is included in the [Datadog Agent][1] package, so you do
 
 ### Configuration
 
-1. Edit the `squid.d/conf.yaml`, in the `conf.d/` folder at the root of your Agent's configuration directory.
+1. Edit the `squid.d/conf.yaml`, in the `conf.d/` folder at the root of your [Agent's configuration directory][11].
     See the [sample squid.d/conf.yaml][2] for all available configuration options:
 
 ```
@@ -79,3 +79,4 @@ Reach out to our team and other Datadog users on [Slack][9].
 [8]: mailto:support@datadoghq.com
 [9]: https://chat.datadoghq.com/
 [10]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
+[11]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/ssh_check/README.md
+++ b/ssh_check/README.md
@@ -11,7 +11,7 @@ The SSH/SFTP check is included in the [Datadog Agent][1] package, so you don't n
 
 ### Configuration
 
-1. Edit the `ssh_check.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory.
+1. Edit the `ssh_check.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][7].
     See the [sample ssh_check.d/conf.yaml][2] for all available configuration options:
 
     ```yaml
@@ -61,3 +61,4 @@ Need help? Contact [Datadog Support][6].
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [5]: https://github.com/DataDog/integrations-core/blob/master/ssh_check/metadata.csv
 [6]: https://docs.datadoghq.com/help/
+[7]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/statsd/README.md
+++ b/statsd/README.md
@@ -13,7 +13,7 @@ The StatsD check is included in the [Datadog Agent][1] package, so you don't nee
 
 ### Configuration
 
-1. Edit the `statsd.d/conf.yaml` in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample statsd.d/conf.yaml][2] for all available configuration options:
+1. Edit the `statsd.d/conf.yaml` in the `conf.d/` folder at the root of your [Agent's configuration directory][9]. See the [sample statsd.d/conf.yaml][2] for all available configuration options:
 
     ```yaml
         init_config:
@@ -70,3 +70,4 @@ To get a better idea of how (or why) to visualize StatsD metrics with Counts Gra
 [6]: https://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/statsd/
 [8]: https://www.datadoghq.com/blog/visualize-statsd-metrics-counts-graphing/
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/supervisord/README.md
+++ b/supervisord/README.md
@@ -50,7 +50,7 @@ Reload supervisord.
 
 #### Connect the Agent
 
-Edit the `supervisord.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample supervisord.d/conf.yaml][2] for all available configuration options:
+Edit the `supervisord.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][9]. See the [sample supervisord.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -135,3 +135,4 @@ Need help? Contact [Datadog Support][6].
 [6]: https://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/supervisor-monitors-your-processes-datadog-monitors-supervisor/
 [8]: https://raw.githubusercontent.com/DataDog/integrations-core/master/supervisord/images/supervisorevent.png
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/system_core/README.md
+++ b/system_core/README.md
@@ -13,7 +13,7 @@ The system_core check is included in the [Datadog Agent][1] package, so you don'
 
 ### Configuration
 
-1. Edit the `system_core.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample system_core.d/conf.yaml][2] for all available configuration options:
+1. Edit the `system_core.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][9]. See the [sample system_core.d/conf.yaml][2] for all available configuration options:
 
     ```
     init_config:
@@ -53,3 +53,4 @@ Need help? Contact [Datadog Support][6].
 [5]: https://github.com/DataDog/integrations-core/blob/master/system_core/metadata.csv
 [6]: https://docs.datadoghq.com/help/
 [8]: https://raw.githubusercontent.com/DataDog/integrations-core/master/system_core/images/syscoredash.png
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/system_swap/README.md
+++ b/system_swap/README.md
@@ -11,7 +11,7 @@ The system swap check is included in the [Datadog Agent][1] package, so you don'
 
 ### Configuration
 
-1. Edit the `system_swap.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample system_swap.d/conf.yaml][2] for all available configuration options:
+1. Edit the `system_swap.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][7]. See the [sample system_swap.d/conf.yaml][2] for all available configuration options:
 
     ```
     # This check takes no initial configuration
@@ -46,3 +46,4 @@ Need help? Contact [Datadog Support][6].
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [5]: https://github.com/DataDog/integrations-core/blob/master/system_swap/metadata.csv
 [6]: https://docs.datadoghq.com/help/
+[7]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/tcp_check/README.md
+++ b/tcp_check/README.md
@@ -14,7 +14,7 @@ The TCP check is included in the [Datadog Agent][1] package, so you don't need t
 
 ### Configuration
 
-Edit the `tcp_check.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample tcp_check.d/conf.yaml][2] for all available configuration options:
+Edit the `tcp_check.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][10]. See the [sample tcp_check.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -70,3 +70,4 @@ Need help? Contact [Datadog Support][7].
 [6]: https://app.datadoghq.com/monitors#/create
 [7]: https://docs.datadoghq.com/help/
 [9]: https://raw.githubusercontent.com/DataDog/integrations-core/master/tcp_check/images/netgraphs.png
+[10]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/teamcity/README.md
+++ b/teamcity/README.md
@@ -16,7 +16,7 @@ The Teamcity check is included in the [Datadog Agent][1] package, so you don't n
 
 Follow [Teamcity's documentation][2] to enable Guest Login.
 
-Edit the `teamcity.d/conf.yaml` in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample teamcity.d/conf.yaml][3] for all available configuration options:
+Edit the `teamcity.d/conf.yaml` in the `conf.d/` folder at the root of your [Agent's configuration directory][8]. See the [sample teamcity.d/conf.yaml][3] for all available configuration options:
 
 ```
 init_config:
@@ -67,3 +67,4 @@ Need help? Contact [Datadog Support][6].
 [5]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [6]: https://docs.datadoghq.com/help/
 [7]: https://www.datadoghq.com/blog/track-performance-impact-of-code-changes-with-teamcity-and-datadog/
+[8]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/tokumx/README.md
+++ b/tokumx/README.md
@@ -50,7 +50,7 @@ For more details about creating and managing users in MongoDB, refer to [the Mon
 
 #### Connect the Agent
 
-1. Edit the `tokumx.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory.
+1. Edit the `tokumx.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][9].
     See the [sample tokumx.d/conf.yaml][3] for all available configuration options:
 
     ```yaml
@@ -97,3 +97,4 @@ Need help? Contact [Datadog Support][7].
 [6]: https://github.com/DataDog/integrations-core/blob/master/tokumx/metadata.csv
 [7]: https://docs.datadoghq.com/help/
 [8]: https://www.datadoghq.com/blog/monitor-key-tokumx-metrics-mongodb-applications/
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -21,7 +21,7 @@ This check is JMX-based, so you'll need to enable JMX Remote on your Tomcat serv
 
 ### Configuration
 
-1. Edit the `tomcat.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Tomcat [metrics](#metric-collection) and [logs](#log-collection).
+1. Edit the `tomcat.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][24] to start collecting your Tomcat [metrics](#metric-collection) and [logs](#log-collection).
   See the [sample tomcat.d/conf.yaml][17] for all available configuration options.
 
 2. [Restart the Agent][16]
@@ -347,3 +347,4 @@ The `datadog-agent jmx` command was added in version 4.1.0.
 [21]: https://github.com/DataDog/integrations-core/blob/master/tomcat/metadata.csv
 [22]: https://www.datadoghq.com/blog/monitor-tomcat-metrics/
 [23]: https://raw.githubusercontent.com/DataDog/integrations-core/master/yarn/images/yarn_dashboard.png
+[24]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/twemproxy/README.md
+++ b/twemproxy/README.md
@@ -11,7 +11,7 @@ The Agent's Twemproxy check is included in the [Datadog Agent][1] package, so yo
 
 ### Configuration
 
-1. Edit the `twemproxy.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample twemproxy.d/conf.yaml][2] for all available configuration options:
+1. Edit the `twemproxy.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][7]. See the [sample twemproxy.d/conf.yaml][2] for all available configuration options:
 
     ```
     init_config:
@@ -50,3 +50,4 @@ Need help? Contact [Datadog Support][6].
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [5]: https://github.com/DataDog/integrations-core/blob/master/twemproxy/metadata.csv
 [6]: https://docs.datadoghq.com/help/
+[7]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/varnish/README.md
+++ b/varnish/README.md
@@ -20,7 +20,7 @@ The Varnish check is included in the [Datadog Agent][1] package, so you don't ne
 
 ### Configuration
 
-1. Edit the `varnish.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Varnish [metrics](#metric-collection) and [logs](#log-collection).
+1. Edit the `varnish.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][12] to start collecting your Varnish [metrics](#metric-collection) and [logs](#log-collection).
   See the [sample varnish.d/conf.yaml][2] for all available configuration options.
 
 2. [Restart the Agent][3]
@@ -135,3 +135,4 @@ Need help? Contact [Datadog Support][7].
 [9]: https://www.datadoghq.com/blog/how-to-collect-varnish-metrics/
 [10]: https://www.datadoghq.com/blog/monitor-varnish-using-datadog/
 [11]: https://raw.githubusercontent.com/DataDog/integrations-core/master/varnish/images/varnish.png
+[12]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/vault/README.md
+++ b/vault/README.md
@@ -11,7 +11,7 @@ The Vault check is included in the [Datadog Agent][2] package, so you don't need
 
 ### Configuration
 
-1. Edit the `vault.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your vault performance data.
+1. Edit the `vault.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][7] to start collecting your vault performance data.
   See the [sample vault.d/conf.yaml][3] for all available configuration options.
 
 2. [Restart the Agent][4]
@@ -55,3 +55,4 @@ Need help? Contact [Datadog Support][6].
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
 [5]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [6]: https://docs.datadoghq.com/help/
+[7]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/vsphere/README.md
+++ b/vsphere/README.md
@@ -15,7 +15,7 @@ The vSphere check is included in the [Datadog Agent][1] package, so you don't ne
 
 In the Administration section of vCenter, add a read-only user called datadog-readonly.
 
-Then, edit the `vsphere.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample vsphere.d/conf.yaml][2] for all available configuration options:
+Then, edit the `vsphere.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][9]. See the [sample vsphere.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -93,3 +93,4 @@ See our [blog post][7] on monitoring vSphere environments with Datadog.
 [6]: https://docs.datadoghq.com/integrations/faq/can-i-limit-the-number-of-vms-that-are-pulled-in-via-the-vmware-integration
 [7]: https://www.datadoghq.com/blog/unified-vsphere-app-monitoring-datadog/#auto-discovery-across-vm-and-app-layers
 [8]: https://raw.githubusercontent.com/DataDog/integrations-core/master/vsphere/images/vsphere_graph.png
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -11,7 +11,7 @@ The Windows Event Log check is included in the [Datadog Agent][1] package, so yo
 
 ### Configuration
 
-Edit the `win32_event_log.d/conf.yaml` in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample win32_event_log.d/conf.yaml][2] for all available configuration options:
+Edit the `win32_event_log.d/conf.yaml` in the `conf.d/` folder at the root of your [Agent's configuration directory][10]. See the [sample win32_event_log.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -63,3 +63,4 @@ Need help? Contact [Datadog Support][5].
 [7]: https://www.datadoghq.com/blog/monitoring-windows-server-2012/
 [8]: https://www.datadoghq.com/blog/collect-windows-server-2012-metrics/
 [9]: https://www.datadoghq.com/blog/windows-server-monitoring/
+[10]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/windows_service/README.md
+++ b/windows_service/README.md
@@ -11,7 +11,7 @@ The Windows Service check is included in the [Datadog Agent][1] package, so you 
 
 ### Configuration
 
-Edit the `windows_service.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample windows_service.d/conf.yaml][2] for all available configuration options:
+Edit the `windows_service.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][9]. See the [sample windows_service.d/conf.yaml][2] for all available configuration options:
 
 ```
 init_config:
@@ -77,3 +77,4 @@ Need help? Contact [Datadog Support][5].
 [6]: https://www.datadoghq.com/blog/monitoring-windows-server-2012/
 [7]: https://www.datadoghq.com/blog/collect-windows-server-2012-metrics/
 [8]: https://www.datadoghq.com/blog/windows-server-monitoring/
+[9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -18,7 +18,7 @@ The YARN check is included in the [Datadog Agent][1] package, so you don't need 
 
 ### Configuration
 
-1. Edit the `yarn.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory.
+1. Edit the `yarn.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][12].
 
     ```yaml
     	init_config:
@@ -72,3 +72,4 @@ Need help? Contact [Datadog Support][6].
 [9]: https://www.datadoghq.com/blog/collecting-hadoop-metrics/
 [10]: https://www.datadoghq.com/blog/monitor-hadoop-metrics-datadog/
 [11]: https://raw.githubusercontent.com/DataDog/integrations-core/master/yarn/images/yarn_dashboard.png
+[12]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory

--- a/zk/README.md
+++ b/zk/README.md
@@ -13,7 +13,7 @@ The Zookeeper check is included in the [Datadog Agent][13] package, so you don't
 
 ### Configuration
 
-1. Edit the `zk.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Zookeeper [metrics](#metric-collection) and [logs](#log-collection).
+1. Edit the `zk.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][21] to start collecting your Zookeeper [metrics](#metric-collection) and [logs](#log-collection).
   See the [sample zk.d/conf.yaml][14] for all available configuration options.
 
 2. [Restart the Agent][15]
@@ -143,3 +143,4 @@ Need help? Contact [Datadog Support][18].
 [17]: https://github.com/DataDog/integrations-core/blob/master/zk/metadata.csv
 [18]: https://docs.datadoghq.com/help/
 [20]: https://raw.githubusercontent.com/DataDog/integrations-core/master/zk/images/zk_dashboard.png
+[21]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory


### PR DESCRIPTION
### What does this PR do?

Adds link to https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory everytime the Agent's configuration directory is mentioned.

### Motivation

Support feedback

