### PR TITLE
Fix WMI check, add to appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ install:
   - cd ..
 build: off
 test_script:
-  - ddev test datadog_checks_base active_directory aspdotnet dotnetclr exchange_server iis pdh_check sqlserver win32_event_log windows_service
+  - ddev test datadog_checks_base active_directory aspdotnet dotnetclr exchange_server iis pdh_check sqlserver win32_event_log windows_service wmi_check
 
 # Uncomment the following to enable RDP connection into the builder and debug a build
 # on_finish:

--- a/datadog_checks_base/datadog_checks/checks/win/wmi/__init__.py
+++ b/datadog_checks_base/datadog_checks/checks/win/wmi/__init__.py
@@ -176,6 +176,8 @@ class WinWMICheck(AgentCheck):
                 except TagQueryUniquenessFailure:
                     continue
 
+            self.log.warning(wmi_obj)
+
             for wmi_property, wmi_value in iteritems(wmi_obj):
                 # skips any property not in arguments since SWbemServices.ExecQuery will return key prop properties
                 # https://msdn.microsoft.com/en-us/library/aa393866(v=vs.85).aspx

--- a/datadog_checks_base/datadog_checks/checks/win/wmi/__init__.py
+++ b/datadog_checks_base/datadog_checks/checks/win/wmi/__init__.py
@@ -176,8 +176,6 @@ class WinWMICheck(AgentCheck):
                 except TagQueryUniquenessFailure:
                     continue
 
-            self.log.warning(wmi_obj)
-
             for wmi_property, wmi_value in iteritems(wmi_obj):
                 # skips any property not in arguments since SWbemServices.ExecQuery will return key prop properties
                 # https://msdn.microsoft.com/en-us/library/aa393866(v=vs.85).aspx

--- a/wmi_check/tests/common.py
+++ b/wmi_check/tests/common.py
@@ -22,8 +22,10 @@ INSTANCE_METRICS = [
 
 WMI_CONFIG = {
     'class': "Win32_PerfFormattedData_PerfDisk_LogicalDisk",
-    'metrics': [["AvgDiskBytesPerWrite", "winsys.disk.avgdiskbytesperwrite", "gauge"],
-                ["FreeMegabytes", "winsys.disk.freemegabytes", "gauge"]],
+    'metrics': [
+        ["AvgDiskBytesPerWrite", "winsys.disk.avgdiskbytesperwrite", "gauge"],
+        ["FreeMegabytes", "winsys.disk.freemegabytes", "gauge"]
+    ],
     'tag_by': "Name",
     'constant_tags': ["foobar"],
 }

--- a/wmi_check/tests/common.py
+++ b/wmi_check/tests/common.py
@@ -21,11 +21,11 @@ INSTANCE_METRICS = [
 ]
 
 WMI_CONFIG = {
-    'class': "Win32_PerfFormattedData_PerfDisk_LogicalDisk",
+    'class': 'Win32_PerfFormattedData_PerfDisk_LogicalDisk',
     'metrics': [
-        ["AvgDiskBytesPerWrite", "winsys.disk.avgdiskbytesperwrite", "gauge"],
-        ["FreeMegabytes", "winsys.disk.freemegabytes", "gauge"]
+        ['AvgDiskBytesPerWrite', 'winsys.disk.avgdiskbytesperwrite', 'gauge'],
+        ['FreeMegabytes', 'winsys.disk.freemegabytes', 'gauge']
     ],
-    'tag_by': "Name",
-    'constant_tags': ["foobar"],
+    'tag_by': 'Name',
+    'constant_tags': ['foobar'],
 }

--- a/wmi_check/tests/conftest.py
+++ b/wmi_check/tests/conftest.py
@@ -66,8 +66,8 @@ def mock_proc_sampler():
 @pytest.fixture
 def mock_disk_sampler():
     WMI_Mock = [{
-        "AvgDiskBytesPerWrite", 1536,
-        "FreeMegabytes", 19742,
+        "AvgDiskBytesPerWrite": 1536,
+        "FreeMegabytes": 19742,
     }]
     property_names = [
         "AvgDiskBytesPerWrite",

--- a/wmi_check/tests/test_wmi_check.py
+++ b/wmi_check/tests/test_wmi_check.py
@@ -60,7 +60,7 @@ def test_check(mock_disk_sampler, aggregator, check):
         log.warning('{} {}'.format(metric, value))
 
     for _, mname, _ in common.WMI_CONFIG['metrics']:
-        aggregator.assert_metric(mname, tags=["foobar", "name:c:"], count=1)
-        aggregator.assert_metric(mname, tags=["foobar", "name:d:"], count=1)
+        aggregator.assert_metric(mname, tags=["foobar"], count=1)
+        aggregator.assert_metric(mname, tags=["foobar"], count=1)
 
     aggregator.assert_all_metrics_covered()

--- a/wmi_check/tests/test_wmi_check.py
+++ b/wmi_check/tests/test_wmi_check.py
@@ -53,7 +53,7 @@ def test_invalid_metrics(aggregator, check):
     aggregator.assert_all_metrics_covered()
 
 
-def test_check(aggregator, check):
+def test_check(mock_disk_sampler, aggregator, check):
     check.check(common.WMI_CONFIG)
 
     for _, mname, _ in common.WMI_CONFIG['metrics']:

--- a/wmi_check/tests/test_wmi_check.py
+++ b/wmi_check/tests/test_wmi_check.py
@@ -20,8 +20,6 @@ def test_basic_check(mock_proc_sampler, aggregator, check):
 
     aggregator.assert_all_metrics_covered()
 
-    assert False
-
 
 def test_tags(mock_proc_sampler, aggregator, check):
     instance = copy.deepcopy(common.INSTANCE)

--- a/wmi_check/tests/test_wmi_check.py
+++ b/wmi_check/tests/test_wmi_check.py
@@ -56,9 +56,6 @@ def test_invalid_metrics(aggregator, check):
 def test_check(mock_disk_sampler, aggregator, check):
     check.check(common.WMI_CONFIG)
 
-    for metric, value in aggregator._metrics.iteritems():
-        log.warning('{} {}'.format(metric, value))
-
     for _, mname, _ in common.WMI_CONFIG['metrics']:
         aggregator.assert_metric(mname, tags=["foobar"], count=1)
         aggregator.assert_metric(mname, tags=["foobar"], count=1)

--- a/wmi_check/tests/test_wmi_check.py
+++ b/wmi_check/tests/test_wmi_check.py
@@ -56,6 +56,9 @@ def test_invalid_metrics(aggregator, check):
 def test_check(mock_disk_sampler, aggregator, check):
     check.check(common.WMI_CONFIG)
 
+    for metric, value in aggregator._metrics.iteritems():
+        log.warning('{} {}'.format(metric, value))
+
     for _, mname, _ in common.WMI_CONFIG['metrics']:
         aggregator.assert_metric(mname, tags=["foobar", "name:c:"], count=1)
         aggregator.assert_metric(mname, tags=["foobar", "name:d:"], count=1)

--- a/wmi_check/tests/test_wmi_check.py
+++ b/wmi_check/tests/test_wmi_check.py
@@ -20,6 +20,8 @@ def test_basic_check(mock_proc_sampler, aggregator, check):
 
     aggregator.assert_all_metrics_covered()
 
+    assert False
+
 
 def test_tags(mock_proc_sampler, aggregator, check):
     instance = copy.deepcopy(common.INSTANCE)


### PR DESCRIPTION
### What does this PR do?

In https://github.com/DataDog/integrations-core/pull/2133 I forgot to add the check to appveyor after removing the rake command. This will do that!

I also realized after adding it that the test was slightly broken. This will fix it.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

