### PR TITLE
Report number of services per namespace and type

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -169,6 +169,7 @@ class KubernetesState(OpenMetricsBaseCheck):
                 'kube_replicationcontroller_status_fully_labeled_replicas': 'replicationcontroller.fully_labeled_replicas',  # noqa: E501
                 'kube_replicationcontroller_status_ready_replicas': 'replicationcontroller.replicas_ready',
                 'kube_replicationcontroller_status_replicas': 'replicationcontroller.replicas',
+                'kube_service_spec_type': 'service.count',
                 'kube_statefulset_replicas': 'statefulset.replicas_desired',
                 'kube_statefulset_status_replicas': 'statefulset.replicas',
                 'kube_statefulset_status_replicas_current': 'statefulset.replicas_current',

--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -87,6 +87,7 @@ kubernetes_state.resourcequota.requests.memory.limit,gauge,,byte,,Hard limit on 
 kubernetes_state.resourcequota.requests.storage.limit,gauge,,byte,,Hard limit on the total of storage bytes requested for a resource quota,0,kubernetes,k8s_state.resourcequota.requests.storage.limit
 kubernetes_state.resourcequota.limits.cpu.limit,gauge,,cpu,,Hard limit on the sum of CPU core limits for a resource quota,0,kubernetes,k8s_state.resourcequota.limits.cpu.limit
 kubernetes_state.resourcequota.limits.memory.limit,gauge,,byte,,Hard limit on the sum of memory bytes limits for a resource quota,0,kubernetes,k8s_state.resourcequota.limits.mem.limit
+kubernetes_state.service.count,gauge,,,,Sum by namespace and type to count active services,0,kubernetes,k8s_state.svc.count
 kubernetes_state.statefulset.replicas,gauge,,,,The number of replicas per statefulset,0,kubernetes,k8s_state.statefulset.replicas
 kubernetes_state.statefulset.replicas_desired,gauge,,,,The number of desired replicas per statefulset,0,kubernetes,k8s_state.statefulset.replicas_desired
 kubernetes_state.statefulset.replicas_current,gauge,,,,The number of current replicas per StatefulSet,0,kubernetes,k8s_state.statefulset.replicas_current

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -812,6 +812,18 @@ kube_service_labels{label_app="helm",label_name="tiller",namespace="kube-system"
 kube_service_labels{label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="kube-dns",label_kubernetes_io_name="KubeDNS",namespace="kube-system",service="kube-dns"} 1
 kube_service_labels{label_addonmanager_kubernetes_io_mode="Reconcile",label_app="kubernetes-dashboard",label_kubernetes_io_minikube_addons="dashboard",label_kubernetes_io_minikube_addons_endpoint="dashboard",namespace="kube-system",service="kubernetes-dashboard"} 1
 kube_service_labels{label_app="kube-state-metrics",label_chart="kube-state-metrics-0.3.1",label_heritage="Tiller",label_release="jaundiced-numbat",namespace="default",service="jaundiced-numbat-kube-state-metrics"} 1
+# HELP kube_service_spec_type Type about service.
+# TYPE kube_service_spec_type gauge
+kube_service_spec_type{namespace="default",service="datadog-cluster-agent",type="ClusterIP"} 1
+kube_service_spec_type{namespace="default",service="ddrc1-kube-state-metrics",type="ClusterIP"} 1
+kube_service_spec_type{namespace="default",service="kubernetes",type="ClusterIP"} 1
+kube_service_spec_type{namespace="default",service="redis-db2",type="LoadBalancer"} 1
+kube_service_spec_type{namespace="default",service="redis-db2-bis",type="LoadBalancer"} 1
+kube_service_spec_type{namespace="kube-system",service="default-http-backend",type="NodePort"} 1
+kube_service_spec_type{namespace="kube-system",service="heapster",type="ClusterIP"} 1
+kube_service_spec_type{namespace="kube-system",service="kube-dns",type="ClusterIP"} 1
+kube_service_spec_type{namespace="kube-system",service="metrics-server",type="ClusterIP"} 1
+kube_service_spec_type{namespace="kube-system",service="tiller-deploy",type="ClusterIP"} 1
 # HELP kube_resourcequota Information about resource quota.
 # TYPE kube_resourcequota gauge
 kube_resourcequota{namespace="default",resource="cpu",resourcequota="custom-resource-quotas",type="hard"} 65

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -91,6 +91,8 @@ METRICS = [
     NAMESPACE + '.resourcequota.limits.memory.limit',
     # limitrange
     NAMESPACE + '.limitrange.cpu.default_request',
+    # services
+    NAMESPACE + '.service.count',
 ]
 
 TAGS = {
@@ -121,7 +123,16 @@ TAGS = {
     ],
     NAMESPACE + '.persistentvolumeclaim.request_storage': [
         'storageclass:manual'
-    ]
+    ],
+    NAMESPACE + '.service.count': [
+        'namespace:kube-system',
+        'namespace:default',
+        'type:ClusterIP',
+        'type:NodePort',
+        'type:LoadBalancer',
+        'service:redis-db2',
+        'service:tiller-deploy',
+    ],
 }
 
 JOINED_METRICS = {

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -130,8 +130,6 @@ TAGS = {
         'type:ClusterIP',
         'type:NodePort',
         'type:LoadBalancer',
-        'service:redis-db2',
-        'service:tiller-deploy',
     ],
 }
 


### PR DESCRIPTION
### What does this PR do?

Add a `kubernetes_state.service.count` gauge, tagged by `namespace`, `type` and `service` name, to monitor the number of services in a cluster.

Instead of sending one gauge per service, the same strategy as `persistentvolumes.by_phase` is used: count by relevant tags. The PV code has been refactored in a generic `count_objects_by_tags` method to do that.

Other object types could benefit from this generic client-side counting logic, to reduce the number of gauges the check sends

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
