### PR TITLE
Rearrange the code to keep the list of known servers

### DIFF
--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -88,4 +88,4 @@ def test_get_instance_metrics_instance(check):
     another = ('localhost', '5432', 'FOO')
     res = check._get_instance_metrics(another, 'dbname', False, False)
     assert res is None
-    assert check.instance_metrics[another] is None
+    assert check.instance_metrics[another] == []


### PR DESCRIPTION
### What does this PR do?

See title

### Motivation

Preparation work to implement this feature in A6, currently persisting data at the check instance level only works for A5.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

None
