### PR TITLE
[Release] Bumped datadog_checks_dev version to 0.3.1

### DIFF
--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - Datadog Checks Dev
 
+## 0.3.1 / 2018-08-03
+
+* [Fixed] Fix clean command. See [#1992](https://github.com/DataDog/integrations-core/pull/1992).
+
 ## 0.3.0 / 2018-07-30
 
 * [Added] Allow passing --build to compose up. See [#1962](https://github.com/DataDog/integrations-core/pull/1962).

--- a/datadog_checks_dev/datadog_checks/dev/__about__.py
+++ b/datadog_checks_dev/datadog_checks/dev/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '0.3.0'
+__version__ = '0.3.1'


### PR DESCRIPTION
### What does this PR do?

Adds a new release for datadog checks dev

