### PR TITLE
Removed deprecated agentConfig option locations

### DIFF
--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -35,17 +35,6 @@ def test_bad_config():
         Disk('disk', None, {}, [{}, {}])
 
 
-def test_legacy_option(instance_basic_mount, instance_basic_volume):
-    """
-    Ensure check option overrides datadog.conf
-    """
-    c = Disk('disk', None, instance_basic_mount, [{}])
-    assert c._use_mount is True
-
-    c = Disk('disk', None, instance_basic_mount, [instance_basic_volume])
-    assert c._use_mount is False
-
-
 def test_ignore_empty_regex():
     """
     Ignore empty regex as they match all strings


### PR DESCRIPTION
### Motivation

They were actually intended to be removed in 6.0