### PR TITLE
Add new filtering options, continue deprecations

### DIFF
--- a/disk/datadog_checks/disk/data/conf.yaml.default
+++ b/disk/datadog_checks/disk/data/conf.yaml.default
@@ -5,57 +5,123 @@
 init_config:
 
 instances:
-  # The use_mount parameter will instruct the check to collect disk
-  # and fs metrics using mount points instead of volumes
+  ## @param use_mount - boolean - required
+  ## Instruct the check to collect using mount points instead of volumes.
+  #
   - use_mount: false
-    # The (optional) excluded_filesystems parameter will instruct the check to
-    # ignore disks using these filesystems. Note: On some linux distributions,
-    # rootfs will be found and tagged as a device, add rootfs here to exclude.
-    # excluded_filesystems:
-    #   - tmpfs
 
-    # The (optional) excluded_disks parameter will instruct the check to
-    # ignore this list of disks.
-    # Linux example:
-    # excluded_disks:
-    #   - /dev/sda1
-    #   - /dev/sda2
-    #
-    # Windows example:
-    # excluded_disks:
-    #  - F:\
-    #
-    # The (optional) excluded_disk_re parameter will instruct the check to
-    # ignore all disks matching this regex.
-    # excluded_disk_re: /dev/sde.*
-    #
-    # The (optional) tag_by_filesystem parameter will instruct the check to
-    # tag all disks with their filesystem (for ex: filesystem:nfs).
-    # tag_by_filesystem: false
-    #
-    # The (optional) excluded_mountpoint_re parameter will instruct the check to
-    # ignore all mountpoints matching this regex.
-    # excluded_mountpoint_re: /mnt/somebody-elses-problem.*
-    #
-    # The (optional) all_partitions parameter will instruct the check to
-    # get metrics for all partitions. use_mount should be set to yes (to avoid
-    # collecting empty device names) when using this option.
-    # all_partitions: false
-    #
-    # The (optional) device_tag_re parameter will instruct the check to apply additional tags to
-    # volumes/mountpoints matching these regexes. Multiple comma-separated tags are supported.
-    # You must properly quote the string if the pattern contains special characters e.g. colons.
-    # Character casing is ignored on Windows.
-    # device_tag_re:
-    #  /san/.*: device_type:san
-    #  /dev/sda3: role:db,disk_size:large
-    #  "c:": volume:boot
-    #
-    # The (optional) tags parameter allows you to customize tags for the instance
-    # tags:
-    #   - optional_tag1
-    #   - optional_tag2
-    #
-    # The (optional) service_check_rw parameter notifies when one of the partitions is in
-    # read-only mode
-    # service_check_rw: false
+  ## @param all_partitions - boolean - optional
+  ## Instruct the check to collect from partitions even without device names.
+  ## Setting `use_mount` to true is strongly recommended in this case.
+  #
+  #  all_partitions: false
+
+  ## @param tags  - list of key:value string - optional
+  ## List of tags to attach to every metric and service check emitted by this integration.
+  ##
+  ## Learn more about tagging at https://docs.datadoghq.com/tagging
+  #
+  #  tags:
+  #    - <KEY_1>:<VALUE_1>
+  #    - <KEY_2>:<VALUE_2>
+
+  ## @param file_system_whitelist - list of regex - optional
+  ## Instruct the check to only collect from matching file systems.
+  ##
+  ## Character casing is ignored. For convenience, the regular expressions
+  ## start matching from the beginning and therefore to match anywhere you
+  ## must prepend `.*`. For exact matches append `$`.
+  #
+  #  file_system_whitelist:
+  #    - ext[34]$
+  #    - ntfs$
+
+  ## @param file_system_blacklist - list of regex - optional
+  ## Instruct the check to not collect from matching file systems.
+  ##
+  ## Character casing is ignored. For convenience, the regular expressions
+  ## start matching from the beginning and therefore to match anywhere you
+  ## must prepend `.*`. For exact matches append `$`.
+  ##
+  ## When conflicts arise, this will override `file_system_whitelist`.
+  #
+  #  file_system_blacklist:
+  #    - tmpfs$
+  #    - rootfs$
+  #    - autofs$
+  #    - .*binfmt_misc
+
+  ## @param device_whitelist - list of regex - optional
+  ## Instruct the check to only collect from matching devices.
+  ##
+  ## Character casing is ignored on Windows. For convenience, the regular
+  ## expressions start matching from the beginning and therefore to match
+  ## anywhere you must prepend `.*`. For exact matches append `$`.
+  #
+  #  device_whitelist:
+  #    - /dev/sda[1-3]
+  #    - C:
+
+  ## @param device_blacklist - list of regex - optional
+  ## Instruct the check to not collect from matching devices.
+  ##
+  ## Character casing is ignored on Windows. For convenience, the regular
+  ## expressions start matching from the beginning and therefore to match
+  ## anywhere you must prepend `.*`. For exact matches append `$`.
+  ##
+  ## When conflicts arise, this will override `device_whitelist`.
+  #
+  #  device_blacklist:
+  #    - /dev/sde
+  #    - [FJ]:
+
+  ## @param mount_point_whitelist - list of regex - optional
+  ## Instruct the check to only collect from matching mount points.
+  ##
+  ## Character casing is ignored on Windows. For convenience, the regular
+  ## expressions start matching from the beginning and therefore to match
+  ## anywhere you must prepend `.*`. For exact matches append `$`.
+  #
+  #  mount_point_whitelist:
+  #    - /dev/sda[1-3]
+  #    - C:
+
+  ## @param mount_point_blacklist - list of regex - optional
+  ## Instruct the check to not collect from matching mount points.
+  ##
+  ## Character casing is ignored on Windows. For convenience, the regular
+  ## expressions start matching from the beginning and therefore to match
+  ## anywhere you must prepend `.*`. For exact matches append `$`.
+  ##
+  ## When conflicts arise, this will override `mount_point_whitelist`.
+  #
+  #  mount_point_blacklist:
+  #    - /dev/sde
+  #    - [FJ]:
+
+  ## @param service_check_rw - boolean - optional
+  ## Instruct the check to notify based on partition state.
+  ##
+  ## read-write -> OK
+  ## read-only  -> CRITICAL
+  ## other      -> UNKNOWN
+  #
+  #  service_check_rw: false
+
+  ## @param tag_by_filesystem - boolean - optional
+  ## Instruct the check to tag all disks with their file system e.g. filesystem:ntfs.
+  #
+  #  tag_by_filesystem: false
+
+  ## @param device_tag_re - list of regex:tags string - optional
+  ## Instruct the check to apply additional tags to matching
+  ## devices (or mount points if `use_mount` is true).
+  ##
+  ## Character casing is ignored on Windows. Multiple comma-separated
+  ## tags are supported. You must properly quote the string if the
+  ## pattern contains special characters e.g. colons.
+  #
+  #  device_tag_re:
+  #    /san/.*: device_type:san
+  #    /dev/sda3: role:db,disk_size:large
+  #    "c:": volume:boot

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -155,29 +155,23 @@ class Disk(AgentCheck):
         mount_point = mount_point.rsplit(' ', 1)[0]
 
         return (
-            self._blacklist_disk(device, file_system, mount_point)
-            or not self._whitelist_disk(device, file_system, mount_point)
+            self._disk_blacklisted(device, file_system, mount_point)
+            or not self._disk_whitelisted(device, file_system, mount_point)
         )
 
-    def _whitelist_disk(self, device, file_system, mount_point):
-        if not self._whitelist_file_system(file_system):
-            return False
-        elif not self._whitelist_device(device):
-            return False
-        elif not self._whitelist_mount_point(mount_point):
-            return False
+    def _disk_whitelisted(self, device, file_system, mount_point):
+        return (
+            self._whitelist_file_system(file_system)
+            and self._whitelist_device(device)
+            and self._whitelist_mount_point(mount_point)
+        )
 
-        return True
-
-    def _blacklist_disk(self, device, file_system, mount_point):
-        if self._blacklist_file_system(file_system):
-            return True
-        elif self._blacklist_device(device):
-            return True
-        elif self._blacklist_mount_point(mount_point):
-            return True
-
-        return False
+    def _disk_blacklisted(self, device, file_system, mount_point):
+        return (
+            self._blacklist_file_system(file_system)
+            or self._blacklist_device(device)
+            or self._blacklist_mount_point(mount_point)
+        )
 
     def _whitelist_file_system(self, file_system):
         if self._file_system_whitelist is None:

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -155,55 +155,55 @@ class Disk(AgentCheck):
         mount_point = mount_point.rsplit(' ', 1)[0]
 
         return (
-            self._disk_blacklisted(device, file_system, mount_point)
-            or not self._disk_whitelisted(device, file_system, mount_point)
+            self._partition_blacklisted(device, file_system, mount_point)
+            or not self._partition_whitelisted(device, file_system, mount_point)
         )
 
-    def _disk_whitelisted(self, device, file_system, mount_point):
+    def _partition_whitelisted(self, device, file_system, mount_point):
         return (
-            self._whitelist_file_system(file_system)
-            and self._whitelist_device(device)
-            and self._whitelist_mount_point(mount_point)
+            self._file_system_whitelisted(file_system)
+            and self._device_whitelisted(device)
+            and self._mount_point_whitelisted(mount_point)
         )
 
