### PR TITLE
Add number of "idle in transaction" transactions and open transactions

### DIFF
--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -104,6 +104,11 @@ instances:
 #    collect_count_metrics: False
 #
 
+#    Collect metrics regarding transactions from pg_stat_activity, default value is False. Please make sure the user
+#    has sufficient privileges to read from pg_stat_activity before enabling this option.
+#    collect_activity_metrics: False
+#
+
 #    Collect database size metrics. Default value is True but they might be slow with large databases
 #    collect_database_size_metrics: False
 #

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -601,11 +601,11 @@ GROUP BY datid, datname
             metrics_query = None
             if self._is_9_2_or_above(key, db):
                 metrics_query = self.ACTIVITY_METRICS_9_2
-            elif self._is_8_3_or_above(key,db):
+            elif self._is_8_3_or_above(key, db):
                 metrics_query = self.ACTIVITY_METRICS_8_3
             else:
                 metrics_query = self.ACTIVITY_METRICS_LT_8_3
-            
+
             metrics = {k: v for k, v in zip(metrics_query, self.ACTIVITY_DD_METRICS)}
             self.activity_metrics[key] = (metrics, query)
         else:
@@ -780,7 +780,7 @@ GROUP BY datid, datname
                               False, programming_error, relations_config)
             self._query_scope(cursor, archiver_instance_metrics, key, db, instance_tags, relations,
                               False, programming_error, relations_config)
-            
+
             if collect_activity_metrics:
                 activity_metrics = self._get_activity_metrics(key, db)
                 self._query_scope(cursor, activity_metrics, key, db, instance_tags, relations,

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -308,6 +308,47 @@ SELECT s.schemaname,
         'relation': False
     }
 
+    # The metrics we retrieve from pg_stat_activity when the postgres version >= 9.2
+    ACTIVITY_METRICS_9_2 = [
+        "SUM(CASE WHEN xact_start IS NOT NULL THEN 1 ELSE 0 END)",
+        "SUM(CASE WHEN state = 'idle in transaction' THEN 1 ELSE 0 END)",
+    ]
+
+    # The metrics we retrieve from pg_stat_activity when the postgres version >= 8.3
+    ACTIVITY_METRICS_8_3 = [
+        "SUM(CASE WHEN xact_start IS NOT NULL THEN 1 ELSE 0 END)",
+        "SUM(CASE WHEN current_query LIKE '<IDLE> in transaction' THEN 1 ELSE 0 END)",
+    ]
+
+    # The metrics we retrieve from pg_stat_activity when the postgres version < 8.3
+    ACTIVITY_METRICS_LT_8_3 = [
+        "SUM(CASE WHEN query_start IS NOT NULL THEN 1 ELSE 0 END)",
+        "SUM(CASE WHEN current_query LIKE '<IDLE> in transaction' THEN 1 ELSE 0 END)",
+    ]
+
+    # The metrics we collect from pg_stat_activity that we zip with one of the lists above
+    ACTIVITY_DD_METRICS = [
+        ('postgresql.transactions.open', GAUGE),
+        ('postgresql.transactions.idle_in_transaction', GAUGE),
+    ]
+
+    # The base query for postgres version >= 10
+    ACTIVITY_QUERY_10 = """
+SELECT datname,
+    %s
+FROM pg_stat_activity
+WHERE backend_type = 'client backend'
+GROUP BY datid, datname
+"""
+
+    # The base query for postgres version < 10
+    ACTIVITY_QUERY_LT_10 = """
+SELECT datname,
+    %s
+FROM pg_stat_activity
+GROUP BY datid, datname
+"""
+
     # keep track of host/port present in any configured instance
     _known_servers = set()
     _known_servers_lock = threading.RLock()
@@ -322,6 +363,7 @@ SELECT s.schemaname,
         self.db_bgw_metrics = []
         self.db_archiver_metrics = []
         self.replication_metrics = {}
+        self.activity_metrics = {}
         self.custom_metrics = {}
 
         # Deprecate custom_metrics in favor of custom_queries
@@ -383,6 +425,9 @@ SELECT s.schemaname,
             return version >= version_to_compare
 
         return False
+
+    def _is_8_3_or_above(self, key, db):
+        return self._is_above(key, db, [8, 3, 0])
 
     def _is_9_1_or_above(self, key, db):
         return self._is_above(key, db, [9, 1, 0])
@@ -543,6 +588,38 @@ SELECT s.schemaname,
             metrics = self.replication_metrics.get(key)
         return metrics
 
