### PR TITLE
Fix import of _get_py_loglevel

### DIFF
--- a/datadog_checks_base/datadog_checks/log.py
+++ b/datadog_checks_base/datadog_checks/log.py
@@ -2,3 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from .base.log import *
+from .base.log import _get_py_loglevel

--- a/datadog_checks_base/tests/test_log.py
+++ b/datadog_checks_base/tests/test_log.py
@@ -1,0 +1,11 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datadog_checks import log
+
+
+def test_get_py_loglevel():
+    """
+    Ensure function _get_py_loglevel is exposed
+    """
+    assert getattr(log, "_get_py_loglevel")


### PR DESCRIPTION
### What does this PR do?

`import *` doesn't import functions starting with `_`, so we need to explicitly import them

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?