-    def _disk_blacklisted(self, device, file_system, mount_point):
+    def _partition_blacklisted(self, device, file_system, mount_point):
         return (
-            self._blacklist_file_system(file_system)
-            or self._blacklist_device(device)
-            or self._blacklist_mount_point(mount_point)
+            self._file_system_blacklisted(file_system)
+            or self._device_blacklisted(device)
+            or self._mount_point_blacklisted(mount_point)
         )
 
-    def _whitelist_file_system(self, file_system):
+    def _file_system_whitelisted(self, file_system):
         if self._file_system_whitelist is None:
             return True
 
         return not not self._file_system_whitelist.match(file_system)
 
-    def _blacklist_file_system(self, file_system):
+    def _file_system_blacklisted(self, file_system):
         if self._file_system_blacklist is None:
             return False
 
         return not not self._file_system_blacklist.match(file_system)
 
-    def _whitelist_device(self, device):
+    def _device_whitelisted(self, device):
         if not device or self._device_whitelist is None:
             return True
 
         return not not self._device_whitelist.match(device)
 
-    def _blacklist_device(self, device):
+    def _device_blacklisted(self, device):
         if not device or self._device_blacklist is None:
             return False
 
         return not not self._device_blacklist.match(device)
 
-    def _whitelist_mount_point(self, mount_point):
+    def _mount_point_whitelisted(self, mount_point):
         if self._mount_point_whitelist is None:
             return True
 
         return not not self._mount_point_whitelist.match(mount_point)
 
-    def _blacklist_mount_point(self, mount_point):
+    def _mount_point_blacklisted(self, mount_point):
         if self._mount_point_blacklist is None:
             return False
 

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -7,13 +7,14 @@ import os
 import platform
 import re
 
-from six import iteritems
+from six import iteritems, string_types
+
 try:
     import psutil
 except ImportError:
     psutil = None
 
-from datadog_checks.base import AgentCheck, is_affirmative
+from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 from datadog_checks.base.utils.timeout import timeout, TimeoutException
@@ -30,11 +31,24 @@ class Disk(AgentCheck):
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         if instances is not None and len(instances) > 1:
-            raise Exception('Disk check only supports one configured instance.')
+            raise ConfigurationError('Disk check only supports one configured instance.')
         AgentCheck.__init__(self, name, init_config, agentConfig, instances=instances)
 
-        # Get the configuration once for all
-        self._load_conf(instances[0])
+        instance = instances[0]
+        self._use_mount = is_affirmative(instance.get('use_mount', False))
+        self._all_partitions = is_affirmative(instance.get('all_partitions', False))
+        self._file_system_whitelist = instance.get('file_system_whitelist', [])
+        self._file_system_blacklist = instance.get('file_system_blacklist', [])
+        self._device_whitelist = instance.get('device_whitelist', [])
+        self._device_blacklist = instance.get('device_blacklist', [])
+        self._mount_point_whitelist = instance.get('mount_point_whitelist', [])
+        self._mount_point_blacklist = instance.get('mount_point_blacklist', [])
+        self._tag_by_filesystem = is_affirmative(instance.get('tag_by_filesystem', False))
+        self._device_tag_re = instance.get('device_tag_re', {})
+        self._custom_tags = instance.get('tags', [])
+        self._service_check_rw = is_affirmative(instance.get('service_check_rw', False))
+
+        self._compile_pattern_filters(instance)
         self._compile_tag_re()
 
     def check(self, instance):
@@ -51,26 +65,11 @@ class Disk(AgentCheck):
     def _psutil(cls):
         return psutil is not None
 
-    def _load_conf(self, instance):
-        self._use_mount = is_affirmative(instance.get('use_mount', False))
-        self._excluded_filesystems = instance.get('excluded_filesystems', [])
-        self._excluded_disks = instance.get('excluded_disks', [])
-        self._excluded_disk_re = re.compile(instance.get('excluded_disk_re', '^$'))
-        self._excluded_mountpoint_re = re.compile(instance.get('excluded_mountpoint_re', '^$'))
-        self._tag_by_filesystem = is_affirmative(instance.get('tag_by_filesystem', False))
-        self._all_partitions = is_affirmative(instance.get('all_partitions', False))
-        self._device_tag_re = instance.get('device_tag_re', {})
-        self._custom_tags = instance.get('tags', [])
-        self._service_check_rw = is_affirmative(instance.get('service_check_rw', False))
-
-        # Force exclusion of CDROM (iso9660) from disk check
-        self._excluded_filesystems.append('iso9660')
-
     def collect_metrics_psutil(self):
         self._valid_disks = {}
         for part in psutil.disk_partitions(all=True):
             # we check all exclude conditions
-            if self._exclude_disk_psutil(part):
+            if self.exclude_disk(part):
                 continue
 
             # Get disk metrics here to be able to exclude on total usage
@@ -128,7 +127,7 @@ class Disk(AgentCheck):
 
         self.collect_latency_metrics()
 
