### PR TITLE
fix: CouchDB 2.2.0 compatibility

### DIFF
--- a/couch/datadog_checks/couch/couch.py
+++ b/couch/datadog_checks/couch/couch.py
@@ -204,7 +204,7 @@ class CouchDB2:
         for key, value in data['sizes'].items():
             self.gauge("couchdb.by_db.{0}_size".format(key), value, tags)
 
-        for key in ['purge_seq', 'doc_del_count', 'doc_count']:
+        for key in ['doc_del_count', 'doc_count']:
             self.gauge("couchdb.by_db.{0}".format(key), data[key], tags)
 
     def _build_dd_metrics(self, info, tags):

--- a/couch/metadata.csv
+++ b/couch/metadata.csv
@@ -202,7 +202,6 @@ couchdb.fabric.doc_update.write_quorum_errors,gauge,,error,,number of write quor
 couchdb.by_db.file_size,gauge,,byte,,size of the database file on disk,0,couchdb2,
 couchdb.by_db.external_size,gauge,,byte,,size of the database uncompressed,0,couchdb2,
 couchdb.by_db.active_size,gauge,,byte,,size of live data,0,couchdb2,
-couchdb.by_db.purge_seq,gauge,,operation,,number of purge operations on the databse,0,couchdb2,
 couchdb.by_db.doc_del_count,gauge,,document,,number of deleted documents,0,couchd2,
 couchdb.by_db.doc_count,gauge,,document,,number of documents,0,couchdb2,
 couchdb.erlang.message_queues.size,gauge,,,,,0,couchdb2,

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -472,7 +472,7 @@ def test_view_compaction_metrics(aggregator, check, gauges, couch_cluster):
                 check.check(config)
 
             for m_name in aggregator._metrics:
-                if re.search('view_compaction\.progress', m_name) is not None:
+                if re.search(r'view_compaction\.progress', m_name) is not None:
                     metric_found = True
                     for gauge in gauges["view_compaction_tasks_gauges"]:
                         aggregator.assert_metric(gauge)


### PR DESCRIPTION
### What does this PR do?

This PR fixes compatibility with CouchDB 2.2.0 by dropping the reporting of an used key

### Motivation

In CouchDB < 2.2.0, the `/db/` info object included a key `purge_seq` that was an integer. This is now an opaque string.

Furthermore, there is no good use-case for monitoring this value, so this PR drops it.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

