### PR TITLE
document ddev scaffolding

### DIFF
--- a/datadog_checks_dev/README.md
+++ b/datadog_checks_dev/README.md
@@ -63,7 +63,7 @@ This is the layer that provides the developer CLI.
 ### Installation
 
 ```console
-$ pip install datadog-checks-dev[cli]
+$ pip install "datadog-checks-dev[cli]"
 ```
 
 At this point there should be a working executable, `ddev`, in your PATH. The

--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -25,12 +25,11 @@ You'll also need `docker-compose` in order to run the test harness.
 
 ## Setup
 
-Clone both the [integrations-extras repository][7] *and* the [integrations-core repository][8]. The Extras repository is where you'll be working, but you'll need tooling from the Core repository to get yourself up and running. By default, that tooling expects you to be working in the `$HOME/dd/` directory — this is optional and can be adjusted via configuration later.
+Clone the [integrations-extras repository][7]. By default, that tooling expects you to be working in the `$HOME/dd/` directory — this is optional and can be adjusted via configuration later.
 
 ```shell
 mkdir $HOME/dd && cd $HOME/dd       # optional
 git clone https://github.com/DataDog/integrations-extras.git
-git clone https://github.com/DataDog/integrations-core.git
 ```
 
 ### Developer toolkit
@@ -38,21 +37,14 @@ git clone https://github.com/DataDog/integrations-core.git
 The [developer toolkit][17] is comprehensive and includes a lot of functionality. Here's what you need to get started:
 
 ```
-cd integrations-core
+cd integrations-extras
 pip install "datadog-checks-dev[cli]"
 ```
 
