### PR TITLE
adding v5 disclaimer

### DIFF
--- a/docker_daemon/README.md
+++ b/docker_daemon/README.md
@@ -146,9 +146,7 @@ Returns `OK` otherwise.
 
 **docker.container_health**:
 
-Returns `CRITICAL` if a container is unhealthy.
-Returns `UNKNOWN` if the health is unknown.
-Returns `OK` otherwise.
+This Service Check is only available for Agent v5. It Returns `CRITICAL` if a container is unhealthy, `UNKNOWN` if the health is unknown, `OK` otherwise.
 
 **docker.exit**:
 


### PR DESCRIPTION
### What does this PR do?

Adds a disclaimer for a service check

### Motivation

Docker integration on Agent 6 doesn't support docker.container_health check anymore.
