### PR TITLE
Allow configuring cert expiration time in seconds

### DIFF
--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -1,171 +1,237 @@
 init_config:
-  # Change default path of trusted certificates
-  # ca_certs: /etc/ssl/certs/ca-certificates.crt
+  ## @param ca_certs - string - optional
+  ## Change default path of trusted certificates
+  #
+  ## ca_certs: /etc/ssl/certs/ca-certificates.crt
 
 instances:
+
+  ## @param name - string - required
+  ## Name of your Http check instance
+  ## To create multiple http checks, create multiple http check instances
+  #
   - name: My first service
+
+  ## @param url - string - required
+  ## Url to check 
+  #  
     url: http://some.url.example.com
+    
+  ## @param timeout - integer - required
+  ## Timeout for your HTTP check
+  #
     timeout: 1
 
-    # The default HTTP method is GET but the (optional) method parameter allows you to change the HTTP method used in
-    # the request.
-    # If any one of the POST, PUT, DELETE, or PATCH method is specified, you can choose to send data in the body of the
-    # request with the data parameter.
-    # SOAP requests are supported if you use the POST method and supply an XML string as the data parameter.
-    #
-    # method: get
-    # data:
-    #   key: value
+  ## @param method - string - optional - default: get
+  ## The method parameter allows you to change the HTTP method used in the request.
+  #
+  #  method: get
+   
+  ## @param data - list of key:value elements - optional
+  ## If any one of the POST, PUT, DELETE, or PATCH method is specified, you can choose to send data in the body of the
+  ## request with the data parameter.
+  ## SOAP requests are supported if you use the POST method and supply an XML string as the data parameter.
+  #
+  #  data:
+  #    <KEY>: <VALUE>
 
-    # The (optional) content_match parameter will allow the check
-    # to look for a particular string within the response. The check
-    # will report as DOWN if the string is not found.
-    #
-    # content_match uses Python regular expressions which means that
-    # you will have to escape the following "special" characters with
-    # a backslash (\) if you're trying to match them in your content:
-    #  . ^ $ * + ? { } [ ] \ | ( )
-    #
-    # Examples:
-    # content_match: 'In Stock'
-    # content_match: '^(Bread|Apples|Very small rocks|Cider|Gravy|Cherries|Mud|Churches|Lead) float(s)? in water'
+  ## @param content_match - string - optional
+  ## The content_match parameter allows the check
+  ## to look for a particular string within the response. The check
+  ## will report as DOWN if the string is not found.
+  ##
+  ## content_match uses Python regular expressions which means that
+  ## you will have to escape the following "special" characters with
+  ## a backslash (\) if you're trying to match them in your content:
+  ##  . ^ $ * + ? { } [ ] \ | ( )
+  ##
+  ## Examples:
+  ## content_match: 'In Stock'
+  ## content_match: '^(Bread|Apples|Very small rocks|Cider|Gravy|Cherries|Mud|Churches|Lead) float(s)? in water'
+  # 
+  #  content_match: '<REGEX>''
 
-    # The (optional) reverse_content_match parameter will allow the content_match
-    # to work the other way around. That means that the check will report
-    # as DOWN if the string is found.
-    # reverse_content_match: false
+  ## @param reverse_content_match - boolean - optional - default: false 
+  ## The reverse_content_match parameter will allow the content_match
+  ## to work the other way around. That means that the check will report
+  ## as DOWN if the string is found.
+  #
+  #  reverse_content_match: false
 
-    # If your service uses basic authentication, you can optionally
-    # specify a username and password that will be used in the check.
-    #
-    # username: user
-    # password: pass
+  ## @param username - string - optional
+  ## If your service uses basic authentication, you can optionally
+  ## specify a username that will be used in the check.
+  #
+  #  username: <USERNAME>
 
-    # If your service uses NTLM authentication, you can optionally
-    # specify a domain and password that will be used in the check.
-    #
-    # ntlm_domain: domain
-    # password: pass
+  ## @param ntlm_domain - string - optional
+  ## If your service uses NTLM authentication, you can optionally
+  ## specify a domain that will be used in the check.
+  #
+  #  ntlm_domain: <DOMAIN>
 
-    # If your service uses client side certificates, you can optionally
-    # specify a client certificate and key files that will be used in the check.
-    # The private key to your local certificate must be unencrypted.
-    #
-    # client_cert: /opt/client.crt
-    # client_key: /opt/client.key
+  ## @param password - string - optional
+  ## If your service uses basic or NTLM authentication, you can optionally
+  ## specify a password that will be used in the check.
+  #
+  #  password: <PASSWORD>
 
