### PR TITLE
Adding check for stratum > 15 to ignore out of sync servers

### DIFF
--- a/ntp/datadog_checks/ntp/ntp.py
+++ b/ntp/datadog_checks/ntp/ntp.py
@@ -66,7 +66,7 @@ class NtpCheck(AgentCheck):
                 # Anything over 15 is considered an unsynced source, or problematic
                 # and should not be relied on.
                 self.log.debug("Stratum ({}) too high for sync checking, Host: {}".format(ntp_stats.stratum,
-                    req_args['host']))
+                                                                                          req_args['host']))
                 status = AgentCheck.UNKNOWN
                 ntp_ts = None
 


### PR DESCRIPTION
### What does this PR do?

This adds a check to see if the stratum of the time server being checked is over 15, and exits with an unknown if it is. a stratum of 16 is an unsynced device and should not be trusted for checking.

### Motivation

Alarms causing false pages due to the datadog ntp pool having a stratum 16 server, and 10 seconds out of sync.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Case 163157
