### PR TITLE
Add option to prevent duplicate hostnames

### DIFF
--- a/elastic/datadog_checks/elastic/config.py
+++ b/elastic/datadog_checks/elastic/config.py
@@ -12,6 +12,7 @@ ESInstanceConfig = namedtuple('ESInstanceConfig', [
     'admin_forwarder',
     'pshard_stats',
     'pshard_graceful_to',
+    'node_name_as_host',
     'cluster_stats',
     'index_stats',
     'password',
@@ -41,6 +42,7 @@ def from_instance(instance):
 
     pshard_stats = is_affirmative(instance.get('pshard_stats', False))
     pshard_graceful_to = is_affirmative(instance.get('pshard_graceful_timeout', False))
+    node_name_as_host = is_affirmative(instance.get('node_name_as_host', False))
     index_stats = is_affirmative(instance.get('index_stats', False))
     cluster_stats = is_affirmative(instance.get('cluster_stats', False))
     if 'is_external' in instance:
@@ -74,6 +76,7 @@ def from_instance(instance):
         admin_forwarder=admin_forwarder,
         pshard_stats=pshard_stats,
         pshard_graceful_to=pshard_graceful_to,
+        node_name_as_host=node_name_as_host,
         cluster_stats=cluster_stats,
         index_stats=index_stats,
         password=instance.get('password'),

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -15,7 +15,12 @@ instances:
   # This parameter was also called `is_external` and you can still use it but it
   # will be removed in version 6.
   #
-  # If you enable the "index_stats" flag, you will collect metrics for individual 
+  # If each machine only runs a single Elasticsearch node per cluster, you will
+  # want to set each Elasticsearch `node.name` to the machine hostname. You may
+  # then set `node_name_as_host` to `true` to avoid duplicate hostnames. See:
+  # https://www.elastic.co/guide/en/elasticsearch/reference/current/node.name.html
+  #
+  # If you enable the "index_stats" flag, you will collect metrics for individual
   # indices.
   #
   # If you enable the "pshard_stats" flag, statistics over primary shards
@@ -39,6 +44,7 @@ instances:
   - url: http://localhost:9200
     # username: username
     # password: password
+    # node_name_as_host: false
     # cluster_stats: false
     # index_stats: false
     # pshard_stats: false
@@ -51,7 +57,7 @@ instances:
     # tags:
     #   - 'tag1:key1'
     #   - 'tag2:key2'
-    
+
 ## Log Section (Available for Agent >=6.0)
 
 #logs:
@@ -62,7 +68,7 @@ instances:
     #   source : (mandatory) attribute that defines which integration is sending the logs
     #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribute
     #   tags: (optional) add tags to each logs collected
-    
+
     # - type: file
     #   path: /var/log/elasticsearch/*.log
     #   source: elasticsearch

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -265,7 +265,6 @@ class ESCheck(AgentCheck):
             self._process_metric(node_data, metric, *desc, tags=config.tags)
 
     def _process_stats_data(self, data, stats_metrics, config):
-        cluster_stats = config.cluster_stats
         for node_data in itervalues(data.get('nodes', {})):
             metric_hostname = None
             metrics_tags = list(config.tags)
@@ -278,7 +277,10 @@ class ESCheck(AgentCheck):
                 )
 
             # Resolve the node's hostname
-            if cluster_stats:
+            if config.node_name_as_host:
+                if node_name:
+                    metric_hostname = node_name
+            elif config.cluster_stats:
                 for k in ['hostname', 'host']:
                     if k in node_data:
                         metric_hostname = node_data[k]

--- a/elastic/tests/conftest.py
+++ b/elastic/tests/conftest.py
@@ -57,6 +57,17 @@ def instance():
     }
 
 
+@pytest.fixture(scope='session')
+def instance_normalize_hostname():
+    return {
+        'url': URL,
+        'username': USER,
+        'password': PASSWORD,
+        'tags': CUSTOM_TAGS,
+        'node_name_as_host': True,
+    }
+
+
 def _cluster_tags():
     tags = [
         'url:{}'.format(URL),
@@ -74,4 +85,6 @@ def cluster_tags():
 
 @pytest.fixture
 def node_tags():
-    return _cluster_tags().append('node_name:test-node')
+    tags = _cluster_tags()
+    tags.append('node_name:test-node')
+    return tags


### PR DESCRIPTION
### Motivation

Customer requests

### Additional Notes

The `node_tags` test fixture was broken, now it's not