### PR TITLE
Fix fetching ca_certs from init_config

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -42,7 +42,9 @@ class HTTPCheck(NetworkCheck):
     def __init__(self, name, init_config, agentConfig, instances=None):
         NetworkCheck.__init__(self, name, init_config, agentConfig, instances)
 
-        self.ca_certs = init_config.get('ca_certs', get_ca_certs_path())
+        self.ca_certs = init_config.get('ca_certs')
+        if not self.ca_certs:
+            self.ca_certs = get_ca_certs_path()
 
     def _load_conf(self, instance):
         # Fetches the conf

--- a/http_check/tests/test_http_check.py
+++ b/http_check/tests/test_http_check.py
@@ -20,14 +20,22 @@ from .common import (
 
 @pytest.mark.unit
 def test__init__():
+    # empty values should be ignored
+    init_config = {
+        'ca_certs': ''
+    }
+    # `get_ca_certs_path` needs to be mocked because it's used as fallback when
+    # init_config doesn't contain `ca_certs`
+    with mock.patch('datadog_checks.http_check.http_check.get_ca_certs_path', return_value='bar'):
+        http_check = HTTPCheck('http_check', init_config, {})
+        assert http_check.ca_certs == 'bar'
+
+    # normal case
     init_config = {
         'ca_certs': 'foo'
     }
-    # `get_ca_certs_path` needs to be mocked because it's used as the default
-    # value for `init_config.get('ca_certs')`
-    with mock.patch('datadog_checks.http_check.http_check.get_ca_certs_path'):
-        http_check = HTTPCheck('http_check', init_config, {})
-        assert http_check.ca_certs == 'foo'
+    http_check = HTTPCheck('http_check', init_config, {})
+    assert http_check.ca_certs == 'foo'
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### What does this PR do?

It makes fetching the `ca_certs` path from `init_config` more robust by checking that the config key actually has a non empty value.

### Motivation

User's request

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Tests were fixed accordingly
