### PR TITLE
Refactoring: isolate config parsing

### DIFF
--- a/http_check/datadog_checks/http_check/config.py
+++ b/http_check/datadog_checks/http_check/config.py
@@ -1,0 +1,66 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from collections import namedtuple
+
+from datadog_checks.config import _is_affirmative
+from datadog_checks.utils.headers import headers as agent_headers
+
+
+DEFAULT_EXPECTED_CODE = "(1|2|3)\d\d"
+
+
+Config = namedtuple('Config',
+                    'url, ntlm_domain, username, password, client_cert,'
+                    'client_key, method, data, http_response_status_code,'
+                    'timeout, include_content, headers, response_time,'
+                    'content_match, reverse_content_match, tags,'
+                    'disable_ssl_validation, ssl_expire, instance_ca_certs,'
+                    'weakcipher, check_hostname, ignore_ssl_warning,'
+                    'skip_proxy, allow_redirects')
+
+
+def from_instance(instance, default_ca_certs=None):
+    """
+    Create a config object from an instance dictionary
+    """
+    method = instance.get('method', 'get')
+    data = instance.get('data', {})
+    tags = instance.get('tags', [])
+    ntlm_domain = instance.get('ntlm_domain')
+    username = instance.get('username')
+    password = instance.get('password')
+    client_cert = instance.get('client_cert')
+    client_key = instance.get('client_key')
+    http_response_status_code = str(instance.get('http_response_status_code', DEFAULT_EXPECTED_CODE))
+    timeout = int(instance.get('timeout', 10))
+    config_headers = instance.get('headers', {})
+    default_headers = _is_affirmative(instance.get("include_default_headers", True))
+    if default_headers:
+        headers = agent_headers({})
+    else:
+        headers = {}
+    headers.update(config_headers)
+    url = instance.get('url')
+    content_match = instance.get('content_match')
+    reverse_content_match = _is_affirmative(instance.get('reverse_content_match', False))
+    response_time = _is_affirmative(instance.get('collect_response_time', True))
+    if not url:
+        raise Exception("Bad configuration. You must specify a url")
+    include_content = _is_affirmative(instance.get('include_content', False))
+    disable_ssl_validation = _is_affirmative(instance.get('disable_ssl_validation', True))
+    ssl_expire = _is_affirmative(instance.get('check_certificate_expiration', True))
+    instance_ca_certs = instance.get('ca_certs', default_ca_certs)
+    weakcipher = _is_affirmative(instance.get('weakciphers', False))
+    ignore_ssl_warning = _is_affirmative(instance.get('ignore_ssl_warning', False))
+    check_hostname = _is_affirmative(instance.get('check_hostname', True))
+    skip_proxy = _is_affirmative(
+        instance.get('skip_proxy', instance.get('no_proxy', False)))
+    allow_redirects = _is_affirmative(instance.get('allow_redirects', True))
+
+    return Config(url, ntlm_domain, username, password, client_cert, client_key,
+                  method, data, http_response_status_code, timeout,
+                  include_content, headers, response_time, content_match,
+                  reverse_content_match, tags, disable_ssl_validation,
+                  ssl_expire, instance_ca_certs, weakcipher, check_hostname,
+                  ignore_ssl_warning, skip_proxy, allow_redirects)

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -15,16 +15,13 @@ from urlparse import urlparse
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from requests_ntlm import HttpNtlmAuth
-
 from datadog_checks.checks import NetworkCheck, Status
-from datadog_checks.config import _is_affirmative
-from datadog_checks.utils.headers import headers as agent_headers
 
 from .adapters import WeakCiphersAdapter, WeakCiphersHTTPSConnection
 from .utils import get_ca_certs_path
+from .config import from_instance, DEFAULT_EXPECTED_CODE
 
 
-DEFAULT_EXPECTED_CODE = "(1|2|3)\d\d"
 DEFAULT_EXPIRE_DAYS_WARNING = 14
 DEFAULT_EXPIRE_DAYS_CRITICAL = 7
 DEFAULT_EXPIRE_WARNING = DEFAULT_EXPIRE_DAYS_WARNING * 24 * 3600
@@ -46,52 +43,11 @@ class HTTPCheck(NetworkCheck):
         if not self.ca_certs:
             self.ca_certs = get_ca_certs_path()
 