-    def _exclude_disk_psutil(self, part):
+    def exclude_disk(self, part):
         # skip cd-rom drives with no disk in it; they may raise
         # ENOENT, pop-up a Windows GUI error for a non-ready
         # partition or just hang;
@@ -136,38 +135,85 @@ class Disk(AgentCheck):
         skip_win = Platform.is_win32() and ('cdrom' in part.opts or part.fstype == '')
         return skip_win or self._exclude_disk(part.device, part.fstype, part.mountpoint)
 
-    def _exclude_disk(self, name, filesystem, mountpoint):
+    def _exclude_disk(self, device, file_system, mount_point):
         """
         Return True for disks we don't want or that match regex in the config file
         """
-        self.log.debug('_exclude_disk: {}, {}, {}'.format(name, filesystem, mountpoint))
+        self.log.debug('_exclude_disk: {}, {}, {}'.format(device, file_system, mount_point))
+
+        if not device or device == 'none':
+            device = None
+
+            # Allow no device if `all_partitions` is true so we can evaluate mount points
+            if not self._all_partitions:
+                return True
 
         # Hack for NFS secure mounts
         # Secure mounts might look like this: '/mypath (deleted)', we should
-        # ignore all the bits not part of the mountpoint name. Take also into
-        # account a space might be in the mountpoint.
-        mountpoint = mountpoint.rsplit(' ', 1)[0]
+        # ignore all the bits not part of the mount point name. Take also into
+        # account a space might be in the mount point.
+        mount_point = mount_point.rsplit(' ', 1)[0]
 
-        name_empty = not name or name == 'none'
+        return (
+            self._blacklist_disk(device, file_system, mount_point)
+            or not self._whitelist_disk(device, file_system, mount_point)
+        )
 
-        # allow empty names if `all_partitions` is `true` so we can evaluate mountpoints
-        if name_empty and not self._all_partitions:
-            return True
-        # device is listed in `excluded_disks`
-        elif not name_empty and name in self._excluded_disks:
-            return True
-        # device name matches `excluded_disk_re`
-        elif not name_empty and self._excluded_disk_re.match(name):
-            return True
-        # device mountpoint matches `excluded_mountpoint_re`
-        elif self._excluded_mountpoint_re.match(mountpoint):
-            return True
-        # fs is listed in `excluded_filesystems`
-        elif filesystem in self._excluded_filesystems:
-            return True
-        # all good, don't exclude the disk
-        else:
+    def _whitelist_disk(self, device, file_system, mount_point):
+        if not self._whitelist_file_system(file_system):
             return False
+        elif not self._whitelist_device(device):
+            return False
+        elif not self._whitelist_mount_point(mount_point):
+            return False
+
+        return True
+
+    def _blacklist_disk(self, device, file_system, mount_point):
+        if self._blacklist_file_system(file_system):
+            return True
+        elif self._blacklist_device(device):
+            return True
+        elif self._blacklist_mount_point(mount_point):
+            return True
+
+        return False
+
+    def _whitelist_file_system(self, file_system):
+        if self._file_system_whitelist is None:
+            return True
+
+        return not not self._file_system_whitelist.match(file_system)
+
+    def _blacklist_file_system(self, file_system):
+        if self._file_system_blacklist is None:
+            return False
+
+        return not not self._file_system_blacklist.match(file_system)
+
+    def _whitelist_device(self, device):
+        if not device or self._device_whitelist is None:
+            return True
+
+        return not not self._device_whitelist.match(device)
+
+    def _blacklist_device(self, device):
+        if not device or self._device_blacklist is None:
+            return False
+
+        return not not self._device_blacklist.match(device)
+
+    def _whitelist_mount_point(self, mount_point):
+        if self._mount_point_whitelist is None:
+            return True
+
+        return not not self._mount_point_whitelist.match(mount_point)
+
+    def _blacklist_mount_point(self, mount_point):
+        if self._mount_point_blacklist is None:
+            return False
+
+        return not not self._mount_point_blacklist.match(mount_point)
 
     def _collect_part_metrics(self, part, usage):
         metrics = {}
@@ -311,6 +357,80 @@ class Disk(AgentCheck):
 
         # Filter fake or unwanteddisks.
         return [d for d in flattened_devices if self._keep_device(d)]
