### PR TITLE
Fix 'attempted connection' metrics

### DIFF
--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -1,15 +1,10 @@
 # (C) Datadog, Inc. 2010-2017
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-
-'''
-Check the performance counters from IIS
-'''
-
-# project
 from datadog_checks.checks import AgentCheck
 from datadog_checks.checks.win import PDHBaseCheck
 from datadog_checks.utils.containers import hash_mutable
+
 
 DEFAULT_COUNTERS = [
     ["Web Service", None, "Service Uptime", "iis.uptime", "gauge"],
@@ -21,6 +16,7 @@ DEFAULT_COUNTERS = [
     ["Web Service", None, "Files Sent/sec", "iis.net.files_sent", "gauge"],
     ["Web Service", None, "Files Received/sec", "iis.net.files_rcvd", "gauge"],
     ["Web Service", None, "Total Connection Attempts (all instances)", "iis.net.connection_attempts", "gauge"],
+    ["Web Service", None, "Connection Attempts/sec", "iis.net.connection_attempts_sec", "gauge"],
 
     # HTTP Methods
     ["Web Service", None, "Get Requests/sec", "iis.httpd_request_method.get", "gauge"],

--- a/iis/metadata.csv
+++ b/iis/metadata.csv
@@ -6,7 +6,8 @@ iis.net.bytes_total,gauge,,byte,second,The total number of bytes transferred per
 iis.net.num_connections,gauge,,connection,,The number of active connections,0,iis,net conns
 iis.net.files_sent,gauge,,file,second,The number of files sent per second,0,iis,net files sent
 iis.net.files_rcvd,gauge,,file,second,The number of files received per second,0,iis,net files rcvd
-iis.net.connection_attempts,gauge,,connection,second,The number of connection attempts per second,0,iis,net conn attempts
+iis.net.connection_attempts,gauge,,connection,,The number of connection attempts since service startup,0,iis,net conn attempts
+iis.net.connection_attempts_sec,gauge,,connection,second,The number of connection attempts per second,0,iis,net conn attempts sec
 iis.httpd_request_method.get,gauge,,request,second,The number of GET requests per second,0,iis,requests http get
 iis.httpd_request_method.post,gauge,,request,second,The number of POST requests per second,0,iis,requests http post
 iis.httpd_request_method.head,gauge,,request,second,The number of HEAD requests per second,0,iis,requests http head

--- a/iis/tox.ini
+++ b/iis/tox.ini
@@ -19,6 +19,7 @@ commands =
     pytest -v
 
 [testenv:flake8]
+platform = linux2|darwin|win32
 skip_install = true
 deps = flake8
 commands = flake8 .


### PR DESCRIPTION
### What does this PR do?

IIS reports the total attempted connections since startup along with the rate of attempted connections per second. We were reporting only the former but with the wrong description. This PR ensures we now report both with the right descriptions.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)


