### PR TITLE
Catch when a metric value isn't a float

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/base.py
+++ b/datadog_checks_base/datadog_checks/checks/base.py
@@ -175,7 +175,13 @@ class AgentCheck(object):
                 if self.metric_limiter.is_reached(context):
                     return
 
-        aggregator.submit_metric(self, self.check_id, mtype, ensure_bytes(name), float(value), tags, hostname)
+        try:
+            value = float(value)
+        except ValueError:
+            self.log.debug("Metric {} has non float value {}. Only float values can be submitted as metrics".format(name, value))
+            return
+
+        aggregator.submit_metric(self, self.check_id, mtype, ensure_bytes(name), value, tags, hostname)
 
     def gauge(self, name, value, tags=None, hostname=None, device_name=None):
         self._submit_metric(aggregator.GAUGE, name, value, tags=tags, hostname=hostname, device_name=device_name)

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -1,16 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.checks import AgentCheck
-
-
-@pytest.fixture
-def aggregator():
-    from datadog_checks.stubs import aggregator
-    aggregator.reset()
-    return aggregator
 
 
 def test_instance():
@@ -19,6 +10,13 @@ def test_instance():
     """
     AgentCheck()
 
+
+class TestMetrics:
+    def test_non_float_metric(self, aggregator):
+        check = AgentCheck()
+        metric_name = 'test_metric'
+        check.gauge(metric_name, '85k')
+        aggregator.assert_metric(metric_name, count=0)
 
 class TestTags:
     def test_default_string(self):


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
