### PR TITLE
Handle `host:` command when parsing commandstats output

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -408,8 +408,13 @@ class Redis(AgentCheck):
 
         for key, stats in command_stats.iteritems():
             command = key.split('_', 1)[1]
-            command_tags = tags + ['command:%s' % command]
-            self.gauge('redis.command.calls', stats['calls'], tags=command_tags)
+            command_tags = tags + ['command:{}'.format(command)]
+
+            # When `host:` is passed as a command, `calls` ends up having a leading `:`
+            # see https://github.com/DataDog/integrations-core/issues/839
+            calls = stats.get('calls') if command != 'host' else stats.get(':calls')
+
+            self.gauge('redis.command.calls', calls, tags=command_tags)
             self.gauge('redis.command.usec_per_call', stats['usec_per_call'], tags=command_tags)
 
     def check(self, instance):

--- a/redisdb/tests/conftest.py
+++ b/redisdb/tests/conftest.py
@@ -7,6 +7,7 @@ import time
 import pytest
 import redis
 
+from datadog_checks.redisdb import Redis
 from datadog_checks.dev import LazyFunction, RetryError, docker_run
 from .common import HOST, PORT, MASTER_PORT, REPLICA_PORT, PASSWORD
 
@@ -86,13 +87,6 @@ def redis_cluster():
 
 
 @pytest.fixture
-def aggregator():
-    from datadog_checks.stubs import aggregator
-    aggregator.reset()
-    return aggregator
-
-
-@pytest.fixture
 def redis_instance():
     return {
         'host': HOST,
@@ -118,3 +112,8 @@ def master_instance():
         'host': HOST,
         'port': MASTER_PORT,
     }
+
+
+@pytest.fixture
+def check():
+    return Redis('redisdb', {}, {}, None)

--- a/redisdb/tests/test_unit.py
+++ b/redisdb/tests/test_unit.py
@@ -1,19 +1,15 @@
 # (C) Datadog, Inc. 2010-2017
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-from __future__ import unicode_literals
-
-from datadog_checks.redisdb import Redis
+import mock
 
 
-def test_init():
-    check = Redis('redisdb', {}, {}, None)
+def test_init(check):
     assert check.connections == {}
     assert len(check.last_timestamp_seen) == 0
 
 
-def test__get_conn():
-    check = Redis('redisdb', {}, {}, None)
+def test__get_conn(check):
     instance = {}
 
     # create a connection
@@ -32,3 +28,22 @@ def test__get_conn():
     key2, conn2 = next(check.connections.iteritems())
     assert key2 == key1
     assert conn2 != conn1
+
+
+def test__check_command_stats(check, aggregator):
+    conn = mock.MagicMock()
+    conn.info.return_value = {
+        # this is from a real use case in Redis >5.0 where this line can be
+        # seen (notice the double ':')
+        # cmdstat_host::calls=2,usec=145,usec_per_call=72.50
+        'cmdstat_host': {
+            'usec_per_call': 72.5,
+            'usec': 145,
+            ':calls': 2
+        }
+    }
+    check._check_command_stats(conn, ['foo:bar'])
+
+    expected_tags = ['foo:bar', 'command:host']
+    aggregator.assert_metric('redis.command.calls', value=2, count=1, tags=expected_tags)
+    aggregator.assert_metric('redis.command.usec_per_call', value=72.5, count=1, tags=expected_tags)


### PR DESCRIPTION
### What does this PR do?

Fixes #839 

### Motivation

Collection breaks with a `KeyError` when `cmdstat_host:` is present in `commandstats` output (legit use case introduced with https://github.com/antirez/redis/commit/a81a92ca2ceba364f4bb51efde9284d939e7ff47)

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Added a test case to test the fix and avoid future regressions
