### PR TITLE
Fix multiple db key length

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from copy import deepcopy
 
 import redis
+import six
 
 from datadog_checks.checks import AgentCheck
 from datadog_checks.config import is_affirmative
@@ -166,7 +167,6 @@ class Redis(AgentCheck):
 
     def _check_db(self, instance, custom_tags=None):
         conn = self._get_conn(instance)
-
         tags = self._get_tags(custom_tags, instance)
 
         # Ping the database for info, and track the latency.
@@ -231,55 +231,88 @@ class Redis(AgentCheck):
                        tags=tags)
 
         # Check some key lengths if asked
-        key_list = instance.get('keys')
-        if key_list is not None:
-            if not isinstance(key_list, list) or len(key_list) == 0:
-                self.warning("keys in redis configuration is either not a list or empty")
-            else:
-                l_tags = list(tags)
+        self._check_key_lengths(conn, instance, list(tags))
 
-                num_databases = int(conn.config_get('databases').get('databases', 1))
-                new_instance = deepcopy(instance)
-
-                for i in range(num_databases):
-                    new_instance['db'] = i
-                    db_conn = self._get_conn(new_instance)
-
-                    for key_pattern in key_list:
-                        if re.search(r"(?<!\\)[*?[]", key_pattern):
-                            keys = db_conn.scan_iter(match=key_pattern)
-                        else:
-                            keys = [key_pattern, ]
-
-                        for key in keys:
-                            try:
-                                key_type = db_conn.type(key)
-                            except redis.ResponseError:
-                                self.log.info("key {} on remote server; skipping".format(key))
-                                continue
-                            key_tags = l_tags + ['key:' + key]
-
-                            if key_type == 'list':
-                                self.gauge('redis.key.length', db_conn.llen(key), tags=key_tags)
-                            elif key_type == 'set':
-                                self.gauge('redis.key.length', db_conn.scard(key), tags=key_tags)
-                            elif key_type == 'zset':
-                                self.gauge('redis.key.length', db_conn.zcard(key), tags=key_tags)
-                            elif key_type == 'hash':
-                                self.gauge('redis.key.length', db_conn.hlen(key), tags=key_tags)
-                            else:
-                                # If the type is unknown, it might be because the key doesn't exist,
-                                # which can be because the list is empty. So always send 0 in that case.
-                                if instance.get("warn_on_missing_keys", True):
-                                    self.warning("{0} key not found in redis".format(key))
-                                self.gauge('redis.key.length', 0, tags=key_tags)
-
+        # Check replication
         self._check_replication(info, tags)
         if instance.get("command_stats", False):
             self._check_command_stats(conn, tags)
 
-    def _check_replication(self, info, tags):
+    def _check_key_lengths(self, conn, instance, tags):
+        """
+        Compute the length of the configured keys across all the databases
+        """
+        key_list = instance.get('keys')
 
+        if key_list is None:
+            return
+
+        if not isinstance(key_list, list) or len(key_list) == 0:
+            self.warning("keys in redis configuration is either not a list or empty")
+            return
+
+        # get all the available databases
+        databases = conn.info('keyspace').keys()
+        if not databases:
+            self.warning("Redis database is empty")
+            return
+
+        # convert to integer the output of `keyspace`, from `db0` to `0`
+        # and store items in a set
+        databases = [int(dbstring[2:]) for dbstring in databases]
+
+        # user might have configured the instance to target one specific db
+        if 'db' in instance:
+            db = instance['db']
+            if db not in databases:
+                self.warning("Cannot find database {}".format(instance['db']))
+                return
+            databases = [db, ]
+
+        # maps a key to the total length across databases
+        lengths = defaultdict(int)
+
+        # don't overwrite the configured instance, use a copy
+        tmp_instance = deepcopy(instance)
+
+        for db in databases:
+            tmp_instance['db'] = db
+            db_conn = self._get_conn(tmp_instance)
+
+            for key_pattern in key_list:
+                if re.search(r"(?<!\\)[*?[]", key_pattern):
+                    keys = db_conn.scan_iter(match=key_pattern)
+                else:
+                    keys = [key_pattern, ]
+
+                for key in keys:
+                    try:
+                        key_type = db_conn.type(key)
+                    except redis.ResponseError:
+                        self.log.info("key {} on remote server; skipping".format(key))
+                        continue
+
+                    if key_type == 'list':
+                        lengths[key] += db_conn.llen(key)
+                    elif key_type == 'set':
+                        lengths[key] += db_conn.scard(key)
+                    elif key_type == 'zset':
+                        lengths[key] += db_conn.zcard(key)
+                    elif key_type == 'hash':
+                        lengths[key] += db_conn.hlen(key)
+                    else:
+                        # If the type is unknown, it might be because the key doesn't exist,
+                        # which can be because the list is empty. So always send 0 in that case.
+                        lengths[key] += 0
+
+        # send the metrics
+        print(lengths)
+        for key, total in six.iteritems(lengths):
+            self.gauge('redis.key.length', total, tags=tags + ['key:' + key])
+            if total == 0 and instance.get("warn_on_missing_keys", True):
+                self.warning("{0} key not found in redis".format(key))
+
+    def _check_replication(self, info, tags):
         # Save the replication delay for each slave
         for key in info:
             if self.slave_key_pattern.match(key) and isinstance(info[key], dict):

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from copy import deepcopy
 
 import redis
-import six
+from six import iteritems
 
 from datadog_checks.checks import AgentCheck
 from datadog_checks.config import is_affirmative
@@ -306,8 +306,7 @@ class Redis(AgentCheck):
                         lengths[key] += 0
 
         # send the metrics
-        print(lengths)
-        for key, total in six.iteritems(lengths):
+        for key, total in iteritems(lengths):
             self.gauge('redis.key.length', total, tags=tags + ['key:' + key])
             if total == 0 and instance.get("warn_on_missing_keys", True):
                 self.warning("{0} key not found in redis".format(key))


### PR DESCRIPTION
### What does this PR do?

Fixes the behaviour of counting length for a given key across multiple databases.
The logic is the following:

 * if a `db` was specified in the config instance, key length will be computed on that db only
 * if `db` is missing from the config instance, length will be computed across all the available databases. In this case, a warning will be emitted if `warn_on_missing_keys` is true and a key has length 0 across all the databases.

### Motivation

Check is currently sending always `0` when only a couple of databases have keys among the 16 default ones. This happens because key length is computed also on those databases that are empty, so a gauge of `0` is always sent.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Moved the logic to a dedicated function to ease testing.