+
+    def _compile_pattern_filters(self, instance):
+        # Force exclusion of CDROM (iso9660)
+        file_system_blacklist_extras = ['iso9660']
+        device_blacklist_extras = []
+        mount_point_blacklist_extras = []
+
+        deprecation_message = '`{old}` is deprecated and will be removed in 6.9. Please use `{new}` instead.'
+
+        if 'excluded_filesystems' in instance:
+            file_system_blacklist_extras.extend(
+                '{}$'.format(pattern) for pattern in instance['excluded_filesystems'] if pattern
+            )
+            self.warning(deprecation_message.format(old='excluded_filesystems', new='file_system_blacklist'))
+
+        if 'excluded_disks' in instance:
+            device_blacklist_extras.extend(
+                '{}$'.format(pattern) for pattern in instance['excluded_disks'] if pattern
+            )
+            self.warning(deprecation_message.format(old='excluded_disks', new='device_blacklist'))
+
+        if 'excluded_disk_re' in instance:
+            device_blacklist_extras.append(instance['excluded_disk_re'])
+            self.warning(deprecation_message.format(old='excluded_disk_re', new='device_blacklist'))
+
+        if 'excluded_mountpoint_re' in instance:
+            mount_point_blacklist_extras.append(instance['excluded_mountpoint_re'])
+            self.warning(deprecation_message.format(old='excluded_mountpoint_re', new='mount_point_blacklist'))
+
+        # Any without valid patterns will become None
+        self._file_system_whitelist = self._compile_valid_patterns(self._file_system_whitelist, casing=re.I)
+        self._file_system_blacklist = self._compile_valid_patterns(
+            self._file_system_blacklist,
+            casing=re.I,
+            extra_patterns=file_system_blacklist_extras
+        )
+        self._device_whitelist = self._compile_valid_patterns(self._device_whitelist)
+        self._device_blacklist = self._compile_valid_patterns(
+            self._device_blacklist,
+            extra_patterns=device_blacklist_extras
+        )
+        self._mount_point_whitelist = self._compile_valid_patterns(self._mount_point_whitelist)
+        self._mount_point_blacklist = self._compile_valid_patterns(
+            self._mount_point_blacklist,
+            extra_patterns=mount_point_blacklist_extras
+        )
+
+    def _compile_valid_patterns(self, patterns, casing=IGNORE_CASE, extra_patterns=None):
+        valid_patterns = []
+
+        if isinstance(patterns, string_types):
+            patterns = [patterns]
+        else:
+            patterns = list(patterns)
+
+        if extra_patterns:
+            for extra_pattern in extra_patterns:
+                if extra_pattern not in patterns:
+                    patterns.append(extra_pattern)
+
+        for pattern in patterns:
+            # Ignore empty patterns as they match everything
+            if not pattern:
+                continue
+
+            try:
+                re.compile(pattern, casing)
+            except Exception:
+                self.log.warning('{} is not a valid regular expression and will be ignored'.format(pattern))
+            else:
+                valid_patterns.append(pattern)
+
+        if valid_patterns:
+            return re.compile('|'.join(valid_patterns), casing)
 
     def _compile_tag_re(self):
         """

--- a/disk/tests/test_filter.py
+++ b/disk/tests/test_filter.py
@@ -1,0 +1,299 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import re
+
+from datadog_checks.dev.utils import ON_WINDOWS
+from datadog_checks.disk.disk import Disk, IGNORE_CASE
+from .mocks import MockPart
+from .utils import requires_windows
+
+
+def test_default_casing():
+    if ON_WINDOWS:
+        assert IGNORE_CASE == re.I
+    else:
+        assert IGNORE_CASE == 0
+
+
+def test_default_mock():
+    c = Disk('disk', None, {}, [{}])
+
+    assert c.exclude_disk(MockPart()) is False
+
+
+def test_bad_config_string_regex():
+    instance = {
+        'file_system_whitelist': 'test',
+        'file_system_blacklist': 'test',
+        'device_whitelist': 'test',
+        'device_blacklist': 'test',
+        'mount_point_whitelist': 'test',
+        'mount_point_blacklist': 'test',
+    }
+    c = Disk('disk', None, {}, [instance])
+
+    assert c._file_system_whitelist == re.compile('test', re.I)
+    assert c._file_system_blacklist == re.compile('test|iso9660', re.I)
+    assert c._device_whitelist == re.compile('test', IGNORE_CASE)
+    assert c._device_blacklist == re.compile('test', IGNORE_CASE)
+    assert c._mount_point_whitelist == re.compile('test', IGNORE_CASE)
+    assert c._mount_point_blacklist == re.compile('test', IGNORE_CASE)
+
+
+def test_ignore_empty_regex():
+    instance = {
+        'file_system_whitelist': ['test', ''],
+        'file_system_blacklist': ['test', ''],
+        'device_whitelist': ['test', ''],
+        'device_blacklist': ['test', ''],
+        'mount_point_whitelist': ['test', ''],
+        'mount_point_blacklist': ['test', ''],
+    }
+    c = Disk('disk', None, {}, [instance])
+
+    assert c._file_system_whitelist == re.compile('test', re.I)
+    assert c._file_system_blacklist == re.compile('test|iso9660', re.I)
+    assert c._device_whitelist == re.compile('test', IGNORE_CASE)
+    assert c._device_blacklist == re.compile('test', IGNORE_CASE)
+    assert c._mount_point_whitelist == re.compile('test', IGNORE_CASE)
+    assert c._mount_point_blacklist == re.compile('test', IGNORE_CASE)
+
+
+def test_exclude_bad_devices():
+    c = Disk('disk', None, {}, [{}])
+
+    assert c.exclude_disk(MockPart(device='')) is True
+    assert c.exclude_disk(MockPart(device='none')) is True
+
+
+@requires_windows
+def test_exclude_cdrom():
+    c = Disk('disk', None, {}, [{}])
+
+    assert c.exclude_disk(MockPart(fstype='ISO9660')) is True
+    assert c.exclude_disk(MockPart(opts='rw,cdrom')) is True
+
+
+def test_file_system_whitelist():
+    instance = {
+        'file_system_whitelist': [
+            'ext[34]',
+            'ntfs',
+        ],
+    }
+    c = Disk('disk', None, {}, [instance])
+
+    assert c.exclude_disk(MockPart(fstype='ext3')) is False
+    assert c.exclude_disk(MockPart(fstype='ext4')) is False
+    assert c.exclude_disk(MockPart(fstype='NTFS')) is False
+    assert c.exclude_disk(MockPart(fstype='apfs')) is True
+
+
+def test_file_system_blacklist():
+    instance = {
+        'file_system_blacklist': [
+            'fat',
+        ],
+    }
+    c = Disk('disk', None, {}, [instance])
+
+    assert c.exclude_disk(MockPart(fstype='FAT32')) is True
+    assert c.exclude_disk(MockPart(fstype='zfs')) is False
+
+
+def test_file_system_whitelist_blacklist():
+    instance = {
+        'file_system_whitelist': [
+            'ext[2-4]',
+        ],
+        'file_system_blacklist': [
+            'ext2',
+        ],
+    }
+    c = Disk('disk', None, {}, [instance])
+
+    assert c.exclude_disk(MockPart(fstype='ext2')) is True
+    assert c.exclude_disk(MockPart(fstype='ext3')) is False
+    assert c.exclude_disk(MockPart(fstype='ext4')) is False
+    assert c.exclude_disk(MockPart(fstype='NTFS')) is True
+
+
+def test_device_whitelist():
+    instance = {
+        'device_whitelist': [
+            '/dev/sda[1-3]',
+            'c:',
+        ],
+    }
+    c = Disk('disk', None, {}, [instance])
+
+    assert c.exclude_disk(MockPart(device='/dev/sda1')) is False
+    assert c.exclude_disk(MockPart(device='/dev/sda2')) is False
+    assert c.exclude_disk(MockPart(device='/dev/sda3')) is False
+    assert c.exclude_disk(MockPart(device='/dev/sda4')) is True
+    assert c.exclude_disk(MockPart(device='path/dev/sda1')) is True
+
+    assert c.exclude_disk(MockPart(device='c:\\')) is False
+    assert c.exclude_disk(MockPart(device='path\\c:\\')) is True
+
+
+def test_device_blacklist():
+    instance = {
+        'device_blacklist': [
+            '/dev/sda[1-3]',
+        ],
+    }
+    c = Disk('disk', None, {}, [instance])
+
+    assert c.exclude_disk(MockPart(device='/dev/sda1')) is True
+    assert c.exclude_disk(MockPart(device='/dev/sda2')) is True
+    assert c.exclude_disk(MockPart(device='/dev/sda3')) is True
+    assert c.exclude_disk(MockPart(device='/dev/sda4')) is False
+
+
+def test_device_whitelist_blacklist():
+    instance = {
+        'device_whitelist': [
+            '/dev/sda[1-3]',
+        ],
+        'device_blacklist': [
+            '/dev/sda3',
+        ],
+    }
+    c = Disk('disk', None, {}, [instance])
+
+    assert c.exclude_disk(MockPart(device='/dev/sda1')) is False
+    assert c.exclude_disk(MockPart(device='/dev/sda2')) is False
+    assert c.exclude_disk(MockPart(device='/dev/sda3')) is True
+    assert c.exclude_disk(MockPart(device='/dev/sda4')) is True
+
+
+def test_mount_point_whitelist():
+    instance = {
+        'mount_point_whitelist': [
+            '/dev/sda[1-3]',
+            'c:',
+        ],
+    }
+    c = Disk('disk', None, {}, [instance])
+
+    assert c.exclude_disk(MockPart(mountpoint='/dev/sda1')) is False
+    assert c.exclude_disk(MockPart(mountpoint='/dev/sda2')) is False
+    assert c.exclude_disk(MockPart(mountpoint='/dev/sda3')) is False
+    assert c.exclude_disk(MockPart(mountpoint='/dev/sda4')) is True
+    assert c.exclude_disk(MockPart(mountpoint='path/dev/sda1')) is True
+
+    assert c.exclude_disk(MockPart(mountpoint='c:\\')) is False
+    assert c.exclude_disk(MockPart(mountpoint='path\\c:\\')) is True
+
+
+def test_mount_point_blacklist():
+    instance = {
+        'mount_point_blacklist': [
+            '/dev/sda[1-3]',
+        ],
+    }
+    c = Disk('disk', None, {}, [instance])
+
+    assert c.exclude_disk(MockPart(mountpoint='/dev/sda1')) is True
+    assert c.exclude_disk(MockPart(mountpoint='/dev/sda2')) is True
+    assert c.exclude_disk(MockPart(mountpoint='/dev/sda3')) is True
+    assert c.exclude_disk(MockPart(mountpoint='/dev/sda4')) is False
+
+
+def test_mount_point_whitelist_blacklist():
+    instance = {
+        'mount_point_whitelist': [
+            '/dev/sda[1-3]',
+        ],
+        'mount_point_blacklist': [
+            '/dev/sda3',
+        ],
+    }
+    c = Disk('disk', None, {}, [instance])
+
+    assert c.exclude_disk(MockPart(mountpoint='/dev/sda1')) is False
+    assert c.exclude_disk(MockPart(mountpoint='/dev/sda2')) is False
+    assert c.exclude_disk(MockPart(mountpoint='/dev/sda3')) is True
+    assert c.exclude_disk(MockPart(mountpoint='/dev/sda4')) is True
+
+
+def test_all_partitions_allow_no_device():
+    instance = {
+        'all_partitions': 'true',
+        'mount_point_blacklist': ['/run$'],
+    }
+    c = Disk('disk', None, {}, [instance])
+
+    assert c.exclude_disk(MockPart(device='', mountpoint='/run')) is True
+    assert c.exclude_disk(MockPart(device='', mountpoint='/run/shm')) is False
+
+
+def test_legacy_config():
+    instance = {
+        'excluded_filesystems': ['test', ''],
+        'excluded_disks': ['test1', ''],
+        'excluded_disk_re': 'test2',
+        'excluded_mountpoint_re': 'test',
+    }
+    c = Disk('disk', None, {}, [instance])
+
+    assert c._file_system_blacklist == re.compile('iso9660|test$', re.I)
+    assert c._device_blacklist == re.compile('test1$|test2', IGNORE_CASE)
+    assert c._mount_point_blacklist == re.compile('test', IGNORE_CASE)
+
+
+def test_legacy_exclude_disk():
+    """
+    Test legacy exclusion logic config
+    """
+    instance = {
+        'use_mount': 'no',
+        'excluded_filesystems': ['aaaaaa'],
+        'excluded_mountpoint_re': '^/run$',
+        'excluded_disks': ['bbbbbb'],
+        'excluded_disk_re': '^tev+$'
+    }
+    c = Disk('disk', None, {}, [instance])
+
+    # should pass, default mock is a normal disk
+    assert c.exclude_disk(MockPart()) is False
+
+    # standard fake devices
+    assert c.exclude_disk(MockPart(device='')) is True
+    assert c.exclude_disk(MockPart(device='none')) is True
+    assert c.exclude_disk(MockPart(device='udev')) is False
+
+    # excluded filesystems list
+    assert c.exclude_disk(MockPart(fstype='aaaaaa')) is True
+    assert c.exclude_disk(MockPart(fstype='a')) is False
+
+    # excluded devices list
+    assert c.exclude_disk(MockPart(device='bbbbbb')) is True
+    assert c.exclude_disk(MockPart(device='b')) is False
+
+    # excluded devices regex
+    assert c.exclude_disk(MockPart(device='tevvv')) is True
+    assert c.exclude_disk(MockPart(device='tevvs')) is False
+
+    # and now with all_partitions
+    c._all_partitions = True
+    assert c.exclude_disk(MockPart(device='')) is False
+    assert c.exclude_disk(MockPart(device='none')) is False
+    assert c.exclude_disk(MockPart(device='udev')) is False
+    # excluded mountpoint regex
+    assert c.exclude_disk(MockPart(device='sdz', mountpoint='/run')) is True
+    assert c.exclude_disk(MockPart(device='sdz', mountpoint='/run/shm')) is False
+
+
+def test_legacy_device_exclusion_logic_no_name():
+    instance = {
+        'use_mount': 'yes',
+        'excluded_mountpoint_re': '^/run$',
+        'all_partitions': 'yes'
+    }
+    c = Disk('disk', None, {}, [instance])
+
+    assert c.exclude_disk(MockPart(device='', mountpoint='/run')) is True
+    assert c.exclude_disk(MockPart(device='', mountpoint='/run/shm')) is False

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -9,7 +9,7 @@ from six import iteritems
 
 from datadog_checks.disk import Disk
 from .common import DEFAULT_DEVICE_NAME, DEFAULT_FILE_SYSTEM, DEFAULT_MOUNT_POINT
-from .mocks import MockInodesMetrics, MockPart, mock_df_output
+from .mocks import MockInodesMetrics, mock_df_output
 from .utils import requires_unix
 
 
@@ -17,11 +17,14 @@ def test_default_options():
     check = Disk('disk', None, {}, [{}])
 
     assert check._use_mount is False
-    assert check._excluded_filesystems == ['iso9660']
-    assert check._excluded_disks == []
-    assert check._tag_by_filesystem is False
     assert check._all_partitions is False
-    assert check._excluded_disk_re == re.compile('^$')
+    assert check._file_system_whitelist is None
+    assert check._file_system_blacklist == re.compile('iso9660', re.I)
+    assert check._device_whitelist is None
+    assert check._device_blacklist is None
+    assert check._mount_point_whitelist is None
+    assert check._mount_point_blacklist is None
+    assert check._tag_by_filesystem is False
     assert check._device_tag_re == []
     assert check._service_check_rw is False
 
@@ -33,73 +36,6 @@ def test_bad_config():
     """
     with pytest.raises(Exception):
         Disk('disk', None, {}, [{}, {}])
