### PR TITLE
[WIP]Change prometheus check name in agent status page

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
@@ -104,9 +104,13 @@ class GenericPrometheusCheck(AgentCheck):
             endpoint,
             send_histograms_buckets=instance.get('send_histograms_buckets', True),
             send_monotonic_counter=instance.get('send_monotonic_counter', True),
-            instance=instance,
+            instance=ƒ,
             ignore_unmapped=True
         )
+
+        # Change name to namespace in order to display it in the status page
+        namespace = instance.get("namespace", "prometheus")
+        self.name = namespace
 
     def _extract_rate_metrics(self, type_overrides):
         rate_metrics = []

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
@@ -104,7 +104,7 @@ class GenericPrometheusCheck(AgentCheck):
             endpoint,
             send_histograms_buckets=instance.get('send_histograms_buckets', True),
             send_monotonic_counter=instance.get('send_monotonic_counter', True),
-            instance=ƒ,
+            instance=instance,
             ignore_unmapped=True
         )
 


### PR DESCRIPTION
## What does this PR do?

https://trello.com/c/ZrUuImt8/612-report-namespace-as-check-name-in-prometheus-checks
Goal is to display the namespace in the status page of the agent for the prometheus check.
Like this:

```
prometheus (2.0.0)
    ------------------
        Instance ID: namespace1:2d1631fc3d3bedff [OK]
        Total Runs: 2
        Metric Samples: 0, Total: 0
        Events: 0, Total: 0
        Service Checks: 0, Total: 0
        Average Execution Time : 46ms

        Instance ID: namespace2:fe5abc3f065f410f [OK]
        Total Runs: 2
        Metric Samples: 0, Total: 0
        Events: 0, Total: 0
        Service Checks: 0, Total: 0
        Average Execution Time : 50ms
```

## Motivation
At the moment, the display is not really useful.