### PR TITLE
 Fix `KeyError` due to race condition on the cache

### DIFF
--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -4,7 +4,7 @@ init_config:
   # If too many API calls are made by the check, consider increasing this value
   # If payloads are too large, consider decreasing this value
   # A value <= 0 means unlimited: it will make one query for all the monitored objects
-  # Default to 50
+  # Optional, default to 50
   # batch_morlist_size: 50
 
   # This value is used to determine the maximum number of MORs returned by vCenter in the same API call,
@@ -12,8 +12,23 @@ init_config:
   # If too many API calls are made by the check, consider increasing this value
   # If payloads are too large, consider decreasing this value
   # A value <= 0 means unlimited: it will query for the maximum number of objects at once
-  # Default to 500
+  # Optional, default to 500
   # batch_property_collector_size: 500
+
+  # Number of seconds between each discovering and caching of your vSphere environment
+  # Consider increasing this value if your environment is large, as caching can take some time to complete
+  # Optional, default to 180 seconds
+  # refresh_morlist_interval: 180
+
+  # Number of seconds to wait before an object is considered deleted from your vSphere environment and removed from the cache
+  # This value should be higher than refresh_morlist_interval.
+  # Optional, default to 2 * refresh_morlist_interval
+  # clean_morlist_interval: 360
+
+  # Number of seconds between each refresh of the metrics metadata cache
+  # Optional, default to 600 seconds
+  # refresh_metrics_metadata_interval: 600
+
 
 # Define your list of instances here
 # each item is a vCenter instance you want to connect to and

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -9,7 +9,6 @@ from Queue import Empty, Queue
 import re
 import ssl
 import time
-import threading
 import traceback
 
 from pyVim import connect
@@ -150,7 +149,6 @@ class VSphereCheck(AgentCheck):
         self.morlist_raw = {}
         # Second layer, processed from the first one
         self.morlist = {}
-        self.morlist_lock = threading.RLock()
         # Metrics metadata, basically perfCounterId -> {name, group, description}
         self.metrics_metadata = {}
         self.latest_event_query = {}
@@ -335,18 +333,16 @@ class VSphereCheck(AgentCheck):
         external_host_tags = []
         for instance in self.instances:
             i_key = self._instance_key(instance)
-            with self.morlist_lock:
-                mor_by_mor_name = self.morlist.get(i_key)
+            mor_by_mor_name = self.morlist.get(i_key)
 
-                if not mor_by_mor_name:
-                    self.log.warning(
-                        u"Unable to extract hosts' tags for vSphere instance named %s. "
-                        u"Is the check failing on this instance?", i_key
-                    )
-                    continue
-                mors = list(mor_by_mor_name.values())
+            if not mor_by_mor_name:
+                self.log.warning(
+                    u"Unable to extract hosts' tags for vSphere instance named %s. "
+                    u"Is the check failing on this instance?", i_key
+                )
+                continue
 
-            for mor in mors:
+            for mor in list(mor_by_mor_name.values()):
                 if mor.get('hostname'):  # some mor's have a None hostname
                     external_host_tags.append((mor['hostname'], {SOURCE_TYPE: mor['tags']}))
 
@@ -516,6 +512,9 @@ class VSphereCheck(AgentCheck):
     def _cache_morlist_raw_atomic(self, instance, tags, regexes=None, include_only_marked=False):
         i_key = self._instance_key(instance)
         server_instance = self._get_server_instance(instance)
+        if i_key not in self.morlist_raw:
+            self.morlist_raw[i_key] = {}
+
         all_objs = self._get_all_objs(server_instance, regexes, include_only_marked, tags)
         self.morlist_raw[i_key] = {resource: objs for resource, objs in all_objs.items()}
 
@@ -566,7 +565,7 @@ class VSphereCheck(AgentCheck):
         i_key = self._instance_key(instance)
         self.log.debug("Caching the morlist for vcenter instance %s" % i_key)
         for resource_type in RESOURCE_TYPE_METRICS:
