### PR TITLE
Precompute list of metric IDs to improve performance

### DIFF
--- a/vsphere/datadog_checks/vsphere/metadata_cache.py
+++ b/vsphere/datadog_checks/vsphere/metadata_cache.py
@@ -16,14 +16,14 @@ class MetadataCache:
     def __init__(self):
         self._metadata = {}
         self._metric_ids = {}
-        self._metadata_lock = threading.RLock()
+        self._lock = threading.RLock()
 
     def init_instance(self, key):
         """
         Create an empty instance if it doesn't exist.
         If the instance already exists, this is a noop.
         """
-        with self._metadata_lock:
+        with self._lock:
             if key not in self._metadata:
                 self._metadata[key] = {}
                 self._metric_ids[key] = []
@@ -33,21 +33,21 @@ class MetadataCache:
         Return whether a counter_id is present for a given instance key.
         If the key is not in the cache, raises a KeyError.
         """
-        with self._metadata_lock:
+        with self._lock:
             return counter_id in self._metadata[key]
 
     def set_metadata(self, key, metadata):
         """
         Store the metadata for the given instance key.
         """
-        with self._metadata_lock:
+        with self._lock:
             self._metadata[key] = metadata
 
     def set_metric_ids(self, key, metric_ids):
         """
         Store the list of metric IDs we will want to collect for the given instance key
         """
-        with self._metadata_lock:
+        with self._lock:
             self._metric_ids[key] = metric_ids
 
     def get_metric_ids(self, key):
@@ -55,7 +55,7 @@ class MetadataCache:
         Return the list of metric IDs to collect for the given instance key
         If the key is not in the cache, raises a KeyError.
         """
-        with self._metadata_lock:
+        with self._lock:
             return self._metric_ids[key]
 
     def get_metadata(self, key, counter_id):
@@ -64,7 +64,7 @@ class MetadataCache:
         If the key is not in the cache, raises a KeyError.
         If there's no metric with the given counter_id, raises a MetadataNotFoundError.
         """
-        with self._metadata_lock:
+        with self._lock:
             metadata = self._metadata[key]
             try:
                 return metadata[counter_id]

--- a/vsphere/datadog_checks/vsphere/metadata_cache.py
+++ b/vsphere/datadog_checks/vsphere/metadata_cache.py
@@ -15,6 +15,7 @@ class MetadataCache:
     """
     def __init__(self):
         self._metadata = {}
+        self._metric_ids = {}
         self._metadata_lock = threading.RLock()
 
     def init_instance(self, key):
@@ -25,6 +26,7 @@ class MetadataCache:
         with self._metadata_lock:
             if key not in self._metadata:
                 self._metadata[key] = {}
+                self._metric_ids[key] = []
 
     def contains(self, key, counter_id):
         """
@@ -40,6 +42,21 @@ class MetadataCache:
         """
         with self._metadata_lock:
             self._metadata[key] = metadata
+
+    def set_metric_ids(self, key, metric_ids):
+        """
+        Store the list of metric IDs we will want to collect for the given instance key
+        """
+        with self._metadata_lock:
+            self._metric_ids[key] = metric_ids
+
+    def get_metric_ids(self, key):
+        """
+        Return the list of metric IDs to collect for the given instance key
+        If the key is not in the cache, raises a KeyError.
+        """
+        with self._metadata_lock:
+            return self._metric_ids[key]
 
     def get_metadata(self, key, counter_id):
         """

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -794,6 +794,8 @@ class VSphereCheck(AgentCheck):
             for mor_name, mor in batch.iteritems():
                 if mor['mor_type'] == 'vm':
                     vm_count += 1
+                if mor['mor_type'] not in REALTIME_RESOURCES and ('metrics' not in mor or not mor['metrics']):
+                    continue
 
                 query_spec = vim.PerformanceManager.QuerySpec()
                 query_spec.entity = mor["mor"]
@@ -802,7 +804,7 @@ class VSphereCheck(AgentCheck):
                 if mor['mor_type'] in REALTIME_RESOURCES:
                     query_spec.metricId = self.metadata_cache.get_metric_ids(i_key)
                 else:
-                    query_spec.metricId = mor.get("metrics")
+                    query_spec.metricId = mor["metrics"]
                 query_specs.append(query_spec)
 
             if query_specs:

--- a/vsphere/tests/test_metadata_cache.py
+++ b/vsphere/tests/test_metadata_cache.py
@@ -25,6 +25,13 @@ def test_set_metadata(cache):
     assert "foo_id" in cache._metadata["foo_instance"]
 
 
+def test_set_metrics(cache):
+    cache._metric_ids["foo_instance"] = []
+    cache.set_metric_ids("foo_instance", ["foo"])
+    assert "foo" in cache._metric_ids["foo_instance"]
+    assert len(cache._metric_ids["foo_instance"]) == 1
+
+
 def test_get_metadata(cache):
     with pytest.raises(KeyError):
         cache.get_metadata("instance", "id")
@@ -37,3 +44,12 @@ def test_get_metadata(cache):
 
     with pytest.raises(MetadataNotFoundError):
         cache.get_metadata("foo_instance", "bar_id")
+
+
+def test_get_metrics(cache):
+    with pytest.raises(KeyError):
+        cache.get_metric_ids("instance")
+
+    cache._metric_ids["foo_instance"] = ["foo"]
+
+    assert cache.get_metric_ids("foo_instance") == ["foo"]


### PR DESCRIPTION
### What does this PR do?

Do not compute and store the list of metrics for each object. This will save time when caching, as well as memory

### Motivation

We were caching useless information

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
