### PR TITLE
Fix PDH title, use Windows Performance Counters instead of PDH

### DIFF
--- a/pdh_check/README.md
+++ b/pdh_check/README.md
@@ -1,10 +1,10 @@
-# Wmi_check Integration
+# Windows Performance Counters Integration
 
 ## Overview
 
 Get metrics from Windows performance counters in real time to:
 
-* Visualize and monitor windows performance counters
+* Visualize and monitor windows performance counters through the pdh api
 
 ## Setup
 ### Installation

--- a/pdh_check/manifest.json
+++ b/pdh_check/manifest.json
@@ -12,7 +12,7 @@
   "metric_to_check": "pdh.system.file_read_per_se",
   "name": "pdh_check",
   "public_title": "Datadog-Pdh Check Integration",
-  "short_description": "Collect and graph any Windows PDH metrics.",
+  "short_description": "Collect and graph any Windows Performance Counters.",
   "support": "core",
   "supported_os": [
     "windows"


### PR DESCRIPTION
### What does this PR do?

The PDH check was titled WMI Check, this changes it to the proper name. It also changes it to Windows Performance Counters instead of pdh, so that we get a better name for it. While we can't easily change the name of the check, changing the title isn't so hard.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
