### PR TITLE
Handle SSL exception and send a DOWN service check status

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -278,6 +278,9 @@ class HTTPCheck(NetworkCheck):
         except ssl.CertificateError as e:
             self.log.debug("The hostname on the SSL certificate does not match the given host: {}".format(e))
             return (Status.CRITICAL, 0, 0, str(e))
+        except ssl.SSLError as e:
+            self.log.debug("{} error: {}. Cert might be expired.".format(e.library, e.reason))
+            return (Status.DOWN, 0, 0, str(e))
         except Exception as e:
             self.log.debug("Site is down, unable to connect to get cert expiration: {}".format(e))
             return (Status.DOWN, 0, 0, str(e))
@@ -290,10 +293,7 @@ class HTTPCheck(NetworkCheck):
         self.log.debug("Exp_date: {}".format(exp_date))
         self.log.debug("seconds_left: {}".format(seconds_left))
 
-        if seconds_left < 0:
-            return (Status.DOWN, days_left, seconds_left, "Expired by {} days".format(days_left))
-
-        elif seconds_left < seconds_critical:
+        if seconds_left < seconds_critical:
             return (Status.CRITICAL, days_left, seconds_left,
                     "This cert TTL is critical: only {} days before it expires".format(days_left))
 


### PR DESCRIPTION
### What does this PR do?

Handles `SSLError` instead of falling back to generic `Exception` handler. Most likely use case scenario when getting there is an expired certificate.

Since we wrap the socket connection to the server with a context configured like `context.verify_mode = ssl.CERT_REQUIRED`, if the certificate is expired SSL will raise and the connection aborted, so there's no way to retrieve certificate informations with `getpeercert()`.

For this reason, the conditional branch checking `if seconds_left < 0:` will never be hit and it was removed.

### Motivation

Cleaning up the check

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

The only workaround would be retrieving the cert file in x509 format without verification and use PyOpenssl to parse what was the expiration date but this would require adding another dependency and changing the current logic.
