### PR TITLE
Update kubelet to use the new OpenMetricsBaseCheck

### DIFF
--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -223,13 +223,16 @@ class KubeletCredentials(object):
         """
         return self._ssl_verify
 
-    def configure_scraper(self, scraper, endpoint):
+    def configure_scraper(self, scraper_config):
         """
         Configures a PrometheusScaper object with query credentials
         :param scraper: valid PrometheusScaper object
         :param endpoint: url that will be scraped
         """
-        scraper.ssl_ca_cert = self._ssl_verify
-        scraper.ssl_cert = self._ssl_cert
-        scraper.ssl_private_key = self._ssl_private_key
-        scraper.extra_headers = self.headers(endpoint) or {}
+        endpoint = scraper_config['prometheus_url']
+        scraper_config.update({
+            'ssl_ca_cert': self._ssl_verify,
+            'ssl_cert': self._ssl_cert,
+            'ssl_private_key': self._ssl_private_key,
+            'extra_headers': self.headers(endpoint) or {}
+        })

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -85,7 +85,10 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
                 'rest_client_requests_total': 'rest.client.requests',
                 'kubelet_runtime_operations': 'kubelet.runtime.operations',
                 'kubelet_runtime_operations_errors': 'kubelet.runtime.errors',
-            }]
+            }],
+            # Defaults that were set when the Kubelet scraper was based on PrometheusScraper
+            'send_monotonic_counter': instance.get('send_monotonic_counter', False),
+            'health_service_check': instance.get('health_service_check', False)
         })
         return kubelet_instance
 

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -76,9 +76,17 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
         self.kubelet_scraper_config = self.get_scraper_config(kubelet_instance)
 
     def _create_kubelet_prometheus_instance(self, instance):
+        """
+        Create a copy of the instance and set default values.
+        This is so the base class can create a scraper_config with the proper values.
+        """
         kubelet_instance = deepcopy(instance)
         kubelet_instance.update({
             'namespace': self.NAMESPACE,
+
+            # We need to specify a prometheus_url so the base class can use it as the key for our config_map,
+            # we specify a dummy url that will be replaced in the `check()` function. We append it with "kubelet"
+            # so the key is different than the cadvisor scraper.
             'prometheus_url': instance.get('kubelet_metrics_endpoint', 'dummy_url/kubelet'),
             'metrics': [{
                 'apiserver_client_certificate_expiration_seconds': 'apiserver.certificate.expiration',

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -52,9 +52,17 @@ class CadvisorPrometheusScraperMixin(object):
         }
 
     def _create_cadvisor_prometheus_instance(self, instance):
+        """
+        Create a copy of the instance and set default values.
+        This is so the base class can create a scraper_config with the proper values.
+        """
         cadvisor_instance = deepcopy(instance)
         cadvisor_instance.update({
             'namespace': self.NAMESPACE,
+
+            # We need to specify a prometheus_url so the base class can use it as the key for our config_map,
+            # we specify a dummy url that will be replaced in the `check()` function. We append it with "cadvisor"
+            # so the key is different than the kubelet scraper.
             'prometheus_url': instance.get('cadvisor_metrics_endpoint', 'dummy_url/cadvisor'),
             'ignore_metrics': [
                 'container_cpu_cfs_periods_total',

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -78,7 +78,10 @@ class CadvisorPrometheusScraperMixin(object):
                 'container_start_time_seconds',
                 'container_spec_memory_swap_limit_bytes',
                 'container_scrape_error'
-            ]
+            ],
+            # Defaults that were set when CadvisorPrometheusScraper was based on PrometheusScraper
+            'send_monotonic_counter': instance.get('send_monotonic_counter', False),
+            'health_service_check': instance.get('health_service_check', False)
         })
         return cadvisor_instance
 

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -49,11 +49,11 @@ class CadvisorPrometheusScraperMixin(object):
             'container_spec_memory_limit_bytes': self.container_spec_memory_limit_bytes
         }
 
-    def _create_cadvisor_prometheus_scraper(self, instance):
+    def _create_cadvisor_prometheus_instance(self, instance):
         cadvisor_instance = deepcopy(instance)
         cadvisor_instance.update({
             'namespace': self.NAMESPACE,
-            'prometheus_url': "dummy_url",
+            'prometheus_url': instance.get('cadvisor_metrics_endpoint', 'dummy_url/cadvisor'),
             'ignore_metrics': [
                 'container_cpu_cfs_periods_total',
                 'container_cpu_cfs_throttled_periods_total',
@@ -80,8 +80,7 @@ class CadvisorPrometheusScraperMixin(object):
                 'container_scrape_error'
             ]
         })
-        scraper_config = self.create_scraper_configuration(cadvisor_instance)
-        return scraper_config
+        return cadvisor_instance
 
     @staticmethod
     def _is_container_metric(labels):

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -4,12 +4,14 @@
 
 # project
 from copy import deepcopy
+from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 from tagger import get_tags
 
 # check
 from .common import is_static_pending_pod, get_pod_by_uid
 
 METRIC_TYPES = ['counter', 'gauge', 'summary']
+
 # container-specific metrics should have all these labels
 CONTAINER_LABELS = ['container_name', 'namespace', 'pod_name', 'name', 'image', 'id']
 
@@ -96,11 +98,10 @@ class CadvisorPrometheusScraperMixin(object):
         """
         for lbl in CONTAINER_LABELS:
             if lbl == 'container_name':
