### PR TITLE
Fix resourcequota and limitrange collection

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -326,7 +326,6 @@ class KubernetesState(OpenMetricsBaseCheck):
             self.log.debug("Unable to handle {} - unknown condition {}".format(service_check_name, label_value))
         else:
             self.service_check(service_check_name, mapping[label_value], tags=tags, message=message)
-            self.log.debug("{} {} {}".format(service_check_name, mapping[label_value], tags))
 
     def _get_metric_condition_map(self, base_sc_name, labels):
         if base_sc_name == 'kubernetes_state.node':
@@ -598,8 +597,8 @@ class KubernetesState(OpenMetricsBaseCheck):
         suffixes = {'used': 'used', 'hard': 'limit'}
         if metric.type in METRIC_TYPES:
             for sample in metric.samples:
-                mtype = self._extract_label_value("type", sample[self.SAMPLE_LABELS])
-                resource = self._extract_label_value("resource", sample[self.SAMPLE_LABELS])
+                mtype = sample[self.SAMPLE_LABELS].get("type")
+                resource = sample[self.SAMPLE_LABELS].get("resource")
                 tags = [
                     self._label_to_tag("namespace", sample[self.SAMPLE_LABELS], scraper_config),
                     self._label_to_tag("resourcequota", sample[self.SAMPLE_LABELS], scraper_config)
@@ -630,7 +629,7 @@ class KubernetesState(OpenMetricsBaseCheck):
                 else:
                     self.error("Constraint %s unsupported for metric %s" % (constraint, metric.name))
                     continue
-                resource = self._extract_label_value("resource", sample[self.SAMPLE_LABELS])
+                resource = sample[self.SAMPLE_LABELS].get("resource")
                 tags = [
                     self._label_to_tag("namespace", sample[self.SAMPLE_LABELS], scraper_config),
                     self._label_to_tag("limitrange", sample[self.SAMPLE_LABELS], scraper_config),

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -812,3 +812,18 @@ kube_service_labels{label_app="helm",label_name="tiller",namespace="kube-system"
 kube_service_labels{label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="kube-dns",label_kubernetes_io_name="KubeDNS",namespace="kube-system",service="kube-dns"} 1
 kube_service_labels{label_addonmanager_kubernetes_io_mode="Reconcile",label_app="kubernetes-dashboard",label_kubernetes_io_minikube_addons="dashboard",label_kubernetes_io_minikube_addons_endpoint="dashboard",namespace="kube-system",service="kubernetes-dashboard"} 1
 kube_service_labels{label_app="kube-state-metrics",label_chart="kube-state-metrics-0.3.1",label_heritage="Tiller",label_release="jaundiced-numbat",namespace="default",service="jaundiced-numbat-kube-state-metrics"} 1
+# HELP kube_resourcequota Information about resource quota.
+# TYPE kube_resourcequota gauge
+kube_resourcequota{namespace="default",resource="cpu",resourcequota="custom-resource-quotas",type="hard"} 65
+kube_resourcequota{namespace="default",resource="cpu",resourcequota="custom-resource-quotas",type="used"} 15.904
+kube_resourcequota{namespace="default",resource="limits.cpu",resourcequota="custom-resource-quotas",type="hard"} 100
+kube_resourcequota{namespace="default",resource="limits.cpu",resourcequota="custom-resource-quotas",type="used"} 15.904
+kube_resourcequota{namespace="default",resource="limits.memory",resourcequota="custom-resource-quotas",type="hard"} 1.34217728e+11
+kube_resourcequota{namespace="default",resource="limits.memory",resourcequota="custom-resource-quotas",type="used"} 7.7129056256e+10
+kube_resourcequota{namespace="default",resource="memory",resourcequota="custom-resource-quotas",type="hard"} 1.34217728e+11
+kube_resourcequota{namespace="default",resource="memory",resourcequota="custom-resource-quotas",type="used"} 7.7129056256e+10
+kube_resourcequota{namespace="default",resource="pods",resourcequota="custom-resource-quotas",type="hard"} 1000
+kube_resourcequota{namespace="default",resource="pods",resourcequota="custom-resource-quotas",type="used"} 497
+# HELP kube_limitrange Information about limit range.
+# TYPE kube_limitrange gauge
+kube_limitrange{constraint="defaultRequest",limitrange="limits",namespace="default",resource="cpu",type="Container"} 0.1

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -78,6 +78,19 @@ METRICS = [
     NAMESPACE + '.statefulset.replicas_current',
     NAMESPACE + '.statefulset.replicas_ready',
     NAMESPACE + '.statefulset.replicas_updated',
+    # resourcequotas
+    NAMESPACE + '.resourcequota.cpu.used',
+    NAMESPACE + '.resourcequota.cpu.limit',
+    NAMESPACE + '.resourcequota.memory.used',
+    NAMESPACE + '.resourcequota.memory.limit',
+    NAMESPACE + '.resourcequota.pods.used',
+    NAMESPACE + '.resourcequota.pods.limit',
+    NAMESPACE + '.resourcequota.limits.cpu.used',
+    NAMESPACE + '.resourcequota.limits.cpu.limit',
+    NAMESPACE + '.resourcequota.limits.memory.used',
+    NAMESPACE + '.resourcequota.limits.memory.limit',
+    # limitrange
+    NAMESPACE + '.limitrange.cpu.default_request',
 ]
 
 TAGS = {


### PR DESCRIPTION
### What does this PR do?

Fix removed calls to `self._extract_label_value` that disappeared with the openmetrics migration

### Motivation

Correctly submit `resourcequota` and `limitrange` metrics

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
