### PR TITLE
Add ability to run all jobs in a PR at will

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ stages:
   - name: test_changed
     if: type = pull_request
   - name: test
-    if: (branch = master) AND (type != pull_request)
+    if: ((branch = master) AND (type != pull_request)) OR ((commit_message =~ /ci run all/) AND (type != pull_request))
 
 script:
   - travis_retry ddev test --cov ${CHECK}

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
 
 stages:
   - name: test_changed
-    if: type = pull_request
+    if: ((type = pull_request) AND (NOT commit_message =~ /ci run all/))
   - name: test
     if: ((branch = master) AND (type != pull_request)) OR ((commit_message =~ /ci run all/) AND (type = pull_request))
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ stages:
   - name: test_changed
     if: type = pull_request
   - name: test
-    if: ((branch = master) AND (type != pull_request)) OR ((commit_message =~ /ci run all/) AND (type != pull_request))
+    if: ((branch = master) AND (type != pull_request)) OR ((commit_message =~ /ci run all/) AND (type = pull_request))
 
 script:
   - travis_retry ddev test --cov ${CHECK}


### PR DESCRIPTION
### What does this PR do?

If you put `ci run all` in a pull request like `[ci run all] Test base check API changes` it will test each check in its own runner like merges to master. If there are many checks that have changed this will therefore avoid timeouts.