-                for ml in labels:
-                    if ml.name == lbl:
-                        if ml.value == '' or ml.value == 'POD':
+                if lbl in labels:
+                    if labels[lbl] == '' or labels[lbl] == 'POD':
                             return False
-            if lbl not in [ml.name for ml in labels]:
+            if lbl not in labels:
                 return False
         return True
 
@@ -113,15 +114,16 @@ class CadvisorPrometheusScraperMixin(object):
         :param metric
         :return bool
         """
-        for ml in labels:
-            if ml.name == 'container_name' and ml.value == 'POD':
+        if 'container_name' in labels:
+            if labels['container_name'] == 'POD':
                 return True
-            # container_cpu_usage_seconds_total has an id label that is a cgroup path
-            # eg: /kubepods/burstable/pod531c80d9-9fc4-11e7-ba8b-42010af002bb
-            # FIXME: this was needed because of a bug:
-            # https://github.com/kubernetes/kubernetes/pull/51473
-            # starting from k8s 1.8 we can remove this
-            elif ml.name == 'id' and ml.value.split('/')[-1].startswith('pod'):
+        # container_cpu_usage_seconds_total has an id label that is a cgroup path
+        # eg: /kubepods/burstable/pod531c80d9-9fc4-11e7-ba8b-42010af002bb
+        # FIXME: this was needed because of a bug:
+        # https://github.com/kubernetes/kubernetes/pull/51473
+        # starting from k8s 1.8 we can remove this
+        if 'id' in labels:
+            if labels['id'].split('/')[-1].startswith('pod'):
                 return True
         return False
 
@@ -133,9 +135,8 @@ class CadvisorPrometheusScraperMixin(object):
         :param l_name: str
         :return: str or None
         """
-        for label in labels:
-            if label.name == l_name:
-                return label.value
+        if l_name in labels:
+            return labels[l_name]
 
     def _get_container_id(self, labels):
         """
@@ -218,42 +219,48 @@ class CadvisorPrometheusScraperMixin(object):
         return []
 
     @staticmethod
-    def _sum_values_by_context(message, uid_from_labels):
+    def _sum_values_by_context(metric, uid_from_labels):
         """
-        Iterates over all metrics in a message and sums the values
+        Iterates over all metrics in a metric and sums the values
         matching the same uid. Modifies the metric family in place.
