### PR TITLE
change boolean values in config from yes/no to true/false

### DIFF
--- a/agent_metrics/datadog_checks/agent_metrics/data/conf.yaml.default
+++ b/agent_metrics/datadog_checks/agent_metrics/data/conf.yaml.default
@@ -6,16 +6,16 @@ init_config:
     process_metrics:
         - name: memory_info
           type: gauge
-          active: yes
+          active: true
         - name: io_counters
           type: rate
-          active: yes
+          active: true
         - name: num_threads
           type: gauge
-          active: yes
+          active: true
         - name: connections
           type: gauge
-          active: no
+          active: false
 
 instances:
   - tags:

--- a/consul/README.md
+++ b/consul/README.md
@@ -46,12 +46,12 @@ See the [sample consul.d/conf.yaml][2] for all available configuration options.
           # client_cert_file: '/path/to/client.concatenated.pem'
 
           # submit per-service node status and per-node service status?
-          catalog_checks: yes
+          catalog_checks: true
 
           # emit leader election events
-          self_leader_check: yes
+          self_leader_check: true
 
-          network_latency_checks: yes
+          network_latency_checks: true
     ```
 
     See the [sample consul.d/conf.yaml][2] for all available configuration options.

--- a/consul/datadog_checks/consul/data/auto_conf.yaml
+++ b/consul/datadog_checks/consul/data/auto_conf.yaml
@@ -5,6 +5,6 @@ init_config:
 
 instances:
   - url: "http://%%host%%:8500"
-    catalog_checks: yes
-    new_leader_checks: yes
+    catalog_checks: true
+    new_leader_checks: true
     # service_whitelist:

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -24,26 +24,26 @@ instances:
       # acl_token: 'token'
 
       # Whether to perform checks against the Consul service Catalog
-      catalog_checks: yes
+      catalog_checks: true
 
       # Whether to enable self leader checks. Each instance with this enabled will
       # watch for itself to become the leader and will emit an event when that
       # happens. It is safe/expected to enable this on all nodes in a consul
       # cluster since only the new leader will emit the (single) event. This
       # flag takes precedence over new_leader_checks.
-      self_leader_check: yes
+      self_leader_check: true
 
       # Whether to enable new leader checks from this instance
       # Note: if this is set on multiple instances/agents in the same cluster
       # you will receive one event per leader change per instance. See
       # self_leader_check for a more robust option.
-      new_leader_checks: yes
+      new_leader_checks: true
 
       # Whether to enable network latency metrics collection. When enabled
       # consul network coordinates will be retrieved and latency calculated for
       # each node and between data centers.
       # See https://www.consul.io/docs/internals/coordinates.html
-      network_latency_checks: yes
+      network_latency_checks: true
 
       # Services to restrict catalog querying to
       # The default settings query up to 50 services. So if you have more than
@@ -74,7 +74,7 @@ instances:
     #   source : (mandatory) attribute that defines which integration is sending the logs
     #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
     #   tags: (optional) add tags to each logs collected
-    
+
     # - type: file
     #   path: /var/log/consul_server.log
     #   source: consul

--- a/disk/datadog_checks/disk/data/conf.yaml.default
+++ b/disk/datadog_checks/disk/data/conf.yaml.default
@@ -7,7 +7,7 @@ init_config:
 instances:
   # The use_mount parameter will instruct the check to collect disk
   # and fs metrics using mount points instead of volumes
-  - use_mount: no
+  - use_mount: false
     # The (optional) excluded_filesystems parameter will instruct the check to
     # ignore disks using these filesystems. Note: On some linux distributions,
     # rootfs will be found and tagged as a device, add rootfs here to exclude.
@@ -31,7 +31,7 @@ instances:
     #
     # The (optional) tag_by_filesystem parameter will instruct the check to
     # tag all disks with their filesystem (for ex: filesystem:nfs).
-    # tag_by_filesystem: no
+    # tag_by_filesystem: false
     #
     # The (optional) excluded_mountpoint_re parameter will instruct the check to
     # ignore all mountpoints matching this regex.
@@ -40,7 +40,7 @@ instances:
     # The (optional) all_partitions parameter will instruct the check to
     # get metrics for all partitions. use_mount should be set to yes (to avoid
     # collecting empty device names) when using this option.
-    # all_partitions: no
+    # all_partitions: false
     #
     # The (optional) device_tag_re parameter will instruct the check to apply additional tags to
     # volumes/mountpoints matching these regexes. Multiple comma-separated tags are supported.

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -151,7 +151,7 @@ class Disk(AgentCheck):
 
         name_empty = not name or name == 'none'
 
-        # allow empty names if `all_partitions` is `yes` so we can evaluate mountpoints
+        # allow empty names if `all_partitions` is `true` so we can evaluate mountpoints
         if name_empty and not self._all_partitions:
             return True
         # device is listed in `excluded_disks`

--- a/mesos_master/README.md
+++ b/mesos_master/README.md
@@ -23,7 +23,7 @@ docker run -d --name datadog-agent \
   -v /proc/:/host/proc/:ro \
   -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
   -e DD_API_KEY=<YOUR_DATADOG_API_KEY> \
-  -e MESOS_MASTER=yes \
+  -e MESOS_MASTER=true \
   -e MARATHON_URL=http://leader.mesos:8080 \
   datadog/agent:latest
 ```
@@ -43,7 +43,7 @@ Datadog Agent version 6 and greater can collect logs from containers. You can ei
 Add those extra variables to the Datadog Agent run command to start collecting logs:
 
 * `-e DD_LOGS_ENABLED=true`: this enables the log collection when set to `true`. The Agent now looks for log instructions in configuration files or container labels
-* `-e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true`: this enables log collection for all containers 
+* `-e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true`: this enables log collection for all containers
 * `-v /opt/datadog-agent/run:/opt/datadog-agent/run:rw`: this mounts the directory the Agent uses to store pointers on each container logs to track what have been sent to Datadog or not.
 
 This gives the following command:
@@ -55,7 +55,7 @@ docker run -d --name datadog-agent \
   -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
   -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
   -e DD_API_KEY=<YOUR_DATADOG_API_KEY> \
-  -e MESOS_MASTER=yes \
+  -e MESOS_MASTER=true \
   -e MARATHON_URL=http://leader.mesos:8080 \
   -e DD_LOGS_ENABLED=true \
   -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \


### PR DESCRIPTION
### What does this PR do?
Changes all boolean values in agent 6 config files from `yes`/`no` to `true`/`false`.

### Motivation
Sister of https://github.com/DataDog/datadog-agent/pull/2171
Main goal was to avoid confusion when using environment variable instead of config files as `yes`/`no` is not supported in that case.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

