### PR TITLE
Fix kubelet input filtering

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -74,6 +74,9 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
         self.cadvisor_legacy_url = None
 
         self.cadvisor_scraper_config = self.get_scraper_config(cadvisor_instance)
+        # Filter out system slices (empty pod name) to reduce memory footprint
+        self.cadvisor_scraper_config['_text_filter_blacklist'] = ['pod_name=""']
+
         self.kubelet_scraper_config = self.get_scraper_config(kubelet_instance)
 
     def _create_kubelet_prometheus_instance(self, instance):

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -25,11 +25,6 @@ class CadvisorPrometheusScraperMixin(object):
     def __init__(self, *args, **kwargs):
         super(CadvisorPrometheusScraperMixin, self).__init__(*args, **kwargs)
 
-        # List of strings to filter the input text payload on. If any line contains
-        # one of these strings, it will be filtered out before being parsed.
-        # INTERNAL FEATURE, might be removed in future versions
-        self._text_filter_blacklist = ['pod_name=""']
-
         # these are filled by container_<metric-name>_usage_<metric-unit>
         # and container_<metric-name>_limit_<metric-unit> reads it to compute <metric-name>usage_pct
         self.fs_usage_bytes = {}

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -246,6 +246,24 @@ def test_prometheus_net_summed(monkeypatch, aggregator):
         assert c not in check.rate.mock_calls
 
 
+def test_prometheus_filtering(monkeypatch, aggregator):
+    # Let's intercept the container_cpu_usage_seconds_total
+    # metric to make sure no sample with an empty pod_name
+    # goes through input filtering
+    # 12 out of the 45 samples should pass through the filter
+    method_name = "datadog_checks.kubelet.prometheus.CadvisorPrometheusScraperMixin.container_cpu_usage_seconds_total"
+    with mock.patch(method_name) as mock_method:
+        check = mock_kubelet_check(monkeypatch, [{}])
+        check.check({"cadvisor_metrics_endpoint": "http://dummy/metrics/cadvisor", "kubelet_metrics_endpoint": ""})
+
+        mock_method.assert_called_once()
+        metric = mock_method.call_args[0][0]
+        assert len(metric.samples) == 12
+        for name, labels, value in metric.samples:
+            assert name == "container_cpu_usage_seconds_total"
+            assert labels["pod_name"] != ""
+
+
 def test_kubelet_check_instance_config(monkeypatch):
     def mock_kubelet_check_no_prom():
         check = mock_kubelet_check(monkeypatch, [{}])


### PR DESCRIPTION
### What does this PR do?

The openmetric refactoring made the input filtering introduced by https://github.com/DataDog/integrations-core/pull/1872 ineffective, making the kubelet check's memory usage unbounded again.

This PR restores the filtering by correctly injecting the blacklist in the scraper configuration. Benchmark on a 70 MB kubelet cadvisor metric payload (patched in yellow, 652 in light blue):

![](https://cl.ly/8a4af86f6f4f/Image%202018-10-04%20at%202.31.28%20PM.png)

### Backport
`datadog/agent-dev:backport_2344` has this PR backported on top of `datadog/agent:6.5.2-jmx`
