### PR TITLE
Adding optional service_check_rw parameter to check for read-only filesystem

### DIFF
--- a/disk/CHANGELOG.md
+++ b/disk/CHANGELOG.md
@@ -1,9 +1,5 @@
 # CHANGELOG - disk
 
-## 1.3.0 / 2018-08-21
-
-* [FEATURE] Adds optional read-only filesystem check
-
 ## 1.2.0 / 2018-03-23
 
 * [FEATURE] Adds custom tag support

--- a/disk/CHANGELOG.md
+++ b/disk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - disk
 
+## 1.3.0 / 2018-08-21
+
+* [FEATURE] Adds optional read-only filesystem check
+
 ## 1.2.0 / 2018-03-23
 
 * [FEATURE] Adds custom tag support

--- a/disk/README.md
+++ b/disk/README.md
@@ -27,7 +27,9 @@ See [metadata.csv][4] for a list of metrics provided by this integration.
 The Disk check does not include any events at this time.
 
 ### Service Checks
-The Disk check does not include any service checks at this time.
+
+**`disk.service_check_rw`**:
+Returns `CRITICAL` if filesystem is in read-only mode.
 
 ## Troubleshooting
 Need help? Contact [Datadog Support][5].

--- a/disk/datadog_checks/disk/data/conf.yaml.default
+++ b/disk/datadog_checks/disk/data/conf.yaml.default
@@ -55,3 +55,7 @@ instances:
     # tags:
     #   - optional_tag1
     #   - optional_tag2
+    #
+    # The (optional) service_check_rw parameter notifies when one of the partitions is in
+    # read-only mode
+    # service_check_rw: no

--- a/disk/datadog_checks/disk/data/conf.yaml.default
+++ b/disk/datadog_checks/disk/data/conf.yaml.default
@@ -58,4 +58,4 @@ instances:
     #
     # The (optional) service_check_rw parameter notifies when one of the partitions is in
     # read-only mode
-    # service_check_rw: no
+    # service_check_rw: false

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -130,14 +130,20 @@ class Disk(AgentCheck):
                            tags=tags, device_name=device_name)
 
             # Add in a disk read write or read only check
-            if self.instances[0].get('service_check_rw', False):
+            if self._service_check_rw:
                 rwro = list(set(['rw', 'ro']) & set(part.opts.split(',')))
                 if len(rwro) == 1:
                     self.service_check(
                         'disk.read_write',
                         AgentCheck.OK if rwro[0] == 'rw' else AgentCheck.CRITICAL,
-                        tags=tags+['device_name:%s' % (device_name)]
+                        tags=tags+['device:%s' % (device_name)]
                     )
+                else:
+                    self.service_check(
+                        'disk.read_write', AgentCheck.UNKNOWN,
+                        tags=tags+['device:%s' % (device_name)]
+                    )
+
 
         self.collect_latency_metrics()
 

--- a/disk/service_checks.json
+++ b/disk/service_checks.json
@@ -1,0 +1,11 @@
+[
+    {
+        "agent_version": "5.22.3",
+        "integration":"disk",
+        "check": "disk.service_check_rw",
+        "statuses": ["ok", "critical", "unknown"],
+        "groups": ["device"],
+        "name": "Disk read_write",
+        "description": "Returns `CRITICAL` if filesystem is in read-only mode."
+    }
+]

--- a/disk/service_checks.json
+++ b/disk/service_checks.json
@@ -1,6 +1,6 @@
 [
     {
-        "agent_version": "5.22.3",
+        "agent_version": "6.5.0",
         "integration":"disk",
         "check": "disk.service_check_rw",
         "statuses": ["ok", "critical", "unknown"],

--- a/disk/tests/test_check.py
+++ b/disk/tests/test_check.py
@@ -234,7 +234,7 @@ def test_psutil_rw(aggregator, psutil_mocks):
     c = Disk('disk', None, {}, instances)
     c.check(instances[0])
 
-    aggregator.assert_service_check('disk.read_write', status=2)
+    aggregator.assert_service_check('disk.read_write', status=Disk.CRITICAL)
 
 def mock_df_output(fname):
     """

--- a/disk/tests/test_check.py
+++ b/disk/tests/test_check.py
@@ -49,10 +49,11 @@ RATES_VALUES = {
 
 
 class MockPart(object):
-    def __init__(self, device=DEFAULT_DEVICE_NAME, fstype='ext4', mountpoint='/'):
+    def __init__(self, device=DEFAULT_DEVICE_NAME, fstype='ext4', mountpoint='/', opts='ro'):
         self.device = device
         self.fstype = fstype
         self.mountpoint = mountpoint
+        self.opts = opts
 
 
 class MockDiskMetrics(object):
@@ -121,6 +122,7 @@ def test_default_options():
     assert check._all_partitions is False
     assert check._excluded_disk_re == re.compile('^$')
     assert check._device_tag_re == []
+    assert check._service_check_rw is False
 
 def test_disk_check(aggregator):
     """
@@ -223,6 +225,16 @@ def test_use_mount(aggregator, psutil_mocks):
         aggregator.assert_metric(name, value=value, tags=['device:{}'.format(DEFAULT_DEVICE_NAME)])
 
     assert aggregator.metrics_asserted_pct == 100.0
+
+def test_psutil_rw(aggregator, psutil_mocks):
+    """
+    Check for 'ro' option in the mounts
+    """
+    instances = [{'service_check_rw': 'yes'}]
+    c = Disk('disk', None, {}, instances)
+    c.check(instances[0])
+
+    aggregator.assert_service_check('disk.read_write', status=2)
 
 def mock_df_output(fname):
     """


### PR DESCRIPTION
### What does this PR do?

This PR adds read-write/read-only service check for disk.py which notifies if any of the disks are in read-only state.

### Motivation

We need this functionality in our production environment in addition to standard disk metrics in order to catch any of the disks falling back to read-only mode.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

The test for this change passes our local testing environment replicated from TravisCI configuration
