### PR TITLE
Change order of precedence of whitelist and blacklist for pattern filtering

### DIFF
--- a/datadog_checks_base/tests/test_utils.py
+++ b/datadog_checks_base/tests/test_utils.py
@@ -38,12 +38,12 @@ class TestPatternFilter:
 
         assert pattern_filter(items, blacklist=blacklist) == ['ghi']
 
-    def test_whitelist_override(self):
+    def test_whitelist_blacklist(self):
         items = ['abc', 'def', 'abcdef', 'ghi']
         whitelist = ['def']
-        blacklist = ['abc', 'def']
+        blacklist = ['abc']
 
-        assert pattern_filter(items, whitelist=whitelist, blacklist=blacklist) == ['def', 'abcdef', 'ghi']
+        assert pattern_filter(items, whitelist=whitelist, blacklist=blacklist) == ['def']
 
     def test_key_function(self):
         items = [Item('abc'), Item('def'), Item('abcdef'), Item('ghi')]

--- a/envoy/README.md
+++ b/envoy/README.md
@@ -106,7 +106,7 @@ Setting | Description
 
 #### Metric filtering
 
-Metrics can be filtered using a regular expression `metric_whitelist` or `metric_blacklist`. If both are used, the blacklist is applied as long as it doesn't conflict with the whitelist.
+Metrics can be filtered using a regular expression `metric_whitelist` or `metric_blacklist`. If both are used, then whitelist is applied first, and then blacklist is applied on the resulting set.
 
 The filtering occurs before tag extraction, so you have the option to have certain tags decide whether or not to keep or ignore metrics. An exhaustive list of all metrics and tags can be found in [metrics.py][15]. Let's walk through an example of Envoy metric tagging!
 

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -129,7 +129,7 @@ class Envoy(AgentCheck):
         if self.whitelist:
             whitelisted = any(pattern.search(metric) for pattern in self.whitelist)
             if self.blacklist:
-                whitelisted = whitelisted or not any(pattern.search(metric) for pattern in self.blacklist)
+                whitelisted = whitelisted and not any(pattern.search(metric) for pattern in self.blacklist)
 
             if self.caching_metrics and whitelisted:
                 self.whitelisted_metrics.add(metric)

--- a/envoy/tests/common.py
+++ b/envoy/tests/common.py
@@ -30,10 +30,10 @@ INSTANCES = {
     'whitelist_blacklist': {
         'stats_url': 'http://{}:{}/stats'.format(HOST, PORT),
         'metric_whitelist': [
-            r'envoy\.cluster\.(in|out)\..*',
+            r'envoy\.cluster\.',
         ],
         'metric_blacklist': [
-            r'envoy\..*',
+            r'envoy\.cluster\.out',
         ],
     },
 }

--- a/envoy/tests/test_envoy.py
+++ b/envoy/tests/test_envoy.py
@@ -65,10 +65,7 @@ class TestEnvoy:
             c.check(instance)
 
         for metric in aggregator.metric_names:
-            metric_stubs = aggregator.metrics(metric)
-            for metric_stub in metric_stubs:
-                for tag in metric_stub.tags:
-                    assert tag.split(':', 1)[1].startswith(('in', 'out'))
+            assert metric.startswith("envoy.cluster.") and not metric.startswith("envoy.cluster.out")
 
     def test_service_check(self, aggregator):
         instance = INSTANCES['main']


### PR DESCRIPTION
### What does this PR do?

The order is now: apply whitelist, then apply blacklist on remaining set of elements

### Motivation

The other way is really counter intuitive and confusing. For example, if you blacklist a single element, that doesn't appear in your original set, then no matter what you set as a whitelist, the filter will always return your entire set. 
This can appear as a bug, but technically it is not since the metrics you whitelisted are here all right, and the ones you blacklisted aren't.
This should answer https://github.com/DataDog/integrations-core/pull/1527#issuecomment-389351322

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?