### PR TITLE
explicitly turn off a few features for pip+TUF+in-toto

### DIFF
--- a/.public-tuf-config.json
+++ b/.public-tuf-config.json
@@ -1,4 +1,6 @@
 {
+  "download_in_toto_metadata": false,
+  "enable_logging": false,
   "repositories_dir": "repositories",
   "repository_dir": "public-integrations-core",
   "target_path_patterns": [


### PR DESCRIPTION
### What does this PR do?

Explicitly turn off a few features for pip+TUF+in-toto.

### Motivation

Update the TUF config for our updated pip.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

For Agent 6.6 code freeze next week.