### PR TITLE
Fix empty event issue with Agent 6

### DIFF
--- a/nagios/datadog_checks/nagios/nagios.py
+++ b/nagios/datadog_checks/nagios/nagios.py
@@ -338,12 +338,14 @@ class NagiosEventLogTailer(NagiosTailer):
         # Any remaining fields that aren't a part of the datadog-agent payload
         # specification will be dropped.
         event_payload = fields._asdict()
-        msg_title = "event_soft_hard:" + event_payload.pop('event_soft_hard', "None")
-        msg_title += " | " + "event_type:" + event_payload.pop('event_type', "None")
-        msg_title += " | " + "check_name:" + event_payload.pop('check_name', "None")
-        msg_title += " | " + "event_state:" + event_payload.pop('event_state', "None")
-        msg_title += " | " + "payload:" + event_payload.pop('payload', "None")
-        msg_title += " | " + "ack_author:" + event_payload.pop('ack_author', "None")
+        for key, val in event_payload.iteritems():
+            event_payload[key] = val.lower()
+        msg_title = "event_soft_hard:" + event_payload.pop('event_soft_hard', " ")
+        msg_title += "|" + "event_type:" + event_payload.pop('event_type', " ")
+        msg_title += "|" + "check_name:" + event_payload.pop('check_name', " ")
+        msg_title += "|" + "event_state:" + event_payload.pop('event_state', " ")
+        msg_title += "|" + "payload:" + event_payload.pop('payload', " ")
+        msg_title += "|" + "ack_author:" + event_payload.pop('ack_author', " ")
 
         event_payload.update({
                 'timestamp': timestamp,

--- a/nagios/datadog_checks/nagios/nagios.py
+++ b/nagios/datadog_checks/nagios/nagios.py
@@ -2,12 +2,11 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-# stdlib
 from collections import namedtuple
+import json
 import re
 from inspect import getargspec
 
-# project
 from datadog_checks.checks import AgentCheck
 from datadog_checks.utils.tailfile import TailFile
 
@@ -339,17 +338,27 @@ class NagiosEventLogTailer(NagiosTailer):
         # specification will be dropped.
         event_payload = fields._asdict()
 
-        msg_title = "event_soft_hard:" + event_payload.get('event_soft_hard', " ")
-        msg_title += "|" + "event_type:" + event_payload.get('event_type', " ")
-        msg_title += "|" + "check_name:" + event_payload.get('check_name', " ")
-        msg_title += "|" + "event_state:" + event_payload.get('event_state', " ")
-        msg_title += "|" + "payload:" + event_payload.get('payload', " ")
-        msg_title += "|" + "ack_author:" + event_payload.get('ack_author', " ")
+        json_text = """{
+            "event_type": "%s",
+            "event_soft_hard": "%s",
+            "check_name": "%s",
+            "event_state": "%s",
+            "payload": "%s",
+            "ack_author": "%s"
+        }""" % (
+                event_payload.pop('event_type', None),
+                event_payload.pop('event_soft_hard', None),
+                event_payload.pop('check_name', None),
+                event_payload.pop('event_state', None),
+                event_payload.pop('payload', None),
+                event_payload.pop('ack_author', None)
+        )
+        msg_text = json.loads(json_text)
 
         event_payload.update({
                 'timestamp': timestamp,
                 'event_type': event_type,
-                'msg_title': msg_title,
+                'msg_text': msg_text,
                 'source_type_name': SOURCE_TYPE_NAME,
         })
 

--- a/nagios/datadog_checks/nagios/nagios.py
+++ b/nagios/datadog_checks/nagios/nagios.py
@@ -338,14 +338,13 @@ class NagiosEventLogTailer(NagiosTailer):
         # Any remaining fields that aren't a part of the datadog-agent payload
         # specification will be dropped.
         event_payload = fields._asdict()
-        for key, val in event_payload.iteritems():
-            event_payload[key] = val.lower()
-        msg_title = "event_soft_hard:" + event_payload.pop('event_soft_hard', " ")
-        msg_title += "|" + "event_type:" + event_payload.pop('event_type', " ")
-        msg_title += "|" + "check_name:" + event_payload.pop('check_name', " ")
-        msg_title += "|" + "event_state:" + event_payload.pop('event_state', " ")
-        msg_title += "|" + "payload:" + event_payload.pop('payload', " ")
-        msg_title += "|" + "ack_author:" + event_payload.pop('ack_author', " ")
+
+        msg_title = "event_soft_hard:" + event_payload.get('event_soft_hard', " ")
+        msg_title += "|" + "event_type:" + event_payload.get('event_type', " ")
+        msg_title += "|" + "check_name:" + event_payload.get('check_name', " ")
+        msg_title += "|" + "event_state:" + event_payload.get('event_state', " ")
+        msg_title += "|" + "payload:" + event_payload.get('payload', " ")
+        msg_title += "|" + "ack_author:" + event_payload.get('ack_author', " ")
 
         event_payload.update({
                 'timestamp': timestamp,

--- a/nagios/datadog_checks/nagios/nagios.py
+++ b/nagios/datadog_checks/nagios/nagios.py
@@ -338,22 +338,17 @@ class NagiosEventLogTailer(NagiosTailer):
         # specification will be dropped.
         event_payload = fields._asdict()
 
-        json_text = """{
-            "event_type": "%s",
-            "event_soft_hard": "%s",
-            "check_name": "%s",
-            "event_state": "%s",
-            "payload": "%s",
-            "ack_author": "%s"
-        }""" % (
-                event_payload.pop('event_type', None),
-                event_payload.pop('event_soft_hard', None),
-                event_payload.pop('check_name', None),
-                event_payload.pop('event_state', None),
-                event_payload.pop('payload', None),
-                event_payload.pop('ack_author', None)
-        )
-        msg_text = json.loads(json_text)
+        msg_text = {
+            'event_type': event_payload.pop('event_type', None),
+            'event_soft_hard': event_payload.pop('event_soft_hard', None),
+            'check_name': event_payload.pop('check_name', None),
+            'event_state': event_payload.pop('event_state', None),
+            'payload': event_payload.pop('payload', None),
+            'ack_author': event_payload.pop('ack_author', None)
+        }
+
+        msg_text = json.dumps(msg_text)
+        self.log.info("Nagios Event pack: {}".format(msg_text))
 
         event_payload.update({
                 'timestamp': timestamp,

--- a/nagios/test/test_nagios.py
+++ b/nagios/test/test_nagios.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
+import json
 import tempfile
 import time
 import pytest
@@ -41,6 +41,7 @@ class TestEventLogTailer:
                 assert int(event["timestamp"]) > 0, line
                 assert event["host"] is not None, line
                 counters[t] = counters.get(t, 0) + 1
+                event['msg_text'] = json.loads(event['msg_text'])
 
                 if t == "SERVICE ALERT":
                     assert event['msg_text']["event_soft_hard"] in ("SOFT", "HARD"), line

--- a/nagios/test/test_nagios.py
+++ b/nagios/test/test_nagios.py
@@ -43,11 +43,11 @@ class TestEventLogTailer:
                 counters[t] = counters.get(t, 0) + 1
 
                 if t == "SERVICE ALERT":
-                    assert event["event_soft_hard"] in ("SOFT", "HARD"), line
-                    assert event["event_state"] in ("CRITICAL", "WARNING", "UNKNOWN", "OK"), line
-                    assert event["check_name"] is not None
+                    assert event['msg_text']["event_soft_hard"] in ("SOFT", "HARD"), line
+                    assert event['msg_text']["event_state"] in ("CRITICAL", "WARNING", "UNKNOWN", "OK"), line
+                    assert event['msg_text']["check_name"] is not None
                 elif t == "SERVICE NOTIFICATION":
-                    assert event["event_state"] in (
+                    assert event['msg_text']["event_state"] in (
                         "ACKNOWLEDGEMENT",
                         "OK",
                         "CRITICAL",
@@ -56,14 +56,14 @@ class TestEventLogTailer:
                     ), line
                 elif t == "SERVICE FLAPPING ALERT":
                     assert event["flap_start_stop"] in ("STARTED", "STOPPED"), line
-                    assert event["check_name"] is not None
+                    assert event['msg_text']["check_name"] is not None
                 elif t == "ACKNOWLEDGE_SVC_PROBLEM":
-                    assert event["check_name"] is not None
-                    assert event["ack_author"] is not None
+                    assert event['msg_text']["check_name"] is not None
+                    assert event['msg_text']["ack_author"] is not None
                     assert int(event["sticky_ack"]) >= 0
                     assert int(event["notify_ack"]) >= 0
                 elif t == "ACKNOWLEDGE_HOST_PROBLEM":
-                    assert event["ack_author"] is not None
+                    assert event['msg_text']["ack_author"] is not None
                     assert int(event["sticky_ack"]) >= 0
                     assert int(event["notify_ack"]) >= 0
                 elif t == "HOST DOWNTIME ALERT":


### PR DESCRIPTION
### What does this PR do?

Packs all extra non-standard event fields into the msg_title section of the UI. 

### Motivation

Agent 6 uses a more strict event payload (as its a go struct as opposed to an arbitrary python dictionary). The Nagios integration previously submitted these fields as extra arbitrary parts of the event. However in Agent 6, these extra fields are chopped off at the aggregator and not submitted to the backend, causing empty events to appear. This resolves that

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
