### PR TITLE
add a command to print out changed checks

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/__init__.py
@@ -10,6 +10,7 @@ from .meta import meta
 from .release import release
 from .test import test
 from .metadata import metadata
+from .changed import changed
 
 ALL_COMMANDS = (
     clean,
@@ -21,4 +22,5 @@ ALL_COMMANDS = (
     metadata,
     release,
     test,
+    changed,
 )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/changed.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/changed.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import click
+
+from .utils import CONTEXT_SETTINGS, echo_info
+from ..git import files_changed
+from ..constants import TESTABLE_FILE_EXTENSIONS
+from ..utils import get_testable_checks
+
+
+def testable_files(files):
+    """
+    Given a list of files, return the files that have an extension listed in TESTABLE_FILE_EXTENSIONS
+    """
+    return [f for f in files if f.endswith(TESTABLE_FILE_EXTENSIONS)]
+
+
+def get_changed_checks():
+    # Get files that changed compared to `master`
+    changed_files = files_changed()
+
+    # Filter by files that can influence the testing of a check
+    changed_files[:] = testable_files(changed_files)
+
+    return {line.split('/')[0] for line in changed_files}
+
+
+@click.command(
+    context_settings=CONTEXT_SETTINGS,
+    short_help='Print out changed checks'
+)
+def changed():
+    checks = sorted(get_testable_checks() & get_changed_checks())
+
+    for check in checks:
+        echo_info(check)


### PR DESCRIPTION
### What does this PR do?

It would be nice to get a command to print out changed checks

### Motivation

I want to limit the ibm mq setup scripts to run only when that's in the changed checks list

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
