### PR TITLE
Ignore 'azure_maintenance' db to avoid permission error

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -496,7 +496,8 @@ GROUP BY datid, datname
             'query': "SELECT datname, %s "
             "FROM pg_stat_database "
             "WHERE datname not ilike 'template%%' "
-            "  AND datname not ilike 'rdsadmin' ",
+            "  AND datname not ilike 'rdsadmin' "
+            "  AND datname not ilike 'azure_maintenance' ",
             'relation': False,
         }
 


### PR DESCRIPTION
Ignore azure_maintenance database in postgres check to avoid permission error

### What does this PR do?

This PR should fix a permission error that is appearing when using the Postgres integration with an Agent on an Azure VM.

### Motivation

It results from this ticket: https://datadog.zendesk.com/agent/tickets/170933 where the customer is missing some `postgresql` metrics including `postgresql.rows_inserted`, `postgresql.rows_deleted`, etc.

The log that we are seeing: 
```
2018-09-27 08:28:04 UTC | WARN | (datadog_agent.go:149 in LogMessage) | (postgres.py:681) | Not all metrics may be available: ('ERROR', '42501', 'permission denied for database azure_maintenance')
```

It looks like customers previously bumped into the same error with Agent 5 and RDS and the fix that was released was this one: https://github.com/DataDog/dd-agent/commit/c24edc45e33edae4c9060c4887b6fa0bee9b24d9#commitcomment-11215580

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
