### PR TITLE
Control size of the thread pool job queue

### DIFF
--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -578,7 +578,6 @@ class VSphereCheck(AgentCheck):
             available_metrics = [value.id for value in mor_perfs.value]
             try:
                 self.morlist[i_key][mor_name]['metrics'] = self._compute_needed_metrics(instance, available_metrics)
-                self.morlist[i_key][mor_name]['last_seen'] = time.time()
             except KeyError:
                 self.log.error("Trying to compute needed metrics from object %s deleted from the cache, skipping. "
                                "Consider increasing the parameter `clean_morlist_interval` to avoid that", mor_name)
@@ -609,7 +608,7 @@ class VSphereCheck(AgentCheck):
                     mor["interval"] = REAL_TIME_INTERVAL if mor['mor_type'] in REALTIME_RESOURCES else None
                     if mor_name not in self.morlist[i_key]:
                         self.morlist[i_key][mor_name] = mor
-                        self.morlist[i_key][mor_name]["last_seen"] = time.time()
+                    self.morlist[i_key][mor_name]["last_seen"] = time.time()
 
                     query_spec = vim.PerformanceManager.QuerySpec()
                     query_spec.entity = mor["mor"]

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -804,6 +804,8 @@ class VSphereCheck(AgentCheck):
 
             # Second part: do the job
             self.collect_metrics(instance)
+        else:
+            self.log.debug("Thread pool is still processing jobs from previous run. Not scheduling anything.")
         self._query_event(instance)
 
         thread_crashed = False

--- a/vsphere/tests/utils.py
+++ b/vsphere/tests/utils.py
@@ -114,6 +114,7 @@ def disable_thread_pool(check):
     Disable the thread pool on the check instance
     """
     check.pool = MagicMock(apply_async=lambda func, args: func(*args))
+    check.pool._workq.qsize.return_value = 0
     check.pool_started = True  # otherwise the mock will be overwritten
     return check
 


### PR DESCRIPTION
### What does this PR do?

Prevent the job queue from growing beyond reasonable size. It does it by preventing subsequent check runs from scheduling more jobs on the queue if the previous check run jobs haven't finished.
There is not point in trying to collect a new batch of metrics for every object if we haven't even finished retrieving the first.
It should also remove some stress on the vCenter server which is receiving all of the API calls.

It also updates the `last_seen` time of cached MORs synchronously before we clean the cache instead of in a separate thread with the rest of the processing. This is to prevent objects from being deleted from the cache while they are actually there but the weren't updated yet because the job was lost in the queue. 

### Motivation

For large infrastructures, where metric collection can span several check runs, the queue could grow to a steady 3000+ jobs. This would result in cache being cleared, and metrics would stop being collected.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?