### PR TITLE
Making the integration private

### DIFF
--- a/cockroachdb/manifest.json
+++ b/cockroachdb/manifest.json
@@ -20,5 +20,5 @@
     "data store"
   ],
   "type": "check",
-  "is_public": true
+  "is_public": false
 }


### PR DESCRIPTION
This integration is not shipped with agent 6.5, we need to wait for next version to make it public.
