### PR TITLE
Enable pytest plugin to control environments

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/_env.py
+++ b/datadog_checks_dev/datadog_checks/dev/_env.py
@@ -3,8 +3,15 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 
-TEAR_DOWN_ENV = 'DDEV_TEAR_DOWN_ENV'
+E2E_FIXTURE_NAME = 'dd_environment'
+E2E_SET_UP = 'DDEV_E2E_UP'
+E2E_TEAR_DOWN = 'DDEV_E2E_DOWN'
+TESTING_PLUGIN = 'DDEV_TESTING_PLUGIN'
+
+
+def set_up_env():
+    return os.getenv(E2E_SET_UP, 'true') != 'false'
 
 
 def tear_down_env():
-    return os.getenv(TEAR_DOWN_ENV, 'true') != 'false'
+    return os.getenv(E2E_TEAR_DOWN, 'true') != 'false'

--- a/datadog_checks_dev/datadog_checks/dev/plugin/plugin.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/plugin.py
@@ -1,17 +1,78 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+import os
+from base64 import urlsafe_b64encode
+
 import pytest
+
+from .._env import E2E_FIXTURE_NAME, TESTING_PLUGIN
 
 try:
     from datadog_checks.stubs import aggregator as __aggregator
 
     @pytest.fixture
     def aggregator():
+        """This fixture returns a mocked Agent aggregator with state cleared."""
         __aggregator.reset()
         return __aggregator
 
 except ImportError:
+    __aggregator = None
+
     @pytest.fixture
     def aggregator():
         raise ImportError('datadog-checks-base is not installed!')
+
+
+@pytest.fixture(scope='session', autouse=True)
+def dd_environment_runner(request):
+    testing_plugin = os.getenv(TESTING_PLUGIN) == 'true'
+
+    # Do nothing if no e2e action is triggered and continue with tests
+    if not testing_plugin and not any(ev.startswith('DDEV_E2E_') for ev in os.environ):  # no cov
+        return
+
+    try:
+        config = request.getfixturevalue(E2E_FIXTURE_NAME)
+    except Exception as e:
+        # pytest doesn't export this exception class so we have to do some introspection
+        if e.__class__.__name__ == 'FixtureLookupError':
+            # Make it explicit for our command
+            pytest.exit('NO E2E FIXTURE AVAILABLE')
+
+        raise
+
+    # Environment fixture also returned some metadata
+    if isinstance(config, tuple):
+        config, metadata = config
+
+        # Support only defining the env_type for ease-of-use
+        if isinstance(metadata, str):
+            metadata = {'env_type': metadata}
+
+    # Default to Docker as that is the most common
+    else:
+        metadata = {'env_type': 'docker'}
+
+    data = {
+        'config': config,
+        'metadata': metadata,
+    }
+
+    # Serialize to json
+    data = json.dumps(data, separators=(',', ':'))
+
+    # Using base64 ensures:
+    # 1. Printing to stdout won't fail
+    # 2. Easy parsing since there are no spaces
+    message = urlsafe_b64encode(data.encode('utf-8'))
+
+    message = 'DDEV_E2E_START_MESSAGE {} DDEV_E2E_END_MESSAGE'.format(message.decode('utf-8'))
+
+    if testing_plugin:
+        return message
+    else:  # no cov
+        # Exit testing and pass data back up to command
+        pytest.exit(message)

--- a/datadog_checks_dev/tests/conftest.py
+++ b/datadog_checks_dev/tests/conftest.py
@@ -1,0 +1,28 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+
+@pytest.fixture(scope='session')
+def mock_e2e_config():
+    return {
+        'prometheus_url': 'http://localhost:2379/metrics',
+        'tags': [
+            'tag1:value1',
+            'tag2:value2',
+        ],
+    }
+
+
+@pytest.fixture(scope='session')
+def mock_e2e_metadata():
+    return {
+        'env_type': 'vagrant',
+        'future': 'now',
+    }
+
+
+@pytest.fixture(scope='session')
+def dd_environment(mock_e2e_config, mock_e2e_metadata):
+    yield mock_e2e_config, mock_e2e_metadata

--- a/datadog_checks_dev/tests/plugin/__init__.py
+++ b/datadog_checks_dev/tests/plugin/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/datadog_checks_dev/tests/plugin/test_environment_runner.py
+++ b/datadog_checks_dev/tests/plugin/test_environment_runner.py
@@ -1,0 +1,22 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+from base64 import urlsafe_b64decode
+
+
+def test_runner(dd_environment_runner, mock_e2e_config, mock_e2e_metadata):
+    message = dd_environment_runner
+
+    encoded = message.split(' ')[1]
+    decoded = urlsafe_b64decode(encoded.encode('utf-8'))
+    data = json.loads(decoded.decode('utf-8'))
+
+    assert 'config' in data
+    assert 'metadata' in data
+
+    config = data['config']
+    metadata = data['metadata']
+
+    assert config == mock_e2e_config
+    assert metadata == mock_e2e_metadata

--- a/datadog_checks_dev/tests/test__env.py
+++ b/datadog_checks_dev/tests/test__env.py
@@ -1,0 +1,25 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datadog_checks.dev import EnvVars
+from datadog_checks.dev._env import E2E_SET_UP, E2E_TEAR_DOWN, set_up_env, tear_down_env
+
+
+def test_set_up_env_default_true():
+    with EnvVars(ignore=[E2E_SET_UP]):
+        assert set_up_env() is True
+
+
+def test_set_up_env_false():
+    with EnvVars({E2E_SET_UP: 'false'}):
+        assert set_up_env() is False
+
+
+def test_tear_down_env_default_true():
+    with EnvVars(ignore=[E2E_TEAR_DOWN]):
+        assert tear_down_env() is True
+
+
+def test_tear_down_env_false():
+    with EnvVars({E2E_TEAR_DOWN: 'false'}):
+        assert tear_down_env() is False

--- a/datadog_checks_dev/tests/tooling/test_create.py
+++ b/datadog_checks_dev/tests/tooling/test_create.py
@@ -4,8 +4,9 @@
 import os
 import sys
 
-from datadog_checks.dev.subprocess import run_command
+from datadog_checks.dev import EnvVars, run_command
 from datadog_checks.dev.utils import chdir, remove_path
+from datadog_checks.dev._env import TESTING_PLUGIN
 
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -28,7 +29,8 @@ def test_new_check_test():
         )
 
         with chdir(check_path):
-            run_command([sys.executable, '-m', 'pytest'], capture=True, check=True)
+            with EnvVars(ignore=[TESTING_PLUGIN]):
+                run_command([sys.executable, '-m', 'pytest'], capture=True, check=True)
 
         run_command(
             [sys.executable, '-m', 'pip', 'uninstall', '-y', 'my-check'],

--- a/datadog_checks_dev/tox.ini
+++ b/datadog_checks_dev/tox.ini
@@ -15,6 +15,8 @@ deps =
 passenv =
     DOCKER*
     COMPOSE*
+setenv =
+    DDEV_TESTING_PLUGIN=true
 commands =
     pytest tests
 


### PR DESCRIPTION
### E2E part 1

This adds a global pytest fixture that allows the tooling to:

1. control the setup and tear down of environments
2. get information from environments' setups

Control is achieved via env vars for setup/tear down, with each defaulting to `true` (for regular testing).

Configuration for a check's environment is written to stdout for our tooling to catch via pytest (only when doing E2E things).

### Additional Notes

Part 2 will be adding the E2E commands
Part 3 will be standardizing the name of the environment setup test fixture for every check so they can be detected for E2E