### PR TITLE
[Release] Bumped datadog_checks_dev version to 0.7.0

### DIFF
--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - Datadog Checks Dev
 
+## 0.7.0 / 2018-09-18
+
+* [Added] Fix manifest validation policy. See [#2258](https://github.com/DataDog/integrations-core/pull/2258).
+* [Added] Add config option to select the default repository. See [#2243](https://github.com/DataDog/integrations-core/pull/2243).
+
 ## 0.6.2 / 2018-09-14
 
 * [Fixed] Revert "Update base package paths (#2235)". See [#2240](https://github.com/DataDog/integrations-core/pull/2240).

--- a/datadog_checks_dev/datadog_checks/dev/__about__.py
+++ b/datadog_checks_dev/datadog_checks/dev/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '0.6.2'
+__version__ = '0.7.0'


### PR DESCRIPTION
### What does this PR do?

See title
