### PR TITLE
improve example

### DIFF
--- a/sqlserver/README.md
+++ b/sqlserver/README.md
@@ -18,7 +18,7 @@ Make sure that your SQL Server instance supports SQL Server authentication by en
 
 ### Configuration
 
-1. Create a read-only user to connect to your server:
+1. Create a read-only login to connect to your server:
 
     ```
         CREATE LOGIN datadog WITH PASSWORD = 'YOUR_PASSWORD';
@@ -35,8 +35,8 @@ Make sure that your SQL Server instance supports SQL Server authentication by en
 
         instances:
           - host: <SQL_HOST>,<SQL_PORT>
-            username: <SQL_ADMIN_USER>
-            password: <SQL_ADMIN_PASSWORD>
+            username: datadog
+            password: <YOUR_PASSWORD>
             connector: odbc # alternative is 'adodbapi'
             driver: SQL Server
     ```


### PR DESCRIPTION
* The configuration step 1 creates `datadog` login. So , configuration example of step 2 should use `datadog` created at step1.
* SQL Server uses `login` to connect SQL Server instance.

### What does this PR do?

* To improve configuration example and to fix the term.

### Motivation

* I'm SQL Server DBA and I'd like to correct document for sql server.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
