### PR TITLE
Add option to use guest hostname instead of VM name

### DIFF
--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -41,7 +41,7 @@ init_config:
 ## vCenter instance you want to connect to and fetch metrics from
 
 instances:
-  
+
   ## @param name - string - required
   ## name must be a unique key representing your vCenter instance
   #
@@ -52,18 +52,18 @@ instances:
   #
     host: <HOSTNAME>
 
-  ## @param username - string - required 
-  ## Enter the username of the read-only credentials 
+  ## @param username - string - required
+  ## Enter the username of the read-only credentials
   ## to connect to vCenter
   ## see https://app.datadoghq.com/account/settings#integrations/vsphere
   #
     username: datadog-readonly@vsphere.local
 
-  ## @param password - string - required 
-  ## Enter the password of the read-only credentials 
+  ## @param password - string - required
+  ## Enter the password of the read-only credentials
   ## to connect to vCenter
   ## see https://app.datadoghq.com/account/settings#integrations/vsphere
-  # 
+  #
     password: <PASSWORD>
 
   ## @param ssl_verify - boolean - optional - default: true
@@ -93,7 +93,7 @@ instances:
   ## @param include_only_marked - boolean - optional - default: false
   ## Set to true if you'd like to only collect metrics on vSphere VMs which
   ## are marked by a custom field with the value 'DatadogMonitored'
-  ## To set this custom field with PowerCLI, use the follow command: 
+  ## To set this custom field with PowerCLI, use the follow command:
   ##   Get-VM <MyVMName> | Set-CustomField -Name "DatadogMonitored" -Value "DatadogMonitored"
   #
   #  include_only_marked: false
@@ -110,10 +110,19 @@ instances:
   ## 1: Only basic metrics - 4: every metric available.
   ## Warning: Depending on the size of the vSphere environment, metric collection can be slow,
   ## very CPU intensive and put pressure on the vCenter Server
-  # 
+  #
   #  collection_level: 1
 
-  ## @param event_config - dictionary - optional 
+  ## @param use_guest_hostname - boolean - optional - default: false
+  ## If true, the check will use the guest hostname for VMs instead of the VM name
+  ## This requires the VM to have VM tools installed in it. If the guest hostname is
+  ## not available, it will fallback to the VM name.
+  ## Use this if you install the agent in VMs so that the hosts are not duplicated
+  ## in the web application UI.
+  #
+  #  use_guest_hostname: false
+
+  ## @param event_config - dictionary - optional
   ## Event config is a dictionary
   ## For now the only switch you can flip is collect_vcenter_alarms
   ## which will send as events the alarms set in vCenter
@@ -121,9 +130,9 @@ instances:
   #  event_config:
   #    collect_vcenter_alarms: true
 
-  ## @param tags  - list of key:value element - optional 
+  ## @param tags  - list of key:value element - optional
   ## List of tags to attach to every metric, event and service check emitted by this integration.
-  ## 
+  ##
   ## Learn more about tagging: https://docs.datadoghq.com/tagging/
   #
   #  tags:

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -115,7 +115,7 @@ instances:
 
   ## @param use_guest_hostname - boolean - optional - default: false
   ## If true, the check will use the guest hostname for VMs instead of the VM name
-  ## This requires the VM to have VM tools installed in it. If the guest hostname is
+  ## This requires the VM to have VMware tools installed in it. If the guest hostname is
   ## not available, it will fallback to the VM name.
   ## Use this if you install the agent in VMs so that the hosts are not duplicated
   ## in the web application UI.

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -419,7 +419,14 @@ class VSphereCheck(AgentCheck):
 
         return mor_attrs
 
-    def _get_all_objs(self, server_instance, regexes=None, include_only_marked=False, tags=None, use_guest_hostname=False):
+    def _get_all_objs(
+        self,
+        server_instance,
+        regexes=None,
+        include_only_marked=False,
+        tags=None,
+        use_guest_hostname=False
+    ):
         """
         Explore vCenter infrastructure to discover hosts, virtual machines, etc.
         and compute their associated tags.

--- a/vsphere/tests/fixtures/vsphere_topology.json
+++ b/vsphere/tests/fixtures/vsphere_topology.json
@@ -56,6 +56,7 @@
     "parent_name": "host3",
     "runtime.powerState": "poweredOn",
     "runtime.host_name": "host3",
+    "guest.hostName": "vm2_guest",
     "label": true
   },
   {
@@ -72,6 +73,7 @@
     "parent_name": "host3",
     "runtime.powerState": "poweredOn",
     "runtime.host_name": "host3",
+    "guest.hostName": "vm4_guest",
     "label": true
   }
 ]

--- a/vsphere/tests/utils.py
+++ b/vsphere/tests/utils.py
@@ -30,10 +30,13 @@ class MockedMOR(Mock):
         self.customValue = []
         power_state = kwargs.get('runtime.powerState', None)
         host_name = kwargs.get('runtime.host_name', None)
+        guest_hostname = kwargs.get('guest.hostName', None)
         if power_state:
             self.runtime_powerState = getattr(vim.VirtualMachinePowerState, power_state)
         if host_name:
             self.runtime_host_name = host_name
+        if guest_hostname:
+            self.guest_hostName = guest_hostname
 
         if kwargs.get('label', False):
             self.customValue.append(Mock(value="DatadogMonitored"))
@@ -59,7 +62,7 @@ def create_topology(topology_json):
 def retrieve_properties_mock(all_mors):
     objects = []
     properties_res = MagicMock(objects=objects, token=None)
-    mor_properties = ["name", "parent", "customValue", "runtime_powerState", "runtime_host"]
+    mor_properties = ["name", "parent", "customValue", "runtime_powerState", "runtime_host", "guest_hostName"]
     for mor in all_mors:
         prop_set = []
         for prop_name in mor_properties:


### PR DESCRIPTION
### What does this PR do?

Add option to use guest hostname instead of VM name

### Motivation

This is needed to prevent host duplication when an agent is running inside a VM managed by vsphere

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?