### PR TITLE
Add more AgentCheck tests

### DIFF
--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -40,7 +40,7 @@ class TestEvents:
             "tags": None
         }
         check.event(event)
-        aggregator.assert_event(event['msg_text'])
+        aggregator.assert_event('test event test event')
 
 
 class TestServiceChecks:

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -29,6 +29,34 @@ class TestMetrics:
         aggregator.assert_metric(metric_name, count=0)
 
 
+class TestEvents:
+    def test_valid_event(self, aggregator):
+        check = AgentCheck()
+        event = {
+            "event_type": "new.event",
+            "msg_title": "new test event",
+            "aggregation_key": "test.event",
+            "msg_text": "test event test event",
+            "tags": None
+        }
+        check.event(event)
+        aggregator.assert_event(event['msg_text'])
+
+
+class TestServiceChecks:
+    def test_valid_sc(self, aggregator):
+        check = AgentCheck()
+
+        check.service_check("testservicecheck", AgentCheck.OK, tags=None, message="")
+        aggregator.assert_service_check("testservicecheck", status=AgentCheck.OK)
+
+        check.service_check("testservicecheckwithhostname", AgentCheck.OK, tags=["foo", "bar"], hostname="testhostname", message="a message")
+        aggregator.assert_service_check("testservicecheckwithhostname", status=AgentCheck.OK, tags=["foo", "bar"], hostname="testhostname", message="a message")
+
+        check.service_check("testservicecheckwithnonemessage", AgentCheck.OK, message=None)
+        aggregator.assert_service_check("testservicecheckwithnonemessage", status=AgentCheck.OK, )
+
+
 class TestTags:
     def test_default_string(self):
         check = AgentCheck()


### PR DESCRIPTION
### What does this PR do?

Adds a couple of agentCheck tests for valid Events and Service Checks

### Motivation

There are tests in datadog-agent that we should start moving over to datadog_checks_base and helps not have regressions. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
