### PR TITLE
Update yaml to mention point to consul leader

### DIFF
--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -3,6 +3,7 @@ init_config:
 
 instances:
     # Where your Consul HTTP Server Lives
+    # Point the URL at the leader to get metrics about your Consul Cluster. 
     # Remind to use https instead of http if your Consul setup is configured to do so.
     - url: http://localhost:8500
 


### PR DESCRIPTION
### What does this PR do?

Add line to the yaml file to mention this should be the leader the URL points to. 

### Motivation

The Consul check is designed around pulling metrics from the leader node. If the URL specified in the yaml is *not* the leader, then most of the metrics/service check functions are skipped and the consul.peers metric is submitted. This makes it clearer that the provided URL should be the URL of the leader. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
