### PR TITLE
Gracefully handle failed version regex match

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -394,20 +394,21 @@ GROUP BY datid, datname
         if key not in self.versions:
             cursor = db.cursor()
             cursor.execute('SHOW SERVER_VERSION;')
-            result = cursor.fetchone()
+            version = cursor.fetchone()[0]
             try:
-                version = map(int, result[0].split(' ')[0].split('.'))
+                version_parts = version.split(' ')[0].split('.')
+                version = [int(part) for part in version_parts]
             except Exception:
                 # Postgres might be in beta, with format \d+beta\d+
-                version = list(re.match('(\d+)(beta)(\d+)', result[0]).groups())
+                match = re.match('(\d+)(beta)(\d+)', version)
+                if match:
+                    version_parts = list(match.groups())
 
-                # We found a valid beta version
-                if len(version) == 3:
-                    # Replace beta with a negative number to properly compare versions
-                    version[1] = -1
-                    version = map(int, version)
-                else:
-                    version = result[0]
+                    # We found a valid beta version
+                    if len(version_parts) == 3:
+                        # Replace `beta` with a negative number to properly compare versions
+                        version_parts[1] = -1
+                        version = [int(part) for part in version_parts]
 
             self.versions[key] = version
 

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -100,6 +100,10 @@ def test_get_version(check):
     db.cursor().fetchone.return_value = ['11beta3']
     assert check._get_version('beta_version', db) == [11, -1, 3]
 
+    # Test #unknown# style versions
+    db.cursor().fetchone.return_value = ['11nightly3']
+    assert check._get_version('unknown_version', db) == '11nightly3'
+
 
 def test_is_above(check):
     """

--- a/postgres/tox.ini
+++ b/postgres/tox.ini
@@ -9,8 +9,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    -e../datadog_checks_base
-    -r../datadog_checks_base/requirements.in
+    -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt


### PR DESCRIPTION
### Motivation

A failed match causes:

```
>               version = list(re.match('(\d+)(beta)(\d+)', result[0]).groups())
E               AttributeError: 'NoneType' object has no attribute 'groups'
```