### PR TITLE
Fix job metrics tagging on KSM 1.4+

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -484,7 +484,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         for sample in metric.samples:
             tags = []
             for label_name, label_value in sample[self.SAMPLE_LABELS].iteritems():
-                if label_name == 'job':
+                if label_name == 'job' or label_name == 'job_name':
                     trimmed_job = self._trim_job_tag(label_value)
                     tags.append(self._format_tag(label_name, trimmed_job, scraper_config))
                 else:
@@ -496,7 +496,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         for sample in metric.samples:
             tags = []
             for label_name, label_value in sample[self.SAMPLE_LABELS].iteritems():
-                if label_name == 'job':
+                if label_name == 'job' or label_name == 'job_name':
                     trimmed_job = self._trim_job_tag(label_value)
                     tags.append(self._format_tag(label_name, trimmed_job, scraper_config))
                 else:
@@ -507,7 +507,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         for sample in metric.samples:
             tags = [] + scraper_config['custom_tags']
             for label_name, label_value in sample[self.SAMPLE_LABELS].iteritems():
-                if label_name == 'job':
+                if label_name == 'job' or label_name == 'job_name':
                     trimmed_job = self._trim_job_tag(label_value)
                     tags.append(self._format_tag(label_name, trimmed_job, scraper_config))
                 else:
@@ -518,7 +518,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         for sample in metric.samples:
             tags = [] + scraper_config['custom_tags']
             for label_name, label_value in sample[self.SAMPLE_LABELS].iteritems():
-                if label_name == 'job':
+                if label_name == 'job' or label_name == 'job_name':
                     trimmed_job = self._trim_job_tag(label_value)
                     tags.append(self._format_tag(label_name, trimmed_job, scraper_config))
                 else:

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -147,6 +147,15 @@ kube_job_complete{condition="true",job="hello-1509998460",namespace="default"} 1
 kube_job_complete{condition="unknown",job="hello-1509998340",namespace="default"} 0
 kube_job_complete{condition="unknown",job="hello-1509998400",namespace="default"} 0
 kube_job_complete{condition="unknown",job="hello-1509998460",namespace="default"} 0
+kube_job_complete{condition="false",job_name="hello-1509998340",namespace="default"} 0
+kube_job_complete{condition="false",job_name="hello-1509998400",namespace="default"} 0
+kube_job_complete{condition="false",job_name="hello-1509998460",namespace="default"} 0
+kube_job_complete{condition="true",job_name="hello-1509998340",namespace="default"} 1
+kube_job_complete{condition="true",job_name="hello-1509998400",namespace="default"} 1
+kube_job_complete{condition="true",job_name="hello-1509998460",namespace="default"} 1
+kube_job_complete{condition="unknown",job_name="hello-1509998340",namespace="default"} 0
+kube_job_complete{condition="unknown",job_name="hello-1509998400",namespace="default"} 0
+kube_job_complete{condition="unknown",job_name="hello-1509998460",namespace="default"} 0
 # HELP kube_job_created Unix creation timestamp
 # TYPE kube_job_created gauge
 kube_job_created{job="hello-1509998340",namespace="default"} 1.509998347e+09
@@ -182,6 +191,9 @@ kube_job_status_completion_time{job="hello-1509998460",namespace="default"} 1.50
 kube_job_status_failed{job="hello-1509998340",namespace="default"} 0
 kube_job_status_failed{job="hello-1509998400",namespace="default"} 0
 kube_job_status_failed{job="hello-1509998460",namespace="default"} 0
+kube_job_status_failed{job_name="hello-1509998340",namespace="default"} 0
+kube_job_status_failed{job_name="hello-1509998400",namespace="default"} 0
+kube_job_status_failed{job_name="hello-1509998460",namespace="default"} 0
 # HELP kube_job_status_start_time StartTime represents time when the job was acknowledged by the Job Manager.
 # TYPE kube_job_status_start_time counter
 kube_job_status_start_time{job="hello-1509998340",namespace="default"} 1.509998347e+09
@@ -192,6 +204,9 @@ kube_job_status_start_time{job="hello-1509998460",namespace="default"} 1.5099984
 kube_job_status_succeeded{job="hello-1509998340",namespace="default"} 1
 kube_job_status_succeeded{job="hello-1509998400",namespace="default"} 1
 kube_job_status_succeeded{job="hello-1509998460",namespace="default"} 1
+kube_job_status_succeeded{job_name="hello-1509998340",namespace="default"} 1
+kube_job_status_succeeded{job_name="hello-1509998400",namespace="default"} 1
+kube_job_status_succeeded{job_name="hello-1509998460",namespace="default"} 1
 # HELP kube_namespace_created Unix creation timestamp
 # TYPE kube_namespace_created gauge
 kube_namespace_created{namespace="default"} 1.508406437e+09

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -147,15 +147,6 @@ kube_job_complete{condition="true",job="hello-1509998460",namespace="default"} 1
 kube_job_complete{condition="unknown",job="hello-1509998340",namespace="default"} 0
 kube_job_complete{condition="unknown",job="hello-1509998400",namespace="default"} 0
 kube_job_complete{condition="unknown",job="hello-1509998460",namespace="default"} 0
