### PR TITLE
[RFC] Using new comment layout

### DIFF
--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -2,41 +2,41 @@ init_config:
 
 instances:
     
-    ## apache_status_url - mandatory - string  
+    ## @param apache_status_url - mandatory - string  
     ## Status url of your Apache server.
   
   - apache_status_url: http://localhost/server-status?auto
 
-    ## apache_user - optional - string
+    ## @param apache_user - optional - string
     ## <USERNAME> for the Apache status endpoint authentication.
     
     # apache_user: <USERNAME>
 
-    ## apache_password - optional - string
+    ## @param apache_password - optional - string
     ## <PASSWORD> for the Apache status endpoint authentication.
     
     # apache_password: <PASSWORD>
 
-    ## tags - optional - list of key:value element
+    ## @param tags - optional - list of key:value element
     ## List of tags to attach to every metrics, events and service checks emitted by this integration.
     ## Learn more about tagging: https://docs.datadoghq.com/tagging/
     
     # tags:
     #   - <KEY>:<VALUE>
 
-    ## disable_ssl_validation - optional - boolean - default: false
+    ## @param disable_ssl_validation - optional - boolean - default: false
     ## Instructs the check to skip the validation of the SSL certificate of the URL being tested.
     ## Defaults to false, set to true if you want to disable SSL certificate validation.
 
     # disable_ssl_validation: false
 
-    ## connect_timeout - optional - integer 
+    ## @param connect_timeout - optional - integer 
     ## Overrides the default connection timeout value, and fails the check if the time to establish the (TCP) connection 
     ## exceeds the connect_timeout value (in seconds)
     
     # connect_timeout: <VALUE_IN_SECOND>
     
-    ## receive_timeout - optional - integer 
+    ## @param receive_timeout - optional - integer 
     ## Overrides the default received timeout value, and fails the check if the time to receive 
     ## the server status from the Apache server exceeds the receive_timeout value (in seconds)
     
@@ -47,38 +47,38 @@ instances:
 
 #logs:
 
-    ## type - mandatory - string
+    ## @param type - mandatory - string
     ## Type of log input source, to choose between tcp / udp / file / journald / docker
     
     # - type: file
 
-    ## path - mandatory - string
+    ## @param path - mandatory - string
     ## If type is file, enter the file path to gather logs from
     
     #   path: <FILE_PATH>
 
-    ## port - mandatory -  integer
+    ## @param port - mandatory -  integer
     ## If type is udp/tcp, enter the port to listen to
     
     #   port: <PORT_NUMBER>
 
-    ## service - mandatory - string
+    ## @param service - mandatory - string
     ## Name of the service owning the log, allows binding logs and Traces 
     ## coming from the same <SERVICE>. 
     
     #   service: <SERVICE>
 
-    ## source - mandatory - string
+    ## @param source - mandatory - string
     ## Attribute that defines which integration is sending the logs
     
     #   source: <SOURCE_NAME>
     
-    ## sourcecategory - optional - coma separated list of strings 
+    ## @param sourcecategory - optional - coma separated list of strings 
     ## Multiple value attribute. Can be used to refine the source attribtue
     
     #   sourcecategory: <SOURCE_CATEGORY>
 
-    ## tags - optional - list of key:value element
+    ## @param tags - optional - list of key:value element
     ## List of tags to attach to every logs gathered by this integration.
     
     #   tags:

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -54,60 +54,19 @@ instances:
 #
 #logs:
 
-    ## @param type - required
-    ## @type  string
-    ## @desc  Type of log input source, to choose between tcp / udp / file / journald / docker
-    #    
-    # - type: file
-
-    ## @param path - required
-    ## @type  string
-    ## @desc  If type is file, enter the file path to gather logs from
-    #
-    #   path: <FILE_PATH>
-
-    ## @param port - required  
-    ## @type  integer
-    ## @desc  If type is udp/tcp, enter the port to listen to
-    #
-    #   port: <PORT_NUMBER>
-
-    ## @param service - required
-    ## @type  string
-    ## @desc  Name of the service owning the log, allows binding logs and Traces 
-    ##        coming from the same <SERVICE>. 
-    #
-    #   service: <SERVICE>
-
-    ## @param source - required
-    ## @type  string
-    ## @desc  Attribute that defines which integration is sending the logs
-    #
-    #   source: <SOURCE_NAME>
+    ##   type - mandatory - type of log input source (tcp / udp / file)
+    ##   port / path - mandatory - Set port if type is tcp or udp. Set path if type is file
+    ##   service - mandatory - name of the service owning the log
+    ##   source - mandatory - attribute that defines which integration is sending the logs
+    ##   sourcecategory - optional -  Multiple value attribute. Can be used to refine the source attribtue
+    ##   tags - optional - add tags to each logs collected
     
-    ## @param sourcecategory - optional
-    ## @type  coma separated list of strings 
-    ## @desc  Multiple value attribute. Can be used to refine the source attribtue
-    #
-    #   sourcecategory: <SOURCE_CATEGORY>
-
-    ## @param tags - optional
-    ## @type  list of key:value element
-    ## @desc  List of tags to attach to every logs gathered by this integration.
-    #
-    #   tags:
-    #   - <KEY>:<VALUE>
-
-    ## Gathering your Apache Access logs
-    #
     # - type: file
     #   path: /var/log/apache2/access.log
     #   source: apache
     #   sourcecategory: http_web_access
     #   service: apache
-    
-    ## Gathering your Apache Error logs
-    #
+       
     # - type: file
     #   path: /var/log/apache2/error.log
     #   source: apache

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -54,10 +54,10 @@ instances:
 #
 #logs:
 
-    ##   type - mandatory - type of log input source (tcp / udp / file)
-    ##   port / path - mandatory - Set port if type is tcp or udp. Set path if type is file
-    ##   service - mandatory - name of the service owning the log
-    ##   source - mandatory - attribute that defines which integration is sending the logs
+    ##   type - required - type of log input source (tcp / udp / file)
+    ##   port / path - required - Set port if type is tcp or udp. Set path if type is file
+    ##   service - required - name of the service owning the log
+    ##   source - required - attribute that defines which integration is sending the logs
     ##   sourcecategory - optional -  Multiple value attribute. Can be used to refine the source attribtue
     ##   tags - optional - add tags to each logs collected
     

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -2,57 +2,50 @@ init_config:
 
 instances:
     
-    ## @param apache_status_url string  
-    ## @required
-    ## @type string
-    ## @description: Status url of your Apache server.
+    ## @param apache_status_url string - required
+    ## @type  string
+    ## @desc  Status url of your Apache server.
     #
   - apache_status_url: http://localhost/server-status?auto
 
-    ## @param apache_user
-    ## @optional 
-    ## @type string
-    ## @description: <USERNAME> for the Apache status endpoint authentication.
+    ## @param apache_user - optional 
+    ## @type  string
+    ## @desc  <USERNAME> for the Apache status endpoint authentication.
     #
     # apache_user: <USERNAME>
 
-    ## @param apache_password
-    ## @optional
-    ## @type string
-    ## @description <PASSWORD> for the Apache status endpoint authentication.
+    ## @param apache_password - optional
+    ## @type  string
+    ## @desc  <PASSWORD> for the Apache status endpoint authentication.
     #
     # apache_password: <PASSWORD>
 
-    ## @param tags 
-    ## @optional 
-    ## @type list of key:value element
-    ## @description List of tags to attach to every metrics, events and service checks emitted by this integration.
-    ##              Learn more about tagging: https://docs.datadoghq.com/tagging/
+    ## @param tags  - optional 
+    ## @type  list of key:value element
+    ## @desc  List of tags to attach to every metrics, events and service checks emitted by this integration.
+    ##        Learn more about tagging: https://docs.datadoghq.com/tagging/
     #
     # tags:
     #   - <KEY>:<VALUE>
 
