### PR TITLE
Add option to run the full check on any node

### DIFF
--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -268,11 +268,13 @@ class ConsulCheck(AgentCheck):
         for tag in instance.get('tags', []):
             main_tags.append(tag)
 
+        single_node_install = is_affirmative(instance.get('single_node_install', False))
         if not self._is_instance_leader(instance, instance_state):
             self.gauge("consul.peers", len(peers), tags=main_tags + ["mode:follower"])
-            self.log.debug("This consul agent is not the cluster leader. "
-                           "Skipping service and catalog checks for this instance")
-            return
+            if not single_node_install:
+                self.log.debug("This consul agent is not the cluster leader. "
+                               "Skipping service and catalog checks for this instance")
+                return
         else:
             self.gauge("consul.peers", len(peers), tags=main_tags + ["mode:leader"])
 

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -3,7 +3,7 @@ init_config:
 
 instances:
     # Where your Consul HTTP Server Lives
-    # Point the URL at the leader to get metrics about your Consul Cluster. 
+    # Point the URL at the leader to get metrics about your Consul Cluster.
     # Remind to use https instead of http if your Consul setup is configured to do so.
     - url: http://localhost:8500
 
@@ -23,6 +23,10 @@ instances:
 
       # ACL token to use for authentication
       # acl_token: 'token'
+
+      # Whether or not to perform the full check even when not the leader. Useful
+      # if you don't want to install the Agent on every node in a data center.
+      # single_node_install: false
 
       # Whether to perform checks against the Consul service Catalog
       catalog_checks: true

--- a/consul/tests/conftest.py
+++ b/consul/tests/conftest.py
@@ -30,7 +30,7 @@ def ping_cluster():
 
 
 @pytest.fixture(scope='session')
-def dd_environment(instance):
+def dd_environment(instance_single_node_install):
     """
     Start a cluster with one master, one replica, and one unhealthy replica.
     """
@@ -44,13 +44,26 @@ def dd_environment(instance):
         conditions=[WaitFor(ping_cluster)],
         env_vars=env_vars,
     ):
-        yield instance
+        yield instance_single_node_install
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def instance():
     return {
         'url': common.URL,
+        'catalog_checks': True,
+        'network_latency_checks': True,
+        'new_leader_checks': True,
+        'self_leader_check': True,
+        'acl_token': 'token',
+    }
+
+
+@pytest.fixture(scope='session')
+def instance_single_node_install():
+    return {
+        'url': common.URL,
+        'single_node_install': True,
         'catalog_checks': True,
         'network_latency_checks': True,
         'new_leader_checks': True,

--- a/consul/tests/test_integration.py
+++ b/consul/tests/test_integration.py
@@ -18,20 +18,20 @@ METRICS = [
     'consul.catalog.services_warning',
     'consul.catalog.services_critical',
     'consul.catalog.total_nodes',
-    'consul.net.node.latency.p95',
-    'consul.net.node.latency.min',
-    'consul.net.node.latency.p25',
-    'consul.net.node.latency.median',
-    'consul.net.node.latency.max',
-    'consul.net.node.latency.max',
-    'consul.net.node.latency.p99',
-    'consul.net.node.latency.p90',
-    'consul.net.node.latency.p75'
+    # Enable again when it's figured out why only followers submit these
+    # 'consul.net.node.latency.p95',
+    # 'consul.net.node.latency.min',
+    # 'consul.net.node.latency.p25',
+    # 'consul.net.node.latency.median',
+    # 'consul.net.node.latency.max',
+    # 'consul.net.node.latency.p99',
+    # 'consul.net.node.latency.p90',
+    # 'consul.net.node.latency.p75'
 ]
 
 
 @pytest.mark.integration
-def test_integration(aggregator, instance, dd_environment):
+def test_check(aggregator, instance, dd_environment):
     """
     Testing Consul Integration
     """
@@ -40,6 +40,23 @@ def test_integration(aggregator, instance, dd_environment):
 
     for m in METRICS:
         aggregator.assert_metric(m, at_least=0)
+
+    aggregator.assert_metric('consul.peers', value=3)
+
+    aggregator.assert_service_check('consul.check')
+    aggregator.assert_service_check('consul.up', tags=[
+        'consul_datacenter:dc1',
+        'consul_url:{}'.format(common.URL)
+    ])
+
+
+@pytest.mark.integration
+def test_single_node_install(aggregator, instance_single_node_install, dd_environment):
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, {})
+    consul_check.check(instance_single_node_install)
+
+    for m in METRICS:
+        aggregator.assert_metric(m, at_least=1)
 
     aggregator.assert_metric('consul.peers', value=3)
 


### PR DESCRIPTION
### Motivation

Customer requests

Note: I disabled a few metrics to assert in tests for now until we discover why they only submit for followers. They weren't asserted before anyway fyi because we had `at_least=0`.