### PR TITLE
Fix Prometheus scraping for Python 3

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/checks/openmetrics/mixins.py
@@ -210,7 +210,7 @@ class OpenMetricsScraperMixin(object):
         :param response: requests.Response
         :return: core.Metric
         """
-        input_gen = response.iter_lines(chunk_size=self.REQUESTS_CHUNK_SIZE)
+        input_gen = response.iter_lines(chunk_size=self.REQUESTS_CHUNK_SIZE, decode_unicode=True)
         if scraper_config['_text_filter_blacklist']:
             input_gen = self._text_filter_input(input_gen, scraper_config)
 

--- a/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
@@ -197,7 +197,7 @@ class PrometheusScraperMixin(object):
                 yield message
 
         elif 'text/plain' in response.headers['Content-Type']:
-            input_gen = response.iter_lines(chunk_size=self.REQUESTS_CHUNK_SIZE)
+            input_gen = response.iter_lines(chunk_size=self.REQUESTS_CHUNK_SIZE, decode_unicode=True)
             if self._text_filter_blacklist:
                 input_gen = self._text_filter_input(input_gen)
 


### PR DESCRIPTION
### Motivation

```
        for line in fd:                                                               
            line = line.strip()                                                       
                                                                                      
>           if line.startswith('#'):                                                  
E           TypeError: startswith first arg must be bytes or a tuple of bytes, not str
                                                                                      
.tox\py36-cockroachdb\lib\site-packages\prometheus_client\parser.py:138: TypeError    
```

### Additional Notes

We do the same thing here https://github.com/DataDog/integrations-core/pull/2117/files#diff-4e5d5c986dbd1ca04f508a0cd7f1c8e5R40