### PR TITLE
Catch exception when string sent as metric value

### DIFF
--- a/datadog_checks_base/datadog_checks/checks/base.py
+++ b/datadog_checks_base/datadog_checks/checks/base.py
@@ -20,6 +20,7 @@ except ImportError:
 
 try:
     import aggregator
+    using_stub_aggregator = False
 except ImportError:
     from ..stubs import aggregator
     using_stub_aggregator = True

--- a/datadog_checks_base/datadog_checks/checks/base.py
+++ b/datadog_checks_base/datadog_checks/checks/base.py
@@ -175,7 +175,13 @@ class AgentCheck(object):
                 if self.metric_limiter.is_reached(context):
                     return
 
-        aggregator.submit_metric(self, self.check_id, mtype, ensure_bytes(name), float(value), tags, hostname)
+        try:
+            value = float(value)
+        except ValueError:
+            self.warning("Metric: {} has non float value: {}. Only float values can be submitted as metrics".format(name, value))
+            return
+
+        aggregator.submit_metric(self, self.check_id, mtype, ensure_bytes(name), value, tags, hostname)
 
     def gauge(self, name, value, tags=None, hostname=None, device_name=None):
         self._submit_metric(aggregator.GAUGE, name, value, tags=tags, hostname=hostname, device_name=device_name)

--- a/datadog_checks_base/datadog_checks/checks/base.py
+++ b/datadog_checks_base/datadog_checks/checks/base.py
@@ -22,6 +22,7 @@ try:
     import aggregator
 except ImportError:
     from ..stubs import aggregator
+    using_stub_aggregator = True
 
 from ..config import is_affirmative
 from ..utils.common import ensure_bytes
@@ -178,7 +179,10 @@ class AgentCheck(object):
         try:
             value = float(value)
         except ValueError:
-            self.warning("Metric: {} has non float value: {}. Only float values can be submitted as metrics".format(name, value))
+            err_msg = "Metric: {} has non float value: {}. Only float values can be submitted as metrics".format(name, value)
+            if using_stub_aggregator:
+                raise ValueError(err_msg)
+            self.warning(err_msg)
             return
 
         aggregator.submit_metric(self, self.check_id, mtype, ensure_bytes(name), value, tags, hostname)

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -24,7 +24,8 @@ class TestMetrics:
     def test_non_float_metric(self, aggregator):
         check = AgentCheck()
         metric_name = 'test_metric'
-        check.gauge(metric_name, '85k')
+        with pytest.raises(ValueError):
+            check.gauge(metric_name, '85k')
         aggregator.assert_metric(metric_name, count=0)
 
 

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -20,6 +20,14 @@ def test_instance():
     AgentCheck()
 
 
+class TestMetrics:
+    def test_non_float_metric(self, aggregator):
+        check = AgentCheck()
+        metric_name = 'test_metric'
+        check.gauge(metric_name, '85k')
+        aggregator.assert_metric(metric_name, count=0)
+
+
 class TestTags:
     def test_default_string(self):
         check = AgentCheck()


### PR DESCRIPTION
### What does this PR do?

Supersedes - https://github.com/DataDog/integrations-core/pull/2274

Catches when a metric is not a float and logs a warning to the status page. Includes test

### Motivation

The current behavior is that when a non numeric value is submitted as a metric, the check will completely fail and stop running. As an example, if a single postgres custom query starts returning a string instead of a number, this will cause the whole postgres check to stop running, causing ALL monitors over postgres to trigger. Instead, this makes it clear for the reason a metric stopped being submitted and also lets other, possibly mission critical metrics continue to be submitted. 

Performance:
Worst case, we previously throw an exception and the check stops working, now we throw an exception and the check continues. This will incur a performance impact, but with the benefit of continuing to receive available metrics

In the best case, we have an extra try around something we wouldn't otherwise have had:
```
python -m "try:
    float(6)
except ValueError:
    pass"
```
returns:
```
10000000 loops, best of 3: 0.117 usec per loop
```

And in the existing functionality:
```
python -m timeit "float(6)"
```
returns:
```
10000000 loops, best of 3: 0.103 usec per loop
```


Ultimately a 0.01 usec difference with the gain of getting all other available metrics. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

This adheres to the similar case where, if a single endpoint isn't available for an application, we continue retrieving available metrics. 