### PR TITLE
Re-enable instance tags for server metrics on Agent version 6

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -678,16 +678,15 @@ SELECT s.schemaname,
 
         try:
             cursor = db.cursor()
-            server_metric_tags = instance_tags
-            results_len = self._query_scope(cursor, db_instance_metrics, key, db, server_metric_tags, relations,
+            results_len = self._query_scope(cursor, db_instance_metrics, key, db, instance_tags, relations,
                                             False, programming_error, relations_config)
             if results_len is not None:
                 self.gauge("postgresql.db.count", results_len,
-                           tags=[t for t in server_metric_tags if not t.startswith("db:")])
+                           tags=[t for t in instance_tags if not t.startswith("db:")])
 
-            self._query_scope(cursor, bgw_instance_metrics, key, db, server_metric_tags, relations,
+            self._query_scope(cursor, bgw_instance_metrics, key, db, instance_tags, relations,
                               False, programming_error, relations_config)
-            self._query_scope(cursor, archiver_instance_metrics, key, db, server_metric_tags, relations,
+            self._query_scope(cursor, archiver_instance_metrics, key, db, instance_tags, relations,
                               False, programming_error, relations_config)
 
             for scope in list(metric_scope) + custom_metrics:

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import socket
+import threading
 
 try:
     import psycopg2
@@ -309,6 +310,10 @@ SELECT s.schemaname,
         'relation': False
     }
 
+    # keep track of host/port present in any configured instance
+    _known_servers = set()
+    _known_servers_lock = threading.RLock()
+
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
         self.dbs = {}
@@ -320,20 +325,20 @@ SELECT s.schemaname,
         self.db_archiver_metrics = []
         self.replication_metrics = {}
         self.custom_metrics = {}
-        # keep track of host/port present in any configured instance
-        self._known_servers = set()
 
     def _server_known(self, host, port):
         """
         Return whether the hostname and port combination was already seen
         """
-        return (host, port) in self._known_servers
+        with PostgreSql._known_servers_lock:
+            return (host, port) in PostgreSql._known_servers
 
     def _set_server_known(self, host, port):
         """
         Store the host/port combination for this server
         """
-        self._known_servers.add((host, port))
+        with PostgreSql._known_servers_lock:
+            PostgreSql._known_servers.add((host, port))
 
     def _get_pg_attrs(self, instance):
         if _is_affirmative(instance.get('use_psycopg2', False)):
@@ -673,13 +678,7 @@ SELECT s.schemaname,
 
         try:
             cursor = db.cursor()
-
-            # server wide metrics aren't tagged anymore with instance tags, starting from Agent 6.0
-            if add_instance_tags_to_server_metrics():
-                server_metric_tags = instance_tags
-            else:
-                server_metric_tags = []
-
+            server_metric_tags = instance_tags
             results_len = self._query_scope(cursor, db_instance_metrics, key, db, server_metric_tags, relations,
                                             False, programming_error, relations_config)
             if results_len is not None:

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -6,11 +6,21 @@ import os
 import time
 
 import pytest
+import mock
+from datadog_checks.postgres import PostgreSql
 
 from .common import HOST, PORT, USER, PASSWORD, DB_NAME
 
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+@pytest.fixture
+def check():
+    check = PostgreSql('postgres', {}, {})
+    check._is_9_2_or_above = mock.MagicMock()
+    PostgreSql._known_servers = set()  # reset the global state
+    return check
 
 
 @pytest.fixture(scope="session")

--- a/postgres/tests/test_common.py
+++ b/postgres/tests/test_common.py
@@ -1,12 +1,12 @@
 # (C) Datadog, Inc. 2010-2018
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-
 import pytest
-import mock
 import os
 
 from datadog_checks.postgres import PostgreSql
+
+from .common import HOST, PORT, DB_NAME
 
 
 COMMON_METRICS = [
@@ -64,54 +64,37 @@ def check_bgw_metrics(aggregator, expected_tags):
             aggregator.assert_metric(name, count=1, tags=expected_tags)
 
 
-# Agent5 add instance_tag tag to the COMMON_METRICS
-@mock.patch("datadog_checks.postgres.postgres.add_instance_tags_to_server_metrics", return_value=True)
 @pytest.mark.integration
-def test_common_metrics_with_agent5(instance_tag, aggregator, postgres_standalone, pg_instance):
-    posgres_check = PostgreSql('postgres', {}, {})
-    expected_tags = pg_instance['tags'] + ['db:%s' % pg_instance['dbname']]
+def test_common_metrics(aggregator, check, postgres_standalone, pg_instance):
+    expected_tags = pg_instance['tags'] + ['db:{}'.format(DB_NAME)]
 
-    posgres_check.check(pg_instance)
+    check.check(pg_instance)
     check_common_metrics(aggregator, expected_tags)
     check_bgw_metrics(aggregator, pg_instance['tags'])
 
 
-# Agent6 does NOT add instance_tag tag to the COMMON_METRICS
-@mock.patch("datadog_checks.postgres.postgres.add_instance_tags_to_server_metrics", return_value=False)
 @pytest.mark.integration
-def test_common_metrics_with_agent6(instance_tag, aggregator, postgres_standalone, pg_instance):
-    posgres_check = PostgreSql('postgres', {}, {})
-    expected_tags = ['db:%s' % pg_instance['dbname']]
-
-    posgres_check.check(pg_instance)
-    check_common_metrics(aggregator, expected_tags)
-    check_bgw_metrics(aggregator, [])
-
-
-@pytest.mark.integration
-def test_common_metrics_without_size(aggregator, postgres_standalone, pg_instance):
-    posgres_check = PostgreSql('postgres', {}, {})
+def test_common_metrics_without_size(aggregator, check, postgres_standalone, pg_instance):
     pg_instance['collect_database_size_metrics'] = False
-
-    posgres_check.check(pg_instance)
+    check.check(pg_instance)
     assert 'postgresql.database_size' not in aggregator.metric_names
 
 
 @pytest.mark.integration
-def test_can_connect_service_check(aggregator, postgres_standalone, pg_instance):
-    return
-    posgres_check = PostgreSql('postgres', {}, {})
-    posgres_check.check(pg_instance)
-
-    aggregator.assert_service_check('postgres.can_connect',
-                                    count=1, status=PostgreSql.OK,
-                                    tags=['host:localhost', 'port:15432', 'db:datadog_test', pg_instance['tags']])
+def test_can_connect_service_check(aggregator, check, postgres_standalone, pg_instance):
+    expected_tags = pg_instance['tags'] + [
+        'host:{}'.format(HOST),
+        'port:{}'.format(PORT),
+        'db:{}'.format(DB_NAME),
+    ]
+    check.check(pg_instance)
+    print(aggregator._service_checks)
+    aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.OK, tags=expected_tags)
 
 
 @pytest.mark.integration
-def test_schema_metrics(aggregator, postgres_standalone, pg_instance):
-    posgres_check = PostgreSql('postgres', {}, {})
-    posgres_check.check(pg_instance)
+def test_schema_metrics(aggregator, check, postgres_standalone, pg_instance):
+    check.check(pg_instance)
 
     aggregator.assert_metric('postgresql.table.count', value=1, count=1,
                              tags=pg_instance['tags']+['schema:public'])
@@ -119,9 +102,8 @@ def test_schema_metrics(aggregator, postgres_standalone, pg_instance):
 
 
 @pytest.mark.integration
-def test_connections_metrics(aggregator, postgres_standalone, pg_instance):
-    posgres_check = PostgreSql('postgres', {}, {})
-    posgres_check.check(pg_instance)
+def test_connections_metrics(aggregator, check, postgres_standalone, pg_instance):
+    check.check(pg_instance)
 
     for name in CONNECTION_METRICS:
         aggregator.assert_metric(name, count=1, tags=pg_instance['tags'])

--- a/postgres/tests/test_common.py
+++ b/postgres/tests/test_common.py
@@ -88,7 +88,6 @@ def test_can_connect_service_check(aggregator, check, postgres_standalone, pg_in
         'db:{}'.format(DB_NAME),
     ]
     check.check(pg_instance)
-    print(aggregator._service_checks)
     aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.OK, tags=expected_tags)
 
 

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -2,21 +2,11 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import pytest
-import mock
-
-from datadog_checks.postgres import PostgreSql
 
 # Mark the entire module as tests of type `unit`
 pytestmark = pytest.mark.unit
 
 KEY = ('localhost', '5432', 'dbname')
-
-
-@pytest.fixture
-def check():
-    check = PostgreSql('postgres', {}, {})
-    check._is_9_2_or_above = mock.MagicMock()
-    return check
 
 
 def test_get_instance_metrics_lt_92(check):
@@ -80,7 +70,7 @@ def test_get_instance_with_default(check):
 def test_get_instance_metrics_instance(check):
     """
     Test the caching system preventing instance metrics to be collected more than
-    once when two instances are configured for the same server but different database
+    once when two instances are configured for the same server but different databases
     """
     res = check._get_instance_metrics(KEY, 'dbname', False, False)
     assert res is not None


### PR DESCRIPTION
### What does this PR do?

Stores the list of known databases at the class level instead of at instance level, so the state is persisted across multiple instance when the check runs within Agent 6.x.
State is protected with a mutex to make the check thread safe.

### Motivation

Fixes https://github.com/DataDog/integrations-core/issues/1460

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
