### PR TITLE
removing wrong metric_to_check

### DIFF
--- a/pdh_check/manifest.json
+++ b/pdh_check/manifest.json
@@ -9,7 +9,6 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "pdh.",
-  "metric_to_check": "pdh.system.file_read_per_se",
   "name": "pdh_check",
   "public_title": "Datadog-Pdh Check Integration",
   "short_description": "Collect and graph any Windows PDH metrics.",


### PR DESCRIPTION
### What does this PR do?

removing wrong metric_to_check from pdh integration manifest

### Motivation


### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes
