### PR TITLE
Allow checks to manually specify in their configuration which defaults to use

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/checks/openmetrics/base_check.py
@@ -53,10 +53,7 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
             return self.config_map[endpoint]
 
         # Otherwise, we create the scraper configuration
-        #   To get the same behaviour for GenericPrometheusCheck-based checks porting to this class,
-        #   we must set the proper default values (which are different than the ones in mixins.py) by setting
-        #   created_by_base_class to True
-        config = self.create_scraper_configuration(instance, created_by_base_class=True)
+        config = self.create_scraper_configuration(instance)
 
         # Add this configuration to the config_map
         self.config_map[endpoint] = config

--- a/datadog_checks_base/datadog_checks/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/checks/openmetrics/mixins.py
@@ -36,7 +36,7 @@ class OpenMetricsScraperMixin(object):
         # Initialize AgentCheck's base class
         super(OpenMetricsScraperMixin, self).__init__(*args, **kwargs)
 
-    def create_scraper_configuration(self, instance=None, created_by_base_class=False):
+    def create_scraper_configuration(self, instance=None):
 
         # We can choose to create a default mixin configuration for an empty instance
         if instance is None:
@@ -138,12 +138,9 @@ class OpenMetricsScraperMixin(object):
                                                            default_instance.get('send_histograms_buckets', True)))
 
         # If you want to send `counter` metrics as monotonic counts, set this value to True.
-        # Set to False if you want to instead send those metrics as `gauge`. This is True by default, unless otherwise
-        # specified by the instance configuration or if it's created by the OpenMetricsBaseCheck class. This is to ensure
-        # backwards compatibility for checks that want to easily use OpenMetricsBaseCheck instead of GenericPrometheusCheck.
+        # Set to False if you want to instead send those metrics as `gauge`.
         config['send_monotonic_counter'] = is_affirmative(instance.get('send_monotonic_counter',
-                                                          default_instance.get('send_monotonic_counter',
-                                                          not created_by_base_class)))
+                                                          default_instance.get('send_monotonic_counter', True)))
 
         # If the `labels_mapper` dictionary is provided, the metrics labels names
         # in the `labels_mapper` will use the corresponding value as tag name
@@ -169,12 +166,9 @@ class OpenMetricsScraperMixin(object):
         # a label can hold this information, this transfers it to the hostname
         config['label_to_hostname'] = instance.get('label_to_hostname', default_instance.get('label_to_hostname', None))
 
-        # Add a 'health' service check for the prometheus endpoint, this is True by default, unless otherwise specified
-        # by the instance configuration or if it's created by the OpenMetricsBaseCheck class. This is to ensure backwards
-        # compatibility for checks that want to easily use OpenMetricsBaseCheck instead of GenericPrometheusCheck.
+        # Add a 'health' service check for the prometheus endpoint
         config['health_service_check'] = is_affirmative(instance.get('health_service_check',
-                                                        default_instance.get('health_service_check',
-                                                        not created_by_base_class)))
+                                                        default_instance.get('health_service_check', True)))
 
         # Can either be only the path to the certificate and thus you should specify the private key
         # or it can be the path to a file containing both the certificate & the private key

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -42,37 +42,28 @@ def aggregator():
     return aggregator
 
 
-GENERIC_PROMETHEUS_INSTANCE = {
+PROMETHEUS_CHECK_INSTANCE = {
     'prometheus_url': 'http://fake.endpoint:10055/metrics',
     'metrics': [{'process_virtual_memory_bytes': 'process.vm.bytes'}],
     'namespace': 'prometheus',
+
+    # Defaults for checks that were based on PrometheusCheck
+    'send_monotonic_counter': False,
+    'health_service_check': True
 }
 
 
 @pytest.fixture
 def mocked_prometheus_check():
-    # We make sure the defaults used in OpenMetricsScraperMixin are the same defaults used in PrometheusScraperMixin
-    orig_create_scraper_configuration = OpenMetricsBaseCheck.create_scraper_configuration
-
-    def remove_created_by_base_class(self, *args, **kwargs):
-        if 'created_by_base_class' in kwargs:
-            del kwargs['created_by_base_class']
-        elif len(args) > 1:
-            del args[1]
-
-        return orig_create_scraper_configuration(self, *args, **kwargs)
-
-    with mock.patch('datadog_checks.checks.openmetrics.OpenMetricsBaseCheck.create_scraper_configuration',
-                    side_effect=remove_created_by_base_class, autospec=True):
-        check = OpenMetricsBaseCheck('prometheus_check', {}, {})
-        check.log = logging.getLogger('datadog-prometheus.test')
-        check.log.debug = mock.MagicMock()
-        yield check
+    check = OpenMetricsBaseCheck('prometheus_check', {}, {})
+    check.log = logging.getLogger('datadog-prometheus.test')
+    check.log.debug = mock.MagicMock()
+    return check
 
 
 @pytest.fixture
 def mocked_prometheus_scraper_config(mocked_prometheus_check):
-    yield mocked_prometheus_check.get_scraper_config(GENERIC_PROMETHEUS_INSTANCE)
+    yield mocked_prometheus_check.get_scraper_config(PROMETHEUS_CHECK_INSTANCE)
 
 
 @pytest.fixture


### PR DESCRIPTION
### What does this PR do?

This PR essentially allows checks to manually specify the configurations they want to use, rather than making that an option in the base class.

### Motivation

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes
