### PR TITLE
Fix version detection for new development releases

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -402,14 +402,14 @@ GROUP BY datid, datname
                 version_parts = version.split(' ')[0].split('.')
                 version = [int(part) for part in version_parts]
             except Exception:
-                # Postgres might be in beta, with format \d+beta\d+
-                match = re.match('(\d+)(beta)(\d+)', version)
+                # Postgres might be in development, with format \d+[beta|rc]\d+
+                match = re.match('(\d+)([a-zA-Z]+)(\d+)', version)
                 if match:
                     version_parts = list(match.groups())
 
-                    # We found a valid beta version
+                    # We found a valid development version
                     if len(version_parts) == 3:
-                        # Replace `beta` with a negative number to properly compare versions
+                        # Replace development tag with a negative number to properly compare versions
                         version_parts[1] = -1
                         version = [int(part) for part in version_parts]
 

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -100,9 +100,13 @@ def test_get_version(check):
     db.cursor().fetchone.return_value = ['11beta3']
     assert check._get_version('beta_version', db) == [11, -1, 3]
 
+    # Test #rc# style versions
+    db.cursor().fetchone.return_value = ['11rc1']
+    assert check._get_version('rc_version', db) == [11, -1, 1]
+
     # Test #unknown# style versions
     db.cursor().fetchone.return_value = ['11nightly3']
-    assert check._get_version('unknown_version', db) == '11nightly3'
+    assert check._get_version('unknown_version', db) == [11, -1, 3]
 
 
 def test_is_above(check):


### PR DESCRIPTION
### Motivation

Previously, `beta` was all they used. Now they use `rc` as well. We now accept any number of letters to be more future-proof.