-    ## @param disable_ssl_validation
-    ## @optional
-    ## @type boolean - default: false
-    ## @description Instructs the check to skip the validation of the SSL certificate of the URL being tested.
-    ##              Defaults to false, set to true if you want to disable SSL certificate validation.
+    ## @param disable_ssl_validation - optional
+    ## @type  boolean - default: false
+    ## @desc  Instructs the check to skip the validation of the SSL certificate of the URL being tested.
+    ##        Defaults to false, set to true if you want to disable SSL certificate validation.
     #
     # disable_ssl_validation: false
 
-    ## @param connect_timeout
-    ## @optional
-    ## @type integer 
-    ## @description Overrides the default connection timeout value, and fails the check if the time to establish the (TCP) connection 
+    ## @param connect_timeout - optional
+    ## @type  integer 
+    ## @desc  Overrides the default connection timeout value, and fails the check if the time to establish the (TCP) connection 
     ##              exceeds the connect_timeout value (in seconds)
     #
     # connect_timeout: <VALUE_IN_SECOND>
     
-    ## @param receive_timeout
-    ## @optional
-    ## @type integer 
-    ## @description Overrides the default received timeout value, and fails the check if the time to receive 
-    ##              the server status from the Apache server exceeds the receive_timeout value (in seconds)
+    ## @param receive_timeout - optional
+    ## @type  integer 
+    ## @desc  Overrides the default received timeout value, and fails the check if the time to receive 
+    ##        the server status from the Apache server exceeds the receive_timeout value (in seconds)
     #
     # receive_timeout: <VALUE_IN_SECOND>
     
@@ -61,51 +54,46 @@ instances:
 #
 #logs:
 
-    ## @param type
-    ## @mandatory
-    ## @type string
-    ## @descrption Type of log input source, to choose between tcp / udp / file / journald / docker
+    ## @param type - required
+    ## @type  string
+    ## @desc  Type of log input source, to choose between tcp / udp / file / journald / docker
     #    
     # - type: file
 
-    ## @param path
-    ## @mandatory
-    ## @type string
-    ## @description If type is file, enter the file path to gather logs from
+    ## @param path - required
+    ## @type  string
+    ## @desc  If type is file, enter the file path to gather logs from
     #
     #   path: <FILE_PATH>
 
-    ## @param port - mandatory -  integer
-    ## If type is udp/tcp, enter the port to listen to
+    ## @param port - required  
+    ## @type  integer
+    ## @desc  If type is udp/tcp, enter the port to listen to
     #
     #   port: <PORT_NUMBER>
 
-    ## @param service
-    ## @mandatory
-    ## @type string
-    ## @decription Name of the service owning the log, allows binding logs and Traces 
-    ##             coming from the same <SERVICE>. 
+    ## @param service - required
+    ## @type  string
+    ## @desc  Name of the service owning the log, allows binding logs and Traces 
+    ##        coming from the same <SERVICE>. 
     #
     #   service: <SERVICE>
 
-    ## @param source
-    ## @mandatory
-    ## @type string
-    ## @description Attribute that defines which integration is sending the logs
+    ## @param source - required
+    ## @type  string
+    ## @desc  Attribute that defines which integration is sending the logs
     #
     #   source: <SOURCE_NAME>
     
-    ## @param sourcecategory
-    ## @optional
-    ## @type coma separated list of strings 
-    ## @description Multiple value attribute. Can be used to refine the source attribtue
+    ## @param sourcecategory - optional
+    ## @type  coma separated list of strings 
+    ## @desc  Multiple value attribute. Can be used to refine the source attribtue
     #
     #   sourcecategory: <SOURCE_CATEGORY>
 
-    ## @param tags
-    ## @optional
-    ## @type list of key:value element
-    ## @description List of tags to attach to every logs gathered by this integration.
+    ## @param tags - optional
+    ## @type  list of key:value element
+    ## @desc  List of tags to attach to every logs gathered by this integration.
     #
     #   tags:
     #   - <KEY>:<VALUE>

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -1,27 +1,45 @@
 init_config:
 
 instances:
+    
+    ## apache_status_url - mandatory - string  
+    ## Status url of your Apache server.
+  
   - apache_status_url: http://localhost/server-status?auto
-    # apache_user: example_user
-    # apache_password: example_password
-    # tags:
-    #   - optional_tag
 
-    # The (optional) disable_ssl_validation will instruct the check
-    # to skip the validation of the SSL certificate of the URL being tested.
-    # Defaults to false, set to true if you want to disable SSL certificate validation.
-    #
+    ## apache_user - optional - string
+    ## <USERNAME> for the Apache status endpoint authentication.
+    
+    # apache_user: <USERNAME>
+
+    ## apache_password - optional - string
+    ## <PASSWORD> for the Apache status endpoint authentication.
+    
+    # apache_password: <PASSWORD>
+
+    ## tags - optional - list of key:value element
+    ## List of tags to attach to every metrics, events and service checks emitted by this integration.
+    
+    # tags:
+    #   - <KEY>:<VALUE>
+
+    ## disable_ssl_validation - optional - boolean - default: false
+    ## Instructs the check to skip the validation of the SSL certificate of the URL being tested.
+    ## Defaults to false, set to true if you want to disable SSL certificate validation.
+
     # disable_ssl_validation: false
 
-    # The (optional) connect_timeout will override the default value, and fail
-    # the check if the time to establish the (TCP) connection exceeds the
-    # connect_timeout value (in seconds)
-    # connect_timeout: 5
+    ## connect_timeout - optional - integer 
+    ## Overrides the default connection timeout value, and fails the check if the time to establish the (TCP) connection 
+    ## exceeds the connect_timeout value (in seconds)
     
-    # The (optional) receive_timeout will override the default value, and fail
-    # the check if the time to receive the server status from the Apache server
-    # exceeds the receive_timeout value (in seconds)
-    # receive_timeout: 15
+    # connect_timeout: <VALUE_IN_SECOND>
+    
+    ## receive_timeout - optional - integer 
+    ## Overrides the default received timeout value, and fails the check if the time to receive 
+    ## the server status from the Apache server exceeds the receive_timeout value (in seconds)
+    
+    # receive_timeout: <VALUE_IN_SECOND>
     
 
 ## Log Section (Available for Agent >=6.0)

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -2,43 +2,57 @@ init_config:
 
 instances:
     
-    ## @param apache_status_url - mandatory - string  
-    ## Status url of your Apache server.
+    ## @param apache_status_url string  
+    ## @required
+    ## @type string
+    ## @description: Status url of your Apache server.
     #
   - apache_status_url: http://localhost/server-status?auto
 
-    ## @param apache_user - optional - string
-    ## <USERNAME> for the Apache status endpoint authentication.
+    ## @param apache_user
+    ## @optional 
+    ## @type string
+    ## @description: <USERNAME> for the Apache status endpoint authentication.
     #
     # apache_user: <USERNAME>
 
-    ## @param apache_password - optional - string
-    ## <PASSWORD> for the Apache status endpoint authentication.
+    ## @param apache_password
+    ## @optional
+    ## @type string
+    ## @description <PASSWORD> for the Apache status endpoint authentication.
     #
     # apache_password: <PASSWORD>
 
-    ## @param tags - optional - list of key:value element
-    ## List of tags to attach to every metrics, events and service checks emitted by this integration.
-    ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+    ## @param tags 
+    ## @optional 
+    ## @type list of key:value element
+    ## @description List of tags to attach to every metrics, events and service checks emitted by this integration.
+    ##              Learn more about tagging: https://docs.datadoghq.com/tagging/
     #
     # tags:
     #   - <KEY>:<VALUE>
 
-    ## @param disable_ssl_validation - optional - boolean - default: false
-    ## Instructs the check to skip the validation of the SSL certificate of the URL being tested.
-    ## Defaults to false, set to true if you want to disable SSL certificate validation.
+    ## @param disable_ssl_validation
+    ## @optional
+    ## @type boolean - default: false
+    ## @description Instructs the check to skip the validation of the SSL certificate of the URL being tested.
+    ##              Defaults to false, set to true if you want to disable SSL certificate validation.
     #
     # disable_ssl_validation: false
 
-    ## @param connect_timeout - optional - integer 
-    ## Overrides the default connection timeout value, and fails the check if the time to establish the (TCP) connection 
-    ## exceeds the connect_timeout value (in seconds)
+    ## @param connect_timeout
+    ## @optional
+    ## @type integer 
+    ## @description Overrides the default connection timeout value, and fails the check if the time to establish the (TCP) connection 
+    ##              exceeds the connect_timeout value (in seconds)
     #
     # connect_timeout: <VALUE_IN_SECOND>
     
-    ## @param receive_timeout - optional - integer 
-    ## Overrides the default received timeout value, and fails the check if the time to receive 
-    ## the server status from the Apache server exceeds the receive_timeout value (in seconds)
+    ## @param receive_timeout
+    ## @optional
+    ## @type integer 
+    ## @description Overrides the default received timeout value, and fails the check if the time to receive 
+    ##              the server status from the Apache server exceeds the receive_timeout value (in seconds)
     #
     # receive_timeout: <VALUE_IN_SECOND>
     
@@ -47,13 +61,17 @@ instances:
 #
 #logs:
 
-    ## @param type - mandatory - string
-    ## Type of log input source, to choose between tcp / udp / file / journald / docker
+    ## @param type
+    ## @mandatory
+    ## @type string
+    ## @descrption Type of log input source, to choose between tcp / udp / file / journald / docker
     #    
     # - type: file
 
-    ## @param path - mandatory - string
-    ## If type is file, enter the file path to gather logs from
+    ## @param path
+    ## @mandatory
+    ## @type string
+    ## @description If type is file, enter the file path to gather logs from
     #
     #   path: <FILE_PATH>
 
@@ -62,24 +80,32 @@ instances:
     #
     #   port: <PORT_NUMBER>
 
-    ## @param service - mandatory - string
-    ## Name of the service owning the log, allows binding logs and Traces 
-    ## coming from the same <SERVICE>. 
+    ## @param service
+    ## @mandatory
+    ## @type string
+    ## @decription Name of the service owning the log, allows binding logs and Traces 
+    ##             coming from the same <SERVICE>. 
     #
     #   service: <SERVICE>
 
-    ## @param source - mandatory - string
-    ## Attribute that defines which integration is sending the logs
+    ## @param source
+    ## @mandatory
+    ## @type string
+    ## @description Attribute that defines which integration is sending the logs
     #
     #   source: <SOURCE_NAME>
     
-    ## @param sourcecategory - optional - coma separated list of strings 
-    ## Multiple value attribute. Can be used to refine the source attribtue
+    ## @param sourcecategory
+    ## @optional
+    ## @type coma separated list of strings 
+    ## @description Multiple value attribute. Can be used to refine the source attribtue
     #
     #   sourcecategory: <SOURCE_CATEGORY>
 
-    ## @param tags - optional - list of key:value element
-    ## List of tags to attach to every logs gathered by this integration.
+    ## @param tags
+    ## @optional
+    ## @type list of key:value element
+    ## @description List of tags to attach to every logs gathered by this integration.
     #
     #   tags:
     #   - <KEY>:<VALUE>

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -4,88 +4,88 @@ instances:
     
     ## @param apache_status_url - mandatory - string  
     ## Status url of your Apache server.
-  
+    #
   - apache_status_url: http://localhost/server-status?auto
 
     ## @param apache_user - optional - string
     ## <USERNAME> for the Apache status endpoint authentication.
-    
+    #
     # apache_user: <USERNAME>
 
     ## @param apache_password - optional - string
     ## <PASSWORD> for the Apache status endpoint authentication.
-    
+    #
     # apache_password: <PASSWORD>
 
     ## @param tags - optional - list of key:value element
     ## List of tags to attach to every metrics, events and service checks emitted by this integration.
     ## Learn more about tagging: https://docs.datadoghq.com/tagging/
-    
+    #
     # tags:
     #   - <KEY>:<VALUE>
 
     ## @param disable_ssl_validation - optional - boolean - default: false
     ## Instructs the check to skip the validation of the SSL certificate of the URL being tested.
     ## Defaults to false, set to true if you want to disable SSL certificate validation.
-
+    #
     # disable_ssl_validation: false
 
     ## @param connect_timeout - optional - integer 
     ## Overrides the default connection timeout value, and fails the check if the time to establish the (TCP) connection 
     ## exceeds the connect_timeout value (in seconds)
-    
+    #
     # connect_timeout: <VALUE_IN_SECOND>
     
     ## @param receive_timeout - optional - integer 
     ## Overrides the default received timeout value, and fails the check if the time to receive 
     ## the server status from the Apache server exceeds the receive_timeout value (in seconds)
-    
+    #
     # receive_timeout: <VALUE_IN_SECOND>
     
 
 ## Log Section (Available for Agent >=6.0)
-
+#
 #logs:
 
     ## @param type - mandatory - string
     ## Type of log input source, to choose between tcp / udp / file / journald / docker
-    
+    #    
     # - type: file
 
     ## @param path - mandatory - string
     ## If type is file, enter the file path to gather logs from
-    
+    #
     #   path: <FILE_PATH>
 
     ## @param port - mandatory -  integer
     ## If type is udp/tcp, enter the port to listen to
-    
+    #
     #   port: <PORT_NUMBER>
 
     ## @param service - mandatory - string
     ## Name of the service owning the log, allows binding logs and Traces 
     ## coming from the same <SERVICE>. 
-    
+    #
     #   service: <SERVICE>
 
     ## @param source - mandatory - string
     ## Attribute that defines which integration is sending the logs
-    
+    #
     #   source: <SOURCE_NAME>
     
     ## @param sourcecategory - optional - coma separated list of strings 
     ## Multiple value attribute. Can be used to refine the source attribtue
-    
+    #
     #   sourcecategory: <SOURCE_CATEGORY>
 
     ## @param tags - optional - list of key:value element
     ## List of tags to attach to every logs gathered by this integration.
-    
+    #
     #   tags:
     #   - <KEY>:<VALUE>
 
     ## Gathering your Apache Access logs
-    
+    #
     # - type: file
     #   path: /var/log/apache2/access.log
     #   source: apache
@@ -93,7 +93,7 @@ instances:
     #   service: apache
     
     ## Gathering your Apache Error logs
-
+    #
     # - type: file
     #   path: /var/log/apache2/error.log
     #   source: apache

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -19,6 +19,7 @@ instances:
 
     ## tags - optional - list of key:value element
     ## List of tags to attach to every metrics, events and service checks emitted by this integration.
+    ## Learn more about tagging: https://docs.datadoghq.com/tagging/
     
     # tags:
     #   - <KEY>:<VALUE>
@@ -46,19 +47,53 @@ instances:
 
 #logs:
 
-    # - type : (mandatory) type of log input source (tcp / udp / file)
-    #   port / path : (mandatory) Set port if type is tcp or udp. Set path if type is file
-    #   service : (mandatory) name of the service owning the log
-    #   source : (mandatory) attribute that defines which integration is sending the logs
-    #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
-    #   tags: (optional) add tags to each logs collected
+    ## type - mandatory - string
+    ## Type of log input source, to choose between tcp / udp / file / journald / docker
+    
+    # - type: file
+
+    ## path - mandatory - string
+    ## If type is file, enter the file path to gather logs from
+    
+    #   path: <FILE_PATH>
+
+    ## port - mandatory -  integer
+    ## If type is udp/tcp, enter the port to listen to
+    
+    #   port: <PORT_NUMBER>
+
+    ## service - mandatory - string
+    ## Name of the service owning the log, allows binding logs and Traces 
+    ## coming from the same <SERVICE>. 
+    
+    #   service: <SERVICE>
+
+    ## source - mandatory - string
+    ## Attribute that defines which integration is sending the logs
+    
+    #   source: <SOURCE_NAME>
+    
+    ## sourcecategory - optional - coma separated list of strings 
+    ## Multiple value attribute. Can be used to refine the source attribtue
+    
+    #   sourcecategory: <SOURCE_CATEGORY>
+
+    ## tags - optional - list of key:value element
+    ## List of tags to attach to every logs gathered by this integration.
+    
+    #   tags:
+    #   - <KEY>:<VALUE>
+
+    ## Gathering your Apache Access logs
     
     # - type: file
     #   path: /var/log/apache2/access.log
     #   source: apache
     #   sourcecategory: http_web_access
     #   service: apache
-       
+    
+    ## Gathering your Apache Error logs
+
     # - type: file
     #   path: /var/log/apache2/error.log
     #   source: apache

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -38,7 +38,7 @@ instances:
     ## @param connect_timeout - optional
     ## @type  integer 
     ## @desc  Overrides the default connection timeout value, and fails the check if the time to establish the (TCP) connection 
-    ##              exceeds the connect_timeout value (in seconds)
+    ##        exceeds the connect_timeout value (in seconds)
     #
     # connect_timeout: <VALUE_IN_SECOND>
     

--- a/cassandra/datadog_checks/cassandra/data/conf.yaml.example
+++ b/cassandra/datadog_checks/cassandra/data/conf.yaml.example
@@ -1,70 +1,83 @@
 instances:
 
-    ## @param host - mandatory - string
-    ## Cassandra hostname to connect to.
+    ## @param host - required
+    ## @type  string
+    ## @desc  Cassandra hostname to connect to.
     #
   - host: localhost
 
-    ## @param port - mandatory - integer
-    ## Cassandra port to connect to.
+    ## @param port - required 
+    ## @type  integer
+    ## @desc  Cassandra port to connect to.
     #
     port: 7199
 
-    ## @param cassandra_aliasing - mandatory - boolean
-    ## Description of this parameter
+    ## @param cassandra_aliasing - required
+    ## @type  boolean
+    ## @desc  Description of this parameter
     #
     cassandra_aliasing: true
 
-    ## @param tags - optional - list of key:value element
-    ## List of tags to attach to every metrics, events and service checks emitted by this integration.
-    ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+    ## @param tags - optional
+    ## @type  list of key:value element
+    ## @desc  List of tags to attach to every metrics, events and service checks emitted by this integration.
+    ##        Learn more about tagging: https://docs.datadoghq.com/tagging/
     #
     # tags:
     #   - <KEY>:<VALUE>
     
-    ## @param user - optional - string
-    ## <USERNAME> for the Cassandra status endpoint authentication.
+    ## @param user - optional
+    ## @type  string
+    ## @desc  <USERNAME> for the Cassandra status endpoint authentication.
     #
     # user: <USERNAME>
 
-    ## @param password - optional - string
-    ## <PASSWORD> for the Cassandra status endpoint authentication.
+    ## @param password - optional
+    ## @type  string
+    ## @desc  <PASSWORD> for the Cassandra status endpoint authentication.
     #
     # password: <PASSWORD>
 
-    ## @param process_name_regex - optional - string
-    ## Instead of specifying a host, and port. The agent can connect using the attach api.
-    ## This requires the JDK to be installed and the path to tools.jar to be set below.
+    ## @param process_name_regex - optional
+    ## @type  string
+    ## @desc  Instead of specifying a host, and port. The agent can connect using the attach api.
+    ##        This requires the JDK to be installed and the path to tools.jar to be set below.
     #
     # process_name_regex: .*<PROCESS_NAME>.* 
 
-    ## @param tools_jar_path - optional - string
-    ## Needs to be set when process_name_regex is set
+    ## @param tools_jar_path - optional
+    ## @type  string
+    ## @desc  Needs to be set when process_name_regex is set
     #
     # tools_jar_path: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar 
     
-    ## @param name - optional - string 
-    ## Description of the parameter 
+    ## @param name - optional
+    ## @type  string 
+    ## @desc  Description of the parameter 
     #
     # name: cassandra_instance
 
-    ## @param java_bin_path - optional - string
-    ## Should be set if the agent cannot find your java executable
+    ## @param java_bin_path - optional
+    ## @type  string
+    ## @desc  Should be set if the agent cannot find your java executable
     #
     # java_bin_path: <JAVA_PATH>
 
-    ## @param java_options - optional - string
-    ## Java JVM options
+    ## @param java_options - optional
+    ## @type  string
+    ## @desc  Java JVM options
     #
     # java_options: "-Xmx200m -Xms50m"
     
-    ## @param trust_store_path - optional - string
-    ## If ssl is enabled, set the path to your trustStore
+    ## @param trust_store_path - optional
+    ## @type  string
+    ## @desc  If ssl is enabled, set the path to your trustStore
     #
     # trust_store_path: <TRUSTSTORE_PATH>.jks
 
-    ## @param trust_store_password - optional - string
-    ## If ssl is enabled, set your <PASSWORD> here.
+    ## @param trust_store_password - optional
+    ## @type  string
+    ## @desc  If ssl is enabled, set your <PASSWORD> here.
     #
     # trust_store_password: <PASSWORD>
 
@@ -72,42 +85,12 @@ instances:
 #
 #logs:
 
-    ## @param type - mandatory - string
-    ## Type of log input source, to choose between tcp / udp / file / journald / docker
-    #   
-    # - type: file
-
-    ## @param path - mandatory - string
-    ## If type is file, enter the file path to gather logs from
-    #
-    #   path: <FILE_PATH>
-
-    ## @param port - mandatory -  integer
-    ## If type is udp/tcp, enter the port to listen to
-    #
-    #   port: <PORT_NUMBER>
-
-    ## @param service - mandatory - string
-    ## Name of the service owning the log, allows binding logs and Traces 
-    ## coming from the same <SERVICE>. 
-    #
-    #   service: <SERVICE>
-
-    ## @param source - mandatory - string
-    ## Attribute that defines which integration is sending the logs
-    #
-    #   source: <SOURCE_NAME>
-    
-    ## @param sourcecategory - optional - coma separated list of strings 
-    ## Multiple value attribute. Can be used to refine the source attribtue
-    #
-    #   sourcecategory: <SOURCE_CATEGORY>
-
-    ## @param tags - optional - list of key:value element
-    ## List of tags to attach to every logs gathered by this integration.
-    #
-    #   tags:
-    #   - <KEY>:<VALUE>
+    ##   type - mandatory - type of log input source (tcp / udp / file)
+    ##   port / path - mandatory - Set port if type is tcp or udp. Set path if type is file
+    ##   service - mandatory - name of the service owning the log
+    ##   source - mandatory - attribute that defines which integration is sending the logs
+    ##   sourcecategory - optional -  Multiple value attribute. Can be used to refine the source attribtue
+    ##   tags - optional - add tags to each logs collected
 
     ## Gathering all your Cassandra logs
     #
@@ -120,13 +103,15 @@ instances:
     
 init_config:
 
-  ## @param is_jmx - optional - boolean
-  ## Specify if this configuration file is for a JMX integration
+  ## @param is_jmx - optional
+  ## @type  boolean
+  ## @desc  Specify if this configuration file is for a JMX integration
   #
   is_jmx: true
   
-  ## @param collect_default_metrics - mandatory - boolean
-  ## Whether or not this check should collect all default metrics
+  ## @param collect_default_metrics - required
+  ## @type  boolean
+  ## @desc  Whether or not this check should collect all default metrics
   #
   collect_default_metrics: true
 

--- a/cassandra/datadog_checks/cassandra/data/conf.yaml.example
+++ b/cassandra/datadog_checks/cassandra/data/conf.yaml.example
@@ -1,40 +1,112 @@
 instances:
+
+    ## host - mandatory - string
+    ## Cassandra hostname to connect to.
   - host: localhost
+
+    ## port - mandatory - integer
+    ## Cassandra port to connect to.
     port: 7199
