### PR TITLE
Document datadog minimum permissions

### DIFF
--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -24,12 +24,14 @@ Edit the `rabbitmq.d/conf.yaml` file, in the `conf.d/` folder at the root of you
 
 Enable the RabbitMQ management plugin. See [RabbitMQ's documentation][2] to enable it.
 
-Agent user needs at least `monitoring` tag and minimum required permissions:  
-**conf** - `^aliveness-test$`  
-**write** - `^amq\.default$`  
-**read** - `.*`  
+Agent user needs at least the `monitoring` tag and those required permissions:
 
-You can create user for default vhost like this:
+* **conf** - `^aliveness-test$`  
+* **write** - `^amq\.default$`  
+* **read** - `.*`  
+
+Create a user for default vhost with the following commands:
+
 ```
 rabbitmqctl add_user datadog somesecret
 rabbitmqctl set_permissions  -p / datadog "^aliveness-test$" "^amq\.default$" ".*"

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -24,16 +24,16 @@ Edit the `rabbitmq.d/conf.yaml` file, in the `conf.d/` folder at the root of you
 
 Enable the RabbitMQ management plugin. See [RabbitMQ's documentation][2] to enable it.
 
-Agent user needs at least the `monitoring` tag and those required permissions:
+Agent user then needs at least the `monitoring` tag and those required permissions:
 
 * **conf** - `^aliveness-test$`  
 * **write** - `^amq\.default$`  
 * **read** - `.*`  
 
-Create a user for default vhost with the following commands:
+Create an Agent user for your default vhost with the following commands:
 
 ```
-rabbitmqctl add_user datadog somesecret
+rabbitmqctl add_user datadog <SECRET>
 rabbitmqctl set_permissions  -p / datadog "^aliveness-test$" "^amq\.default$" ".*"
 rabbitmqctl set_user_tags datadog monitoring
 ```

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -24,6 +24,18 @@ Edit the `rabbitmq.d/conf.yaml` file, in the `conf.d/` folder at the root of you
 
 Enable the RabbitMQ management plugin. See [RabbitMQ's documentation][2] to enable it.
 
+Agent user needs at least `monitoring` tag and minimum required permissions:  
+**conf** - `^aliveness-test$`  
+**write** - `^amq\.default$`  
+**read** - `.*`  
+
+You can create user for default vhost like this:
+```
+rabbitmqctl add_user datadog somesecret
+rabbitmqctl set_permissions  -p / datadog "^aliveness-test$" "^amq\.default$" ".*"
+rabbitmqctl set_user_tags datadog monitoring
+```
+
 #### Metric Collection
 
 * Add this configuration block to your `rabbitmq.d/conf.yaml` file to start gathering your [RabbitMQ metrics](#metrics):


### PR DESCRIPTION
### What does this PR do?

Documents minimum required permissions for datadog user and how to set them.

It's a good idea to disable `guest` user and create a user with minimal permissions for monitoring.

