### PR TITLE
Submit metrics with instance tags

### DIFF
--- a/kube_dns/datadog_checks/kube_dns/kube_dns.py
+++ b/kube_dns/datadog_checks/kube_dns/kube_dns.py
@@ -86,7 +86,7 @@ class KubeDNSCheck(OpenMetricsBaseCheck):
         """
         metric_name = scraper_config['namespace'] + metric_suffix
         for sample in metric.samples:
-            _tags = []
+            _tags = scraper_config['custom_tags']
             for label_name, label_value in sample[self.SAMPLE_LABELS].iteritems():
                 _tags.append('{}:{}'.format(label_name, label_value))
             # submit raw metric

--- a/kube_dns/tests/test_kube_dns.py
+++ b/kube_dns/tests/test_kube_dns.py
@@ -12,8 +12,11 @@ import pytest
 from datadog_checks.kube_dns import KubeDNSCheck
 
 
+customtag = "custom:tag"
+
 instance = {
     'prometheus_endpoint': 'http://localhost:10055/metrics',
+    'tags': [customtag]
 }
 
 
@@ -87,5 +90,6 @@ class TestKubeDNS:
         check.check(instance)
         for metric in self.METRICS + self.COUNT_METRICS:
             aggregator.assert_metric(metric)
+            aggregator.assert_metric_has_tag(metric, customtag)
 
         aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

Metrics going through the `submit_as_gauge_and_monotonic_count` method didn't inherit instance tags.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
