### PR TITLE
Make all tox envs available to E2E

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env_commands/ls.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env_commands/ls.py
@@ -20,7 +20,7 @@ def ls(checks):
         checks = sorted(get_testable_checks() & set(checks))
 
         for check in checks:
-            envs = get_available_tox_envs(check, test_only=True)
+            envs = get_available_tox_envs(check, e2e_only=True)
 
             if envs:
                 echo_success('{}:'.format(check))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env_commands/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env_commands/start.py
@@ -34,7 +34,7 @@ def start(ctx, check, env, agent, dev):
     if not file_exists(get_tox_file(check)):
         abort('`{}` is not a testable check.'.format(check))
 
-    envs = get_available_tox_envs(check, test_only=True)
+    envs = get_available_tox_envs(check, e2e_only=True)
 
     if env not in envs:
         echo_failure('`{}` is not an available environment.'.format(env))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/test.py
@@ -70,13 +70,13 @@ def get_tox_envs(checks, style=False, benchmark=False, every=False, changed_only
         yield check, envs_selected
 
 
-def get_available_tox_envs(check, sort=False, test_only=False):
+def get_available_tox_envs(check, sort=False, e2e_only=False):
     with chdir(path_join(get_root(), check)):
-        env_list = run_command('tox --listenvs', capture='out').stdout
+        env_list = run_command('tox --listenvs-all', capture='out').stdout
 
     env_list = [e.strip() for e in env_list.splitlines()]
 
-    if test_only:
+    if e2e_only:
         sort = True
 
     if sort:
@@ -91,19 +91,19 @@ def get_available_tox_envs(check, sort=False, test_only=False):
 
         for e in benchmark_envs:
             env_list.remove(e)
-            if not test_only:
+            if not e2e_only:
                 env_list.append(e)
 
         # Put style checks at the end always
         for style_type in STYLE_ENVS:
             try:
                 env_list.remove(style_type)
-                if not test_only:
+                if not e2e_only:
                     env_list.append(style_type)
             except ValueError:
                 pass
 
-        if test_only:
+        if e2e_only:
             # No need for unit tests as they wouldn't set up a real environment
             try:
                 env_list.remove('unit')


### PR DESCRIPTION
### What does this PR do?

Previously e2e would behave like our tests and only consider what is specified in `envlist`. This removes that limitation.

### Motivation

We will eventually acquire many complex and niche (for support, etc.) envs that we don't want/need to run the tests for.