### PR TITLE
Support specifying type of semver version bumps

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -19,8 +19,10 @@ VERSION_BUMP = OrderedDict([
     ('minor', semver.bump_minor),
     ('patch', semver.bump_patch),
     ('fix', semver.bump_patch),
-    ('pre', semver.bump_prerelease),
     ('build', semver.bump_build),
+    ('pre', semver.bump_prerelease),
+    ('rc', semver.bump_prerelease),
+    ('beta', semver.bump_prerelease),
 ])
 
 # The checks requirement file used by the agent

--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -19,10 +19,13 @@ VERSION_BUMP = OrderedDict([
     ('minor', semver.bump_minor),
     ('patch', semver.bump_patch),
     ('fix', semver.bump_patch),
-    ('build', semver.bump_build),
-    ('pre', semver.bump_prerelease),
-    ('rc', semver.bump_prerelease),
-    ('beta', semver.bump_prerelease),
+    ('build', lambda v: semver.bump_build(v, 'build')),
+    ('nightly', lambda v: semver.bump_build(v, 'nightly')),
+    ('dev', lambda v: semver.bump_prerelease(v, 'dev')),
+    ('rc', lambda v: semver.bump_prerelease(v, 'rc')),
+    ('pre', lambda v: semver.bump_prerelease(v, 'pre')),
+    ('alpha', lambda v: semver.bump_prerelease(v, 'alpha')),
+    ('beta', lambda v: semver.bump_prerelease(v, 'beta')),
 ])
 
 # The checks requirement file used by the agent


### PR DESCRIPTION
Instead of

`ddev release make <CHECK> [ver_number]`

we now can do

`ddev release make <CHECK> [ver_number|major|minor|patch|rc|etc.]`