+
+    ##  cassandra_aliasing - mandatory - boolean
+    ## Description of this parameter
     cassandra_aliasing: true
-    # Tags are used to be able to filter and aggregate metrics properly, in all the charts.
-    #
-    # The 'environment' tag depends on the <cluster_name> in Cassandra configuration:
-    #   - if the environment information (eg 'prod' or 'test') is included in the <cluster_name>, just use <cluster_name>.
-    #   - otherwise it's good to add the information to the 'environment' tag (eg 'prod-<cluster_name>').
-    # This will prevent aggregating metrics matchingly named clusters in distinct environments.
-    #
-    # The 'datacenter' tag should be the name of the Cassandra data center the node belongs to.
+
+    ## tags - optional - list of key:value element
+    ## List of tags to attach to every metrics, events and service checks emitted by this integration.
+    ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+
     # tags:
-    #   environment: default_environment
-    #   datacenter: default_datacenter
+    #   - <KEY>:<VALUE>
     
-    # user: username
-    # password: password
-    # process_name_regex: .*process_name.* # Instead of specifying a host, and port. The agent can connect using the attach api.
-                                           # This requires the JDK to be installed and the path to tools.jar to be set below.
-    # tools_jar_path: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar # To be set when process_name_regex is set
+    ## user - optional - string
+    ## <USERNAME> for the Cassandra status endpoint authentication.
+    
+    # user: <USERNAME>
+
+    ## password - optional - string
+    ## <PASSWORD> for the Cassandra status endpoint authentication.
+
+    # password: <PASSWORD>
+
+    ## process_name_regex - optional - string
+    ## Instead of specifying a host, and port. The agent can connect using the attach api.
+    ## This requires the JDK to be installed and the path to tools.jar to be set below.
+
+    # process_name_regex: .*<PROCESS_NAME>.* 
+
+    ## tools_jar_path - optional - string
+    ## Needs to be set when process_name_regex is set
+
+    # tools_jar_path: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar 
+    
+    ## name - optional - string 
+    ## Description of the parameter 
+
     # name: cassandra_instance
-    # java_bin_path: /path/to/java # Optional, should be set if the agent cannot find your java executable
-    # java_options: "-Xmx200m -Xms50m" # Optional, Java JVM options
-    # trust_store_path: /path/to/trustStore.jks # Optional, should be set if ssl is enabled
-    # trust_store_password: password
+
+    ## java_bin_path - optional - string
+    ## Should be set if the agent cannot find your java executable
+
+    # java_bin_path: <JAVA_PATH>
+
+    ## java_options - optional - string
+    ## Java JVM options
+    
+    # java_options: "-Xmx200m -Xms50m"
+    
+    ## trust_store_path - optional - string
+    ## If ssl is enabled, set the path to your trustStore
+    
+    # trust_store_path: <TRUSTSTORE_PATH>.jks
+
+    ## trust_store_password - optional - string
+    ## If ssl is enabled, set your <PASSWORD> here.
+    
+    # trust_store_password: <PASSWORD>
 
 ## Log Section (Available for Agent >=6.0)
 
 #logs:
 
-    # - type : (mandatory) type of log input source (tcp / udp / file)
-    #   port / path : (mandatory) Set port if type is tcp or udp. Set path if type is file
-    #   service : (mandatory) name of the service owning the log
-    #   source : (mandatory) attribute that defines which integration is sending the logs
-    #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
-    #   tags: (optional) add tags to each logs collected
+    ## type - mandatory - string
+    ## Type of log input source, to choose between tcp / udp / file / journald / docker
+    
+    # - type: file
+
+    ## path - mandatory - string
+    ## If type is file, enter the file path to gather logs from
+    
+    #   path: <FILE_PATH>
+
+    ## port - mandatory -  integer
+    ## If type is udp/tcp, enter the port to listen to
+    
+    #   port: <PORT_NUMBER>
+
+    ## service - mandatory - string
+    ## Name of the service owning the log, allows binding logs and Traces 
+    ## coming from the same <SERVICE>. 
+    
+    #   service: <SERVICE>
+
+    ## source - mandatory - string
+    ## Attribute that defines which integration is sending the logs
+    
+    #   source: <SOURCE_NAME>
+    
+    ## sourcecategory - optional - coma separated list of strings 
+    ## Multiple value attribute. Can be used to refine the source attribtue
+    
+    #   sourcecategory: <SOURCE_CATEGORY>
+
+    ## tags - optional - list of key:value element
+    ## List of tags to attach to every logs gathered by this integration.
+    
+    #   tags:
+    #   - <KEY>:<VALUE>
+
+    ## Gathering all your Cassandra logs
     
     # - type: file
     #   path: /var/log/cassandra/*.log
@@ -44,13 +116,22 @@ instances:
     
     
 init_config:
+
+  ## is_jmx - optional - boolean
+  ## Specify if this configuration file is for a JMX integration
+   
   is_jmx: true
+  
+  ## collect_default_metrics - mandatory - boolean
+  ## Whether or not this check should collect all default metrics
+
   collect_default_metrics: true
 
-  # List of metrics to be collected by the integration
-  # Read http://docs.datadoghq.com/integrations/java/ to learn how to customize it
-  # Agent 5: Customize all your metrics below
-  # Agent 6: The default metrics to be collected are kept in metrics.yaml, but you can still add your own metrics here
+  ## List of metrics to be collected by the integration
+  ## Read http://docs.datadoghq.com/integrations/java/ to learn how to customize it
+  ## Agent 5: Customize all your metrics below
+  ## Agent 6: The default metrics to be collected are kept in metrics.yaml, but you can still add your own metrics here
+
   conf:
     - include:
         domain: org.apache.cassandra.metrics

--- a/cassandra/datadog_checks/cassandra/data/conf.yaml.example
+++ b/cassandra/datadog_checks/cassandra/data/conf.yaml.example
@@ -2,115 +2,115 @@ instances:
 
     ## @param host - mandatory - string
     ## Cassandra hostname to connect to.
-  
+    #
   - host: localhost
 
     ## @param port - mandatory - integer
     ## Cassandra port to connect to.
-    
+    #
     port: 7199
 
     ## @param cassandra_aliasing - mandatory - boolean
     ## Description of this parameter
-    
+    #
     cassandra_aliasing: true
 
     ## @param tags - optional - list of key:value element
     ## List of tags to attach to every metrics, events and service checks emitted by this integration.
     ## Learn more about tagging: https://docs.datadoghq.com/tagging/
-
+    #
     # tags:
     #   - <KEY>:<VALUE>
     
     ## @param user - optional - string
     ## <USERNAME> for the Cassandra status endpoint authentication.
-    
+    #
     # user: <USERNAME>
 
     ## @param password - optional - string
     ## <PASSWORD> for the Cassandra status endpoint authentication.
-
+    #
     # password: <PASSWORD>
 
     ## @param process_name_regex - optional - string
     ## Instead of specifying a host, and port. The agent can connect using the attach api.
     ## This requires the JDK to be installed and the path to tools.jar to be set below.
-
+    #
     # process_name_regex: .*<PROCESS_NAME>.* 
 
     ## @param tools_jar_path - optional - string
     ## Needs to be set when process_name_regex is set
-
+    #
     # tools_jar_path: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar 
     
     ## @param name - optional - string 
     ## Description of the parameter 
-
+    #
     # name: cassandra_instance
 
     ## @param java_bin_path - optional - string
     ## Should be set if the agent cannot find your java executable
-
+    #
     # java_bin_path: <JAVA_PATH>
 
     ## @param java_options - optional - string
     ## Java JVM options
-    
+    #
     # java_options: "-Xmx200m -Xms50m"
     
     ## @param trust_store_path - optional - string
     ## If ssl is enabled, set the path to your trustStore
-    
+    #
     # trust_store_path: <TRUSTSTORE_PATH>.jks
 
     ## @param trust_store_password - optional - string
     ## If ssl is enabled, set your <PASSWORD> here.
-    
+    #
     # trust_store_password: <PASSWORD>
 
 ## Log Section (Available for Agent >=6.0)
-
+#
 #logs:
 
     ## @param type - mandatory - string
     ## Type of log input source, to choose between tcp / udp / file / journald / docker
-    
+    #   
     # - type: file
 
     ## @param path - mandatory - string
     ## If type is file, enter the file path to gather logs from
-    
+    #
     #   path: <FILE_PATH>
 
     ## @param port - mandatory -  integer
     ## If type is udp/tcp, enter the port to listen to
-    
+    #
     #   port: <PORT_NUMBER>
 
     ## @param service - mandatory - string
     ## Name of the service owning the log, allows binding logs and Traces 
     ## coming from the same <SERVICE>. 
-    
+    #
     #   service: <SERVICE>
 
     ## @param source - mandatory - string
     ## Attribute that defines which integration is sending the logs
-    
+    #
     #   source: <SOURCE_NAME>
     
     ## @param sourcecategory - optional - coma separated list of strings 
     ## Multiple value attribute. Can be used to refine the source attribtue
-    
+    #
     #   sourcecategory: <SOURCE_CATEGORY>
 
     ## @param tags - optional - list of key:value element
     ## List of tags to attach to every logs gathered by this integration.
-    
+    #
     #   tags:
     #   - <KEY>:<VALUE>
 
     ## Gathering all your Cassandra logs
-    
+    #
     # - type: file
     #   path: /var/log/cassandra/*.log
     #   source: cassandra
@@ -122,12 +122,12 @@ init_config:
 
   ## @param is_jmx - optional - boolean
   ## Specify if this configuration file is for a JMX integration
-   
+  #
   is_jmx: true
   
   ## @param collect_default_metrics - mandatory - boolean
   ## Whether or not this check should collect all default metrics
-
+  #
   collect_default_metrics: true
 
   ## List of metrics to be collected by the integration

--- a/cassandra/datadog_checks/cassandra/data/conf.yaml.example
+++ b/cassandra/datadog_checks/cassandra/data/conf.yaml.example
@@ -85,10 +85,10 @@ instances:
 #
 #logs:
 
-    ##   type - mandatory - type of log input source (tcp / udp / file)
-    ##   port / path - mandatory - Set port if type is tcp or udp. Set path if type is file
-    ##   service - mandatory - name of the service owning the log
-    ##   source - mandatory - attribute that defines which integration is sending the logs
+    ##   type - required - type of log input source (tcp / udp / file)
+    ##   port / path - required - Set port if type is tcp or udp. Set path if type is file
+    ##   service - required - name of the service owning the log
+    ##   source - required - attribute that defines which integration is sending the logs
     ##   sourcecategory - optional -  Multiple value attribute. Can be used to refine the source attribtue
     ##   tags - optional - add tags to each logs collected
 

--- a/cassandra/datadog_checks/cassandra/data/conf.yaml.example
+++ b/cassandra/datadog_checks/cassandra/data/conf.yaml.example
@@ -2,14 +2,17 @@ instances:
 
     ## host - mandatory - string
     ## Cassandra hostname to connect to.
+  
   - host: localhost
 
     ## port - mandatory - integer
     ## Cassandra port to connect to.
+    
     port: 7199
 
     ##  cassandra_aliasing - mandatory - boolean
     ## Description of this parameter
+    
     cassandra_aliasing: true
 
     ## tags - optional - list of key:value element

--- a/cassandra/datadog_checks/cassandra/data/conf.yaml.example
+++ b/cassandra/datadog_checks/cassandra/data/conf.yaml.example
@@ -1,69 +1,69 @@
 instances:
 
-    ## host - mandatory - string
+    ## @param host - mandatory - string
     ## Cassandra hostname to connect to.
   
   - host: localhost
 
-    ## port - mandatory - integer
+    ## @param port - mandatory - integer
     ## Cassandra port to connect to.
     
     port: 7199
 
-    ##  cassandra_aliasing - mandatory - boolean
+    ## @param cassandra_aliasing - mandatory - boolean
     ## Description of this parameter
     
     cassandra_aliasing: true
 
-    ## tags - optional - list of key:value element
+    ## @param tags - optional - list of key:value element
     ## List of tags to attach to every metrics, events and service checks emitted by this integration.
     ## Learn more about tagging: https://docs.datadoghq.com/tagging/
 
     # tags:
     #   - <KEY>:<VALUE>
     
-    ## user - optional - string
+    ## @param user - optional - string
     ## <USERNAME> for the Cassandra status endpoint authentication.
     
     # user: <USERNAME>
 
-    ## password - optional - string
+    ## @param password - optional - string
     ## <PASSWORD> for the Cassandra status endpoint authentication.
 
     # password: <PASSWORD>
 
-    ## process_name_regex - optional - string
+    ## @param process_name_regex - optional - string
     ## Instead of specifying a host, and port. The agent can connect using the attach api.
     ## This requires the JDK to be installed and the path to tools.jar to be set below.
 
     # process_name_regex: .*<PROCESS_NAME>.* 
 
-    ## tools_jar_path - optional - string
+    ## @param tools_jar_path - optional - string
     ## Needs to be set when process_name_regex is set
 
     # tools_jar_path: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar 
     
-    ## name - optional - string 
+    ## @param name - optional - string 
     ## Description of the parameter 
 
     # name: cassandra_instance
 
-    ## java_bin_path - optional - string
+    ## @param java_bin_path - optional - string
     ## Should be set if the agent cannot find your java executable
 
     # java_bin_path: <JAVA_PATH>
 
-    ## java_options - optional - string
+    ## @param java_options - optional - string
     ## Java JVM options
     
     # java_options: "-Xmx200m -Xms50m"
     
-    ## trust_store_path - optional - string
+    ## @param trust_store_path - optional - string
     ## If ssl is enabled, set the path to your trustStore
     
     # trust_store_path: <TRUSTSTORE_PATH>.jks
 
-    ## trust_store_password - optional - string
+    ## @param trust_store_password - optional - string
     ## If ssl is enabled, set your <PASSWORD> here.
     
     # trust_store_password: <PASSWORD>
@@ -72,38 +72,38 @@ instances:
 
 #logs:
 
-    ## type - mandatory - string
+    ## @param type - mandatory - string
     ## Type of log input source, to choose between tcp / udp / file / journald / docker
     
     # - type: file
 
-    ## path - mandatory - string
+    ## @param path - mandatory - string
     ## If type is file, enter the file path to gather logs from
     
     #   path: <FILE_PATH>
 
-    ## port - mandatory -  integer
+    ## @param port - mandatory -  integer
     ## If type is udp/tcp, enter the port to listen to
     
     #   port: <PORT_NUMBER>
 
-    ## service - mandatory - string
+    ## @param service - mandatory - string
     ## Name of the service owning the log, allows binding logs and Traces 
     ## coming from the same <SERVICE>. 
     
     #   service: <SERVICE>
 
-    ## source - mandatory - string
+    ## @param source - mandatory - string
     ## Attribute that defines which integration is sending the logs
     
     #   source: <SOURCE_NAME>
     
-    ## sourcecategory - optional - coma separated list of strings 
+    ## @param sourcecategory - optional - coma separated list of strings 
     ## Multiple value attribute. Can be used to refine the source attribtue
     
     #   sourcecategory: <SOURCE_CATEGORY>
 
-    ## tags - optional - list of key:value element
+    ## @param tags - optional - list of key:value element
     ## List of tags to attach to every logs gathered by this integration.
     
     #   tags:
@@ -120,12 +120,12 @@ instances:
     
 init_config:
 
-  ## is_jmx - optional - boolean
+  ## @param is_jmx - optional - boolean
   ## Specify if this configuration file is for a JMX integration
    
   is_jmx: true
   
