### PR TITLE
Fixed error when using multiple custom queries in a single instance

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -853,8 +853,6 @@ GROUP BY datid, datname
         """
         Given a list of custom_queries, execute each query and parse the result for metrics
         """
-        cursor = db.cursor()
-
         for custom_query in custom_queries:
             metric_prefix = custom_query.get('metric_prefix')
             if not metric_prefix:
@@ -876,6 +874,7 @@ GROUP BY datid, datname
                 )
                 continue
 
+            cursor = db.cursor()
             with closing(cursor) as cursor:
                 try:
                     self.log.debug("Running query: {}".format(query))

--- a/postgres/tests/test_custom_metrics.py
+++ b/postgres/tests/test_custom_metrics.py
@@ -29,20 +29,36 @@ def test_custom_metrics(aggregator, postgres_standalone, pg_instance):
 @pytest.mark.integration
 def test_custom_queries(aggregator, postgres_standalone, pg_instance):
     pg_instance.update({
-        'custom_queries': [{
-            'metric_prefix': 'custom',
-            'query': "SELECT letter, num FROM (VALUES (21, 'a'), (22, 'b'), (23, 'c')) AS t (num,letter) LIMIT 1",
-            'columns': [
-                {
-                    'name': 'customtag',
-                    'type': 'tag',
-                },
-                {
-                    'name': 'num',
-                    'type': 'gauge',
-                }
-            ],
-        }],
+        'custom_queries': [
+            {
+                'metric_prefix': 'custom',
+                'query': "SELECT letter, num FROM (VALUES (21, 'a'), (22, 'b'), (23, 'c')) AS t (num,letter) LIMIT 1",
+                'columns': [
+                    {
+                        'name': 'customtag',
+                        'type': 'tag',
+                    },
+                    {
+                        'name': 'num',
+                        'type': 'gauge',
+                    }
+                ],
+            },
+            {
+                'metric_prefix': 'another_custom_one',
+                'query': "SELECT letter, num FROM (VALUES (21, 'a'), (22, 'b'), (23, 'c')) AS t (num,letter) LIMIT 1",
+                'columns': [
+                    {
+                        'name': 'customtag',
+                        'type': 'tag',
+                    },
+                    {
+                        'name': 'num',
+                        'type': 'gauge',
+                    }
+                ],
+            }
+        ],
     })
     postgres_check = PostgreSql('postgres', {}, {})
     postgres_check.check(pg_instance)


### PR DESCRIPTION
### What does this PR do?

Before the patch, when using more than one custom queries per instance the check fails with

`AttributeError: 'NoneType' object has no attribute '_lock'`

This is due to the first query that closes the cursor, so subsequent queries in the `for` loop can't use it anymore. Fix consists in creating a new cursor at each iteration (read: for each custom query).

### Motivation

Support request

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

