### PR TITLE
Adding -e option to test dependencies for datadog packages

### DIFF
--- a/active_directory/tox.ini
+++ b/active_directory/tox.ini
@@ -11,9 +11,9 @@ platform = win32|linux2|darwin
 [testenv:active_directory]
 platform = win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
-    ../datadog_checks_tests_helper
+    -e../datadog_checks_tests_helper
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/activemq_xml/tox.ini
+++ b/activemq_xml/tox.ini
@@ -6,7 +6,7 @@ envlist = activemq_xml, flake8
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 passenv =

--- a/apache/tox.ini
+++ b/apache/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:apache]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 setenv = APACHE_VERSION=2.4.12

--- a/aspdotnet/tox.ini
+++ b/aspdotnet/tox.ini
@@ -11,9 +11,9 @@ platform = win32|linux2|darwin
 [testenv:aspdotnet]
 platform = win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
-    ../datadog_checks_tests_helper
+    -e../datadog_checks_tests_helper
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/btrfs/tox.ini
+++ b/btrfs/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin
 
 [testenv:btrfs]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/cacti/tox.ini
+++ b/cacti/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin|win32
 
 [testenv:cacti]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/cassandra_nodetool/tox.ini
+++ b/cassandra_nodetool/tox.ini
@@ -11,7 +11,7 @@ platform = linux|darwin|win32
 
 [testenv:unit_test]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 setenv =
@@ -22,7 +22,7 @@ commands =
 
 [testenv:integration]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 setenv =

--- a/ceph/tox.ini
+++ b/ceph/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:ceph]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/cisco_aci/tox.ini
+++ b/cisco_aci/tox.ini
@@ -7,7 +7,7 @@ envlist =
 
 [testenv:unit]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/consul/tox.ini
+++ b/consul/tox.ini
@@ -14,7 +14,7 @@ platform = linux|darwin|win32
 
 [common]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/couch/tox.ini
+++ b/couch/tox.ini
@@ -6,7 +6,7 @@ envlist = couch{1_6,2_0}, flake8
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 passenv =

--- a/couchbase/tox.ini
+++ b/couchbase/tox.ini
@@ -9,7 +9,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 passenv =

--- a/datadog_checks_dev/tox.ini
+++ b/datadog_checks_dev/tox.ini
@@ -10,7 +10,7 @@ envlist =
 skip_install = true
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 passenv =

--- a/disk/tox.ini
+++ b/disk/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin
 
 [testenv:disk]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rtests/requirements.txt
 commands =

--- a/dns_check/tox.ini
+++ b/dns_check/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:dns_check]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/dotnetclr/tox.ini
+++ b/dotnetclr/tox.ini
@@ -10,9 +10,9 @@ platform = win32
 
 [testenv:dotnetclr]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
-    ../datadog_checks_tests_helper
+    -e../datadog_checks_tests_helper
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/elastic/tox.ini
+++ b/elastic/tox.ini
@@ -6,7 +6,7 @@ envlist = elastic{0.90,1.0,1.1,1.2,2.4,5.2,5.6,6.0,6.2}, bench, flake8
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/exchange_server/tox.ini
+++ b/exchange_server/tox.ini
@@ -10,9 +10,9 @@ platform = win32
 
 [testenv:exchange_server]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
-    ../datadog_checks_tests_helper
+    -e../datadog_checks_tests_helper
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/fluentd/tox.ini
+++ b/fluentd/tox.ini
@@ -8,7 +8,7 @@ envlist =
 [testenv]
 platform = linux|darwin|winn32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 passenv =

--- a/gearmand/tox.ini
+++ b/gearmand/tox.ini
@@ -8,7 +8,7 @@ envlist =
 [testenv]
 platform = linux|darwin|winn32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 passenv =

--- a/gitlab/tox.ini
+++ b/gitlab/tox.ini
@@ -13,7 +13,7 @@ passenv =
 
 [testenv:gitlab]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/gitlab_runner/tox.ini
+++ b/gitlab_runner/tox.ini
@@ -13,7 +13,7 @@ passenv =
 
 [testenv:gitlab_runner]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/gunicorn/tox.ini
+++ b/gunicorn/tox.ini
@@ -10,7 +10,7 @@ platform = linux
 
 [testenv:gunicorn]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/haproxy/tox.ini
+++ b/haproxy/tox.ini
@@ -18,7 +18,7 @@ passenv =
 
 [common]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/hdfs_datanode/tox.ini
+++ b/hdfs_datanode/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:hdfs_datanode]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/hdfs_namenode/tox.ini
+++ b/hdfs_namenode/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:hdfs_namenode]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/http_check/tox.ini
+++ b/http_check/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:http_check]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/iis/tox.ini
+++ b/iis/tox.ini
@@ -10,9 +10,9 @@ platform = win32
 
 [testenv:iis]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
-    ../datadog_checks_tests_helper
+    -e../datadog_checks_tests_helper
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/istio/tox.ini
+++ b/istio/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:istio]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -r./tests/requirements.txt
 commands =

--- a/kafka_consumer/tox.ini
+++ b/kafka_consumer/tox.ini
@@ -16,7 +16,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 

--- a/kong/tox.ini
+++ b/kong/tox.ini
@@ -13,7 +13,7 @@ passenv =
 
 [testenv:kong]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 setenv = KONG_VERSION=0.13.0

--- a/kube_proxy/tox.ini
+++ b/kube_proxy/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin
 
 [testenv:kube_proxy]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rtests/requirements.txt
 commands =

--- a/kubelet/tox.ini
+++ b/kubelet/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin
 
 [testenv:kubelet]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rtests/requirements.txt
 commands =

--- a/kubernetes_state/tox.ini
+++ b/kubernetes_state/tox.ini
@@ -6,7 +6,7 @@ envlist = unit, flake8
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 

--- a/kyototycoon/tox.ini
+++ b/kyototycoon/tox.ini
@@ -13,7 +13,7 @@ passenv =
 
 [testenv:kyototycoon]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/lighttpd/tox.ini
+++ b/lighttpd/tox.ini
@@ -13,7 +13,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/linkerd/tox.ini
+++ b/linkerd/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:linkerd]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -r./tests/requirements.txt
 commands =

--- a/linux_proc_extras/tox.ini
+++ b/linux_proc_extras/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin
 
 [testenv:linux_proc_extras]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/mapreduce/tox.ini
+++ b/mapreduce/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:mapreduce]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/marathon/tox.ini
+++ b/marathon/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:marathon]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/mcache/tox.ini
+++ b/mcache/tox.ini
@@ -11,7 +11,7 @@ platform = linux|darwin|win32
 
 [testenv:unit]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt
@@ -22,7 +22,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/mongo/tox.ini
+++ b/mongo/tox.ini
@@ -14,7 +14,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -15,7 +15,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/nagios/tox.ini
+++ b/nagios/tox.ini
@@ -8,7 +8,7 @@ envlist =
 
 [testenv]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 platform = linux|darwin|win32

--- a/network/tox.ini
+++ b/network/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin|win32
 
 [testenv:network]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/nfsstat/tox.ini
+++ b/nfsstat/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:nfsstat]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/nginx/tox.ini
+++ b/nginx/tox.ini
@@ -11,7 +11,7 @@ passenv =
 
 [common]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/ntp/tox.ini
+++ b/ntp/tox.ini
@@ -8,7 +8,7 @@ platform = linux|darwin|win32
 
 [testenv:ntp]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/openldap/tox.ini
+++ b/openldap/tox.ini
@@ -9,7 +9,7 @@ envlist =
 [testenv]
 platform = linux|darwin
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 

--- a/openstack/tox.ini
+++ b/openstack/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:openstack]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/oracle/tox.ini
+++ b/oracle/tox.ini
@@ -6,7 +6,7 @@ envlist = oracle, flake8
 [testenv]
 platform = darwin|linux|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 

--- a/pdh_check/tox.ini
+++ b/pdh_check/tox.ini
@@ -11,7 +11,7 @@ platform = win32|linux2|darwin
 [testenv:pdh_check]
 platform = win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt

--- a/pgbouncer/tox.ini
+++ b/pgbouncer/tox.ini
@@ -9,7 +9,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/postgres/tox.ini
+++ b/postgres/tox.ini
@@ -9,7 +9,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/powerdns_recursor/tox.ini
+++ b/powerdns_recursor/tox.ini
@@ -14,7 +14,7 @@ passenv =
 
 [testenv:powerdns373]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 setenv =
@@ -27,7 +27,7 @@ commands =
 
 [testenv:powerdns403]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 setenv =

--- a/process/tox.ini
+++ b/process/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin|windows
 
 [testenv:process]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/prometheus/tox.ini
+++ b/prometheus/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin
 
 [testenv:prometheus]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rtests/requirements.txt
 commands =

--- a/redisdb/tox.ini
+++ b/redisdb/tox.ini
@@ -9,7 +9,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/riak/tox.ini
+++ b/riak/tox.ini
@@ -11,7 +11,7 @@ passenv =
 
 [testenv:riak]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 setenv = REDIS_VERSION=3.2

--- a/spark/tox.ini
+++ b/spark/tox.ini
@@ -8,7 +8,7 @@ platform = linux|darwin|win32
 
 [testenv:spark]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/sqlserver/tox.ini
+++ b/sqlserver/tox.ini
@@ -9,7 +9,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 passenv =

--- a/squid/tox.ini
+++ b/squid/tox.ini
@@ -6,7 +6,7 @@ envlist = unit, squid-latest, flake8
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 

--- a/ssh_check/tox.ini
+++ b/ssh_check/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:ssh_check]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/statsd/tox.ini
+++ b/statsd/tox.ini
@@ -8,7 +8,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/system_core/tox.ini
+++ b/system_core/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:system_core]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/tcp_check/tox.ini
+++ b/tcp_check/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin|windows
 
 [testenv:unit]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/teamcity/tox.ini
+++ b/teamcity/tox.ini
@@ -9,7 +9,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 

--- a/twemproxy/tox.ini
+++ b/twemproxy/tox.ini
@@ -6,7 +6,7 @@ envlist = twemproxy, flake8
 [testenv]
 platform = linux|darwin
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 passenv =

--- a/varnish/tox.ini
+++ b/varnish/tox.ini
@@ -10,7 +10,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 passenv =

--- a/vsphere/tox.ini
+++ b/vsphere/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin
 
 [testenv:vsphere]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/windows_service/tox.ini
+++ b/windows_service/tox.ini
@@ -10,7 +10,7 @@ platform = win32
 
 [testenv:windows_service]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/yarn/tox.ini
+++ b/yarn/tox.ini
@@ -10,7 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:yarn]
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =

--- a/zk/tox.ini
+++ b/zk/tox.ini
@@ -8,7 +8,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =


### PR DESCRIPTION
### What does this PR do?

Adding -e option to test dependencies for datadog packages

### Motivation

This will make it easier to make changes to datadog packages.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

