### PR TITLE
Really collect all metrics when `all_metrics` flag is true

### DIFF
--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -17,7 +17,6 @@ from pyVmomi import vmodl  # pylint: disable=E0611
 from datadog_checks.config import _is_affirmative
 from datadog_checks.checks import AgentCheck
 from datadog_checks.checks.libs.vmware.basic_metrics import BASIC_METRICS
-from datadog_checks.checks.libs.vmware.all_metrics import ALL_METRICS
 from datadog_checks.checks.libs.thread_pool import Pool
 from datadog_checks.checks.libs.timer import Timer
 from .common import SOURCE_TYPE
@@ -693,10 +692,6 @@ class VSphereCheck(AgentCheck):
 
                     # Metric types are absolute, delta, and rate
                     metric_name = self.metrics_metadata[i_key].get(result.id.counterId, {}).get('name')
-
-                    if metric_name not in ALL_METRICS:
-                        self.log.debug(u"Skipping unknown `%s` metric.", metric_name)
-                        continue
 
                     if not result.value:
                         self.log.debug(u"Skipping `%s` metric because the value is empty", metric_name)


### PR DESCRIPTION
### What does this PR do?

If the `all_metrics` flag is true, really send all the metrics to Datadog. We already have them from vCenter, there is no point is filtering with a fixed and outdated list afterwards.

We could end up sending a lot of contexts depending on the size of the vsphere environment. Maybe we should instead consider allowing one to specify in its config a list of additional metrics to send ?

A list of all the metrics can be found here: https://code.vmware.com/apis/358/vsphere#/doc/vim.PerformanceManager.html

### Motivation

Newer versions of vSphere include new metrics that are not listed in the constant. The `all_metrics` flag is then misleading since we would only collect metrics that we know about, not all.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?