### PR TITLE
Adding timeout to kubernetes_state integration

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
@@ -34,3 +34,6 @@ instances:
     #  tags:
     #    - optional_tag1
     #    - optional_tag2
+
+    # Set a timeout for the prometheus query, defaults to 10
+    # prometheus_timeout: 10


### PR DESCRIPTION
Related to: https://github.com/DataDog/integrations-core/pull/1790

### What does this PR do?
Adds prometheus_timeout to sample conf file

### Motivation

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