-  ## collect_default_metrics - mandatory - boolean
+  ## @param collect_default_metrics - mandatory - boolean
   ## Whether or not this check should collect all default metrics
 
   collect_default_metrics: true

--- a/gunicorn/datadog_checks/gunicorn/data/conf.yaml.example
+++ b/gunicorn/datadog_checks/gunicorn/data/conf.yaml.example
@@ -9,60 +9,60 @@ instances:
   ## The name of the gunicorn process. For the following gunicorn server
   ##
   ##   gunicorn --name <WEB_APP> <WEB_APP>_config.ini
-
+  #
   # - proc_name: <WEB_APP>
   
   ## @param tags - optional - list of key:value element
   ## List of tags to attach to every metrics, events and service checks emitted by this integration.
   ## Learn more about tagging: https://docs.datadoghq.com/tagging/
-  
+  #
   # tags:
   #   - <KEY>:<VALUE>
   
 ## Log section (Available for Agent >=6.0)
-
+#
 #logs:
 
     ## @param type - mandatory - string
     ## Type of log input source, to choose between tcp / udp / file / journald / docker
-    
+    #   
     # - type: file
 
     ## @param path - mandatory - string
     ## If type is file, enter the file path to gather logs from
-    
+    #
     #   path: <FILE_PATH>
 
     ## @param port - mandatory -  integer
     ## If type is udp/tcp, enter the port to listen to
-    
+    #
     #   port: <PORT_NUMBER>
 
     ## @param service - mandatory - string
     ## Name of the service owning the log, allows binding logs and Traces 
     ## coming from the same <SERVICE>. 
-    
+    #
     #   service: <SERVICE>
 
     ## @param source - mandatory - string
     ## Attribute that defines which integration is sending the logs
-    
+    #
     #   source: <SOURCE_NAME>
     
     ## @param sourcecategory - optional - coma separated list of strings 
     ## Multiple value attribute. Can be used to refine the source attribtue
-    
+    #
     #   sourcecategory: <SOURCE_CATEGORY>
 
     ## @param tags - optional - list of key:value element
     ## List of tags to attach to every logs gathered by this integration.
-    
+    #
     #   tags:
     #   - <KEY>:<VALUE>
 
 
     ## Gathering Access logs from your Gunicorn server
-
+    #
     # - type: file
     #   path: /var/log/gunicorn/access.log
     #   service: <MY_SERVICE>
@@ -70,7 +70,7 @@ instances:
     #   sourcecategory: http_web_access
 
     ## Gathering Error logs from your Gunicorn server 
-
+    #
     # - type: file
     #   path: /var/log/gunicorn/error.log
     #   service: <MY_SERVICE>

--- a/gunicorn/datadog_checks/gunicorn/data/conf.yaml.example
+++ b/gunicorn/datadog_checks/gunicorn/data/conf.yaml.example
@@ -1,18 +1,22 @@
-# NB: This check requires the python environment on which gunicorn runs to
-# have the `setproctitle` module installed (https://pypi.python.org/pypi/setproctitle/)
+## NB: This check requires the python environment on which gunicorn runs to
+## have the `setproctitle` module installed (https://pypi.python.org/pypi/setproctitle/)
 
 init_config:
 
 instances:
-  # The name of the gunicorn process. For the following gunicorn server ...
-  #
-  #    gunicorn --name my_web_app my_web_app_config.ini
-  #
-  #  ... we'd use the name `my_web_app`.
-  #
-  # - proc_name: my_web_app
-  #   tags:
-  #     - optional:tag1
+  
+  ## proc_name - mandatory - string 
+  ## The name of the gunicorn process. For the following gunicorn server
+  ##
+  ##   gunicorn --name <WEB_APP> <WEB_APP>_config.ini
+
+  # - proc_name: <WEB_APP>
+  
+  ## tags - optional - list of key:value element
+  ## List of tags to attach to every metrics, events and service checks emitted by this integration.
+    
+  # tags:
+  #   - <KEY>:<VALUE>
   
 ## Log section (Available for Agent >=6.0)
 #logs:

--- a/gunicorn/datadog_checks/gunicorn/data/conf.yaml.example
+++ b/gunicorn/datadog_checks/gunicorn/data/conf.yaml.example
@@ -5,7 +5,7 @@ init_config:
 
 instances:
   
-  ## @param proc_name - mandatory
+  ## @param proc_name - required
   ## @type  string 
   ## @desc  The name of the gunicorn process. For the following gunicorn server
   ##
@@ -25,10 +25,10 @@ instances:
 #
 #logs:
     
-    ##   type - mandatory - type of log input source (tcp / udp / file)
-    ##   port / path - mandatory - Set port if type is tcp or udp. Set path if type is file
-    ##   service - mandatory - name of the service owning the log
-    ##   source - mandatory - attribute that defines which integration is sending the logs
+    ##   type - required - type of log input source (tcp / udp / file)
+    ##   port / path - required - Set port if type is tcp or udp. Set path if type is file
+    ##   service - required - name of the service owning the log
+    ##   source - required - attribute that defines which integration is sending the logs
     ##   sourcecategory - optional -  Multiple value attribute. Can be used to refine the source attribtue
     ##   tags - optional - add tags to each logs collected
 

--- a/gunicorn/datadog_checks/gunicorn/data/conf.yaml.example
+++ b/gunicorn/datadog_checks/gunicorn/data/conf.yaml.example
@@ -5,16 +5,18 @@ init_config:
 
 instances:
   
-  ## @param proc_name - mandatory - string 
-  ## The name of the gunicorn process. For the following gunicorn server
+  ## @param proc_name - mandatory
+  ## @type  string 
+  ## @desc  The name of the gunicorn process. For the following gunicorn server
   ##
   ##   gunicorn --name <WEB_APP> <WEB_APP>_config.ini
   #
   # - proc_name: <WEB_APP>
   
-  ## @param tags - optional - list of key:value element
-  ## List of tags to attach to every metrics, events and service checks emitted by this integration.
-  ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+  ## @param tags - optional
+  ## @type  list of key:value element
+  ## @desc  List of tags to attach to every metrics, events and service checks emitted by this integration.
+  ##        Learn more about tagging: https://docs.datadoghq.com/tagging/
   #
   # tags:
   #   - <KEY>:<VALUE>
@@ -22,44 +24,13 @@ instances:
 ## Log section (Available for Agent >=6.0)
 #
 #logs:
-
-    ## @param type - mandatory - string
-    ## Type of log input source, to choose between tcp / udp / file / journald / docker
-    #   
-    # - type: file
-
-    ## @param path - mandatory - string
-    ## If type is file, enter the file path to gather logs from
-    #
-    #   path: <FILE_PATH>
-
-    ## @param port - mandatory -  integer
-    ## If type is udp/tcp, enter the port to listen to
-    #
-    #   port: <PORT_NUMBER>
-
-    ## @param service - mandatory - string
-    ## Name of the service owning the log, allows binding logs and Traces 
-    ## coming from the same <SERVICE>. 
-    #
-    #   service: <SERVICE>
-
-    ## @param source - mandatory - string
-    ## Attribute that defines which integration is sending the logs
-    #
-    #   source: <SOURCE_NAME>
     
-    ## @param sourcecategory - optional - coma separated list of strings 
-    ## Multiple value attribute. Can be used to refine the source attribtue
-    #
-    #   sourcecategory: <SOURCE_CATEGORY>
-
-    ## @param tags - optional - list of key:value element
-    ## List of tags to attach to every logs gathered by this integration.
-    #
-    #   tags:
-    #   - <KEY>:<VALUE>
-
+    ##   type - mandatory - type of log input source (tcp / udp / file)
+    ##   port / path - mandatory - Set port if type is tcp or udp. Set path if type is file
+    ##   service - mandatory - name of the service owning the log
+    ##   source - mandatory - attribute that defines which integration is sending the logs
+    ##   sourcecategory - optional -  Multiple value attribute. Can be used to refine the source attribtue
+    ##   tags - optional - add tags to each logs collected
 
     ## Gathering Access logs from your Gunicorn server
     #

