### PR TITLE
Add the kubernetes.containers.running metric

### DIFF
--- a/kubelet/tests/fixtures/pods.json
+++ b/kubelet/tests/fixtures/pods.json
@@ -430,6 +430,286 @@
                 "containerStatuses": [
                     {
                         "restartCount": 0,
+                        "name": "fluentd-gcp",
+                        "image": "asia.gcr.io/google-containers/fluentd-gcp:2.0.10",
+                        "imageID": "docker-pullable://asia.gcr.io/google-containers/fluentd-gcp@sha256:a81a2c0137aee9f8a3e870898773976df9b63b27809bed2a4b9297531fb3c3c9",
+                        "state": {
+                            "running": {
+                                "startedAt": "2018-02-13T16:10:45Z"
+                            }
+                        },
+                        "ready": true,
+                        "lastState": {},
+                        "containerID": "docker://6941ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76561"
+                    },
+                    {
+                        "restartCount": 0,
+                        "name": "prometheus-to-sd-exporter",
+                        "image": "asia.gcr.io/google-containers/prometheus-to-sd:v0.2.2",
+                        "imageID": "docker-pullable://asia.gcr.io/google-containers/prometheus-to-sd@sha256:5831390762c790b0375c202579fd41dd5f40c71950f7538adbe14b0c16f35d56",
+                        "state": {
+                            "running": {
+                                "startedAt": "2018-02-13T16:10:46Z"
+                            }
+                        },
+                        "ready": true,
+                        "lastState": {},
+                        "containerID": "docker://690cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b05"
+                    }
+                ],
+                "podIP": "10.8.2.4",
+                "startTime": "2018-02-13T14:57:17Z",
+                "hostIP": "10.132.0.4",
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "Initialized",
+                        "lastTransitionTime": "2018-02-13T14:57:17Z"
+                    },
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "Ready",
+                        "lastTransitionTime": "2018-02-13T16:10:47Z"
+                    },
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "PodScheduled",
+                        "lastTransitionTime": "2018-02-13T14:57:27Z"
+                    }
+                ]
+            },
+            "spec": {
+                "dnsPolicy": "Default",
+                "securityContext": {},
+                "serviceAccountName": "fluentd-gcp",
+                "schedulerName": "default-scheduler",
+                "serviceAccount": "fluentd-gcp",
+                "nodeSelector": {
+                    "beta.kubernetes.io/fluentd-ds-ready": "true"
+                },
+                "terminationGracePeriodSeconds": 30,
+                "restartPolicy": "Always",
+                "volumes": [
+                    {
+                        "hostPath": {
+                            "path": "/var/log",
+                            "type": ""
+                        },
+                        "name": "varlog"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/var/lib/docker/containers",
+                            "type": ""
+                        },
+                        "name": "varlibdockercontainers"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/usr/lib64",
+                            "type": ""
+                        },
+                        "name": "libsystemddir"
+                    },
+                    {
+                        "configMap": {
+                            "name": "fluentd-gcp-config-v1.2.3",
+                            "defaultMode": 420
+                        },
+                        "name": "config-volume"
+                    },
+                    {
+                        "secret": {
+                            "defaultMode": 420,
+                            "secretName": "fluentd-gcp-token-vcd8d"
+                        },
+                        "name": "fluentd-gcp-token-vcd8d"
+                    }
+                ],
+                "tolerations": [
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.alpha.kubernetes.io/ismaster"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/disk-pressure"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/memory-pressure"
+                    }
+                ],
+                "containers": [
+                    {
+                        "livenessProbe": {
+                            "timeoutSeconds": 1,
+                            "exec": {
+                                "command": [
+                                    "/bin/sh",
+                                    "-c",
+                                    "LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300}; STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900}; if [ ! -e /var/log/fluentd-buffers ]; then\n  exit 1;\nfi; LAST_MODIFIED_DATE=`stat /var/log/fluentd-buffers | grep Modify | sed -r \"s/Modify: (.*)/\\1/\"`; LAST_MODIFIED_TIMESTAMP=`date -d \"$LAST_MODIFIED_DATE\" +%s`; if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $STUCK_THRESHOLD_SECONDS` ]; then\n  rm -rf /var/log/fluentd-buffers;\n  exit 1;\nfi; if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $LIVENESS_THRESHOLD_SECONDS` ]; then\n  exit 1;\nfi;\n"
+                                ]
+                            },
+                            "initialDelaySeconds": 600,
+                            "periodSeconds": 60,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "name": "fluentd-gcp",
+                        "image": "gcr.io/google-containers/fluentd-gcp:2.0.10",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/var/log",
+                                "name": "varlog"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/var/lib/docker/containers",
+                                "name": "varlibdockercontainers"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/host/lib",
+                                "name": "libsystemddir"
+                            },
+                            {
+                                "mountPath": "/etc/fluent/config.d",
+                                "name": "config-volume"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "fluentd-gcp-token-vcd8d"
+                            }
+                        ],
+                        "terminationMessagePolicy": "File",
+                        "env": [
+                            {
+                                "name": "FLUENTD_ARGS",
+                                "value": "--no-supervisor -q"
+                            }
+                        ],
+                        "imagePullPolicy": "IfNotPresent",
+                        "resources": {
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "200Mi"
+                            },
+                            "limits": {
+                                "memory": "300Mi"
+                            }
+                        }
+                    },
+                    {
+                        "terminationMessagePath": "/dev/termination-log",
+                        "name": "prometheus-to-sd-exporter",
+                        "image": "gcr.io/google-containers/prometheus-to-sd:v0.2.2",
+                        "volumeMounts": [
+                            {
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "fluentd-gcp-token-vcd8d"
+                            }
+                        ],
+                        "terminationMessagePolicy": "File",
+                        "command": [
+                            "/monitor",
+                            "--stackdriver-prefix=container.googleapis.com/internal/addons",
+                            "--api-override=https://monitoring.googleapis.com/",
+                            "--source=fluentd:http://localhost:31337?whitelisted=stackdriver_successful_requests_count,stackdriver_failed_requests_count,stackdriver_ingested_entries_count,stackdriver_dropped_entries_count",
+                            "--pod-id=$(POD_NAME)",
+                            "--namespace-id=$(POD_NAMESPACE)"
+                        ],
+                        "env": [
+                            {
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "fieldPath": "metadata.name",
+                                        "apiVersion": "v1"
+                                    }
+                                },
+                                "name": "POD_NAME"
+                            },
+                            {
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "fieldPath": "metadata.namespace",
+                                        "apiVersion": "v1"
+                                    }
+                                },
+                                "name": "POD_NAMESPACE"
+                            }
+                        ],
+                        "imagePullPolicy": "IfNotPresent",
+                        "resources": {}
+                    }
+                ],
+                "nodeName": "gke-haissam-default-pool-be5066f1-wnvn"
+            },
+            "metadata": {
+                "name": "fluentd-gcp-v2.0.10-9q9t4",
+                "labels": {
+                    "k8s-app": "fluentd-gcp",
+                    "version": "v2.0.10",
+                    "pod-template-generation": "1",
+                    "kubernetes.io/cluster-service": "true",
+                    "controller-revision-hash": "1108666223"
+                },
+                "namespace": "kube-system",
+                "ownerReferences": [
+                    {
+                        "kind": "DaemonSet",
+                        "name": "fluentd-gcp-v2.0.10",
+                        "apiVersion": "extensions/v1beta1",
+                        "controller": true,
+                        "blockOwnerDeletion": true,
+                        "uid": "77585c76-10cc-11e8-bd5a-42010af00137"
+                    }
+                ],
+                "resourceVersion": "30704838",
+                "generateName": "fluentd-gcp-v2.0.10-",
+                "creationTimestamp": "2018-02-13T14:57:17Z",
+                "annotations": {
+                    "scheduler.alpha.kubernetes.io/critical-pod": "",
+                    "kubernetes.io/config.source": "api",
+                    "kubernetes.io/config.seen": "2018-02-13T16:10:19.509264637Z"
+                },
+                "selfLink": "/api/v1/namespaces/kube-system/pods/fluentd-gcp-v2.0.10-9q9t4",
+                "uid": "2fdfd4d9-10ce-11e8-bd5a-42010af00137"
+            }
+        },
+        {
+            "status": {
+                "qosClass": "Burstable",
+                "containerStatuses": [
+                    {
+                        "restartCount": 0,
                         "name": "datadog-agent",
                         "image": "datadog/agent-dev:haissam-tagger-pod-entity",
                         "imageID": "docker-pullable://datadog/agent-dev@sha256:894fb66f89be0332a47388d7219ab8b365520ff0e3bbf597bd0a378b19efa7ee",

--- a/kubelet/tests/test_common.py
+++ b/kubelet/tests/test_common.py
@@ -31,7 +31,7 @@ def test_container_filter(monkeypatch):
     pod_list_utils = PodListUtils(pods)
 
     assert pod_list_utils is not None
-    assert len(pod_list_utils.containers) == 5
+    assert len(pod_list_utils.containers) == 7
     assert long_cid in pod_list_utils.containers
     is_excluded.assert_not_called()
 

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -186,8 +186,8 @@ def test_prometheus_cpu_summed(monkeypatch, aggregator):
     #
     calls = [
         mock.call('kubernetes.cpu.usage.total', 2053640000000.0, [
-            'pod_name:fluentd-gcp-v2.0.10-9q9t4',
-            'kube_container_name:fluentd-gcp'
+            'kube_container_name:fluentd-gcp',
+            'kube_deployment:fluentd-gcp-v2.0.10'
         ]),
         mock.call('kubernetes.cpu.usage.total', 7756358313.0, ['pod_name=demo-app-success-c485bc67b-klj45']),
     ]
@@ -196,12 +196,12 @@ def test_prometheus_cpu_summed(monkeypatch, aggregator):
     # Make sure the per-core metrics are not submitted
     bad_calls = [
         mock.call('kubernetes.cpu.usage.total', 1228320000000.0, [
-            'pod_name:fluentd-gcp-v2.0.10-9q9t4',
-            'kube_container_name:fluentd-gcp'
+            'kube_container_name:fluentd-gcp',
+            'kube_deployment:fluentd-gcp-v2.0.10'
         ]),
         mock.call('kubernetes.cpu.usage.total', 825320000000.0, [
-            'pod_name:fluentd-gcp-v2.0.10-9q9t4',
-            'kube_container_name:fluentd-gcp'
+            'kube_container_name:fluentd-gcp',
+            'kube_deployment:fluentd-gcp-v2.0.10'
         ]),
     ]
     for c in bad_calls:
@@ -221,7 +221,7 @@ def test_prometheus_net_summed(monkeypatch, aggregator):
     #
     calls = [
         mock.call('kubernetes.network.rx_bytes', 35276103554.0, ['pod_name:dd-agent-q6hpw']),
-        mock.call('kubernetes.network.rx_bytes', 58107648.0, ['pod_name:fluentd-gcp-v2.0.10-9q9t4']),
+        mock.call('kubernetes.network.rx_bytes', 58107648.0, ['pod_name:fluentd-gcp-v2.0.10-fkeuj']),
     ]
     check.rate.assert_has_calls(calls, any_order=True)
 
@@ -268,13 +268,24 @@ def mocked_get_tags(entity, _):
         "kubernetes_pod://2edfd4d9-10ce-11e8-bd5a-42010af00137": [
             "pod_name:fluentd-gcp-v2.0.10-9q9t4"
         ],
+        "kubernetes_pod://2fdfd4d9-10ce-11e8-bd5a-42010af00137": [
+            "pod_name:fluentd-gcp-v2.0.10-fkeuj"
+        ],
         'docker://5741ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76561': [
-            'pod_name:fluentd-gcp-v2.0.10-9q9t4',
-            'kube_container_name:fluentd-gcp'
+            'kube_container_name:fluentd-gcp',
+            'kube_deployment:fluentd-gcp-v2.0.10'
         ],
         "docker://580cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b05": [
-            'pod_name:fluentd-gcp-v2.0.10-9q9t4',
-            'kube_container_name:prometheus-to-sd-exporter'
+            'kube_container_name:prometheus-to-sd-exporter',
+            'kube_deployment:fluentd-gcp-v2.0.10'
+        ],
+        'docker://6941ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76561': [
+            'kube_container_name:fluentd-gcp',
+            'kube_deployment:fluentd-gcp-v2.0.10'
+        ],
+        "docker://690cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b05": [
+            'kube_container_name:prometheus-to-sd-exporter',
+            'kube_deployment:fluentd-gcp-v2.0.10'
         ],
         "docker://5f93d91c7aee0230f77fbe9ec642dd60958f5098e76de270a933285c24dfdc6f": [
             "pod_name=demo-app-success-c485bc67b-klj45"
@@ -300,13 +311,14 @@ def test_report_pods_running(monkeypatch):
 
     calls = [
         mock.call('kubernetes.pods.running', 1, ["pod_name:fluentd-gcp-v2.0.10-9q9t4"]),
-        mock.call('kubernetes.containers.running', 1, [
+        mock.call('kubernetes.pods.running', 1, ["pod_name:fluentd-gcp-v2.0.10-fkeuj"]),
+        mock.call('kubernetes.containers.running', 2, [
             "kube_container_name:fluentd-gcp",
-            "pod_name:fluentd-gcp-v2.0.10-9q9t4"
+            "kube_deployment:fluentd-gcp-v2.0.10"
         ]),
-        mock.call('kubernetes.containers.running', 1, [
+        mock.call('kubernetes.containers.running', 2, [
             "kube_container_name:prometheus-to-sd-exporter",
-            "pod_name:fluentd-gcp-v2.0.10-9q9t4"
+            "kube_deployment:fluentd-gcp-v2.0.10"
         ]),
     ]
     check.gauge.assert_has_calls(calls, any_order=True)
@@ -328,16 +340,16 @@ def test_report_container_spec_metrics(monkeypatch):
 
     calls = [
         mock.call('kubernetes.cpu.requests', 0.1, [
-            'pod_name:fluentd-gcp-v2.0.10-9q9t4',
-            'kube_container_name:fluentd-gcp'
+            'kube_container_name:fluentd-gcp',
+            'kube_deployment:fluentd-gcp-v2.0.10'
         ] + instance_tags),
         mock.call('kubernetes.memory.requests', 209715200.0, [
-            'pod_name:fluentd-gcp-v2.0.10-9q9t4',
-            'kube_container_name:fluentd-gcp'
+            'kube_container_name:fluentd-gcp',
+            'kube_deployment:fluentd-gcp-v2.0.10'
         ] + instance_tags),
         mock.call('kubernetes.memory.limits', 314572800.0, [
-            'pod_name:fluentd-gcp-v2.0.10-9q9t4',
-            'kube_container_name:fluentd-gcp'
+            'kube_container_name:fluentd-gcp',
+            'kube_deployment:fluentd-gcp-v2.0.10'
         ] + instance_tags),
         mock.call('kubernetes.cpu.requests', 0.1, instance_tags),
         mock.call('kubernetes.cpu.requests', 0.1, instance_tags),

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -185,15 +185,24 @@ def test_prometheus_cpu_summed(monkeypatch, aggregator):
     # - demo-app-success-c485bc67b-klj45 is mono-threaded, we submit 7.756358313 * 10**9 = 7756358313
     #
     calls = [
-        mock.call('kubernetes.cpu.usage.total', 2053640000000.0, ['pod_name:fluentd-gcp-v2.0.10-9q9t4']),
+        mock.call('kubernetes.cpu.usage.total', 2053640000000.0, [
+            'pod_name:fluentd-gcp-v2.0.10-9q9t4',
+            'kube_container_name:fluentd-gcp'
+        ]),
         mock.call('kubernetes.cpu.usage.total', 7756358313.0, ['pod_name=demo-app-success-c485bc67b-klj45']),
     ]
     check.rate.assert_has_calls(calls, any_order=True)
 
     # Make sure the per-core metrics are not submitted
     bad_calls = [
-        mock.call('kubernetes.cpu.usage.total', 1228320000000.0, ['pod_name:fluentd-gcp-v2.0.10-9q9t4']),
-        mock.call('kubernetes.cpu.usage.total', 825320000000.0, ['pod_name:fluentd-gcp-v2.0.10-9q9t4']),
+        mock.call('kubernetes.cpu.usage.total', 1228320000000.0, [
+            'pod_name:fluentd-gcp-v2.0.10-9q9t4',
+            'kube_container_name:fluentd-gcp'
+        ]),
+        mock.call('kubernetes.cpu.usage.total', 825320000000.0, [
+            'pod_name:fluentd-gcp-v2.0.10-9q9t4',
+            'kube_container_name:fluentd-gcp'
+        ]),
     ]
     for c in bad_calls:
         assert c not in check.rate.mock_calls
@@ -260,7 +269,12 @@ def mocked_get_tags(entity, _):
             "pod_name:fluentd-gcp-v2.0.10-9q9t4"
         ],
         'docker://5741ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76561': [
-            'pod_name:fluentd-gcp-v2.0.10-9q9t4'
+            'pod_name:fluentd-gcp-v2.0.10-9q9t4',
+            'kube_container_name:fluentd-gcp'
+        ],
+        "docker://580cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b05": [
+            'pod_name:fluentd-gcp-v2.0.10-9q9t4',
+            'kube_container_name:prometheus-to-sd-exporter'
         ],
         "docker://5f93d91c7aee0230f77fbe9ec642dd60958f5098e76de270a933285c24dfdc6f": [
             "pod_name=demo-app-success-c485bc67b-klj45"
@@ -284,7 +298,17 @@ def test_report_pods_running(monkeypatch):
     with mock.patch("datadog_checks.kubelet.kubelet.get_tags", side_effect=mocked_get_tags):
         check._report_pods_running(pod_list, [])
 
-    calls = [mock.call('kubernetes.pods.running', 1, ["pod_name:fluentd-gcp-v2.0.10-9q9t4"])]
+    calls = [
+        mock.call('kubernetes.pods.running', 1, ["pod_name:fluentd-gcp-v2.0.10-9q9t4"]),
+        mock.call('kubernetes.containers.running', 1, [
+            "kube_container_name:fluentd-gcp",
+            "pod_name:fluentd-gcp-v2.0.10-9q9t4"
+        ]),
+        mock.call('kubernetes.containers.running', 1, [
+            "kube_container_name:prometheus-to-sd-exporter",
+            "pod_name:fluentd-gcp-v2.0.10-9q9t4"
+        ]),
+    ]
     check.gauge.assert_has_calls(calls, any_order=True)
 
 
@@ -303,9 +327,18 @@ def test_report_container_spec_metrics(monkeypatch):
         check._report_container_spec_metrics(pod_list, instance_tags)
 
     calls = [
-        mock.call('kubernetes.cpu.requests', 0.1, ['pod_name:fluentd-gcp-v2.0.10-9q9t4'] + instance_tags),
-        mock.call('kubernetes.memory.requests', 209715200.0, ['pod_name:fluentd-gcp-v2.0.10-9q9t4'] + instance_tags),
-        mock.call('kubernetes.memory.limits', 314572800.0, ['pod_name:fluentd-gcp-v2.0.10-9q9t4'] + instance_tags),
+        mock.call('kubernetes.cpu.requests', 0.1, [
+            'pod_name:fluentd-gcp-v2.0.10-9q9t4',
+            'kube_container_name:fluentd-gcp'
+        ] + instance_tags),
+        mock.call('kubernetes.memory.requests', 209715200.0, [
+            'pod_name:fluentd-gcp-v2.0.10-9q9t4',
+            'kube_container_name:fluentd-gcp'
+        ] + instance_tags),
+        mock.call('kubernetes.memory.limits', 314572800.0, [
+            'pod_name:fluentd-gcp-v2.0.10-9q9t4',
+            'kube_container_name:fluentd-gcp'
+        ] + instance_tags),
         mock.call('kubernetes.cpu.requests', 0.1, instance_tags),
         mock.call('kubernetes.cpu.requests', 0.1, instance_tags),
         mock.call('kubernetes.memory.requests', 134217728.0, instance_tags),


### PR DESCRIPTION
### What does this PR do?

It adds the `kubernetes.containers.running` metric with some interesting tags such as the `image_name` and `image_tag`.

### Motivation

Inspired by the need to have an overview of an infrastructure, with running applications and versions.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