-    def _load_conf(self, instance):
-        # Fetches the conf
-        method = instance.get('method', 'get')
-        data = instance.get('data', {})
-        tags = instance.get('tags', [])
-        ntlm_domain = instance.get('ntlm_domain')
-        username = instance.get('username')
-        password = instance.get('password')
-        client_cert = instance.get('client_cert')
-        client_key = instance.get('client_key')
-        http_response_status_code = str(instance.get('http_response_status_code', DEFAULT_EXPECTED_CODE))
-        timeout = int(instance.get('timeout', 10))
-        config_headers = instance.get('headers', {})
-        default_headers = _is_affirmative(instance.get("include_default_headers", True))
-        if default_headers:
-            headers = agent_headers(self.agentConfig)
-        else:
-            headers = {}
-        headers.update(config_headers)
-        url = instance.get('url')
-        content_match = instance.get('content_match')
-        reverse_content_match = _is_affirmative(instance.get('reverse_content_match', False))
-        response_time = _is_affirmative(instance.get('collect_response_time', True))
-        if not url:
-            raise Exception("Bad configuration. You must specify a url")
-        include_content = _is_affirmative(instance.get('include_content', False))
-        disable_ssl_validation = _is_affirmative(instance.get('disable_ssl_validation', True))
-        ssl_expire = _is_affirmative(instance.get('check_certificate_expiration', True))
-        instance_ca_certs = instance.get('ca_certs', self.ca_certs)
-        weakcipher = _is_affirmative(instance.get('weakciphers', False))
-        ignore_ssl_warning = _is_affirmative(instance.get('ignore_ssl_warning', False))
-        check_hostname = _is_affirmative(instance.get('check_hostname', True))
-        skip_proxy = _is_affirmative(
-            instance.get('skip_proxy', instance.get('no_proxy', False)))
-        allow_redirects = _is_affirmative(instance.get('allow_redirects', True))
-
-        return url, ntlm_domain, username, password, client_cert, client_key, method, data, http_response_status_code, \
-            timeout, include_content, headers, response_time, content_match, reverse_content_match, tags, \
-            disable_ssl_validation, ssl_expire, instance_ca_certs, weakcipher, check_hostname, ignore_ssl_warning, \
-            skip_proxy, allow_redirects
-
     def _check(self, instance):
         addr, ntlm_domain, username, password, client_cert, client_key, method, data, http_response_status_code, \
             timeout, include_content, headers, response_time, content_match, reverse_content_match, tags, \
             disable_ssl_validation, ssl_expire, instance_ca_certs, weakcipher, check_hostname, ignore_ssl_warning, \
-            skip_proxy, allow_redirects = self._load_conf(instance)
+            skip_proxy, allow_redirects = from_instance(instance, self.ca_certs)
 
         start = time.time()
 

--- a/http_check/tests/test_config.py
+++ b/http_check/tests/test_config.py
@@ -1,0 +1,102 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.utils.headers import headers as agent_headers
+from datadog_checks.http_check.config import from_instance, DEFAULT_EXPECTED_CODE
+
+
+@pytest.mark.unit
+def test_from_instance():
+    """
+    Test the defaults and the pieces of _load_conf that actually perform some logic
+    """
+    # misconfiguration
+    with pytest.raises(Exception) as e:
+        from_instance({})
+        assert 'Bad configuration' in str(e)
+
+    # defaults
+    params = from_instance({
+        'url': 'https://example.com',
+        'name': 'UpService',
+    })
+    assert len(params) == 24
+
+    # `url` is mandatory
+    assert params[0] == 'https://example.com'
+    # default `ntlm_domain` is None
+    assert params[1] is None
+    # default `username` is None
+    assert params[2] is None
+    # default `password` is None
+    assert params[3] is None
+    # defualt `client_cert` is None
+    assert params[4] is None
+    # defualt `client_key` is None
+    assert params[5] is None
+    # default `method` is get
+    assert params[6] == 'get'
+    # default `data` is an empty dict
+    assert params[7] == {}
+    # default `http_response_status_code`
+    assert params[8] == DEFAULT_EXPECTED_CODE
+    # default `timeout` is 10
+    assert params[9] == 10
+    # default `include_content` is False
+    assert params[10] is False
+    # default headers
+    assert params[11] == agent_headers({})
+    # default `collect_response_time` is True
+    assert params[12] is True
+    # default `content_match` is None
+    assert params[13] is None
+    # default `reverse_content_match` is False
+    assert params[14] is False
+    # default `tags` is an empty list
+    assert params[15] == []
+    # default `disable_ssl_validation` is True
+    assert params[16] is True
+    # default `check_certificate_expiration` is True
+    assert params[17] is True
+    # default `ca_certs`, it's mocked we don't care
+    assert params[18] != ''
+    # default `weakciphers` is False
+    assert params[19] is False
+    # default `check_hostname` is True
+    assert params[20] is True
+    # default `ignore_ssl_warning` is False
+    assert params[21] is False
+    # default `skip_proxy` is False
+    assert params[22] is False
+    # default `allow_redirects` is True
+    assert params[23] is True
+
+    # headers
+    params = from_instance({
+        'url': 'https://example.com',
+        'name': 'UpService',
+        'headers': {"X-Auth-Token": "SOME-AUTH-TOKEN"}
+    })
+
+    headers = params[11]
+    expected_headers = agent_headers({}).get('User-Agent')
+    assert headers["X-Auth-Token"] == "SOME-AUTH-TOKEN", headers
+    assert expected_headers == headers.get('User-Agent'), headers
+
+    # proxy
+    params = from_instance({
+        'url': 'https://example.com',
+        'name': 'UpService',
+        'no_proxy': True,
+    })
+    assert params[22] is True
+
+    params = from_instance({
+        'url': 'https://example.com',
+        'name': 'UpService',
+        'no_proxy': False,
+        'skip_proxy': True,
+    })
+    assert params[22] is True

