### PR TITLE
Use subprocess to get sudo capabilities instead of system()

### DIFF
--- a/postfix/datadog_checks/postfix/postfix.py
+++ b/postfix/datadog_checks/postfix/postfix.py
@@ -176,8 +176,9 @@ class PostfixCheck(AgentCheck):
                 count = sum(len(files) for root, dirs, files in os.walk(queue_path))
             else:
                 # can dd-agent user run sudo?
-                test_sudo = os.system('setsid sudo -l < /dev/null')
-                if test_sudo == 0:
+                test_sudo = ['sudo', '-l']
+                _, _, exit_code = get_subprocess_output(test_sudo, self.log, False)
+                if exit_code == 0:
                     # default to `root` for backward compatibility
                     postfix_user = self.init_config.get('postfix_user', 'root')
                     cmd = ['sudo', '-u', postfix_user, 'find', queue_path, '-type', 'f']

--- a/postfix/tox.ini
+++ b/postfix/tox.ini
@@ -3,11 +3,11 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py27
 envlist =
-    unit,
+    integration,
     flake8
 
 [testenv]
-platform = linux
+platform = linux|darwin
 passenv =
     DOCKER*
     COMPOSE*
@@ -15,10 +15,10 @@ deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 
-[testenv:unit]
+[testenv:integration]
 commands =
     pip install --require-hashes -r requirements.txt
-    pytest -v
+    pytest -v -s
 
 [testenv:flake8]
 skip_install = true

--- a/postfix/tox.ini
+++ b/postfix/tox.ini
@@ -18,7 +18,7 @@ deps =
 [testenv:integration]
 commands =
     pip install --require-hashes -r requirements.txt
-    pytest -v -s
+    pytest -v
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
### What does this PR do?

Fixes #2292 

### Motivation

We use `os.system` to check `sudo` capabilities by executing `sudo -l` but redirecting to `/dev/null` seems not working on some platforms. To avoid the problem altogether, with this PR we use `subprocess` for doing the same so we're in control of both stderr and stdout.

Also coming with this PR:

* Tests now run on OSX too

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
