### PR TITLE
Update kube_proxy to use the new OpenMetricsBaseCheck

### DIFF
--- a/kube_proxy/datadog_checks/kube_proxy/kube_proxy.py
+++ b/kube_proxy/datadog_checks/kube_proxy/kube_proxy.py
@@ -1,9 +1,9 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.checks.prometheus import GenericPrometheusCheck
+from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 
-class KubeProxyCheck(GenericPrometheusCheck):
+class KubeProxyCheck(OpenMetricsBaseCheck):
     DEFAULT_METRIC_LIMIT = 0
 
     def __init__(self, name, init_config, agentConfig, instances=None):

--- a/kube_proxy/tests/test_kube_proxy.py
+++ b/kube_proxy/tests/test_kube_proxy.py
@@ -72,8 +72,7 @@ def test_check_iptables(aggregator, mock_iptables):
     aggregator.assert_metric(NAMESPACE + '.client.http.requests', tags=['method:GET', 'code:404', 'host:127.0.0.1:8080'])
     aggregator.assert_metric(NAMESPACE + '.sync_rules.latency.count')
     aggregator.assert_metric(NAMESPACE + '.sync_rules.latency.sum')
-
-    assert aggregator.metrics_asserted_pct == 100.0
+    aggregator.assert_all_metrics_covered()
 
 
 def test_check_userspace(aggregator, mock_userspace):
@@ -89,5 +88,4 @@ def test_check_userspace(aggregator, mock_userspace):
     aggregator.assert_metric(NAMESPACE + '.client.http.requests', tags=['method:POST', 'host:127.0.0.1:8080', 'code:201'])
     aggregator.assert_metric(NAMESPACE + '.client.http.requests', tags=['method:GET', 'host:127.0.0.1:8080', 'code:200'])
     aggregator.assert_metric(NAMESPACE + '.client.http.requests', tags=['method:POST', 'host:127.0.0.1:8080', 'code:201'])
-
-    assert aggregator.metrics_asserted_pct == 100.0
+    aggregator.assert_all_metrics_covered()

--- a/kube_proxy/tox.ini
+++ b/kube_proxy/tox.ini
@@ -10,11 +10,11 @@ platform = linux2|darwin
 
 [testenv:kube_proxy]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
-    pytest
+    pip install --require-hashes -r requirements.txt
+    pytest -v
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
### What does this PR do?

Cleans up kube_proxy tests.

### Motivation

Going through prometheus checks and fixing tests.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes