### PR TITLE
Add datadog- prefix to packages name

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/release.py
@@ -43,20 +43,22 @@ def get_agent_requirement_line(check, version):
     """
     # base check and siblings have no manifest
     if check in ('datadog_checks_base', 'datadog_checks_tests_helper'):
-        return '{}=={}'.format(check, version)
+        return '{}=={}'.format(check.replace("_", "-"), version)
 
     m = load_manifest(check)
     platforms = sorted(m.get('supported_os', []))
 
     # all platforms
     if platforms == ALL_PLATFORMS:
-        return '{}=={}'.format(check, version)
+        return 'datadog-{}=={}'.format(check.replace("_", "-"), version)
     # one specific platform
     elif len(platforms) == 1:
-        return "{}=={}; sys_platform == '{}'".format(check, version, PLATFORMS_TO_PY.get(platforms[0]))
+        return "datadog-{}=={}; sys_platform == '{}'".format(
+            check.replace("_", "-"), version, PLATFORMS_TO_PY.get(platforms[0])
+        )
     # assuming linux+mac here for brevity
     elif platforms and 'windows' not in platforms:
-        return "{}=={}; sys_platform != 'win32'".format(check, version)
+        return "datadog-{}=={}; sys_platform != 'win32'".format(check.replace("_", "-"), version)
     else:
         raise Exception("Can't parse the `supported_os` list for the check {}: {}".format(check, platforms))
 

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -1,101 +1,101 @@
-active_directory==1.2.0; sys_platform == 'win32'
-activemq==1.1.0
-activemq_xml==1.0.1
-apache==1.3.1
-aspdotnet==1.0.0; sys_platform == 'win32'
-btrfs==1.3.0; sys_platform != 'win32'
-cacti==1.1.2; sys_platform == 'linux2'
-cassandra==1.3.0
-cassandra_nodetool==1.0.0
-ceph==1.3.1; sys_platform != 'win32'
-cisco_aci==1.2.1
-cockroachdb==1.0.0
-consul==1.5.2
-coredns==1.0.0; sys_platform == 'linux2'
-couch==2.6.1
-couchbase==1.5.1
-crio==1.0.0
-datadog_checks_base==4.2.0
-directory==1.3.1
-disk==1.4.0
-dns_check==1.1.2
-dotnetclr==1.1.0; sys_platform == 'win32'
-ecs_fargate==1.3.0
-elastic==1.8.0
-envoy==1.4.0
-etcd==1.5.1
-exchange_server==1.2.0; sys_platform == 'win32'
-fluentd==1.0.1
-gearmand==1.1.1; sys_platform != 'win32'
-gitlab==2.0.0
-gitlab_runner==2.0.0
-go-metro==1.0.0; sys_platform == 'linux2'
-go_expvar==1.0.4
-gunicorn==1.3.0; sys_platform != 'win32'
-haproxy==1.3.1
-hdfs_datanode==1.3.1; sys_platform != 'win32'
-hdfs_namenode==1.3.1; sys_platform != 'win32'
-http_check==3.0.0
-iis==2.2.0; sys_platform == 'win32'
-istio==2.0.0
-kafka==1.2.0
-kafka_consumer==1.4.1; sys_platform != 'win32'
-kong==1.2.1
-kube_dns==2.0.1
-kube_proxy==3.0.0
-kubelet==2.2.0; sys_platform == 'linux2'
-kubernetes_state==3.1.0; sys_platform != 'win32'
-kyototycoon==1.4.1
-lighttpd==1.2.1
-linkerd==2.0.0
-linux_proc_extras==1.0.1; sys_platform == 'linux2'
-mapreduce==1.2.1
-marathon==1.5.0; sys_platform != 'win32'
-mcache==1.3.2; sys_platform != 'win32'
-mesos_master==1.2.1; sys_platform != 'win32'
-mesos_slave==1.2.1; sys_platform != 'win32'
-mongo==1.6.1
-mysql==1.4.0
-nagios==1.1.2
-network==1.7.0
-nfsstat==1.0.0; sys_platform == 'linux2'
-nginx==3.0.0
-openldap==1.0.0
-openmetrics==1.0.0
-openstack==1.5.0
-oracle==1.4.0
-pdh_check==1.3.0; sys_platform == 'win32'
-pgbouncer==1.3.0; sys_platform != 'win32'
-php_fpm==1.3.1
-postfix==1.2.3; sys_platform != 'win32'
-postgres==2.2.3
-powerdns_recursor==1.1.1
-process==1.5.0
-prometheus==3.0.0
-rabbitmq==1.5.2
-redisdb==1.7.1
-riak==1.3.1
-riakcs==1.1.1
-snmp==1.4.2
-solr==1.2.0
-spark==1.4.1
-sqlserver==1.7.0; sys_platform == 'win32'
-squid==1.0.2
-ssh_check==1.3.1
-statsd==1.1.1
-supervisord==1.1.3
-system_core==1.1.0
-system_swap==1.2.0
-tcp_check==2.0.2
-teamcity==1.1.1
-tokumx==1.2.1
-tomcat==1.2.0
-twemproxy==1.2.1
-varnish==1.2.1
-vault==1.2.0
-vsphere==3.3.1
-win32_event_log==1.3.0; sys_platform == 'win32'
-windows_service==2.0.0; sys_platform == 'win32'
-wmi_check==1.2.0; sys_platform == 'win32'
-yarn==1.4.0
-zk==1.2.1; sys_platform != 'win32'
+datadog-active-directory==1.2.0; sys_platform == 'win32'
+datadog-activemq==1.1.0
+datadog-activemq-xml==1.0.1
+datadog-apache==1.3.1
+datadog-aspdotnet==1.0.0; sys_platform == 'win32'
+datadog-btrfs==1.3.0; sys_platform != 'win32'
+datadog-cacti==1.1.2; sys_platform == 'linux2'
+datadog-cassandra==1.3.0
+datadog-cassandra-nodetool==1.0.0
+datadog-ceph==1.3.1; sys_platform != 'win32'
+datadog-cisco-aci==1.2.1
+datadog-cockroachdb==1.0.0
+datadog-consul==1.5.2
+datadog-coredns==1.0.0; sys_platform == 'linux2'
+datadog-couch==2.6.1
+datadog-couchbase==1.5.1
+datadog-crio==1.0.0
+datadog-datadog-checks-base==4.2.0
+datadog-directory==1.3.1
+datadog-disk==1.4.0
+datadog-dns-check==1.1.2
+datadog-dotnetclr==1.1.0; sys_platform == 'win32'
+datadog-ecs-fargate==1.3.0
+datadog-elastic==1.8.0
+datadog-envoy==1.4.0
+datadog-etcd==1.5.1
+datadog-exchange-server==1.2.0; sys_platform == 'win32'
+datadog-fluentd==1.0.1
+datadog-gearmand==1.1.1; sys_platform != 'win32'
+datadog-gitlab==2.0.0
+datadog-gitlab-runner==2.0.0
+datadog-go-metro==1.0.0; sys_platform == 'linux2'
+datadog-go-expvar==1.0.4
+datadog-gunicorn==1.3.0; sys_platform != 'win32'
+datadog-haproxy==1.3.1
+datadog-hdfs-datanode==1.3.1; sys_platform != 'win32'
+datadog-hdfs-namenode==1.3.1; sys_platform != 'win32'
+datadog-http-check==3.0.0
+datadog-iis==2.2.0; sys_platform == 'win32'
+datadog-istio==2.0.0
+datadog-kafka==1.2.0
+datadog-kafka-consumer==1.4.1; sys_platform != 'win32'
+datadog-kong==1.2.1
+datadog-kube-dns==2.0.1
+datadog-kube-proxy==3.0.0
+datadog-kubelet==2.2.0; sys_platform == 'linux2'
+datadog-kubernetes-state==3.1.0; sys_platform != 'win32'
+datadog-kyototycoon==1.4.1
+datadog-lighttpd==1.2.1
+datadog-linkerd==2.0.0
+datadog-linux-proc-extras==1.0.1; sys_platform == 'linux2'
+datadog-mapreduce==1.2.1
+datadog-marathon==1.5.0; sys_platform != 'win32'
+datadog-mcache==1.3.2; sys_platform != 'win32'
+datadog-mesos-master==1.2.1; sys_platform != 'win32'
+datadog-mesos-slave==1.2.1; sys_platform != 'win32'
+datadog-mongo==1.6.1
+datadog-mysql==1.4.0
+datadog-nagios==1.1.2
+datadog-network==1.7.0
+datadog-nfsstat==1.0.0; sys_platform == 'linux2'
+datadog-nginx==3.0.0
+datadog-openldap==1.0.0
+datadog-openmetrics==1.0.0
+datadog-openstack==1.5.0
+datadog-oracle==1.4.0
+datadog-pdh-check==1.3.0; sys_platform == 'win32'
+datadog-pgbouncer==1.3.0; sys_platform != 'win32'
+datadog-php-fpm==1.3.1
+datadog-postfix==1.2.3; sys_platform != 'win32'
+datadog-postgres==2.2.3
+datadog-powerdns-recursor==1.1.1
+datadog-process==1.5.0
+datadog-prometheus==3.0.0
+datadog-rabbitmq==1.5.2
+datadog-redisdb==1.7.1
+datadog-riak==1.3.1
+datadog-riakcs==1.1.1
+datadog-snmp==1.4.2
+datadog-solr==1.2.0
+datadog-spark==1.4.1
+datadog-sqlserver==1.7.0; sys_platform == 'win32'
+datadog-squid==1.0.2
+datadog-ssh-check==1.3.1
+datadog-statsd==1.1.1
+datadog-supervisord==1.1.3
+datadog-system-core==1.1.0
+datadog-system-swap==1.2.0
+datadog-tcp-check==2.0.2
+datadog-teamcity==1.1.1
+datadog-tokumx==1.2.1
+datadog-tomcat==1.2.0
+datadog-twemproxy==1.2.1
+datadog-varnish==1.2.1
+datadog-vault==1.2.0
+datadog-vsphere==3.3.1
+datadog-win32-event-log==1.3.0; sys_platform == 'win32'
+datadog-windows-service==2.0.0; sys_platform == 'win32'
+datadog-wmi-check==1.2.0; sys_platform == 'win32'
+datadog-yarn==1.4.0
+datadog-zk==1.2.1; sys_platform != 'win32'


### PR DESCRIPTION
### What does this PR do?

Add datadog- prefix to packages name so that it can be used in the `datadog-agent integration install` command. It also converts `_` in `-` to have a consistent usage of `-` for the command and string comparisons.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?