### PR TITLE
Fix AgentCheck import

### DIFF
--- a/supervisord/datadog_checks/supervisord/supervisord.py
+++ b/supervisord/datadog_checks/supervisord/supervisord.py
@@ -11,7 +11,7 @@ import xmlrpclib
 
 import supervisor.xmlrpc
 
-from datadog_checks.checks.base import AgentCheck
+from datadog_checks.base import AgentCheck
 
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = '9001'


### PR DESCRIPTION
### Motivation

Regression in https://github.com/DataDog/integrations-core/pull/2230 caused AgentCheck to not be imported from the compatibility layer and therefore will not run on A5