-    # The (optional) http_response_status_code parameter will instruct the check
-    # to look for a particular HTTP response status code or a Regex identifying
-    # a set of possible status codes.
-    # The check will report as DOWN if status code returned differs.
-    # This defaults to 1xx, 2xx and 3xx HTTP status code: (1|2|3)\d\d.
-    # http_response_status_code: 401
+  ## @param client_cert - string - optional
+  ## If your service uses client side certificates, you can optionally
+  ## specify a client certificate file that will be used in the check.
+  #
+  #  client_cert: /opt/client.crt
+  
+  ## @param client_key - string - optional
+  ## If your service uses client side certificates, you can optionally
+  ## specify a client key file that will be used in the check.
+  ## The private key to your local certificate must be unencrypted.
+  #
+  #  client_key: /opt/client.key
 
-    # The (optional) include_content parameter will instruct the check
-    # to include the first 200 characters of the HTTP response body
-    # in notifications sent by this plugin. This is best used with
-    # "healthcheck"-type URLs, where the body contains a brief, human-
-    # readable summary of failure reasons in the case of errors. This
-    # defaults to false.
-    #
-    # include_content: false
+    
+  ## @param http_response_status_code - integer - optional - default: (1|2|3)\d\d
+  ## The http_response_status_code parameter will instruct the check
+  ## to look for a particular HTTP response status code or a Regex identifying
+  ## a set of possible status codes.
+  ## The check will report as DOWN if status code returned differs.
+  ## This defaults to 1xx, 2xx and 3xx HTTP status code.
+  #
+  #  http_response_status_code: (1|2|3)\d\d
 
-    # The (optional) collect_response_time parameter will instruct the
-    # check to create a metric 'network.http.response_time', tagged with
-    # the url, reporting the response time in seconds.
-    #
-    # collect_response_time: true
+  ## @param include_content - boolean - optional - default: false    
+  ## The include_content parameter will instruct the check
+  ## to include the first 200 characters of the HTTP response body
+  ## in notifications sent by this plugin. This is best used with
+  ## "healthcheck"-type URLs, where the body contains a brief, human-
+  ## readable summary of failure reasons in the case of errors.
+  #
+  #  include_content: false
 
-    # The (optional) disable_ssl_validation will instruct the check
-    # to skip the validation of the SSL certificate of the URL being tested.
-    # This is useful when checking SSL connections signed with certificates
-    # that are not themselves signed by a public authority. Even if you are using
-    # HTTPS URLs, you must explicitly set this parameter to false if you want SSL
-    # certificate validation.
-    # When true or unset, the check logs a warning in the Agent's log file.
-    # Defaults to true, set to false if you want SSL certificate validation.
-    #
-    # disable_ssl_validation: true
+  ## @param collect_response_time - boolean - optional - default: true
+  ## Set collect_response_time parameter to true to instruct the check to
+  ## create a metric 'network.http.response_time', tagged with
+  ## the url, reporting the response time in seconds.
+  #
+  #  collect_response_time: true
 
-    # If you enable the disable_ssl_validation above, you might want to disable security warnings
-    # You can use the flag below to do so
-    # ignore_ssl_warning: false
+  ## @param disable_ssl_validation - boolean - optional - default: true
+  ## The (optional) disable_ssl_validation will instruct the check
+  ## to skip the validation of the SSL certificate of the URL being tested.
+  ## This is useful when checking SSL connections signed with certificates
+  ## that are not themselves signed by a public authority. Even if you are using
+  ## HTTPS URLs, you must explicitly set this parameter to false if you want SSL
+  ## certificate validation.
+  ## When true or unset, the check logs a warning in the Agent's log file.
+  ## set to false if you want SSL certificate validation.
+  #
+  #  disable_ssl_validation: true
 
-    # Path of trusted CA certificates used to validate the SSL certificate
-    # for this url.
-    # Overrides the default path and the one specified in init_config.
-    #
-    # ca_certs: /etc/ssl/certs/ca-certificates.crt
+  ## @param ignore_ssl_warning - boolean - optional
+  ## If you enable the disable_ssl_validation above, you might want to disable security warnings
+  ## You can use the flag below to do so
+  #
+  #  ignore_ssl_warning: false
 
