### PR TITLE
Updated kafka.producer.record_error_rate to gauge

### DIFF
--- a/kafka/datadog_checks/kafka/data/conf.yaml.example
+++ b/kafka/datadog_checks/kafka/data/conf.yaml.example
@@ -187,7 +187,7 @@ init_config:
               metric_type: rate
               alias: kafka.producer.record_retry_rate
           - record-error-rate:
-              metric_type: rate
+              metric_type: gauge
               alias: kafka.producer.record_error_rate
           - record-size-max:
               metric_type: gauge

--- a/kafka/datadog_checks/kafka/data/conf.yaml.example
+++ b/kafka/datadog_checks/kafka/data/conf.yaml.example
@@ -178,13 +178,13 @@ init_config:
               metric_type: gauge
               alias: kafka.producer.request_latency_max
           - record-send-rate:
-              metric_type: rate
+              metric_type: gauge
               alias: kafka.producer.records_send_rate
           - records-per-request-avg:
               metric_type: gauge
               alias: kafka.producer.records_per_request
           - record-retry-rate:
-              metric_type: rate
+              metric_type: gauge
               alias: kafka.producer.record_retry_rate
           - record-error-rate:
               metric_type: gauge

--- a/kafka/datadog_checks/kafka/data/metrics.yaml
+++ b/kafka/datadog_checks/kafka/data/metrics.yaml
@@ -118,7 +118,7 @@ jmx_metrics:
               metric_type: rate
               alias: kafka.producer.record_retry_rate
           - record-error-rate:
-              metric_type: rate
+              metric_type: gauge
               alias: kafka.producer.record_error_rate
           - record-size-max:
               metric_type: gauge

--- a/kafka/datadog_checks/kafka/data/metrics.yaml
+++ b/kafka/datadog_checks/kafka/data/metrics.yaml
@@ -109,13 +109,13 @@ jmx_metrics:
               metric_type: gauge
               alias: kafka.producer.request_latency_max
           - record-send-rate:
-              metric_type: rate
+              metric_type: gauge
               alias: kafka.producer.records_send_rate
           - records-per-request-avg:
               metric_type: gauge
               alias: kafka.producer.records_per_request
           - record-retry-rate:
-              metric_type: rate
+              metric_type: gauge
               alias: kafka.producer.record_retry_rate
           - record-error-rate:
               metric_type: gauge


### PR DESCRIPTION
### What does this PR do?

This PR changes the `kafka.producer.record_error_rate` metric type from rate to gauge.

### Motivation

Changing the metric value to keep this metric consistent with `kafka.producer.record_error_rate` scoped to the topic level.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
