### PR TITLE
[openstack] Isolate retry logic

### DIFF
--- a/openstack/datadog_checks/openstack/retry_backoff.py
+++ b/openstack/datadog_checks/openstack/retry_backoff.py
@@ -1,0 +1,55 @@
+# (C) Datadog, Inc. 2010-2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+import time
+import random
+
+from .utils import get_instance_key
+
+BASE_BACKOFF_SECS = 15
+MAX_BACKOFF_SECS = 300
+
+
+class BackOffRetry(object):
+
+    def __init__(self, check):
+        self.backoff = {}
+        random.seed()
+        self.check = check
+
+    def should_run(self, instance):
+        i_key = get_instance_key(instance)
+        if i_key not in self.backoff:
+            self.backoff[i_key] = {'retries': 0, 'scheduled': time.time()}
+
+        if self.backoff[i_key]['scheduled'] <= time.time():
+            return True
+
+        return False
+
+    def do_backoff(self, instance):
+        i_key = get_instance_key(instance)
+        tracker = self.backoff[i_key]
+
+        self.backoff[i_key]['retries'] += 1
+        jitter = min(MAX_BACKOFF_SECS, BASE_BACKOFF_SECS * 2 ** self.backoff[i_key]['retries'])
+
+        # let's add some jitter  (half jitter)
+        backoff_interval = jitter / 2
+        backoff_interval += random.randint(0, backoff_interval)
+
+        tags = instance.get('tags', [])
+        hypervisor_name = self.check.hypervisor_name_cache.get(i_key)
+        if hypervisor_name:
+            tags.extend("hypervisor:{}".format(hypervisor_name))
+
+        self.check.gauge("openstack.backoff.interval", backoff_interval, tags=tags)
+        self.check.gauge("openstack.backoff.retries", self.backoff[i_key]['retries'], tags=tags)
+
+        tracker['scheduled'] = time.time() + backoff_interval
+
+    def reset_backoff(self, instance):
+        i_key = get_instance_key(instance)
+        self.backoff[i_key]['retries'] = 0
+        self.backoff[i_key]['scheduled'] = time.time()

--- a/openstack/datadog_checks/openstack/utils.py
+++ b/openstack/datadog_checks/openstack/utils.py
@@ -1,0 +1,13 @@
+# (C) Datadog, Inc. 2010-2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+from .exceptions import IncompleteConfig
+
+
+def get_instance_key(instance):
+    i_key = instance.get('name')
+    if not i_key:
+        # We need a name to identify this instance
+        raise IncompleteConfig()
+    return i_key


### PR DESCRIPTION
### What does this PR do?

The openstack check is the empirical result of individual contributions, bug and performance fix.
As a result the check is complex to understand. This is mainly because everything is in one python file.

This PR isolates the retry logic in a separate files in order to remove some code from the core part.

### Motivation

- Better readability
- Better testability (the idea is also to add tests to each individual part at some points)

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