-    # The (optional) check_certificate_expiration will instruct the check
-    # to create a service check that checks the expiration of the
-    # ssl certificate. Allow for a warning to occur when x days are
-    # left in the certificate, and alternatively raise a critical
-    # warning if the certificate is y days from the expiration date.
-    #
-    # When "days" doesn't provide enough granularity (e.g. when a certificate is
-    # expected to expire in less than 24h) "seconds" can be used. Please note
-    # that configuration parameters expressed in seconds take precedence over
-    # the corresponding ones expressed in days.
-    #
-    # The SSL certificate will always be validated for this additional
-    # service check regardless of the value of disable_ssl_validation.
-    # By default, for the expiration check, the Agent validates the SSL certificate
-    # hostname against the host of the provided url. If necessary, you can
-    # override the hostname to match with ssl_server_name.
-    # You can also disable the verification check for matching hostnames by explicitly
-    # setting check_hostname to false.
-    #
-    # check_certificate_expiration: true
-    #
-    # Express thresholds in days
-    # days_warning: 14
-    # days_critical: 7
-    #
-    # Alternatively, express the thresholds in seconds
-    # seconds_warning: 1209600
-    # seconds_critical: 604800
-    #
-    # check_hostname: true
-    # ssl_server_name: hostname
+  ## @param ca_certs - string - optional
+  ## Path of trusted CA certificates used to validate the SSL certificate
+  ## for this url.
+  ## Overrides the default path and the one specified in init_config.
+  #
+  #  ca_certs: /etc/ssl/certs/ca-certificates.crt
 
-    # The (optional) headers parameter allows you to send extra headers
-    # with the request. This is useful for explicitly specifying the host
-    # header or perhaps adding headers for authorisation purposes. Note
-    # that the http client library converts all headers to lowercase.
-    # This is legal according to RFC2616
-    # (See: http://tools.ietf.org/html/rfc2616#section-4.2)
-    # but may be problematic with some HTTP servers
-    # (See: https://code.google.com/p/httplib2/issues/detail?id=169)
-    #
-    # headers:
-    #   Host: alternative.host.example.com
-    #   X-Auth-Token: SOME-AUTH-TOKEN
+  ## @param check_certificate_expiration - boolean - optional
+  ## The check_certificate_expiration will instruct the check
+  ## to create a service check that checks the expiration of the
+  ## ssl certificate. Allow for a warning to occur when x days are
+  ## left in the certificate, and alternatively raise a critical
+  ## warning if the certificate is y days from the expiration date.
+  ##
+  ## When "days" doesn't provide enough granularity (e.g. when a certificate is
+  ## expected to expire in less than 24h) "seconds" can be used. Please note
+  ## that configuration parameters expressed in seconds take precedence over
+  ## the corresponding ones expressed in days.
+  ##
+  ## The SSL certificate will always be validated for this additional
+  ## service check regardless of the value of disable_ssl_validation.
+  ## By default, for the expiration check, the Agent validates the SSL certificate
+  ## hostname against the host of the provided url. 
+  #
+  #  check_certificate_expiration: true
 
-    # The (optional) skip_proxy parameter would bypass any proxy settings enabled
-    # and attempt to reach the the URL directly.
-    # If no proxy is defined at any level, this flag bears no effect.
-    # Defaults to false.
-    #
-    # skip_proxy: false
+  ## @param days_warning - integer - optional
+  ## Express warning threshold for the HTTP check in days
+  #
+  #  days_warning: <THRESHOLD_DAYS>
 
