### PR TITLE
Properly respect platform-specific connectors

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -12,11 +12,17 @@ from contextlib import contextmanager
 from collections import defaultdict
 
 # 3rd party
-import adodbapi
+try:
+    import adodbapi
+except ImportError:
+    adodbapi = None
 try:
     import pyodbc
 except ImportError:
     pyodbc = None
+
+if adodbapi is None and pyodbc is None:
+    raise ImportError('adodbapi or pyodbc must be installed to use this check.')
 
 # project
 from datadog_checks.checks import AgentCheck
@@ -90,9 +96,11 @@ class SQLServer(AgentCheck):
         ('sqlserver.stats.procs_blocked', 'Processes blocked', ''),  # LARGE_RAWCOUNT
         ('sqlserver.buffer.checkpoint_pages', 'Checkpoint pages/sec', '')  # BULK_COUNT
     ]
-    valid_connectors = ['adodbapi']
+    valid_connectors = []
     valid_adoproviders = ['SQLOLEDB', 'MSOLEDBSQL']
     default_adoprovider = 'SQLOLEDB'
+    if adodbapi is not None:
+        valid_connectors.append('adodbapi')
     if pyodbc is not None:
         valid_connectors.append('odbc')
     valid_tables = [

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -16,17 +16,18 @@ try:
     import adodbapi
 except ImportError:
     adodbapi = None
+
 try:
     import pyodbc
 except ImportError:
     pyodbc = None
 
-if adodbapi is None and pyodbc is None:
-    raise ImportError('adodbapi or pyodbc must be installed to use this check.')
-
 # project
 from datadog_checks.checks import AgentCheck
 from datadog_checks.config import is_affirmative
+
+if adodbapi is None and pyodbc is None:
+    raise ImportError('adodbapi or pyodbc must be installed to use this check.')
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'sql server'
 ALL_INSTANCES = 'ALL'


### PR DESCRIPTION
### Motivation

Until https://github.com/DataDog/integrations-core/pull/2322, sqlserver dependency environment markers were not in sync and therefore `adodbapi` was being install everywhere for tests even though it is Windows-only. Now that it isn't (matching the Agent), an import error occurs when it should not as `pyodbc` is an equally valid connector.

### Additional Notes

As we don't yet offer _official_ support for linux, no changelog entry is needed since this only fixes our ci.