### PR TITLE
Make every check's `tests` directory path unique for coverage

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -7,7 +7,7 @@ import click
 
 from .utils import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_waiting
 from ..constants import get_root
-from ..test import get_tox_envs, pytest_coverage_sources
+from ..test import fix_coverage_report, get_tox_envs, pytest_coverage_sources
 from ...subprocess import run_command
 from ...utils import chdir, file_exists, remove_path, running_on_ci
 
@@ -132,6 +132,7 @@ def test(checks, style, bench, coverage, cov_missing, enter_pdb, debug, verbose,
                     if result.code:
                         abort('\nFailed!', code=result.code)
 
+                    fix_coverage_report(check, 'coverage.xml')
                     run_command('codecov -X gcov -F {} -f coverage.xml'.format(check))
                 else:
                     if not cov_keep:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/test.py
@@ -5,7 +5,7 @@ from .constants import TESTABLE_FILE_EXTENSIONS, get_root
 from .git import files_changed
 from .utils import get_testable_checks
 from ..subprocess import run_command
-from ..utils import chdir, path_join
+from ..utils import chdir, path_join, read_file_binary, write_file_binary
 
 STYLE_ENVS = {
     'flake8',
@@ -123,6 +123,15 @@ def coverage_sources(check):
         package_path = 'datadog_checks/{}'.format(check)
 
     return package_path, 'tests'
+
+
+def fix_coverage_report(check, report_file):
+    report = read_file_binary(report_file)
+
+    # Make every check's `tests` directory path unique so they don't get combined in UI
+    report = report.replace(b'"tests/', '"{}/tests/'.format(check).encode('utf-8'))
+
+    write_file_binary(report_file, report)
 
 
 def pytest_coverage_sources(*checks):


### PR DESCRIPTION
### Motivation

Some were getting combined in UI due to identical file names

```
		</package>
		<package branch-rate="0.8636" complexity="0" line-rate="0.9817" name="tests">
			<classes>
				<class branch-rate="1" complexity="0" filename="tests/__init__.py" line-rate="1" name="__init__.py">
					<methods/>
					<lines/>
				</class>
				<class branch-rate="1" complexity="0" filename="tests/common.py" line-rate="1" name="common.py">
```

every report just saw `tests`, not unique path. affected tests dirs were any that had a file that others have

test_unit
test_integration
test_check