### PR TITLE
Handle unicode strings in non-float handler's error message

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -180,7 +180,10 @@ class AgentCheck(object):
         try:
             value = float(value)
         except ValueError:
-            err_msg = "Metric: {} has non float value: {}. Only float values can be submitted as metrics".format(name, value)
+            err_msg = (
+                "Metric: {} has non float value: {}. "
+                "Only float values can be submitted as metrics.".format(repr(name), repr(value))
+            )
             if using_stub_aggregator:
                 raise ValueError(err_msg)
             self.warning(err_msg)


### PR DESCRIPTION
### Motivation

```
Python 2.7.15 |Anaconda, Inc.| (default, May  1 2018, 18:37:09) [MSC v.1500 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> v = u'Θ'
>>> 'value: {}'.format(v)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode character u'\u0398' in position 0: ordinal not in range(128)
>>> 'value: {}'.format(repr(v))
"value: u'\\u0398'"
```