### PR TITLE
update outdated link in conf.yaml.example

### DIFF
--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -20,7 +20,7 @@ instances:
 #    pid_file: STRING. A Pid file.
 #    exact_match: (optional) Boolean. Default value of True matches your search_string on proc.name().
 #                 If you want to match on a substring within proc.cmdline(), set this to False
-#                 https://docs.datadoghq.com/agent/faq/i-have-issues-with-my-process-check-it-doesn-t-find-my-processes/
+#                 https://docs.datadoghq.com/integrations/process/#configuration
 #    ignore_denied_access: (optional) Boolean. Default to True, when getting the number of files descriptors, dd-agent user might
 #    get a denied access. Set this to true to not issue a warning if that happens.
 #    thresholds: (optional) Two ranges: critical and warning


### PR DESCRIPTION
### What does this PR do?

In the sample process.yaml we point to this FAQ doc - https://docs.datadoghq.com/agent/faq/i-have-issues-with-my-process-check-it-doesn-t-find-my-processes/ - but it 404s.   This PR changes that link to point to where this content lives now -> https://docs.datadoghq.com/integrations/process/#configuration

### Motivation

Update the link

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
