### PR TITLE
Only test against Zookeeper 3.4.11 until we fully support 3.5

### DIFF
--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -227,7 +227,8 @@ class ZookeeperCheck(AgentCheck):
             gauge_name = 'zookeeper.instances.%s' % k
             self.gauge(gauge_name, v)
 
-    def _send_command(self, command, host, port, timeout):
+    @staticmethod
+    def _send_command(command, host, port, timeout):
         sock = socket.socket()
         sock.settimeout(timeout)
         buf = StringIO()

--- a/zk/requirements-dev.txt
+++ b/zk/requirements-dev.txt
@@ -1,1 +1,1 @@
-pytest
+datadog-checks-dev

--- a/zk/tests/compose/zk.yaml
+++ b/zk/tests/compose/zk.yaml
@@ -3,7 +3,5 @@ version: '3.5'
 services:
   zk:
     image: "zookeeper:${ZK_VERSION}"
-    environment:
-      - "ZOO_TICK_TIME=2000"
     ports:
       - "12181:2181"

--- a/zk/tests/conftest.py
+++ b/zk/tests/conftest.py
@@ -5,9 +5,11 @@ import os
 import sys
 import time
 import subprocess
-import requests
+import socket
 import pytest
 from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.zk import ZookeeperCheck
+from datadog_checks.zk.zk import ZKConnectionFailure
 
 CHECK_NAME = 'zk'
 HOST = get_docker_hostname()
@@ -104,12 +106,21 @@ def spin_up_zk():
         'docker-compose', '-f', os.path.join(HERE, 'compose', 'zk.yaml')
     ]
     subprocess.check_call(args + ["up", "-d"], env=env)
-    sys.stderr.write("Waiting for ZK to boot")
-    for _ in xrange(2):
+    sys.stderr.write("Waiting for ZK to boot...\n")
+    booted = False
+    for _ in xrange(3):
         try:
-            res = requests.get(URL)
-            res.raise_for_status()
-        except Exception:
+            out = ZookeeperCheck._send_command('ruok', HOST, PORT, 500)
+            out.seek(0)
+            if out.readline() != 'imok':
+                raise ZKConnectionFailure()
+            booted = True
+        except ZKConnectionFailure:
             time.sleep(1)
+
+    if not booted:
+        raise Exception("Zookeeper failed to boot!")
+
+    sys.stderr.write("ZK boot complete.\n")
     yield
     subprocess.check_call(args + ["down"], env=env)

--- a/zk/tests/conftest.py
+++ b/zk/tests/conftest.py
@@ -4,8 +4,6 @@
 import os
 import sys
 import time
-import subprocess
-import socket
 import pytest
 from datadog_checks.dev import docker_run, RetryError
 from datadog_checks.utils.common import get_docker_hostname

--- a/zk/tox.ini
+++ b/zk/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    zk-{latest,3.4.9,3.4.11}
+    zk-{3.4}
     flake8
 
 [testenv]
@@ -18,17 +18,9 @@ passenv =
     DOCKER*
     COMPOSE*
 
-[testenv:zk-latest]
-setenv = 
-    ZK_VERSION=latest
-
-[testenv:zk-3.4.11]
-setenv = 
+[testenv:zk-3.4]
+setenv =
     ZK_VERSION=3.4.11
-
-[testenv:zk-3.4.9]
-setenv = 
-    ZK_VERSION=3.4.9
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
### What does this PR do?

 * Remove useless testing against multiple 3.4.x
 * Only test against 3.4.11 that was the latest working version
 * Do not test against `latest` to avoid unexpected failures

### Motivation

3.4.13 was promoted to `latest` and broke the tests on `master`

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)


