### PR TITLE
Making the integration not public

### DIFF
--- a/coredns/manifest.json
+++ b/coredns/manifest.json
@@ -16,6 +16,6 @@
   ],
   "type":"check",
   "aliases":[],
-  "is_public": true,
+  "is_public": false,
   "creates_events": false
 }


### PR DESCRIPTION
This integration is not yet shipped with the Agent, hence we need to remove the public flag until agent 6.6

### Motivation

A customer asked why this integration wasn't in the conf.d folder

