### PR TITLE
Add doc in prometheus default config for disabling ssl

### DIFF
--- a/prometheus/datadog_checks/prometheus/data/conf.yaml.example
+++ b/prometheus/datadog_checks/prometheus/data/conf.yaml.example
@@ -79,7 +79,7 @@ instances:
   # /!\ The private key to your local certificate must be unencrypted.
   # ssl_private_key: "/path/to/key"
   #
-  # The path to the trusted CA used for generating custom certificates
+  # The path to the trusted CA used for generating custom certificates. Set this to False to disable SSL
   # ssl_ca_cert: "/path/to/cacert"
 
   # The check limits itself to 2000 metrics by default, you can increase this limit if needed


### PR DESCRIPTION
### What does this PR do?

Add documentation in the prometheus default config for disabling SSL verification. Related code: https://github.com/DataDog/integrations-core/blob/38ebab797b67ec5a58aa6fa828456435a7b1bbaa/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L437-L439

### Motivation

Support requests