### PR TITLE
Move config parser to its own module

### DIFF
--- a/elastic/datadog_checks/elastic/config.py
+++ b/elastic/datadog_checks/elastic/config.py
@@ -1,0 +1,91 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from collections import namedtuple
+import urlparse
+
+from datadog_checks.errors import ConfigurationError
+from datadog_checks.config import _is_affirmative
+
+
+ESInstanceConfig = namedtuple('ESInstanceConfig', [
+    'admin_forwarder',
+    'pshard_stats',
+    'pshard_graceful_to',
+    'cluster_stats',
+    'index_stats',
+    'password',
+    'service_check_tags',
+    'health_tags',
+    'tags',
+    'timeout',
+    'url',
+    'username',
+    'pending_task_stats',
+    'ssl_verify',
+    'ssl_cert',
+    'ssl_key',
+])
+
+
+DEFAULT_TIMEOUT = 5
+
+
+def from_instance(instance):
+    """
+    Create a config object from an instance dictionary
+    """
+    url = instance.get('url')
+    if not url:
+        raise ConfigurationError("A URL must be specified in the instance")
+
+    pshard_stats = _is_affirmative(instance.get('pshard_stats', False))
+    pshard_graceful_to = _is_affirmative(instance.get('pshard_graceful_timeout', False))
+    index_stats = _is_affirmative(instance.get('index_stats', False))
+    cluster_stats = _is_affirmative(instance.get('cluster_stats', False))
+    if 'is_external' in instance:
+        cluster_stats = _is_affirmative(instance.get('is_external', False))
+    pending_task_stats = _is_affirmative(instance.get('pending_task_stats', True))
+    admin_forwarder = _is_affirmative(instance.get('admin_forwarder', False))
+
+    # Support URLs that have a path in them from the config, for
+    # backwards-compatibility.
+    parsed = urlparse.urlparse(url)
+    if parsed[2] and not admin_forwarder:
+        url = '{}://{}'.format(parsed[0], parsed[1])
+    port = parsed.port
+    host = parsed.hostname
+
+    custom_tags = instance.get('tags', [])
+    service_check_tags = [
+        'host:{}'.format(host),
+        'port:{}'.format(port),
+    ]
+    service_check_tags.extend(custom_tags)
+
+    # Tag by URL so we can differentiate the metrics
+    # from multiple instances
+    tags = ['url:{}'.format(url)]
+    tags.extend(custom_tags)
+
+    timeout = instance.get('timeout') or DEFAULT_TIMEOUT
+
+    config = ESInstanceConfig(
+        admin_forwarder=admin_forwarder,
+        pshard_stats=pshard_stats,
+        pshard_graceful_to=pshard_graceful_to,
+        cluster_stats=cluster_stats,
+        index_stats=index_stats,
+        password=instance.get('password'),
+        service_check_tags=service_check_tags,
+        health_tags=[],
+        ssl_cert=instance.get('ssl_cert'),
+        ssl_key=instance.get('ssl_key'),
+        ssl_verify=instance.get('ssl_verify'),
+        tags=tags,
+        timeout=timeout,
+        url=url,
+        username=instance.get('username'),
+        pending_task_stats=pending_task_stats
+    )
+    return config

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -1,19 +1,19 @@
-# (C) Datadog, Inc. 2010-2017
+# (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-
-# stdlib
 from collections import defaultdict, namedtuple
 import time
 import urlparse
+
 import requests
+
 from datadog_checks.checks import AgentCheck
 from datadog_checks.config import _is_affirmative
 from datadog_checks.utils.headers import headers
 
 
-class NodeNotFound(Exception):
-    pass
+class AuthenticationError(requests.exceptions.HTTPError):
+    """Authentication Error, unable to reach server"""
 
 
 ESInstanceConfig = namedtuple(
@@ -909,7 +909,3 @@ class ESCheck(AgentCheck):
             'event_object': hostname,
             'tags': tags
         }
-
-
-class AuthenticationError(requests.exceptions.HTTPError):
-    """Authentication Error, unable to reach server"""

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -479,8 +479,10 @@ class ESCheck(AgentCheck):
         return version
 
     def _join_url(self, base, url, admin_forwarder=False):
