### PR TITLE
Make some checks' compose files use a unique network

### DIFF
--- a/cockroachdb/tests/conftest.py
+++ b/cockroachdb/tests/conftest.py
@@ -13,16 +13,23 @@ DOCKER_DIR = os.path.join(HERE, 'docker')
 
 
 @pytest.fixture(scope='session', autouse=True)
-def dd_environment(instance):
+def dd_environment(instance, instance_e2e):
     with docker_run(
         os.path.join(DOCKER_DIR, 'docker-compose.yaml'),
         endpoints=instance['prometheus_url'],
     ):
-        yield instance
+        yield instance_e2e
 
 
 @pytest.fixture(scope='session')
 def instance():
     return {
         'prometheus_url': 'http://{}:{}/_status/vars'.format(HOST, PORT),
+    }
+
+
+@pytest.fixture(scope='session')
+def instance_e2e():
+    return {
+        'prometheus_url': 'http://cockroachdb:{}/_status/vars'.format(PORT),
     }

--- a/cockroachdb/tests/docker/docker-compose.yaml
+++ b/cockroachdb/tests/docker/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 services:
   cockroachdb:
@@ -12,8 +12,7 @@ services:
     ports:
       - "26257:26257"
       - "8080:8080"
-    networks:
-     - roachnet
 
 networks:
-  roachnet: {}
+  default:
+    name: dd_cockroachdb

--- a/envoy/tests/common.py
+++ b/envoy/tests/common.py
@@ -15,6 +15,9 @@ INSTANCES = {
     'main': {
         'stats_url': 'http://{}:{}/stats'.format(HOST, PORT),
     },
+    'e2e': {
+        'stats_url': 'http://front-envoy:{}/stats'.format(PORT),
+    },
     'whitelist': {
         'stats_url': 'http://{}:{}/stats'.format(HOST, PORT),
         'metric_whitelist': [

--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -19,4 +19,4 @@ def dd_environment():
         build=True,
         endpoints=instance['stats_url']
     ):
-        yield instance
+        yield INSTANCES['e2e']

--- a/envoy/tests/docker/default/docker-compose.yaml
+++ b/envoy/tests/docker/default/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 services:
 
@@ -10,8 +10,6 @@ services:
         ENVOY_VERSION: ${ENVOY_VERSION}
     volumes:
       - ./front-envoy.yaml:/etc/front-envoy.yaml
-    networks:
-      - envoymesh
     expose:
       - "80"
       - "8001"
@@ -26,7 +24,7 @@ services:
     volumes:
       - ./service-envoy.yaml:/etc/service-envoy.yaml
     networks:
-      envoymesh:
+      default:
         aliases:
           - service1
     environment:
@@ -41,7 +39,7 @@ services:
     volumes:
       - ./service-envoy.yaml:/etc/service-envoy.yaml
     networks:
-      envoymesh:
+      default:
         aliases:
           - service2
     environment:
@@ -50,4 +48,5 @@ services:
       - "80"
 
 networks:
-  envoymesh: {}
+  default:
+    name: dd_envoy

--- a/vault/tests/common.py
+++ b/vault/tests/common.py
@@ -11,6 +11,10 @@ INSTANCES = {
         'tags': ['instance:foobar'],
         'detect_leader': True,
     },
+    'e2e': {
+        'api_url': 'http://vault:{}/v1'.format(PORT),
+        'detect_leader': True,
+    },
     'bad_url': {
         'api_url': 'http://1.2.3.4:555/v1',
         'tags': ['instance:foobar'],

--- a/vault/tests/conftest.py
+++ b/vault/tests/conftest.py
@@ -20,4 +20,4 @@ def dd_environment():
         os.path.join(DOCKER_DIR, 'docker-compose.yaml'),
         endpoints='{}/sys/health'.format(instance['api_url'])
     ):
-        yield instance
+        yield INSTANCES['e2e']

--- a/vault/tests/docker/docker-compose.yaml
+++ b/vault/tests/docker/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 services:
 
@@ -11,3 +11,7 @@ services:
       - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
     ports:
       - "8200:8200"
+
+networks:
+  default:
+    name: dd_vault


### PR DESCRIPTION
### Motivation

E2E for docker needs an easy way to see what is running/up. This will also avoid port collisions.