### PR TITLE
Send correct count values for NGINX ever increasing counters

### DIFF
--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -90,7 +90,7 @@ class Nginx(AgentCheck):
         funcs = {
             'gauge': self.gauge,
             'rate': self.rate,
-            'count': self.count
+            'count': self.monotonic_count
         }
         conn = None
         handled = None


### PR DESCRIPTION
### What does this PR do?

The check should be using the `monotonic_count` method to send counters for ever increasing values. This PR corrects it.
Resolves #2020.

This change can trigger monitors since values in the app will change.

### Motivation

With the `count` method, the values are wrong and unusable. This is due to the fact that the `count` method expects a delta of the counter between the last check run and the current one, while the `monotonic_count` method expects the current value of the counter, and deals with computing the delta on its own. More info on the metric methods here: https://docs.datadoghq.com/developers/metrics/counts/ 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?