### PR TITLE
Fix unicode handling on A6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
     - stage: test
       env: CHECK=ecs_fargate
     - stage: test
-      env: CHECK=elastic
+      env: CHECK=elastic PYTHON3=true
     - stage: test
       env: CHECK=envoy PYTHON3=true
     - stage: test
@@ -123,7 +123,7 @@ jobs:
     - stage: test
       env: CHECK=hdfs_namenode
     - stage: test
-      env: CHECK=http_check
+      env: CHECK=http_check PYTHON3=true
     - stage: test
       env: CHECK=iis
     - stage: test

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -282,15 +282,15 @@ class AgentCheck(object):
             if prefix is not None:
                 prefix = self.convert_to_underscore_separated(prefix)
         else:
-            name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", metric_name)
+            name = re.sub(br"[,\+\*\-/()\[\]{}\s]", b"_", metric_name)
         # Eliminate multiple _
-        name = re.sub(r"__+", "_", name)
+        name = re.sub(br"__+", b"_", name)
         # Don't start/end with _
-        name = re.sub(r"^_", "", name)
-        name = re.sub(r"_$", "", name)
+        name = re.sub(br"^_", b"", name)
+        name = re.sub(br"_$", b"", name)
         # Drop ._ and _.
-        name = re.sub(r"\._", ".", name)
-        name = re.sub(r"_\.", ".", name)
+        name = re.sub(br"\._", b".", name)
+        name = re.sub(br"_\.", b".", name)
 
         if prefix is not None:
             return prefix + "." + name

--- a/http_check/datadog_checks/http_check/adapters.py
+++ b/http_check/datadog_checks/http_check/adapters.py
@@ -5,10 +5,10 @@ import ssl
 import warnings
 
 from requests.adapters import HTTPAdapter
-from requests.packages import urllib3
-from requests.packages.urllib3.util import ssl_
-from requests.packages.urllib3.exceptions import SecurityWarning
-from requests.packages.urllib3.packages.ssl_match_hostname import match_hostname
+import urllib3
+from urllib3.util import ssl_
+from urllib3.exceptions import SecurityWarning
+from urllib3.packages.ssl_match_hostname import match_hostname
 
 
 class WeakCiphersHTTPSConnection(urllib3.connection.VerifiedHTTPSConnection):

--- a/http_check/datadog_checks/http_check/config.py
+++ b/http_check/datadog_checks/http_check/config.py
@@ -3,8 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from collections import namedtuple
 
-from datadog_checks.config import _is_affirmative
-from datadog_checks.errors import ConfigurationError
+from datadog_checks.base import ConfigurationError, is_affirmative
 from datadog_checks.utils.headers import headers as agent_headers
 
 
@@ -36,7 +35,7 @@ def from_instance(instance, default_ca_certs=None):
     http_response_status_code = str(instance.get('http_response_status_code', DEFAULT_EXPECTED_CODE))
     timeout = int(instance.get('timeout', 10))
     config_headers = instance.get('headers', {})
-    default_headers = _is_affirmative(instance.get("include_default_headers", True))
+    default_headers = is_affirmative(instance.get("include_default_headers", True))
     if default_headers:
         headers = agent_headers({})
     else:
@@ -44,22 +43,22 @@ def from_instance(instance, default_ca_certs=None):
     headers.update(config_headers)
     url = instance.get('url')
     content_match = instance.get('content_match')
-    reverse_content_match = _is_affirmative(instance.get('reverse_content_match', False))
-    response_time = _is_affirmative(instance.get('collect_response_time', True))
+    reverse_content_match = is_affirmative(instance.get('reverse_content_match', False))
+    response_time = is_affirmative(instance.get('collect_response_time', True))
     if not url:
         raise ConfigurationError("Bad configuration. You must specify a url")
     if not url.startswith("http"):
         raise ConfigurationError("The url {} must start with the scheme http or https".format(url))