-    # The (optional) allow_redirects parameter can enable redirection.
-    # Defaults to true.
-    #
-    # allow_redirects: true
+  ## @param days_warning - integer - optional
+  ## Express critical threshold for the HTTP check in days
+  #
+  #  days_critical: <THRESHOLD_DAYS>
+
+  ## @param seconds_warning - integer - optional
+  ## Alternatively to days_warning, seconds_warning expresses 
+  ## the warning threshold for the HTTP check in second
+  # 
+  #  seconds_warning: <THRESHOLD_SECONDS>
+
+  ## @param seconds_critical - integer - optional
+  ## Alternatively to days_critical, seconds_critical expresses 
+  ## the critical threshold for the HTTP check in second
+  # 
+  #  seconds_critical: <THRESHOLD_SECONDS>
+
+  ## @param check_hostname - boolean - optional - default: true
+  ## Set check_hostname to false to disable the verification check for matching hostnames.
+  #
+  #  check_hostname: true
+
+  ## @param ssl_server_name - string - optional
+  ## If necessary and check_hostname is set to true, 
+  ## override the hostname to match with ssl_server_name.
+  # 
+  #  ssl_server_name: <HOSTNAME>
+
+  ## @param headers: list of key:value elements - optional
+  ## The headers parameter allows you to send extra headers
+  ## with the check request. This is useful for explicitly specifying the host
+  ## header or perhaps adding headers for authorisation purposes. Note
+  ## that the http client library converts all headers to lowercase.
+  ## This is legal according to RFC2616
+  ## (See: http://tools.ietf.org/html/rfc2616#section-4.2)
+  ## but may be problematic with some HTTP servers
+  ## (See: https://code.google.com/p/httplib2/issues/detail?id=169)
+  #
+  #  headers:
+  #    Host: alternative.host.example.com
+  #    X-Auth-Token: <AUTH_TOKEN>
+
+  ## @param skip_proxy - boolean - optional - default: false
+  ## The skip_proxy parameter would bypass any proxy settings enabled
+  ## and attempt to reach the the URL directly.
+  ## If no proxy is defined at any level, this flag bears no effect.
+  #
+  #  skip_proxy: false
+
+  ## @param allow_redirects - boolean - optional - default: true
+  ## The allow_redirects parameter can enable redirection for the
+  ## HTTP check.
+  #
+  #  allow_redirects: true
 
 
-    # The (optional) include_default_headers parameter instructs the check to include the default headers.
-    # Default headers can be found at:
-    # https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/utils/headers.py
-    #
-    # Defaults to true.
-    #
-    # include_default_headers: true
+  ## @param include_default_headers - boolean - optional - default: true
+  ## The (optional) include_default_headers parameter instructs the check to include the default headers.
+  ## Default headers can be found at:
+  ## https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/utils/headers.py
+  #
+  #  include_default_headers: true
 
-    # tags:
-    #   - url:http://alternative.host.example.com
-    #   - env:production
-
-  # - name: My second service
-  #   url: https://another.url.example.com
+  ## @param tags  - list of key:value element - optional 
+  ## List of tags to attach to every metric, event and service check emitted by this integration.
+  ## 
+  ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+  #
+  #  tags:
+  #    - <KEY_1>:<VALUE_1>
+  #    - <KEY_2>:<VALUE_2>

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -103,10 +103,10 @@ instances:
     # left in the certificate, and alternatively raise a critical
     # warning if the certificate is y days from the expiration date.
     #
-    # If "days" doesn't provide enough granularity (e.g. when a certificate is
+    # When "days" doesn't provide enough granularity (e.g. when a certificate is
     # expected to expire in less than 24h) "seconds" can be used. Please note
     # that configuration parameters expressed in seconds take precedence over
-    # the corresponding one expressed in days.
+    # the corresponding ones expressed in days.
     #
     # The SSL certificate will always be validated for this additional
     # service check regardless of the value of disable_ssl_validation.

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -102,6 +102,12 @@ instances:
     # ssl certificate. Allow for a warning to occur when x days are
     # left in the certificate, and alternatively raise a critical
     # warning if the certificate is y days from the expiration date.
+    #
+    # If "days" doesn't provide enough granularity (e.g. when a certificate is
+    # expected to expire in less than 24h) "seconds" can be used. Please note
+    # that configuration parameters expressed in seconds take precedence over
+    # the corresponding one expressed in days.
+    #
     # The SSL certificate will always be validated for this additional
     # service check regardless of the value of disable_ssl_validation.
     # By default, for the expiration check, the Agent validates the SSL certificate
@@ -111,8 +117,15 @@ instances:
     # setting check_hostname to false.
     #
     # check_certificate_expiration: true
+    #
+    # Express thresholds in days
     # days_warning: 14
     # days_critical: 7
+    #
+    # Alternatively, express the thresholds in seconds
+    # seconds_warning: 1209600
+    # seconds_critical: 604800
+    #
     # check_hostname: true
     # ssl_server_name: hostname
 

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -30,6 +30,10 @@ from datadog_checks.config import _is_affirmative
 from datadog_checks.utils.headers import headers as agent_headers
 
 DEFAULT_EXPECTED_CODE = "(1|2|3)\d\d"
