### PR TITLE
Added regex support to process check when exact_match is False.

### DIFF
--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -21,6 +21,7 @@ instances:
 #    exact_match: (optional) Boolean. Default value of True matches your search_string on proc.name().
 #                 If you want to match on a substring within proc.cmdline(), set this to False
 #                 https://docs.datadoghq.com/integrations/process/#configuration
+#                 Regex is also supported when this flag is set to False.
 #    ignore_denied_access: (optional) Boolean. Default to True, when getting the number of files descriptors, dd-agent user might
 #    get a denied access. Set this to true to not issue a warning if that happens.
 #    thresholds: (optional) Two ranges: critical and warning
@@ -49,6 +50,10 @@ instances:
 #      warning: [3, 5]
 #      ok if 3, 4, 5 processes are running
 #    try_sudo: False
+#
+#  - name: django_management_commands
+#    search_string: ['python manage\.py \w+']
+#    exact_match: False
 #
 #  - name: postgres
 #    search_string: ['postgres']

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -7,6 +7,7 @@
 from collections import defaultdict
 import time
 import os
+import re
 import subprocess
 
 # 3p
@@ -145,10 +146,10 @@ class ProcessCheck(AgentCheck):
                         cmdline = proc.cmdline()
                         if os.name == 'nt':
                             lstring = string.lower()
-                            if lstring in ' '.join(cmdline).lower():
+                            if re.search(lstring, ' '.join(cmdline).lower()):
                                 found = True
                         else:
-                            if string in ' '.join(cmdline):
+                            if re.search(string, ' '.join(cmdline)):
                                 found = True
                 except psutil.NoSuchProcess:
                     self.log.warning('Process disappeared while scanning')

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -229,7 +229,7 @@ def test_check_real_process(aggregator):
 
     instance = {
         'name': 'py',
-        'search_string': ['python'],
+        'search_string': ['.*python.*pytest'],
         'exact_match': False,
         'ignored_denied_access': True,
         'thresholds': {'warning': [1, 10], 'critical': [1, 100]},

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -229,6 +229,43 @@ def test_check_real_process(aggregator):
 
     instance = {
         'name': 'py',
+        'search_string': ['python'],
+        'exact_match': True,
+        'ignored_denied_access': True,
+        'thresholds': {'warning': [1, 10], 'critical': [1, 100]},
+    }
+    process = ProcessCheck(common.CHECK_NAME, {}, {})
+    expected_tags = generate_expected_tags(instance)
+    process.check(instance)
+    for mname in common.PROCESS_METRIC:
+        # cases where we don't actually expect some metrics here:
+        #  - if io_counters() is not available
+        #  - if memory_info_ex() is not available
+        #  - first run so no `cpu.pct`
+        if (not _PSUTIL_IO_COUNTERS and '.io' in mname) or (not _PSUTIL_MEM_SHARED and 'mem.real' in mname) \
+                or mname == 'system.processes.cpu.pct':
+            continue
+
+        if Platform.is_windows():
+            metric = common.UNIX_TO_WINDOWS_MAP.get(mname, mname)
+        else:
+            metric = mname
+        aggregator.assert_metric(metric, at_least=1, tags=expected_tags)
+
+    aggregator.assert_service_check('process.up', count=1, tags=expected_tags + ['process:py'])
+
+    # this requires another run
+    process.check(instance)
+    aggregator.assert_metric('system.processes.cpu.pct', count=1, tags=expected_tags)
+    aggregator.assert_metric('system.processes.cpu.normalized_pct', count=1, tags=expected_tags)
+
+
+def test_check_real_process_regex(aggregator):
+    "Check to specifically find this python pytest running process using regex."
+    from datadog_checks.utils.platform import Platform
+
+    instance = {
+        'name': 'py',
         'search_string': ['.*python.*pytest'],
         'exact_match': False,
         'ignored_denied_access': True,

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -230,7 +230,7 @@ def test_check_real_process(aggregator):
     instance = {
         'name': 'py',
         'search_string': ['python'],
-        'exact_match': True,
+        'exact_match': False,
         'ignored_denied_access': True,
         'thresholds': {'warning': [1, 10], 'critical': [1, 100]},
     }


### PR DESCRIPTION
### What does this PR do?

Adds regex support to Datadog process check when exact_match is not enabled.

### Motivation

This will help monitoring processes where the keywords to be searched in process command line doesn't fall in continuation. 
We recently felt the need for this when we wanted to use process check to track some of the Django management commands that were being executed on a server. The commands had below syntax:
```bash
python manage.py <command> <object_id> <sub_command>
```
Where `object_id` changed with every execution, and we wanted to track these processes while being aware of both command and sub_command parameters. So, our instance configuration would look something like below:

```yml
- name: sub_command_1 
  search_string: ['<command> .\w <sub_command_1>'] 
  exact_match: False

- name: sub_command_2 
  search_string: ['<command> .\w <sub_command_2>'] 
  exact_match: False
```
### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
