### PR TITLE
[KSM] Deprecate sending pod phase service checks

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
@@ -10,6 +10,7 @@ instances:
     # them to other tags, you can use the labels_mapper dictionary
     # labels_mapper:
     #   namespace: kube_namespace
+    #
     # Add the tags to join from the KSM.
     # Example: Joining for deployment metrics. Based on: kube_deployment_labels{deployment="kube-dns",label_addonmanager_kubernetes_io_mode="Reconcile"}
     # Use the following config to add the value of label_addonmanager_kubernetes_io_mode as a tag to your KSM deployment metrics.
@@ -18,3 +19,12 @@ instances:
     #    label_to_match: deployment
     #    labels_to_get:
     #      - label_addonmanager_kubernetes_io_mode
+    #
+    # By default the hostname for metrics containing the node label will be
+    # overriden by the value of the label, this can be deactivated (all metrics
+    # will be attached to the host running KSM)
+    # hostname_override: true
+    #
+    # Send (deprecated) pod.phase service checks (default true, will be turned off in future versions)
+    # We recommend using the corresponding gauges instead, which benefit from historical data unlike service checks
+    # send_pod_phase_service_checks: false

--- a/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
@@ -11,6 +11,7 @@ instances:
     # them to other tags, you can use the labels_mapper dictionary
     # labels_mapper:
     #   namespace: kube_namespace
+    #
     # Add the tags to join from the KSM.
     # Example: Joining for deployment metrics. Based on: kube_deployment_labels{deployment="kube-dns",label_addonmanager_kubernetes_io_mode="Reconcile"}
     # Use the following config to add the value of label_addonmanager_kubernetes_io_mode as a tag to your KSM deployment metrics.
@@ -19,10 +20,15 @@ instances:
     #    label_to_match: deployment
     #    labels_to_get:
     #      - label_addonmanager_kubernetes_io_mode
+    #
     # By default the hostname for metrics containing the node label will be
     # overriden by the value of the label, this can be deactivated (all metrics
     # will be attached to the host running KSM)
     # hostname_override: true
+    #
+    # Send (deprecated) pod.phase service checks (default true, will be turned off in future versions)
+    # We recommend using the corresponding gauges instead, which benefit from historical data unlike service checks
+    # send_pod_phase_service_checks: false
 
     # You can also specify here custom tags to be added to all metrics reported by this integration
     #  tags:

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -293,3 +293,16 @@ def test_disabling_hostname_override(instance):
     instance["hostname_override"] = False
     check = KubernetesState(CHECK_NAME, {}, {}, [instance])
     assert check.label_to_hostname is None
+
+
+def test_removing_pod_phase_service_checks(aggregator, instance, check):
+    check.send_pod_phase_service_checks = False
+    for _ in range(2):
+        check.check(instance)
+    # We should still send gauges
+    aggregator.assert_metric(NAMESPACE + '.pod.status_phase',
+                             tags=['namespace:default', 'phase:Running', 'optional:tag1'], value=3)
+    aggregator.assert_metric(NAMESPACE + '.pod.status_phase',
+                             tags=['namespace:default', 'phase:Failed', 'optional:tag1'], value=2)
+    # the service checks should not be sent
+    assert NAMESPACE + '.pod.status_phase' not in aggregator._service_checks


### PR DESCRIPTION
### What does this PR do?

Deprecate sending pod phase service checks, add an option to disable sending them.
An integration warning will be sent if the option is enabled.

### Motivation

Deprecate and eventually remove these service checks, the respective gauges should be used.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