-
-
-def test_ignore_empty_regex():
-    """
-    Ignore empty regex as they match all strings
-    (and so exclude all disks from the check)
-    """
-    check = Disk('disk', None, {'device_blacklist_re': ''}, [{}])
-    assert check._excluded_disk_re == re.compile('^$')
-
-
-def test__exclude_disk_psutil():
-    """
-    Test exclusion logic
-    """
-    instance = {
-        'use_mount': 'no',
-        'excluded_filesystems': ['aaaaaa'],
-        'excluded_mountpoint_re': '^/run$',
-        'excluded_disks': ['bbbbbb'],
-        'excluded_disk_re': '^tev+$'
-    }
-    c = Disk('disk', None, {}, [instance])
-
-    # should pass, default mock is a normal disk
-    assert c._exclude_disk_psutil(MockPart()) is False
-
-    # standard fake devices
-    assert c._exclude_disk_psutil(MockPart(device='')) is True
-    assert c._exclude_disk_psutil(MockPart(device='none')) is True
-    assert c._exclude_disk_psutil(MockPart(device='udev')) is False
-
-    # excluded filesystems list
-    assert c._exclude_disk_psutil(MockPart(fstype='aaaaaa')) is True
-    assert c._exclude_disk_psutil(MockPart(fstype='a')) is False
-
-    # excluded devices list
-    assert c._exclude_disk_psutil(MockPart(device='bbbbbb')) is True
-    assert c._exclude_disk_psutil(MockPart(device='b')) is False
-
-    # excluded devices regex
-    assert c._exclude_disk_psutil(MockPart(device='tevvv')) is True
-    assert c._exclude_disk_psutil(MockPart(device='tevvs')) is False
-
-    # and now with all_partitions
-    c._all_partitions = True
-    assert c._exclude_disk_psutil(MockPart(device='')) is False
-    assert c._exclude_disk_psutil(MockPart(device='none')) is False
-    assert c._exclude_disk_psutil(MockPart(device='udev')) is False
-    # excluded mountpoint regex
-    assert c._exclude_disk_psutil(MockPart(device='sdz', mountpoint='/run')) is True
-    assert c._exclude_disk_psutil(MockPart(device='sdz', mountpoint='/run/shm')) is False
-
-
-def test_device_exclusion_logic_no_name():
-    """
-    Same as above but with default configuration values and device='' to expose a bug in #2359
-    """
-    instance = {
-        'use_mount': 'yes',
-        'excluded_mountpoint_re': '^/run$',
-        'all_partitions': 'yes'
-    }
-    c = Disk('disk', None, {}, [instance])
-
-    assert c._exclude_disk_psutil(MockPart(device='', mountpoint='/run')) is True
-    assert c._exclude_disk_psutil(MockPart(device='', mountpoint='/run/shm')) is False
 
 
 @pytest.mark.usefixtures('psutil_mocks')


### PR DESCRIPTION
### What does this PR do?

Adds new partition filtering options

- `file_system_whitelist`
- `file_system_blacklist`
- `device_whitelist`
- `device_blacklist`
- `mount_point_whitelist`
- `mount_point_blacklist`

And began deprecation of

- `excluded_filesystems`
- `excluded_disks`
- `excluded_disk_re`
- `excluded_mountpoint_re`

### Motivation

- Customer requests for ability to white list
- Less confusing options: disk vs device, duplicate options, options of different types, etc.

### Additional Notes

Also converted config to new style