### PR TITLE
Added generic error class ConfigurationError

### DIFF
--- a/datadog_checks_base/datadog_checks/base/errors.py
+++ b/datadog_checks_base/datadog_checks/base/errors.py
@@ -8,3 +8,10 @@ class CheckException(Exception):
     Generic base class for errors coming from checks
     """
     pass
+
+
+class ConfigurationError(CheckException):
+    """
+    The configuration file is invalid
+    """
+    pass


### PR DESCRIPTION
### What does this PR do?

See title

### Motivation

We have a bunch of checks raising in case the config file is invalid and all of them redefine their own generic exception class, not a big deal but this way the code is more consistent

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

