### PR TITLE
Allow to force text format for cadvisor metrics

### DIFF
--- a/kubelet/datadog_checks/kubelet/data/conf.yaml.example
+++ b/kubelet/datadog_checks/kubelet/data/conf.yaml.example
@@ -21,6 +21,13 @@ instances:
     # cadvisor metrics collection
     # cadvisor_metrics_endpoint: http://10.8.0.1:10255/metrics/cadvisor
     #
+    # Kubelets affected by https://github.com/kubernetes/kubernetes/issues/64137#issuecomment-394342449
+    # will generate a very large protobuf payload that might trigger OOM during parsing. As a mitigation
+    # strategy, set this option to True to switch to the text format and filter the input, at the cost
+    # of an added CPU usage.
+    #
+    # cadvisor_metrics_force_text: True
+    #
     # url of the kubelet metrics prometheus endpoint
     # Pass an empty string to disable kubelet metrics collection
     # kubelet_metrics_endpoint: http://10.8.0.1:10255/metrics

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -4,6 +4,7 @@
 
 # project
 from datadog_checks.checks.prometheus import PrometheusScraper
+from datadog_checks.config import _is_affirmative
 from tagger import get_tags
 
 # check
@@ -203,6 +204,7 @@ class CadvisorPrometheusScraper(PrometheusScraper):
         instance = kwargs.get('instance')
         if instance:
             self.instance_tags = instance.get('tags', [])
+            self._force_text_format = _is_affirmative(instance.get('cadvisor_metrics_force_text', False))
 
         super(CadvisorPrometheusScraper, self).process(endpoint, **kwargs)
 


### PR DESCRIPTION
### What does this PR do?

 Kubelets affected by https://github.com/kubernetes/kubernetes/issues/64137#issuecomment-394342449 will generate a very large protobuf payload that might trigger OOM during parsing. As a mitigation, users will be able to set the `cadvisor_metrics_force_text` option to:

- force the agent to download the cadvisor metric payload as text instead of protobuf
- use the payload filtering feature introduced in https://github.com/DataDog/integrations-core/pull/1872

Benchmarking in progress https://app.datadoghq.com/notebook/46082 (org `datadog-dev`)

**Note:** this should become obsolete with 6.5.0's switch to text by default, this patch is only intended for the 6.4.x series -> no sister PR for `master`

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
