### PR TITLE
Use editable install of datadog_checks_base for tests

### DIFF
--- a/active_directory/setup.py
+++ b/active_directory/setup.py
@@ -55,7 +55,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.active_directory'],
+    packages=['datadog_checks', 'datadog_checks.active_directory'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/active_directory/tox.ini
+++ b/active_directory/tox.ini
@@ -11,7 +11,7 @@ platform = win32|linux2|darwin
 [testenv:active_directory]
 platform = win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt

--- a/activemq/setup.py
+++ b/activemq/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.activemq'],
+    packages=['datadog_checks', 'datadog_checks.activemq'],
 
     # Run-time dependencies
     install_requires=['datadog_checks_base'],

--- a/activemq_xml/setup.py
+++ b/activemq_xml/setup.py
@@ -55,7 +55,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.activemq_xml'],
+    packages=['datadog_checks', 'datadog_checks.activemq_xml'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/activemq_xml/tox.ini
+++ b/activemq_xml/tox.ini
@@ -6,7 +6,7 @@ envlist = activemq_xml, flake8
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 passenv =

--- a/agent_metrics/setup.py
+++ b/agent_metrics/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.agent_metrics'],
+    packages=['datadog_checks', 'datadog_checks.agent_metrics'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/apache/setup.py
+++ b/apache/setup.py
@@ -64,7 +64,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.apache'],
+    packages=['datadog_checks', 'datadog_checks.apache'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/apache/tox.ini
+++ b/apache/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:apache]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 setenv = APACHE_VERSION=2.4.12

--- a/aspdotnet/setup.py
+++ b/aspdotnet/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.aspdotnet'],
+    packages=['datadog_checks', 'datadog_checks.aspdotnet'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/aspdotnet/tox.ini
+++ b/aspdotnet/tox.ini
@@ -11,7 +11,7 @@ platform = win32|linux2|darwin
 [testenv:aspdotnet]
 platform = win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt

--- a/btrfs/setup.py
+++ b/btrfs/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.btrfs'],
+    packages=['datadog_checks', 'datadog_checks.btrfs'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/btrfs/tox.ini
+++ b/btrfs/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin
 
 [testenv:btrfs]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/cacti/setup.py
+++ b/cacti/setup.py
@@ -55,7 +55,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.cacti'],
+    packages=['datadog_checks', 'datadog_checks.cacti'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/cacti/tox.ini
+++ b/cacti/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin|win32
 
 [testenv:cacti]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/cassandra/setup.py
+++ b/cassandra/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.cassandra'],
+    packages=['datadog_checks', 'datadog_checks.cassandra'],
 
     # Run-time dependencies
     install_requires=['datadog_checks_base'],

--- a/cassandra_nodetool/setup.py
+++ b/cassandra_nodetool/setup.py
@@ -55,7 +55,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.cassandra_nodetool'],
+    packages=['datadog_checks', 'datadog_checks.cassandra_nodetool'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/cassandra_nodetool/tox.ini
+++ b/cassandra_nodetool/tox.ini
@@ -11,7 +11,7 @@ platform = linux|darwin|win32
 
 [testenv:unit_test]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 setenv =
@@ -22,7 +22,7 @@ commands =
 
 [testenv:integration]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 setenv =

--- a/ceph/setup.py
+++ b/ceph/setup.py
@@ -53,7 +53,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.ceph'],
+    packages=['datadog_checks', 'datadog_checks.ceph'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/ceph/tox.ini
+++ b/ceph/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:ceph]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/cisco_aci/setup.py
+++ b/cisco_aci/setup.py
@@ -47,7 +47,7 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
 
-    packages=['datadog_checks.cisco_aci'],
+    packages=['datadog_checks', 'datadog_checks.cisco_aci'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/cisco_aci/tox.ini
+++ b/cisco_aci/tox.ini
@@ -7,7 +7,7 @@ envlist =
 
 [testenv:unit]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/consul/setup.py
+++ b/consul/setup.py
@@ -54,7 +54,7 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
 
-    packages=['datadog_checks.consul'],
+    packages=['datadog_checks', 'datadog_checks.consul'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/consul/tox.ini
+++ b/consul/tox.ini
@@ -14,7 +14,7 @@ platform = linux|darwin|win32
 
 [common]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/couch/setup.py
+++ b/couch/setup.py
@@ -56,7 +56,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.couch'],
+    packages=['datadog_checks', 'datadog_checks.couch'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/couch/tox.ini
+++ b/couch/tox.ini
@@ -6,7 +6,7 @@ envlist = couch{1_6,2_0}, flake8
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 passenv =

--- a/couchbase/setup.py
+++ b/couchbase/setup.py
@@ -56,7 +56,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.couchbase'],
+    packages=['datadog_checks', 'datadog_checks.couchbase'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/couchbase/tox.ini
+++ b/couchbase/tox.ini
@@ -9,7 +9,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 passenv =

--- a/datadog_checks_dev/tox.ini
+++ b/datadog_checks_dev/tox.ini
@@ -10,7 +10,7 @@ envlist =
 skip_install = true
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 passenv =

--- a/directory/setup.py
+++ b/directory/setup.py
@@ -57,7 +57,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.directory'],
+    packages=['datadog_checks', 'datadog_checks.directory'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/disk/setup.py
+++ b/disk/setup.py
@@ -55,7 +55,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.disk'],
+    packages=['datadog_checks', 'datadog_checks.disk'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/disk/tox.ini
+++ b/disk/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin
 
 [testenv:disk]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rtests/requirements.txt
 commands =

--- a/dns_check/setup.py
+++ b/dns_check/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.dns_check'],
+    packages=['datadog_checks', 'datadog_checks.dns_check'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/dns_check/tox.ini
+++ b/dns_check/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:dns_check]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/docker_daemon/setup.py
+++ b/docker_daemon/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.docker_daemon'],
+    packages=['datadog_checks', 'datadog_checks.docker_daemon'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/dotnetclr/setup.py
+++ b/dotnetclr/setup.py
@@ -55,7 +55,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.dotnetclr'],
+    packages=['datadog_checks', 'datadog_checks.dotnetclr'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/dotnetclr/tox.ini
+++ b/dotnetclr/tox.ini
@@ -10,7 +10,7 @@ platform = win32
 
 [testenv:dotnetclr]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt

--- a/ecs_fargate/setup.py
+++ b/ecs_fargate/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.ecs_fargate'],
+    packages=['datadog_checks', 'datadog_checks.ecs_fargate'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/elastic/setup.py
+++ b/elastic/setup.py
@@ -56,7 +56,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.elastic'],
+    packages=['datadog_checks', 'datadog_checks.elastic'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/elastic/tox.ini
+++ b/elastic/tox.ini
@@ -6,7 +6,7 @@ envlist = elastic{0.90,1.0,1.1,1.2,2.4,5.2,5.6,6.0,6.2}, bench, flake8
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/envoy/setup.py
+++ b/envoy/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.envoy'],
+    packages=['datadog_checks', 'datadog_checks.envoy'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/etcd/setup.py
+++ b/etcd/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.etcd'],
+    packages=['datadog_checks', 'datadog_checks.etcd'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/exchange_server/setup.py
+++ b/exchange_server/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.exchange_server'],
+    packages=['datadog_checks', 'datadog_checks.exchange_server'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/exchange_server/tox.ini
+++ b/exchange_server/tox.ini
@@ -10,7 +10,7 @@ platform = win32
 
 [testenv:exchange_server]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt

--- a/fluentd/setup.py
+++ b/fluentd/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.fluentd'],
+    packages=['datadog_checks', 'datadog_checks.fluentd'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/gearmand/setup.py
+++ b/gearmand/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.gearmand'],
+    packages=['datadog_checks', 'datadog_checks.gearmand'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/gitlab/setup.py
+++ b/gitlab/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.gitlab'],
+    packages=['datadog_checks', 'datadog_checks.gitlab'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/gitlab/tox.ini
+++ b/gitlab/tox.ini
@@ -13,7 +13,7 @@ passenv =
 
 [testenv:gitlab]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/gitlab_runner/setup.py
+++ b/gitlab_runner/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.gitlab_runner'],
+    packages=['datadog_checks', 'datadog_checks.gitlab_runner'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/gitlab_runner/tox.ini
+++ b/gitlab_runner/tox.ini
@@ -13,7 +13,7 @@ passenv =
 
 [testenv:gitlab_runner]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/go-metro/setup.py
+++ b/go-metro/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.go-metro'],
+    packages=['datadog_checks', 'datadog_checks.go-metro'],
 
     # Run-time dependencies
     install_requires=['datadog_checks_base'],

--- a/go_expvar/setup.py
+++ b/go_expvar/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.go_expvar'],
+    packages=['datadog_checks', 'datadog_checks.go_expvar'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/gunicorn/setup.py
+++ b/gunicorn/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.gunicorn'],
+    packages=['datadog_checks', 'datadog_checks.gunicorn'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/haproxy/setup.py
+++ b/haproxy/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.haproxy'],
+    packages=['datadog_checks', 'datadog_checks.haproxy'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/haproxy/tox.ini
+++ b/haproxy/tox.ini
@@ -18,7 +18,7 @@ passenv =
 
 [common]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/hdfs_datanode/setup.py
+++ b/hdfs_datanode/setup.py
@@ -56,7 +56,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.hdfs_datanode'],
+    packages=['datadog_checks', 'datadog_checks.hdfs_datanode'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/hdfs_datanode/tox.ini
+++ b/hdfs_datanode/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:hdfs_datanode]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/hdfs_namenode/setup.py
+++ b/hdfs_namenode/setup.py
@@ -56,7 +56,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.hdfs_namenode'],
+    packages=['datadog_checks', 'datadog_checks.hdfs_namenode'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/hdfs_namenode/tox.ini
+++ b/hdfs_namenode/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:hdfs_namenode]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/http_check/setup.py
+++ b/http_check/setup.py
@@ -56,7 +56,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.http_check'],
+    packages=['datadog_checks', 'datadog_checks.http_check'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/http_check/tox.ini
+++ b/http_check/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:http_check]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/iis/setup.py
+++ b/iis/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.iis'],
+    packages=['datadog_checks', 'datadog_checks.iis'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/iis/tox.ini
+++ b/iis/tox.ini
@@ -10,7 +10,7 @@ platform = win32
 
 [testenv:iis]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt

--- a/istio/setup.py
+++ b/istio/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.istio'],
+    packages=['datadog_checks', 'datadog_checks.istio'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/istio/tox.ini
+++ b/istio/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:istio]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -r./tests/requirements.txt
 commands =

--- a/kafka/setup.py
+++ b/kafka/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.kafka'],
+    packages=['datadog_checks', 'datadog_checks.kafka'],
 
     # Run-time dependencies
     install_requires=['datadog_checks_base'],

--- a/kafka_consumer/setup.py
+++ b/kafka_consumer/setup.py
@@ -48,7 +48,7 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
 
-    packages=['datadog_checks.kafka_consumer'],
+    packages=['datadog_checks', 'datadog_checks.kafka_consumer'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/kafka_consumer/tox.ini
+++ b/kafka_consumer/tox.ini
@@ -16,7 +16,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 

--- a/kong/setup.py
+++ b/kong/setup.py
@@ -55,7 +55,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.kong'],
+    packages=['datadog_checks', 'datadog_checks.kong'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/kong/tox.ini
+++ b/kong/tox.ini
@@ -13,7 +13,7 @@ passenv =
 
 [testenv:kong]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 setenv = KONG_VERSION=0.13.0

--- a/kube_dns/setup.py
+++ b/kube_dns/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.kube_dns'],
+    packages=['datadog_checks', 'datadog_checks.kube_dns'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/kube_proxy/setup.py
+++ b/kube_proxy/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.kube_proxy'],
+    packages=['datadog_checks', 'datadog_checks.kube_proxy'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/kube_proxy/tox.ini
+++ b/kube_proxy/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin
 
 [testenv:kube_proxy]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rtests/requirements.txt
 commands =

--- a/kubelet/setup.py
+++ b/kubelet/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.kubelet'],
+    packages=['datadog_checks', 'datadog_checks.kubelet'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/kubelet/tox.ini
+++ b/kubelet/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin
 
 [testenv:kubelet]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rtests/requirements.txt
 commands =

--- a/kubernetes/setup.py
+++ b/kubernetes/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.kubernetes'],
+    packages=['datadog_checks', 'datadog_checks.kubernetes'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/kubernetes_state/setup.py
+++ b/kubernetes_state/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.kubernetes_state'],
+    packages=['datadog_checks', 'datadog_checks.kubernetes_state'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/kubernetes_state/tox.ini
+++ b/kubernetes_state/tox.ini
@@ -6,7 +6,7 @@ envlist = unit, flake8
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 

--- a/kyototycoon/setup.py
+++ b/kyototycoon/setup.py
@@ -57,7 +57,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.kyototycoon'],
+    packages=['datadog_checks', 'datadog_checks.kyototycoon'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/kyototycoon/tox.ini
+++ b/kyototycoon/tox.ini
@@ -13,7 +13,7 @@ passenv =
 
 [testenv:kyototycoon]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/lighttpd/setup.py
+++ b/lighttpd/setup.py
@@ -47,7 +47,7 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
 
-    packages=['datadog_checks.lighttpd'],
+    packages=['datadog_checks', 'datadog_checks.lighttpd'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/lighttpd/tox.ini
+++ b/lighttpd/tox.ini
@@ -13,7 +13,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/linkerd/setup.py
+++ b/linkerd/setup.py
@@ -53,7 +53,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.linkerd'],
+    packages=['datadog_checks', 'datadog_checks.linkerd'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/linkerd/tox.ini
+++ b/linkerd/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:linkerd]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -r./tests/requirements.txt
 commands =

--- a/linux_proc_extras/setup.py
+++ b/linux_proc_extras/setup.py
@@ -55,7 +55,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.linux_proc_extras'],
+    packages=['datadog_checks', 'datadog_checks.linux_proc_extras'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/linux_proc_extras/tox.ini
+++ b/linux_proc_extras/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin
 
 [testenv:linux_proc_extras]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/mapreduce/setup.py
+++ b/mapreduce/setup.py
@@ -56,7 +56,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.mapreduce'],
+    packages=['datadog_checks', 'datadog_checks.mapreduce'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/mapreduce/tox.ini
+++ b/mapreduce/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:mapreduce]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/marathon/setup.py
+++ b/marathon/setup.py
@@ -52,7 +52,7 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
 
-    packages=['datadog_checks.marathon'],
+    packages=['datadog_checks', 'datadog_checks.marathon'],
 
     install_requires=[CHECKS_BASE_REQ],
     tests_require=get_requirements("requirements-dev.txt"),

--- a/marathon/tox.ini
+++ b/marathon/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:marathon]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/mcache/setup.py
+++ b/mcache/setup.py
@@ -48,7 +48,7 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
 
-    packages=['datadog_checks.mcache'],
+    packages=['datadog_checks', 'datadog_checks.mcache'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/mcache/tox.ini
+++ b/mcache/tox.ini
@@ -11,7 +11,7 @@ platform = linux|darwin|win32
 
 [testenv:unit]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt
@@ -22,7 +22,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/mesos_master/setup.py
+++ b/mesos_master/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.mesos_master'],
+    packages=['datadog_checks', 'datadog_checks.mesos_master'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/mesos_slave/setup.py
+++ b/mesos_slave/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.mesos_slave'],
+    packages=['datadog_checks', 'datadog_checks.mesos_slave'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/mongo/setup.py
+++ b/mongo/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.mongo'],
+    packages=['datadog_checks', 'datadog_checks.mongo'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/mongo/tox.ini
+++ b/mongo/tox.ini
@@ -14,7 +14,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/mysql/setup.py
+++ b/mysql/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.mysql'],
+    packages=['datadog_checks', 'datadog_checks.mysql'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -15,7 +15,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/nagios/setup.py
+++ b/nagios/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.nagios'],
+    packages=['datadog_checks', 'datadog_checks.nagios'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/nagios/tox.ini
+++ b/nagios/tox.ini
@@ -8,7 +8,7 @@ envlist =
 
 [testenv]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 platform = linux|darwin|win32

--- a/network/setup.py
+++ b/network/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.network'],
+    packages=['datadog_checks', 'datadog_checks.network'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/network/tox.ini
+++ b/network/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin|win32
 
 [testenv:network]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/nfsstat/setup.py
+++ b/nfsstat/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.nfsstat'],
+    packages=['datadog_checks', 'datadog_checks.nfsstat'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/nfsstat/tox.ini
+++ b/nfsstat/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:nfsstat]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/nginx/setup.py
+++ b/nginx/setup.py
@@ -55,7 +55,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.nginx'],
+    packages=['datadog_checks', 'datadog_checks.nginx'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/nginx/tox.ini
+++ b/nginx/tox.ini
@@ -11,7 +11,7 @@ passenv =
 
 [common]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/ntp/setup.py
+++ b/ntp/setup.py
@@ -49,7 +49,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.ntp'],
+    packages=['datadog_checks', 'datadog_checks.ntp'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/ntp/tox.ini
+++ b/ntp/tox.ini
@@ -8,7 +8,7 @@ platform = linux|darwin|win32
 
 [testenv:ntp]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/openldap/setup.py
+++ b/openldap/setup.py
@@ -46,7 +46,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
     ],
-    packages=['datadog_checks.openldap'],
+    packages=['datadog_checks', 'datadog_checks.openldap'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/openldap/tox.ini
+++ b/openldap/tox.ini
@@ -9,7 +9,7 @@ envlist =
 [testenv]
 platform = linux|darwin
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 

--- a/openstack/setup.py
+++ b/openstack/setup.py
@@ -56,7 +56,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.openstack'],
+    packages=['datadog_checks', 'datadog_checks.openstack'],
 
     # Run-time dependencies
 

--- a/openstack/tox.ini
+++ b/openstack/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:openstack]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/oracle/setup.py
+++ b/oracle/setup.py
@@ -56,7 +56,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.oracle'],
+    packages=['datadog_checks', 'datadog_checks.oracle'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/oracle/tox.ini
+++ b/oracle/tox.ini
@@ -6,7 +6,7 @@ envlist = oracle, flake8
 [testenv]
 platform = darwin|linux|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 

--- a/pdh_check/setup.py
+++ b/pdh_check/setup.py
@@ -56,7 +56,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.pdh_check'],
+    packages=['datadog_checks', 'datadog_checks.pdh_check'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/pdh_check/tox.ini
+++ b/pdh_check/tox.ini
@@ -11,7 +11,7 @@ platform = win32|linux2|darwin
 [testenv:pdh_check]
 platform = win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt

--- a/pgbouncer/setup.py
+++ b/pgbouncer/setup.py
@@ -43,7 +43,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
     ],
-    packages=['datadog_checks.pgbouncer'],
+    packages=['datadog_checks', 'datadog_checks.pgbouncer'],
     install_requires=[CHECKS_BASE_REQ],
     tests_require=get_requirements("requirements-dev.txt"),
     # Extra files to ship with the wheel package

--- a/pgbouncer/tox.ini
+++ b/pgbouncer/tox.ini
@@ -9,7 +9,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/php_fpm/setup.py
+++ b/php_fpm/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.php_fpm'],
+    packages=['datadog_checks', 'datadog_checks.php_fpm'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/postfix/setup.py
+++ b/postfix/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.postfix'],
+    packages=['datadog_checks', 'datadog_checks.postfix'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/postgres/setup.py
+++ b/postgres/setup.py
@@ -49,7 +49,7 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
 
-    packages=['datadog_checks.postgres'],
+    packages=['datadog_checks', 'datadog_checks.postgres'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/postgres/tox.ini
+++ b/postgres/tox.ini
@@ -5,7 +5,7 @@ envlist = postgres{93,94,95,96,10}-pg8000, postgres{93,94,95,96,10}-psycopg2, fl
 
 [common]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/powerdns_recursor/setup.py
+++ b/powerdns_recursor/setup.py
@@ -56,7 +56,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.powerdns_recursor'],
+    packages=['datadog_checks', 'datadog_checks.powerdns_recursor'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/powerdns_recursor/tox.ini
+++ b/powerdns_recursor/tox.ini
@@ -14,7 +14,7 @@ passenv =
 
 [testenv:powerdns373]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 setenv =
@@ -27,7 +27,7 @@ commands =
 
 [testenv:powerdns403]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 setenv =

--- a/process/setup.py
+++ b/process/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.process'],
+    packages=['datadog_checks', 'datadog_checks.process'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/process/tox.ini
+++ b/process/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin|windows
 
 [testenv:process]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/prometheus/setup.py
+++ b/prometheus/setup.py
@@ -53,7 +53,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.prometheus'],
+    packages=['datadog_checks', 'datadog_checks.prometheus'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/prometheus/tox.ini
+++ b/prometheus/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin
 
 [testenv:prometheus]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rtests/requirements.txt
 commands =

--- a/rabbitmq/setup.py
+++ b/rabbitmq/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.rabbitmq'],
+    packages=['datadog_checks', 'datadog_checks.rabbitmq'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/redisdb/setup.py
+++ b/redisdb/setup.py
@@ -48,7 +48,7 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
 
-    packages=['datadog_checks.redisdb'],
+    packages=['datadog_checks', 'datadog_checks.redisdb'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/redisdb/tox.ini
+++ b/redisdb/tox.ini
@@ -9,7 +9,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/riak/setup.py
+++ b/riak/setup.py
@@ -55,7 +55,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.riak'],
+    packages=['datadog_checks', 'datadog_checks.riak'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/riak/tox.ini
+++ b/riak/tox.ini
@@ -11,7 +11,7 @@ passenv =
 
 [testenv:riak]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 setenv = REDIS_VERSION=3.2

--- a/riakcs/setup.py
+++ b/riakcs/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.riakcs'],
+    packages=['datadog_checks', 'datadog_checks.riakcs'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/snmp/setup.py
+++ b/snmp/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.snmp'],
+    packages=['datadog_checks', 'datadog_checks.snmp'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/solr/setup.py
+++ b/solr/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.solr'],
+    packages=['datadog_checks', 'datadog_checks.solr'],
 
     # Run-time dependencies
     install_requires=['datadog_checks_base'],

--- a/spark/setup.py
+++ b/spark/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.spark'],
+    packages=['datadog_checks', 'datadog_checks.spark'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/spark/tox.ini
+++ b/spark/tox.ini
@@ -8,7 +8,7 @@ platform = linux|darwin|win32
 
 [testenv:spark]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/sqlserver/setup.py
+++ b/sqlserver/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.sqlserver'],
+    packages=['datadog_checks', 'datadog_checks.sqlserver'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/sqlserver/tox.ini
+++ b/sqlserver/tox.ini
@@ -9,7 +9,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 passenv =

--- a/squid/setup.py
+++ b/squid/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.squid'],
+    packages=['datadog_checks', 'datadog_checks.squid'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/squid/tox.ini
+++ b/squid/tox.ini
@@ -6,7 +6,7 @@ envlist = unit, squid-latest, flake8
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 

--- a/ssh_check/setup.py
+++ b/ssh_check/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.ssh_check'],
+    packages=['datadog_checks', 'datadog_checks.ssh_check'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/ssh_check/tox.ini
+++ b/ssh_check/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:ssh_check]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/statsd/setup.py
+++ b/statsd/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.statsd'],
+    packages=['datadog_checks', 'datadog_checks.statsd'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/statsd/tox.ini
+++ b/statsd/tox.ini
@@ -8,7 +8,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/supervisord/setup.py
+++ b/supervisord/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.supervisord'],
+    packages=['datadog_checks', 'datadog_checks.supervisord'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/system_core/setup.py
+++ b/system_core/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.system_core'],
+    packages=['datadog_checks', 'datadog_checks.system_core'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/system_core/tox.ini
+++ b/system_core/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:system_core]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/system_swap/setup.py
+++ b/system_swap/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.system_swap'],
+    packages=['datadog_checks', 'datadog_checks.system_swap'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/tcp_check/setup.py
+++ b/tcp_check/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.tcp_check'],
+    packages=['datadog_checks', 'datadog_checks.tcp_check'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/tcp_check/tox.ini
+++ b/tcp_check/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin|windows
 
 [testenv:unit]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/teamcity/setup.py
+++ b/teamcity/setup.py
@@ -47,7 +47,7 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
 
-    packages=['datadog_checks.teamcity'],
+    packages=['datadog_checks', 'datadog_checks.teamcity'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/teamcity/tox.ini
+++ b/teamcity/tox.ini
@@ -9,7 +9,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 

--- a/tokumx/setup.py
+++ b/tokumx/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.tokumx'],
+    packages=['datadog_checks', 'datadog_checks.tokumx'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/tomcat/setup.py
+++ b/tomcat/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.tomcat'],
+    packages=['datadog_checks', 'datadog_checks.tomcat'],
 
     # Run-time dependencies
     install_requires=['datadog_checks_base'],

--- a/twemproxy/setup.py
+++ b/twemproxy/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.twemproxy'],
+    packages=['datadog_checks', 'datadog_checks.twemproxy'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/varnish/setup.py
+++ b/varnish/setup.py
@@ -55,7 +55,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.varnish'],
+    packages=['datadog_checks', 'datadog_checks.varnish'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/varnish/tox.ini
+++ b/varnish/tox.ini
@@ -10,7 +10,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 passenv =

--- a/vault/setup.py
+++ b/vault/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.vault'],
+    packages=['datadog_checks', 'datadog_checks.vault'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/vsphere/setup.py
+++ b/vsphere/setup.py
@@ -47,7 +47,7 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
 
-    packages=['datadog_checks.vsphere'],
+    packages=['datadog_checks', 'datadog_checks.vsphere'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/vsphere/tox.ini
+++ b/vsphere/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin
 
 [testenv:vsphere]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/win32_event_log/setup.py
+++ b/win32_event_log/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.win32_event_log'],
+    packages=['datadog_checks', 'datadog_checks.win32_event_log'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/windows_service/setup.py
+++ b/windows_service/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.windows_service'],
+    packages=['datadog_checks', 'datadog_checks.windows_service'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/windows_service/tox.ini
+++ b/windows_service/tox.ini
@@ -10,7 +10,7 @@ platform = win32
 
 [testenv:windows_service]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/wmi_check/setup.py
+++ b/wmi_check/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.wmi_check'],
+    packages=['datadog_checks', 'datadog_checks.wmi_check'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/yarn/setup.py
+++ b/yarn/setup.py
@@ -56,7 +56,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.yarn'],
+    packages=['datadog_checks', 'datadog_checks.yarn'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/yarn/tox.ini
+++ b/yarn/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:yarn]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/zk/setup.py
+++ b/zk/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks.zk'],
+    packages=['datadog_checks', 'datadog_checks.zk'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/zk/tox.ini
+++ b/zk/tox.ini
@@ -8,7 +8,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =


### PR DESCRIPTION
### Motivation

- Always use the version of `datadog_checks_base` on your branch
- https://github.com/pypa/pip/issues/2195

### Additional Notes

Script (Python 3 only)

```python
import os
import re

CORE_DIR = r'C:\Users\ofek.lev\Desktop\code\integrations-core'
CHECKS_BASE_PATTERN = re.compile(rb'(?<!-e)..(/|\\)datadog_checks_base$', re.M)
PACKAGES_PATTERN = re.compile(rb'packages *=.*,$', re.M)


def get_setup_file(check_name):
    f = os.path.join(CORE_DIR, check_name, 'setup.py')
    if os.path.isfile(f):
        return f


def get_tox_file(check_name):
    f = os.path.join(CORE_DIR, check_name, 'tox.ini')
    if os.path.isfile(f):
        return f


def main():
    for check_name in os.listdir(CORE_DIR):
        setup_file = get_setup_file(check_name)
        if setup_file and not check_name.startswith('datadog_checks'):
            with open(setup_file, 'rb') as f:
                setup_contents = f.read()

            setup_contents = PACKAGES_PATTERN.sub(
                "packages=['datadog_checks', 'datadog_checks.{}'],".format(check_name).encode('utf-8'),
                setup_contents
            )

            with open(setup_file, 'wb') as f:
                f.write(setup_contents)

        tox_file = get_tox_file(check_name)
        if tox_file:
            with open(tox_file, 'rb') as f:
                tox_contents = f.read()

            tox_contents = CHECKS_BASE_PATTERN.sub(
                b'-e../datadog_checks_base',
                tox_contents
            )

            with open(tox_file, 'wb') as f:
                f.write(tox_contents)


if __name__ == '__main__':
    main()
```