### PR TITLE
Add extra Kafka broker metrics

### DIFF
--- a/kafka/datadog_checks/kafka/data/conf.yaml.example
+++ b/kafka/datadog_checks/kafka/data/conf.yaml.example
@@ -421,6 +421,38 @@ init_config:
             alias: kafka.net.bytes_rejected.rate
 
     #
+    # Brokers: Per Topic Metrics
+    #
+    - include:
+        domain: 'kafka.server'
+        bean_regex: 'kafka\.server:type=BrokerTopicMetrics,name=BytesOutPerSec,topic=.*'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.topics.net.bytes_out.rate
+    - include:
+        domain: 'kafka.server'
+        bean_regex: 'kafka\.server:type=BrokerTopicMetrics,name=BytesInPerSec,topic=.*'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.topics.net.bytes_in.rate
+    - include:
+        domain: 'kafka.server'
+        bean_regex: 'kafka\.server:type=BrokerTopicMetrics,name=MessagesInPerSec,topic=.*'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.topics.messages_in.rate
+    - include:
+        domain: 'kafka.server'
+        bean_regex: 'kafka\.server:type=BrokerTopicMetrics,name=BytesRejectedPerSec,topic=.*'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.topics.net.bytes_rejected.rate
+
+    #
     # Request timings
     #
     - include:
@@ -519,12 +551,30 @@ init_config:
             metric_type: gauge
             alias: kafka.request.offsets.time.99percentile
     - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestChannel,name=RequestQueueSize'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.request.channel.queue.size
+    - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=SocketServer,name=NetworkProcessorAvgIdlePercent'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.net.handler.avg.idle.pct.rate
+    - include:
         domain: 'kafka.server'
         bean: 'kafka.server:type=KafkaRequestHandlerPool,name=RequestHandlerAvgIdlePercent'
         attribute:
           OneMinuteRate:
             metric_type: gauge
             alias: kafka.request.handler.avg.idle.pct.rate
+
+    #
+    # Request Purgatory (only v0.8.2.x)
+    #
     - include:
         domain: 'kafka.server'
         bean: 'kafka.server:type=ProducerRequestPurgatory,name=PurgatorySize'
@@ -535,6 +585,24 @@ init_config:
     - include:
         domain: 'kafka.server'
         bean: 'kafka.server:type=FetchRequestPurgatory,name=PurgatorySize'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.request.fetch_request_purgatory.size
+
+    #
+    # Request Purgatory (v0.9.0.x onwards)
+    #
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=DelayedOperationPurgatory,name=PurgatorySize,delayedOperation=Produce'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.request.producer_request_purgatory.size
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=DelayedOperationPurgatory,name=PurgatorySize,delayedOperation=Fetch'
         attribute:
           Value:
             metric_type: gauge

--- a/kafka/datadog_checks/kafka/data/metrics.yaml
+++ b/kafka/datadog_checks/kafka/data/metrics.yaml
@@ -193,7 +193,7 @@ jmx_metrics:
         tags:
           client: $1
           topic: $2
-          
+
     #
     # Consumers (only v0.8.2.x)
     #
@@ -314,7 +314,7 @@ jmx_metrics:
         tags:
           client: $1
           topic: $2
-            
+
     #
     # Aggregate cluster stats
     #
@@ -348,7 +348,7 @@ jmx_metrics:
             alias: kafka.net.bytes_rejected.rate
     
     #
-    # Per Topic Broker Stats
+    # Per Topic Broker Stats (only v0.8.x)
     #
     - include:
         domain: '"kafka.server"'
@@ -359,6 +359,38 @@ jmx_metrics:
             alias: kafka.topic.messages_in.rate
         tags:
           topic: $1
+
+    #
+    # Brokers: Per Topic Metrics (v0.9.0.x+)
+    #
+    - include:
+        domain: 'kafka.server'
+        bean_regex: 'kafka\.server:type=BrokerTopicMetrics,name=MessagesInPerSec,topic=.*'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.topic.messages_in.rate
+    - include:
+        domain: 'kafka.server'
+        bean_regex: 'kafka\.server:type=BrokerTopicMetrics,name=BytesOutPerSec,topic=.*'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.topic.net.bytes_out.rate
+    - include:
+        domain: 'kafka.server'
+        bean_regex: 'kafka\.server:type=BrokerTopicMetrics,name=BytesInPerSec,topic=.*'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.topic.net.bytes_in.rate
+    - include:
+        domain: 'kafka.server'
+        bean_regex: 'kafka\.server:type=BrokerTopicMetrics,name=BytesRejectedPerSec,topic=.*'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.topic.net.bytes_rejected.rate
 
     #
     # Request timings