+    def _get_activity_metrics(self, key, db):
+        """ Use ACTIVITY_METRICS_LT_8_3 or ACTIVITY_METRICS_8_3 or ACTIVITY_METRICS_9_2
+        depending on the postgres version in conjunction with ACTIVITY_QUERY_10 or ACTIVITY_QUERY_LT_10.
+        Uses a dictionnary to save the result for each instance
+        """
+        metrics_data = self.activity_metrics.get(key)
+        metrics = None
+        query = None
+        if metrics_data is None:
+            query = self.ACTIVITY_QUERY_10 if self._is_10_or_above(key, db) else self.ACTIVITY_QUERY_LT_10
+            metrics_query = None
+            if self._is_9_2_or_above(key, db):
+                metrics_query = self.ACTIVITY_METRICS_9_2
+            elif self._is_8_3_or_above(key,db):
+                metrics_query = self.ACTIVITY_METRICS_8_3
+            else:
+                metrics_query = self.ACTIVITY_METRICS_LT_8_3
+            
+            metrics = {k: v for k, v in zip(metrics_query, self.ACTIVITY_DD_METRICS)}
+            self.activity_metrics[key] = (metrics, query)
+        else:
+            metrics, query = metrics_data
+
+        return {
+            'descriptors': [
+                ('datname', 'db'),
+            ],
+            'metrics': metrics,
+            'query': query,
+            'relation': False
+        }
+
     def _build_relations_config(self, yamlconfig):
         """Builds a dictionary from relations configuration while maintaining compatibility
         """
@@ -651,15 +728,16 @@ SELECT s.schemaname,
 
         return len(results)
 
-    def _collect_stats(self, key, db, instance_tags, relations, custom_metrics, function_metrics, count_metrics,
-                       database_size_metrics, collect_default_db, interface_error, programming_error):
+    def _collect_stats(self, key, db, instance_tags, relations, custom_metrics, collect_function_metrics,
+                       collect_count_metrics, collect_activity_metrics, collect_database_size_metrics,
+                       collect_default_db, interface_error, programming_error):
         """Query pg_stat_* for various metrics
         If relations is not an empty list, gather per-relation metrics
         on top of that.
         If custom_metrics is not an empty list, gather custom metrics defined in postgres.yaml
         """
 
-        db_instance_metrics = self._get_instance_metrics(key, db, database_size_metrics, collect_default_db)
+        db_instance_metrics = self._get_instance_metrics(key, db, collect_database_size_metrics, collect_default_db)
         bgw_instance_metrics = self._get_bgw_metrics(key, db)
         archiver_instance_metrics = self._get_archiver_metrics(key, db)
 
@@ -668,10 +746,11 @@ SELECT s.schemaname,
             self.LOCK_METRICS,
         ]
 
-        if function_metrics:
+        if collect_function_metrics:
             metric_scope.append(self.FUNCTION_METRICS)
-        if count_metrics:
+        if collect_count_metrics:
             metric_scope.append(self.COUNT_METRICS)
+
         # Do we need relation-specific metrics?
         relations_config = {}
         if relations:
@@ -701,16 +780,18 @@ SELECT s.schemaname,
                               False, programming_error, relations_config)
             self._query_scope(cursor, archiver_instance_metrics, key, db, instance_tags, relations,
                               False, programming_error, relations_config)
+            
+            if collect_activity_metrics:
+                activity_metrics = self._get_activity_metrics(key, db)
+                self._query_scope(cursor, activity_metrics, key, db, instance_tags, relations,
+                                  False, programming_error, relations_config)
 
             for scope in list(metric_scope) + custom_metrics:
                 self._query_scope(cursor, scope, key, db, instance_tags, relations,
                                   scope in custom_metrics, programming_error, relations_config)
 
             cursor.close()
-        except interface_error as e:
-            self.log.error("Connection error: %s" % str(e))
-            raise ShouldRestartException
-        except socket.error as e:
+        except (interface_error, socket.error) as e:
             self.log.error("Connection error: %s" % str(e))
             raise ShouldRestartException
 
@@ -900,10 +981,11 @@ SELECT s.schemaname,
         dbname = instance.get('dbname', None)
         relations = instance.get('relations', [])
         ssl = _is_affirmative(instance.get('ssl', False))
-        function_metrics = _is_affirmative(instance.get('collect_function_metrics', False))
+        collect_function_metrics = _is_affirmative(instance.get('collect_function_metrics', False))
         # Default value for `count_metrics` is True for backward compatibility
-        count_metrics = _is_affirmative(instance.get('collect_count_metrics', True))
-        database_size_metrics = _is_affirmative(instance.get('collect_database_size_metrics', True))
+        collect_count_metrics = _is_affirmative(instance.get('collect_count_metrics', True))
+        collect_activity_metrics = _is_affirmative(instance.get('collect_activity_metrics', False))
+        collect_database_size_metrics = _is_affirmative(instance.get('collect_database_size_metrics', True))
         collect_default_db = _is_affirmative(instance.get('collect_default_database', False))
 
         if relations and not dbname:
@@ -940,14 +1022,16 @@ SELECT s.schemaname,
             db = self.get_connection(key, host, port, user, password, dbname, ssl, connect_fct, tags)
             version = self._get_version(key, db)
             self.log.debug("Running check against version %s" % version)
-            self._collect_stats(key, db, tags, relations, custom_metrics, function_metrics, count_metrics,
-                                database_size_metrics, collect_default_db, interface_error, programming_error)
+            self._collect_stats(key, db, tags, relations, custom_metrics, collect_function_metrics,
+                                collect_count_metrics, collect_activity_metrics, collect_database_size_metrics,
+                                collect_default_db, interface_error, programming_error)
             self._get_custom_queries(db, tags, custom_queries, programming_error)
         except ShouldRestartException:
             self.log.info("Resetting the connection")
             db = self.get_connection(key, host, port, user, password, dbname, ssl, connect_fct, tags, use_cached=False)
