### PR TITLE
Update base dependency in all tox.ini

### DIFF
--- a/active_directory/tox.ini
+++ b/active_directory/tox.ini
@@ -11,8 +11,7 @@ platform = win32|linux2|darwin
 [testenv:active_directory]
 platform = win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt
 commands =

--- a/activemq_xml/tox.ini
+++ b/activemq_xml/tox.ini
@@ -6,8 +6,7 @@ envlist = activemq_xml, flake8
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =
     COMPOSE*

--- a/agent_metrics/tox.ini
+++ b/agent_metrics/tox.ini
@@ -10,8 +10,7 @@ platform = darwin|linux|win32
 
 [testenv:agent_metrics]
 deps =
-    -e../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/apache/tox.ini
+++ b/apache/tox.ini
@@ -10,8 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:apache]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv = APACHE_VERSION=2.4.12
 passenv =

--- a/aspdotnet/tox.ini
+++ b/aspdotnet/tox.ini
@@ -11,8 +11,7 @@ platform = win32|linux2|darwin
 [testenv:aspdotnet]
 platform = win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt
 commands =

--- a/btrfs/tox.ini
+++ b/btrfs/tox.ini
@@ -10,8 +10,7 @@ platform = linux2|darwin
 
 [testenv:btrfs]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/cacti/tox.ini
+++ b/cacti/tox.ini
@@ -10,8 +10,7 @@ platform = linux2|darwin|win32
 
 [testenv:cacti]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/cassandra_nodetool/tox.ini
+++ b/cassandra_nodetool/tox.ini
@@ -11,8 +11,7 @@ platform = linux|darwin|win32
 
 [testenv:unit_test]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =
     CONTAINER_PORT=7199
@@ -22,8 +21,7 @@ commands =
 
 [testenv:integration]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =
     CASSANDRA_VERSION=2.1.14

--- a/ceph/tox.ini
+++ b/ceph/tox.ini
@@ -10,8 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:ceph]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/cisco_aci/tox.ini
+++ b/cisco_aci/tox.ini
@@ -7,8 +7,7 @@ envlist =
 
 [testenv:unit]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/consul/tox.ini
+++ b/consul/tox.ini
@@ -14,8 +14,7 @@ platform = linux|darwin|win32
 
 [common]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/couch/tox.ini
+++ b/couch/tox.ini
@@ -6,8 +6,7 @@ envlist = couch{1_6,2_0}, flake8
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =
     COMPOSE*

--- a/couchbase/tox.ini
+++ b/couchbase/tox.ini
@@ -9,8 +9,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =
     DOCKER*

--- a/directory/tox.ini
+++ b/directory/tox.ini
@@ -10,8 +10,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    -e../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/disk/tox.ini
+++ b/disk/tox.ini
@@ -10,8 +10,7 @@ platform = linux2|darwin
 
 [testenv:disk]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/dns_check/tox.ini
+++ b/dns_check/tox.ini
@@ -10,8 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:dns_check]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/dotnetclr/tox.ini
+++ b/dotnetclr/tox.ini
@@ -10,8 +10,7 @@ platform = win32
 
 [testenv:dotnetclr]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt
 commands =

--- a/elastic/tox.ini
+++ b/elastic/tox.ini
@@ -6,8 +6,7 @@ envlist = elastic{0.90,1.0,1.1,1.2,2.4,5.2,5.6,6.0,6.2}, bench, flake8
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/envoy/tox.ini
+++ b/envoy/tox.ini
@@ -10,8 +10,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    -e../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =
     DOCKER*

--- a/etcd/tox.ini
+++ b/etcd/tox.ini
@@ -9,8 +9,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    -e../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =
     DOCKER*

--- a/exchange_server/tox.ini
+++ b/exchange_server/tox.ini
@@ -10,8 +10,7 @@ platform = win32
 
 [testenv:exchange_server]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt
 commands =

--- a/fluentd/tox.ini
+++ b/fluentd/tox.ini
@@ -8,8 +8,7 @@ envlist =
 [testenv]
 platform = linux|darwin|winn32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =
     COMPOSE*

--- a/gearmand/tox.ini
+++ b/gearmand/tox.ini
@@ -8,8 +8,7 @@ envlist =
 [testenv]
 platform = linux|darwin|winn32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =
     COMPOSE*

--- a/gitlab/tox.ini
+++ b/gitlab/tox.ini
@@ -12,8 +12,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/gitlab_runner/tox.ini
+++ b/gitlab_runner/tox.ini
@@ -13,8 +13,7 @@ passenv =
 
 [testenv:gitlab_runner]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/gunicorn/tox.ini
+++ b/gunicorn/tox.ini
@@ -10,8 +10,7 @@ platform = linux
 
 [testenv:gunicorn]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/haproxy/tox.ini
