### PR TITLE
Fix base class imports for Agent 5

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/base.py
+++ b/datadog_checks_base/datadog_checks/checks/base.py
@@ -30,13 +30,11 @@ from ..utils.limiter import Limiter
 
 
 # Metric types for which it's only useful to submit once per set of tags
-ONE_PER_CONTEXT_METRIC_TYPES = set()
-
-# Agent 5 doesn't have these
-for __metric_type in ('GAUGE', 'RATE', 'MONOTONIC_COUNT'):
-    __metric_type_value = getattr(aggregator, __metric_type, None)
-    if __metric_type_value is not None:
-        ONE_PER_CONTEXT_METRIC_TYPES.add(__metric_type_value)
+ONE_PER_CONTEXT_METRIC_TYPES = [
+    aggregator.GAUGE,
+    aggregator.RATE,
+    aggregator.MONOTONIC_COUNT,
+]
 
 
 class AgentCheck(object):

--- a/datadog_checks_base/datadog_checks/checks/network.py
+++ b/datadog_checks_base/datadog_checks/checks/network.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from .base import AgentCheck
+from . import AgentCheck
 
 
 class Status:

--- a/datadog_checks_base/datadog_checks/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/checks/openmetrics/base_check.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from .mixins import OpenMetricsScraperMixin
-from ..base import AgentCheck
+from .. import AgentCheck
 from ...errors import CheckException
 
 

--- a/datadog_checks_base/datadog_checks/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/checks/openmetrics/mixins.py
@@ -12,7 +12,7 @@ from prometheus_client.parser import text_fd_to_metric_families
 
 from six import PY3, iteritems, string_types
 
-from ..base import AgentCheck
+from .. import AgentCheck
 
 from datadog_checks.config import is_affirmative
 

--- a/datadog_checks_base/datadog_checks/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/base_check.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from .mixins import PrometheusScraperMixin
-from ..base import AgentCheck
+from .. import AgentCheck
 from ...errors import CheckException
 
 from six import string_types

--- a/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/mixins.py
@@ -15,7 +15,7 @@ from prometheus_client.parser import text_fd_to_metric_families
 
 from six import PY3, iteritems, string_types
 
-from ..base import AgentCheck
+from .. import AgentCheck
 
 if PY3:
     long = int

--- a/datadog_checks_base/datadog_checks/checks/prometheus/prometheus_base.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/prometheus_base.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from .mixins import PrometheusScraperMixin
-from ..base import AgentCheck
+from .. import AgentCheck
 
 # Prometheus check is a parent class providing a structure and some helpers
 # to collect metrics, events and service checks exposed via Prometheus.

--- a/datadog_checks_base/datadog_checks/checks/win/winpdh_base.py
+++ b/datadog_checks_base/datadog_checks/checks/win/winpdh_base.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     from .winpdh_stub import WinPDHCounter, DATA_TYPE_INT, DATA_TYPE_DOUBLE
 
-from ..base import AgentCheck
+from .. import AgentCheck
 from ...utils.containers import hash_mutable
 
 int_types = [


### PR DESCRIPTION
### What does this PR do?

Makes it so every subclass of `AgentCheck` imports from the compatibility layer https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/checks/__init__.py

### Motivation

https://travis-ci.org/DataDog/dd-agent/jobs/423975966#L1596