### PR TITLE
Allow installation of base dependencies

### DIFF
--- a/datadog_checks_base/setup.py
+++ b/datadog_checks_base/setup.py
@@ -51,5 +51,7 @@ setup(
     packages=['datadog_checks'],
     include_package_data=True,
 
-    install_requires=[],
+    extras_require={
+        'deps': get_requirements('requirements.in'),
+    },
 )


### PR DESCRIPTION
### Motivation

- Allow tests in `integrations-extras` to continue working seamlessly when we release a new version of `datadog_checks_base` to PyPI without deps
- Get rid of `-r../datadog_checks_base/requirements.in` in every `tox.ini`