+DEFAULT_EXPIRE_DAYS_WARNING = 14
+DEFAULT_EXPIRE_DAYS_CRITICAL = 7
+DEFAULT_EXPIRE_WARNING = DEFAULT_EXPIRE_DAYS_WARNING * 24 * 3600
+DEFAULT_EXPIRE_CRITICAL = DEFAULT_EXPIRE_DAYS_CRITICAL * 24 * 3600
 CONTENT_LENGTH = 200
 
 DATA_METHODS = ['POST', 'PUT', 'DELETE', 'PATCH']
@@ -420,8 +424,14 @@ class HTTPCheck(NetworkCheck):
     def check_cert_expiration(self, instance, timeout, instance_ca_certs, check_hostname,
                               client_cert=None, client_key=None):
         # thresholds expressed in seconds take precendence over those expressed in days
-        seconds_warning = int(instance.get('seconds_warning', 0)) or int(instance.get('days_warning', 14)) * 24 * 3600
-        seconds_critical = int(instance.get('seconds_critical', 0)) or int(instance.get('days_critical', 7)) * 24 * 3600
+        seconds_warning = \
+            int(instance.get('seconds_warning', 0)) or \
+            int(instance.get('days_warning', 0)) * 24 * 3600 or \
+            DEFAULT_EXPIRE_WARNING
+        seconds_critical = \
+            int(instance.get('seconds_critical', 0)) or \
+            int(instance.get('days_critical', 0)) * 24 * 3600 or \
+            DEFAULT_EXPIRE_CRITICAL
         url = instance.get('url')
 
         o = urlparse(url)

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -382,12 +382,12 @@ class HTTPCheck(NetworkCheck):
             self.gauge('network.http.cant_connect', cant_status, tags=tags_list)
 
         if ssl_expire and parsed_uri.scheme == "https":
-            status, days_left, msg = self.check_cert_expiration(instance, timeout, instance_ca_certs, check_hostname,
-                                                                client_cert, client_key)
-
+            status, days_left, seconds_left, msg = self.check_cert_expiration(instance, timeout, instance_ca_certs,
+                                                                              check_hostname, client_cert, client_key)
             tags_list = list(tags)
             tags_list.append('url:{}'.format(addr))
             self.gauge('http.ssl.days_left', days_left, tags=tags_list)
+            self.gauge('http.ssl.seconds_left', seconds_left, tags=tags_list)
 
             service_checks.append((self.SC_SSL_CERT, status, msg))
 
@@ -419,14 +419,14 @@ class HTTPCheck(NetworkCheck):
 
     def check_cert_expiration(self, instance, timeout, instance_ca_certs, check_hostname,
                               client_cert=None, client_key=None):
-        warning_days = int(instance.get('days_warning', 14))
-        critical_days = int(instance.get('days_critical', 7))
+        # thresholds expressed in seconds take precendence over those expressed in days
+        seconds_warning = int(instance.get('seconds_warning', 0)) or int(instance.get('days_warning', 14)) * 24 * 3600
+        seconds_critical = int(instance.get('seconds_critical', 0)) or int(instance.get('days_critical', 7)) * 24 * 3600
         url = instance.get('url')
 
         o = urlparse(url)
         host = o.hostname
         server_name = instance.get('ssl_server_name', o.hostname)
-
         port = o.port or 443
 
         try:
@@ -446,27 +446,29 @@ class HTTPCheck(NetworkCheck):
 
         except ssl.CertificateError as e:
             self.log.debug("The hostname on the SSL certificate does not match the given host: {}".format(e))
-            return (Status.CRITICAL, 0, str(e))
+            return (Status.CRITICAL, 0, 0, str(e))
         except Exception as e:
             self.log.debug("Site is down, unable to connect to get cert expiration: {}".format(e))
-            return (Status.DOWN, 0, str(e))
+            return (Status.DOWN, 0, 0, str(e))
 
         exp_date = datetime.strptime(cert['notAfter'], "%b %d %H:%M:%S %Y %Z")
-        days_left = exp_date - datetime.utcnow()
+        time_left = exp_date - datetime.utcnow()
+        days_left = time_left.days
+        seconds_left = time_left.total_seconds()
 
         self.log.debug("Exp_date: {}".format(exp_date))
-        self.log.debug("days_left: {}".format(days_left))
+        self.log.debug("seconds_left: {}".format(seconds_left))
 
