### PR TITLE
Fixed off-by-one missing latest release

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
@@ -891,7 +891,7 @@ def agent_changelog(since, to, output, force):
         catalog_to = parse_agent_req_file(contents_to)
 
         version_changes = OrderedDict()
-        changes_per_agent[agent_tags[i]] = version_changes
+        changes_per_agent[agent_tags[i-1]] = version_changes
 
         for name, ver in catalog_to.iteritems():
             old_ver = catalog_from.get(name, "")

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
@@ -893,7 +893,7 @@ def agent_changelog(since, to, output, force):
         version_changes = OrderedDict()
         changes_per_agent[agent_tags[i-1]] = version_changes
 
-        for name, ver in catalog_to.iteritems():
+        for name, ver in iteritems(catalog_to):
             old_ver = catalog_from.get(name, "")
             if old_ver != ver:
                 # determine whether major version changed

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
@@ -884,14 +884,14 @@ def agent_changelog(since, to, output, force):
     changes_per_agent = OrderedDict()
 
     for i in range(1, len(agent_tags)):
-        contents_from = git_show_file(AGENT_REQ_FILE, agent_tags[i-1])
+        contents_from = git_show_file(AGENT_REQ_FILE, agent_tags[i - 1])
         catalog_from = parse_agent_req_file(contents_from)
 
         contents_to = git_show_file(AGENT_REQ_FILE, agent_tags[i])
         catalog_to = parse_agent_req_file(contents_to)
 
         version_changes = OrderedDict()
-        changes_per_agent[agent_tags[i-1]] = version_changes
+        changes_per_agent[agent_tags[i - 1]] = version_changes
 
         for name, ver in iteritems(catalog_to):
             old_ver = catalog_from.get(name, "")


### PR DESCRIPTION
### What does this PR do?

Fix the task producing the agent changelog at the root of this repo

### Motivation

It was missing changes from latest version

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
