### PR TITLE
Temporarily increase the limit of prometheus metrics sent for 6.5

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/checks/openmetrics/base_check.py
@@ -20,7 +20,9 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
         - bar
         - foo
     """
-    DEFAULT_METRIC_LIMIT = 2000
+    # This limit is set artificially high for v6.5, it will be reduced to 2000 in 6.6
+    # If you need more than 2000, determine your needed limit by then.
+    DEFAULT_METRIC_LIMIT = 250000
 
     def __init__(self, name, init_config, agentConfig, instances=None, default_instances=None, default_namespace=None):
         super(OpenMetricsBaseCheck, self).__init__(name, init_config, agentConfig, instances=instances)

--- a/datadog_checks_base/datadog_checks/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/base_check.py
@@ -84,7 +84,9 @@ class GenericPrometheusCheck(AgentCheck):
         - bar
         - foo
     """
-    DEFAULT_METRIC_LIMIT = 2000
+    # This limit is set artificially high for v6.5, it will be reduced to 2000 in 6.6
+    # If you need more than 2000, determine your needed limit by then.
+    DEFAULT_METRIC_LIMIT = 250000
 
     def __init__(self, name, init_config, agentConfig, instances=None, default_instances=None, default_namespace=""):
         super(GenericPrometheusCheck, self).__init__(name, init_config, agentConfig, instances)

--- a/datadog_checks_base/datadog_checks/checks/prometheus/prometheus_base.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/prometheus_base.py
@@ -22,7 +22,9 @@ from ..base import AgentCheck
 #
 
 class PrometheusCheck(PrometheusScraperMixin, AgentCheck):
-    DEFAULT_METRIC_LIMIT = 2000
+    # This limit is set artificially high for v6.5, it will be reduced to 2000 in 6.6
+    # If you need more than 2000, determine your needed limit by then.
+    DEFAULT_METRIC_LIMIT = 250000
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         super(PrometheusCheck, self).__init__(name, init_config, agentConfig, instances)

--- a/datadog_checks_base/datadog_checks/utils/limiter.py
+++ b/datadog_checks_base/datadog_checks/utils/limiter.py
@@ -6,7 +6,7 @@
 class Limiter(object):
     """
     Limiter implements a simple cut-off capping logic for object count.
-    It is used by the AgentCheck class to limit the number of metric contexts
+    It is used by the AgentCheck class to limit the number of sets of tags
     that can be set by an instance.
     """
     def __init__(self, object_name, object_limit, warning_func=None):

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -79,14 +79,14 @@ class TestLimits():
         check = LimitedCheck()
         assert check.get_warnings() == []
 
-        # Multiple calls for a single context should not trigger
+        # Multiple calls for a single set of (metric_name, tags) should not trigger
         for i in range(0, 20):
             check.count("metric", 0, hostname="host-single")
         assert len(check.get_warnings()) == 0
         assert len(aggregator.metrics("metric")) == 20
 
-        # Multiple contexts should trigger
-        # Only 9 new contexts should pass through
+        # Multiple sets of tags should trigger
+        # Only 9 new sets of tags should pass through
         for i in range(0, 20):
             check.count("metric", 0, hostname="host-{}".format(i))
         assert len(check.get_warnings()) == 1

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -28,7 +28,7 @@ If you are monitoring an off-the-shelf software and you think it would deserve a
 
 Due to the nature of this integration, it is possible to submit a high number of custom metrics
 to Datadog. To provide users control over the maximum number of metrics sent in the case of
-configuration errors or input changes, the check has a default limit of 2000 metrics.
+configuration errors or input changes, the check has a default limit of 2000 (note: this limit was increased to 250,000 for 6.5 to leave users enough time to upgrade, it will go back to 2000 in 6.6) metrics.
 You can increase this limit, if needed, by setting the `max_returned_metrics` option.
 
 ### Validation

--- a/prometheus/datadog_checks/prometheus/data/conf.yaml.example
+++ b/prometheus/datadog_checks/prometheus/data/conf.yaml.example
@@ -82,7 +82,7 @@ instances:
   # The path to the trusted CA used for generating custom certificates
   # ssl_ca_cert: "/path/to/cacert"
 
-  # The check limits itself to 2000 metrics by default, you can increase this limit if needed
+  # The check limits itself to 2000 metrics (250,000 in 6.5.0) by default, you can increase this limit if needed
   # max_returned_metrics: 2000
 
   # Set a timeout for the prometheus query, defaults to 10


### PR DESCRIPTION
### What does this PR do?

Temporarily increase the limit of prometheus metrics sent for 6.5. Also make the wording simpler around it.

### Motivation

We communicated about the limit to close to the release, we'll enforce it in 6.6 to leave users enough time to set their own limit.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
