### PR TITLE
Fix batch implementation logic

### DIFF
--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -629,11 +629,11 @@ class VSphereCheck(AgentCheck):
             return
 
         for resource_type in RESOURCE_TYPE_METRICS:
-            query_specs = []
             # Batch size can prevent querying large payloads at once if the environment is too large
             # If batch size is set to 0, process everything at once
             batch_size = self.batch_morlist_size or self.mor_objects_queue.size(i_key, resource_type)
             while self.mor_objects_queue.size(i_key, resource_type):
+                query_specs = []
                 for _ in xrange(batch_size):
                     mor = self.mor_objects_queue.pop(i_key, resource_type)
                     if mor is None:

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -832,8 +832,8 @@ class VSphereCheck(AgentCheck):
         # Request metrics for several objects at once. We can limit the number of objects with batch_size
         # If batch_size is 0, process everything at once
         batch_size = self.batch_morlist_size or n_mors
-        query_specs = []
         for batch in self.mor_cache.mors_batch(i_key, batch_size):
+            query_specs = []
             for mor_name, mor in batch.iteritems():
                 if mor['mor_type'] == 'vm':
                     vm_count += 1

--- a/vsphere/tests/test_vsphere.py
+++ b/vsphere/tests/test_vsphere.py
@@ -233,6 +233,7 @@ def test__cache_morlist_raw_async(vsphere, instance):
 
 def test__process_mor_objects_queue(vsphere, instance):
     vsphere.log = MagicMock()
+    vsphere._process_mor_objects_queue_async = MagicMock()
     vsphere._process_mor_objects_queue(instance)
     # Queue hasn't been initialized
     vsphere.log.debug.assert_called_once_with(
@@ -248,6 +249,10 @@ def test__process_mor_objects_queue(vsphere, instance):
         vsphere._process_mor_objects_queue(instance)
         # Object queue should be empty after processing
         assert sum(vsphere.mor_objects_queue.size(i_key, resource_type) for resource_type in RESOURCE_TYPE_METRICS) == 0
+        assert vsphere._process_mor_objects_queue_async.call_count == 2  # Once for each datacenter
+        for call_args in vsphere._process_mor_objects_queue_async.call_args_list:
+            # query_specs parameter should be a list of size 1 since the batch size is 1
+            assert len(call_args[0][1]) == 1
 
 
 def test_collect_realtime_only(vsphere, instance):
@@ -353,6 +358,7 @@ def test_collect_metrics(vsphere, instance):
         vsphere.collect_metrics(instance)
         assert vsphere._collect_metrics_async.call_count == 6  # One for each VM/host, datacenters are not collected
         for call_args in vsphere._collect_metrics_async.call_args_list:
+            # query_specs parameter should be a list of size 1 since the batch size is 1
             assert len(call_args[0][1]) == 1
 
 


### PR DESCRIPTION
### What does this PR do?

Fixes the batch implementation logic. Before this fix, we didn't reset the `query_spec` object at each loop run, so we ended up doing `total_nb_objects / batch_size` requests, each querying metrics for every objects instead of just the objects of the batch.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?