### PR TITLE
Update gitlab_runner to use the new OpenMetricsBaseCheck

### DIFF
--- a/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
@@ -67,7 +67,6 @@ class GitlabRunnerCheck(OpenMetricsBaseCheck):
         """
         # Mapping from Prometheus metrics names to Datadog ones
         # For now it's a 1:1 mapping
-        # TODO: mark some metrics as rate
         allowed_metrics = init_config.get('allowed_metrics')
         if allowed_metrics is None:
             raise CheckException("At least one metric must be whitelisted in `allowed_metrics`.")

--- a/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
@@ -9,12 +9,12 @@ import urlparse
 import requests
 
 from datadog_checks.errors import CheckException
-from datadog_checks.checks.prometheus import PrometheusCheck
+from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.config import _is_affirmative
 from datadog_checks.utils.headers import headers
 
 
-class GitlabRunnerCheck(PrometheusCheck):
+class GitlabRunnerCheck(OpenMetricsBaseCheck):
     """
     Collect Gitlab Runner metrics from Prometheus and validates that the connectivity with Gitlab
     """
@@ -28,42 +28,58 @@ class GitlabRunnerCheck(PrometheusCheck):
     DEFAULT_METRIC_LIMIT = 0
 
     def __init__(self, name, init_config, agentConfig, instances=None):
-        super(GitlabRunnerCheck, self).__init__(name, init_config, agentConfig, instances)
-        # Mapping from Prometheus metrics names to Datadog ones
-        # For now it's a 1:1 mapping
-        # TODO: mark some metrics as rate
-        allowed_metrics = init_config.get('allowed_metrics')
 
-        if not allowed_metrics:
-            raise CheckException("At least one metric must be whitelisted in `allowed_metrics`.")
+        generic_instances = []
+        if instances is not None:
+            for instance in instances:
+                generic_instances.append(self._create_gitlab_runner_prometheus_instance(instance, init_config))
 
-        self.metrics_mapper = dict(zip(allowed_metrics, allowed_metrics))
-        self.NAMESPACE = 'gitlab_runner'
+        super(GitlabRunnerCheck, self).__init__(name, init_config, agentConfig, instances=generic_instances)
 
     def check(self, instance):
         # Metrics collection
         endpoint = instance.get('prometheus_endpoint')
-        custom_tags = instance.get('tags', [])
         if endpoint is None:
             raise CheckException("Unable to find prometheus_endpoint in config file.")
 
-        # By default we send the buckets
-        send_buckets = _is_affirmative(instance.get('send_histograms_buckets', True))
+        scraper_config = self.config_map[endpoint]
+        custom_tags = instance.get('tags', [])
 
         try:
-            self.process(endpoint, send_histograms_buckets=send_buckets, instance=instance)
-            self.service_check(self.PROMETHEUS_SERVICE_CHECK_NAME, PrometheusCheck.OK, tags=custom_tags)
+            self.process(scraper_config)
+            self.service_check(self.PROMETHEUS_SERVICE_CHECK_NAME, OpenMetricsBaseCheck.OK, tags=custom_tags)
         except requests.exceptions.ConnectionError as e:
             # Unable to connect to the metrics endpoint
             self.service_check(
                 self.PROMETHEUS_SERVICE_CHECK_NAME,
-                PrometheusCheck.CRITICAL,
+                OpenMetricsBaseCheck.CRITICAL,
                 message="Unable to retrieve Prometheus metrics from endpoint {}: {}".format(endpoint, e.message),
                 tags=custom_tags,
             )
 
         # Service check to check whether the Runner can talk to the Gitlab master
         self._check_connectivity_to_master(instance, custom_tags)
+
+    def _create_gitlab_runner_prometheus_instance(self, instance, init_config):
+        """
+        Set up the gitlab_runner instance so it can be used in OpenMetricsBaseCheck
+        """
+        # Mapping from Prometheus metrics names to Datadog ones
+        # For now it's a 1:1 mapping
+        # TODO: mark some metrics as rate
+        allowed_metrics = init_config.get('allowed_metrics')
+        if allowed_metrics is None:
+            raise CheckException("At least one metric must be whitelisted in `allowed_metrics`.")
+
+        # gitlab uses 'prometheus_endpoint' and not 'prometheus_url', so we have to rename the key
+        instance['prometheus_url'] = instance.get('prometheus_endpoint', None)
+
+        instance.update({
+            'namespace': 'gitlab_runner',
+            'metrics': allowed_metrics
+        })
+
+        return instance
 
     # Validates that the runner can connect to Gitlab
     #
@@ -106,7 +122,7 @@ class GitlabRunnerCheck(PrometheusCheck):
             if r.status_code != 200:
                 self.service_check(
                     self.MASTER_SERVICE_CHECK_NAME,
-                    PrometheusCheck.CRITICAL,
+                    OpenMetricsBaseCheck.CRITICAL,
                     message="Got {} when hitting {}".format(r.status_code, url),
                     tags=service_check_tags,
                 )
@@ -118,7 +134,7 @@ class GitlabRunnerCheck(PrometheusCheck):
             # If there's a timeout
             self.service_check(
                 self.MASTER_SERVICE_CHECK_NAME,
-                PrometheusCheck.CRITICAL,
+                OpenMetricsBaseCheck.CRITICAL,
                 message="Timeout when hitting {}".format(url),
                 tags=service_check_tags,
             )
@@ -126,11 +142,11 @@ class GitlabRunnerCheck(PrometheusCheck):
         except Exception as e:
             self.service_check(
                 self.MASTER_SERVICE_CHECK_NAME,
-                PrometheusCheck.CRITICAL,
+                OpenMetricsBaseCheck.CRITICAL,
                 message="Error hitting {}. Error: {}".format(url, e.message),
                 tags=service_check_tags,
             )
             raise
         else:
-            self.service_check(self.MASTER_SERVICE_CHECK_NAME, PrometheusCheck.OK, tags=service_check_tags)
+            self.service_check(self.MASTER_SERVICE_CHECK_NAME, OpenMetricsBaseCheck.OK, tags=service_check_tags)
         self.log.debug("gitlab check succeeded")

--- a/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
@@ -4,6 +4,7 @@
 
 # stdlib
 import urlparse
+from copy import deepcopy
 
 # 3rd party
 import requests
@@ -71,15 +72,20 @@ class GitlabRunnerCheck(OpenMetricsBaseCheck):
         if allowed_metrics is None:
             raise CheckException("At least one metric must be whitelisted in `allowed_metrics`.")
 
-        # gitlab uses 'prometheus_endpoint' and not 'prometheus_url', so we have to rename the key
-        instance['prometheus_url'] = instance.get('prometheus_endpoint', None)
+        gitlab_runner_instance = deepcopy(instance)
 
-        instance.update({
+        # gitlab_runner uses 'prometheus_endpoint' and not 'prometheus_url', so we have to rename the key
+        gitlab_runner_instance['prometheus_url'] = instance.get('prometheus_endpoint', None)
+
+        gitlab_runner_instance.update({
             'namespace': 'gitlab_runner',
-            'metrics': allowed_metrics
+            'metrics': allowed_metrics,
+            # Defaults that were set when gitlab_runner was based on PrometheusCheck
+            'send_monotonic_counter': instance.get('send_monotonic_counter', False),
+            'health_service_check': instance.get('health_service_check', False)
         })
 
-        return instance
+        return gitlab_runner_instance
 
     # Validates that the runner can connect to Gitlab
     #

--- a/gitlab_runner/tests/conftest.py
+++ b/gitlab_runner/tests/conftest.py
@@ -48,7 +48,7 @@ def gitlab_runner_service(request):
     subprocess.check_call(args + ['up', '-d'], env=env)
 
     # wait for gitlab_runner to be up, it depends on gitlab
-    if not wait_for(GITLAB_RUNNER_URL, timeout=160):
+    if not wait_for(GITLAB_RUNNER_URL):
         raise Exception("gitlab_runner container timed out!")
 
     # run pre-test commands
@@ -59,12 +59,12 @@ def gitlab_runner_service(request):
     yield
 
 
-def wait_for(URL, timeout):
+def wait_for(URL):
     """
     Wait for specified URL
     """
 
-    for i in xrange(timeout):
+    for i in xrange(180):
         try:
             r = requests.get(URL)
             r.raise_for_status()

--- a/gitlab_runner/tests/test_gitlab_runner.py
+++ b/gitlab_runner/tests/test_gitlab_runner.py
@@ -5,12 +5,15 @@
 from datadog_checks.gitlab_runner import GitlabRunnerCheck
 from .common import HOST, CONFIG, BAD_CONFIG, GITLAB_RUNNER_TAGS, CUSTOM_TAGS, ALLOWED_METRICS
 
+import pytest
+from requests.exceptions import ConnectionError
+
 
 def test_check(aggregator):
     """
     Basic Test for gitlab integration.
     """
-    gitlab_runner = GitlabRunnerCheck('gitlab_runner', CONFIG['init_config'], {})
+    gitlab_runner = GitlabRunnerCheck('gitlab_runner', CONFIG['init_config'], {}, instances=CONFIG['instances'])
 
     gitlab_runner.check(CONFIG['instances'][0])
 
@@ -40,14 +43,10 @@ def test_connection_failure(aggregator):
     Make sure we're failing when the URL isn't right
     """
 
-    gitlab_runner = GitlabRunnerCheck('gitlab', BAD_CONFIG['init_config'], {})
+    gitlab_runner = GitlabRunnerCheck('gitlab', BAD_CONFIG['init_config'], {}, instances=BAD_CONFIG['instances'])
 
-    try:
+    with pytest.raises(ConnectionError):
         gitlab_runner.check(BAD_CONFIG['instances'][0])
-    except Exception:
-        pass
-    else:
-        assert False, "Gitlab Check should not be able to connect to this URL"
 
     # We should get two failed service checks
     aggregator.assert_service_check(


### PR DESCRIPTION
### What does this PR do?

Updates gitlab_runner to use the new OpenMetricsBaseCheck class.

### Motivation

This fixes the check for when we use the new OpenMetricsBaseCheck class.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes