### PR TITLE
Fix Postgres version parsing for beta versions

### DIFF
--- a/postgres/tox.ini
+++ b/postgres/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.0
 basepython = py27
-envlist = unit, postgres{93,94,95,96,10}-pg8000, postgres{93,94,95,96,10}-psycopg2, flake8
+envlist = unit, postgres{93,94,95,96,10,11}-pg8000, postgres{93,94,95,96,10,11}-psycopg2, flake8
 
 [testenv]
 platform = linux|darwin|win32
@@ -9,7 +9,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
+    -e../datadog_checks_base
     -r../datadog_checks_base/requirements.in
     -rrequirements-dev.txt
 commands =
@@ -50,6 +50,11 @@ setenv =
     POSTGRES_VERSION=10
     use_psycopg2=true
 
+[testenv:postgres11-psycopg2]
+setenv =
+    POSTGRES_VERSION=11
+    use_psycopg2=true
+
 #
 # PG8000 lib
 #
@@ -68,6 +73,9 @@ setenv = POSTGRES_VERSION=9.6
 
 [testenv:postgres10-pg8000]
 setenv = POSTGRES_VERSION=10
+
+[testenv:postgres11-pg8000]
+setenv = POSTGRES_VERSION=11
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
### What does this PR do?

Adds minimal support for beta Postgres versions. In other words, the check will attempt to retrieve the same metrics for beta versions it already retrieves for older, official versions, rather than defaulting back to only retrieving < 9.1 metrics.

### Motivation

Users should be given the option to retrieve Postgres metrics from versions the check does not officially support.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes
