### PR TITLE
Improve output of `ddev manifest verify` command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/manifest.py
@@ -78,12 +78,11 @@ def verify(fix, include_extras):
 
             try:
                 decoded = json.loads(read_file(manifest_file).strip(), object_pairs_hook=OrderedDict)
-            except JSONDecodeError:
-                file_failures += 1
-                display_queue.append((echo_failure, '  invalid json: {}'.format(manifest_file)))
-
-                for display, message in display_queue:
-                    display(message)
+            except JSONDecodeError as e:
+                failed_checks += 1
+                echo_info("{}/manifest.json... ".format(check_name), nl=False)
+                echo_failure("FAILED")
+                echo_failure('  invalid json: {}'.format(e))
                 continue
 
             # attributes are valid

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/manifest.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 import click
 from six import string_types
 
-from .utils import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_warning
+from .utils import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_warning, parse_version_parts
 from ..constants import get_root
 from ...compat import JSONDecodeError
 from ...utils import basepath, file_exists, read_file, write_file
@@ -43,13 +43,6 @@ OPTIONAL_ATTRIBUTES = {
 ALL_ATTRIBUTES = REQUIRED_ATTRIBUTES | OPTIONAL_ATTRIBUTES
 
 
-def parse_version_parts(version):
-    return (
-        [int(v) for v in version.split('.') if v.isdigit()]
-        if isinstance(version, string_types) else []
-    )
-
-
 @click.group(
     context_settings=CONTEXT_SETTINGS,
     short_help='Manage manifest files'
@@ -67,7 +60,7 @@ def manifest():
 def verify(fix, include_extras):
     """Validate all `manifest.json` files."""
     all_guids = {}
-    failed = 0
+    task_failed = True
 
     root = get_root()
     root_name = basepath(get_root())
@@ -76,12 +69,15 @@ def verify(fix, include_extras):
         manifest_file = os.path.join(root, check_name, 'manifest.json')
 
         if file_exists(manifest_file):
-            display_queue = [(echo_info, '{} ->'.format(check_name))]
+            echo_info('Checking {}/manifest.json...'.format(check_name), nl=False)
+            file_failures = 0
+            file_fixed = False
+            display_queue = []
 
             try:
                 decoded = json.loads(read_file(manifest_file).strip(), object_pairs_hook=OrderedDict)
             except JSONDecodeError:
-                failed += 1
+                file_failures += 1
                 display_queue.append((echo_failure, '  invalid json: {}'.format(manifest_file)))
 
                 for display, message in display_queue:
@@ -91,16 +87,16 @@ def verify(fix, include_extras):
             # attributes are valid
             attrs = set(decoded)
             for attr in sorted(attrs - ALL_ATTRIBUTES):
-                failed += 1
+                file_failures += 1
                 display_queue.append((echo_failure, '  Attribute `{}` is invalid'.format(attr)))
             for attr in sorted(REQUIRED_ATTRIBUTES - attrs):
-                failed += 1
+                file_failures += 1
                 display_queue.append((echo_failure, '  Attribute `{}` is required'.format(attr)))
 
             # guid
             guid = decoded.get('guid')
             if guid in all_guids:
-                failed += 1
+                file_failures += 1
                 output = '  duplicate `guid`: `{}` from `{}`'.format(guid, all_guids[guid])
                 if fix:
                     new_guid = uuid.uuid4()
@@ -110,11 +106,12 @@ def verify(fix, include_extras):
                     display_queue.append((echo_warning, output))
                     display_queue.append((echo_success, '  new `guid`: {}'.format(new_guid)))
 
-                    failed -= 1
+                    file_failures -= 1
+                    file_fixed = True
                 else:
                     display_queue.append((echo_failure, output))
             elif not guid or not isinstance(guid, string_types):
-                failed += 1
+                file_failures += 1
                 output = '  required non-null string: guid'
                 if fix:
                     new_guid = uuid.uuid4()
@@ -124,7 +121,8 @@ def verify(fix, include_extras):
                     display_queue.append((echo_warning, output))
                     display_queue.append((echo_success, '  new `guid`: {}'.format(new_guid)))
 
-                    failed -= 1
+                    file_failures -= 1
+                    file_fixed = True
                 else:
                     display_queue.append((echo_failure, output))
             else:
@@ -135,7 +133,7 @@ def verify(fix, include_extras):
             manifest_version = decoded.get('manifest_version')
             version_parts = parse_version_parts(manifest_version)
             if len(version_parts) != 3:
-                failed += 1
+                file_failures += 1
 
                 if not manifest_version:
                     output = '  required non-null string: manifest_version'
@@ -151,7 +149,8 @@ def verify(fix, include_extras):
                         echo_success, '  new `manifest_version`: {}'.format(correct_manifest_version)
                     ))
 
-                    failed -= 1
+                    file_failures -= 1
+                    file_fixed = True
                 else:
                     display_queue.append((echo_failure, output))
 
