### PR TITLE
Retrieve no_proxy directly from the Datadog Agent's configuration

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/base.py
+++ b/datadog_checks_base/datadog_checks/checks/base.py
@@ -106,7 +106,6 @@ class AgentCheck(object):
 
     def get_instance_proxy(self, instance, uri, proxies=None):
         proxies = proxies if proxies is not None else self.proxies.copy()
-        proxies['no'] = os.getenv('no_proxy', os.getenv('NO_PROXY', None))
 
         deprecated_skip = instance.get('no_proxy', None)
         skip = (

--- a/datadog_checks_base/datadog_checks/checks/base.py
+++ b/datadog_checks_base/datadog_checks/checks/base.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from collections import defaultdict
 import logging
-import os
 import re
 import json
 import copy

--- a/datadog_checks_base/tests/test_proxy.py
+++ b/datadog_checks_base/tests/test_proxy.py
@@ -20,6 +20,11 @@ SKIP_PROXY_SETTINGS = {
     'https': '',
     'no': None
 }
+NO_PROXY_DD_CONFIG_SETTINGS = {
+    'http': 'http://1.2.3.4:567',
+    'https': 'https://1.2.3.4:567',
+    'no': 'localhost'
+}
 BAD_PROXY_SETTINGS = {
     'http': 'http://1.2.3.4:567',
     'https': 'https://1.2.3.4:567',
@@ -100,3 +105,9 @@ def test_https_proxy_fail():
     finally:
         os.environ.clear()
         os.environ.update(old_env)
+
+def test_config_no_proxy():
+    with mock.patch('datadog_checks.checks.AgentCheck._get_requests_proxy', return_value=NO_PROXY_DD_CONFIG_SETTINGS):
+        check = AgentCheck()
+        proxy_results = check.get_instance_proxy({}, 'uri/health')
+        assert 'localhost' in proxy_results['no']

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -676,7 +676,6 @@ class Network(AgentCheck):
         Gather metrics about connections states and interfaces counters
         using psutil facilities
         """
-        # import pdb; pdb.set_trace()
         custom_tags = instance.get('tags', [])
         if self._collect_cx_state:
             self._cx_state_psutil(tags=custom_tags)


### PR DESCRIPTION
### What does this PR do?

Remove the check for the `no_proxy` environment variables in `get_instance_proxy`. The logic should be done by the Datadog Agent and the https, http, and no_proxy options should all be available in the agents config to retrieve by the time the integrations request it. 

### Motivation

User had a `no_proxy` setup in the datadog.yaml file, however this wasn't being propogated to the integrations that use `get_instance_proxy` and instead these checks were using the proxy directly.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Noticed some commented out pdbs in the network check, so removed those for cleanliness