### PR TITLE
Add `check` command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/__init__.py
@@ -11,6 +11,7 @@ from .release import release
 from .test import test
 from .metadata import metadata
 from .changed import changed
+from .run import run
 
 ALL_COMMANDS = (
     clean,
@@ -23,4 +24,5 @@ ALL_COMMANDS = (
     release,
     test,
     changed,
+    run,
 )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/run.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/run.py
@@ -30,7 +30,8 @@ SC_NAMES = {
 )
 @click.argument('check')
 @click.argument('config_file')
-def run(check, config_file):
+@click.option('--pdb', '-b', is_flag=True, help='Break execution right after collection and show pdb prompt')
+def run(check, config_file, pdb):
     """Run a check by invoking the `check()` method of the class."""
     root = get_root()
 
@@ -86,6 +87,10 @@ def run(check, config_file):
         check_instance.check(instance)
         print_report(aggregator)
         echo_success("Check run done in {:.3f} seconds.".format(time.time() - t0))
+
+        if pdb:
+            import pdb
+            pdb.set_trace()
 
 
 def print_report(aggregator):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/run.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/run.py
@@ -1,0 +1,110 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+import sys
+import importlib
+import inspect
+import time
+
+import pkgutil
+import click
+import yaml
+
+import datadog_checks
+from .utils import CONTEXT_SETTINGS, abort, echo_waiting, echo_info, echo_success
+from ..constants import get_root
+
+
+SC_NAMES = {
+    0: "Ok",
+    1: "Warning",
+    2: "Critical",
+    3: "Unknown",
+}
+
+
+@click.command(
+    context_settings=CONTEXT_SETTINGS,
+    short_help='Run a check'
+)
+@click.argument('check')
+@click.argument('config_file')
+def run(check, config_file):
+    """Run a check by invoking the `check()` method of the class."""
+    root = get_root()
+
+    check_path = os.path.join(root, check, 'datadog_checks')
+    if not os.path.exists(check_path):
+        abort("Check '{}' does not exist".format(check))
+
+    # Tweak the module search path so we can import the check package
+    check_base_path = os.path.join(root, 'datadog_checks_base')
+    sys.path.insert(1, check_base_path)
+    sys.path.insert(1, check_path)
+
+    # Reload the namepace module to make the interpreter aware of the new
+    # package layout after tweaking sys.path. This is only needed because
+    # datadog-checks-dev is part of the same `datadog_checks` namespace as
+    # all the checks.
+    reload(datadog_checks)
+
+    # Load the check module
+    try:
+
+        check_module = importlib.import_module(check)
+    except ImportError as e:
+        abort("Error loading check '{}': {}".format(check, e))
+
+    # Find the check class
+    check_class = None
+    from datadog_checks.checks import AgentCheck
+    for x in dir(check_module):
+        obj = getattr(check_module, x)
+        if inspect.isclass(obj) and issubclass(obj, AgentCheck):
+            check_class = obj
+            break
+    else:
+        abort("Unable to find the check class!")
+
+    # Load the configuration file
+    with open(config_file, 'r') as f:
+        config = yaml.load(f.read())
+
+    # Create the check
+    init_config = config.get('init_config') or {}
+    instances = config.get('instances', [])
+    check_instance = check_class('vsphere', init_config, {}, instances)
+
+    # Run the check
+    from datadog_checks.stubs import aggregator
+    for i, instance in enumerate(instances):
+        echo_waiting("Running check '{}' with instance n.{}...".format(check, i+1))
+        t0 = time.time()
+        # Reset the aggregator at each run
+        aggregator.reset()
+        check_instance.check(instance)
+        print_report(aggregator)
+        echo_success("Check run done in {:.3f} seconds.".format(time.time() - t0))
+
+
+def print_report(aggregator):
+    """
+    Nicely display what the check collected.
+    """
+    echo_info("")
+
+    all_metrics = aggregator.metric_names
+    echo_info("Metrics collected: {}".format(len(all_metrics)))
+    for name in all_metrics:
+        for m in aggregator.metrics(name):
+            echo_info("  {}, {}".format(m.name, m.value))
+    echo_info("")
+
+    all_sc = aggregator.service_check_names
+    echo_info("Service Checks: {}".format(len(all_sc)))
+    for name in all_sc:
+        for sc in aggregator.service_checks(name):
+            echo_info("  {}, status: {}, tags: {}".format(sc.name, SC_NAMES.get(sc.status), sc.tags))
+    echo_info("")
+

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/run.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/run.py
@@ -75,7 +75,7 @@ def run(check, config_file, pdb):
     # Create the check
     init_config = config.get('init_config') or {}
     instances = config.get('instances', [])
-    check_instance = check_class('vsphere', init_config, {}, instances)
+    check_instance = check_class(check, init_config, {}, instances)
 
     # Run the check
     from datadog_checks.stubs import aggregator

--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -61,7 +61,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 
-    packages=['datadog_checks', 'datadog_checks.dev'],
+    packages=['datadog_checks.dev'],
     install_requires=REQUIRES,
     include_package_data=True,
 

--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -29,6 +29,7 @@ REQUIRES = [
     'pytest-benchmark',
     'pytest-cov',
     'pytest-mock',
+    'PyYAML',
     'six',
 ]
 
@@ -61,7 +62,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 
-    packages=['datadog_checks.dev'],
+    packages=['datadog_checks', 'datadog_checks.dev'],
     install_requires=REQUIRES,
     include_package_data=True,
 


### PR DESCRIPTION
### What does this PR do?

Adds a `check` command to execute the `check()` method for any check in the repo. The command is supposed to be invoked like

```
ddev check <check_name> <path_to_config_file>
```

To inspect the objects in memory, pdb can be used to interrupt execution right after collection:

```
ddev check <check_name> <path_to_config_file> --pdb
```

### Motivation

Iterate faster during checks development, ease debugging, put the basis to integrate a profiler.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