--- a/http_check/tests/test_http_check.py
+++ b/http_check/tests/test_http_check.py
@@ -9,8 +9,6 @@ import pytest
 import mock
 
 from datadog_checks.http_check import HTTPCheck
-from datadog_checks.http_check.http_check import DEFAULT_EXPECTED_CODE
-from datadog_checks.utils.headers import headers as agent_headers
 from .common import (
     HERE, FAKE_CERT, CONFIG, CONFIG_SSL_ONLY, CONFIG_EXPIRED_SSL, CONFIG_CUSTOM_NAME,
     CONFIG_DATA_METHOD, CONFIG_HTTP_REDIRECTS, CONFIG_UNORMALIZED_INSTANCE_NAME,
@@ -38,102 +36,6 @@ def test__init__():
     assert http_check.ca_certs == 'foo'
 
 
-@pytest.mark.unit
-def test__load_conf(http_check):
-    """
-    Test the defaults and the pieces of _load_conf that actually perform some logic
-    """
-    # misconfiguration
-    with pytest.raises(Exception) as e:
-        http_check._load_conf({})
-        assert 'Bad configuration' in str(e)
-
-    # defaults
-    params = http_check._load_conf({
-        'url': 'https://example.com',
-        'name': 'UpService',
-    })
-    assert len(params) == 24
-
-    # `url` is mandatory
-    assert params[0] == 'https://example.com'
-    # default `ntlm_domain` is None
-    assert params[1] is None
-    # default `username` is None
-    assert params[2] is None
-    # default `password` is None
-    assert params[3] is None
-    # defualt `client_cert` is None
-    assert params[4] is None
-    # defualt `client_key` is None
-    assert params[5] is None
-    # default `method` is get
-    assert params[6] == 'get'
-    # default `data` is an empty dict
-    assert params[7] == {}
-    # default `http_response_status_code`
-    assert params[8] == DEFAULT_EXPECTED_CODE
-    # default `timeout` is 10
-    assert params[9] == 10
-    # default `include_content` is False
-    assert params[10] is False
-    # default headers
-    assert params[11] == agent_headers({})
-    # default `collect_response_time` is True
-    assert params[12] is True
-    # default `content_match` is None
-    assert params[13] is None
-    # default `reverse_content_match` is False
-    assert params[14] is False
-    # default `tags` is an empty list
-    assert params[15] == []
-    # default `disable_ssl_validation` is True
-    assert params[16] is True
-    # default `check_certificate_expiration` is True
-    assert params[17] is True
-    # default `ca_certs`, it's mocked we don't care
-    assert params[18] != ''
-    # default `weakciphers` is False
-    assert params[19] is False
-    # default `check_hostname` is True
-    assert params[20] is True
-    # default `ignore_ssl_warning` is False
-    assert params[21] is False
-    # default `skip_proxy` is False
-    assert params[22] is False
-    # default `allow_redirects` is True
-    assert params[23] is True
-
-    # headers
-    params = http_check._load_conf({
-        'url': 'https://example.com',
-        'name': 'UpService',
-        'headers': {"X-Auth-Token": "SOME-AUTH-TOKEN"}
-    })
-
-    headers = params[11]
-    expected_headers = agent_headers({}).get('User-Agent')
-    assert headers["X-Auth-Token"] == "SOME-AUTH-TOKEN", headers
-    assert expected_headers == headers.get('User-Agent'), headers
-
-    # proxy
-    params = http_check._load_conf({
-        'url': 'https://example.com',
-        'name': 'UpService',
-        'no_proxy': True,
-    })
-    assert params[22] is True
-
-    params = http_check._load_conf({
-        'url': 'https://example.com',
-        'name': 'UpService',
-        'no_proxy': False,
-        'skip_proxy': True,
-    })
-    assert params[22] is True
-
-
-@pytest.mark.unit
 def test_check_cert_expiration(http_check):
     cert_path = os.path.join(HERE, 'fixtures', 'cacert.pem')
     check_hostname = True


### PR DESCRIPTION
### What does this PR do?

Parses an `instance` into a `Config` object. `Config` is a named tuple. Having all the options in a single object will ease further refactoring but for now tuple is unpacked in the `_check` method to avoid changing too much code in a single PR.

### Motivation

Removing technical debt and legacy code from the check.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Waiting until `2.3.1` is out before merging this so we can ship a fix some users are waiting for before the refactoring.
