### PR TITLE
Add cluster-name suffix to node-names in kubernetes state

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
@@ -131,6 +131,7 @@ class PrometheusScraperMixin(object):
         # Some metrics are retrieved from differents hosts and often
         # a label can hold this information, this transfers it to the hostname
         self.label_to_hostname = None
+        self.label_to_hostname_suffix = ""
 
         # Add a "health" service check for the prometheus endpoint
         self.health_service_check = False
@@ -590,7 +591,7 @@ class PrometheusScraperMixin(object):
         if hostname is None and self.label_to_hostname is not None:
             for label in metric.label:
                 if label.name == self.label_to_hostname:
-                    return label.value
+                    return (label.value + self.label_to_hostname_suffix)
 
         return hostname
 

--- a/datadog_checks_base/tests/test_prometheus.py
+++ b/datadog_checks_base/tests/test_prometheus.py
@@ -366,7 +366,14 @@ def test_submit_gauge_with_labels_and_hostname_override(mocked_prometheus_check,
     check.gauge.assert_called_with('prometheus.process.vm.bytes', 39211008.0,
                                    ['my_1st_label:my_1st_label_value', 'node:foo'],
                                    hostname="foo")
-
+    # also test with a hostname suffix
+    check2 = mocked_prometheus_check
+    check2.label_to_hostname = 'node'
+    check2.label_to_hostname_suffix = '-cluster-blue'
+    check2._submit(check2.metrics_mapper[ref_gauge.name], ref_gauge)
+    check.gauge.assert_called_with('prometheus.process.vm.bytes', 39211008.0,
+                                   ['my_1st_label:my_1st_label_value', 'node:foo'],
+                                   hostname="foo-cluster-blue")
 
 def test_submit_gauge_with_labels_and_hostname_already_overridden(mocked_prometheus_check, ref_gauge):
     """ submitting metrics that contain labels should result in tags on the gauge call """

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -9,7 +9,12 @@ from collections import defaultdict, Counter
 from datadog_checks.errors import CheckException
 from datadog_checks.checks.prometheus import PrometheusCheck
 
-from datadog_agent import get_clustername
+try:
+    # this module is only available in agent 6
+    from datadog_agent import get_clustername
+except ImportError:
+    def get_clustername():
+        return ""
 
 
 METRIC_TYPES = ['counter', 'gauge']

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -9,6 +9,8 @@ from collections import defaultdict, Counter
 from datadog_checks.errors import CheckException
 from datadog_checks.checks.prometheus import PrometheusCheck
 
+from datadog_agent import get_clustername
+
 
 METRIC_TYPES = ['counter', 'gauge']
 
@@ -173,6 +175,9 @@ class KubernetesState(PrometheusCheck):
         hostname_override = instances[0].get('hostname_override', True)
         if hostname_override:
             self.label_to_hostname = 'node'
+            clustername = get_clustername()
+            if clustername != "":
+                self.label_to_hostname_suffix = "-" + clustername
 
     def check(self, instance):
         endpoint = instance.get('kube_state_url')


### PR DESCRIPTION
### What does this PR do?
Following PR https://github.com/DataDog/datadog-agent/pull/2172
This fetches the cluster-name defined or auto-detected in the agent and use it in the kubernetes_state check.
This adds a `label_to_hostname_suffix` option in the base `PrometheusCheck` class used by the check.

### Motivation

This allows to fix the duplicated issue while avoiding merging hosts when hostnames have a collision between several clusters.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Tested on a GKE cluster
Mother PR: https://github.com/DataDog/datadog-agent/pull/2172, should be merged _after_