+++ b/haproxy/tox.ini
@@ -18,8 +18,7 @@ passenv =
 
 [common]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/hdfs_datanode/tox.ini
+++ b/hdfs_datanode/tox.ini
@@ -10,8 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:hdfs_datanode]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/hdfs_namenode/tox.ini
+++ b/hdfs_namenode/tox.ini
@@ -10,8 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:hdfs_namenode]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/http_check/tox.ini
+++ b/http_check/tox.ini
@@ -9,8 +9,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 
 [testenv:unit]

--- a/iis/tox.ini
+++ b/iis/tox.ini
@@ -10,8 +10,7 @@ platform = win32
 
 [testenv:iis]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt
 commands =

--- a/kafka_consumer/tox.ini
+++ b/kafka_consumer/tox.ini
@@ -16,8 +16,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 
 [testenv:kafkaconsumer-0_9_0_1-kafka]

--- a/kong/tox.ini
+++ b/kong/tox.ini
@@ -13,8 +13,7 @@ passenv =
 
 [testenv:kong]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv = KONG_VERSION=0.13.0
 commands =

--- a/kubelet/tox.ini
+++ b/kubelet/tox.ini
@@ -10,8 +10,7 @@ platform = linux2|darwin
 
 [testenv:kubelet]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/kubernetes_state/tox.ini
+++ b/kubernetes_state/tox.ini
@@ -6,8 +6,7 @@ envlist = unit, flake8
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 
 [testenv:unit]

--- a/kyototycoon/tox.ini
+++ b/kyototycoon/tox.ini
@@ -13,8 +13,7 @@ passenv =
 
 [testenv:kyototycoon]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/lighttpd/tox.ini
+++ b/lighttpd/tox.ini
@@ -13,8 +13,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/linkerd/tox.ini
+++ b/linkerd/tox.ini
@@ -10,8 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:linkerd]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/linux_proc_extras/tox.ini
+++ b/linux_proc_extras/tox.ini
@@ -10,8 +10,7 @@ platform = linux2|darwin
 
 [testenv:linux_proc_extras]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/mapreduce/tox.ini
+++ b/mapreduce/tox.ini
@@ -10,8 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:mapreduce]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/marathon/tox.ini
+++ b/marathon/tox.ini
@@ -9,8 +9,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 
 [testenv:unit]

--- a/mcache/tox.ini
+++ b/mcache/tox.ini
@@ -11,7 +11,7 @@ platform = linux|darwin|win32
 
 [testenv:unit]
 deps =
-    ../datadog_checks_base
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt
@@ -22,8 +22,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/mongo/tox.ini
+++ b/mongo/tox.ini
@@ -14,8 +14,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -15,8 +15,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/nagios/tox.ini
+++ b/nagios/tox.ini
@@ -8,8 +8,7 @@ envlist =
 
 [testenv]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 platform = linux|darwin|win32
 

--- a/network/tox.ini
+++ b/network/tox.ini
@@ -10,8 +10,7 @@ platform = linux2|darwin|win32
 
 [testenv:network]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/nfsstat/tox.ini
+++ b/nfsstat/tox.ini
@@ -10,8 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:nfsstat]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/nginx/tox.ini
+++ b/nginx/tox.ini
@@ -11,8 +11,7 @@ passenv =
 
 [common]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/ntp/tox.ini
+++ b/ntp/tox.ini
@@ -8,8 +8,7 @@ platform = linux|darwin|win32
 
 [testenv:ntp]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/openldap/tox.ini
+++ b/openldap/tox.ini
@@ -9,8 +9,7 @@ envlist =
 [testenv]
 platform = linux|darwin
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 
 [testenv:unit]

--- a/openstack/tox.ini
+++ b/openstack/tox.ini
@@ -10,8 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:openstack]
 deps =
-    -e../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/oracle/tox.ini
+++ b/oracle/tox.ini
@@ -6,8 +6,7 @@ envlist = oracle, flake8
 [testenv]
 platform = darwin|linux|win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 
 [testenv:oracle]

--- a/pdh_check/tox.ini
+++ b/pdh_check/tox.ini
@@ -11,8 +11,7 @@ platform = win32|linux2|darwin
 [testenv:pdh_check]
 platform = win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt
 commands =

--- a/pgbouncer/tox.ini
+++ b/pgbouncer/tox.ini
@@ -9,8 +9,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/php_fpm/tox.ini
+++ b/php_fpm/tox.ini
@@ -13,8 +13,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    -e../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 
 [testenv:unit]

--- a/powerdns_recursor/tox.ini
+++ b/powerdns_recursor/tox.ini
@@ -14,8 +14,7 @@ passenv =
 
 [testenv:powerdns373]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =
   POWERDNS_VERSION=3.7.3
@@ -27,8 +26,7 @@ commands =
 
 [testenv:powerdns403]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =
   POWERDNS_VERSION=4.0.3