@@ -459,12 +491,30 @@ jmx_metrics:
             metric_type: gauge
             alias: kafka.request.offsets.time.99percentile
     - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestChannel,name=RequestQueueSize'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.request.channel.queue.size
+    - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=SocketServer,name=NetworkProcessorAvgIdlePercent'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.net.processor.avg.idle.pct.rate
+    - include:
         domain: 'kafka.server'
         bean: 'kafka.server:type=KafkaRequestHandlerPool,name=RequestHandlerAvgIdlePercent'
         attribute:
           OneMinuteRate:
             metric_type: gauge
             alias: kafka.request.handler.avg.idle.pct.rate
+
+    #
+    # Request Purgatory (only v0.8.2.x)
+    #
     - include:
         domain: 'kafka.server'
         bean: 'kafka.server:type=ProducerRequestPurgatory,name=PurgatorySize'
@@ -475,6 +525,24 @@ jmx_metrics:
     - include:
         domain: 'kafka.server'
         bean: 'kafka.server:type=FetchRequestPurgatory,name=PurgatorySize'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.request.fetch_request_purgatory.size
+
+    #
+    # Request Purgatory (v0.9.0.x onwards)
+    #
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=DelayedOperationPurgatory,name=PurgatorySize,delayedOperation=Produce'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.request.producer_request_purgatory.size
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=DelayedOperationPurgatory,name=PurgatorySize,delayedOperation=Fetch'
         attribute:
           Value:
             metric_type: gauge
@@ -564,3 +632,35 @@ jmx_metrics:
           Count:
             metric_type: rate
             alias: kafka.log.flush_rate.rate
+
+    #
+    # Zookeeper stats
+    #
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=SessionExpireListener,name=ZooKeeperDisconnectsPerSec'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.session.zookeeper.disconnect.rate
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=SessionExpireListener,name=ZooKeeperExpiresPerSec'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.session.zookeeper.expire.rate
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=SessionExpireListener,name=ZooKeeperReadOnlyConnectsPerSec'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.session.zookeeper.readonly.rate
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=SessionExpireListener,name=ZooKeeperSyncConnectsPerSec'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.session.zookeeper.sync.rate

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -2,9 +2,12 @@ metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation
 kafka.net.bytes_out,gauge,10,byte,second,Outgoing byte rate.,0,kafka,bytes out
 kafka.net.bytes_in,gauge,10,byte,second,Incoming byte rate.,0,kafka,bytes in
 kafka.net.bytes_rejected,gauge,10,byte,second,Rejected byte rate.,-1,kafka,bytes rejected
+kafka.net.processor.avg.idle.pct,gauge,10,fraction,,Average fraction of time the network processor threads are idle.,1,kafka,net processor avg idle
 kafka.messages_in,gauge,10,message,,Incoming message rate.,0,kafka,messages in
+kafka.request.channel.queue.size,gauge,10,request,,Number of queued requests.,-1,kafka,req channel queue size
 kafka.request.fetch.failed,gauge,10,request,,Number of client fetch request failures.,-1,kafka,req fetch fail
 kafka.request.fetch.failed_per_second,gauge,10,request,second,Rate of client fetch request failures per second.,-1,kafka,req fetch fail rate
+kafka.request.handler.avg.idle.pct,gauge,10,fraction,,Average fraction of time the request handler threads are idle.,1,kafka,req handle avg idle
 kafka.request.produce.time.avg,gauge,10,request,second,Average time for a produce request.,0,kafka,req prod time avg
 kafka.request.produce.time.99percentile,gauge,10,request,second,Time for produce requests for 99th percentile.,0,kafka,req prod time 99
 kafka.request.produce.failed_per_second,gauge,10,request,second,Rate of failed produce requests per second.,-1,kafka,req prod fail rate
@@ -17,12 +20,15 @@ kafka.request.metadata.time.avg,gauge,10,millisecond,,Average time for metadata 
 kafka.request.metadata.time.99percentile,gauge,10,millisecond,,Time for metadata requests for 99th percentile.,0,kafka,req meta time 99
 kafka.request.offsets.time.avg,gauge,10,millisecond,,Average time for an offset request.,0,kafka,req offset time avg
 kafka.request.offsets.time.99percentile,gauge,10,millisecond,,Time for offset requests for 99th percentile.,0,kafka,req offset time 99
