### PR TITLE
Adds in the ability to specify 'use_cached' in the pgbouncer config.

### DIFF
--- a/pgbouncer/datadog_checks/pgbouncer/data/conf.yaml.example
+++ b/pgbouncer/datadog_checks/pgbouncer/data/conf.yaml.example
@@ -5,6 +5,7 @@ instances:
 #     port: 15433
 #     username: my_username
 #     password: my_password
+#     use_cached: True
 #     tags:
 #       - optional_tag1
 #       - optional_tag2

--- a/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
+++ b/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
@@ -7,6 +7,7 @@ import psycopg2 as pg
 import psycopg2.extras as pgextras
 
 from datadog_checks.checks import AgentCheck
+from datadog_checks.config import is_affirmative
 from datadog_checks.errors import CheckException
 
 
@@ -206,7 +207,7 @@ class PgBouncer(AgentCheck):
         password = instance.get('password', '')
         tags = instance.get('tags', [])
         database_url = instance.get('database_url')
-        use_cached = instance.get('use_cached', True)
+        use_cached = is_affirmative(instance.get('use_cached', True))
 
         if database_url:
             key = database_url

--- a/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
+++ b/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
@@ -206,6 +206,7 @@ class PgBouncer(AgentCheck):
         password = instance.get('password', '')
         tags = instance.get('tags', [])
         database_url = instance.get('database_url')
+        use_cached = instance.get('use_cached', True)
 
         if database_url:
             key = database_url
@@ -219,7 +220,7 @@ class PgBouncer(AgentCheck):
 
         try:
             db = self._get_connection(key, host, port, user, password, tags=tags,
-                                      database_url=database_url)
+                                      database_url=database_url, use_cached=use_cached)
             self._collect_stats(db, tags)
         except ShouldRestartException:
             self.log.info("Resetting the connection")


### PR DESCRIPTION
During our use of the datadog pgbouncer check, we found an issue where the agent would fail to reconnect to a recovered pgbouncer process.  We simulated this by starting our `pgbouncer` and `datadog-agent` processes, and then subsequently stopping `pgbouncer`, waiting a few minutes, and restarting `pgbouncer`.

The agent would correctly alert us that `pgbouncer` was down, but upon recovery, the agent would continue to be in an error state.  We would have to restart the agent to get it reporting "healthy" again. We have reason to believe this is due to the caching of the underlying Postgres connection.

We simulated this again with the change in this PR and the agent behaved as expected.

Please let us know if there's additional testing coverage or simulations we can provide.

Cheers!

### What does this PR do?

This enables users to configure whether or not they want to used cached connections to check pgbouncer.

### Motivation

As mentioned above, we were evaluating this check in our development environment and we observed that when a `pgbouncer` process stopped, and restarted again, the datadog agent would continually think it was in an error state.  We have reason to believe it is due to caching the connection object and attempting to call functions on it after it has been closed.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

I'm more than open to explore other possibilities too, like catching a different exception or finding out why [`ShouldRestartException`](https://github.com/DataDog/integrations-core/blob/master/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py#L132) isn't being thrown in this instance.