### PR TITLE
add additional pformats for prometheus check

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -390,7 +390,7 @@ class PrometheusScraperMixin(object):
             kwargs['custom_tags'] = instance.get('tags', [])
 
         # define in config the pFormat if there is any
-        pFormat = instance.get('pFormat') if instance.get('pFormat') else None
+        pFormat = instance.get('pFormat') if instance.get('pFormat')
 
         for metric in self.scrape_metrics(endpoint, pFormat=pFormat):
             self.process_metric(metric, **kwargs)

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -390,9 +390,7 @@ class PrometheusScraperMixin(object):
             kwargs['custom_tags'] = instance.get('tags', [])
 
         # define in config the pFormat if there is any
-        pFormat = instance.get('pFormat') if instance.get('pFormat')
-
-        for metric in self.scrape_metrics(endpoint, pFormat=pFormat):
+        for metric in self.scrape_metrics(endpoint, pFormat=instance.get('pFormat')):
             self.process_metric(metric, **kwargs)
 
     def store_labels(self, message):


### PR DESCRIPTION
### What does this PR do?

Extends the Prometheus mixins.py file to accommodate additional pFormats outside of just Protobuf.
Takes a pFormat argument at instance config level if it exists and passes it to the poll() method of mixin.
For this case, if pFormat in {PROTOBUF, TEXT} then the changes to behavior does something. 

### Motivation

Working on a SpringBoot v2 Application and turned on Prometheus via actuator.
Curling the endpoint that containers my prometheus metrics:
```curl SPRINGBOOT_SERVICE_ENDPOINT:8080/actuator/prometheus -v -H "Accept: application/json"```
will provide a 406 error

```curl SPRINGBOOT_SERVICE_ENDPOINT:8080/actuator/prometheus -v -H "Accept: application/vnd.google.protobuf"```
also returns a 406 error

```curl SPRINGBOOT_SERVICE_ENDPOINT:8080/actuator/prometheus -v -H "Accept: plain/text"```
returns the actual prometheus metric space

To reproduce the error I am seeing via this [project](https://github.com/ziquanmiao/kubernetes_datadog)

```
kubectl create -f agent_daemon.yaml
kubectl create -f flask_deployment.yaml
kubectl create -f postgres_deployment.yaml
kubectl create -f springboot_deployment.yaml
```

Get the cluster-ip of springboot service
```
kubectl get services
```
wait some minutes
```
kubectl get pods
kubectl exec -it <AGENT_POD> bash
python
```

```
import requests
headers['accept-encoding'] = 'gzip'
headers['accept'] = 'application/vnd.google.protobuf; ' \
                    'proto=io.prometheus.client.MetricFamily; ' \
                    'encoding=delimited'>>> >>> >>> ... ... 
g = requests.get('http://SPRINGBOOT_SERVICE_CLUSTER_IP:8080/actuator/prometheus',headers=headers)g
### it will be<Response [406]>
```

```
import requests
headers['accept-encoding'] = 'gzip'
headers['accept'] = 'text/plain; ' \
                    'proto=io.prometheus.client.MetricFamily; ' \
                    'encoding=delimited'>>> >>> >>> ... ... 
g = requests.get('http://SPRINGBOOT_SERVICE_CLUSTER_IP:8080/actuator/prometheus',headers=headers)g
### it will be<Response [200]>
```

What inspired you to submit this pull request?
Working on a reproducable Demo Environment

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