-        # overrides `urlparse.urljoin` since it removes base url path
-        # https://docs.python.org/2/library/urlparse.html#urlparse.urljoin
+        """
+        overrides `urlparse.urljoin` since it removes base url path
+        https://docs.python.org/2/library/urlparse.html#urlparse.urljoin
+        """
         if admin_forwarder:
             return base + url
         else:
@@ -520,10 +522,10 @@ class ESCheck(AgentCheck):
                 self._process_metric(index_data, metric, *desc, tags=tags)
 
     def _define_params(self, version, cluster_stats):
-        """ Define the set of URLs and METRICS to use depending on the
-            running ES version.
         """
-
+        Define the set of URLs and METRICS to use depending on the
+        running ES version.
+        """
         pshard_stats_url = "/_stats"
 
         if version >= [0, 90, 10]:
@@ -617,7 +619,8 @@ class ESCheck(AgentCheck):
             stats_metrics, pshard_stats_metrics
 
     def _get_data(self, url, config, send_sc=True):
-        """ Hit a given URL and return the parsed json
+        """
+        Hit a given URL and return the parsed json
         """
         # Load basic authentication configuration, if available.
         if config.username and config.password:
@@ -744,7 +747,7 @@ class ESCheck(AgentCheck):
             else:
                 self.rate(metric, value, tags=tags, hostname=hostname)
         else:
-            self._metric_not_found(metric, path)
+            self.log.debug("Metric not found: %s -> %s", path, metric)
 
     def _process_health_data(self, data, config, version):
         cluster_status = data.get('status')
@@ -797,9 +800,6 @@ class ESCheck(AgentCheck):
             message=msg,
             tags=config.service_check_tags+config.health_tags
         )
-
-    def _metric_not_found(self, metric, path):
-        self.log.debug("Metric not found: %s -> %s", path, metric)
 
     def _create_event(self, status, tags=None):
         hostname = self.hostname.decode('utf-8')

--- a/elastic/tests/common.py
+++ b/elastic/tests/common.py
@@ -5,8 +5,6 @@ import os
 
 from datadog_checks.utils.common import get_docker_hostname
 
-CHECK_NAME = "elastic"
-
 HERE = os.path.dirname(os.path.abspath(__file__))
 USER = "elastic"
 PASSWORD = "changeme"
@@ -20,7 +18,6 @@ URL = 'http://{0}:{1}'.format(HOST, PORT)
 BAD_URL = 'http://{0}:{1}'.format(HOST, BAD_PORT)
 
 CONFIG = {'url': URL, 'username': USER, 'password': PASSWORD, 'tags': TAGS}
