### PR TITLE
Additional debug logging when calling a stored procedure

### DIFF
--- a/mysql/README.md
+++ b/mysql/README.md
@@ -32,6 +32,13 @@ mysql> CREATE USER 'datadog'@'localhost' IDENTIFIED BY '<UNIQUEPASSWORD>';
 Query OK, 0 rows affected (0.00 sec)
 ```
 
+For mySQL 8.0+ create the `datadog` user with the native password hashing method:
+
+```
+mysql> CREATE USER 'datadog'@'localhost' IDENTIFIED WITH mysql_native_password by '<UNIQUEPASSWORD>';
+Query OK, 0 rows affected (0.00 sec)
+```
+
 Please note that `@'localhost'` is only for local connections - use the hostname/IP of your Agent for remote connections. For more information, see the [MySQL documentation][14].
 
 
@@ -53,6 +60,13 @@ mysql> GRANT REPLICATION CLIENT ON *.* TO 'datadog'@'localhost' WITH MAX_USER_CO
 Query OK, 0 rows affected, 1 warning (0.00 sec)
 
 mysql> GRANT PROCESS ON *.* TO 'datadog'@'localhost';
+Query OK, 0 rows affected (0.00 sec)
+```
+
+For mySQL 8.0+ set `max_user_connections` with:
+
+```
+mysql> ALTER USER 'datadog'@'localhost' WITH MAX_USER_CONNECTIONS 5;
 Query OK, 0 rows affected (0.00 sec)
 ```
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 from collections import defaultdict
 
 # 3rd party
+import json
 import adodbapi
 try:
     import pyodbc
@@ -531,8 +532,15 @@ class SQLServer(AgentCheck):
             cursor = self.get_cursor(instance, self.DEFAULT_DB_KEY)
 
             try:
+                self.log.debug("Calling Stored Procedure : {}".format(proc))
                 cursor.callproc(proc)
                 rows = cursor.fetchall()
+                self.log.debug("Row count ({}) : {}".format(proc, cursor.rowcount))
+
+                log_rows = 5
+                items = [dict(zip([key[0] for key in cursor.description], row)) for row in rows]
+                self.log.debug("First {} rows : {}".format(log_rows, json.dumps({'rows': items[:log_rows]})))
+
                 for row in rows:
                     tags = [] if row.tags is None or row.tags == '' else row.tags.split(',')
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -12,7 +12,6 @@ from contextlib import contextmanager
 from collections import defaultdict
 
 # 3rd party
-import json
 import adodbapi
 try:
     import pyodbc
@@ -536,10 +535,6 @@ class SQLServer(AgentCheck):
                 cursor.callproc(proc)
                 rows = cursor.fetchall()
                 self.log.debug("Row count ({}) : {}".format(proc, cursor.rowcount))
-
-                log_rows = 5
-                items = [dict(zip([key[0] for key in cursor.description], row)) for row in rows]
-                self.log.debug("First {} rows : {}".format(log_rows, json.dumps({'rows': items[:log_rows]})))
 
                 for row in rows:
                     tags = [] if row.tags is None or row.tags == '' else row.tags.split(',')


### PR DESCRIPTION
logs rowcount and first 5 rows returned

### What does this PR do?

Adds a view debug lines.
- What stored procedure is to be called.
- Number of rows returned by fetchall
- logs up to the first 5 rows as json

### Motivation

incident-related. helps to determine if a sproc is being called by a check, and if the check received results from the sproc

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
