### PR TITLE
Fix manifest validation policy

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/manifest.py
@@ -350,19 +350,6 @@ def verify(fix, include_extras):
                         failed -= 1
                     else:
                         display_queue.append((echo_failure, output))
-                elif is_public != correct_is_public:
-                    failed += 1
-                    output = '  invalid `is_public`: {}'.format(is_public)
-
-                    if fix:
-                        decoded['is_public'] = correct_is_public
-
-                        display_queue.append((echo_warning, output))
-                        display_queue.append((echo_success, '  new `is_public`: {}'.format(correct_is_public)))
-
-                        failed -= 1
-                    else:
-                        display_queue.append((echo_failure, output))
 
             # See if anything happened
             if len(display_queue) > 1:


### PR DESCRIPTION
### What does this PR do?

Allows `is_public` to be `false`

### Motivation

Manifest validation fails on non-public integrations, see https://github.com/DataDog/integrations-core/pull/2254

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
