### PR TITLE
Adding baklava as code owner for doc material

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,8 @@
 
 # Documentation
 /docs/             @DataDog/baklava @DataDog/agent-integrations
+*.md               @DataDog/baklava @DataDog/agent-integrations                          
+manifest.json      @DataDog/baklava @DataDog/agent-integrations
 
 # Container monitoring
 /docker_daemon/    @DataDog/kenafeh @DataDog/agent-integrations


### PR DESCRIPTION
Adding baklava as a code owner for:

* `README.md` files (and more over all .md files) 
* All `manifest.json` files since they can impact the doc and are used to create in-app tiles.

The idea is to always notify baklava if a change is made to one of those two types of files in order to reduce Asymmetry of information and also to avoid impacting mistakes
