### PR TITLE
Stop leaking db password when a connection is not in the pool

### DIFF
--- a/sqlserver/tests/test_sqlserver.py
+++ b/sqlserver/tests/test_sqlserver.py
@@ -32,6 +32,7 @@ def test_check_docker(aggregator, init_config, instance_docker, sqlserver):
     _assert_metrics(aggregator, expected_tags)
 
 
+@pytest.mark.local
 def test_check_local(aggregator, init_config, instance_sql2008):
     sqlserver_check = SQLServer(CHECK_NAME, init_config, {}, [instance_sql2008])
     sqlserver_check.check(instance_sql2008)

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -1,0 +1,22 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.sqlserver import SQLServer
+from datadog_checks.sqlserver.sqlserver import SQLConnectionError
+
+# mark the whole module
+pytestmark = pytest.mark.unit
+
+CHECK_NAME = 'sqlserver'
+
+
+def test_get_cursor(instance_sql2008):
+    """
+    Ensure we don't leak connection info in case of a KeyError when the
+    connection pool is empty or the params for `get_cursor` are invalid.
+    """
+    check = SQLServer(CHECK_NAME, {}, {}, [])
+    with pytest.raises(SQLConnectionError):
+        check.get_cursor(instance_sql2008, 'foo')

--- a/sqlserver/tox.ini
+++ b/sqlserver/tox.ini
@@ -2,6 +2,7 @@
 minversion = 2.0
 basepython = py27
 envlist =
+    unit
     sqlserver-{docker,local}
     flake8
 
@@ -14,6 +15,12 @@ deps =
 passenv =
     DOCKER*
     COMPOSE*
+
+[testenv:unit]
+platform = linux|darwin|win32
+commands =
+    pip install --require-hashes -r requirements.txt
+    pytest -v -m"unit"
 
 [testenv:sqlserver-docker]
 platform = linux|darwin
@@ -30,7 +37,7 @@ platform = win32
 passenv = *
 commands =
     pip install --require-hashes -r requirements.txt
-    pytest -v -m"not docker"
+    pytest -v -m"local"
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
### What does this PR do?

See title. Conditions to expose the issue are quite difficult to reproduce but still an issue.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

The real fix would be avoid using the password when composing the key for the connections pool but change might be breaking, this PR is a good mitigation for now.

I added a new test env to tox to run unit tests (tests that can be run without connecting to the database)