### PR TITLE
Ianb/httpcheck attributeerror

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -85,8 +85,8 @@ class HTTPCheck(NetworkCheck):
 
                     # Emit a warning if disable_ssl_validation is not explicitly set and we're not ignoring warnings
                     else:
-                        self.log.warning('Parameter disable_ssl_validation for {} is not explicitly set, '
-                                     'defaults to true'.format(addr))
+                        self.log.warning("Parameter disable_ssl_validation for {} is not explicitly set, "
+                                     "defaults to true".format(addr))
 
             instance_proxy = self.get_instance_proxy(instance, addr)
             self.log.debug("Proxies used for {} - {}".format(addr, instance_proxy))

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -85,8 +85,8 @@ class HTTPCheck(NetworkCheck):
 
                     # Emit a warning if disable_ssl_validation is not explicitly set and we're not ignoring warnings
                     else:
-                        self.warning("Parameter disable_ssl_validation for {} is not explicitly set, "
-                                     "defaults to true".format(addr))
+                        self.log.warning('Parameter disable_ssl_validation for {} is not explicitly set, '
+                                     'defaults to true'.format(addr))
 
             instance_proxy = self.get_instance_proxy(instance, addr)
             self.log.debug("Proxies used for {} - {}".format(addr, instance_proxy))


### PR DESCRIPTION
### What does this PR do?

changes `self.warning` to `self.log.warning`. Prevents
```AttributeError: 'HTTPCheck' object has no attribute 'warning'```

### Motivation

attributeerror on warning experienced on 6.2

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

