### PR TITLE
base: add check name to Limiter warning message

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -133,7 +133,7 @@ class AgentCheck(object):
         except Exception:
             metric_limit = self.DEFAULT_METRIC_LIMIT
         if metric_limit > 0:
-            self.metric_limiter = Limiter("metrics", metric_limit, self.warning)
+            self.metric_limiter = Limiter(self.name, "metrics", metric_limit, self.warning)
 
     @property
     def in_developer_mode(self):

--- a/datadog_checks_base/datadog_checks/base/utils/limiter.py
+++ b/datadog_checks_base/datadog_checks/base/utils/limiter.py
@@ -9,8 +9,9 @@ class Limiter(object):
     It is used by the AgentCheck class to limit the number of sets of tags
     that can be set by an instance.
     """
-    def __init__(self, object_name, object_limit, warning_func=None):
+    def __init__(self, check_name, object_name, object_limit, warning_func=None):
         """
+        :param check_name: name of the check using this limiter
         :param object_name: (plural) name of counted objects for warning wording
         :param object_limit: maximum number of objects to accept before limiting
         :param warning_func: callback function, called with a string when limit is exceeded
@@ -18,6 +19,7 @@ class Limiter(object):
         self.warning = warning_func
         self.name = object_name
         self.limit = object_limit
+        self.check_name = check_name
 
         self.reached_limit = False
         self.count = 0
@@ -55,7 +57,7 @@ class Limiter(object):
 
         if self.count > self.limit:
             if self.warning:
-                self.warning("Exceeded limit of {} {}, ignoring next ones".format(self.limit, self.name))
+                self.warning("Check {} exceeded limit of {} {}, ignoring next ones".format(self.check_name, self.limit, self.name))
             self.reached_limit = True
             return True
         return False

--- a/datadog_checks_base/tests/test_utils.py
+++ b/datadog_checks_base/tests/test_utils.py
@@ -57,7 +57,7 @@ class TestPatternFilter:
 class TestLimiter():
     def test_no_uid(self):
         warnings = []
-        limiter = Limiter("names", 10, warning_func=warnings.append)
+        limiter = Limiter("my_check", "names", 10, warning_func=warnings.append)
         for i in range(0, 10):
             assert limiter.is_reached() is False
         assert limiter.get_status() == (10, 10, False)
@@ -65,7 +65,7 @@ class TestLimiter():
         # Reach limit
         assert limiter.is_reached() is True
         assert limiter.get_status() == (11, 10, True)
-        assert warnings == ["Exceeded limit of 10 names, ignoring next ones"]
+        assert warnings == ["Check my_check exceeded limit of 10 names, ignoring next ones"]
 
         # Make sure warning is only sent once
         assert limiter.is_reached() is True
@@ -73,7 +73,7 @@ class TestLimiter():
 
     def test_with_uid(self):
         warnings = []
-        limiter = Limiter("names", 10, warning_func=warnings.append)
+        limiter = Limiter("my_check", "names", 10, warning_func=warnings.append)
         for i in range(0, 20):
             assert limiter.is_reached("dummy1") is False
         assert limiter.get_status() == (1, 10, False)
@@ -84,7 +84,7 @@ class TestLimiter():
         assert len(warnings) == 0
 
     def test_mixed(self):
-        limiter = Limiter("names", 10)
+        limiter = Limiter("my_check", "names", 10)
 
         for i in range(0, 20):
             assert limiter.is_reached("dummy1") is False
@@ -95,7 +95,7 @@ class TestLimiter():
         assert limiter.get_status() == (6, 10, False)
 
     def test_reset(self):
-        limiter = Limiter("names", 10)
+        limiter = Limiter("my_check", "names", 10)
 
         for i in range(1, 20):
             limiter.is_reached("dummy1")


### PR DESCRIPTION
Add check name to the warning generated by the Limiter.


Looking at logs, it's not obvious which check is hitting the limit. Though this change may not be perfect (it does not indicate which instance of the check hit the limit), it's still better than the generic log message.


- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)