### PR TITLE
Fix indentation of comments in code block

### DIFF
--- a/pgbouncer/README.md
+++ b/pgbouncer/README.md
@@ -21,18 +21,18 @@ instances:
     port: 15433
     username: <YOUR_USERNAME>
     password: <YOUR_PASSWORD>
-#   tags:
-#     - env:prod
+    # tags:
+    #   - env:prod
   - database_url: postgresql://<DB_USER>:<DB_PASS>@<DB_HOST>:<DB_PORT>/dbname?sslmode=require
-#   tags:
-#     - role:main
+    # tags:
+    #   - role:main
 ```
 
 **Note**: `database_url` parameter value should point to PgBouncer stats database.
 
 In your PgBouncer userlist.txt file add
 ```
-  "datadog" "<your_pass>"
+"datadog" "<your_pass>"
 ```
 
 Next, in your PgBouncer pgbouncer.ini file add


### PR DESCRIPTION
### What does this PR do?

Fixes the indentation of the comments in the code block of the example yaml part of the README

### Motivation

This is required to keep everything in sync from the tile to the Readme/docs. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
