### PR TITLE
Expose core functionality at the root

### DIFF
--- a/datadog_checks_base/datadog_checks/base/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/__init__.py
@@ -2,8 +2,17 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from .__about__ import __version__
+from .checks import AgentCheck
+from .checks.openmetrics import OpenMetricsBaseCheck
+from .checks.win import PDHBaseCheck
+from .config import is_affirmative
+from .errors import ConfigurationError
 
 __all__ = [
-    '__version__'
+    '__version__',
+    'AgentCheck',
+    'OpenMetricsBaseCheck',
+    'PDHBaseCheck',
+    'ConfigurationError',
+    'is_affirmative',
 ]
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/datadog_checks_base/datadog_checks/base/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/__init__.py
@@ -4,9 +4,14 @@
 from .__about__ import __version__
 from .checks import AgentCheck
 from .checks.openmetrics import OpenMetricsBaseCheck
-from .checks.win import PDHBaseCheck
 from .config import is_affirmative
 from .errors import ConfigurationError
+
+# Windows-only
+try:
+    from .checks.win import PDHBaseCheck
+except ImportError:
+    PDHBaseCheck = None
 
 __all__ = [
     '__version__',


### PR DESCRIPTION
### Motivation

This

```python
from datadog_checks.base.checks import AgentCheck
from datadog_checks.base.config import is_affirmative
```

would become

```python
from datadog_checks.base import AgentCheck, is_affirmative
```

### Note

Removed namespace machinery that didn't belong