-        :param message: prometheus metric family
+        :param metric: prometheus metric family
         :param uid_from_labels: function mapping a metric.label to a unique context id
         :return: dict with uid as keys, metric object references as values
         """
         seen = {}
-        metric_type = METRIC_TYPES[message.type]
-        for metric in message.metric:
-            uid = uid_from_labels(metric.label)
+        for sample in metric.samples:
+            uid = uid_from_labels(sample[OpenMetricsBaseCheck.SAMPLE_LABELS])
             if not uid:
-                metric.Clear()  # Ignore this metric message
+                # TODO
+                # metric.Clear()  # Ignore this metric message
                 continue
             # Sum the counter value accross all contexts
             if uid not in seen:
-                seen[uid] = metric
+                seen[uid] = sample
             else:
-                getattr(seen[uid], metric_type).value += getattr(metric, metric_type).value
-                metric.Clear()  # Ignore this metric message
+                # We have to create a new tuple
+                seen[uid] = (
+                    seen[uid][OpenMetricsBaseCheck.SAMPLE_NAME],
+                    seen[uid][OpenMetricsBaseCheck.SAMPLE_LABELS],
+                    seen[uid][OpenMetricsBaseCheck.SAMPLE_VALUE] + sample[OpenMetricsBaseCheck.SAMPLE_VALUE]
+                )
+                # TODO
+                # metric.Clear()  # Ignore this metric message
 
         return seen
 
-    def _process_container_rate(self, metric_name, message, scraper_config):
+    def _process_container_rate(self, metric_name, metric, scraper_config):
         """
         Takes a simple metric about a container, reports it as a rate.
         If several series are found for a given container, values are summed before submission.
         """
-        if message.type >= len(METRIC_TYPES):
-            self.log.error("Metric type %s unsupported for metric %s" % (message.type, message.name))
+        if metric.type not in METRIC_TYPES:
+            self.log.error("Metric type %s unsupported for metric %s" % (metric.type, metric.name))
             return
 
-        metrics = self._sum_values_by_context(message, self._get_container_id_if_container_metric)
-        for c_id, metric in metrics.iteritems():
-            pod_uid = self._get_pod_uid(metric.label)
+        samples = self._sum_values_by_context(metric, self._get_container_id_if_container_metric)
+        for c_id, sample in samples.iteritems():
+            pod_uid = self._get_pod_uid(sample[self.SAMPLE_LABELS])
             if self.pod_list_utils.is_excluded(c_id, pod_uid):
                 continue
 
@@ -262,49 +269,49 @@ class CadvisorPrometheusScraperMixin(object):
 
             # FIXME we are forced to do that because the Kubelet PodList isn't updated
             # for static pods, see https://github.com/kubernetes/kubernetes/pull/59948
-            pod = self._get_pod_by_metric_label(metric.label)
+            pod = self._get_pod_by_metric_label(sample[self.SAMPLE_LABELS])
             if pod is not None and is_static_pending_pod(pod):
                 tags += get_tags('kubernetes_pod://%s' % pod["metadata"]["uid"], True)
-                tags += self._get_kube_container_name(metric.label)
+                tags += self._get_kube_container_name(sample[self.SAMPLE_LABELS])
                 tags = list(set(tags))
 
-            val = getattr(metric, METRIC_TYPES[message.type]).value
+            val = sample[self.SAMPLE_VALUE]
 
             self.rate(metric_name, val, tags)
 
-    def _process_pod_rate(self, metric_name, message, scraper_config):
+    def _process_pod_rate(self, metric_name, metric, scraper_config):
         """
         Takes a simple metric about a pod, reports it as a rate.
         If several series are found for a given pod, values are summed before submission.
         """
-        if message.type >= len(METRIC_TYPES):
-            self.log.error("Metric type %s unsupported for metric %s" % (message.type, message.name))
+        if metric.type not in METRIC_TYPES:
+            self.log.error("Metric type %s unsupported for metric %s" % (metric.type, metric.name))
             return
 
-        metrics = self._sum_values_by_context(message, self._get_pod_uid_if_pod_metric)
-        for pod_uid, metric in metrics.iteritems():
+        samples = self._sum_values_by_context(metric, self._get_pod_uid_if_pod_metric)
+        for pod_uid, sample in samples.iteritems():
             if '.network.' in metric_name and self._is_pod_host_networked(pod_uid):
                 continue
             tags = get_tags('kubernetes_pod://%s' % pod_uid, True)
             tags += scraper_config['custom_tags']
-            val = getattr(metric, METRIC_TYPES[message.type]).value
+            val = sample[self.SAMPLE_VALUE]
             self.rate(metric_name, val, tags)
 
-    def _process_usage_metric(self, m_name, message, cache, scraper_config):
+    def _process_usage_metric(self, m_name, metric, cache, scraper_config):
         """
-        Takes a metrics message, a metric name, and a cache dict where it will store
+        Takes a metric object, a metric name, and a cache dict where it will store
         container_name --> (value, tags) so that _process_limit_metric can compute usage_pct
         it also submit said value and tags as a gauge.
         """
         # track containers that still exist in the cache
         seen_keys = {k: False for k in cache}
 
-        metrics = self._sum_values_by_context(message, self._get_container_id_if_container_metric)
-        for c_id, metric in metrics.iteritems():
-            c_name = self._get_container_label(metric.label, 'name')
+        samples = self._sum_values_by_context(metric, self._get_container_id_if_container_metric)
+        for c_id, sample in samples.iteritems():
+            c_name = self._get_container_label(sample[self.SAMPLE_LABELS], 'name')
             if not c_name:
                 continue
-            pod_uid = self._get_pod_uid(metric.label)
+            pod_uid = self._get_pod_uid(sample[self.SAMPLE_LABELS])
             if self.pod_list_utils.is_excluded(c_id, pod_uid):
                 continue
 
@@ -313,13 +320,13 @@ class CadvisorPrometheusScraperMixin(object):
 
             # FIXME we are forced to do that because the Kubelet PodList isn't updated
             # for static pods, see https://github.com/kubernetes/kubernetes/pull/59948
-            pod = self._get_pod_by_metric_label(metric.label)
+            pod = self._get_pod_by_metric_label(sample[self.SAMPLE_LABELS])
             if pod is not None and is_static_pending_pod(pod):
                 tags += get_tags('kubernetes_pod://%s' % pod["metadata"]["uid"], True)
-                tags += self._get_kube_container_name(metric.label)
+                tags += self._get_kube_container_name(sample[self.SAMPLE_LABELS])
                 tags = list(set(tags))
 
-            val = getattr(metric, METRIC_TYPES[message.type]).value
+            val = sample[self.SAMPLE_VALUE]
             cache[c_name] = (val, tags)
             seen_keys[c_name] = True
             self.gauge(m_name, val, tags)
@@ -329,16 +336,16 @@ class CadvisorPrometheusScraperMixin(object):
             if not seen:
                 del cache[k]
 
-    def _process_limit_metric(self, m_name, message, cache, scraper_config, pct_m_name=None):
+    def _process_limit_metric(self, m_name, metric, cache, scraper_config, pct_m_name=None):
         """
         Reports limit metrics if m_name is not an empty string,
         and optionally checks in the given cache if there's a usage
