### PR TITLE
Lower case reasons before matching container.status_report.count.* metrics

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -11,8 +11,10 @@ from datadog_checks.checks.prometheus import PrometheusCheck
 
 
 METRIC_TYPES = ['counter', 'gauge']
-WHITELISTED_WAITING_REASONS = ['ErrImagePull', 'ImagePullBackoff', 'CrashLoopBackoff']
-WHITELISTED_TERMINATED_REASONS = ['OOMKilled', 'ContainerCannotRun', 'Error']
+
+# As case can vary depending on Kubernetes versions, we match the lowercase string
+WHITELISTED_WAITING_REASONS = ['errimagepull', 'imagepullbackoff', 'crashloopbackoff']
+WHITELISTED_TERMINATED_REASONS = ['oomkilled', 'containercannotrun', 'error']
 
 
 class KubernetesState(PrometheusCheck):
@@ -370,7 +372,7 @@ class KubernetesState(PrometheusCheck):
             skip_metric = False
             for label in metric.label:
                 if label.name == "reason":
-                    if label.value in WHITELISTED_WAITING_REASONS:
+                    if label.value.lower() in WHITELISTED_WAITING_REASONS:
                         tags.append(self._format_tag(label.name, label.value))
                     else:
                         skip_metric = True
@@ -388,7 +390,7 @@ class KubernetesState(PrometheusCheck):
             skip_metric = False
             for label in metric.label:
                 if label.name == "reason":
-                    if label.value in WHITELISTED_TERMINATED_REASONS:
+                    if label.value.lower() in WHITELISTED_TERMINATED_REASONS:
                         tags.append(self._format_tag(label.name, label.value))
                     else:
                         skip_metric = True

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -425,6 +425,7 @@ kube_pod_container_status_waiting_reason{container="hello",namespace="default",p
 kube_pod_container_status_waiting_reason{container="hello",namespace="default",pod="hello-1509998400-rb8bs",reason="ErrImagePull"} 0
 kube_pod_container_status_waiting_reason{container="hello",namespace="default",pod="hello-1509998460-tzh8k",reason="ContainerCreating"} 0
 kube_pod_container_status_waiting_reason{container="hello",namespace="default",pod="hello-1509998460-tzh8k",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{container="hello",namespace="default",pod="hello-1509998460-tzh8k",reason="CrashLoopBackOff"} 1
 kube_pod_container_status_waiting_reason{container="kube-addon-manager",namespace="kube-system",pod="kube-addon-manager-minikube",reason="ContainerCreating"} 0
 kube_pod_container_status_waiting_reason{container="kube-addon-manager",namespace="kube-system",pod="kube-addon-manager-minikube",reason="ErrImagePull"} 0
 kube_pod_container_status_waiting_reason{container="kube-state-metrics",namespace="default",pod="jaundiced-numbat-kube-state-metrics-b7fbc487d-4phhj",reason="ContainerCreating"} 0

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -91,6 +91,7 @@ TAGS = {
     ],
     NAMESPACE + '.container.status_report.count.waiting': [
         'reason:CrashLoopBackoff',
+        'reason:CrashLoopBackOff',
         'reason:ErrImagePull',
         'reason:ImagePullBackoff'
     ]


### PR DESCRIPTION
### What does this PR do?

Move to case-insensitive matching of the reason label for the `kubernetes_state.container.status_report.count.*` reason whitelisting.

### Motivation

Make sure we support both `reason:CrashLoopBackoff` and `reason:CrashLoopBackOff`, as both cases are encountered.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- ~~[ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)~~

### Additional Notes

Anything else we should know when reviewing?
