### PR TITLE
Ensure new integrations is_public is true for 6.6

### DIFF
--- a/cockroachdb/manifest.json
+++ b/cockroachdb/manifest.json
@@ -20,5 +20,5 @@
     "data store"
   ],
   "type": "check",
-  "is_public": false
+  "is_public": true
 }

--- a/coredns/manifest.json
+++ b/coredns/manifest.json
@@ -17,6 +17,6 @@
   ],
   "type":"check",
   "aliases":[],
-  "is_public": false,
+  "is_public": true,
   "creates_events": false
 }

--- a/cri/manifest.json
+++ b/cri/manifest.json
@@ -5,7 +5,7 @@
   "creates_events": false,
   "display_name": "CRI",
   "guid": "6eb96c6a-3e2d-4236-9387-fa3b0c455336",
-  "is_public": false,
+  "is_public": true,
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "cri.",

--- a/crio/manifest.json
+++ b/crio/manifest.json
@@ -5,7 +5,7 @@
   "creates_events": false,
   "display_name": "CRI-O",
   "guid": "40fd8230-d178-4e8e-9e6a-6ce4acc19a85",
-  "is_public": false,
+  "is_public": true,
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "crio.",

--- a/openmetrics/manifest.json
+++ b/openmetrics/manifest.json
@@ -5,7 +5,7 @@
   "creates_events": false,
   "display_name": "OpenMetrics",
   "guid": "3f67af75-6987-468c-99b3-5001ba5ab414",
-  "is_public": false,
+  "is_public": true,
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "name": "openmetrics",


### PR DESCRIPTION
### Motivation

Enable bots to index `README.md` content for the Datadog public documentation.