-        for each metric in the message and reports the usage_pct
+        for each sample in the metric and reports the usage_pct
         """
-        metrics = self._sum_values_by_context(message, self._get_container_id_if_container_metric)
-        for c_id, metric in metrics.iteritems():
-            limit = getattr(metric, METRIC_TYPES[message.type]).value
-            pod_uid = self._get_pod_uid(metric.label)
+        samples = self._sum_values_by_context(metric, self._get_container_id_if_container_metric)
+        for c_id, sample in samples.iteritems():
+            limit = sample[self.SAMPLE_VALUE]
+            pod_uid = self._get_pod_uid(sample[self.SAMPLE_LABELS])
             if self.pod_list_utils.is_excluded(c_id, pod_uid):
                 continue
 
@@ -349,7 +356,7 @@ class CadvisorPrometheusScraperMixin(object):
                 self.gauge(m_name, limit, tags)
 
             if pct_m_name and limit > 0:
-                c_name = self._get_container_label(metric.label, 'name')
+                c_name = self._get_container_label(sample[self.SAMPLE_LABELS], 'name')
                 if not c_name:
                     continue
                 usage, tags = cache.get(c_name, (None, None))
@@ -359,79 +366,81 @@ class CadvisorPrometheusScraperMixin(object):
                     self.log.debug("No corresponding usage found for metric %s and "
                                    "container %s, skipping usage_pct for now." % (pct_m_name, c_name))
 
-    def container_cpu_usage_seconds_total(self, message, scraper_config):
+    def container_cpu_usage_seconds_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.cpu.usage.total'
 
-        for metric in message.metric:
-            # Convert cores in nano cores
-            metric.counter.value *= 10. ** 9
-        self._process_container_rate(metric_name, message, scraper_config)
+        for i, sample in enumerate(metric.samples):
+            # Replacing the sample tuple to convert cores in nano cores
+            metric.samples[i] = (sample[self.SAMPLE_NAME], sample[self.SAMPLE_LABELS],
+                                 sample[self.SAMPLE_VALUE] * 10. ** 9)
 
-    def container_fs_reads_bytes_total(self, message, scraper_config):
+        self._process_container_rate(metric_name, metric, scraper_config)
+
+    def container_fs_reads_bytes_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.io.read_bytes'
-        self._process_container_rate(metric_name, message, scraper_config)
+        self._process_container_rate(metric_name, metric, scraper_config)
 
-    def container_fs_writes_bytes_total(self, message, scraper_config):
+    def container_fs_writes_bytes_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.io.write_bytes'
-        self._process_container_rate(metric_name, message, scraper_config)
+        self._process_container_rate(metric_name, metric, scraper_config)
 
-    def container_network_receive_bytes_total(self, message, scraper_config):
+    def container_network_receive_bytes_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.network.rx_bytes'
-        self._process_pod_rate(metric_name, message, scraper_config)
+        self._process_pod_rate(metric_name, metric, scraper_config)
 
-    def container_network_transmit_bytes_total(self, message, scraper_config):
+    def container_network_transmit_bytes_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.network.tx_bytes'
-        self._process_pod_rate(metric_name, message, scraper_config)
+        self._process_pod_rate(metric_name, metric, scraper_config)
 
-    def container_network_receive_errors_total(self, message, scraper_config):
+    def container_network_receive_errors_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.network.rx_errors'
-        self._process_pod_rate(metric_name, message, scraper_config)
+        self._process_pod_rate(metric_name, metric, scraper_config)
 
-    def container_network_transmit_errors_total(self, message, scraper_config):
+    def container_network_transmit_errors_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.network.tx_errors'
-        self._process_pod_rate(metric_name, message, scraper_config)
+        self._process_pod_rate(metric_name, metric, scraper_config)
 
-    def container_network_transmit_packets_dropped_total(self, message, scraper_config):
+    def container_network_transmit_packets_dropped_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.network.tx_dropped'
-        self._process_pod_rate(metric_name, message, scraper_config)
+        self._process_pod_rate(metric_name, metric, scraper_config)
 
-    def container_network_receive_packets_dropped_total(self, message, scraper_config):
+    def container_network_receive_packets_dropped_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.network.rx_dropped'
-        self._process_pod_rate(metric_name, message, scraper_config)
+        self._process_pod_rate(metric_name, metric, scraper_config)
 
-    def container_fs_usage_bytes(self, message, scraper_config):
+    def container_fs_usage_bytes(self, metric, scraper_config):
         """
         Number of bytes that are consumed by the container on this filesystem.
         """
         metric_name = scraper_config['namespace'] + '.filesystem.usage'
-        if message.type >= len(METRIC_TYPES):
-            self.log.error("Metric type %s unsupported for metric %s" % (message.type, message.name))
+        if metric.type not in METRIC_TYPES:
+            self.log.error("Metric type %s unsupported for metric %s" % (metric.type, metric.name))
             return
-        self._process_usage_metric(metric_name, message, self.fs_usage_bytes, scraper_config)
+        self._process_usage_metric(metric_name, metric, self.fs_usage_bytes, scraper_config)
 
-    def container_fs_limit_bytes(self, message, scraper_config):
+    def container_fs_limit_bytes(self, metric, scraper_config):
         """
         Number of bytes that can be consumed by the container on this filesystem.
         This method is used by container_fs_usage_bytes, it doesn't report any metric
         """
         pct_m_name = scraper_config['namespace'] + '.filesystem.usage_pct'
-        if message.type >= len(METRIC_TYPES):
-            self.log.error("Metric type %s unsupported for metric %s" % (message.type, message.name))
+        if metric.type not in METRIC_TYPES:
+            self.log.error("Metric type %s unsupported for metric %s" % (metric.type, metric.name))
             return
-        self._process_limit_metric('', message, self.fs_usage_bytes, scraper_config, pct_m_name)
+        self._process_limit_metric('', metric, self.fs_usage_bytes, scraper_config, pct_m_name)
 
-    def container_memory_usage_bytes(self, message, scraper_config):
+    def container_memory_usage_bytes(self, metric, scraper_config):
         """TODO: add swap, cache, failcnt and rss"""
         metric_name = scraper_config['namespace'] + '.memory.usage'
-        if message.type >= len(METRIC_TYPES):
-            self.log.error("Metric type %s unsupported for metric %s" % (message.type, message.name))
+        if metric.type not in METRIC_TYPES:
+            self.log.error("Metric type %s unsupported for metric %s" % (metric.type, metric.name))
             return
-        self._process_usage_metric(metric_name, message, self.mem_usage_bytes, scraper_config)
+        self._process_usage_metric(metric_name, metric, self.mem_usage_bytes, scraper_config)
 
-    def container_spec_memory_limit_bytes(self, message, scraper_config):
+    def container_spec_memory_limit_bytes(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.memory.limits'
         pct_m_name = scraper_config['namespace'] + '.memory.usage_pct'
-        if message.type >= len(METRIC_TYPES):
-            self.log.error("Metric type %s unsupported for metric %s" % (message.type, message.name))
+        if metric.type not in METRIC_TYPES:
+            self.log.error("Metric type %s unsupported for metric %s" % (metric.type, metric.name))
             return
-        self._process_limit_metric(metric_name, message, self.mem_usage_bytes, scraper_config, pct_m_name=pct_m_name)
+        self._process_limit_metric(metric_name, metric, self.mem_usage_bytes, scraper_config, pct_m_name=pct_m_name)

--- a/kubelet/tests/test_cadvisor.py
+++ b/kubelet/tests/test_cadvisor.py
@@ -59,10 +59,8 @@ def test_kubelet_check_cadvisor(monkeypatch, aggregator):
     monkeypatch.setattr(check, '_perform_kubelet_check', mock.Mock(return_value=None))
     monkeypatch.setattr(check, '_retrieve_cadvisor_metrics',
                         mock.Mock(return_value=json.loads(mock_from_file('cadvisor_1.2.json'))))
-    monkeypatch.setattr(check.cadvisor_scraper, 'process', mock.Mock(return_value=None))
-    monkeypatch.setattr(check.kubelet_scraper, 'process', mock.Mock(return_value=None))
     monkeypatch.setattr(check, 'detect_cadvisor', mock.Mock(return_value=cadvisor_url))
-
+    monkeypatch.setattr(check, 'process', mock.Mock(return_value=None))
     # We filter out slices unknown by the tagger, mock a non-empty taglist
     monkeypatch.setattr('datadog_checks.kubelet.cadvisor.get_tags',
                         mock.Mock(return_value=["foo:bar"]))
@@ -75,8 +73,6 @@ def test_kubelet_check_cadvisor(monkeypatch, aggregator):
     check._retrieve_node_spec.assert_called_once()
     check._retrieve_cadvisor_metrics.assert_called_once()
     check._perform_kubelet_check.assert_called_once()
-    check.cadvisor_scraper.process.assert_not_called()
-    check.kubelet_scraper.process.assert_called_once()
 
     # called twice so pct metrics are guaranteed to be there
     check.check(instance_with_tag)

--- a/kubelet/tests/test_common.py
+++ b/kubelet/tests/test_common.py
@@ -9,8 +9,7 @@ import pytest
 import json
 
 from datadog_checks.kubelet import PodListUtils, KubeletCredentials, get_pod_by_uid, is_static_pending_pod
-from datadog_checks.checks.prometheus import PrometheusScraper
-
+from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 from .test_kubelet import mock_from_file
 
 # Skip the whole tests module on Windows
@@ -115,12 +114,14 @@ def test_credentials_empty():
     assert creds.cert_pair() is None
     assert creds.headers("https://dummy") is None
 
-    scraper = PrometheusScraper(None)
-    creds.configure_scraper(scraper, "https://dummy")
-    assert scraper.ssl_ca_cert is None
-    assert scraper.ssl_cert is None
-    assert scraper.ssl_private_key is None
-    assert scraper.extra_headers == {}
+    scraper = OpenMetricsBaseCheck('prometheus', {}, {})
+    scraper_config = scraper.create_scraper_configuration()
+    scraper_config['prometheus_url'] = "https://dummy"
+    creds.configure_scraper(scraper_config)
+    assert scraper_config['ssl_ca_cert'] is None
+    assert scraper_config['ssl_cert'] is None
+    assert scraper_config['ssl_private_key'] is None
+    assert scraper_config['extra_headers'] == {}
 
 
 def test_credentials_certificates():
@@ -135,12 +136,14 @@ def test_credentials_certificates():
     assert creds.cert_pair() == ("crt", "key")
     assert creds.headers("https://dummy") is None
 
-    scraper = PrometheusScraper(None)
-    creds.configure_scraper(scraper, "https://dummy")
-    assert scraper.ssl_ca_cert == "ca_cert"
-    assert scraper.ssl_cert == "crt"
-    assert scraper.ssl_private_key == "key"
-    assert scraper.extra_headers == {}
+    scraper = OpenMetricsBaseCheck('prometheus', {}, {})
+    scraper_config = scraper.create_scraper_configuration({})
+    scraper_config['prometheus_url'] = "https://dummy"
+    creds.configure_scraper(scraper_config)
+    assert scraper_config['ssl_ca_cert'] == "ca_cert"
+    assert scraper_config['ssl_cert'] == "crt"
+    assert scraper_config['ssl_private_key'] == "key"
+    assert scraper_config['extra_headers'] == {}
 
 
 def test_credentials_token_noverify():
@@ -157,16 +160,19 @@ def test_credentials_token_noverify():
     # Make sure we don't leak the token over http
     assert creds.headers("http://dummy") is None
 
-    scraper = PrometheusScraper(None)
-    creds.configure_scraper(scraper, "https://dummy")
-    assert scraper.ssl_ca_cert is False
-    assert scraper.ssl_cert is None
-    assert scraper.ssl_private_key is None
-    assert scraper.extra_headers == expected_headers
+    scraper = OpenMetricsBaseCheck('prometheus', {}, {})
+    scraper_config = scraper.create_scraper_configuration()
+    scraper_config['prometheus_url'] = 'https://dummy'
+    creds.configure_scraper(scraper_config)
+    assert scraper_config['ssl_ca_cert'] is False
+    assert scraper_config['ssl_cert'] is None
+    assert scraper_config['ssl_private_key'] is None
+    assert scraper_config['extra_headers'] == expected_headers
 
     # Make sure we don't leak the token over http
-    creds.configure_scraper(scraper, "http://dummy")
-    assert scraper.ssl_ca_cert is False
-    assert scraper.ssl_cert is None
-    assert scraper.ssl_private_key is None
-    assert scraper.extra_headers == {}
+    scraper_config['prometheus_url'] = "http://dummy"
+    creds.configure_scraper(scraper_config)
+    assert scraper_config['ssl_ca_cert'] is False
+    assert scraper_config['ssl_cert'] is None
+    assert scraper_config['ssl_private_key'] is None
+    assert scraper_config['extra_headers'] == {}

--- a/kubelet/tests/test_prometheus.py
+++ b/kubelet/tests/test_prometheus.py
@@ -4,7 +4,6 @@
 import json
 import os
 import sys
-from collections import namedtuple
 
 import pytest
 import mock
@@ -18,13 +17,11 @@ pytestmark = pytest.mark.skipif(sys.platform == 'win32', reason='tests for linux
 # Constants
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-Label = namedtuple('Label', 'name value')
-
 
 class MockMetric(object):
     def __init__(self, name, labels=None, value=None):
         self.name = name
-        self.label = labels if labels else []
+        self.label = labels if labels else {}
         self.value = value
 
 
@@ -62,24 +59,24 @@ def test_is_container_metric():
         MockMetric('foo', []),
         MockMetric(
             'bar',
-            [
-                Label(name='container_name', value='POD'),  # POD --> False
-                Label(name='namespace', value='default'),
-                Label(name='pod_name', value='pod0'),
-                Label(name='name', value='foo'),
-                Label(name='image', value='foo'),
-                Label(name='id', value='deadbeef'),
-            ]
+            {
+                'container_name': 'POD',
+                'namespace': 'default',
+                'pod_name': 'pod0',
+                'name': 'foo',
+                'image': 'foo',
+                'id': 'deadbeef',
+            }
         ),
         MockMetric(  # missing container_name
             'foobar',
-            [
-                Label(name='namespace', value='default'),
-                Label(name='pod_name', value='pod0'),
-                Label(name='name', value='foo'),
-                Label(name='image', value='foo'),
-                Label(name='id', value='deadbeef'),
-            ]
+            {
+                'namespace': 'default',
+                'pod_name': 'pod0',
+                'name': 'foo',
+                'image': 'foo',
+                'id': 'deadbeef',
+            }
         ),
     ]
     for metric in false_metrics:
@@ -87,31 +84,32 @@ def test_is_container_metric():
 
     true_metric = MockMetric(
         'foo',
-        [
-            Label(name='container_name', value='ctr0'),
-            Label(name='namespace', value='default'),
-            Label(name='pod_name', value='pod0'),
-            Label(name='name', value='foo'),
-            Label(name='image', value='foo'),
-            Label(name='id', value='deadbeef'),
-        ]
+        {
+            'container_name': 'ctr0',
+            'namespace': 'default',
+            'pod_name': 'pod0',
+            'name': 'foo',
+            'image': 'foo',
+            'id': 'deadbeef',
+        }
     )
     assert CadvisorPrometheusScraperMixin._is_container_metric(true_metric.label) is True
 
 
 def test_is_pod_metric():
     false_metrics = [
-        MockMetric('foo', []),
-        MockMetric('bar', [Label(name='container_name', value='ctr0')]),
-        MockMetric('foobar', [Label(name='container_name', value='ctr0'), Label(name='id', value='deadbeef')]),
+        MockMetric('foo', {}),
+        MockMetric('bar', {'container_name': 'ctr0'}),
+        MockMetric('foobar', {'container_name': 'ctr0', 'id': 'deadbeef'}),
     ]
 
     true_metrics = [
-        MockMetric('foo', [Label(name='container_name', value='POD')]),
-        MockMetric('bar', [Label(name='id', value='/kubepods/burstable/pod531c80d9-9fc4-11e7-ba8b-42010af002bb')]),
-        MockMetric('foobar', [
-            Label(name='container_name', value='POD'),
-            Label(name='id', value='/kubepods/burstable/pod531c80d9-9fc4-11e7-ba8b-42010af002bb')]),
+        MockMetric('foo', {'container_name': 'POD'}),
+        MockMetric('bar', {'id': '/kubepods/burstable/pod531c80d9-9fc4-11e7-ba8b-42010af002bb'}),
+        MockMetric('foobar', {
+            'container_name': 'POD',
+            'id': '/kubepods/burstable/pod531c80d9-9fc4-11e7-ba8b-42010af002bb'
+        }),
     ]
 
     for metric in false_metrics:
@@ -122,32 +120,32 @@ def test_is_pod_metric():
 
 
 def test_get_container_label():
-    labels = [
-        Label("container_name", value="POD"),
-        Label("id", value="/kubepods/burstable/pod531c80d9-9fc4-11e7-ba8b-42010af002bb"),
-    ]
+    labels = {
+        "container_name": "POD",
+        "id": "/kubepods/burstable/pod531c80d9-9fc4-11e7-ba8b-42010af002bb",
+    }
     assert CadvisorPrometheusScraperMixin._get_container_label(labels, "container_name") == "POD"
-    assert CadvisorPrometheusScraperMixin._get_container_label([], "not-in") is None
+    assert CadvisorPrometheusScraperMixin._get_container_label({}, "not-in") is None
 
 
 def test_get_container_id(cadvisor_scraper):
-    labels = [
-        Label("container_name", value="datadog-agent"),
-        Label("namespace", value="default"),
-        Label("pod_name", value="datadog-agent-pbqt2"),
-        Label("container_name", value="datadog-agent"),
-    ]
+    labels = {
+        "container_name": "datadog-agent",
+        "namespace": "default",
+        "pod_name": "datadog-agent-pbqt2",
+        "container_name": "datadog-agent",
+    }
     container_id = cadvisor_scraper._get_container_id(labels)
     assert container_id == "containerd://51cba2ca229069039575750d44ed3a67e9b5ead651312ba7ff218dd9202fde64"
     assert cadvisor_scraper._get_container_id([]) is None
 
 
 def test_get_pod_uid(cadvisor_scraper):
-    labels = [
-        Label("container_name", value="POD"),
-        Label("namespace", value="default"),
-        Label("pod_name", value="datadog-agent-pbqt2"),
-    ]
+    labels = {
+        "container_name": "POD",
+        "namespace": "default",
+        "pod_name": "datadog-agent-pbqt2",
+    }
     assert cadvisor_scraper._get_pod_uid(labels) == "b66c40af-997d-11e8-96a3-42010a840157"
     assert cadvisor_scraper._get_pod_uid([]) is None
 
@@ -161,33 +159,31 @@ def test_is_pod_host_networked(cadvisor_scraper):
 
 def test_get_pod_by_metric_label(cadvisor_scraper):
     assert len(cadvisor_scraper.pod_list) == 4
-    kube_proxy = cadvisor_scraper._get_pod_by_metric_label([
-        Label("container_name", value="POD"),
-        Label("namespace", value="kube-system"),
-        Label("pod_name", value="kube-proxy-2d2bq")
-    ])
-    fluentd = cadvisor_scraper._get_pod_by_metric_label([
-        Label("container_name", value="POD"),
-        Label("namespace", value="kube-system"),
-        Label("pod_name", value="fluentd-gcp-v3.0.0-z55q5")
-    ])
+    kube_proxy = cadvisor_scraper._get_pod_by_metric_label({
+        "container_name": "POD",
+        "namespace": "kube-system",
+        "pod_name": "kube-proxy-2d2bq",
+    })
+    fluentd = cadvisor_scraper._get_pod_by_metric_label({
+        "container_name": "POD",
+        "namespace": "kube-system",
+        "pod_name": "fluentd-gcp-v3.0.0-z55q5",
+    })
     assert kube_proxy["metadata"]["uid"] == "8abf1ed0-94c4-11e8-96a3-42010a840157"
     assert fluentd["metadata"]["uid"] == "fe3d57c4-94c4-11e8-96a3-42010a840157"
 
 
 def test_get_kube_container_name():
-    tags = CadvisorPrometheusScraperMixin._get_kube_container_name([
-        Label("container_name", value="datadog-agent"),
-        Label("id",
-              value="/kubepods/burstable/"
-                    "podc2319815-10d0-11e8-bd5a-42010af00137/"
-                    "a335589109ce5506aa69ba7481fc3e6c943abd23c5277016c92dac15d0f40479"),
-        Label("image",
-              value="datadog/agent-dev@sha256:894fb66f89be0332a47388d7219ab8b365520ff0e3bbf597bd0a378b19efa7ee"),
-        Label("name", value="k8s_datadog-agent_datadog-agent-jbm2k_default_c2319815-10d0-11e8-bd5a-42010af00137_0"),
-        Label("namespace", value="default"),
-        Label("pod_name", value="datadog-agent-jbm2k"),
-    ])
+    tags = CadvisorPrometheusScraperMixin._get_kube_container_name({
+        "container_name": "datadog-agent",
+        "id": "/kubepods/burstable/"
+              "podc2319815-10d0-11e8-bd5a-42010af00137/"
+              "a335589109ce5506aa69ba7481fc3e6c943abd23c5277016c92dac15d0f40479",
+        "image": "datadog/agent-dev@sha256:894fb66f89be0332a47388d7219ab8b365520ff0e3bbf597bd0a378b19efa7ee",
+        "name": "k8s_datadog-agent_datadog-agent-jbm2k_default_c2319815-10d0-11e8-bd5a-42010af00137_0",
+        "namespace": "default",
+        "pod_name": "datadog-agent-jbm2k",
+    })
     assert tags == ["kube_container_name:datadog-agent"]
 
     tags = CadvisorPrometheusScraperMixin._get_kube_container_name([])


### PR DESCRIPTION
### What does this PR do?

Updates kubelet to use the new OpenMetricsBaseCheck class.

### Motivation

This fixes the check for when we use the new OpenMetricsBaseCheck class.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes