### PR TITLE
[kubernetes_state] don't send pod phase service checks by default

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
@@ -27,4 +27,4 @@ instances:
     #
     # Send (deprecated) pod.phase service checks (default false)
     # We recommend using the corresponding gauges instead, which benefit from historical data unlike service checks
-    # send_pod_phase_service_checks: true
+    # send_pod_phase_service_checks: false

--- a/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
@@ -25,6 +25,6 @@ instances:
     # will be attached to the host running KSM)
     # hostname_override: true
     #
-    # Send (deprecated) pod.phase service checks (default true, will be turned off in future versions)
+    # Send (deprecated) pod.phase service checks (default false)
     # We recommend using the corresponding gauges instead, which benefit from historical data unlike service checks
-    # send_pod_phase_service_checks: false
+    # send_pod_phase_service_checks: true

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -41,7 +41,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         generic_instances = [kubernetes_state_instance]
         super(KubernetesState, self).__init__(name, init_config, agentConfig, instances=generic_instances)
 
-        self.send_pod_phase_service_checks = is_affirmative(instance.get('send_pod_phase_service_checks', True))
+        self.send_pod_phase_service_checks = is_affirmative(instance.get('send_pod_phase_service_checks', False))
         if self.send_pod_phase_service_checks:
             self.warning("DEPRECATION NOTICE: pod phase service checks are deprecated. Please set "
                          "`send_pod_phase_service_checks` to false and rely on corresponding gauges instead")

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -239,21 +239,6 @@ def test_update_kube_state_metrics(aggregator, instance, check):
     aggregator.assert_service_check(NAMESPACE + '.node.memory_pressure', check.OK)
     aggregator.assert_service_check(NAMESPACE + '.node.network_unavailable', check.OK)
     aggregator.assert_service_check(NAMESPACE + '.node.disk_pressure', check.OK)
-    # Running
-    aggregator.assert_service_check(NAMESPACE + '.pod.phase', check.OK,
-                                    tags=['namespace:default', 'pod:task-pv-pod', 'optional:tag1'])
-    # Pending
-    aggregator.assert_service_check(NAMESPACE + '.pod.phase', check.WARNING,
-                                    tags=['namespace:default', 'pod:failingtest-f585bbd4-2fsml', 'optional:tag1'])
-    # Succeeded
-    aggregator.assert_service_check(NAMESPACE + '.pod.phase', check.OK,
-                                    tags=['namespace:default', 'pod:hello-1509998340-k4f8q', 'optional:tag1'])
-    # Failed
-    aggregator.assert_service_check(NAMESPACE + '.pod.phase', check.CRITICAL,
-                                    tags=['namespace:default', 'pod:should-run-once', 'optional:tag1'])
-    # Unknown
-    aggregator.assert_service_check(NAMESPACE + '.pod.phase', check.UNKNOWN,
-                                    tags=['namespace:default', 'pod:hello-1509998460-tzh8k', 'optional:tag1'])
 
     # Make sure we send counts for all statuses to avoid no-data graphing issues
     aggregator.assert_metric(NAMESPACE + '.nodes.by_condition',
@@ -293,6 +278,8 @@ def test_update_kube_state_metrics(aggregator, instance, check):
             aggregator.assert_metric_has_tag(metric, tag)
         if metric not in ZERO_METRICS:
             assert_not_all_zeroes(aggregator, metric)
+
+    assert NAMESPACE + '.pod.status_phase' not in aggregator._service_checks
 
     # FIXME: the original assert for resourcequota wasn't working, following line should be uncommented
     # assert resourcequota_was_collected(aggregator)
@@ -352,8 +339,8 @@ def test_disabling_hostname_override(instance):
     assert scraper_config['label_to_hostname'] is None
 
 
-def test_removing_pod_phase_service_checks(aggregator, instance, check):
-    check.send_pod_phase_service_checks = False
+def test_add_pod_phase_service_checks(aggregator, instance, check):
+    check.send_pod_phase_service_checks = True
     for _ in range(2):
         check.check(instance)
     # We should still send gauges
@@ -361,5 +348,19 @@ def test_removing_pod_phase_service_checks(aggregator, instance, check):
                              tags=['namespace:default', 'phase:Running', 'optional:tag1'], value=3)
     aggregator.assert_metric(NAMESPACE + '.pod.status_phase',
                              tags=['namespace:default', 'phase:Failed', 'optional:tag1'], value=2)
-    # the service checks should not be sent
-    assert NAMESPACE + '.pod.status_phase' not in aggregator._service_checks
+    # the service checks should be sent as well
+    # Running
+    aggregator.assert_service_check(NAMESPACE + '.pod.phase', check.OK,
+                                    tags=['namespace:default', 'pod:task-pv-pod', 'optional:tag1'])
+    # Pending
+    aggregator.assert_service_check(NAMESPACE + '.pod.phase', check.WARNING,
+                                    tags=['namespace:default', 'pod:failingtest-f585bbd4-2fsml', 'optional:tag1'])
+    # Succeeded
+    aggregator.assert_service_check(NAMESPACE + '.pod.phase', check.OK,
+                                    tags=['namespace:default', 'pod:hello-1509998340-k4f8q', 'optional:tag1'])
+    # Failed
+    aggregator.assert_service_check(NAMESPACE + '.pod.phase', check.CRITICAL,
+                                    tags=['namespace:default', 'pod:should-run-once', 'optional:tag1'])
+    # Unknown
+    aggregator.assert_service_check(NAMESPACE + '.pod.phase', check.UNKNOWN,
+                                    tags=['namespace:default', 'pod:hello-1509998460-tzh8k', 'optional:tag1'])


### PR DESCRIPTION
### What does this PR do?

Makes the default for sending pod phase service checks to false.
Next step will be to remove it from the code in 6.7.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
