### PR TITLE
Revert default prometheus metric limit to 2000

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/checks/openmetrics/base_check.py
@@ -20,9 +20,7 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
         - bar
         - foo
     """
-    # This limit is set artificially high for v6.5, it will be reduced to 2000 in 6.6
-    # If you need more than 2000, determine your needed limit by then.
-    DEFAULT_METRIC_LIMIT = 250000
+    DEFAULT_METRIC_LIMIT = 2000
 
     def __init__(self, name, init_config, agentConfig, instances=None, default_instances=None, default_namespace=None):
         super(OpenMetricsBaseCheck, self).__init__(name, init_config, agentConfig, instances=instances)

--- a/datadog_checks_base/datadog_checks/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/base_check.py
@@ -84,9 +84,7 @@ class GenericPrometheusCheck(AgentCheck):
         - bar
         - foo
     """
-    # This limit is set artificially high for v6.5, it will be reduced to 2000 in 6.6
-    # If you need more than 2000, determine your needed limit by then.
-    DEFAULT_METRIC_LIMIT = 250000
+    DEFAULT_METRIC_LIMIT = 2000
 
     def __init__(self, name, init_config, agentConfig, instances=None, default_instances=None, default_namespace=""):
         super(GenericPrometheusCheck, self).__init__(name, init_config, agentConfig, instances)

--- a/datadog_checks_base/datadog_checks/checks/prometheus/prometheus_base.py
+++ b/datadog_checks_base/datadog_checks/checks/prometheus/prometheus_base.py
@@ -22,9 +22,7 @@ from .. import AgentCheck
 #
 
 class PrometheusCheck(PrometheusScraperMixin, AgentCheck):
-    # This limit is set artificially high for v6.5, it will be reduced to 2000 in 6.6
-    # If you need more than 2000, determine your needed limit by then.
-    DEFAULT_METRIC_LIMIT = 250000
+    DEFAULT_METRIC_LIMIT = 2000
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         super(PrometheusCheck, self).__init__(name, init_config, agentConfig, instances)

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -28,7 +28,7 @@ If you are monitoring an off-the-shelf software and you think it would deserve a
 
 Due to the nature of this integration, it is possible to submit a high number of custom metrics
 to Datadog. To provide users control over the maximum number of metrics sent in the case of
-configuration errors or input changes, the check has a default limit of 2000 (note: this limit was increased to 250,000 for 6.5 to leave users enough time to upgrade, it will go back to 2000 in 6.6) metrics.
+configuration errors or input changes, the check has a default limit of 2000 metrics.
 You can increase this limit, if needed, by setting the `max_returned_metrics` option.
 
 ### Validation

--- a/prometheus/datadog_checks/prometheus/data/conf.yaml.example
+++ b/prometheus/datadog_checks/prometheus/data/conf.yaml.example
@@ -82,7 +82,7 @@ instances:
   # The path to the trusted CA used for generating custom certificates
   # ssl_ca_cert: "/path/to/cacert"
 
-  # The check limits itself to 2000 metrics (250,000 in 6.5.0) by default, you can increase this limit if needed
+  # The check limits itself to 2000 metrics by default, you can increase this limit if needed
   # max_returned_metrics: 2000
 
   # Set a timeout for the prometheus query, defaults to 10


### PR DESCRIPTION
### What does this PR do?

Partial revert of https://github.com/DataDog/integrations-core/pull/2214 (keeping the wording changes).
Set the default prometheus metric limit to 2000 for 6.6 (was 250k for 6.5)