### PR TITLE
Make the metadata cache thread safe

### DIFF
--- a/vsphere/datadog_checks/vsphere/metadata_cache.py
+++ b/vsphere/datadog_checks/vsphere/metadata_cache.py
@@ -1,0 +1,55 @@
+# (C) Datadog, Inc. 2010-2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+import threading
+
+
+class MetadataNotFoundError(Exception):
+    pass
+
+
+class MetadataCache:
+    """
+    Implements a thread safe storage for metrics metadata.
+    For each instance key the cache maps: counter ID --> metric name, unit
+    """
+    def __init__(self):
+        self._metadata = {}
+        self._metadata_lock = threading.RLock()
+
+    def init_instance(self, key):
+        """
+        Create an empty instance if it doesn't exist.
+        If the instance already exists, this is a noop.
+        """
+        with self._metadata_lock:
+            if key not in self._metadata:
+                self._metadata[key] = {}
+
+    def contains(self, key, counter_id):
+        """
+        Return whether a counter_id is present for a given instance key.
+        If the key is not in the cache, raises a KeyError.
+        """
+        with self._metadata_lock:
+            return counter_id in self._metadata[key]
+
+    def set_metadata(self, key, metadata):
+        """
+        Store the metadata for the given instance key.
+        """
+        with self._metadata_lock:
+            self._metadata[key] = metadata
+
+    def get_metadata(self, key, counter_id):
+        """
+        Return the metadata for the metric identified by `counter_id` for the given instance key.
+        If the key is not in the cache, raises a KeyError.
+        If there's no metric with the given counter_id, raises a MetadataNotFoundError.
+        """
+        with self._metadata_lock:
+            metadata = self._metadata[key]
+            try:
+                return metadata[counter_id]
+            except KeyError:
+                raise MetadataNotFoundError("No metadata for counter id '{}' found in the cache.".format(counter_id))

--- a/vsphere/tests/test_metadata_cache.py
+++ b/vsphere/tests/test_metadata_cache.py
@@ -1,0 +1,39 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.vsphere.metadata_cache import MetadataCache, MetadataNotFoundError
+
+
+@pytest.fixture
+def cache():
+    return MetadataCache()
+
+
+def test_contains(cache):
+    with pytest.raises(KeyError):
+        cache.contains("instance", "foo")
+    cache._metadata["instance"] = {"foo_id": {}}
+    assert cache.contains("instance", "foo_id") is True
+    assert cache.contains("instance", "foo") is False
+
+
+def test_set_metadata(cache):
+    cache._metadata["foo_instance"] = {}
+    cache.set_metadata("foo_instance", {"foo_id": {}})
+    assert "foo_id" in cache._metadata["foo_instance"]
+
+
+def test_get_metadata(cache):
+    with pytest.raises(KeyError):
+        cache.get_metadata("instance", "id")
+
+    cache._metadata["foo_instance"] = {
+        "foo_id": {"name": "metric_name"}
+    }
+
+    assert cache.get_metadata("foo_instance", "foo_id")["name"] == "metric_name"
+
+    with pytest.raises(MetadataNotFoundError):
+        cache.get_metadata("foo_instance", "bar_id")

--- a/vsphere/tests/test_vsphere.py
+++ b/vsphere/tests/test_vsphere.py
@@ -44,7 +44,6 @@ def test__init__(instance):
     assert len(check.event_config) == 1
     assert 'vsphere_mock' in check.event_config
     assert len(check.registry) == 0
-    assert len(check.metrics_metadata) == 0
     assert len(check.latest_event_query) == 0
     assert check.batch_collector_size == 0
     assert check.batch_morlist_size == 50


### PR DESCRIPTION
### What does this PR do?

Make the metrics metadata cache thread safe

### Motivation

Make the check thread safe

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
