### PR TITLE
Adding link to metrics file for consistency

### DIFF
--- a/coredns/README.md
+++ b/coredns/README.md
@@ -61,6 +61,6 @@ for more details about how to test and develop Agent based integrations.
 [2]: https://github.com/DataDog/integrations-core/blob/master/coredns/datadog_checks/coredns/data/conf.yaml.example
 [3]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
-[5]: https://github.com/DataDog/cookiecutter-datadog-check/blob/master/%7B%7Bcookiecutter.check_name%7D%7D/metadata.csv
+[5]: https://github.com/DataDog/integrations-core/blob/master/coredns/metadata.csv
 [6]: https://docs.datadoghq.com/developers/
 [7]: http://docs.datadoghq.com/help/

--- a/cri/README.md
+++ b/cri/README.md
@@ -35,6 +35,8 @@ CRI collect metrics about the resource usage of your containers running through 
 CPU and memory metrics are collected out of the box and you can additionally collect some disk metrics
 if they are supported by your CRI (CRI-O doesn't support them for now)
 
+See [metadata.csv][7] for a list of metrics provided by this integration.
+
 ### Service Checks
 
 CRI does not include service checks.
@@ -52,3 +54,4 @@ Need help? Contact [Datadog Support][6].
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
 [5]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [6]: https://docs.datadoghq.com/help/
+[7]: https://github.com/DataDog/integrations-core/blob/master/cri/metadata.csv

--- a/crio/README.md
+++ b/crio/README.md
@@ -29,6 +29,8 @@ The integration relies on the `--enable-metrics` option of CRI-O that is disable
 CRI-O collect metrics about the count and latency of operations that are done by the runtime.
 We're also collecting CPU and memory usage of CRI-O golang binary itself.
 
+See [metadata.csv][7] for a list of metrics provided by this integration.
+
 ### Service Checks
 
 CRI-O includes a service check about the reachability of the metrics endpoint.
@@ -46,3 +48,4 @@ Need help? Contact [Datadog Support][6].
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
 [5]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [6]: https://docs.datadoghq.com/help/
+[7]: https://github.com/DataDog/integrations-core/blob/master/crio/metadata.csv


### PR DESCRIPTION
### What does this PR do?

Adds links to metrics file to be consistent with other integrations-core integrations Readme.md since these docs will be public soon: https://github.com/DataDog/integrations-core/pull/2403