-            if len(self.morlist_raw.get(i_key, {}).get(resource_type, [])) > 0:
+            if i_key in self.morlist_raw and len(self.morlist_raw[i_key].get(resource_type, [])) > 0:
                 self.log.debug(
                     "Skipping morlist collection now, RAW results "
                     "processing not over (latest refresh was {0}s ago)".format(
@@ -612,14 +611,13 @@ class VSphereCheck(AgentCheck):
         for mor_perfs in res:
             mor_name = str(mor_perfs.entity)
             available_metrics = [value.id for value in mor_perfs.value]
-            with self.morlist_lock:
-                try:
-                    self.morlist[i_key][mor_name]['metrics'] = self._compute_needed_metrics(instance, available_metrics)
-                    self.morlist[i_key][mor_name]['last_seen'] = time.time()
-                except KeyError:
-                    self.log.error("Trying to compute needed metrics from object %s deleted from the cache, skipping. "
-                                   "Consider increasing the parameter `clean_morlist_interval` to avoid that", mor_name)
-                    continue
+            try:
+                self.morlist[i_key][mor_name]['metrics'] = self._compute_needed_metrics(instance, available_metrics)
+                self.morlist[i_key][mor_name]['last_seen'] = time.time()
+            except KeyError:
+                self.log.error("Trying to compute needed metrics from object %s deleted from the cache, skipping. "
+                               "Consider increasing the parameter `clean_morlist_interval` to avoid that", mor_name)
+                continue
 
         # ## <TEST-INSTRUMENTATION>
         self.histogram('datadog.agent.vsphere.morlist_process_atomic.time', t.total(), tags=instance.get('tags', []))
@@ -644,10 +642,9 @@ class VSphereCheck(AgentCheck):
                     mor = self.morlist_raw[i_key][resource_type].pop()
                     mor_name = str(mor["mor"])
                     mor["interval"] = REAL_TIME_INTERVAL if mor['mor_type'] in REALTIME_RESOURCES else None
-                    with self.morlist_lock:
-                        if mor_name not in self.morlist[i_key]:
-                            self.morlist[i_key][mor_name] = mor
-                            self.morlist[i_key][mor_name]["last_seen"] = time.time()
+                    if mor_name not in self.morlist[i_key]:
+                        self.morlist[i_key][mor_name] = mor
+                        self.morlist[i_key][mor_name]["last_seen"] = time.time()
 
                     query_spec = vim.PerformanceManager.QuerySpec()
                     query_spec.entity = mor["mor"]
@@ -667,13 +664,13 @@ class VSphereCheck(AgentCheck):
         we cannot get any metrics from them anyway (or =0)
         """
         i_key = self._instance_key(instance)
-        with self.morlist_lock:
-            morlist = self.morlist[i_key].items()
-            for mor_name, mor in morlist:
-                last_seen = mor['last_seen']
-                if (time.time() - last_seen) > self.clean_morlist_interval:
-                    self.log.debug("Deleting %s from the cache", mor_name)
-                    del self.morlist[i_key][mor_name]
+        morlist = self.morlist[i_key].items()
+
+        for mor_name, mor in morlist:
+            last_seen = mor['last_seen']
+            if (time.time() - last_seen) > self.clean_morlist_interval:
+                self.log.debug("Deleting %s from the cache", mor_name)
+                del self.morlist[i_key][mor_name]
 
     def _cache_metrics_metadata(self, instance):
         """ Get from the server instance, all the performance counters metadata
@@ -735,15 +732,12 @@ class VSphereCheck(AgentCheck):
         if results:
             for mor_perfs in results:
                 mor_name = str(mor_perfs.entity)
-                with self.morlist_lock:
-                    try:
-                        mor = self.morlist[i_key][mor_name]
-                    except KeyError:
-                        self.log.error(
-                            "Trying to get metrics from object %s deleted from the cache, skipping. "
-                            "Consider increasing the parameter `clean_morlist_interval` to avoid that", mor_name
-                        )
-                        continue
+                try:
+                    mor = self.morlist[i_key][mor_name]
+                except KeyError:
+                    self.log.error("Trying to get metrics from object %s deleted from the cache, skipping. "
+                                   "Consider increasing the parameter `clean_morlist_interval` to avoid that", mor_name)
+                    continue
                 for result in mor_perfs.value:
                     if result.id.counterId not in self.metrics_metadata[i_key]:
                         self.log.debug("Skipping this metric value, because there is no metadata about it")
@@ -785,11 +779,11 @@ class VSphereCheck(AgentCheck):
         job queue is processed the Aggregator will receive the metrics.
         """
         i_key = self._instance_key(instance)
-        with self.morlist_lock:
-            if i_key not in self.morlist:
-                self.log.debug("Not collecting metrics for this instance, nothing to do yet: {}".format(i_key))
-                return
-            mors = self.morlist[i_key].items()
+        if i_key not in self.morlist:
+            self.log.debug("Not collecting metrics for this instance, nothing to do yet: {}".format(i_key))
+            return
+
+        mors = self.morlist[i_key].items()
         n_mors = len(mors)
         self.log.debug("Collecting metrics of %d mors", n_mors)
 

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -94,7 +94,7 @@ class ConnectionError(Exception):
     pass
 
 
-class Mor:
+class Mor(object):
     def __init__(self, mor, metrics=None, last_seen=0, interval=None, mor_type=None, tags=None, hostname=None):
         self.mor = mor
         self.name = str(mor)
@@ -104,6 +104,34 @@ class Mor:
         self.mor_type = mor_type
         self.tags = tags
         self.hostname = hostname
+        self.lock = threading.RLock()
+
+    def update(self, **kwargs):
+        with self.lock:
+            for key, val in kwargs.items():
+                self.__setattr__(key, val)
+
+
+class MorDict(dict):
+    def __init__(self):
+        super(MorDict, self).__init__()
+        self.lock = threading.RLock()
+
+    def __delitem__(self, key):
+        with self.lock, self.__getitem__(key).lock:
+            super(MorDict, self).__delitem__(key)
+
+    def __setitem__(self, key, value):
+        with self.lock:
+            try:
+                with self.__getitem__(key).lock():
+                    super(MorDict, self).__setitem__(key, value)
+            except KeyError:
+                super(MorDict, self).__setitem__(key, value)
+
+    def __getitem__(self, key):
+        with self.lock:
+            return super(MorDict, self).__getitem__(key)
 
 
 class VSphereCheck(AgentCheck):
@@ -336,6 +364,10 @@ class VSphereCheck(AgentCheck):
 
         return wanted_metrics
 
+    def _get_cached_mors(self, instance_key):
+        with self.morlist_lock:
+            return self.morlist.get(instance_key, {}).values()
+
     def get_external_host_tags(self):
         """
         Returns a list of tags for every host that is detected by the vSphere
@@ -347,16 +379,13 @@ class VSphereCheck(AgentCheck):
         external_host_tags = []
         for instance in self.instances:
             i_key = self._instance_key(instance)
-            with self.morlist_lock:
-                mor_by_mor_name = self.morlist.get(i_key)
-
-                if not mor_by_mor_name:
-                    self.log.warning(
-                        u"Unable to extract hosts' tags for vSphere instance named %s. "
-                        u"Is the check failing on this instance?", i_key
-                    )
-                    continue
-                mors = list(mor_by_mor_name.values())
+            mors = self._get_cached_mors(i_key)
+            if not mors:
+                self.log.warning(
+                    u"Unable to extract hosts' tags for vSphere instance named %s. "
+                    u"Is the check failing on this instance?", i_key
+                )
+                continue
 
             for mor in mors:
                 if mor.hostname:  # some mor's have a None hostname
@@ -619,15 +648,13 @@ class VSphereCheck(AgentCheck):
         for mor_perfs in res:
             mor_name = str(mor_perfs.entity)
             available_metrics = [value.id for value in mor_perfs.value]
-            with self.morlist_lock:
-                try:
-                    mor = self.morlist[i_key][mor_name]
-                    mor.metrics = self._compute_needed_metrics(instance, available_metrics)
-                    mor.last_seen = time.time()
-                except KeyError:
-                    self.log.error("Trying to compute needed metrics from object %s deleted from the cache, skipping. "
-                                   "Consider increasing the parameter `clean_morlist_interval` to avoid that", mor_name)
-                    continue
+            try:
+                mor = self.morlist[i_key][mor_name]
+                mor.update(metrics=self._compute_needed_metrics(instance, available_metrics), last_seen=time.time())
+            except KeyError:
+                self.log.error("Trying to compute needed metrics from object %s deleted from the cache, skipping. "
+                               "Consider increasing the parameter `clean_morlist_interval` to avoid that", mor_name)
+                continue
 
         # ## <TEST-INSTRUMENTATION>
         self.histogram('datadog.agent.vsphere.morlist_process_atomic.time', t.total(), tags=instance.get('tags', []))
@@ -640,7 +667,7 @@ class VSphereCheck(AgentCheck):
         """
         i_key = self._instance_key(instance)
         if i_key not in self.morlist:
-            self.morlist[i_key] = {}
+            self.morlist[i_key] = MorDict()
 
         for resource_type in self.morlist_raw[i_key]:
             query_specs = []
@@ -650,11 +677,11 @@ class VSphereCheck(AgentCheck):
             for _ in xrange(batch_size):
                 try:
                     mor = self.morlist_raw[i_key][resource_type].pop()
-                    mor.interval = REAL_TIME_INTERVAL if mor.mor_type in REALTIME_RESOURCES else None
-                    with self.morlist_lock:
-                        if mor.name not in self.morlist[i_key]:
-                            mor.last_seen = time.time()
-                            self.morlist[i_key][mor.name] = mor
+                    mor.update(interval=REAL_TIME_INTERVAL if mor.mor_type in REALTIME_RESOURCES else None)
+                    cached_mors = self._get_cached_mors(i_key)
+                    if mor.name not in cached_mors:
+                        mor.update(last_seen=time.time())
+                        self.morlist[i_key][mor.name] = mor
 
                     query_spec = vim.PerformanceManager.QuerySpec()
                     query_spec.entity = mor.mor
@@ -674,11 +701,10 @@ class VSphereCheck(AgentCheck):
         we cannot get any metrics from them anyway (or =0)
         """
         i_key = self._instance_key(instance)
-        with self.morlist_lock:
-            for mor_name, mor in self.morlist[i_key].items():
-                if (time.time() - mor.last_seen) > self.clean_morlist_interval:
-                    self.log.debug("Deleting %s from the cache", mor_name)
-                    del self.morlist[i_key][mor_name]
+        for mor in self._get_cached_mors(i_key):
+            if (time.time() - mor.last_seen) > self.clean_morlist_interval:
+                self.log.debug("Deleting %s from the cache", mor.name)
+                del self.morlist[i_key][mor.name]
 
     def _cache_metrics_metadata(self, instance):
         """ Get from the server instance, all the performance counters metadata
@@ -740,15 +766,14 @@ class VSphereCheck(AgentCheck):
         if results:
             for mor_perfs in results:
                 mor_name = str(mor_perfs.entity)
-                with self.morlist_lock:
-                    try:
-                        mor = self.morlist[i_key][mor_name]
-                    except KeyError:
-                        self.log.error(
-                            "Trying to get metrics from object %s deleted from the cache, skipping. "
-                            "Consider increasing the parameter `clean_morlist_interval` to avoid that", mor_name
-                        )
-                        continue
+                try:
+                    mor = self.morlist[i_key][mor_name]
+                except KeyError:
+                    self.log.error(
+                        "Trying to get metrics from object %s deleted from the cache, skipping. "
+                        "Consider increasing the parameter `clean_morlist_interval` to avoid that", mor_name
+                    )
+                    continue
                 for result in mor_perfs.value:
                     if result.id.counterId not in self.metrics_metadata[i_key]:
                         self.log.debug("Skipping this metric value, because there is no metadata about it")
@@ -769,7 +794,8 @@ class VSphereCheck(AgentCheck):
                     value = self._transform_value(instance, result.id.counterId, result.value[0])
 
                     tags = ['instance:{}'.format(instance_name)]
-                    if not mor.hostname:  # no host tags available
+                    hostname = mor.hostname
+                    if not hostname:  # no host tags available
                         tags.extend(mor.tags)
 
                     # vsphere "rates" should be submitted as gauges (rate is
@@ -777,7 +803,7 @@ class VSphereCheck(AgentCheck):
                     self.gauge(
                         "vsphere.{}".format(metric_name),
                         value,
-                        hostname=mor.hostname,
+                        hostname=hostname,
                         tags=['instance:{}'.format(instance_name)] + custom_tags
                     )
 
@@ -790,11 +816,10 @@ class VSphereCheck(AgentCheck):
         job queue is processed the Aggregator will receive the metrics.
         """
         i_key = self._instance_key(instance)
-        with self.morlist_lock:
-            if i_key not in self.morlist:
-                self.log.debug("Not collecting metrics for this instance, nothing to do yet: {}".format(i_key))
-                return
-            mors = self.morlist[i_key].items()
+        if i_key not in self.morlist:
+            self.log.debug("Not collecting metrics for this instance, nothing to do yet: {}".format(i_key))
+            return
+        mors = self._get_cached_mors(i_key)
         n_mors = len(mors)
         self.log.debug("Collecting metrics of %d mors", n_mors)
 
@@ -807,7 +832,7 @@ class VSphereCheck(AgentCheck):
         query_specs = []
         if n_mors:
             for i in xrange(n_mors / batch_size + 1):
-                for mor_name, mor in mors[i * batch_size:(i + 1) * batch_size]:
+                for mor in mors[i * batch_size:(i + 1) * batch_size]:
                     if mor.mor_type == 'vm':
                         vm_count += 1
                     if not mor.metrics:

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -94,18 +94,6 @@ class ConnectionError(Exception):
     pass
 
 
-class Mor:
-    def __init__(self, mor, metrics=None, last_seen=0, interval=None, mor_type=None, tags=None, hostname=None):
-        self.mor = mor
-        self.name = str(mor)
-        self.metrics = metrics
-        self.last_seen = last_seen
-        self.interval = interval
-        self.mor_type = mor_type
-        self.tags = tags
-        self.hostname = hostname
-
-
 class VSphereCheck(AgentCheck):
     """ Get performance metrics from a vCenter server and upload them to Datadog
     References:
@@ -359,8 +347,8 @@ class VSphereCheck(AgentCheck):
                 mors = list(mor_by_mor_name.values())
 
             for mor in mors:
-                if mor.hostname:  # some mor's have a None hostname
-                    external_host_tags.append((mor.hostname, {SOURCE_TYPE: mor.tags}))
+                if mor.get('hostname'):  # some mor's have a None hostname
+                    external_host_tags.append((mor['hostname'], {SOURCE_TYPE: mor['tags']}))
 
         return external_host_tags
 
@@ -514,7 +502,12 @@ class VSphereCheck(AgentCheck):
 
                 if vsphere_type:
                     instance_tags.append(vsphere_type)
-                obj_list[vimtype].append(Mor(obj, mor_type=mor_type, hostname=hostname, tags=tags + instance_tags))
+                obj_list[vimtype].append({
+                    "mor_type": mor_type,
+                    "mor": obj,
+                    "hostname": hostname,
+                    "tags": tags + instance_tags
+                })
 
         self.log.debug("All objects with attributes cached in {} seconds.".format(time.time() - start))
         return obj_list
@@ -621,9 +614,8 @@ class VSphereCheck(AgentCheck):
             available_metrics = [value.id for value in mor_perfs.value]
             with self.morlist_lock:
                 try:
-                    mor = self.morlist[i_key][mor_name]
-                    mor.metrics = self._compute_needed_metrics(instance, available_metrics)
-                    mor.last_seen = time.time()
+                    self.morlist[i_key][mor_name]['metrics'] = self._compute_needed_metrics(instance, available_metrics)
+                    self.morlist[i_key][mor_name]['last_seen'] = time.time()
                 except KeyError:
                     self.log.error("Trying to compute needed metrics from object %s deleted from the cache, skipping. "
                                    "Consider increasing the parameter `clean_morlist_interval` to avoid that", mor_name)
@@ -642,7 +634,7 @@ class VSphereCheck(AgentCheck):
         if i_key not in self.morlist:
             self.morlist[i_key] = {}
 
-        for resource_type in self.morlist_raw[i_key]:
+        for resource_type in RESOURCE_TYPE_METRICS:
             query_specs = []
             # Batch size can prevent querying large payloads at once if the environment is too large
             # If batch size is set to 0, process everything at once
@@ -650,15 +642,16 @@ class VSphereCheck(AgentCheck):
             for _ in xrange(batch_size):
                 try:
                     mor = self.morlist_raw[i_key][resource_type].pop()
-                    mor.interval = REAL_TIME_INTERVAL if mor.mor_type in REALTIME_RESOURCES else None
+                    mor_name = str(mor["mor"])
+                    mor["interval"] = REAL_TIME_INTERVAL if mor['mor_type'] in REALTIME_RESOURCES else None
                     with self.morlist_lock:
-                        if mor.name not in self.morlist[i_key]:
-                            mor.last_seen = time.time()
-                            self.morlist[i_key][mor.name] = mor
+                        if mor_name not in self.morlist[i_key]:
+                            self.morlist[i_key][mor_name] = mor
+                            self.morlist[i_key][mor_name]["last_seen"] = time.time()
 
                     query_spec = vim.PerformanceManager.QuerySpec()
-                    query_spec.entity = mor.mor
-                    query_spec.intervalId = mor.interval
+                    query_spec.entity = mor["mor"]
+                    query_spec.intervalId = mor["interval"]
                     query_spec.maxSample = 1
                     query_specs.append(query_spec)
 
@@ -675,8 +668,10 @@ class VSphereCheck(AgentCheck):
         """
         i_key = self._instance_key(instance)
         with self.morlist_lock:
-            for mor_name, mor in self.morlist[i_key].items():
-                if (time.time() - mor.last_seen) > self.clean_morlist_interval:
+            morlist = self.morlist[i_key].items()
+            for mor_name, mor in morlist:
+                last_seen = mor['last_seen']
+                if (time.time() - last_seen) > self.clean_morlist_interval:
                     self.log.debug("Deleting %s from the cache", mor_name)
                     del self.morlist[i_key][mor_name]
 
@@ -769,15 +764,15 @@ class VSphereCheck(AgentCheck):
                     value = self._transform_value(instance, result.id.counterId, result.value[0])
 
                     tags = ['instance:{}'.format(instance_name)]
-                    if not mor.hostname:  # no host tags available
-                        tags.extend(mor.tags)
+                    if not mor['hostname']:  # no host tags available
+                        tags.extend(mor['tags'])
 
                     # vsphere "rates" should be submitted as gauges (rate is
                     # precomputed).
                     self.gauge(
                         "vsphere.{}".format(metric_name),
                         value,
-                        hostname=mor.hostname,
+                        hostname=mor['hostname'],
                         tags=['instance:{}'.format(instance_name)] + custom_tags
                     )
 
@@ -808,15 +803,15 @@ class VSphereCheck(AgentCheck):
         if n_mors:
             for i in xrange(n_mors / batch_size + 1):
                 for mor_name, mor in mors[i * batch_size:(i + 1) * batch_size]:
-                    if mor.mor_type == 'vm':
+                    if mor['mor_type'] == 'vm':
                         vm_count += 1
-                    if not mor.metrics:
+                    if 'metrics' not in mor or not mor['metrics']:
                         continue
 
                     query_spec = vim.PerformanceManager.QuerySpec()
-                    query_spec.entity = mor.mor
-                    query_spec.intervalId = mor.interval
-                    query_spec.metricId = mor.metrics
+                    query_spec.entity = mor["mor"]
+                    query_spec.intervalId = mor["interval"]
+                    query_spec.metricId = mor["metrics"]
                     query_spec.maxSample = 1
                     query_specs.append(query_spec)
 

--- a/vsphere/tests/test_vsphere.py
+++ b/vsphere/tests/test_vsphere.py
@@ -52,7 +52,8 @@ def test_init():
         VSphereCheck('vsphere', {}, {}, [{'': ''}])
 
     init_config = {
-        'refresh_morlist_interval': -99,
+        'refresh_morlist_interval': 100,
+        'clean_morlist_interval': 50,
         'refresh_metrics_metadata_interval': -99,
         'batch_property_collector_size': -1,
     }
@@ -63,8 +64,9 @@ def test_init():
     assert len(check.server_instances) == 0
     assert len(check.cache_times) == 1
     assert 'vsphere_foo' in check.cache_times
-    assert check.cache_times['vsphere_foo'][MORLIST][INTERVAL] == -99
+    assert check.cache_times['vsphere_foo'][MORLIST][INTERVAL] == 100
     assert check.cache_times['vsphere_foo'][METRICS_METADATA][INTERVAL] == -99
+    assert check.clean_morlist_interval == check.refresh_morlist_interval
     assert len(check.event_config) == 1
     assert 'vsphere_foo' in check.event_config
     assert len(check.registry) == 0
@@ -186,8 +188,6 @@ def test_check(vsphere, instance):
             vsphere.check(instance)
             set_external_tags.assert_called_once()
             all_the_tags = set_external_tags.call_args[0][0]
-
-            print(all_the_tags)
 
             assert ('vm4', {SOURCE_TYPE: [
                                         'vcenter_server:vsphere_mock', 'vsphere_folder:rootFolder',

--- a/vsphere/tests/utils.py
+++ b/vsphere/tests/utils.py
@@ -87,17 +87,17 @@ def assertMOR(check, instance, name=None, spec=None, tags=None, count=None, subs
     mor_list = [mor for _, mors in check.morlist_raw[instance_name].iteritems() for mor in mors]
 
     for mor in mor_list:
-        if name is not None and name != mor['hostname']:
+        if name is not None and name != mor.hostname:
             continue
 
-        if spec is not None and spec != mor['mor_type']:
+        if spec is not None and spec != mor.mor_type:
             continue
 
         if tags is not None:
             if subset:
-                if not set(tags).issubset(set(mor['tags'])):
+                if not set(tags).issubset(set(mor.tags)):
                     continue
-            elif set(tags) != set(mor['tags']):
+            elif set(tags) != set(mor.tags):
                 continue
 
         candidates.append(mor)

--- a/vsphere/tests/utils.py
+++ b/vsphere/tests/utils.py
@@ -87,17 +87,17 @@ def assertMOR(check, instance, name=None, spec=None, tags=None, count=None, subs
     mor_list = [mor for _, mors in check.morlist_raw[instance_name].iteritems() for mor in mors]
 
     for mor in mor_list:
-        if name is not None and name != mor.hostname:
+        if name is not None and name != mor['hostname']:
             continue
 
-        if spec is not None and spec != mor.mor_type:
+        if spec is not None and spec != mor['mor_type']:
             continue
 
         if tags is not None:
             if subset:
-                if not set(tags).issubset(set(mor.tags)):
+                if not set(tags).issubset(set(mor['tags'])):
                     continue
-            elif set(tags) != set(mor.tags):
+            elif set(tags) != set(mor['tags']):
                 continue
 
         candidates.append(mor)


### PR DESCRIPTION
### What does this PR do?

 Fix `KeyError` due to race condition on the cache.
It happened because the cache could be refreshed at a configurable interval, while deleting object from it was done at a fixed interval. When the configured refresh interval was higher than the clean interval, the check could schedule metric collection for objects in a separate thread, while deleting this same object from the cache right after.

### Motivation

Customer tested and had the issue

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?