### PR TITLE
Fix hostname override and type for status_report.count metrics

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -446,6 +446,12 @@ class OpenMetricsScraperMixin(object):
         return requests.get(endpoint, headers=headers, stream=True, timeout=scraper_config['prometheus_timeout'],
                             cert=cert, verify=verify, auth=auth)
 
+    def get_hostname_for_sample(self, sample, scraper_config):
+        """
+        Expose the label_to_hostname mapping logic to custom handler methods
+        """
+        return self._get_hostname(None, sample, scraper_config)
+
     def _submit(self, metric_name, metric, scraper_config, hostname=None):
         """
         For each sample in the metric, report it as a gauge with all labels as tags

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -450,7 +450,8 @@ class KubernetesState(OpenMetricsBaseCheck):
             if 'pod' in sample[self.SAMPLE_LABELS]:
                 tags.append(self._format_tag('pod', sample[self.SAMPLE_LABELS]['pod'], scraper_config))
 
-            self.count(metric_name, sample[self.SAMPLE_VALUE], tags + scraper_config['custom_tags'])
+            self.gauge(metric_name, sample[self.SAMPLE_VALUE], tags + scraper_config['custom_tags'],
+                       hostname=self.get_hostname_for_sample(sample, scraper_config))
 
     def kube_pod_container_status_waiting_reason(self, metric, scraper_config):
         self._submit_metric_kube_pod_container_status_reason(metric, '.container.status_report.count.waiting',

--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -2,9 +2,9 @@ metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation
 kubernetes_state.container.ready,gauge,,,,Whether the containers readiness check succeeded,0,kubernetes,k8s_state.container.rdy
 kubernetes_state.container.running,gauge,,,,Whether the container is currently in running state,0,kubernetes,k8s_state.container.running
 kubernetes_state.container.terminated,gauge,,,,Whether the container is currently in terminated state,0,kubernetes,k8s_state.container.term
-kubernetes_state.container.status_report.count.terminated,count,,,,Count of the containers currently reporting a in terminated state with the reason as a tag,-1,kubernetes,k8s_state.container.status_report.count.term
+kubernetes_state.container.status_report.count.terminated,gauge,,,,Count of the containers currently reporting a in terminated state with the reason as a tag,-1,kubernetes,k8s_state.container.status_report.count.term
 kubernetes_state.container.waiting,gauge,,,,Whether the container is currently in waiting state,0,kubernetes,k8s_state.container.wait
-kubernetes_state.container.status_report.count.waiting,count,,,,Count of the containers currently reporting a in waiting state with the reason as a tag,-1,kubernetes,k8s_state.container.status_report.count.wait
+kubernetes_state.container.status_report.count.waiting,gauge,,,,Count of the containers currently reporting a in waiting state with the reason as a tag,-1,kubernetes,k8s_state.container.status_report.count.wait
 kubernetes_state.container.gpu.request,gauge,,,,The number of requested gpu devices by a container,0,kubernetes,k8s_state.container.gpu.request
 kubernetes_state.container.gpu.limit,gauge,,,,The limit on gpu devices to be used by a container,0,kubernetes,k8s_state.container.gpu.limit
 kubernetes_state.container.restarts,gauge,,,,The number of restarts per container,-1,kubernetes,k8s_state.container.restarts

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -506,6 +506,7 @@ kube_pod_info{created_by_kind="ReplicaSet",created_by_name="kube-dns-1326421443"
 kube_pod_info{created_by_kind="ReplicaSet",created_by_name="tiller-deploy-1651615695",host_ip="192.168.99.100",namespace="kube-system",node="minikube",pod="tiller-deploy-1651615695-dcphn",pod_ip="172.17.0.6"} 1
 kube_pod_info{created_by_kind="ReplicationController",created_by_name="kubernetes-dashboard",host_ip="192.168.99.100",namespace="kube-system",node="minikube",pod="kubernetes-dashboard-zhtjl",pod_ip="172.17.0.2"} 1
 kube_pod_info{created_by_kind="ReplicationController",created_by_name="registry-creds",host_ip="192.168.99.100",namespace="kube-system",node="minikube",pod="registry-creds-hq249",pod_ip=""} 1
+kube_pod_info{created_by_kind="Job",created_by_name="hello-1509998400",host_ip="192.168.99.100",node="minikube",namespace="ns2",pod="pod2",pod_ip=""} 1
 # HELP kube_pod_labels Kubernetes labels converted to Prometheus labels.
 # TYPE kube_pod_labels gauge
 kube_pod_labels{namespace="default",pod="nxf-126"} 1

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -159,7 +159,9 @@ JOINED_METRICS = {
 
 HOSTNAMES = {
     NAMESPACE + '.pod.ready': 'minikube',
-    NAMESPACE + '.pod.scheduled': 'minikube'
+    NAMESPACE + '.pod.scheduled': 'minikube',
+    NAMESPACE + '.container.status_report.count.waiting': 'minikube',
+    NAMESPACE + '.container.status_report.count.terminated': 'minikube'
 }
 
 ZERO_METRICS = [


### PR DESCRIPTION
### What does this PR do?

The hostname of the `.container.status_report.count.waiting` and `.container.status_report.count.terminated` metrics was not extracted from the label join map.

Add the `OpenMetricsScraperMixin.get_hostname_for_sample` public method to expose the information to checks, and use it for these two metrics.

Also, set the metric type as `gauge`, as `count` bring erroneous values (counted by the app as the number of `count` calls per minutes, instead of per check run). As the timeseries are container cardinality (`pod` and `kube_container_name` tags), no client-side aggregation is needed for gauges.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
