### PR TITLE
Add option to Suppress ‘InsecureRequestWarning’ when disable_ssl_validation is set

### DIFF
--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import requests
 from six.moves.urllib.parse import urlparse
+from urllib3.exceptions import InsecureRequestWarning
 
 from datadog_checks.checks import AgentCheck
 
@@ -56,6 +57,9 @@ class Apache(AgentCheck):
         tags = instance.get('tags', [])
 
         disable_ssl_validation = _is_affirmative(instance.get('disable_ssl_validation', False))
+
+        if disable_ssl_validation:
+            requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
 
         auth = None
         if 'apache_user' in instance and 'apache_password' in instance:

--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -75,7 +75,7 @@ class Apache(AgentCheck):
                 'apache check initiating request, connect timeout %d receive %d' % (connect_timeout, receive_timeout)
             )
             with warnings.catch_warnings():
-                if config['tls_ignore_warning']:
+                if _is_affirmative(instance.get('tls_ignore_warning', False)):
                     warnings.simplefilter('ignore', InsecureRequestWarning)
 
                 r = requests.get(

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -45,6 +45,12 @@ instances:
   #
   #  receive_timeout: <VALUE_IN_SECOND>
 
+  ## @param tls_ignore_warning - boolean - optional - default: false
+  ## Instructs the check to disable the TLS/SSL warnings when the apache_status_url uses https
+  ## and SSL certificate verification is disabled.
+  #
+  # tls_ignore_warning: false
+
 ## Log Section (Available for Agent >=6.0)
 ##
 ## type - mandatory - Type of log input source (tcp / udp / file / windows_event)


### PR DESCRIPTION
### What does this PR do?

When disabling ssl validation suppress this warning from urllib3:
```
InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
InsecureRequestWarning)
```

### Motivation

Stop our logs from being filled with the message above

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
