### PR TITLE
Retry connection once on failure, and correctly send CRITICAL service check if the connection still cannot be made

### DIFF
--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -246,7 +246,7 @@ class VSphereCheck(AgentCheck):
             server_instance.CurrentTime()
         except Exception as e:
             err_msg = (
-                "A connection to {} can be made, but it appears the user {} doesn't have enough permissions: {}"
+                "A connection to {} can be established, but performing operations on the server fails: {}"
             ).format(instance.get('host'), instance.get('username'), e)
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
                                tags=service_check_tags, message=err_msg)

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -244,10 +244,10 @@ class VSphereCheck(AgentCheck):
         # Check that we have sufficient permission for the calls we need to make
         try:
             server_instance.CurrentTime()
-        except Exception:
+        except Exception as e:
             err_msg = (
-                "A connection to {} can be made, but it appears the user {} doesn't have enough permissions"
-            ).format(instance.get('host'), instance.get('username'))
+                "A connection to {} can be made, but it appears the user {} doesn't have enough permissions: {}"
+            ).format(instance.get('host'), instance.get('username'), e)
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
                                tags=service_check_tags, message=err_msg)
             raise ConnectionError(err_msg)


### PR DESCRIPTION
### What does this PR do?

With this PR, when a connection gets broken, the check will first attempt to reconnect, then if it still can't, it will send a CRITICAL service check and fail.

### Motivation

Before this change, a connection could expire, and the check would fail until a restart of the agent, while simply reattempting a connection would be enough.
Plus, when the connection was expired, the method (`RetrieveContent`) we used to test the connection was working would not fail as expected because it didn't require enough privileges on the server (`System.anonymous`, see https://code.vmware.com/apis/358/vsphere#/doc/vim.ServiceInstance.html#retrieveContent). Switch to `CurrentTime` which requires `System.View` privileges, same as all the methods we use in the check to retrieve metrics.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?