### PR TITLE
Disable trigger

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 test:
   only:
     - master
-  script: if [ -n "$DD_TEST_CMD" ] ; then eval "$DD_TEST_CMD" ; else echo "skipping, DD_TEST_CMD is not set" ; fi
+  script: echo "skipping"
+  # script: if [ -n "$DD_TEST_CMD" ] ; then eval "$DD_TEST_CMD" ; else echo "skipping, DD_TEST_CMD is not set" ; fi
   tags: [ "runner:main", "size:large" ]


### PR DESCRIPTION
### Motivation

We need to release changes for every check to keep what we have in wheel bucket in sync.