### PR TITLE
Use different defaults if scraper_config is created by OpenMetricsBaseCheck

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/checks/openmetrics/base_check.py
@@ -43,7 +43,7 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
         self.process(scraper_config)
 
     def get_scraper_config(self, instance):
-        endpoint = instance.get('prometheus_url', None)
+        endpoint = instance.get('prometheus_url')
 
         if endpoint is None:
             raise CheckException("Unable to find prometheus URL in config file.")
@@ -53,7 +53,10 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
             return self.config_map[endpoint]
 
         # Otherwise, we create the scraper configuration
-        config = self.create_scraper_configuration(instance)
+        #   To get the same behaviour for GenericPrometheusCheck-based checks porting to this class,
+        #   we must set the proper default values (which are different than the ones in mixins.py) by setting
+        #   created_by_base_class to True
+        config = self.create_scraper_configuration(instance, created_by_base_class=True)
 
         # Add this configuration to the config_map
         self.config_map[endpoint] = config

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -59,7 +59,20 @@ def mocked_prometheus_check():
 
 @pytest.fixture
 def mocked_prometheus_scraper_config(mocked_prometheus_check):
-    yield mocked_prometheus_check.get_scraper_config(GENERIC_PROMETHEUS_INSTANCE)
+    # We make sure the defaults used in OpenMetricsScraperMixin are the same defaults used in PrometheusScraperMixin
+    orig_create_scraper_configuration = mocked_prometheus_check.create_scraper_configuration
+
+    def remove_created_by_base_class(*args, **kwargs):
+        if 'created_by_base_class' in kwargs:
+            del kwargs['created_by_base_class']
+        elif len(args) > 1:
+            del args[1]
+
+        return orig_create_scraper_configuration(*args, **kwargs)
+
+    with mock.patch('datadog_checks.checks.openmetrics.mixins.OpenMetricsScraperMixin.create_scraper_configuration',
+                    side_effect=remove_created_by_base_class):
+        yield mocked_prometheus_check.get_scraper_config(GENERIC_PROMETHEUS_INSTANCE)
 
 
 @pytest.fixture


### PR DESCRIPTION
### What does this PR do?

This PR changes the defaults used in the `scraper_config` for an instance. Specifically, `send_monotonic_counter` and `health_service_check` is now default to `False` in `mixins.py`, with the default sets to `True` only if the config is being created by the `OpenMetricsBaseCheck` class.

### Motivation

Previously, there were two sets of conflicting defaults used in the old `GenericPrometheusCheck` and `PrometheusScraperMixin` classes. 

This meant that checks based on the `PrometheusScraper` class were _not_ sending health service checks and were _not_ sending count-type as monotonic_count-type metrics.

Since we are now getting all Prometheus-based checks to switch to `OpenMetricsBaseCheck`, we need to get all the checks that were based on `GenericPrometheusCheck` to continue to send health service checks and send counts as monotonic_counts, and we also need to get all the checks based on `PrometheusScraper` to not send health service checks and not send counts as monotonic_counts.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes