### PR TITLE
Add kubelet volume metrics

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -96,6 +96,12 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
                 'kubelet_runtime_operations': 'kubelet.runtime.operations',
                 'kubelet_runtime_operations_errors': 'kubelet.runtime.errors',
                 'kubelet_network_plugin_operations_latency_microseconds': 'kubelet.network_plugin.latency',
+                'kubelet_volume_stats_available_bytes': 'kubelet.volume.stats.available_bytes',
+                'kubelet_volume_stats_capacity_bytes': 'kubelet.volume.stats.capacity_bytes',
+                'kubelet_volume_stats_used_bytes': 'kubelet.volume.stats.used_bytes',
+                'kubelet_volume_stats_inodes': 'kubelet.volume.stats.inodes',
+                'kubelet_volume_stats_inodes_free': 'kubelet.volume.stats.inodes_free',
+                'kubelet_volume_stats_inodes_used': 'kubelet.volume.stats.inodes_used',
             }],
             # Defaults that were set when the Kubelet scraper was based on PrometheusScraper
             'send_monotonic_counter': instance.get('send_monotonic_counter', False),

--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -29,3 +29,9 @@ kubernetes.kubelet.runtime.errors,gauge,,operation,,The number of runtime operat
 kubernetes.kubelet.network_plugin.latency.sum,gauge,,microsecond,,The sum of latency in microseconds of network plugin operations,1,kubelet,k8s.net_plug.lat.sum
 kubernetes.kubelet.network_plugin.latency.count,gauge,,,,The count of network plugin operations by latency,1,kubelet,k8s.net_plug.lat.count
 kubernetes.kubelet.network_plugin.latency.quantile,gauge,,,,The quantiles of network plugin operations by latency,1,kubelet,k8s.net_plug.lat.quant
+kubernetes.kubelet.volume.stats.available_bytes,gauge,,byte,,The number of available bytes in the volume,1,kubelet,k8s.vol.bytes_free
+kubernetes.kubelet.volume.stats.capacity_bytes,gauge,,byte,,The capacity in bytes of the volume,0,kubelet,k8s.vol.bytes_max
+kubernetes.kubelet.volume.stats.used_bytes,gauge,,byte,,The number of used bytes in the volume,-1,kubelet,k8s.vol.bytes_used
+kubernetes.kubelet.volume.stats.inodes,gauge,,inode,,The maximum number of inodes in the volume,0,kubelet,k8s.vol.inodes_max
+kubernetes.kubelet.volume.stats.inodes_free,gauge,,inode,,The number of free inodes in the volume,1,kubelet,k8s.vol.inodes_free
+kubernetes.kubelet.volume.stats.inodes_used,gauge,,inode,,The number of used inodes in the volume,-1,kubelet,k8s.vol.inodes_used

--- a/kubelet/tests/fixtures/kubelet_metrics.txt
+++ b/kubelet/tests/fixtures/kubelet_metrics.txt
@@ -408,6 +408,30 @@ kubelet_runtime_operations_latency_microseconds{operation_type="version",quantil
 kubelet_runtime_operations_latency_microseconds{operation_type="version",quantile="0.99"} 1975
 kubelet_runtime_operations_latency_microseconds_sum{operation_type="version"} 42488
 kubelet_runtime_operations_latency_microseconds_count{operation_type="version"} 33
+# HELP kubelet_volume_stats_available_bytes Number of available bytes in the volume
+# TYPE kubelet_volume_stats_available_bytes gauge
+kubelet_volume_stats_available_bytes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-2"} 9.785049088e+10
+kubelet_volume_stats_available_bytes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-3"} 9.8636845056e+10
+# HELP kubelet_volume_stats_capacity_bytes Capacity in bytes of the volume
+# TYPE kubelet_volume_stats_capacity_bytes gauge
+kubelet_volume_stats_capacity_bytes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-2"} 1.05555197952e+11
+kubelet_volume_stats_capacity_bytes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-3"} 1.05555197952e+11
+# HELP kubelet_volume_stats_inodes Maximum number of inodes in the volume
+# TYPE kubelet_volume_stats_inodes gauge
+kubelet_volume_stats_inodes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-2"} 6.5536e+06
+kubelet_volume_stats_inodes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-3"} 6.5536e+06
+# HELP kubelet_volume_stats_inodes_free Number of free inodes in the volume
+# TYPE kubelet_volume_stats_inodes_free gauge
+kubelet_volume_stats_inodes_free{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-2"} 6.538687e+06
+kubelet_volume_stats_inodes_free{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-3"} 6.535645e+06
+# HELP kubelet_volume_stats_inodes_used Number of used inodes in the volume
+# TYPE kubelet_volume_stats_inodes_used gauge
+kubelet_volume_stats_inodes_used{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-2"} 14913
+kubelet_volume_stats_inodes_used{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-3"} 17955
+# HELP kubelet_volume_stats_used_bytes Number of used bytes in the volume
+# TYPE kubelet_volume_stats_used_bytes gauge
+kubelet_volume_stats_used_bytes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-2"} 2.319220736e+09
+kubelet_volume_stats_used_bytes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-3"} 1.53286656e+09
 # HELP kubernetes_build_info A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.
 # TYPE kubernetes_build_info gauge
 kubernetes_build_info{buildDate="2018-03-26T16:44:10Z",compiler="gc",gitCommit="fc32d2f3698e36b93322a3465f63a14e9f0eaead",gitTreeState="clean",gitVersion="v1.10.0",goVersion="go1.9.3",major="1",minor="10",platform="linux/amd64"} 1

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -69,6 +69,12 @@ EXPECTED_METRICS_PROMETHEUS = [
     'kubernetes.kubelet.network_plugin.latency.sum',
     'kubernetes.kubelet.network_plugin.latency.count',
     'kubernetes.kubelet.network_plugin.latency.quantile',
+    'kubernetes.kubelet.volume.stats.available_bytes',
+    'kubernetes.kubelet.volume.stats.capacity_bytes',
+    'kubernetes.kubelet.volume.stats.used_bytes',
+    'kubernetes.kubelet.volume.stats.inodes',
+    'kubernetes.kubelet.volume.stats.inodes_free',
+    'kubernetes.kubelet.volume.stats.inodes_used',
 ]
 
 


### PR DESCRIPTION
### What does this PR do?

Adding disk volume metrics for PVC bound to kubelets. 

### Motivation

To track the actual disk usage inside PVC volumes, with the tags indicating the PVC ID.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

kubelet_volume stats are available when the kubelet has PVC bound. An example of the stats data is added to the fixtures.
