### PR TITLE
Remove duplicate project call and reword os_host config option

### DIFF
--- a/openstack/datadog_checks/openstack/data/conf.yaml.example
+++ b/openstack/datadog_checks/openstack/data/conf.yaml.example
@@ -5,7 +5,6 @@ init_config:
       keystone_server_url: "https://my-keystone-server.com:<port>/"
 
       # The hostname of this machine registered with Nova. 
-      # This is the host used to make queries against Nova with
       # Defaults to the Hostname detected by the Agent - https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/
       # os_host: my_hostname
 

--- a/openstack/datadog_checks/openstack/data/conf.yaml.example
+++ b/openstack/datadog_checks/openstack/data/conf.yaml.example
@@ -4,7 +4,9 @@ init_config:
       # Where your identity server lives. Note that the server must support Identity API v3
       keystone_server_url: "https://my-keystone-server.com:<port>/"
 
-      # The hostname of this machine registered with Nova. Defaults to socket.gethostname()
+      # The hostname of this machine registered with Nova. 
+      # This is the host used to make queries against Nova with
+      # Defaults to the Hostname detected by the Agent - https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/
       # os_host: my_hostname
 
       # Nova API version to use - this check supports v2 and v2.1 (default)

--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -1269,10 +1269,6 @@ class OpenStackCheck(AgentCheck):
             if set_external_tags is not None:
                 set_external_tags(self.get_external_host_tags())
 
-            if projects:
-                # Ensure projects list and scoped project exists
-                self.get_stats_for_all_projects(projects)
-
         except IncompleteConfig as e:
             if isinstance(e, IncompleteAuthScope):
                 self.warning(


### PR DESCRIPTION
### What does this PR do?

Removes a duplicate call to retrieve project metrics
More explicit and clear messaging around what the os_host yaml option defaults to. 

### Motivation

Clear documentation and to reduce the number of API calls being made to only whats necessary. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
