### PR TITLE
Include ContainerCreating in pod waiting status reasons

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -13,7 +13,7 @@ from datadog_checks.checks.prometheus import PrometheusCheck
 METRIC_TYPES = ['counter', 'gauge']
 
 # As case can vary depending on Kubernetes versions, we match the lowercase string
-WHITELISTED_WAITING_REASONS = ['errimagepull', 'imagepullbackoff', 'crashloopbackoff']
+WHITELISTED_WAITING_REASONS = ['errimagepull', 'imagepullbackoff', 'crashloopbackoff', 'containercreating']
 WHITELISTED_TERMINATED_REASONS = ['oomkilled', 'containercannotrun', 'error']
 
 

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -90,6 +90,7 @@ TAGS = {
         'namespace:kube-system'
     ],
     NAMESPACE + '.container.status_report.count.waiting': [
+        'reason:ContainerCreating',
         'reason:CrashLoopBackoff',  # Lowercase "off"
         'reason:CrashLoopBackOff',  # Uppercase "Off"
         'reason:ErrImagePull',

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -90,8 +90,8 @@ TAGS = {
         'namespace:kube-system'
     ],
     NAMESPACE + '.container.status_report.count.waiting': [
-        'reason:CrashLoopBackoff',
-        'reason:CrashLoopBackOff',
+        'reason:CrashLoopBackoff',  # Lowercase "off"
+        'reason:CrashLoopBackOff',  # Uppercase "Off"
         'reason:ErrImagePull',
         'reason:ImagePullBackoff'
     ]


### PR DESCRIPTION
### What does this PR do?

Adds `ContainerCreating` to the list of whitelisted pod _waiting_ statuses.

### Motivation

I've seen different issues where the container can get stuck in the ContainerCreating status without moving to any of the other listed waiting reasons. For example, a bug in [amazon-vpc-cni-k8s][1] can cause a pod to get stuck in that status if the CNI plugin is unable to assign an IP for the pod. Whitelisting this status allows monitoring for these cases.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

I originally raised the question of whitelisting this status [in another PR][3].

With this reason added to the list, the list now contains all the [possible reasons][2] and is therefore unnecessary barring future addition of reasons. If it were up to me, I'd simply drop the whitelist check, but there seems to be [some opposition][3] to that.

[1]: https://github.com/aws/amazon-vpc-cni-k8s
[2]: https://github.com/kubernetes/kube-state-metrics/blob/bcb230560fe1a32810577762f0b91ad0a5f50d1a/Documentation/pod-metrics.md
[3]: https://github.com/DataDog/integrations-core/pull/1763#issuecomment-407709937