--- a/gunicorn/datadog_checks/gunicorn/data/conf.yaml.example
+++ b/gunicorn/datadog_checks/gunicorn/data/conf.yaml.example
@@ -19,21 +19,48 @@ instances:
   #   - <KEY>:<VALUE>
   
 ## Log section (Available for Agent >=6.0)
+
 #logs:
 
-    # - type : (mandatory) type of log input source (tcp / udp / file / journald / docker)
-    #   port / path : (mandatory) Set port if type is tcp or udp. Set path if type is file
-    #   service : (mandatory) name of the service owning the log
-    #   source : (mandatory) attribute that defines which integration is sending the logs
-    #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
-    #   tags: (optional) add tags to each logs collected
+    ## type - mandatory - string
+    ## Type of log input source, to choose between tcp / udp / file / journald / docker
     
     # - type: file
+
+    ## path - mandatory - string
+    ## If type is file, enter the file path to gather logs from
+    
     #   path: /var/log/gunicorn/access.log
-    #   service: <MY_SERVICE>
+
+    ## port - mandatory -  integer
+    ## If type is udp/tcp, enter the port to listen to
+    
+    #   port: 10514
+
+    ## service - mandatory - string
+    ## Name of the service owning the log, allows binding logs and Traces 
+    ## coming from the same <SERVICE>. 
+    
+    #   service: <SERVICE>
+
+    ## source - mandatory - string
+    ## Attribute that defines which integration is sending the logs
+    
     #   source: gunicorn
+    
+    ## sourcecategory - optional - coma separated list of strings 
+    ## Multiple value attribute. Can be used to refine the source attribtue
+    
     #   sourcecategory: http_web_access
 
+    ## tags - optional - list of key:value element
+    ## List of tags to attach to every logs gathered by this integration.
+    
+    #   tags:
+    #   - <KEY>:<VALUE>
+
+    ## Gathering Error logs from your Gunicorn server 
+    
     # - type: file
     #   path: /var/log/gunicorn/error.log
     #   service: <MY_SERVICE>

--- a/gunicorn/datadog_checks/gunicorn/data/conf.yaml.example
+++ b/gunicorn/datadog_checks/gunicorn/data/conf.yaml.example
@@ -14,7 +14,8 @@ instances:
   
   ## tags - optional - list of key:value element
   ## List of tags to attach to every metrics, events and service checks emitted by this integration.
-    
+  ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+  
   # tags:
   #   - <KEY>:<VALUE>
   
@@ -30,12 +31,12 @@ instances:
     ## path - mandatory - string
     ## If type is file, enter the file path to gather logs from
     
-    #   path: /var/log/gunicorn/access.log
+    #   path: <FILE_PATH>
 
     ## port - mandatory -  integer
     ## If type is udp/tcp, enter the port to listen to
     
-    #   port: 10514
+    #   port: <PORT_NUMBER>
 
     ## service - mandatory - string
     ## Name of the service owning the log, allows binding logs and Traces 
@@ -46,12 +47,12 @@ instances:
     ## source - mandatory - string
     ## Attribute that defines which integration is sending the logs
     
-    #   source: gunicorn
+    #   source: <SOURCE_NAME>
     
     ## sourcecategory - optional - coma separated list of strings 
     ## Multiple value attribute. Can be used to refine the source attribtue
     
-    #   sourcecategory: http_web_access
+    #   sourcecategory: <SOURCE_CATEGORY>
 
     ## tags - optional - list of key:value element
     ## List of tags to attach to every logs gathered by this integration.
@@ -59,8 +60,17 @@ instances:
     #   tags:
     #   - <KEY>:<VALUE>
 
+
+    ## Gathering Access logs from your Gunicorn server
+
+    # - type: file
+    #   path: /var/log/gunicorn/access.log
+    #   service: <MY_SERVICE>
+    #   source: gunicorn
+    #   sourcecategory: http_web_access
+
     ## Gathering Error logs from your Gunicorn server 
-    
+
     # - type: file
     #   path: /var/log/gunicorn/error.log
     #   service: <MY_SERVICE>

--- a/gunicorn/datadog_checks/gunicorn/data/conf.yaml.example
+++ b/gunicorn/datadog_checks/gunicorn/data/conf.yaml.example
@@ -5,14 +5,14 @@ init_config:
 
 instances:
   
-  ## proc_name - mandatory - string 
+  ## @param proc_name - mandatory - string 
   ## The name of the gunicorn process. For the following gunicorn server
   ##
   ##   gunicorn --name <WEB_APP> <WEB_APP>_config.ini
 
   # - proc_name: <WEB_APP>
   
-  ## tags - optional - list of key:value element
+  ## @param tags - optional - list of key:value element
   ## List of tags to attach to every metrics, events and service checks emitted by this integration.
   ## Learn more about tagging: https://docs.datadoghq.com/tagging/
   
@@ -23,38 +23,38 @@ instances:
 
 #logs:
 
-    ## type - mandatory - string
+    ## @param type - mandatory - string
     ## Type of log input source, to choose between tcp / udp / file / journald / docker
     
     # - type: file
 
-    ## path - mandatory - string
+    ## @param path - mandatory - string
     ## If type is file, enter the file path to gather logs from
     
     #   path: <FILE_PATH>
 
-    ## port - mandatory -  integer
+    ## @param port - mandatory -  integer
     ## If type is udp/tcp, enter the port to listen to
     
     #   port: <PORT_NUMBER>
 
-    ## service - mandatory - string
+    ## @param service - mandatory - string
     ## Name of the service owning the log, allows binding logs and Traces 
     ## coming from the same <SERVICE>. 
     
     #   service: <SERVICE>
 
-    ## source - mandatory - string
+    ## @param source - mandatory - string
     ## Attribute that defines which integration is sending the logs
     
     #   source: <SOURCE_NAME>
     
-    ## sourcecategory - optional - coma separated list of strings 
+    ## @param sourcecategory - optional - coma separated list of strings 
     ## Multiple value attribute. Can be used to refine the source attribtue
     
     #   sourcecategory: <SOURCE_CATEGORY>
 
-    ## tags - optional - list of key:value element
+    ## @param tags - optional - list of key:value element
     ## List of tags to attach to every logs gathered by this integration.
     
     #   tags:


### PR DESCRIPTION
### What does this PR do?

Implements a norm for our parameters and their corresponding comments. 

This PR shows examples for 2 "classic integrations" and a JMX integration.

If this norm is validated, it will be propagated to all configuration files.

### Motivation

* Enhance readability of configuration files
* Making it more obvious when a parameter description is missing and as conf files get long, you don't have to scroll up to read what you're supposed to be entering.

* This norm would allow parsing the `conf.yaml` file to look for parameters and their corresponding description in order to display them in the corresponding documentation page or even directly in their in-app tile. (like we have currently for http check: https://docs.datadoghq.com/integrations/http_check/#configuration) 

### Norm

**One comment one parameter** 

Every time we introduce a parameter we have just above the corresponding comment with double `#` in order to show to readers that it’s a comment.

The comments always have the same layout:

```
## @param <PARAM_NAME> - required/optional 
## @type  <PARAM_TYPE> - default: <DEFAULT_VALUE IF ANY>
## @desc  Descritpion of the param
#
# <PARAM_NAME>:<PLACEHOLDER>
```

* All mandatory parameters are not commented by default but can contain placeholders
* All optional parameters are commented by default and can contain placeholders

Placeholders should always follow this format: `<THIS_IS_A_PLACEHOLDER>` according to the documentation [contributing guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md).
 
**Note**: if a placeholder has a default value for an integration (like the status endpoint of an integration), we can use it instead of just a placeholder.

Advantages: 

* A parameter always has its description next to it
* Scales with the amount of parameter
* Consistent with the current logic, we just standardize the way to write comments
* User sees which parameter needs to be set right away

Disadvantages:

* Configuration file can become pretty long
