### PR TITLE
Update consul timestamp to use supported python functions

### DIFF
--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -17,6 +17,8 @@ from datadog_checks.config import is_affirmative
 # 3p
 import requests
 
+EPOCH = datetime(1970, 1, 1)
+
 
 # More information in https://www.consul.io/docs/internals/coordinates.html,
 # code is based on the snippet there.
@@ -190,7 +192,7 @@ class ConsulCheck(AgentCheck):
                     instance_state.last_known_leader, leader))
 
                 self.event({
-                    "timestamp": int((datetime.now() - datetime(1970, 1, 1)).total_seconds()),
+                    "timestamp": int((datetime.now() - EPOCH).total_seconds()),
                     "event_type": "consul.new_leader",
                     "source_type_name": self.SOURCE_TYPE_NAME,
                     "msg_title": "New Consul Leader Elected in consul_datacenter:{0}".format(agent_dc),

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -190,7 +190,7 @@ class ConsulCheck(AgentCheck):
                     instance_state.last_known_leader, leader))
 
                 self.event({
-                    "timestamp": int(datetime.now().strftime("%s")),
+                    "timestamp": int(datetime.now().timestamp()),
                     "event_type": "consul.new_leader",
                     "source_type_name": self.SOURCE_TYPE_NAME,
                     "msg_title": "New Consul Leader Elected in consul_datacenter:{0}".format(agent_dc),

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -4,7 +4,7 @@
 
 # stdlib
 from collections import defaultdict
-from datetime import datetime, timedelta, time
+from datetime import datetime, timedelta
 from itertools import islice
 from math import ceil, floor, sqrt
 from urlparse import urljoin
@@ -190,7 +190,7 @@ class ConsulCheck(AgentCheck):
                     instance_state.last_known_leader, leader))
 
                 self.event({
-                    "timestamp": int(time.mktime(datetime.now())),
+                    "timestamp": int((datetime.now() - datetime(1970, 1, 1)).total_seconds()),
                     "event_type": "consul.new_leader",
                     "source_type_name": self.SOURCE_TYPE_NAME,
                     "msg_title": "New Consul Leader Elected in consul_datacenter:{0}".format(agent_dc),

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -4,7 +4,7 @@
 
 # stdlib
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, time
 from itertools import islice
 from math import ceil, floor, sqrt
 from urlparse import urljoin
@@ -190,7 +190,7 @@ class ConsulCheck(AgentCheck):
                     instance_state.last_known_leader, leader))
 
                 self.event({
-                    "timestamp": int(datetime.now().timestamp()),
+                    "timestamp": int(time.mktime(datetime.now())),
                     "event_type": "consul.new_leader",
                     "source_type_name": self.SOURCE_TYPE_NAME,
                     "msg_title": "New Consul Leader Elected in consul_datacenter:{0}".format(agent_dc),


### PR DESCRIPTION
Update consul implementation to use timestamp instead of strftime('%s') - this is unsupported particularly on Windows

### What does this PR do?

Updates the timestamp property with a supported timestamp value

### Motivation

Python 2.7 + Windows finds that strftime('%s') is invalid.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
