### PR TITLE
fixes cisco for username and password

### DIFF
--- a/cisco_aci/datadog_checks/cisco_aci/api.py
+++ b/cisco_aci/datadog_checks/cisco_aci/api.py
@@ -10,7 +10,7 @@ from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.backends import default_backend
 from six.moves.urllib.parse import unquote
 
-from .exceptions import APIParsingException, ConfigurationException, APIConnectionException
+from .exceptions import APIParsingException, ConfigurationException, APIConnectionException, APIAuthException
 
 
 class SessionWrapper:
@@ -64,7 +64,8 @@ class SessionWrapper:
                       'APIC-Certificate-DN={}').format(signature, self.certDn)
             prepped_request.headers['Cookie'] = cookie
         else:
-            self.log.warning("The Cisco ACI Integration requires either a cert or a username and password")
+            self.warning("The Cisco ACI Integration requires either a cert or a username and password")
+            raise APIAuthException("The Cisco ACI Integration requires either a cert or a username and password")
 
         response = self.session.send(prepped_request, verify=self.verify, timeout=self.timeout)
         try:

--- a/cisco_aci/datadog_checks/cisco_aci/exceptions.py
+++ b/cisco_aci/datadog_checks/cisco_aci/exceptions.py
@@ -7,6 +7,10 @@ class APIException(Exception):
     pass
 
 
+class APIAuthException(Exception)
+    pass
+
+
 class APIConnectionException(APIException):
     pass
 

--- a/cisco_aci/datadog_checks/cisco_aci/exceptions.py
+++ b/cisco_aci/datadog_checks/cisco_aci/exceptions.py
@@ -7,7 +7,7 @@ class APIException(Exception):
     pass
 
 
-class APIAuthException(Exception)
+class APIAuthException(Exception):
     pass
 
 


### PR DESCRIPTION
### What does this PR do?

The Cisco ACI Integration had a regression in username and password when we added certificates

### Motivation

issue #2237 from @jgcasd

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
