### PR TITLE
Fix parsing errors when the podlist is in an inconsistent state

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -266,6 +266,9 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
         for pod in pods['items']:
             # Pod reporting
             pod_id = pod.get('metadata', {}).get('uid')
+            if not pod_id:
+                self.log.debug('skipping pod with no uid')
+                continue
             tags = get_tags('kubernetes_pod://%s' % pod_id, False) or None
             if not tags:
                 continue
@@ -276,6 +279,9 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
             containers = pod.get('status', {}).get('containerStatuses', [])
             for container in containers:
                 container_id = container.get('containerID')
+                if not container_id:
+                    self.log.debug('skipping container with no id')
+                    continue
                 tags = get_tags(container_id, False) or None
                 if not tags:
                     continue


### PR DESCRIPTION
### What does this PR do?

Some `kubelet` check runs fail with the following traceback:
> File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/checks/base.py\", line 352, in run
> self.check(copy.deepcopy(self.instances[0]))
> File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/kubelet/kubelet.py\", line 148, in check
> self._report_pods_running(self.pod_list, self.instance_tags)
> File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/kubelet/kubelet.py\", line 277, in _report_pods_running
> tags = get_tags(container_id, False) or None
> TypeError: argument 1 must be string, not None

This hopefully should transitory, but let's skip these containers and complete the check run.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
