### PR TITLE
Add ability to tag metrics based on marathon labels

### DIFF
--- a/marathon/datadog_checks/marathon/data/conf.yaml.example
+++ b/marathon/datadog_checks/marathon/data/conf.yaml.example
@@ -19,3 +19,9 @@ instances:
   #
   #   acs_url: the base ACS endpoint url if an ACS token is required to access the marathon API
   #   acs_url: https://server:port
+  #
+  #   static tags for all metrics
+  #   tags: ['name:value']
+  #
+  #   dynamic tags for metrics. The tag value is taken from the label in marathon
+  #   label_tags: ['name']

--- a/marathon/datadog_checks/marathon/marathon.py
+++ b/marathon/datadog_checks/marathon/marathon.py
@@ -227,20 +227,25 @@ class Marathon(AgentCheck):
         self.ensure_queue_count(queued, url, timeout, auth, acs_url, ssl_verify, tags, label_tags, group)
 
     def get_app_tags(self, app, tags=None, label_tags=None):
-        if label_tags is None:
+        if tags is None:
             tags = []
         if label_tags is None:
             label_tags = []
 
-        basic_tags = ['app_id:' + app['id'], 'version:' + app['version']]
+        basic_tags = ['app_id:{}'.format(app['id']), 'version:{}'.format(app['version'])]
+
         label_tag_values = []
         for label_name in label_tags:
             try:
                 label_value = app['labels'][label_name]
-                label_tag_values.append(label_name + ':' + label_value)
+                label_tag_values.append('{}:{}'.format(label_name, label_value))
             except KeyError:
                 pass
-        return basic_tags + label_tag_values + tags
+
+        tags.extend(basic_tags)
+        tags.extend(label_tag_values)
+
+        return tags
 
     def ensure_queue_count(self, queued, url, timeout, auth, acs_url, ssl_verify,
                            tags=None, label_tags=None, group=None):

--- a/marathon/datadog_checks/marathon/marathon.py
+++ b/marathon/datadog_checks/marathon/marathon.py
@@ -45,15 +45,16 @@ class Marathon(AgentCheck):
 
     def check(self, instance):
         try:
-            url, auth, acs_url, ssl_verify, group, instance_tags, timeout = self.get_instance_config(instance)
+            (url, auth, acs_url, ssl_verify, group,
+                instance_tags, label_tags, timeout) = self.get_instance_config(instance)
         except Exception as e:
             self.log.error("Invalid instance configuration.")
             raise e
 
         self.apps_response = None
-        self.process_apps(url, timeout, auth, acs_url, ssl_verify, instance_tags, group)
+        self.process_apps(url, timeout, auth, acs_url, ssl_verify, instance_tags, label_tags, group)
         self.process_deployments(url, timeout, auth, acs_url, ssl_verify, instance_tags)
-        self.process_queues(url, timeout, auth, acs_url, ssl_verify, instance_tags)
+        self.process_queues(url, timeout, auth, acs_url, ssl_verify, instance_tags, label_tags)
 
     def refresh_acs_token(self, auth, acs_url, tags=None):
         if tags is None:
@@ -141,10 +142,11 @@ class Marathon(AgentCheck):
         group = instance.get('group', None)
 
         tags = instance.get('tags', [])
+        label_tags = instance.get('label_tags', [])
         default_timeout = self.init_config.get('default_timeout', self.DEFAULT_TIMEOUT)
         timeout = float(instance.get('timeout', default_timeout))
 
-        return url, auth, acs_url, ssl_verify, group, tags, timeout
+        return url, auth, acs_url, ssl_verify, group, tags, label_tags, timeout
 
     def get_apps_json(self, url, timeout, auth, acs_url, ssl_verify, tags=None, group=None):
         if self.apps_response is not None:
@@ -160,13 +162,13 @@ class Marathon(AgentCheck):
         self.apps_response = self.get_json(marathon_path, timeout, auth, acs_url, ssl_verify, tags)
         return self.apps_response
 
-    def process_apps(self, url, timeout, auth, acs_url, ssl_verify, tags=None, group=None):
+    def process_apps(self, url, timeout, auth, acs_url, ssl_verify, tags=None, label_tags=None, group=None):
         response = self.get_apps_json(url, timeout, auth, acs_url, ssl_verify, tags, group)
         if response is None:
             return
         self.gauge('marathon.apps', len(response['apps']), tags=tags)
         for app in response['apps']:
-            app_tags = self.get_app_tags(app, tags)
+            app_tags = self.get_app_tags(app, tags, label_tags)
             for attr in self.APP_METRICS:
                 if attr in app:
                     self.gauge('marathon.' + attr, app[attr], tags=app_tags)
@@ -177,7 +179,7 @@ class Marathon(AgentCheck):
         if response is not None:
             self.gauge('marathon.deployments', len(response), tags=tags)
 
-    def process_queues(self, url, timeout, auth, acs_url, ssl_verify, tags=None, group=None):
+    def process_queues(self, url, timeout, auth, acs_url, ssl_verify, tags=None, label_tags=None, group=None):
         response = self.get_json(urljoin(url, "v2/queue"), timeout, auth, acs_url, ssl_verify, tags)
         if response is None:
             return
