### PR TITLE
Make the cache configuration thread safe

### DIFF
--- a/vsphere/datadog_checks/vsphere/cache_config.py
+++ b/vsphere/datadog_checks/vsphere/cache_config.py
@@ -1,0 +1,66 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import threading
+from collections import defaultdict
+
+
+class CacheConfig:
+    """
+    Wraps configuration and status for the Morlist and Metadata caches.
+    CacheConfig is threadsafe and can be used from different workers in the
+    threading pool.
+    """
+    Morlist = 0
+    Metadata = 1
+
+    def __init__(self):
+        self._lock = threading.RLock()
+        self.clear()
+
+    def _check_type(self, type_):
+        """
+        Basic sanity check to avoid KeyErrors
+        """
+        if type_ not in (CacheConfig.Morlist, CacheConfig.Metadata):
+            raise TypeError("Wrong cache type passed")
+
+    def clear(self):
+        """
+        Reset the config object to its initial state
+        """
+        with self._lock:
+            self._config = {
+                CacheConfig.Morlist: {
+                    'last': defaultdict(float),
+                    'intl': {},
+                },
+                CacheConfig.Metadata: {
+                    'last': defaultdict(float),
+                    'intl': {},
+                }
+            }
+
+    def set_last(self, type_, key, ts):
+        self._check_type(type_)
+        with self._lock:
+            self._config[type_]['last'][key] = ts
+
+    def get_last(self, type_, key):
+        """
+        Notice: this will return the defaultdict default value also for keys
+        that are not in the configuration, this is a tradeoff to keep the code simple.
+        """
+        self._check_type(type_)
+        with self._lock:
+            return self._config[type_]['last'][key]
+
+    def set_interval(self, type_, key, ts):
+        self._check_type(type_)
+        with self._lock:
+            self._config[type_]['intl'][key] = ts
+
+    def get_interval(self, type_, key):
+        self._check_type(type_)
+        with self._lock:
+            return self._config[type_]['intl'].get(key)

--- a/vsphere/tests/test_cache_config.py
+++ b/vsphere/tests/test_cache_config.py
@@ -1,0 +1,43 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.vsphere.cache_config import CacheConfig
+
+
+def test___init__():
+    c = CacheConfig()
+    for t in (CacheConfig.Morlist, CacheConfig.Metadata):
+        for label in ('last', 'intl'):
+            assert len(c._config[t][label]) == 0
+    assert c.get_last
+
+
+def test__check_type():
+    c = CacheConfig()
+    with pytest.raises(TypeError):
+        c._check_type(-99)
+    c._check_type(CacheConfig.Morlist)
+    c._check_type(CacheConfig.Metadata)
+
+
+def test_clear():
+    c = CacheConfig()
+    c.set_interval(CacheConfig.Morlist, 'foo', -99)
+    c.clear()
+    assert c.get_interval(CacheConfig.Morlist, 'foo') is None
+
+
+def test_get_set_last():
+    c = CacheConfig()
+    c.set_last(CacheConfig.Morlist, 'foo', -99)
+    assert c._config[CacheConfig.Morlist]['last']['foo'] == -99
+    assert c.get_last(CacheConfig.Morlist, 'foo') == -99
+
+
+def test_get_set_interval():
+    c = CacheConfig()
+    c.set_interval(CacheConfig.Morlist, 'foo', -99)
+    assert c._config[CacheConfig.Morlist]['intl']['foo'] == -99
+    assert c.get_interval(CacheConfig.Morlist, 'foo') == -99


### PR DESCRIPTION
### What does this PR do?

First step towards making the whole check threadsafe.

Instead of using a plain dict to store configuration for the Mor and Metadata caches, we use a dedicated object with getters and setters protected by a mutex. Given the size of the config object that goes with the number of instances, lock contention shouldn't be an issue but I'm open to discussion.

### Motivation

Make the check thread safe.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

