### PR TITLE
Fix readme rendering for PyPI

### DIFF
--- a/active_directory/setup.py
+++ b/active_directory/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Active Directory check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent active directory check',
 
     # The project's main homepage.

--- a/activemq/setup.py
+++ b/activemq/setup.py
@@ -28,6 +28,7 @@ setup(
     version=ABOUT['__version__'],
     description='The ActiveMQ check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent activemq check',
 
     # The project's main homepage.

--- a/activemq_xml/setup.py
+++ b/activemq_xml/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT["__version__"],
     description='The ActiveMQ XML check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent activemq_xml check',
 
     # The project's main homepage.

--- a/agent_metrics/setup.py
+++ b/agent_metrics/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Agent Metrics check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent agent_metrics check',
 
     # The project's main homepage.

--- a/apache/setup.py
+++ b/apache/setup.py
@@ -40,6 +40,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Apache Check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent apache check',
 
     # The project's main homepage.

--- a/aspdotnet/setup.py
+++ b/aspdotnet/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The ASP .NET check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent aspdotnet check',
 
     # The project's main homepage.

--- a/btrfs/setup.py
+++ b/btrfs/setup.py
@@ -28,6 +28,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Btrfs check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent btrfs check',
 
     # The project's main homepage.

--- a/cacti/setup.py
+++ b/cacti/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Cacti check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent cacti check',
 
     # The project's main homepage.

--- a/cassandra/setup.py
+++ b/cassandra/setup.py
@@ -28,6 +28,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Cassandra check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent cassandra check',
 
     # The project's main homepage.

--- a/cassandra_nodetool/setup.py
+++ b/cassandra_nodetool/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Cassandra Nodetool check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent cassandra_nodetool check',
 
     # The project's main homepage.

--- a/ceph/setup.py
+++ b/ceph/setup.py
@@ -29,6 +29,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Ceph check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent ceph check',
 
     # The project's main homepage.

--- a/cisco_aci/setup.py
+++ b/cisco_aci/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Cisco ACI check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent Cisco ACI check',
     url='https://github.com/DataDog/integrations-core',
     author='Datadog',

--- a/consul/setup.py
+++ b/consul/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Consul Check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent consul check',
 
     # The project's main homepage.

--- a/coredns/setup.py
+++ b/coredns/setup.py
@@ -23,6 +23,7 @@ setup(
     version=ABOUT["__version__"],
     description='CoreDNS collects DNS metrics in Kubernetes.',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent check',
     url='https://github.com/DataDog/integrations-core',
     author='Datadog',

--- a/couch/setup.py
+++ b/couch/setup.py
@@ -32,6 +32,7 @@ setup(
     version=ABOUT["__version__"],
     description='The CouchDB check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent couch check',
 
     # The project's main homepage.

--- a/couchbase/setup.py
+++ b/couchbase/setup.py
@@ -32,6 +32,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Couchbase check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent couchbase check',
 
     # The project's main homepage.

--- a/datadog_checks_tests_helper/setup.py
+++ b/datadog_checks_tests_helper/setup.py
@@ -31,6 +31,7 @@ setup(
     name='datadog_checks_tests_helper',
     description='The Datadog Check Tests Helpers',
     long_description=LONG_DESC,
+    long_description_content_type='text/markdown',
     keywords='datadog agent checks tests',
     url='https://github.com/DataDog/datadog-agent-tk',
     author='Datadog',

--- a/directory/setup.py
+++ b/directory/setup.py
@@ -33,6 +33,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Directory check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent directory check',
 
     # The project's main homepage.

--- a/disk/setup.py
+++ b/disk/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Disk check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent disk check',
 
     # The project's main homepage.

--- a/dns_check/setup.py
+++ b/dns_check/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The DNS check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent dns_check check',
 
     # The project's main homepage.

--- a/docker_daemon/setup.py
+++ b/docker_daemon/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Docker Daemon check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent docker_daemon check',
 
     # The project's main homepage.

--- a/dotnetclr/setup.py
+++ b/dotnetclr/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT["__version__"],
     description='The .NET CLR check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent .NET CLR check',
 
     # The project's main homepage.

--- a/ecs_fargate/setup.py
+++ b/ecs_fargate/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The ECS Fargate check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent ecs_fargate check',
 
     # The project's main homepage.

--- a/elastic/setup.py
+++ b/elastic/setup.py
@@ -32,6 +32,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Elastic Check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent elastic check',
 
     # The project's main homepage.

--- a/envoy/setup.py
+++ b/envoy/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Envoy check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent envoy check',
 
     # The project's main homepage.

--- a/etcd/setup.py
+++ b/etcd/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Etcd check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent etcd check',
 
     # The project's main homepage.

--- a/exchange_server/setup.py
+++ b/exchange_server/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The MS Exchange check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent exchange check',
 
     # The project's main homepage.

--- a/fluentd/setup.py
+++ b/fluentd/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Fluentd check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent fluentd check',
 
     # The project's main homepage.

--- a/gearmand/setup.py
+++ b/gearmand/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Gearmand check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent gearmand check',
 
     # The project's main homepage.

--- a/gitlab/setup.py
+++ b/gitlab/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Gitlab check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent gitlab check',
 
     # The project's main homepage.

--- a/gitlab_runner/setup.py
+++ b/gitlab_runner/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Gitlab Runner check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent gitlab_runner check',
 
     # The project's main homepage.

--- a/go-metro/setup.py
+++ b/go-metro/setup.py
@@ -28,6 +28,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Go-Metro check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent go-metro check',
 
     # The project's main homepage.

--- a/go_expvar/setup.py
+++ b/go_expvar/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Go Expvar check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent go_expvar check',
 
     # The project's main homepage.

--- a/gunicorn/setup.py
+++ b/gunicorn/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Gunicorn check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent gunicorn check',
 
     # The project's main homepage.

--- a/haproxy/setup.py
+++ b/haproxy/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The HAProxy check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent haproxy check',
 
     # The project's main homepage.

--- a/hdfs_datanode/setup.py
+++ b/hdfs_datanode/setup.py
@@ -32,6 +32,7 @@ setup(
     version=ABOUT['__version__'],
     description='The HDFS Datanode Check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent hdfs_datanode check',
 
     # The project's main homepage.

--- a/hdfs_namenode/setup.py
+++ b/hdfs_namenode/setup.py
@@ -32,6 +32,7 @@ setup(
     version=ABOUT['__version__'],
     description='The HDFS Namenode check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent hdfs_namenode check',
 
     # The project's main homepage.

--- a/http_check/setup.py
+++ b/http_check/setup.py
@@ -32,6 +32,7 @@ setup(
     version=ABOUT['__version__'],
     description='The HTTP check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent http_check check',
 
     # The project's main homepage.

--- a/iis/setup.py
+++ b/iis/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The IIS check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent iis check',
 
     # The project's main homepage.

--- a/istio/setup.py
+++ b/istio/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The istio check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent istio check',
 
     # The project's main homepage.

--- a/kafka/setup.py
+++ b/kafka/setup.py
@@ -28,6 +28,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Kafka check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent kafka check',
 
     # The project's main homepage.

--- a/kafka_consumer/setup.py
+++ b/kafka_consumer/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Kafka Consumer check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent kafka_consumer check',
     url='https://github.com/DataDog/integrations-core',
     author='Datadog',

--- a/kong/setup.py
+++ b/kong/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Kong check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent kong check',
 
     # The project's main homepage.

--- a/kube_dns/setup.py
+++ b/kube_dns/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The KubeDNS check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent kube_dns check',
 
     # The project's main homepage.

--- a/kube_proxy/setup.py
+++ b/kube_proxy/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The kube_proxy Check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent kube_proxy check',
 
     # The project's main homepage.

--- a/kubelet/setup.py
+++ b/kubelet/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Kubelet check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent kubelet check',
 
     # The project's main homepage.

--- a/kubernetes/setup.py
+++ b/kubernetes/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Kubernetes check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent kubernetes check',
 
     # The project's main homepage.

--- a/kubernetes_state/setup.py
+++ b/kubernetes_state/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Kubernetes State check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent kubernetes_state check',
 
     # The project's main homepage.

--- a/kyototycoon/setup.py
+++ b/kyototycoon/setup.py
@@ -33,6 +33,7 @@ setup(
     version=ABOUT['__version__'],
     description='The KyotoTycoon check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent kyototycoon check',
 
     # The project's main homepage.

--- a/lighttpd/setup.py
+++ b/lighttpd/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The lighttpd check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent lighttpd check',
     url='https://github.com/DataDog/integrations-core',
     author='Datadog',

--- a/linkerd/setup.py
+++ b/linkerd/setup.py
@@ -29,6 +29,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Linkerd check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent linkerd check',
 
     # The project's main homepage.

--- a/linux_proc_extras/setup.py
+++ b/linux_proc_extras/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Linux Proc Extras check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent linux_proc_extras check',
 
     # The project's main homepage.

--- a/mapreduce/setup.py
+++ b/mapreduce/setup.py
@@ -32,6 +32,7 @@ setup(
     version=ABOUT['__version__'],
     description='The MapReduce check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent mapreduce check',
 
     # The project's main homepage.

--- a/marathon/setup.py
+++ b/marathon/setup.py
@@ -29,6 +29,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Marathon check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent marathon check',
 
     # The project's main homepage.

--- a/mcache/setup.py
+++ b/mcache/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Memcache Check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent Memcache check',
     url='https://github.com/DataDog/integrations-core',
     author='Datadog',

--- a/mesos_master/setup.py
+++ b/mesos_master/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Mesos master check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent mesos_master check',
 
     # The project's main homepage.

--- a/mesos_slave/setup.py
+++ b/mesos_slave/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Mesos slave check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent mesos_slave check',
 
     # The project's main homepage.

--- a/mongo/setup.py
+++ b/mongo/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Mongo check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent mongo check',
 
     # The project's main homepage.

--- a/mysql/setup.py
+++ b/mysql/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The MySQL check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent mysql check',
 
     # The project's main homepage.

--- a/nagios/setup.py
+++ b/nagios/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Nagios check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent nagios check',
 
     # The project's main homepage.

--- a/network/setup.py
+++ b/network/setup.py
@@ -28,6 +28,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Network check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent network check',
 
     # The project's main homepage.

--- a/nfsstat/setup.py
+++ b/nfsstat/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The NFSstat check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent nfsstat check',
 
     # The project's main homepage.

--- a/nginx/setup.py
+++ b/nginx/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Nginx check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent nginx check',
 
     # The project's main homepage.

--- a/ntp/setup.py
+++ b/ntp/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT['__version__'],
     description='The NTP check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent ntp check',
     url='https://github.com/DataDog/integrations-core',
     author='Datadog',

--- a/openldap/setup.py
+++ b/openldap/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT["__version__"],
     description='The OpenLDAP integration collect metrics from your OpenLDAP server using the monitor backend',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent check',
     url='https://github.com/DataDog/integrations-core',
     author='Datadog',

--- a/openmetrics/setup.py
+++ b/openmetrics/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The openmetrics check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent openmetrics check',
 
     # The project's main homepage.

--- a/openstack/setup.py
+++ b/openstack/setup.py
@@ -32,6 +32,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Openstack check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent openstack check',
 
     # The project's main homepage.

--- a/oracle/setup.py
+++ b/oracle/setup.py
@@ -32,6 +32,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Oracle Database check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent oracle check',
 
     # The project's main homepage.

--- a/pdh_check/setup.py
+++ b/pdh_check/setup.py
@@ -32,6 +32,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Windows Performance Counters check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent pdh_check check',
 
     # The project's main homepage.

--- a/pgbouncer/setup.py
+++ b/pgbouncer/setup.py
@@ -28,6 +28,7 @@ setup(
     version=ABOUT["__version__"],
     description='The PGbouncer check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent pgbouncer check',
     url='https://github.com/DataDog/integrations-core',
     author='Datadog',

--- a/php_fpm/setup.py
+++ b/php_fpm/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The PHP FPM check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent php_fpm check',
 
     # The project's main homepage.

--- a/postfix/setup.py
+++ b/postfix/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Postfix check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent postfix check',
 
     # The project's main homepage.

--- a/postgres/setup.py
+++ b/postgres/setup.py
@@ -32,6 +32,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Postgres check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent postgres check',
     url='https://github.com/DataDog/integrations-core',
     author='Datadog',

--- a/powerdns_recursor/setup.py
+++ b/powerdns_recursor/setup.py
@@ -32,6 +32,7 @@ setup(
     version=ABOUT["__version__"],
     description='The PowerDNS check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent powerdns_recursor check',
 
     # The project's main homepage.

--- a/process/setup.py
+++ b/process/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Process check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent process check',
 
     # The project's main homepage.

--- a/prometheus/setup.py
+++ b/prometheus/setup.py
@@ -29,6 +29,7 @@ setup(
     version=ABOUT["__version__"],
     description='The prometheus check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent prometheus check',
 
     # The project's main homepage.

--- a/rabbitmq/setup.py
+++ b/rabbitmq/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The RabbitMQ check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent rabbitmq check',
 
     # The project's main homepage.

--- a/redisdb/setup.py
+++ b/redisdb/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Redis Check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent Redis check',
     url='https://github.com/DataDog/integrations-core',
     author='Datadog',

--- a/riak/setup.py
+++ b/riak/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Riak Check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent riak check',
 
     # The project's main homepage.

--- a/riakcs/setup.py
+++ b/riakcs/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Riak CS check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent riakcs check',
 
     # The project's main homepage.

--- a/snmp/setup.py
+++ b/snmp/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The SNMP check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent snmp check',
 
     # The project's main homepage.

--- a/solr/setup.py
+++ b/solr/setup.py
@@ -28,6 +28,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Solr check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent solr check',
 
     # The project's main homepage.

--- a/spark/setup.py
+++ b/spark/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Spark check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent spark check',
 
     # The project's main homepage.

--- a/sqlserver/setup.py
+++ b/sqlserver/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The SQL Server check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent sqlserver check',
 
     # The project's main homepage.

--- a/squid/setup.py
+++ b/squid/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Squid Check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent squid check',
 
     # The project's main homepage.

--- a/ssh_check/setup.py
+++ b/ssh_check/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The SSH check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent ssh_check check',
 
     # The project's main homepage.

--- a/statsd/setup.py
+++ b/statsd/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The StatsD check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent statsd check',
 
     # The project's main homepage.

--- a/supervisord/setup.py
+++ b/supervisord/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Supervisord check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent supervisord check',
 
     # The project's main homepage.

--- a/system_core/setup.py
+++ b/system_core/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The System Core check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent system_core check',
 
     # The project's main homepage.

--- a/system_swap/setup.py
+++ b/system_swap/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The System Swap check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent system_swap check',
 
     # The project's main homepage.

--- a/tcp_check/setup.py
+++ b/tcp_check/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The TCP check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent tcp_check check',
 
     # The project's main homepage.

--- a/teamcity/setup.py
+++ b/teamcity/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Teamcity check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent teamcity check',
     url='https://github.com/DataDog/integrations-core',
     author='Datadog',

--- a/tokumx/setup.py
+++ b/tokumx/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The TokuMX check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent tokumx check',
 
     # The project's main homepage.

--- a/tomcat/setup.py
+++ b/tomcat/setup.py
@@ -28,6 +28,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Tomcat check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent tomcat check',
 
     # The project's main homepage.

--- a/twemproxy/setup.py
+++ b/twemproxy/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Twemproxy check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent twemproxy check',
 
     # The project's main homepage.

--- a/varnish/setup.py
+++ b/varnish/setup.py
@@ -31,6 +31,7 @@ setup(
     version=ABOUT["__version__"],
     description='The Varnish check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent varnish check',
 
     # The project's main homepage.

--- a/vault/setup.py
+++ b/vault/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Vault check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent vault check',
 
     # The project's main homepage.

--- a/vsphere/setup.py
+++ b/vsphere/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT["__version__"],
     description='The vSphere check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent vSphere check',
     url='https://github.com/DataDog/integrations-core',
     author='Datadog',

--- a/win32_event_log/setup.py
+++ b/win32_event_log/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Win32 Event Log check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent win32_event_log check',
 
     # The project's main homepage.

--- a/windows_service/setup.py
+++ b/windows_service/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Windows Service check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent windows_service check',
 
     # The project's main homepage.

--- a/wmi_check/setup.py
+++ b/wmi_check/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The WMI check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent wmi_check check',
 
     # The project's main homepage.

--- a/yarn/setup.py
+++ b/yarn/setup.py
@@ -32,6 +32,7 @@ setup(
     version=ABOUT['__version__'],
     description='The Yarn check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent yarn check',
 
     # The project's main homepage.

--- a/zk/setup.py
+++ b/zk/setup.py
@@ -30,6 +30,7 @@ setup(
     version=ABOUT['__version__'],
     description='The ZooKeeper check',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords='datadog agent zk check',
 
     # The project's main homepage.


### PR DESCRIPTION
### Motivation

Non-rst rendering requires an extra flag https://packaging.python.org/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata

### Additional Notes

Script (Python 3 only)

```python
import os

CORE_DIR = r'C:\Users\ofek.lev\Desktop\code\integrations-core'


def get_setup_file(check_name):
    f = os.path.join(CORE_DIR, check_name, 'setup.py')
    if os.path.isfile(f):
        return f


def main():
    for check_name in os.listdir(CORE_DIR):
        setup_file = get_setup_file(check_name)
        if setup_file:
            with open(setup_file, 'rb') as f:
                setup_lines = f.readlines()

            if not any(b'long_description_content_type' in l for l in setup_lines):
                for i, line in enumerate(setup_lines):
                    if line.strip().startswith(b'long_description='):
                        setup_lines.insert(
                            i + 1,
                            b"    long_description_content_type='text/markdown',\n"
                        )
                        break

            with open(setup_file, 'wb') as f:
                f.writelines(setup_lines)


if __name__ == '__main__':
    main()
```