### PR TITLE
Update linkerd to use the new OpenMetricsBaseCheck

### DIFF
--- a/linkerd/datadog_checks/linkerd/linkerd.py
+++ b/linkerd/datadog_checks/linkerd/linkerd.py
@@ -2,11 +2,11 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from datadog_checks.checks.prometheus import GenericPrometheusCheck
+from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 
 from .metrics import METRIC_MAP, TYPE_OVERRIDES
 
-class LinkerdCheck(GenericPrometheusCheck):
+class LinkerdCheck(OpenMetricsBaseCheck):
     """
     Collect linkerd metrics from Prometheus
     """


### PR DESCRIPTION
### What does this PR do?

Cleans up linkerd tests.

### Motivation

Going through prometheus checks and porting them.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
