### PR TITLE
Update istio to use the new OpenMetricsBaseCheck

### DIFF
--- a/istio/datadog_checks/istio/istio.py
+++ b/istio/datadog_checks/istio/istio.py
@@ -2,160 +2,154 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-from datadog_checks.checks.prometheus import PrometheusScraper, PrometheusCheck
+from copy import deepcopy
+
+from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.errors import CheckException
 
 
-class Istio(PrometheusCheck):
+class Istio(OpenMetricsBaseCheck):
     MIXER_NAMESPACE = 'istio.mixer'
     MESH_NAMESPACE = 'istio.mesh'
     DEFAULT_METRIC_LIMIT = 0
 
     def __init__(self, name, init_config, agentConfig, instances=None):
-        super(Istio, self).__init__(name, init_config, agentConfig, instances)
-        self._scrapers = {}
+
+        # Create instances we can use in OpenMetricsBaseCheck
+        generic_instances = None
+        if instances is not None:
+            generic_instances = self.create_generic_instances(instances)
+
+        # Set up OpenMetricsBaseCheck with our generic instances
+        super(Istio, self).__init__(name, init_config, agentConfig, instances=generic_instances)
 
     def check(self, instance):
-        self._process_istio_mesh(instance)
-        self._process_mixer(instance)
+        """
+        Process both the istio_mesh instance and process_mixer instance associated with this instance
+        """
 
-    def _process_istio_mesh(self, instance):
-        """
-        Grab the scraper and run the process function for istio mesh
-        """
-        self.log.debug('setting up mesh scraper')
-        endpoint = instance.get('istio_mesh_endpoint')
-        scraper = self._get_istio_mesh_scraper(instance)
-        self.log.debug('processing mesh metrics')
-        scraper.process(
-            endpoint,
-            send_histograms_buckets=instance.get('send_histograms_buckets', True),
-            instance=instance,
-            ignore_unmapped=True
-        )
+        # Get the config for the istio_mesh instance
+        istio_mesh_endpoint = instance.get('istio_mesh_endpoint')
+        istio_mesh_config = self.config_map[istio_mesh_endpoint]
 
-    def _process_mixer(self, instance):
-        """
-        Grab the scraper and run the process function for the mixer
-        """
-        self.log.debug('setting up mixer scraper')
-        endpoint = instance.get('mixer_endpoint')
-        scraper = self._get_mixer_scraper(instance)
-        self.log.debug('processing mixer metrics')
-        scraper.process(
-            endpoint,
-            send_histograms_buckets=instance.get('send_histograms_buckets', True),
-            instance=instance,
-            ignore_unmapped=True
-        )
+        # Process istio_mesh
+        self.process(istio_mesh_config)
 
-    def _get_istio_mesh_scraper(self, instance):
+        # Get the config for the process_mixer instance
+        process_mixer_endpoint = instance.get('mixer_endpoint')
+        process_mixer_config = self.config_map[process_mixer_endpoint]
+
+        # Process process_mixer
+        self.process(process_mixer_config)
+
+    def create_generic_instances(self, instances):
+        """
+        Generalize each (single) Istio instance into two OpenMetricsBaseCheck instances
+        """
+        generic_instances = []
+
+        for instance in instances:
+            istio_mesh_instance = self._create_istio_mesh_instance(instance)
+            process_mixer_instance = self._create_process_mixer_instance(instance)
+
+            generic_instances.extend([istio_mesh_instance, process_mixer_instance])
+
+        return generic_instances
+
+    def _create_istio_mesh_instance(self, instance):
         """
         Grab the istio mesh scraper from the dict and return it if it exists,
         otherwise create the scraper and add it to the dict
         """
         endpoint = instance.get('istio_mesh_endpoint')
 
-        if self._scrapers.get(endpoint, None):
-            return self._scrapers.get(endpoint)
+        if endpoint is None:
+            raise CheckException("Unable to find istio_mesh_endpoint in config file.")
 
-        scraper = PrometheusScraper(self)
-        self._scrapers[endpoint] = scraper
-        scraper.NAMESPACE = self.MESH_NAMESPACE
-        scraper.metrics_mapper = {
-            # These metrics support Istio 1.0
-            'istio_requests_total': 'request.count',
-            'istio_request_duration_seconds': 'request.duration',
-            'istio_request_bytes': 'request.size',
-            'istio_response_bytes': 'response.size',
+        istio_mesh_instance = deepcopy(instance)
+        istio_mesh_instance.update({
+            'namespace': self.MESH_NAMESPACE,
+            'prometheus_url': endpoint,
+            'label_to_hostname': endpoint,
+            'metrics': [{
+                # These metrics support Istio 1.0
+                'istio_requests_total': 'request.count',
+                'istio_request_duration_seconds': 'request.duration',
+                'istio_request_bytes': 'request.size',
+                'istio_response_bytes': 'response.size',
 
-            # These metrics support Istio 0.8
-            'istio_request_count': 'request.count',
-            'istio_request_duration': 'request.duration',
-            'istio_request_size': 'request.size',
-            'istio_response_size': 'response.size',
-        }
-        scraper.label_to_hostname = endpoint
-        scraper = self._shared_scraper_config(scraper, instance)
+                # These metrics support Istio 0.8
+                'istio_request_count': 'request.count',
+                'istio_request_duration': 'request.duration',
+                'istio_request_size': 'request.size',
+                'istio_response_size': 'response.size',
+            }]
+        })
 
-        return scraper
+        return istio_mesh_instance
 
-    def _get_mixer_scraper(self, instance):
+    def _create_process_mixer_instance(self, instance):
         """
         Grab the mixer scraper from the dict and return it if it exists,
         otherwise create the scraper and add it to the dict
         """
         endpoint = instance.get('mixer_endpoint')
+        if endpoint is None:
+            raise CheckException("Unable to find mixer_endpoint in config file.")
 
-        if self._scrapers.get(endpoint, None):
-            return self._scrapers.get(endpoint)
+        process_mixer_instance = deepcopy(instance)
+        process_mixer_instance.update({
+            'namespace': self.MIXER_NAMESPACE,
+            'prometheus_url': endpoint,
+            'metrics': [{
+                'go_gc_duration_seconds': 'go.gc_duration_seconds',
+                'go_goroutines': 'go.goroutines',
+                'go_info': 'go.info',
+                'go_memstats_alloc_bytes': 'go.memstats.alloc_bytes',
+                'go_memstats_alloc_bytes_total': 'go.memstats.alloc_bytes_total',
+                'go_memstats_buck_hash_sys_bytes': 'go.memstats.buck_hash_sys_bytes',
+                'go_memstats_frees_total': 'go.memstats.frees_total',
+                'go_memstats_gc_cpu_fraction': 'go.memstats.gc_cpu_fraction',
+                'go_memstats_gc_sys_bytes': 'go.memstats.gc_sys_bytes',
+                'go_memstats_heap_alloc_bytes': 'go.memstats.heap_alloc_bytes',
+                'go_memstats_heap_idle_bytes': 'go.memstats.heap_idle_bytes',
+                'go_memstats_heap_inuse_bytes': 'go.memstats.heap_inuse_bytes',
+                'go_memstats_heap_objects': 'go.memstats.heap_objects',
+                'go_memstats_heap_released_bytes': 'go.memstats.heap_released_bytes',
+                'go_memstats_heap_sys_bytes': 'go.memstats.heap_sys_bytes',
+                'go_memstats_last_gc_time_seconds': 'go.memstats.last_gc_time_seconds',
+                'go_memstats_lookups_total': 'go.memstats.lookups_total',
+                'go_memstats_mallocs_total': 'go.memstats.mallocs_total',
+                'go_memstats_mcache_inuse_bytes': 'go.memstats.mcache_inuse_bytes',
+                'go_memstats_mcache_sys_bytes': 'go.memstats.mcache_sys_bytes',
+                'go_memstats_mspan_inuse_bytes': 'go.memstats.mspan_inuse_bytes',
+                'go_memstats_mspan_sys_bytes': 'go.memstats.mspan_sys_bytes',
+                'go_memstats_next_gc_bytes': 'go.memstats.next_gc_bytes',
+                'go_memstats_other_sys_bytes': 'go.memstats.other_sys_bytes',
+                'go_memstats_stack_inuse_bytes': 'go.memstats.stack_inuse_bytes',
+                'go_memstats_stack_sys_bytes': 'go.memstats.stack_sys_bytes',
+                'go_memstats_sys_bytes': 'go.memstats.sys_bytes',
+                'go_threads': 'go.threads',
+                'grpc_server_handled_total': 'grpc.server.handled_total',
+                'grpc_server_handling_seconds': 'grpc.server.handling_seconds',
+                'grpc_server_msg_received_total': 'grpc.server.msg_received_total',
+                'grpc_server_msg_sent_total': 'grpc.server.msg_sent_total',
+                'grpc_server_started_total': 'grpc.server.started_total',
+                'mixer_adapter_dispatch_count': 'adapter.dispatch_count',
+                'mixer_adapter_dispatch_duration': 'adapter.dispatch_duration',
+                'mixer_adapter_old_dispatch_count': 'adapter.old_dispatch_count',
+                'mixer_adapter_old_dispatch_duration': 'adapter.old_dispatch_duration',
+                'mixer_config_resolve_actions': 'config.resolve_actions',
+                'mixer_config_resolve_count': 'config.resolve_count',
+                'mixer_config_resolve_duration': 'config.resolve_duration',
+                'mixer_config_resolve_rules': 'config.resolve_rules',
+                'process_cpu_seconds_total': 'process.cpu_seconds_total',
+                'process_max_fds': 'process.max_fds',
+                'process_open_fds': 'process.open_fds',
+                'process_resident_memory_bytes': 'process.resident_memory_bytes',
+                'process_start_time_seconds': 'process.start_time_seconds',
+                'process_virtual_memory_bytes': 'process.virtual_memory_bytes',
+            }]
+        })
 
-        scraper = PrometheusScraper(self)
-        self._scrapers[endpoint] = scraper
-        scraper.NAMESPACE = self.MIXER_NAMESPACE
-        scraper.metrics_mapper = {
-            'go_gc_duration_seconds': 'go.gc_duration_seconds',
-            'go_goroutines': 'go.goroutines',
-            'go_info': 'go.info',
-            'go_memstats_alloc_bytes': 'go.memstats.alloc_bytes',
-            'go_memstats_alloc_bytes_total': 'go.memstats.alloc_bytes_total',
-            'go_memstats_buck_hash_sys_bytes': 'go.memstats.buck_hash_sys_bytes',
-            'go_memstats_frees_total': 'go.memstats.frees_total',
-            'go_memstats_gc_cpu_fraction': 'go.memstats.gc_cpu_fraction',
-            'go_memstats_gc_sys_bytes': 'go.memstats.gc_sys_bytes',
-            'go_memstats_heap_alloc_bytes': 'go.memstats.heap_alloc_bytes',
-            'go_memstats_heap_idle_bytes': 'go.memstats.heap_idle_bytes',
-            'go_memstats_heap_inuse_bytes': 'go.memstats.heap_inuse_bytes',
-            'go_memstats_heap_objects': 'go.memstats.heap_objects',
-            'go_memstats_heap_released_bytes': 'go.memstats.heap_released_bytes',
-            'go_memstats_heap_sys_bytes': 'go.memstats.heap_sys_bytes',
-            'go_memstats_last_gc_time_seconds': 'go.memstats.last_gc_time_seconds',
-            'go_memstats_lookups_total': 'go.memstats.lookups_total',
-            'go_memstats_mallocs_total': 'go.memstats.mallocs_total',
-            'go_memstats_mcache_inuse_bytes': 'go.memstats.mcache_inuse_bytes',
-            'go_memstats_mcache_sys_bytes': 'go.memstats.mcache_sys_bytes',
-            'go_memstats_mspan_inuse_bytes': 'go.memstats.mspan_inuse_bytes',
-            'go_memstats_mspan_sys_bytes': 'go.memstats.mspan_sys_bytes',
-            'go_memstats_next_gc_bytes': 'go.memstats.next_gc_bytes',
-            'go_memstats_other_sys_bytes': 'go.memstats.other_sys_bytes',
-            'go_memstats_stack_inuse_bytes': 'go.memstats.stack_inuse_bytes',
-            'go_memstats_stack_sys_bytes': 'go.memstats.stack_sys_bytes',
-            'go_memstats_sys_bytes': 'go.memstats.sys_bytes',
-            'go_threads': 'go.threads',
-            'grpc_server_handled_total': 'grpc.server.handled_total',
-            'grpc_server_handling_seconds': 'grpc.server.handling_seconds',
-            'grpc_server_msg_received_total': 'grpc.server.msg_received_total',
-            'grpc_server_msg_sent_total': 'grpc.server.msg_sent_total',
-            'grpc_server_started_total': 'grpc.server.started_total',
-            'mixer_adapter_dispatch_count': 'adapter.dispatch_count',
-            'mixer_adapter_dispatch_duration': 'adapter.dispatch_duration',
-            'mixer_adapter_old_dispatch_count': 'adapter.old_dispatch_count',
-            'mixer_adapter_old_dispatch_duration': 'adapter.old_dispatch_duration',
-            'mixer_config_resolve_actions': 'config.resolve_actions',
-            'mixer_config_resolve_count': 'config.resolve_count',
-            'mixer_config_resolve_duration': 'config.resolve_duration',
-            'mixer_config_resolve_rules': 'config.resolve_rules',
-            'process_cpu_seconds_total': 'process.cpu_seconds_total',
-            'process_max_fds': 'process.max_fds',
-            'process_open_fds': 'process.open_fds',
-            'process_resident_memory_bytes': 'process.resident_memory_bytes',
-            'process_start_time_seconds': 'process.start_time_seconds',
-            'process_virtual_memory_bytes': 'process.virtual_memory_bytes',
-        }
-        scraper = self._shared_scraper_config(scraper, instance)
-        return scraper
-
-    def _shared_scraper_config(self, scraper, instance):
-        """
-        Configuration that is shared by both scrapers
-        """
-        scraper.labels_mapper = instance.get("labels_mapper", {})
-        scraper.label_joins = instance.get("label_joins", {})
-        scraper.type_overrides = instance.get("type_overrides", {})
-        scraper.exclude_labels = instance.get("exclude_labels", [])
-        # For simple values instance settings overrides optional defaults
-        scraper.health_service_check = instance.get("health_service_check", True)
-        scraper.ssl_cert = instance.get("ssl_cert", None)
-        scraper.ssl_private_key = instance.get("ssl_private_key", None)
-        scraper.ssl_ca_cert = instance.get("ssl_ca_cert", None)
-
-        return scraper
+        return process_mixer_instance

--- a/istio/datadog_checks/istio/istio.py
+++ b/istio/datadog_checks/istio/istio.py
@@ -83,7 +83,10 @@ class Istio(OpenMetricsBaseCheck):
                 'istio_request_duration': 'request.duration',
                 'istio_request_size': 'request.size',
                 'istio_response_size': 'response.size',
-            }]
+            }],
+            # Defaults that were set when istio was based on PrometheusCheck
+            'send_monotonic_counter': instance.get('send_monotonic_counter', False),
+            'health_service_check': instance.get('health_service_check', False)
         })
 
         return istio_mesh_instance
@@ -149,7 +152,10 @@ class Istio(OpenMetricsBaseCheck):
                 'process_resident_memory_bytes': 'process.resident_memory_bytes',
                 'process_start_time_seconds': 'process.start_time_seconds',
                 'process_virtual_memory_bytes': 'process.virtual_memory_bytes',
-            }]
+            }],
+            # Defaults that were set when istio was based on PrometheusCheck
+            'send_monotonic_counter': instance.get('send_monotonic_counter', False),
+            'health_service_check': instance.get('health_service_check', False)
         })
 
         return process_mixer_instance

--- a/istio/tests/test_check.py
+++ b/istio/tests/test_check.py
@@ -8,83 +8,80 @@ import os
 
 # 3rd-party
 import pytest
+from requests.exceptions import HTTPError
 
 # project
 from datadog_checks.istio import Istio