@@ -188,7 +190,7 @@ class Marathon(AgentCheck):
         queued = set()
 
         for queue in response['queue']:
-            q_tags = ['app_id:' + queue['app']['id'], 'version:' + queue['app']['version']] + tags
+            q_tags = self.get_app_tags(queue['app'], tags, label_tags)
 
             queued.add(queue['app']['id'])
 
@@ -222,12 +224,26 @@ class Marathon(AgentCheck):
                     except (KeyError, TypeError):
                         self.log.warn("Metric unavailable skipping: {}".format(metric_name))
 
-        self.ensure_queue_count(queued, url, timeout, auth, acs_url, ssl_verify, tags, group)
+        self.ensure_queue_count(queued, url, timeout, auth, acs_url, ssl_verify, tags, label_tags, group)
 
-    def get_app_tags(self, app, tags=None):
-        return ['app_id:' + app['id'], 'version:' + app['version']] + tags
+    def get_app_tags(self, app, tags=None, label_tags=None):
+        if label_tags is None:
+            tags = []
+        if label_tags is None:
+            label_tags = []
 
-    def ensure_queue_count(self, queued, url, timeout, auth, acs_url, ssl_verify, tags=None, group=None):
+        basic_tags = ['app_id:' + app['id'], 'version:' + app['version']]
+        label_tag_values = []
+        for label_name in label_tags:
+            try:
+                label_value = app['labels'][label_name]
+                label_tag_values.append(label_name + ':' + label_value)
+            except KeyError:
+                pass
+        return basic_tags + label_tag_values + tags
+
+    def ensure_queue_count(self, queued, url, timeout, auth, acs_url, ssl_verify,
+                           tags=None, label_tags=None, group=None):
         """
         Ensure `marathon.queue.count` is reported as zero for apps without queued instances.
         """
@@ -237,5 +253,5 @@ class Marathon(AgentCheck):
 
         for app in apps_response['apps']:
             if app['id'] not in queued:
-                q_tags = self.get_app_tags(app, tags)
+                q_tags = self.get_app_tags(app, tags, label_tags)
                 self.gauge(metric_name, 0, tags=q_tags)

--- a/marathon/datadog_checks/marathon/marathon.py
+++ b/marathon/datadog_checks/marathon/marathon.py
@@ -242,10 +242,10 @@ class Marathon(AgentCheck):
             except KeyError:
                 pass
 
-        tags.extend(basic_tags)
-        tags.extend(label_tag_values)
+        basic_tags.extend(tags)
+        basic_tags.extend(label_tag_values)
 
-        return tags
+        return basic_tags
 
     def ensure_queue_count(self, queued, url, timeout, auth, acs_url, ssl_verify,
                            tags=None, label_tags=None, group=None):

--- a/marathon/tests/conftest.py
+++ b/marathon/tests/conftest.py
@@ -32,6 +32,7 @@ def instance():
     return {
         'url': 'http://{}:{}'.format(HOST, PORT),
         'tags': ['optional:tag1'],
+        'label_tags': ['LABEL_NAME'],
         'enable_deployment_metrics': True
     }
 

--- a/marathon/tests/fixtures/apps.json
+++ b/marathon/tests/fixtures/apps.json
@@ -68,7 +68,8 @@
       },
       "labels": {
         "HAPROXY_0_VHOST": "my-app.my-org.net",
-        "HAPROXY_GROUP": "my-app"
+        "HAPROXY_GROUP": "my-app",
+        "LABEL_NAME": "label_value_1"
       },
       "acceptedResourceRoles": null,
       "ipAddress": null,

--- a/marathon/tests/test_marathon.py
+++ b/marathon/tests/test_marathon.py
@@ -50,7 +50,7 @@ def test_default_configuration(aggregator, check, instance, apps, deployments, q
 
     for metric in APP_METRICS:
         aggregator.assert_metric(metric, count=1, tags=['app_id:/my-app', 'version:2016-08-25T18:13:34.079Z',
-                                                        'optional:tag1'])
+                                                        'optional:tag1', 'LABEL_NAME:label_value_1'])
         aggregator.assert_metric(metric, count=1, tags=['app_id:/my-app-2', 'version:2016-08-25T18:13:34.079Z',
                                                         'optional:tag1'])
 
@@ -99,7 +99,8 @@ def test_ensure_queue_count(aggregator, apps, check, instance):
     aggregator.assert_metric('marathon.queue.size', value=0)
     aggregator.assert_metric('marathon.queue.count', value=0, tags=['app_id:/my-app',
                                                                     'version:2016-08-25T18:13:34.079Z',
-                                                                    'optional:tag1'])
+                                                                    'optional:tag1',
+                                                                    'LABEL_NAME:label_value_1'])
     aggregator.assert_metric('marathon.queue.count', value=0, tags=['app_id:/my-app-2',
                                                                     'version:2016-08-25T18:13:34.079Z',
                                                                     'optional:tag1'])


### PR DESCRIPTION
### What does this PR do?

Use label_tags in the config to specify the name of labels to use as
tags for metrics for an application

### Motivation

We label our marathon applications with things like team_name or environment_name and would like this to be reflected in the datadog metrics.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
