### PR TITLE
Fix backticks to single quote

### DIFF
--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -51,4 +51,4 @@ postgresql.toast_blocks_hit,gauge,,hit,second,The number of buffer hits in this 
 postgresql.toast_index_blocks_read,gauge,,block,second,The number of disk blocks read from this table's TOAST table index.,0,postgres,toast idx blks read
 postgresql.toast_index_blocks_hit,gauge,,block,second,The number of buffer hits in this table's TOAST table index.,0,postgres,toast idx blks hit
 postgresql.transactions.open,gauge,,transaction,,The number of open transactions in this database.,0,postgres,transactions open
-postgresql.transactions.idle_in_transaction,gauge,,transaction,,The number of `idle in transaction` transactions in this database.,0,postgres,transactions idle_in_transaction
+postgresql.transactions.idle_in_transaction,gauge,,transaction,,The number of 'idle in transaction' transactions in this database.,0,postgres,transactions idle_in_transaction


### PR DESCRIPTION
### What does this PR do?

Backticks look weird on staging, I think single quotes should work fine.

### Motivation

Checking out the postgres tile on staging

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes
