### PR TITLE
Add additional kubelet metrics

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -92,8 +92,10 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
             'metrics': [{
                 'apiserver_client_certificate_expiration_seconds': 'apiserver.certificate.expiration',
                 'rest_client_requests_total': 'rest.client.requests',
+                'rest_client_request_latency_seconds': 'rest.client.latency',
                 'kubelet_runtime_operations': 'kubelet.runtime.operations',
                 'kubelet_runtime_operations_errors': 'kubelet.runtime.errors',
+                'kubelet_network_plugin_operations_latency_microseconds': 'kubelet.network_plugin.latency',
             }],
             # Defaults that were set when the Kubelet scraper was based on PrometheusScraper
             'send_monotonic_counter': instance.get('send_monotonic_counter', False),

--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -22,5 +22,10 @@ kubernetes.diskio.io_service_bytes.stats.total,gauge,,byte,,The amount of disk s
 kubernetes.apiserver.certificate.expiration.count,gauge,,second,,The count of remaining lifetime on the certificate used to authenticate a request,1,kubelet,k8s.cert.exp.count
 kubernetes.apiserver.certificate.expiration.sum,gauge,,second,,The sum of remaining lifetime on the certificate used to authenticate a request,1,kubelet,k8s.cert.exp.count
 kubernetes.rest.client.requests,gauge,,operation,,The number of HTTP requests,0,kubelet,k8s.rest.req
+kubernetes.rest.client.latency.count,gauge,,,,The count of request latency in seconds broken down by verb and URL,1,kubelet,k8s.rest.lat.count
+kubernetes.rest.client.latency.sum,gauge,,second,,The sum of request latency in seconds broken down by verb and URL,1,kubelet,k8s.rest.lat.sum
 kubernetes.kubelet.runtime.operations,gauge,,operation,,The number of runtime operations,0,kubelet,k8s.runtime.ops
 kubernetes.kubelet.runtime.errors,gauge,,operation,,The number of runtime operations errors,-1,kubelet,k8s.runtime.err
+kubernetes.kubelet.network_plugin.latency.sum,gauge,,microsecond,,The sum of latency in microseconds of network plugin operations,1,kubelet,k8s.net_plug.lat.sum
+kubernetes.kubelet.network_plugin.latency.count,gauge,,,,The count of network plugin operations by latency,1,kubelet,k8s.net_plug.lat.count
+kubernetes.kubelet.network_plugin.latency.quantile,gauge,,,,The quantiles of network plugin operations by latency,1,kubelet,k8s.net_plug.lat.quant

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -62,8 +62,13 @@ EXPECTED_METRICS_PROMETHEUS = [
     'kubernetes.apiserver.certificate.expiration.count',
     'kubernetes.apiserver.certificate.expiration.sum',
     'kubernetes.rest.client.requests',
+    'kubernetes.rest.client.latency.count',
+    'kubernetes.rest.client.latency.sum',
     'kubernetes.kubelet.runtime.operations',
-    'kubernetes.kubelet.runtime.errors'
+    'kubernetes.kubelet.runtime.errors',
+    'kubernetes.kubelet.network_plugin.latency.sum',
+    'kubernetes.kubelet.network_plugin.latency.count',
+    'kubernetes.kubelet.network_plugin.latency.quantile',
 ]
 
 


### PR DESCRIPTION
Add additional kubelet metrics: 
* kubelet client request latency in seconds
* network plugin operation latency in microseconds

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
