### PR TITLE
Fix namespace overwriting

### DIFF
--- a/cockroachdb/setup.py
+++ b/cockroachdb/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks', 'datadog_checks.cockroachdb'],
+    packages=['datadog_checks.cockroachdb'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/coredns/setup.py
+++ b/coredns/setup.py
@@ -46,7 +46,7 @@ setup(
     install_requires=[CHECKS_BASE_REQ, ],
 
     # The package we're going to ship
-    packages=['datadog_checks', 'datadog_checks.coredns'],
+    packages=['datadog_checks.coredns'],
 
     include_package_data=True,
 )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/setup.py
@@ -49,7 +49,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks', 'datadog_checks.{check_name}'],
+    packages=['datadog_checks.{check_name}'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/setup.py
@@ -49,7 +49,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks', 'datadog_checks.{check_name}'],
+    packages=['datadog_checks.{check_name}'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],

--- a/openmetrics/setup.py
+++ b/openmetrics/setup.py
@@ -57,7 +57,7 @@ setup(
     ],
 
     # The package we're going to ship
-    packages=['datadog_checks', 'datadog_checks.openmetrics'],
+    packages=['datadog_checks.openmetrics'],
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],


### PR DESCRIPTION
### Motivation

Installing one of these packages would overwrite the `__init__.py` of `datadog_checks` namespace due to the re-declaration of `datadog_checks` package. We'll begin adding it back after we move base to a subpackage.

### Important

`datadog_checks_dev` requires this, so we're leaving it there.