@@ -161,7 +160,7 @@ def verify(fix, include_extras):
                 )
                 if version_parts >= [1, 0, 0]:
                     if 'version' in decoded and about_exists:
-                        failed += 1
+                        file_failures += 1
                         output = '  outdated field: version'
 
                         if fix:
@@ -170,12 +169,13 @@ def verify(fix, include_extras):
                             display_queue.append((echo_warning, output))
                             display_queue.append((echo_success, '  removed field: version'))
 
-                            failed -= 1
+                            file_failures -= 1
+                            file_fixed = True
                         else:
                             display_queue.append((echo_failure, output))
 
                 elif about_exists:
-                    failed += 1
+                    file_failures += 1
                     output = '  outdated `manifest_version`: {}'.format(manifest_version)
 
                     if fix:
@@ -190,14 +190,15 @@ def verify(fix, include_extras):
                             del decoded['version']
                             display_queue.append((echo_success, '  removed field: version'))
 
-                        failed -= 1
+                        file_failures -= 1
+                        file_fixed = True
                     else:
                         display_queue.append((echo_failure, output))
                 else:
                     version = decoded.get('version')
                     version_parts = parse_version_parts(version)
                     if len(version_parts) != 3:
-                        failed += 1
+                        file_failures += 1
 
                         if not version:
                             display_queue.append((echo_failure, '  required non-null string: version'))
@@ -208,7 +209,7 @@ def verify(fix, include_extras):
             correct_maintainer = 'help@datadoghq.com'
             maintainer = decoded.get('maintainer')
             if maintainer != correct_maintainer:
-                failed += 1
+                file_failures += 1
                 output = '  incorrect `maintainer`: {}'.format(maintainer)
 
                 if fix:
@@ -217,7 +218,8 @@ def verify(fix, include_extras):
                     display_queue.append((echo_warning, output))
                     display_queue.append((echo_success, '  new `maintainer`: {}'.format(correct_maintainer)))
 
-                    failed -= 1
+                    file_failures -= 1
+                    file_fixed = True
                 else:
                     display_queue.append((echo_failure, output))
 
@@ -225,7 +227,7 @@ def verify(fix, include_extras):
             correct_name = check_name
             name = decoded.get('name')
             if not isinstance(name, string_types) or name.lower() != correct_name.lower():
-                failed += 1
+                file_failures += 1
                 output = '  incorrect `name`: {}'.format(name)
 
                 if fix:
@@ -234,24 +236,25 @@ def verify(fix, include_extras):
                     display_queue.append((echo_warning, output))
                     display_queue.append((echo_success, '  new `name`: {}'.format(correct_name)))
 
-                    failed -= 1
+                    file_failures -= 1
+                    file_fixed = True
                 else:
                     display_queue.append((echo_failure, output))
 
             # short_description
             short_description = decoded.get('short_description')
             if not short_description or not isinstance(short_description, string_types):
-                failed += 1
+                file_failures += 1
                 display_queue.append((echo_failure, '  required non-null string: short_description'))
             if len(short_description) > 80:
-                failed += 1
+                file_failures += 1
                 display_queue.append((echo_failure, '  should contain 80 characters maximum: short_description'))
 
             # support
             correct_support = 'contrib' if root_name == 'extras' else 'core'
             support = decoded.get('support')
             if support != correct_support:
-                failed += 1
+                file_failures += 1
                 output = '  incorrect `support`: {}'.format(support)
 
                 if fix:
@@ -260,7 +263,8 @@ def verify(fix, include_extras):
                     display_queue.append((echo_warning, output))
                     display_queue.append((echo_success, '  new `support`: {}'.format(correct_support)))
 
-                    failed -= 1
+                    file_failures -= 1
+                    file_fixed = True
                 else:
                     display_queue.append((echo_failure, output))
 
@@ -268,13 +272,13 @@ def verify(fix, include_extras):
                 # supported_os
                 supported_os = decoded.get('supported_os')
                 if not supported_os or not isinstance(supported_os, list):
-                    failed += 1
+                    file_failures += 1
                     display_queue.append((echo_failure, '  required non-null sequence: supported_os'))
                 else:
                     known_systems = {'linux', 'mac_os', 'windows'}
                     unknown_systems = sorted(set(supported_os) - known_systems)
                     if unknown_systems:
-                        failed += 1
+                        file_failures += 1
                         display_queue.append((
                             echo_failure, '  unknown `supported_os`: {}'.format(', '.join(unknown_systems))
                         ))
@@ -282,7 +286,7 @@ def verify(fix, include_extras):
                 # public_title
                 public_title = decoded.get('public_title')
                 if not public_title or not isinstance(public_title, string_types):
-                    failed += 1
+                    file_failures += 1
                     display_queue.append((echo_failure, '  required non-null string: public_title'))
                 else:
                     title_start = 'Datadog-'
@@ -296,20 +300,20 @@ def verify(fix, include_extras):
                     overlap_enough = len(character_overlap) > int(len(check_name_char_set) * 0.5)
 
                     if not (correct_start and correct_end and overlap_enough):