-kafka.request.handler.avg.idle.pct,gauge,10,fraction,,Average fraction of time the request handler threads are idle.,1,kafka,req handle avg idle
 kafka.replication.isr_shrinks,gauge,10,node,second,Rate of replicas leaving the ISR pool.,-1,kafka,rep isr shrinks
 kafka.replication.isr_expands,gauge,10,node,second,Rate of replicas joining the ISR pool.,-1,kafka,rep isr expands
 kafka.replication.leader_elections,gauge,10,event,second,Leader election rate.,0,kafka,rep leader elect
 kafka.replication.unclean_leader_elections,gauge,10,event,second,Unclean leader election rate.,-1,kafka,rep leader dirty elect
 kafka.replication.under_replicated_partitions,gauge,10,,,Number of unreplicated partitions.,-1,kafka,rep under replicated part
+kafka.session.zookeeper.disconnect,gauge,10,event,second,Zookeeper client disconnect rate.,-1,kafka,zookeeper disconnect rate
+kafka.session.zookeeper.expire,gauge,10,event,second,Zookeeper client session expiration rate.,-1,kafka,zookeeper expiration rate
+kafka.session.zookeeper.readonly,gauge,10,event,second,Zookeeper client readonly rate.,0,kafka,zookeeper readonly rate
+kafka.session.zookeeper.sync,gauge,10,event,second,Zookeeeper client sync rate.,1,kafka,zookeeper sync rate
 kafka.log.flush_rate,gauge,10,flush,second,Log flush rate.,0,kafka,log flush rate
 kafka.consumer.delayed_requests,gauge,10,request,,Number of delayed consumer requests.,-1,kafka,con delayed req
 kafka.consumer.expires_per_second,gauge,10,eviction,second,Rate of delayed consumer request expiration.,-1,kafka,con expire rate
@@ -32,7 +38,7 @@ kafka.producer.available_buffer_bytes,gauge,10,byte,,The total amount of buffer 
 kafka.producer.batch_size_avg,gauge,10,byte,,The average number of bytes sent per partition per-request.,0,kafka,avg batch size
 kafka.producer.compression_rate_avg,rate,10,record,,The average compression rate of record batches.,0,kafka,avg compression rate
 kafka.producer.bufferpool_wait_time,gauge,10,,,The fraction of time an appender waits for space allocation.,-1,kafka,bufferpool wait time
-kafka.producer.compression_rate,gauge,10,record,second,The average compression rate of record batches for a topic,1,kafka,compression rate 
+kafka.producer.compression_rate,gauge,10,record,second,The average compression rate of record batches for a topic,1,kafka,compression rate
 kafka.producer.delayed_requests,gauge,10,request,,Number of producer requests delayed.,-1,kafka,prod expire rate
 kafka.producer.expires_per_seconds,gauge,10,eviction,second,Rate of producer request expiration.,-1,kafka,prod req expire
 kafka.producer.batch_size_max,gauge,10,byte,,The max number of bytes sent per partition per-request.,0,kafka,max batch size
@@ -68,4 +74,7 @@ kafka.consumer.zookeeper_commits,gauge,10,write,second,Rate of offset commits to
 kafka.consumer.kafka_commits,gauge,10,write,second,Rate of offset commits to Kafka.,1,kafka,kafka offset commit
 kafka.consumer.records_consumed,gauge,10,record,second,The average number of records consumed per second for a specific topic.,1,kafka,con rec consumed
 kafka.consumer.records_per_request_avg,gauge,10,record,request,The average number of records in each request for a specific topic.,1,kafka,rec per request
-kafka.topic.messages_in,rate,10,message,,Incoming message rate by topic,0,kafka,topic messages in
+kafka.topic.messages_in,gauge,10,message,,Incoming message rate by topic,0,kafka,topic messages in
+kafka.topic.net.bytes_out,gauge,10,byte,second,Outgoing byte rate by topic.,0,kafka,topic bytes out
+kafka.topic.net.bytes_in,gauge,10,byte,second,Incoming byte rate by topic.,0,kafka,topic bytes in
+kafka.topic.net.bytes_rejected,gauge,10,byte,second,Rejected byte rate by topic.,-1,kafka,topic bytes rejected


### PR DESCRIPTION
### What does this PR do?

- Add per-topic request metrics
- Add network handler idle metric
- Add Zookeeper client session metrics
- Fix request purgatory metrics for Kafka 0.9+

### Motivation

I noticed that Datadog was missing some broker metrics when reviewing [Confluent's Kafka monitoring documentation](https://docs.confluent.io/current/kafka/monitoring.html#server-metrics). This PR helps bring Datadog's checks more inline with the docs.

I also noticed that the request metrics are also available at the topic level. These metrics can be useful for understanding workload patterns. I added the new metrics under the `kafka.topics` prefix to prevent issues with existing aggregations on equivalent the broker-level metrics.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Adding per-topic metrics as a default could be problematic as a large cluster could lead to metrics exceeding the default 350 limit. I left it in the `metrics.yaml` file as that is where the other per-topics metrics were placed.