-BAD_CONFIG = {'url': BAD_URL, 'password': PASSWORD}
 
 INDEX_METRICS_MOCK_DATA = [{
         "health": "green",

--- a/elastic/tests/conftest.py
+++ b/elastic/tests/conftest.py
@@ -8,11 +8,13 @@ import time
 import pytest
 import requests
 
+from datadog_checks.elastic import ESCheck
+
 from .common import HERE, URL
 
 
-@pytest.fixture(scope="session", autouse=True)
-def spin_up_elastic():
+@pytest.fixture(scope="session")
+def elastic_cluster():
     args = [
         'docker-compose', '-f', os.path.join(HERE, 'compose', 'docker-compose.yaml')
     ]
@@ -31,3 +33,8 @@ def spin_up_elastic():
     requests.put(URL, '/datadog/')
     yield
     subprocess.check_call(args + ["down"])
+
+
+@pytest.fixture
+def elastic_check():
+    return ESCheck('elastic', {}, {})

--- a/elastic/tests/test_bench.py
+++ b/elastic/tests/test_bench.py
@@ -9,8 +9,6 @@ from .common import CONFIG, PASSWORD, URL, USER
 
 
 def test_check(benchmark, elastic_cluster, elastic_check):
-    elastic_check = ESCheck(CHECK_NAME, {}, {})
-
     for _ in range(3):
         try:
             elastic_check.check(CONFIG)
@@ -27,9 +25,7 @@ def test_pshard_metrics(benchmark, elastic_cluster, elastic_check):
     requests.put(URL + '/_settings', data='{"index": {"number_of_replicas": 1}}')
     requests.put(URL + '/testindex/testtype/2', data='{"name": "Jane Doe", "age": 27}')
     requests.put(URL + '/testindex/testtype/1', data='{"name": "John Doe", "age": 42}')
-
     time.sleep(elastic_latency)
-    elastic_check = ESCheck(CHECK_NAME, {}, {})
 
     benchmark(elastic_check.check, config)
 

--- a/elastic/tests/test_bench.py
+++ b/elastic/tests/test_bench.py
@@ -5,11 +5,10 @@ import time
 
 import requests
 
-from datadog_checks.elastic import ESCheck
-from .common import CHECK_NAME, CONFIG, PASSWORD, URL, USER
+from .common import CONFIG, PASSWORD, URL, USER
 
 
-def test_check(benchmark):
+def test_check(benchmark, elastic_cluster, elastic_check):
     elastic_check = ESCheck(CHECK_NAME, {}, {})
 
     for _ in range(3):
@@ -21,7 +20,7 @@ def test_check(benchmark):
     benchmark(elastic_check.check, CONFIG)
 
 
-def test_pshard_metrics(benchmark):
+def test_pshard_metrics(benchmark, elastic_cluster, elastic_check):
     elastic_latency = 10
     config = {'url': URL, 'pshard_stats': True, 'username': USER, 'password': PASSWORD}
 
@@ -35,8 +34,6 @@ def test_pshard_metrics(benchmark):
     benchmark(elastic_check.check, config)
 
 
-def test_index_metrics(benchmark):
+def test_index_metrics(benchmark, elastic_cluster, elastic_check):
     config = {'url': URL, 'index_stats': True, 'username': USER, 'password': PASSWORD}
-    elastic_check = ESCheck(CHECK_NAME, {}, {})
-
     benchmark(elastic_check.check, config)

--- a/elastic/tests/test_config.py
+++ b/elastic/tests/test_config.py
@@ -1,10 +1,51 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
 import pytest
 
 from datadog_checks.elastic.config import from_instance, DEFAULT_TIMEOUT
+from datadog_checks.errors import ConfigurationError
+
+
+@pytest.mark.unit
+def test_from_instance_invalid():
+    # missing url
+    with pytest.raises(ConfigurationError):
+        from_instance({})
+    # empty url
+    with pytest.raises(ConfigurationError):
+        from_instance({'url': ''})
+
+
+@pytest.mark.unit
+def test_from_instance_defaults():
+    c = from_instance({'url': 'http://example.com'})
+
+    assert c.admin_forwarder is False
+    assert c.pshard_stats is False
+    assert c.pshard_graceful_to is False
+    assert c.cluster_stats is False
+    assert c.index_stats is False
+    assert c.password is None
+    assert c.service_check_tags == ['host:example.com', 'port:None']
+    assert c.health_tags == []
+    assert c.ssl_cert is None
+    assert c.ssl_key is None
+    assert c.ssl_verify is None
+    assert c.tags == ['url:http://example.com']
+    assert c.timeout == DEFAULT_TIMEOUT
+    assert c.url == 'http://example.com'
+    assert c.username is None
+    assert c.pending_task_stats is True
+
+
+@pytest.mark.unit
+def test_from_instance_cluster_stats():
+    c = from_instance({
+        'url': 'http://example.com',
+        'is_external': True,
+    })
+    assert c.cluster_stats is True
 
 
 @pytest.mark.unit

--- a/elastic/tests/test_config.py
+++ b/elastic/tests/test_config.py
@@ -1,0 +1,61 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pytest
+
+from datadog_checks.elastic.config import from_instance, DEFAULT_TIMEOUT
+
+
+@pytest.mark.unit
+def test_from_instance():
+    instance = {
+        "username": "user",
+        "password": "pass",
+        "is_external": "yes",
+        "url": "http://foo.bar",
+        "tags": ["a", "b:c"],
+    }
+    c = from_instance(instance)
+    assert c.username == "user"
+    assert c.password == "pass"
+    assert c.admin_forwarder is False
+    assert c.cluster_stats is True
+    assert c.url == "http://foo.bar"
+    assert c.tags == ["url:http://foo.bar", "a", "b:c"]
+    assert c.timeout == DEFAULT_TIMEOUT
+    assert c.service_check_tags == ["host:foo.bar", "port:None", "a", "b:c"]
+
+    instance = {
+        "url": "http://192.168.42.42:12999",
+        "timeout": 15}
+    c = from_instance(instance)
+    assert c.username is None
+    assert c.password is None
+    assert c.cluster_stats is False
+    assert c.url == "http://192.168.42.42:12999"
+    assert c.tags == ["url:http://192.168.42.42:12999"]
+    assert c.timeout == 15
+    assert c.service_check_tags == ["host:192.168.42.42", "port:12999"]
+
+    instance = {
+        "username": "user",
+        "password": "pass",
+        "url": "https://foo.bar:9200",
+        "ssl_verify": "true",
+        "ssl_cert": "/path/to/cert.pem",
+        "ssl_key": "/path/to/cert.key",
+        "admin_forwarder": "1"
+    }
+    c = from_instance(instance)
+    assert c.username == "user"
+    assert c.password == "pass"
+    assert c.admin_forwarder is True
+    assert c.cluster_stats is False
+    assert c.url == "https://foo.bar:9200"
+    assert c.tags == ["url:https://foo.bar:9200"]
+    assert c.timeout == DEFAULT_TIMEOUT
+    assert c.service_check_tags == ["host:foo.bar", "port:9200"]
+    assert c.ssl_verify == "true"
+    assert c.ssl_cert == "/path/to/cert.pem"
+    assert c.ssl_key == "/path/to/cert.key"

--- a/elastic/tests/test_elastic.py
+++ b/elastic/tests/test_elastic.py
@@ -22,7 +22,7 @@ log = logging.getLogger('test_elastic')
 
 
 @pytest.mark.unit
-def test_url_join(aggregator, elastic_check):
+def test__join_url(aggregator, elastic_check):
     adm_forwarder_joined_url = elastic_check._join_url(
         "https://localhost:9444/elasticsearch-admin",
         "/stats",

--- a/elastic/tests/test_elastic.py
+++ b/elastic/tests/test_elastic.py
@@ -11,6 +11,8 @@ import pytest
 import requests
 
 from datadog_checks.elastic import ESCheck
+from datadog_checks.elastic.config import from_instance
+
 from .common import (
     CLUSTER_TAG, CONF_HOSTNAME, CONFIG, HOST, PASSWORD, PORT, TAGS, URL, USER,
     INDEX_METRICS_MOCK_DATA, get_es_version
@@ -47,8 +49,8 @@ def test_check(elastic_cluster, elastic_check, aggregator):
     ESCheck.CLUSTER_HEALTH_METRICS.update(ESCheck.CLUSTER_PENDING_TASKS)
     expected_metrics.update(ESCheck.CLUSTER_HEALTH_METRICS)
 
-    instance = elastic_check.get_instance_config(CONFIG)
-    es_version = elastic_check._get_es_version(instance)
+    config = from_instance(CONFIG)
+    es_version = elastic_check._get_es_version(config)
 
     assert es_version == get_es_version()
 

--- a/elastic/tox.ini
+++ b/elastic/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.0
 basepython = py27
-envlist = elastic{0.90,1.0,1.1,1.2,2.4,5.2,5.6,6.0,6.2}, bench, flake8
+envlist = elastic{0.90,1.0,1.1,1.2,2.4,5.2,5.6,6.0,6.2}, unit, bench, flake8
 
 [testenv]
 platform = linux|darwin|win32
@@ -10,13 +10,11 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt
-    pytest -v --benchmark-skip
+    pytest -v --benchmark-skip -m"not unit"
 passenv =
     DOCKER*
     COMPOSE*
-#
-# Supported Versions
-#
+
 [testenv:elastic0.90]
 setenv =
     ELASTIC_DOCKER=datadog/docker-library:elasticsearch_
@@ -100,6 +98,11 @@ setenv =
     ELASTIC_DOCKER=docker.elastic.co/elasticsearch/elasticsearch:
     ELASTIC_VERSION=6.3.2
     ELASTIC_CONFIG="xpack.monitoring.collection.enabled=true"
+
+[testenv:unit]
+commands =
+    pip install --require-hashes -r requirements.txt
+    pytest -v --benchmark-skip -m"unit"
 
 [testenv:bench]
 setenv =


### PR DESCRIPTION
### What does this PR do?

Move config parsing to its own module to ease testing and increase code readability.
Also clean up and rearrange the test suite.

### Motivation

Improve the code

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