--- a/process/tox.ini
+++ b/process/tox.ini
@@ -10,8 +10,7 @@ platform = linux2|darwin|windows
 
 [testenv:process]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/prometheus/tox.ini
+++ b/prometheus/tox.ini
@@ -10,8 +10,7 @@ platform = linux2|darwin
 
 [testenv:prometheus]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pytest

--- a/rabbitmq/tox.ini
+++ b/rabbitmq/tox.ini
@@ -10,8 +10,7 @@ envlist =
 [testenv]
 platform = linux|darwin|winn32
 deps =
-    -e../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =
     COMPOSE*

--- a/redisdb/tox.ini
+++ b/redisdb/tox.ini
@@ -9,8 +9,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/riak/tox.ini
+++ b/riak/tox.ini
@@ -11,8 +11,7 @@ passenv =
 
 [testenv:riak]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv = REDIS_VERSION=3.2
 commands =

--- a/spark/tox.ini
+++ b/spark/tox.ini
@@ -8,8 +8,7 @@ platform = linux|darwin|win32
 
 [testenv:spark]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/sqlserver/tox.ini
+++ b/sqlserver/tox.ini
@@ -9,8 +9,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =
     DOCKER*

--- a/squid/tox.ini
+++ b/squid/tox.ini
@@ -6,8 +6,7 @@ envlist = unit, squid-latest, flake8
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 
 [testenv:unit]

--- a/ssh_check/tox.ini
+++ b/ssh_check/tox.ini
@@ -10,8 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:ssh_check]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/statsd/tox.ini
+++ b/statsd/tox.ini
@@ -8,8 +8,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/supervisord/tox.ini
+++ b/supervisord/tox.ini
@@ -10,8 +10,7 @@ envlist =
 platform = linux|darwin|win32
 setenv = SUPERVISOR_IMAGE=datadog/docker-library:supervisord_3_3_3
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt
@@ -20,8 +19,7 @@ commands =
 [testenv:unit]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/system_core/tox.ini
+++ b/system_core/tox.ini
@@ -10,8 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:system_core]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/tcp_check/tox.ini
+++ b/tcp_check/tox.ini
@@ -10,7 +10,7 @@ platform = linux2|darwin|windows
 
 [testenv:unit]
 deps =
-    ../datadog_checks_base
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/teamcity/tox.ini
+++ b/teamcity/tox.ini
@@ -9,8 +9,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 
 [testenv:teamcity]

--- a/twemproxy/tox.ini
+++ b/twemproxy/tox.ini
@@ -6,8 +6,7 @@ envlist = twemproxy, flake8
 [testenv]
 platform = linux|darwin
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =
     COMPOSE*

--- a/varnish/tox.ini
+++ b/varnish/tox.ini
@@ -10,8 +10,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =
     DOCKER*

--- a/vault/tox.ini
+++ b/vault/tox.ini
@@ -10,8 +10,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    -e../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =
     DOCKER*

--- a/vsphere/tox.ini
+++ b/vsphere/tox.ini
@@ -10,8 +10,7 @@ platform = linux2|darwin
 
 [testenv:vsphere]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/yarn/tox.ini
+++ b/yarn/tox.ini
@@ -10,8 +10,7 @@ platform = linux|darwin|win32
 
 [testenv:yarn]
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt

--- a/zk/tox.ini
+++ b/zk/tox.ini
@@ -8,8 +8,7 @@ envlist =
 [testenv]
 platform = linux|darwin|win32
 deps =
-    ../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt


### PR DESCRIPTION
### Motivation

Avoid need for extra step to install deps

### Additional Notes

Script (Python 3 only)

```python
import os
import re

CORE_DIR = r'C:\Users\ofek.lev\Desktop\code\integrations-core'
CHECKS_BASE_PATTERN = re.compile(rb'..(/|\\)datadog_checks_base$', re.M)
CHECKS_BASE_REQS_PATTERN = re.compile(
    rb'^ *-r../datadog_checks_base/requirements\.in$.', re.M | re.S
)


def get_tox_file(check_name):
    f = os.path.join(CORE_DIR, check_name, 'tox.ini')
    if os.path.isfile(f):
        return f


def main():
    for check_name in os.listdir(CORE_DIR):
        tox_file = get_tox_file(check_name)
        if tox_file:
            with open(tox_file, 'rb') as f:
                tox_contents = f.read()

            tox_contents = CHECKS_BASE_PATTERN.sub(
                b'../datadog_checks_base[deps]',
                tox_contents
            )

            tox_contents = CHECKS_BASE_REQS_PATTERN.sub(
                b'',
                tox_contents
            )

            with open(tox_file, 'wb') as f:
                f.write(tox_contents)


if __name__ == '__main__':
    main()
```