### PR TITLE
Removed incorrect metric name 'bytes_outstanding'

### DIFF
--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -322,9 +322,6 @@ class ZookeeperCheck(AgentCheck):
 
         # Outstanding: 0
         _, value = buf.readline().split(':')
-        # Fixme: This metric name is wrong. It should be removed in a major version of the agent
-        # See https://github.com/DataDog/dd-agent/issues/1383
-        metrics.append(ZKMetric('zookeeper.bytes_outstanding', long(value.strip())))
         metrics.append(ZKMetric('zookeeper.outstanding_requests', long(value.strip())))
 
         # Zxid: 0x1034799c7

--- a/zk/metadata.csv
+++ b/zk/metadata.csv
@@ -1,30 +1,29 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+zookeeper.approximate_data_size,gauge,,,,,0,zookeeper,approx data size
+zookeeper.avg_latency,gauge,,millisecond,,The amount of time it takes for the server to respond to a client request.,0,zookeeper,avg latency
 zookeeper.bytes_received,gauge,,,,Number of bytes received,0,zookeeper,
 zookeeper.bytes_sent,gauge,,,,Number of bytes sent,0,zookeeper,
-zookeeper.bytes_outstanding,gauge,,,,Number of bytes outstanding,0,zookeeper,
-zookeeper.packets_received,gauge,,packet,second,The number of packets received.,0,zookeeper,packets received per second
-zookeeper.packets.received,gauge,,packet,second,The number of packets received.,0,zookeeper,packets received per second
-zookeeper.packets_sent,gauge,,packet,second,The number of packets sent.,0,zookeeper,packets sent per second
-zookeeper.packets.sent,gauge,,packet,second,The number of packets sent.,0,zookeeper,packets sent per second
-zookeeper.num_alive_connections,gauge,,connection,,The total count of client connections.,0,zookeeper,conns
 zookeeper.connections,gauge,,connection,,The total count of client connections.,0,zookeeper,conns
 zookeeper.datadog_client_exception,rate,,error,,The exception rate seen by the Datadog Agent when trying to collect stats.,-1,zookeeper,exceptions
-zookeeper.avg_latency,gauge,,millisecond,,The amount of time it takes for the server to respond to a client request.,0,zookeeper,avg latency
+zookeeper.ephemerals_count,gauge,,,,,0,zookeeper,ephemerals count
+zookeeper.instances,gauge,,,,,0,zookeeper,instances
 zookeeper.latency.avg,gauge,,millisecond,,The amount of time it takes for the server to respond to a client request.,0,zookeeper,avg latency
-zookeeper.max_latency,gauge,,millisecond,,The amount of time it takes for the server to respond to a client request.,-1,zookeeper,max latency
 zookeeper.latency.max,gauge,,millisecond,,The amount of time it takes for the server to respond to a client request.,-1,zookeeper,max latency
-zookeeper.min_latency,gauge,,millisecond,,The amount of time it takes for the server to respond to a client request.,1,zookeeper,min latency
 zookeeper.latency.min,gauge,,millisecond,,The amount of time it takes for the server to respond to a client request.,1,zookeeper,min latency
-zookeeper.znode_count,gauge,,node,,The number of znodes in the ZooKeeper namespace (the data).,0,zookeeper,nodes
+zookeeper.max_file_descriptor_count,gauge,,,,,0,zookeeper,max fd
+zookeeper.max_latency,gauge,,millisecond,,The amount of time it takes for the server to respond to a client request.,-1,zookeeper,max latency
+zookeeper.min_latency,gauge,,millisecond,,The amount of time it takes for the server to respond to a client request.,1,zookeeper,min latency
 zookeeper.nodes,gauge,,node,,The number of znodes in the ZooKeeper namespace (the data).,0,zookeeper,nodes
+zookeeper.num_alive_connections,gauge,,connection,,The total count of client connections.,0,zookeeper,conns
+zookeeper.open_file_descriptor_count,gauge,,,,,0,zookeeper,open fd
 zookeeper.outstanding_requests,gauge,,request,,The number of queued requests when the server is under load and is receiving more sustained requests than it can process.,-1,zookeeper,reqs
+zookeeper.packets.received,gauge,,packet,second,The number of packets received.,0,zookeeper,packets received per second
+zookeeper.packets.sent,gauge,,packet,second,The number of packets sent.,0,zookeeper,packets sent per second
+zookeeper.packets_received,gauge,,packet,second,The number of packets received.,0,zookeeper,packets received per second
+zookeeper.packets_sent,gauge,,packet,second,The number of packets sent.,0,zookeeper,packets sent per second
+zookeeper.server_state,gauge,,,,,0,zookeeper,server state
 zookeeper.timeouts,rate,,occurrence,,The rate of timeouts the Datadog Agent received when trying to collect stats.,-1,zookeeper,timeouts
+zookeeper.watch_count,gauge,,,,,0,zookeeper,watch count
+zookeeper.znode_count,gauge,,node,,The number of znodes in the ZooKeeper namespace (the data).,0,zookeeper,nodes
 zookeeper.zxid.count,gauge,,,,,0,zookeeper,
 zookeeper.zxid.epoch,gauge,,,,,0,zookeeper,
-zookeeper.instances,gauge,,,,,0,zookeeper,instances
-zookeeper.server_state,gauge,,,,,0,zookeeper,server state
-zookeeper.watch_count,gauge,,,,,0,zookeeper,watch count
-zookeeper.ephemerals_count,gauge,,,,,0,zookeeper,ephemerals count
-zookeeper.approximate_data_size,gauge,,,,,0,zookeeper,approx data size
-zookeeper.open_file_descriptor_count,gauge,,,,,0,zookeeper,open fd
-zookeeper.max_file_descriptor_count,gauge,,,,,0,zookeeper,max fd

--- a/zk/tests/conftest.py
+++ b/zk/tests/conftest.py
@@ -25,7 +25,6 @@ STAT_METRICS = [
     'zookeeper.bytes_sent',
     'zookeeper.connections',
     'zookeeper.connections',
-    'zookeeper.bytes_outstanding',
     'zookeeper.outstanding_requests',
     'zookeeper.zxid.epoch',
     'zookeeper.zxid.count',
@@ -90,13 +89,6 @@ def get_conn_failure_config():
         'expected_mode': "down",
         'tags': []
     }
-
-
-@pytest.fixture
-def aggregator():
-    from datadog_checks.stubs import aggregator
-    aggregator.reset()
-    return aggregator
 
 
 def get_version():


### PR DESCRIPTION
### What does this PR do?

See title, supersedes #845 

### Motivation

See https://github.com/DataDog/dd-agent/issues/1383

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Will fix the default dashboard accordingly.
