### PR TITLE
Add postgresql.replication_delay_bytes metric for version 10

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -203,10 +203,13 @@ SELECT schemaname, count(*) FROM
         """.format(table_count_limit=TABLE_COUNT_LIMIT)
     }
 
-    q = ('CASE WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0 ELSE GREATEST '
-         '(0, EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())) END')
+    q1 = ('CASE WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0 ELSE GREATEST '
+          '(0, EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())) END')
+    q2 = ('abs(pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_receive_lsn())) '
+          'AS replication_delay_bytes')
     REPLICATION_METRICS_10 = {
-        q: ('postgresql.replication_delay', GAUGE),
+        q1: ('postgresql.replication_delay', GAUGE),
+        q2: ('postgresql.replication_delay_bytes', GAUGE)
     }
 
     q = ('CASE WHEN pg_last_xlog_receive_location() = pg_last_xlog_replay_location() THEN 0 ELSE GREATEST '

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -205,7 +205,7 @@ SELECT schemaname, count(*) FROM
 
     q1 = ('CASE WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0 ELSE GREATEST '
           '(0, EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())) END')
-    q2 = ('abs(pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_receive_lsn())) '
+    q2 = ('abs(pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn())) '
           'AS replication_delay_bytes')
     REPLICATION_METRICS_10 = {
         q1: ('postgresql.replication_delay', GAUGE),

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -205,11 +205,10 @@ SELECT schemaname, count(*) FROM
 
     q1 = ('CASE WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0 ELSE GREATEST '
           '(0, EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())) END')
-    q2 = ('abs(pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn())) '
-          'AS replication_delay_bytes')
+    q2 = ('abs(pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn()))')
     REPLICATION_METRICS_10 = {
         q1: ('postgresql.replication_delay', GAUGE),
-        q2: ('postgresql.replication_delay_bytes', GAUGE)
+        q2: ('postgresql.replication_delay_bytes', GAUGE),
     }
 
     q = ('CASE WHEN pg_last_xlog_receive_location() = pg_last_xlog_replay_location() THEN 0 ELSE GREATEST '


### PR DESCRIPTION
### What does this PR do?

For postgresql version 10, the `postgresql.replication_delay_bytes` metric was missing. This PR adds the query and metric to the check.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
