### PR TITLE
Added delayed_unassigned_shards metric

### DIFF
--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -843,7 +843,7 @@ class ESCheck(AgentCheck):
         if version >= [2, 4, 0]:
             cluster_health_metrics += self.CLUSTER_HEALTH_METRICS_POST_2_4
 
-        for metric, desc in self.CLUSTER_HEALTH_METRICS.iteritems():
+        for metric, desc in cluster_health_metrics.iteritems():
             self._process_metric(data, metric, *desc, tags=config.tags)
 
         # Process the service check

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -841,7 +841,7 @@ class ESCheck(AgentCheck):
 
         cluster_health_metrics = self.CLUSTER_HEALTH_METRICS
         if version >= [2, 4, 0]:
-            cluster_health_metrics += self.CLUSTER_HEALTH_METRICS_POST_2_4
+            cluster_health_metrics.update(self.CLUSTER_HEALTH_METRICS_POST_2_4)
 
         for metric, desc in cluster_health_metrics.iteritems():
             self._process_metric(data, metric, *desc, tags=config.tags)

--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -206,6 +206,7 @@ elasticsearch.transport.server_open,gauge,,connection,,The number of connections
 elasticsearch.transport.tx_count,gauge,,packet,,The total number of packets sent in cluster communication.,0,elasticsearch,transport packets sent
 elasticsearch.transport.tx_size,gauge,,byte,,The total size of data sent in cluster communication.,0,elasticsearch,transport bytes sent
 elasticsearch.unassigned_shards,gauge,,shard,,The number of shards that are unassigned to a node.,0,elasticsearch,unassigned shards
+elasticsearch.delayed_unassigned_shards,gauge,,shard,,The number of shards whose allocation has been delayed.,0,elasticsearch,delayed unassigned shards
 jvm.gc.collection_count,gauge,,garbage collection,,The total number of garbage collections run by the JVM.,0,elasticsearch,jvm gc count
 jvm.gc.collection_time,gauge,,second,,The total time spent on garbage collection in the JVM.,0,elasticsearch,jvm gc time
 jvm.gc.collectors.old.collection_time,gauge,,second,,The total time spent in major GCs in the JVM that collect old generation objects.,0,elasticsearch,jvm old gc time


### PR DESCRIPTION
### What does this PR do?

Fixes #1056 by adding `elasticsearch.delayed_unassigned_shards`

### Motivation

User request

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)


