### PR TITLE
Document `access_denied_cache_duration` config option

### DIFF
--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -4,6 +4,10 @@ init_config:
   # low if you want to alert on process service checks.
   # pid_cache_duration: 120
   #
+  # the check maintains a list of PIDs for which it got access denied. It won't try to look at them again for the 
+  # duration in seconds specified by access_denied_cache_duration. Default value is 120 seconds.
+  # access_denied_cache_duration: 120
+  #
   # used to override the default procfs path, e.g. for docker containers with the outside fs mounted at /host/proc
   # DEPRECATED: please specify `procfs_path` globally in `datadog.conf` instead
   # procfs_path: /proc


### PR DESCRIPTION
### What does this PR do?

Document `access_denied_cache_duration` config option

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
