### PR TITLE
Add stakeholders to review requirements for checks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,18 +3,22 @@
 # and another the rest of the directory.
 
 # All your base
-*                  @DataDog/agent-integrations
+*                   @DataDog/agent-integrations
 
 # Documentation
-/docs/             @DataDog/baklava @DataDog/agent-integrations
-*.md               @DataDog/baklava @DataDog/agent-integrations                          
-manifest.json      @DataDog/baklava @DataDog/agent-integrations
+/docs/              @DataDog/baklava @DataDog/agent-integrations
+*.md                @DataDog/baklava @DataDog/agent-integrations
+manifest.json       @DataDog/baklava @DataDog/agent-integrations
 
 # Container monitoring
-/docker_daemon/    @DataDog/container-integrations @DataDog/agent-integrations
-/ecs_fargate/      @DataDog/container-integrations @DataDog/agent-integrations
-/kube_dns/         @DataDog/container-integrations @DataDog/agent-integrations
-/kube_proxy/       @DataDog/container-integrations @DataDog/agent-integrations
-/kubelet/          @DataDog/container-integrations @DataDog/agent-integrations
-/kubernetes/       @DataDog/container-integrations @DataDog/agent-integrations
-/kubernetes_state/ @DataDog/container-integrations @DataDog/agent-integrations
+/docker_daemon/     @DataDog/container-integrations @DataDog/agent-integrations
+/ecs_fargate/       @DataDog/container-integrations @DataDog/agent-integrations
+/kube_dns/          @DataDog/container-integrations @DataDog/agent-integrations
+/kube_proxy/        @DataDog/container-integrations @DataDog/agent-integrations
+/kubelet/           @DataDog/container-integrations @DataDog/agent-integrations
+/kubernetes/        @DataDog/container-integrations @DataDog/agent-integrations
+/kubernetes_state/  @DataDog/container-integrations @DataDog/agent-integrations
+
+# To keep ProdSec up-to-date with changes to requirements.txt.
+*/requirements.in   @DataDog/prodsec @DataDog/agent-integrations
+*/requirements.txt  @DataDog/prodsec @DataDog/agent-integrations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,5 +20,5 @@ manifest.json       @DataDog/baklava @DataDog/agent-integrations
 /kubernetes_state/  @DataDog/container-integrations @DataDog/agent-integrations
 
 # To keep ProdSec up-to-date with changes to requirements.txt.
-*/requirements.in   @DataDog/prodsec @DataDog/agent-integrations
-*/requirements.txt  @DataDog/prodsec @DataDog/agent-integrations
+requirements.in   @DataDog/prodsec
+requirements.txt  @DataDog/prodsec


### PR DESCRIPTION
### What does this PR do?

Add agent-integrations, and prodsec to review requirements for all checks.

### Motivation

So that ProdSec is aware of updating datadog/pip whenever its requirements needs to be updated.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

N/A.