-from datadog_checks.checks.prometheus import PrometheusScraper
 
 
-MESH_METRICS = ['istio.mesh.request.count',
-                'istio.mesh.request.duration.count',
-                'istio.mesh.request.duration.sum',
-                'istio.mesh.request.size.count',
-                'istio.mesh.request.size.sum',
-                'istio.mesh.response.size.count',
-                'istio.mesh.response.size.sum']
+MESH_METRICS = [
+    'istio.mesh.request.count',
+    'istio.mesh.request.duration.count',
+    'istio.mesh.request.duration.sum',
+    'istio.mesh.request.size.count',
+    'istio.mesh.request.size.sum',
+    'istio.mesh.response.size.count',
+    'istio.mesh.response.size.sum'
+]
 
 
-MIXER_METRICS = ['istio.mixer.adapter.dispatch_duration.count',
-                 'istio.mixer.adapter.dispatch_duration.sum',
-                 'istio.mixer.go.gc_duration_seconds.count',
-                 'istio.mixer.go.gc_duration_seconds.quantile',
-                 'istio.mixer.go.gc_duration_seconds.sum',
-                 'istio.mixer.go.goroutines',
-                 'istio.mixer.go.info',
-                 'istio.mixer.go.memstats.alloc_bytes',
-                 'istio.mixer.go.memstats.alloc_bytes_total',
-                 'istio.mixer.go.memstats.buck_hash_sys_bytes',
-                 'istio.mixer.go.memstats.frees_total',
-                 'istio.mixer.go.memstats.gc_cpu_fraction',
-                 'istio.mixer.go.memstats.gc_sys_bytes',
-                 'istio.mixer.go.memstats.heap_alloc_bytes',
-                 'istio.mixer.go.memstats.heap_idle_bytes',
-                 'istio.mixer.go.memstats.heap_inuse_bytes',
-                 'istio.mixer.go.memstats.heap_objects',
-                 'istio.mixer.go.memstats.heap_released_bytes',
-                 'istio.mixer.go.memstats.heap_sys_bytes',
-                 'istio.mixer.go.memstats.last_gc_time_seconds',
-                 'istio.mixer.go.memstats.lookups_total',
-                 'istio.mixer.go.memstats.mallocs_total',
-                 'istio.mixer.go.memstats.mcache_inuse_bytes',
-                 'istio.mixer.go.memstats.mcache_sys_bytes',
-                 'istio.mixer.go.memstats.mspan_inuse_bytes',
-                 'istio.mixer.go.memstats.mspan_sys_bytes',
-                 'istio.mixer.go.memstats.next_gc_bytes',
-                 'istio.mixer.go.memstats.other_sys_bytes',
-                 'istio.mixer.go.memstats.stack_inuse_bytes',
-                 'istio.mixer.go.memstats.stack_sys_bytes',
-                 'istio.mixer.go.memstats.sys_bytes',
-                 'istio.mixer.go.threads',
-                 'istio.mixer.grpc.server.handled_total',
-                 'istio.mixer.grpc.server.handling_seconds.count',
-                 'istio.mixer.grpc.server.handling_seconds.sum',
-                 'istio.mixer.grpc.server.msg_received_total',
-                 'istio.mixer.grpc.server.msg_sent_total',
-                 'istio.mixer.grpc.server.started_total',
-                 'istio.mixer.adapter.dispatch_count',
-                 'istio.mixer.adapter.old_dispatch_count',
-                 'istio.mixer.adapter.old_dispatch_duration.count',
-                 'istio.mixer.adapter.old_dispatch_duration.sum',
-                 'istio.mixer.config.resolve_actions.count',
-                 'istio.mixer.config.resolve_actions.sum',
-                 'istio.mixer.config.resolve_count',
-                 'istio.mixer.config.resolve_duration.count',
-                 'istio.mixer.config.resolve_duration.sum',
-                 'istio.mixer.config.resolve_rules.count',
-                 'istio.mixer.config.resolve_rules.sum',
-                 'istio.mixer.process.cpu_seconds_total',
-                 'istio.mixer.process.max_fds',
-                 'istio.mixer.process.open_fds',
-                 'istio.mixer.process.resident_memory_bytes',
-                 'istio.mixer.process.start_time_seconds',
-                 'istio.mixer.process.virtual_memory_bytes']
-
-
-MOCK_INSTANCE = {
-    'istio_mesh_endpoint': 'http://localhost:42422/metrics',
-    'mixer_endpoint': 'http://localhost:9093/metrics'
-}
-
+MIXER_METRICS = [
+    'istio.mixer.adapter.dispatch_duration.count',
+    'istio.mixer.adapter.dispatch_duration.sum',
+    'istio.mixer.go.gc_duration_seconds.count',
+    'istio.mixer.go.gc_duration_seconds.quantile',
+    'istio.mixer.go.gc_duration_seconds.sum',
+    'istio.mixer.go.goroutines',
+    'istio.mixer.go.info',
+    'istio.mixer.go.memstats.alloc_bytes',
+    'istio.mixer.go.memstats.alloc_bytes_total',
+    'istio.mixer.go.memstats.buck_hash_sys_bytes',
+    'istio.mixer.go.memstats.frees_total',
+    'istio.mixer.go.memstats.gc_cpu_fraction',
+    'istio.mixer.go.memstats.gc_sys_bytes',
+    'istio.mixer.go.memstats.heap_alloc_bytes',
+    'istio.mixer.go.memstats.heap_idle_bytes',
+    'istio.mixer.go.memstats.heap_inuse_bytes',
+    'istio.mixer.go.memstats.heap_objects',
+    'istio.mixer.go.memstats.heap_released_bytes',
+    'istio.mixer.go.memstats.heap_sys_bytes',
+    'istio.mixer.go.memstats.last_gc_time_seconds',
+    'istio.mixer.go.memstats.lookups_total',
+    'istio.mixer.go.memstats.mallocs_total',
+    'istio.mixer.go.memstats.mcache_inuse_bytes',
+    'istio.mixer.go.memstats.mcache_sys_bytes',
+    'istio.mixer.go.memstats.mspan_inuse_bytes',
+    'istio.mixer.go.memstats.mspan_sys_bytes',
+    'istio.mixer.go.memstats.next_gc_bytes',
+    'istio.mixer.go.memstats.other_sys_bytes',
+    'istio.mixer.go.memstats.stack_inuse_bytes',
+    'istio.mixer.go.memstats.stack_sys_bytes',
+    'istio.mixer.go.memstats.sys_bytes',
+    'istio.mixer.go.threads',
+    'istio.mixer.grpc.server.handled_total',
+    'istio.mixer.grpc.server.handling_seconds.count',
+    'istio.mixer.grpc.server.handling_seconds.sum',
+    'istio.mixer.grpc.server.msg_received_total',
+    'istio.mixer.grpc.server.msg_sent_total',
+    'istio.mixer.grpc.server.started_total',
+    'istio.mixer.adapter.dispatch_count',
+    'istio.mixer.adapter.old_dispatch_count',
+    'istio.mixer.adapter.old_dispatch_duration.count',
+    'istio.mixer.adapter.old_dispatch_duration.sum',
+    'istio.mixer.config.resolve_actions.count',
+    'istio.mixer.config.resolve_actions.sum',
+    'istio.mixer.config.resolve_count',
+    'istio.mixer.config.resolve_duration.count',
+    'istio.mixer.config.resolve_duration.sum',
+    'istio.mixer.config.resolve_rules.count',
+    'istio.mixer.config.resolve_rules.sum',
+    'istio.mixer.process.cpu_seconds_total',
+    'istio.mixer.process.max_fds',
+    'istio.mixer.process.open_fds',
+    'istio.mixer.process.resident_memory_bytes',
+    'istio.mixer.process.start_time_seconds',
+    'istio.mixer.process.virtual_memory_bytes'
+]
 
 MESH_METRICS_MAPPER = {
     'istio_request_count': 'request.count',
@@ -149,22 +146,30 @@ MESH_MIXER_MAPPER = {
 }
 
 
+MOCK_INSTANCE = {
+    'istio_mesh_endpoint': 'http://localhost:42422/metrics',
+    'mixer_endpoint': 'http://localhost:9093/metrics'
+}
+
+
 class MockResponse:
     """
     MockResponse is used to simulate the object requests.Response commonly returned by requests.get
     """
 
-    def __init__(self, content, content_type):
-        if isinstance(content, list):
-            self.content = content
-        else:
-            self.content = [content]
+    def __init__(self, content, content_type, status=200):
+        self.content = content if isinstance(content, list) else [content]
         self.headers = {'Content-Type': content_type}
+        self.status = status
 
     def iter_lines(self, **_):
         content = self.content.pop(0)
         for elt in content.split("\n"):
             yield elt
+
+    def raise_for_status(self):
+        if self.status != 200:
+            raise HTTPError('Not 200 Client Error')
 
     def close(self):
         pass
@@ -173,6 +178,7 @@ class MockResponse:
 @pytest.fixture
 def aggregator():
     from datadog_checks.stubs import aggregator
+
     aggregator.reset()
     return aggregator
 
@@ -187,57 +193,30 @@ def mesh_mixture_fixture():
     with open(mixer_file_path, 'rb') as f:
         responses.append(f.read())
 
-    p = mock.patch('datadog_checks.checks.prometheus.PrometheusScraper.poll',
-                   return_value=MockResponse(responses, 'text/plain'),
-                   __name__="poll")
-    yield p.start()
-    p.stop()
+    with mock.patch('requests.get', return_value=MockResponse(responses, 'text/plain'), __name__="get"):
+        yield
 
 
 def test_istio(aggregator, mesh_mixture_fixture):
     """
     Test the full check
     """
-    c = Istio('istio', None, {}, [MOCK_INSTANCE])
-    c.check(MOCK_INSTANCE)
+    check = Istio('istio', {}, {}, [MOCK_INSTANCE])
+    check.check(MOCK_INSTANCE)
 
-    metrics = MESH_METRICS + MIXER_METRICS
-    for metric in metrics:
+    for metric in MESH_METRICS + MIXER_METRICS:
         aggregator.assert_metric(metric)
 
-    assert aggregator.metrics_asserted_pct == 100.0
-
-
-def test_process_functions(aggregator, mesh_mixture_fixture):
-    """
-    Test the process functions, ensure that they process correctly
-    """
-    c = Istio('istio', None, {}, [MOCK_INSTANCE])
-    c._process_istio_mesh(MOCK_INSTANCE)
-    c._process_mixer(MOCK_INSTANCE)
-
-    metrics = MESH_METRICS + MIXER_METRICS
-    for metric in metrics:
-        aggregator.assert_metric(metric)
-
-    assert aggregator.metrics_asserted_pct == 100.0
+    aggregator.assert_all_metrics_covered()
 
 
 def test_scraper_creator():
-    c = Istio('istio', None, {}, [MOCK_INSTANCE])
-    istio_mesh_scraper = c._get_istio_mesh_scraper(MOCK_INSTANCE)
-    mixer_scraper = c._get_mixer_scraper(MOCK_INSTANCE)
-    istio_mesh_scraper_dict = c._scrapers.get(MOCK_INSTANCE['istio_mesh_endpoint'])
-    mixer_scraper_dict = c._scrapers.get(MOCK_INSTANCE['mixer_endpoint'])
+    check = Istio('istio', {}, {}, [MOCK_INSTANCE])
+    istio_mesh_config = check.config_map.get(MOCK_INSTANCE['istio_mesh_endpoint'])
+    mixer_scraper_dict = check.config_map.get(MOCK_INSTANCE['mixer_endpoint'])
 
-    assert istio_mesh_scraper == istio_mesh_scraper_dict
-    assert mixer_scraper == mixer_scraper_dict
+    assert istio_mesh_config['namespace'] == Istio.MESH_NAMESPACE
+    assert mixer_scraper_dict['namespace'] == Istio.MIXER_NAMESPACE
 
-    assert isinstance(istio_mesh_scraper, PrometheusScraper)
-    assert isinstance(mixer_scraper, PrometheusScraper)
-
-    assert istio_mesh_scraper.NAMESPACE == 'istio.mesh'
-    assert mixer_scraper.NAMESPACE == 'istio.mixer'
-
-    assert istio_mesh_scraper.metrics_mapper == MESH_METRICS_MAPPER
-    assert mixer_scraper.metrics_mapper == MESH_MIXER_MAPPER
+    assert istio_mesh_config['metrics_mapper'] == MESH_METRICS_MAPPER
+    assert mixer_scraper_dict['metrics_mapper'] == MESH_MIXER_MAPPER

--- a/istio/tox.ini
+++ b/istio/tox.ini
@@ -10,19 +10,17 @@ platform = linux|darwin|win32
 
 [testenv:istio]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt
-    py.test
+    pytest -v
 
 [testenv:flake8]
 skip_install = true
 deps = flake8
-commands =
-    flake8 .
+commands = flake8 .
 
 [flake8]
-exclude = .eggs,.tox,build
+exclude = .eggs,.tox
 max-line-length = 120


### PR DESCRIPTION
### What does this PR do?

Updates istio to use the new OpenMetricsBaseCheck class.

### Motivation

This fixes the check for when we use the new OpenMetricsBaseCheck class.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes