### PR TITLE
Make the error message more clear in case a path is not accessible

### DIFF
--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -8,6 +8,7 @@ from time import time
 
 from datadog_checks.checks import AgentCheck
 from datadog_checks.config import is_affirmative
+from datadog_checks.errors import ConfigurationError
 from .traverse import walk
 
 
@@ -54,15 +55,13 @@ class DirectoryCheck(AgentCheck):
         custom_tags = instance.get('tags', [])
 
         if not exists(abs_directory):
-            if ignore_missing:
-                self.log.info(
-                    'DirectoryCheck: the directory `{}` does not exist. Skipping.'.format(abs_directory)
-                )
-                return
+            msg = "Either directory '{}' doesn't exist or the Agent doesn't "\
+                  "have permissions to access it, skipping.".format(abs_directory)
 
-            raise Exception(
-                'DirectoryCheck: the directory `{}` does not exist. Skipping.'.format(abs_directory)
-            )
+            if not ignore_missing:
+                raise ConfigurationError(msg)
+
+            self.log.info(msg)
 
         self._get_stats(
             abs_directory,

--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -38,7 +38,7 @@ class DirectoryCheck(AgentCheck):
         try:
             directory = instance['directory']
         except KeyError:
-            raise Exception('DirectoryCheck: missing `directory` in config')
+            raise ConfigurationError('DirectoryCheck: missing `directory` in config')
 
         abs_directory = abspath(directory)
         name = instance.get('name', directory)

--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -61,7 +61,7 @@ class DirectoryCheck(AgentCheck):
             if not ignore_missing:
                 raise ConfigurationError(msg)
 
-            self.log.info(msg)
+            self.log.warning(msg)
 
         self._get_stats(
             abs_directory,

--- a/directory/tests/test_directory.py
+++ b/directory/tests/test_directory.py
@@ -6,9 +6,11 @@ import shutil
 import tempfile
 
 import pytest
+import mock
 
 from datadog_checks.dev.utils import create_file, temp_dir as temp_directory
 from datadog_checks.directory import DirectoryCheck
+from datadog_checks.errors import ConfigurationError
 
 CHECK_NAME = 'directory'
 
@@ -227,12 +229,13 @@ def test_non_existent_directory():
     """
     Missing or inaccessible directory coverage.
     """
-    config = {'instances': [{'directory': '/non-existent/directory'}]}
-    with pytest.raises(Exception):
-        dir_check.check(config)
+    with pytest.raises(ConfigurationError):
+        dir_check.check({'directory': '/non-existent/directory'})
 
 
 def test_non_existent_directory_ignore_missing():
     config = {'directory': '/non-existent/directory',
               'ignore_missing': True}
+    dir_check._get_stats = mock.MagicMock()
     dir_check.check(config)
+    dir_check._get_stats.assert_called_once()


### PR DESCRIPTION
### What does this PR do?

On Windows, `os.path.exists` returns `False` both when a directory doesn't exist and when the user can't access it for lack of permissions, we now mention this in the error message.

### Motivation

Since upcoming version of the Agent will run under an unprivileged user, a permission error will be possible in the future, let's be proactive.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Logic doesn't change, it's just the error message
