### PR TITLE
Fix bug making the network check read /proc instead of /host/proc on containers

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/platform.py
+++ b/datadog_checks_base/datadog_checks/base/utils/platform.py
@@ -93,7 +93,7 @@ class Platform(object):
 
     @staticmethod
     def is_containerized():
-        return os.environ.get("DOCKER_DD_AGENT") == "yes"
+        return 'DOCKER_DD_AGENT' in os.environ
 
     @staticmethod
     def is_k8s():


### PR DESCRIPTION
### What does this PR do

Fix is containerized. From 6.5 we set `DOCKER_DD_AGENT` to `true` instead of `yes`.

### Motivation

The network check was reading /proc instead of /host/proc leading to missing metrics for all the hosts interfaces.

### Checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)


Anything else we should know when reviewing?