-            self._collect_stats(key, db, tags, relations, custom_metrics, function_metrics, count_metrics,
-                                database_size_metrics, collect_default_db, interface_error, programming_error)
+            self._collect_stats(key, db, tags, relations, custom_metrics, collect_function_metrics,
+                                collect_count_metrics, collect_activity_metrics, collect_database_size_metrics,
+                                collect_default_db, interface_error, programming_error)
             self._get_custom_queries(db, tags, custom_queries, programming_error)
 
         if db is not None:

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -51,4 +51,4 @@ postgresql.toast_blocks_hit,gauge,,hit,second,The number of buffer hits in this 
 postgresql.toast_index_blocks_read,gauge,,block,second,The number of disk blocks read from this table's TOAST table index.,0,postgres,toast idx blks read
 postgresql.toast_index_blocks_hit,gauge,,block,second,The number of buffer hits in this table's TOAST table index.,0,postgres,toast idx blks hit
 postgresql.transactions.open,gauge,,transaction,,The number of open transactions in this database.,0,postgres,transactions open
-postgresql.transactions.idle_in_transaction,gauge,,transaction,,The number of "idle in transaction" transactions in this database.,0,postgres,transactions idle_in_transaction
+postgresql.transactions.idle_in_transaction,gauge,,transaction,,The number of `idle in transaction` transactions in this database.,0,postgres,transactions idle_in_transaction

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -50,3 +50,5 @@ postgresql.toast_blocks_read,gauge,,block,second,The number of disk blocks read 
 postgresql.toast_blocks_hit,gauge,,hit,second,The number of buffer hits in this table's TOAST table.,0,postgres,toast blks hit
 postgresql.toast_index_blocks_read,gauge,,block,second,The number of disk blocks read from this table's TOAST table index.,0,postgres,toast idx blks read
 postgresql.toast_index_blocks_hit,gauge,,block,second,The number of buffer hits in this table's TOAST table index.,0,postgres,toast idx blks hit
+postgresql.transactions.open,gauge,,transaction,,The number of open transactions in this database.,0,postgres,transactions open
+postgresql.transactions.idle_in_transaction,gauge,,transaction,,The number of "idle in transaction" transactions in this database.,0,postgres,transactions idle_in_transaction

--- a/postgres/tests/test_common.py
+++ b/postgres/tests/test_common.py
@@ -118,8 +118,6 @@ def test_connections_metrics(aggregator, check, postgres_standalone, pg_instance
 def test_activity_metrics(aggregator, check, postgres_standalone, pg_instance):
     pg_instance['collect_activity_metrics'] = True
     check.check(pg_instance)
-    for m in aggregator._metrics.items():
-        print m
 
     for name in ACTIVITY_METRICS:
         aggregator.assert_metric(name, count=1, tags=pg_instance['tags'] + ['db:datadog_test'])

--- a/postgres/tests/test_common.py
+++ b/postgres/tests/test_common.py
@@ -49,6 +49,11 @@ CONNECTION_METRICS = [
     'postgresql.percent_usage_connections',
 ]
 
+ACTIVITY_METRICS = [
+    'postgresql.transactions.open',
+    'postgresql.transactions.idle_in_transaction',
+]
+
 
 def check_common_metrics(aggregator, expected_tags):
     for name in COMMON_METRICS:
@@ -107,3 +112,14 @@ def test_connections_metrics(aggregator, check, postgres_standalone, pg_instance
     for name in CONNECTION_METRICS:
         aggregator.assert_metric(name, count=1, tags=pg_instance['tags'])
     aggregator.assert_metric('postgresql.connections', count=1, tags=pg_instance['tags']+['db:datadog_test'])
+
+
+@pytest.mark.integration
+def test_activity_metrics(aggregator, check, postgres_standalone, pg_instance):
+    pg_instance['collect_activity_metrics'] = True
+    check.check(pg_instance)
+    for m in aggregator._metrics.items():
+        print m
+
+    for name in ACTIVITY_METRICS:
+        aggregator.assert_metric(name, count=1, tags=pg_instance['tags'] + ['db:datadog_test'])

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -82,7 +82,7 @@ def test_get_instance_metrics_instance(check):
     assert check.instance_metrics[another] == []
 
 
-def test__get_version(check):
+def test_get_version(check):
     """
     Test _get_version() to make sure the check is properly parsing Postgres versions
     """
@@ -101,7 +101,7 @@ def test__get_version(check):
     assert check._get_version('beta_version', db) == [11, -1, 3]
 
 
-def test__is_above(check):
+def test_is_above(check):
     """
     Test _is_above() to make sure the check is properly determining order of versions
     """


### PR DESCRIPTION
### What does this PR do?

Adds:
- postgresql.transactions.open: The number of open transactions in this database
- postgresql.transactions.idle_in_transaction: The number of "idle in transaction" transactions in this database

### Motivation

To extend the postgres check

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

We should be testing Postgres versions < 8.3, >= 8.3, <= 9.2 as well