### PR TITLE
Change metadata.csv from histogram to gauge

### DIFF
--- a/gitlab_runner/metadata.csv
+++ b/gitlab_runner/metadata.csv
@@ -1,13 +1,13 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-gitlab_runner.ci_docker_machines_provider_machine_creation_duration_seconds_bucket,histogram,,request,second,Histogram of Docker machine creation time,0,gitlab_runner,docker machine creation time
+gitlab_runner.ci_docker_machines_provider_machine_creation_duration_seconds_bucket,gauge,,request,second,Histogram of Docker machine creation time,0,gitlab_runner,docker machine creation time
 gitlab_runner.ci_docker_machines_provider_machine_creation_duration_seconds_sum,gauge,,request,second,Sum of Docker machine creation time,0,gitlab_runner,sum docker machine creation time
 gitlab_runner.ci_docker_machines_provider_machine_creation_duration_seconds_count,gauge,,request,second,Count of Docker machine creation time,0,gitlab_runner,count docker machine creation time
 gitlab_runner.ci_docker_machines_provider_machine_states,gauge,,request,second,The current number of machines per state in this provider,0,gitlab_runner,total docker machines per state
 gitlab_runner.ci_runner_errors,counter,,request,second,The number of catched errors,0,gitlab_runner,errors
 gitlab_runner.ci_runner_version_info,gauge,,request,,A metric with a constant '1' value labeled by different build stats fields,0,gitlab_runner,version info
-gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_bucket,histogram,,request,second,Histogram of SSH Docker machine creation time,0,gitlab_runner,ssh docker machine creation time
-gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_sum,histogram,,request,second,Sum of SSH Docker machine creation time,0,gitlab_runner,sum ssh docker machine creation time
-gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_count,histogram,,request,second,Count of SSH Docker machine creation time,0,gitlab_runner,count ssh docker machine creation time
+gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_bucket,gauge,,request,second,Histogram of SSH Docker machine creation time,0,gitlab_runner,ssh docker machine creation time
+gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_sum,gauge,,request,second,Sum of SSH Docker machine creation time,0,gitlab_runner,sum ssh docker machine creation time
+gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_count,gauge,,request,second,Count of SSH Docker machine creation time,0,gitlab_runner,count ssh docker machine creation time
 gitlab_runner.ci_ssh_docker_machines_provider_machine_states,gauge,,request,second,The current number of machines per state in this provider,0,gitlab_runner,total ssh docker machines per state
 gitlab_runner.go_gc_duration_seconds,gauge,,request,second,A summary of the GC invocation durations,0,gitlab_runner,gc duration
 gitlab_runner.go_gc_duration_seconds_sum,gauge,,request,second,Sum of the GC invocation durations,0,gitlab_runner,sum gc duration


### PR DESCRIPTION
### What does this PR do?

Fixes the metrics_metadata for gitlab_runner, changes the type from `histogram` -> `gauge`

### Motivation

Prep for creating the tile

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
