### PR TITLE
 Gracefully handle errors when performing custom_queries

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -869,8 +869,9 @@ GROUP BY datid, datname
                     cursor.execute(query)
                     row = cursor.fetchone()
                 except programming_error as e:
-                    self.log.warning("Not all metrics may be available: {}".format(str(e)))
+                    self.log.error("Error executing query for metric_prefix {}: {}".format(metric_prefix, str(e)))
                     db.rollback()
+                    continue
 
                 if not row:
                     self.log.debug("query result for metric_prefix {}: returned an empty result".format(metric_prefix))

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -178,6 +178,7 @@ def test_malformed_get_custom_queries(check):
     malformed_custom_query_column = {}
     malformed_custom_query['columns'] = [malformed_custom_query_column]
     query_return = ['num', 1337]
+    db.cursor().execute.side_effect = None
     db.cursor().fetchone.return_value = query_return
     check._get_custom_queries(db, [], [malformed_custom_query], programming_error)
     check.log.error.assert_called_once_with("query result for metric_prefix {}: expected {} columns, got {}".format(

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -172,6 +172,7 @@ def test_malformed_get_custom_queries(check):
     check._get_custom_queries(db, [], [malformed_custom_query], programming_error)
     check.log.error.assert_called_once_with("Error executing query for metric_prefix {}: ".format(
                                             malformed_custom_query['metric_prefix']))
+    check.log.reset_mock()
 
     # Make sure the number of columns defined is the same as the number of columns return by the query
     malformed_custom_query_column = {}

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -165,6 +165,14 @@ def test_malformed_get_custom_queries(check):
                                             malformed_custom_query['metric_prefix']))
     check.log.reset_mock()
 
+    # Make sure we gracefully handle an error while performing custom queries
+    malformed_custom_query_column = {}
+    malformed_custom_query['columns'] = [malformed_custom_query_column]
+    db.cursor().execute.side_effect = programming_error
+    check._get_custom_queries(db, [], [malformed_custom_query], programming_error)
+    check.log.error.assert_called_once_with("Error executing query for metric_prefix {}: ".format(
+                                            malformed_custom_query['metric_prefix']))
+
     # Make sure the number of columns defined is the same as the number of columns return by the query
     malformed_custom_query_column = {}
     malformed_custom_query['columns'] = [malformed_custom_query_column]
@@ -180,7 +188,7 @@ def test_malformed_get_custom_queries(check):
     db.cursor().fetchone.return_value = []
     check._get_custom_queries(db, [], [malformed_custom_query], programming_error)
     check.log.debug.assert_called_with("query result for metric_prefix {}: returned an empty result".format(
-                                        malformed_custom_query['metric_prefix']))
+                                       malformed_custom_query['metric_prefix']))
     check.log.reset_mock()
 
     # Make sure 'name' is defined in each column


### PR DESCRIPTION
### What does this PR do?

Don't continue collecting custom query metrics if error when executing the query

### Motivation

Check would fail with `variable row referenced before assignement`

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?