-        if days_left.days < 0:
-            return (Status.DOWN, days_left.days, "Expired by {} days".format(days_left.days))
+        if seconds_left < 0:
+            return (Status.DOWN, days_left, seconds_left, "Expired by {} days".format(days_left))
 
-        elif days_left.days < critical_days:
-            return (Status.CRITICAL, days_left.days, "This cert TTL is critical: only {} days before it expires"
-                    .format(days_left.days))
+        elif seconds_left < seconds_critical:
+            return (Status.CRITICAL, days_left, seconds_left,
+                    "This cert TTL is critical: only {} days before it expires".format(days_left))
 
-        elif days_left.days < warning_days:
-            return (Status.WARNING, days_left.days, "This cert is almost expired, only {} days left"
-                    .format(days_left.days))
+        elif seconds_left < seconds_warning:
+            return (Status.WARNING, days_left, seconds_left,
+                    "This cert is almost expired, only {} days left".format(days_left))
 
         else:
-            return (Status.UP, days_left.days, "Days left: {}".format(days_left.days))
+            return (Status.UP, days_left, seconds_left, "Days left: {}".format(days_left))

--- a/http_check/metadata.csv
+++ b/http_check/metadata.csv
@@ -3,3 +3,4 @@ network.http.response_time,gauge,,second,,"The response time of an HTTP request 
 network.http.can_connect,gauge,,,,"Whether the check can connect, 1 if true, 0 otherwise. Tagged by url, e.g. 'url:http://example.com'.",0,network,http can connect
 network.http.cant_connect,gauge,,,,"Whether the check failed to connect, 1 if true, 0 otherwise. Tagged by url, e.g. 'url:http://example.com'.",0,network,http cannot connect
 http.ssl.days_left,gauge,,day,,Days until SSL certificate expiration,+1,network,days till expiration
+http.ssl.seconds_left,gauge,,second,,Seconds until SSL certificate expiration,+1,network,seconds till expiration

--- a/http_check/tests/common.py
+++ b/http_check/tests/common.py
@@ -139,6 +139,14 @@ CONFIG_EXPIRED_SSL = {
             'check_certificate_expiration': True,
             'days_warning': 14,
             'days_critical': 7,
+        },
+        {
+            'name': 'expired_cert_seconds',
+            'url': 'https://github.com',
+            'timeout': 1,
+            'check_certificate_expiration': True,
+            'seconds_warning': 3600,
+            'seconds_critical': 60,
         }
     ]
 }

--- a/http_check/tests/test_http_check.py
+++ b/http_check/tests/test_http_check.py
@@ -108,10 +108,21 @@ def test_check_ssl(aggregator, http_check):
 @mock.patch('ssl.SSLSocket.getpeercert', **{'return_value.raiseError.side_effect': Exception()})
 def test_check_ssl_expire_error(getpeercert_func, aggregator, http_check):
 
-    # Run the check for the one instance
+    # Run the check for the one instance configured with days left
     http_check.check(CONFIG_EXPIRED_SSL['instances'][0])
 
     expired_cert_tags = ['url:https://github.com', 'instance:expired_cert']
+    aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=expired_cert_tags, count=1)
+    aggregator.assert_service_check(HTTPCheck.SC_SSL_CERT, status=HTTPCheck.CRITICAL, tags=expired_cert_tags, count=1)
+
+
+@mock.patch('ssl.SSLSocket.getpeercert', **{'return_value.raiseError.side_effect': Exception()})
+def test_check_ssl_expire_error_secs(getpeercert_func, aggregator, http_check):
+
+    # Run the check for the one instance configured with seconds left
+    http_check.check(CONFIG_EXPIRED_SSL['instances'][1])
+
+    expired_cert_tags = ['url:https://github.com', 'instance:expired_cert_seconds']
     aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=expired_cert_tags, count=1)
     aggregator.assert_service_check(HTTPCheck.SC_SSL_CERT, status=HTTPCheck.CRITICAL, tags=expired_cert_tags, count=1)
 


### PR DESCRIPTION
### What does this PR do?

Adds one new metric:

* `http.ssl.seconds_left` 

and 2 new configuration options:

* `seconds_warning`
* `seconds_critical`

### Motivation

The http check can send one metric and one service check depending on how many days are left before a certificate expire. Sometimes "days" granularity is not enough, for example when a cert is designed to expire in less than 24h.


### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

