### PR TITLE
Handle character limit for Trello card descriptions

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
@@ -378,7 +378,7 @@ def testable(ctx, start_id, agent_version, dry_run):
                     rate_limited, error, response = trello.create_card(
                         value,
                         pr_title,
-                        'Pull request: {}\n\n{}'.format(pr_url, pr_body)
+                        u'Pull request: {}\n\n{}'.format(pr_url, pr_body)
                     )
                     if rate_limited:
                         wait_time = 10

--- a/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
@@ -27,7 +27,8 @@ class TrelloClient:
         params = {
             'idList': self.team_list_map[team],
             'name': name,
-            'desc': body,
+            # It appears the character limit for descriptions is ~5000
+            'desc': body[:5000],
         }
         params.update(self.auth)
 


### PR DESCRIPTION
### Motivation

Trello imposes a limit

### Additional Notes

Also handle unicode better on Python 2