-    include_content = _is_affirmative(instance.get('include_content', False))
-    disable_ssl_validation = _is_affirmative(instance.get('disable_ssl_validation', True))
-    ssl_expire = _is_affirmative(instance.get('check_certificate_expiration', True))
+    include_content = is_affirmative(instance.get('include_content', False))
+    disable_ssl_validation = is_affirmative(instance.get('disable_ssl_validation', True))
+    ssl_expire = is_affirmative(instance.get('check_certificate_expiration', True))
     instance_ca_certs = instance.get('ca_certs', default_ca_certs)
-    weakcipher = _is_affirmative(instance.get('weakciphers', False))
-    ignore_ssl_warning = _is_affirmative(instance.get('ignore_ssl_warning', False))
-    check_hostname = _is_affirmative(instance.get('check_hostname', True))
-    skip_proxy = _is_affirmative(
+    weakcipher = is_affirmative(instance.get('weakciphers', False))
+    ignore_ssl_warning = is_affirmative(instance.get('ignore_ssl_warning', False))
+    check_hostname = is_affirmative(instance.get('check_hostname', True))
+    skip_proxy = is_affirmative(
         instance.get('skip_proxy', instance.get('no_proxy', False)))
-    allow_redirects = _is_affirmative(instance.get('allow_redirects', True))
+    allow_redirects = is_affirmative(instance.get('allow_redirects', True))
 
     return Config(url, ntlm_domain, username, password, client_cert, client_key,
                   method, data, http_response_status_code, timeout,

--- a/http_check/setup.py
+++ b/http_check/setup.py
@@ -25,7 +25,7 @@ def get_requirements(fpath):
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=4.0.0'
+CHECKS_BASE_REQ = 'datadog_checks_base>=4.2.0'
 
 setup(
     name='datadog-http_check',

--- a/http_check/tests/common.py
+++ b/http_check/tests/common.py
@@ -3,7 +3,6 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
 import os
 
 HERE = os.path.dirname(os.path.abspath(__file__))

--- a/http_check/tests/conftest.py
+++ b/http_check/tests/conftest.py
@@ -2,24 +2,27 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+
 import pytest
 from mock import patch
 
-from .common import HERE
+from datadog_checks.http_check import HTTPCheck
+from .common import CONFIG, HERE
+
+
+@pytest.fixture(scope='session')
+def dd_environment():
+    yield dict(
+        init_config={'ca_certs': 'no thanks'},
+        **CONFIG
+    )
 
 
 @pytest.fixture(scope='session')
 def http_check():
-    from datadog_checks.http_check import HTTPCheck
-
     # Patch the function to return the certs located in the `tests/` folder
-    patcher = patch('datadog_checks.http_check.http_check.get_ca_certs_path', new=mock_get_ca_certs_path)
-    patcher.start()
-
-    http_check = HTTPCheck('http_check', {}, {})
-    yield http_check
-
-    patcher.stop()
+    with patch('datadog_checks.http_check.http_check.get_ca_certs_path', new=mock_get_ca_certs_path):
+        yield HTTPCheck('http_check', {}, {})
 
 
 def mock_get_ca_certs_path():

--- a/http_check/tests/test_config.py
+++ b/http_check/tests/test_config.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
-from datadog_checks.errors import ConfigurationError
+from datadog_checks.base import ConfigurationError
 from datadog_checks.utils.headers import headers as agent_headers
 from datadog_checks.http_check.config import from_instance, DEFAULT_EXPECTED_CODE
 

--- a/http_check/tests/test_http_check.py
+++ b/http_check/tests/test_http_check.py
@@ -5,8 +5,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 
-import pytest
 import mock
+import pytest
 
 from datadog_checks.http_check import HTTPCheck
 from .common import (
@@ -196,22 +196,20 @@ def test_check_ssl(aggregator, http_check):
     aggregator.assert_service_check(HTTPCheck.SC_SSL_CERT, status=HTTPCheck.CRITICAL, tags=connection_err_tags, count=1)
 
 
-@mock.patch('ssl.SSLSocket.getpeercert', **{'return_value.raiseError.side_effect': Exception()})
-def test_check_ssl_expire_error(getpeercert_func, aggregator, http_check):
-
-    # Run the check for the one instance configured with days left
-    http_check.check(CONFIG_EXPIRED_SSL['instances'][0])
+def test_check_ssl_expire_error(aggregator, http_check):
+    with mock.patch('ssl.SSLSocket.getpeercert', side_effect=Exception()):
+        # Run the check for the one instance configured with days left
+        http_check.check(CONFIG_EXPIRED_SSL['instances'][0])
 
     expired_cert_tags = ['url:https://github.com', 'instance:expired_cert']
     aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=expired_cert_tags, count=1)
     aggregator.assert_service_check(HTTPCheck.SC_SSL_CERT, status=HTTPCheck.CRITICAL, tags=expired_cert_tags, count=1)
 
 
-@mock.patch('ssl.SSLSocket.getpeercert', **{'return_value.raiseError.side_effect': Exception()})
-def test_check_ssl_expire_error_secs(getpeercert_func, aggregator, http_check):
-
-    # Run the check for the one instance configured with seconds left
-    http_check.check(CONFIG_EXPIRED_SSL['instances'][1])
+def test_check_ssl_expire_error_secs(aggregator, http_check):
+    with mock.patch('ssl.SSLSocket.getpeercert', side_effect=Exception()):
+        # Run the check for the one instance configured with seconds left
+        http_check.check(CONFIG_EXPIRED_SSL['instances'][1])
 
     expired_cert_tags = ['url:https://github.com', 'instance:expired_cert_seconds']
     aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=expired_cert_tags, count=1)
@@ -247,11 +245,10 @@ def test_check_allow_redirects(aggregator, http_check):
                                     tags=redirect_service_tags, count=1)
 
 
-@mock.patch('ssl.SSLSocket.getpeercert', return_value=FAKE_CERT)
-def test_mock_case(getpeercert_func, aggregator, http_check):
-
-    # Run the check for the one instance
-    http_check.check(CONFIG_EXPIRED_SSL['instances'][0])
+def test_mock_case(aggregator, http_check):
+    with mock.patch('ssl.SSLSocket.getpeercert', return_value=FAKE_CERT):
+        # Run the check for the one instance
+        http_check.check(CONFIG_EXPIRED_SSL['instances'][0])
 
     expired_cert_tags = ['url:https://github.com', 'instance:expired_cert']
     aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=expired_cert_tags, count=1)