-                        failed += 1
+                        file_failures += 1
                         display_queue.append((echo_failure, '  invalid `public_title`: {}'.format(public_title)))
 
                 # categories
                 categories = decoded.get('categories')
                 if not categories or not isinstance(categories, list):
-                    failed += 1
+                    file_failures += 1
                     display_queue.append((echo_failure, '  required non-null sequence: categories'))
 
                 # type
                 correct_integration_type = 'check'
                 integration_type = decoded.get('type')
                 if not integration_type or not isinstance(integration_type, string_types):
-                    failed += 1
+                    file_failures += 1
                     output = '  required non-null string: type'
 
                     if fix:
@@ -318,11 +322,12 @@ def verify(fix, include_extras):
                         display_queue.append((echo_warning, output))
                         display_queue.append((echo_success, '  new `type`: {}'.format(correct_integration_type)))
 
-                        failed -= 1
+                        file_failures -= 1
+                        file_fixed = True
                     else:
                         display_queue.append((echo_failure, output))
                 elif integration_type != correct_integration_type:
-                    failed += 1
+                    file_failures += 1
                     output = '  invalid `type`: {}'.format(integration_type)
 
                     if fix:
@@ -331,7 +336,8 @@ def verify(fix, include_extras):
                         display_queue.append((echo_warning, output))
                         display_queue.append((echo_success, '  new `type`: {}'.format(correct_integration_type)))
 
-                        failed -= 1
+                        file_failures -= 1
+                        file_fixed = True
                     else:
                         display_queue.append((echo_failure, output))
 
@@ -339,7 +345,7 @@ def verify(fix, include_extras):
                 correct_is_public = True
                 is_public = decoded.get('is_public')
                 if not isinstance(is_public, bool):
-                    failed += 1
+                    file_failures += 1
                     output = '  required boolean: is_public'
 
                     if fix:
@@ -348,20 +354,24 @@ def verify(fix, include_extras):
                         display_queue.append((echo_warning, output))
                         display_queue.append((echo_success, '  new `is_public`: {}'.format(correct_is_public)))
 
-                        failed -= 1
+                        file_failures -= 1
+                        file_fixed = True
                     else:
                         display_queue.append((echo_failure, output))
 
-            # See if anything happened
-            if len(display_queue) > 1:
-                for display, message in display_queue:
-                    display(message)
+            if file_failures > 0:
+                echo_failure(" FAILED")
+                task_failed = True
+            else:
+                echo_success(" OK" if not file_fixed else " FIXED")
+            for display_func, message in display_queue:
+                display_func(message)
 
-                if fix:
-                    new_manifest = '{}\n'.format(json.dumps(decoded, indent=2, separators=(',', ': ')))
-                    write_file(manifest_file, new_manifest)
+            if fix and file_fixed:
+                new_manifest = '{}\n'.format(json.dumps(decoded, indent=2, separators=(',', ': ')))
+                write_file(manifest_file, new_manifest)
 
-    if failed > 0:
+    if task_failed:
         abort()
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/manifest.py
@@ -60,7 +60,6 @@ def manifest():
 def verify(fix, include_extras):
     """Validate all `manifest.json` files."""
     all_guids = {}
-    task_failed = False
 
     root = get_root()
     root_name = basepath(get_root())
@@ -363,7 +362,6 @@ def verify(fix, include_extras):
                         display_queue.append((echo_failure, output))
 
             if file_failures > 0:
-                task_failed = True
                 failed_checks += 1
                 # Display detailed info if file invalid
                 echo_info("{}/manifest.json... ".format(check_name), nl=False)
@@ -384,9 +382,12 @@ def verify(fix, include_extras):
                     for display_func, message in display_queue:
                         display_func(message)
 
-    echo_info("{} valid files, {} fixed and {} invalid".format(ok_checks, fixed_checks, failed_checks))
-
-    if task_failed:
+    if ok_checks:
+        echo_success("{} valid files".format(ok_checks))
+    if fixed_checks:
+        echo_info("{} fixed files".format(fixed_checks))
+    if failed_checks:
+        echo_failure("{} invalid files".format(failed_checks))
         abort()
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/manifest.py
@@ -9,8 +9,9 @@ from collections import OrderedDict
 import click
 from six import string_types
 
-from .utils import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_warning, parse_version_parts
+from .utils import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_warning
 from ..constants import get_root
+from ..utils import parse_version_parts
 from ...compat import JSONDecodeError
 from ...utils import basepath, file_exists, read_file, write_file
 


### PR DESCRIPTION
### What does this PR do?

Now looks like 
```
Validating all manifest.json files...
snmp/manifest.json... FAILED
  Attribute `supported_o` is invalid
  Attribute `supported_os` is required
107 valid files, 0 fixed and 1 invalid
```

### Motivation

https://github.com/DataDog/integrations-core/pull/2432#discussion_r226623870

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?