-If you chose to clone these repositories to somewhere other than `$HOME/dd/`, you'll need to adjust the configuration file. The location of the file is dependent on your platform:
+If you chose to clone these repositories to somewhere other than `$HOME/dd/`, you'll need to adjust the configuration file:
 
 ```
-ddev config find
-```
-
-Alter the `core` and `extras` options to point to the appropriate directories (don't worry about the other stuff for now).
-
-```ini
-core = "/path/to/integrations-core"
-extras = "/path/to/integrations-extras"
+ddev config set extras "/path/to/integrations-extras"
 ```
 
 ## Scaffolding
@@ -172,7 +164,7 @@ def test_config():
 The scaffolding has already set up `tox` to run tests located at `my_check/tests`. Run the test:
 
 ```
-cd my_check && tox
+ddev -e test my_check
 ```
 
 The test we just wrote doesn't check our collection _logic_ though, so let's add an integration test. We will use `docker-compose` to spin up an Nginx container and let the check retrieve the welcome page. Create a compose file at `my_check/tests/docker-compose.yml` with the following contents:
@@ -292,7 +284,7 @@ Parameters in a configuration file follow these rules:
 
 Each parameter in a configuration file must have a special comment block with the following format:
 
-```
+```yaml
 ## @<COMMAND_1> <ARG_COMMAND_1>
 ## @<COMMAND_2> <ARG_COMMAND_2>
 ## <DESCRIPTION>
@@ -302,7 +294,7 @@ Each parameter in a configuration file must have a special comment block with th
 
 This paragraph contains **commands** which are a special string in the form `@command`. A command is valid only when the comment line containing it starts with a double `#` char:
 
-```
+```yaml
 ## @command this is valid
 
 # @command this is not valid and will be ignored
@@ -335,7 +327,7 @@ Arguments:
 
 For instance, here is the `@param` *command* for the Apache integration check `apache_status_url` parameter:
 
-```
+```yaml
 init_config:
 
 instances:
@@ -481,7 +473,6 @@ python setup.py bdist_wheel
 [5]: https://virtualenv.pypa.io/en/stable/
 [6]: https://github.com/DataDog/integrations-core/blob/master/docs/dev/python.md
 [7]: https://github.com/DataDog/integrations-extras
-[8]: https://github.com/DataDog/integrations-core
 [9]: https://packaging.python.org/tutorials/distributing-packages/
 [10]: https://docs.datadoghq.com/developers/metrics/#metric-types
 [11]: https://docs.datadoghq.com/developers/metrics/#units

--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -25,58 +25,61 @@ You'll also need `docker-compose` in order to run the test harness.
 
 ## Setup
 
-Clone the [integrations-extras repository][7] and point your shell at the base directory:
+Clone both the [integrations-extras repository][7] *and* the [integrations-core repository][8]. The Extras repository is where you'll be working, but you'll need tooling from the Core repository to get yourself up and running. By default, that tooling expects you to be working in the `$HOME/dd/` directory — this is optional and can be adjusted via configuration later.
 
-```
-git clone https://github.com/DataDog/integrations-extras.git && cd integrations-extras
-```
-
-Install the Python packages needed to work on Agent Integrations:
-
-```
-pip install -r requirements-dev.txt
+```shell
+mkdir $HOME/dd && cd $HOME/dd       # optional
+git clone https://github.com/DataDog/integrations-extras.git
+git clone https://github.com/DataDog/integrations-core.git
 ```
 
-[cookiecutter][1] is used to create the skeleton for a new integration:
+### Developer toolkit
+
+The [developer toolkit][17] is comprehensive and includes a lot of functionality. Here's what you need to get started:
 
 ```
-cookiecutter https://github.com/DataDog/cookiecutter-datadog-check.git
+cd integrations-core
+pip install "datadog-checks-dev[cli]"
 ```
 
-Answer the questions when prompted. Once completed succesfully, you will end up with something like this:
+If you chose to clone these repositories to somewhere other than `$HOME/dd/`, you'll need to adjust the configuration file. The location of the file is dependent on your platform:
 
 ```
-    my_check
-    ├── CHANGELOG.md
-    ├── MANIFEST.in
-    ├── README.md
-    ├── datadog_checks
-    │   ├── __init__.py
-    │   └── foo_check
-    │       └── data
-    │           └── conf.yaml.example
-    │       ├── __about__.py
-    │       ├── __init__.py
-    │       └── foo_check.py
-    ├── images
-    │   └── snapshot.png
-    ├── logos
-    │   ├── avatars-bot.png
-    │   ├── saas_logos-bot.png
-    │   └── saas_logos-small.png
-    ├── manifest.json
-    ├── metadata.csv
-    ├── requirements-dev.txt
-    ├── requirements.in
-    ├── requirements.txt
-    ├── service_checks.json
-    ├── setup.py
-    ├── tests
-    │   ├── __init__.py
-    │   ├── conftest.py
-    │   └── test_check.py
-    └── tox.ini
+ddev config find
 ```
+
+Alter the `core` and `extras` options to point to the appropriate directories (don't worry about the other stuff for now).
+
+```ini
+core = "/path/to/integrations-core"
+extras = "/path/to/integrations-extras"
+```
+
+## Scaffolding
+
+One of the developer toolkit features is the `create` command, which creates the basic file and path structure (or "scaffolding") necessary for a new Integration.
+
+### Dry-run
+
+Let's try a dry-run, which won't write anything to disk. There are two important elements to note in the following command:
+1. `-e`, which ensures that the scaffolding is created in the Extras repository.
+2. `-n`, which is a dry-run (nothing gets written).
+
+```
+ddev -e create -n my_check
+```
+
+This will display the path where the files would have been written, as well as the structure itself. For now, just make sure that the path in the *first line* of output matches your Extras repository.
+
+### Interactive mode
+
+The interactive mode is a wizard for creating new Integrations. By answering a handful of questions, the scaffolding will be set up and lightly pre-configured for you.
+
+```
+ddev -e create my_check
+```
+
+After answering the questions, the output will match that of the dry-run above, except in this case the scaffolding for your new Integration will actually exist!
 
 ## Write the check
 
@@ -166,7 +169,7 @@ def test_config():
     c.check({'url': 'http://foobar', 'search_string': 'foo'})
 ```
 
-The cookiecutter template has already setup `tox` to run tests located at `my_check/tests`. Run the test:
+The scaffolding has already set up `tox` to run tests located at `my_check/tests`. Run the test:
 
 ```
 cd my_check && tox
@@ -273,7 +276,9 @@ tox -e integration
 The check is almost done. Let's add the final touches by adding the integration configurations.
 
 ## Configuration
+
 ### Configuration file
+
 #### Parameters
 
 Parameters in a configuration file follow these rules:
@@ -306,6 +311,7 @@ This paragraph contains **commands** which are a special string in the form `@co
 `<DESCRIPTION>` is the description of the parameter. It can span across multiple lines in a special comment block.
 
 ##### Available commands
+
 ###### Param
 
 The `@param` command aims to describe the parameter for documentation purposes.
@@ -342,7 +348,7 @@ instances:
 
 ### Populate the README
 
-The `README.md` file provided by our cookiecutter template already has the correct format. You must fill out the relevant sections - look for the ellipses `[...]`.
+The `README.md` file provided by our scaffolding already has the correct format. You must fill out the document with the relevant information.
 
 ### Add images and logos
 
@@ -359,6 +365,7 @@ The directory structure for images and logos:
 ```
 
 The `images` folder contains all images that are used in the Integration tile. They must be referenced in the `## Overview` and/or `## Setup` sections in `README.md` as Markdown images using their public URLs. Because the `integrations-core` and `integrations-extras` repositories are public, a public URL can be obtained for any of these files via `https://raw.githubusercontent.com`:
+
 ```markdown
 ![snapshot](https://raw.githubusercontent.com/DataDog/integrations-extras/master/MyCheck/images/snapshot.png)
 ```
@@ -474,6 +481,7 @@ python setup.py bdist_wheel
 [5]: https://virtualenv.pypa.io/en/stable/
 [6]: https://github.com/DataDog/integrations-core/blob/master/docs/dev/python.md
 [7]: https://github.com/DataDog/integrations-extras
+[8]: https://github.com/DataDog/integrations-core
 [9]: https://packaging.python.org/tutorials/distributing-packages/
 [10]: https://docs.datadoghq.com/developers/metrics/#metric-types
 [11]: https://docs.datadoghq.com/developers/metrics/#units
@@ -482,3 +490,4 @@ python setup.py bdist_wheel
 [14]: https://docs.datadoghq.com/getting_started/tagging/
 [15]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_dev#development
 [16]: https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md
+[17]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_dev


### PR DESCRIPTION
### What does this PR do?

This replaces the references to cookiecutter in favour of ddev.

### Motivation

ddev is the new hotness.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] ~Feature or bugfix has tests~
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes
