### PR TITLE
Fix the path for the apache configuration file

### DIFF
--- a/apache/README.md
+++ b/apache/README.md
@@ -50,7 +50,7 @@ The Apache check is packaged with the Agent. To start gathering your Apache metr
     logs_enabled: true
     ```
 
-2. Add this configuration block to your `apache.yaml` file to start collecting your Apache Logs:
+2. Add this configuration block to your `apache.d/conf.yaml` file to start collecting your Apache Logs:
 
     ```yaml
       logs:


### PR DESCRIPTION
### What does this PR do?

Update the path to reflect agent 6 real path

### Motivation

Path was incorrect and misleading

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
