### PR TITLE
Revert Openstack Tracing

### DIFF
--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -13,7 +13,7 @@ import simplejson as json
 
 from datadog_checks.checks import AgentCheck
 from datadog_checks.config import is_affirmative
-from datadog_checks.utils.tracing import traced, add_trace_check
+
 
 try:
     # Agent >= 6.0: the check pushes tags invoking `set_external_tags`
@@ -530,9 +530,6 @@ class OpenStackCheck(AgentCheck):
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
-
-        if is_affirmative(init_config.get('trace_check', False)):
-            add_trace_check(self)
 
         self._ssl_verify = is_affirmative(init_config.get("ssl_verify", True))
         self.keystone_server_url = init_config.get("keystone_server_url")
@@ -1179,7 +1176,6 @@ class OpenStackCheck(AgentCheck):
 
         return instance_scope
 
-    @traced
     def check(self, instance):
         # have we been backed off
         if not self.should_run(instance):

--- a/openstack/setup.py
+++ b/openstack/setup.py
@@ -25,7 +25,7 @@ def get_requirements(fpath):
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base >= 3.0.0,<4.0.0'
+CHECKS_BASE_REQ = 'datadog_checks_base'
 
 setup(
     name='datadog-openstack',


### PR DESCRIPTION
### What does this PR do?

Revert Openstack Tracing

### Motivation

This is in order to be able to use the CI for ongoing work going on with the OpenStack integration.
Another PR will be created to bring this back.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