@@ -262,7 +259,7 @@ def test_service_check_instance_name_normalization(aggregator, http_check):
     """
     Service check `instance` tag value is normalized.
 
-    Note: necessary to avoid mismatch and backward incompatiblity.
+    Note: necessary to avoid mismatch and backward incompatibility.
     """
 
     # Run the check for the one instance

--- a/http_check/tests/test_utils.py
+++ b/http_check/tests/test_utils.py
@@ -36,7 +36,7 @@ def test__get_ca_certs_paths_ko():
 @pytest.mark.unit
 def test__get_ca_certs_paths():
     with mock.patch('datadog_checks.http_check.utils.os.path.dirname') as dirname:
-        # create a tmp `embeddeded` folder
+        # create a tmp `embedded` folder
         with temp_dir() as tmp:
             target = os.path.join(tmp, 'embedded')
             os.mkdir(target)

--- a/http_check/tox.ini
+++ b/http_check/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    http_check
+    {py27,py36}-default
     unit
     flake8
 
@@ -11,16 +11,14 @@ platform = linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
+commands =
+    pip install --require-hashes -r requirements.txt
+    pytest -v -m"not unit"
 
 [testenv:unit]
 commands =
     pip install --require-hashes -r requirements.txt
     pytest -v -m"unit"
-
-[testenv:http_check]
-commands =
-    pip install --require-hashes -r requirements.txt
-    pytest -v -m"not unit"
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
### What does this PR do?

Also

- Adds Python 3 support
- Adds e2e support

### Additional Notes

Previously unicode `content_match` would raise error

```
Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/checks/network.py", line 30, in check
    statuses = self._check(instance)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/http_check/http_check.py", line 359, in _check
    send_status_up("{} is found in return content".format(content_match))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe3 in position 0: ordinal not in range(128)
```