### PR TITLE
Fix for Python 3

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -116,4 +116,4 @@ def git_tag_list(pattern=None):
         return result
 
     regex = re.compile(pattern)
-    return filter(regex.search, result)
+    return list(filter(regex.search, result))


### PR DESCRIPTION
### Motivation

https://github.com/DataDog/integrations-core/pull/2277

- `filter` in Python 3 returns an iterator so indexing errors
- some dict methods were removed in py3