-kube_job_complete{condition="false",job_name="hello-1509998340",namespace="default"} 0
-kube_job_complete{condition="false",job_name="hello-1509998400",namespace="default"} 0
-kube_job_complete{condition="false",job_name="hello-1509998460",namespace="default"} 0
-kube_job_complete{condition="true",job_name="hello-1509998340",namespace="default"} 1
-kube_job_complete{condition="true",job_name="hello-1509998400",namespace="default"} 1
-kube_job_complete{condition="true",job_name="hello-1509998460",namespace="default"} 1
-kube_job_complete{condition="unknown",job_name="hello-1509998340",namespace="default"} 0
-kube_job_complete{condition="unknown",job_name="hello-1509998400",namespace="default"} 0
-kube_job_complete{condition="unknown",job_name="hello-1509998460",namespace="default"} 0
 # HELP kube_job_created Unix creation timestamp
 # TYPE kube_job_created gauge
 kube_job_created{job="hello-1509998340",namespace="default"} 1.509998347e+09
@@ -191,9 +182,9 @@ kube_job_status_completion_time{job="hello-1509998460",namespace="default"} 1.50
 kube_job_status_failed{job="hello-1509998340",namespace="default"} 0
 kube_job_status_failed{job="hello-1509998400",namespace="default"} 0
 kube_job_status_failed{job="hello-1509998460",namespace="default"} 0
-kube_job_status_failed{job_name="hello-1509998340",namespace="default"} 0
-kube_job_status_failed{job_name="hello-1509998400",namespace="default"} 0
-kube_job_status_failed{job_name="hello-1509998460",namespace="default"} 0
+kube_job_status_failed{job_name="hello2-1509998340",namespace="default"} 0
+kube_job_status_failed{job_name="hello2-1509998400",namespace="default"} 0
+kube_job_status_failed{job_name="hello2-1509998460",namespace="default"} 0
 # HELP kube_job_status_start_time StartTime represents time when the job was acknowledged by the Job Manager.
 # TYPE kube_job_status_start_time counter
 kube_job_status_start_time{job="hello-1509998340",namespace="default"} 1.509998347e+09
@@ -204,9 +195,9 @@ kube_job_status_start_time{job="hello-1509998460",namespace="default"} 1.5099984
 kube_job_status_succeeded{job="hello-1509998340",namespace="default"} 1
 kube_job_status_succeeded{job="hello-1509998400",namespace="default"} 1
 kube_job_status_succeeded{job="hello-1509998460",namespace="default"} 1
-kube_job_status_succeeded{job_name="hello-1509998340",namespace="default"} 1
-kube_job_status_succeeded{job_name="hello-1509998400",namespace="default"} 1
-kube_job_status_succeeded{job_name="hello-1509998460",namespace="default"} 1
+kube_job_status_succeeded{job_name="hello2-1509998340",namespace="default"} 1
+kube_job_status_succeeded{job_name="hello2-1509998400",namespace="default"} 1
+kube_job_status_succeeded{job_name="hello2-1509998460",namespace="default"} 1
 # HELP kube_namespace_created Unix creation timestamp
 # TYPE kube_namespace_created gauge
 kube_namespace_created{namespace="default"} 1.508406437e+09

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -286,7 +286,6 @@ def test_update_kube_state_metrics(aggregator, instance, check):
                              tags=['storageclass:local-data', 'phase:Pending', 'optional:tag1'], value=0)
     aggregator.assert_metric(NAMESPACE + '.persistentvolumes.by_phase',
                              tags=['storageclass:local-data', 'phase:Released', 'optional:tag1'], value=0)
-    
 
     for metric in METRICS:
         aggregator.assert_metric(metric, hostname=HOSTNAMES.get(metric, None))

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -93,6 +93,9 @@ METRICS = [
     NAMESPACE + '.limitrange.cpu.default_request',
     # services
     NAMESPACE + '.service.count',
+    # jobs
+    NAMESPACE + '.job.failed',
+    NAMESPACE + '.job.succeeded',
 ]
 
 TAGS = {
@@ -130,6 +133,14 @@ TAGS = {
         'type:ClusterIP',
         'type:NodePort',
         'type:LoadBalancer',
+    ],
+    NAMESPACE + '.job.failed': [
+        'job:hello',
+        'job_name:hello2',
+    ],
+    NAMESPACE + '.job.succeeded': [
+        'job:hello',
+        'job_name:hello2',
     ],
 }
 
@@ -172,6 +183,8 @@ ZERO_METRICS = [
     NAMESPACE + '.container.waiting',
     NAMESPACE + '.endpoint.address_available',
     NAMESPACE + '.endpoint.address_not_ready',
+    NAMESPACE + '.job.failed',
+    NAMESPACE + '.job.succeeded',
 ]
 
 
@@ -273,6 +286,7 @@ def test_update_kube_state_metrics(aggregator, instance, check):
                              tags=['storageclass:local-data', 'phase:Pending', 'optional:tag1'], value=0)
     aggregator.assert_metric(NAMESPACE + '.persistentvolumes.by_phase',
                              tags=['storageclass:local-data', 'phase:Released', 'optional:tag1'], value=0)
+    
 
     for metric in METRICS:
         aggregator.assert_metric(metric, hostname=HOSTNAMES.get(metric, None))


### PR DESCRIPTION
### What does this PR do?

[KSM 1.4.0](https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md#v140-rc0--2018-08-06) changed the `job` label to `job_name`, handle this.

### Motivation

The pods created by the jobs were tagged and not the jobs themselves.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)