### PR TITLE
Add metrics for Solr 7

### DIFF
--- a/solr/README.md
+++ b/solr/README.md
@@ -11,7 +11,7 @@ The Solr check tracks the state and performance of a Solr cluster. It collects m
 
 The Solr check is included in the [Datadog Agent][1] package, so you don't need to install anything else on your Solr nodes.
 
-This check is JMX-based, so you'll need to enable JMX Remote on your Tomcat servers. Read the [JMX Check documentation][2] for more information on that.
+This check is JMX-based, so you'll need to enable JMX Remote on your Solr servers. Read the [JMX Check documentation][2] for more information on that.
 
 ### Configuration
 
@@ -19,13 +19,13 @@ Edit the `solr.d/conf.yaml` file, in the `conf.d/` folder at the root of your Ag
 
 ```
 instances:
-# location of tomcat
+  # location of tomcat
   - host: localhost
     port: 9999
 
-# if tomcat requires authentication
-#   user: <TOMCAT_USERNAME>
-#   password: <TOMCAT_PASSWORD>
+  # if tomcat requires authentication
+  #   user: <TOMCAT_USERNAME>
+  #   password: <TOMCAT_PASSWORD>
 
 init_config:
   conf:

--- a/solr/datadog_checks/solr/data/conf.yaml.example
+++ b/solr/datadog_checks/solr/data/conf.yaml.example
@@ -66,16 +66,16 @@ init_config:
         - searcher
       attribute:
         cumulative_lookups:
-          alias: solr.documentCache.lookups
+          alias: solr.document_cache.lookups
           metric_type: counter
         cumulative_hits:
-          alias: solr.documentCache.hits
+          alias: solr.document_cache.hits
           metric_type: counter
         cumulative_inserts:
-          alias: solr.documentCache.inserts
+          alias: solr.document_cache.inserts
           metric_type: counter
         cumulative_evictions:
-          alias: solr.documentCache.evictions
+          alias: solr.document_cache.evictions
           metric_type: counter
 
   - include:
@@ -85,16 +85,16 @@ init_config:
         - searcher
       attribute:
         cumulative_lookups:
-          alias: solr.queryResultCache.lookups
+          alias: solr.query_result_cache.lookups
           metric_type: counter
         cumulative_hits:
-          alias: solr.queryResultCache.hits
+          alias: solr.query_result_cache.hits
           metric_type: counter
         cumulative_inserts:
-          alias: solr.queryResultCache.inserts
+          alias: solr.query_result_cache.inserts
           metric_type: counter
         cumulative_evictions:
-          alias: solr.queryResultCache.evictions
+          alias: solr.query_result_cache.evictions
           metric_type: counter
 
   - include:
@@ -104,16 +104,16 @@ init_config:
         - searcher
       attribute:
         cumulative_lookups:
-          alias: solr.filterCache.lookups
+          alias: solr.filter_cache.lookups
           metric_type: counter
         cumulative_hits:
-          alias: solr.filterCache.hits
+          alias: solr.filter_cache.hits
           metric_type: counter
         cumulative_inserts:
-          alias: solr.filterCache.inserts
+          alias: solr.filter_cache.inserts
           metric_type: counter
         cumulative_evictions:
-          alias: solr.filterCache.evictions
+          alias: solr.filter_cache.evictions
           metric_type: counter
 
   - include:

--- a/solr/datadog_checks/solr/data/conf.yaml.example
+++ b/solr/datadog_checks/solr/data/conf.yaml.example
@@ -25,6 +25,142 @@ init_config:
   # Agent 5: Customize all your metrics below
   # Agent 6: The default metrics to be collected are kept in metrics.yaml, but you can still add your own metrics here
   conf:
+
+
+  # Solr 7 MBeans:
+  - include:
+      category: SEARCHER
+      name:
+        - numDocs
+      scope:
+        - searcher
+      attribute:
+        Value:
+          alias: solr.searcher.numdocs
+          metric_type: gauge
+
+  - include:
+      category: SEARCHER
+      name: maxDoc
+      scope:
+        - searcher
+      attribute:
+        Value:
+          alias: solr.searcher.maxdocs
+          metric_type: gauge
+
+  - include:
+      category: SEARCHER
+      name: warmupTime
+      scope:
+        - searcher
+      attribute:
+        Value:
+          alias: solr.searcher.warmup
+          metric_type: gauge
+
+  - include:
+      category: CACHE
+      name: documentCache
+      scope:
+        - searcher
+      attribute:
+        cumulative_lookups:
+          alias: solr.documentCache.lookups
+          metric_type: counter
+        cumulative_hits:
+          alias: solr.documentCache.hits
+          metric_type: counter
+        cumulative_inserts:
+          alias: solr.documentCache.inserts
+          metric_type: counter
+        cumulative_evictions:
+          alias: solr.documentCache.evictions
+          metric_type: counter
+
+  - include:
+      category: CACHE
+      name: queryResultCache
+      scope:
+        - searcher
+      attribute:
+        cumulative_lookups:
+          alias: solr.queryResultCache.lookups
+          metric_type: counter
+        cumulative_hits:
+          alias: solr.queryResultCache.hits
+          metric_type: counter
+        cumulative_inserts:
+          alias: solr.queryResultCache.inserts
+          metric_type: counter
+        cumulative_evictions:
+          alias: solr.queryResultCache.evictions
+          metric_type: counter
+
+  - include:
+      category: CACHE
+      name: filterCache
+      scope:
+        - searcher
+      attribute:
+        cumulative_lookups:
+          alias: solr.filterCache.lookups
+          metric_type: counter
+        cumulative_hits:
+          alias: solr.filterCache.hits
+          metric_type: counter
+        cumulative_inserts:
+          alias: solr.filterCache.inserts
+          metric_type: counter
+        cumulative_evictions:
+          alias: solr.filterCache.evictions
+          metric_type: counter
+
+  - include:
+      category: QUERY
+      name: requests
+      attribute:
+        Count:
+          alias: solr.search_handler.requests
+          metric_type: counter
+
+  - include:
+      category: QUERY
+      name: timeouts
+      attribute:
+        Count:
+          alias: solr.search_handler.timeouts
+          metric_type: counter
+
+  - include:
+      category: QUERY
+      name: errors
+      attribute:
+        Count:
+          alias: solr.search_handler.errors
+          metric_type: counter
+
+  - include:
+      category: QUERY
+      name: totalTime
+      attribute:
+        Count:
+          alias: solr.search_handler.time
+          metric_type: counter
+
+  - include:
+      category: QUERY
+      name: requestTimes
+      attribute:
+        avgRequestsPerSecond:
+          alias: solr.search_handler.avg_requests_per_sec
+          metric_type: gauge
+        avgTimePerRequest:
+          alias: solr.search_handler.avg_time_per_req
+          metric_type: gauge
+
+
+  # Solr version < 7 MBeans:
     - include:
         type: searcher
         attribute:

--- a/solr/datadog_checks/solr/data/metrics.yaml
+++ b/solr/datadog_checks/solr/data/metrics.yaml
@@ -1,5 +1,140 @@
 # Default metrics collected by this check. You should not have to modify this.
 jmx_metrics:
+
+  # Solr versions >= 7.0
+  - include:
+      category: SEARCHER
+      name:
+        - numDocs
+      scope:
+        - searcher
+      attribute:
+        Value:
+          alias: solr.searcher.numdocs
+          metric_type: gauge
+
+  - include:
+      category: SEARCHER
+      name: maxDoc
+      scope:
+        - searcher
+      attribute:
+        Value:
+          alias: solr.searcher.maxdocs
+          metric_type: gauge
+
+  - include:
+      category: SEARCHER
+      name: warmupTime
+      scope:
+        - searcher
+      attribute:
+        Value:
+          alias: solr.searcher.warmup
+          metric_type: gauge
+
+  - include:
+      category: CACHE
+      name: documentCache
+      scope:
+        - searcher
+      attribute:
+        cumulative_lookups:
+          alias: solr.documentCache.lookups
+          metric_type: counter
+        cumulative_hits:
+          alias: solr.documentCache.hits
+          metric_type: counter
+        cumulative_inserts:
+          alias: solr.documentCache.inserts
+          metric_type: counter
+        cumulative_evictions:
+          alias: solr.documentCache.evictions
+          metric_type: counter
+
+  - include:
+      category: CACHE
+      name: queryResultCache
+      scope:
+        - searcher
+      attribute:
+        cumulative_lookups:
+          alias: solr.queryResultCache.lookups
+          metric_type: counter
+        cumulative_hits:
+          alias: solr.queryResultCache.hits
+          metric_type: counter
+        cumulative_inserts:
+          alias: solr.queryResultCache.inserts
+          metric_type: counter
+        cumulative_evictions:
+          alias: solr.queryResultCache.evictions
+          metric_type: counter
+
+  - include:
+      category: CACHE
+      name: filterCache
+      scope:
+        - searcher
+      attribute:
+        cumulative_lookups:
+          alias: solr.filterCache.lookups
+          metric_type: counter
+        cumulative_hits:
+          alias: solr.filterCache.hits
+          metric_type: counter
+        cumulative_inserts:
+          alias: solr.filterCache.inserts
+          metric_type: counter
+        cumulative_evictions:
+          alias: solr.filterCache.evictions
+          metric_type: counter
+
+  - include:
+      category: QUERY
+      name: requests
+      attribute:
+        Count:
+          alias: solr.search_handler.requests
+          metric_type: counter
+
+  - include:
+      category: QUERY
+      name: timeouts
+      attribute:
+        Count:
+          alias: solr.search_handler.timeouts
+          metric_type: counter
+
+  - include:
+      category: QUERY
+      name: errors
+      attribute:
+        Count:
+          alias: solr.search_handler.errors
+          metric_type: counter
+
+  - include:
+      category: QUERY
+      name: totalTime
+      attribute:
+        Count:
+          alias: solr.search_handler.time
+          metric_type: counter
+
+  - include:
+      category: QUERY
+      name: requestTimes
+      attribute:
+        avgRequestsPerSecond:
+          alias: solr.search_handler.avg_requests_per_sec
+          metric_type: gauge
+        avgTimePerRequest:
+          alias: solr.search_handler.avg_time_per_req
+          metric_type: gauge
+
+
+  # Solr versions < 7.0
   - include:
       type: searcher
       attribute:

--- a/solr/datadog_checks/solr/data/metrics.yaml
+++ b/solr/datadog_checks/solr/data/metrics.yaml
@@ -40,16 +40,16 @@ jmx_metrics:
         - searcher
       attribute:
         cumulative_lookups:
-          alias: solr.documentCache.lookups
+          alias: solr.document_cache.lookups
           metric_type: counter
         cumulative_hits:
-          alias: solr.documentCache.hits
+          alias: solr.document_cache.hits
           metric_type: counter
         cumulative_inserts:
-          alias: solr.documentCache.inserts
+          alias: solr.document_cache.inserts
           metric_type: counter
         cumulative_evictions:
-          alias: solr.documentCache.evictions
+          alias: solr.document_cache.evictions
           metric_type: counter
 
   - include:
@@ -59,16 +59,16 @@ jmx_metrics:
         - searcher
       attribute:
         cumulative_lookups:
-          alias: solr.queryResultCache.lookups
+          alias: solr.query_result_cache.lookups
           metric_type: counter
         cumulative_hits:
-          alias: solr.queryResultCache.hits
+          alias: solr.query_result_cache.hits
           metric_type: counter
         cumulative_inserts:
-          alias: solr.queryResultCache.inserts
+          alias: solr.query_result_cache.inserts
           metric_type: counter
         cumulative_evictions:
-          alias: solr.queryResultCache.evictions
+          alias: solr.query_result_cache.evictions
           metric_type: counter
 
   - include:
@@ -78,16 +78,16 @@ jmx_metrics:
         - searcher
       attribute:
         cumulative_lookups:
-          alias: solr.filterCache.lookups
+          alias: solr.filter_cache.lookups
           metric_type: counter
         cumulative_hits:
-          alias: solr.filterCache.hits
+          alias: solr.filter_cache.hits
           metric_type: counter
         cumulative_inserts:
-          alias: solr.filterCache.inserts
+          alias: solr.filter_cache.inserts
           metric_type: counter
         cumulative_evictions:
-          alias: solr.filterCache.evictions
+          alias: solr.filter_cache.evictions
           metric_type: counter
 
   - include:

--- a/solr/metadata.csv
+++ b/solr/metadata.csv
@@ -12,3 +12,15 @@ solr.search_handler.timeouts,gauge,10,timeout,second,Number of responses per sec
 solr.search_handler.time,gauge,10,,,The sum of all request processing times (in milliseconds) per second.,0,solr,search time
 solr.search_handler.avg_time_per_req,gauge,10,millisecond,request,The average time per request.,-1,solr,search time per req
 solr.search_handler.avg_requests_per_sec,gauge,10,request,second,The average number of requests per second.,1,solr,search reqs per sec
+solr.documentCache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,doc cache gets
+solr.documentCache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,doc cache hits
+solr.documentCache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,doc cache sets
+solr.documentCache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,doc cache evictions
+solr.queryResultCache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,query result cache gets
+solr.queryResultCache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,query result cache hits
+solr.queryResultCache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,query result cache sets
+solr.queryResultCache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,query result cache evictions
+solr.filterCache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,filter cache gets
+solr.filterCache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,filter cache hits
+solr.filterCache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,filter cache sets
+solr.filterCache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,filter cache evictions

--- a/solr/metadata.csv
+++ b/solr/metadata.csv
@@ -12,15 +12,15 @@ solr.search_handler.timeouts,gauge,10,timeout,second,Number of responses per sec
 solr.search_handler.time,gauge,10,,,The sum of all request processing times (in milliseconds) per second.,0,solr,search time
 solr.search_handler.avg_time_per_req,gauge,10,millisecond,request,The average time per request.,-1,solr,search time per req
 solr.search_handler.avg_requests_per_sec,gauge,10,request,second,The average number of requests per second.,1,solr,search reqs per sec
-solr.documentCache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,doc cache gets
-solr.documentCache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,doc cache hits
-solr.documentCache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,doc cache sets
-solr.documentCache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,doc cache evictions
-solr.queryResultCache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,query result cache gets
-solr.queryResultCache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,query result cache hits
-solr.queryResultCache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,query result cache sets
-solr.queryResultCache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,query result cache evictions
-solr.filterCache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,filter cache gets
-solr.filterCache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,filter cache hits
-solr.filterCache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,filter cache sets
-solr.filterCache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,filter cache evictions
+solr.document_cache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,doc cache gets
+solr.document_cache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,doc cache hits
+solr.document_cache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,doc cache sets
+solr.document_cache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,doc cache evictions
+solr.query_result_cache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,query result cache gets
+solr.query_result_cache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,query result cache hits
+solr.query_result_cache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,query result cache sets
+solr.query_result_cache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,query result cache evictions
+solr.filter_cache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,filter cache gets
+solr.filter_cache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,filter cache hits
+solr.filter_cache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,filter cache sets
+solr.filter_cache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,filter cache evictions

--- a/solr/metadata.csv
+++ b/solr/metadata.csv
@@ -1,26 +1,26 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+solr.cache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,cache evictions
+solr.cache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,cache hits
+solr.cache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,cache sets
+solr.cache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,cache gets
+solr.document_cache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,doc cache evictions
+solr.document_cache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,doc cache hits
+solr.document_cache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,doc cache sets
+solr.document_cache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,doc cache gets
+solr.filter_cache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,filter cache evictions
+solr.filter_cache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,filter cache hits
+solr.filter_cache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,filter cache sets
+solr.filter_cache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,filter cache gets
+solr.query_result_cache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,query result cache evictions
+solr.query_result_cache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,query result cache hits
+solr.query_result_cache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,query result cache sets
+solr.query_result_cache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,query result cache gets
+solr.search_handler.avg_requests_per_sec,gauge,10,request,second,The average number of requests per second.,1,solr,search reqs per sec
+solr.search_handler.avg_time_per_req,gauge,10,millisecond,request,The average time per request.,-1,solr,search time per req
+solr.search_handler.errors,gauge,10,error,second,Number of errors per second encountered by the handler.,-1,solr,search errors
+solr.search_handler.requests,gauge,10,request,second,Number of requests per second processed by the handler.,0,solr,search requests
+solr.search_handler.time,gauge,10,,,The sum of all request processing times (in milliseconds) per second.,0,solr,search time
+solr.search_handler.timeouts,gauge,10,timeout,second,Number of responses per second received with partial results.,-1,solr,search timeouts
 solr.searcher.maxdoc,gauge,10,document,,One greater than the largest possible document number.,0,solr,max doc id
 solr.searcher.numdocs,gauge,10,document,,The total number of indexed documents.,0,solr,num docs
 solr.searcher.warmup,gauge,10,millisecond,,The time spent warming up.,-1,solr,warmup time
-solr.cache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,cache hits
-solr.cache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,cache gets
-solr.cache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,cache sets
-solr.cache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,cache evictions
-solr.search_handler.errors,gauge,10,error,second,Number of errors per second encountered by the handler.,-1,solr,search errors
-solr.search_handler.requests,gauge,10,request,second,Number of requests per second processed by the handler.,0,solr,search requests
-solr.search_handler.timeouts,gauge,10,timeout,second,Number of responses per second received with partial results.,-1,solr,search timeouts
-solr.search_handler.time,gauge,10,,,The sum of all request processing times (in milliseconds) per second.,0,solr,search time
-solr.search_handler.avg_time_per_req,gauge,10,millisecond,request,The average time per request.,-1,solr,search time per req
-solr.search_handler.avg_requests_per_sec,gauge,10,request,second,The average number of requests per second.,1,solr,search reqs per sec
-solr.document_cache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,doc cache gets
-solr.document_cache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,doc cache hits
-solr.document_cache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,doc cache sets
-solr.document_cache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,doc cache evictions
-solr.query_result_cache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,query result cache gets
-solr.query_result_cache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,query result cache hits
-solr.query_result_cache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,query result cache sets
-solr.query_result_cache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,query result cache evictions
-solr.filter_cache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,filter cache gets
-solr.filter_cache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,filter cache hits
-solr.filter_cache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,filter cache sets
-solr.filter_cache.evictions,gauge,10,eviction,second,The total number of cache evictions per second.,-1,solr,filter cache evictions


### PR DESCRIPTION
### What does this PR do?

Adds a set of metrics for Solr 7

### Motivation

The mbeans have changed with [Solr 7](https://lucene.apache.org/solr/guide/7_1/major-changes-in-solr-7.html#jmx-support-and-mbeans), so this adds back the set of metrics we were collecting for prior versions to include support for Solr 7

Solr 7 Documentation surrounding an example of new metric names - https://lucene.apache.org/solr/guide/7_4/performance-statistics-reference.html#commonly-used-stats-for-request-handlers


I pulled out an example of some of the matching beans 

```
sudo datadog-agent jmx list everything | grep "errors" | grep "category=QUERY"
```

```
2018-08-13 17:13:18 WEST | INFO | (jmxfetch.go:208 in func1) |        Matching: 65/350. Bean name: solr:dom1=core,dom2=movies,dom3=shard1,dom4=replica_n1,category=QUERY,scope=/query,name=errors - Attribute name: Count  - Attribute type: long
2018-08-13 17:13:19 WEST | INFO | (jmxfetch.go:208 in func1) |        Matching: 66/350. Bean name: solr:dom1=node,category=QUERY,scope=/admin/metrics/collector,name=errors - Attribute name: Count  - Attribute type: long
2018-08-13 17:13:19 WEST | INFO | (jmxfetch.go:208 in func1) |        Matching: 67/350. Bean name: solr:dom1=core,dom2=movies,dom3=shard1,dom4=replica_n1,category=QUERY,scope=/browse,name=errors - Attribute name: Count  - Attribute type: long
```

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Includes changes to the `metrics.yaml` file so these can be collected by default for autodiscovery if the collect default metrics flag is set. Maintains backwards compat with previous versions of Solr. 