### PR TITLE
Make CD-ROM exclusion require an exact match

### DIFF
--- a/disk/datadog_checks/disk/data/conf.yaml.default
+++ b/disk/datadog_checks/disk/data/conf.yaml.default
@@ -49,7 +49,6 @@ instances:
   #    - tmpfs$
   #    - rootfs$
   #    - autofs$
-  #    - .*binfmt_misc
 
   ## @param device_whitelist - list of regex - optional
   ## Instruct the check to only collect from matching devices.
@@ -96,6 +95,7 @@ instances:
   ## When conflicts arise, this will override `mount_point_whitelist`.
   #
   #  mount_point_blacklist:
+  #    - /proc/sys/fs/binfmt_misc
   #    - /dev/sde
   #    - [FJ]:
 

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -354,7 +354,7 @@ class Disk(AgentCheck):
 
     def _compile_pattern_filters(self, instance):
         # Force exclusion of CDROM (iso9660)
-        file_system_blacklist_extras = ['iso9660']
+        file_system_blacklist_extras = ['iso9660$']
         device_blacklist_extras = []
         mount_point_blacklist_extras = []
 

--- a/disk/tests/test_filter.py
+++ b/disk/tests/test_filter.py
@@ -34,7 +34,7 @@ def test_bad_config_string_regex():
     c = Disk('disk', None, {}, [instance])
 
     assert c._file_system_whitelist == re.compile('test', re.I)
-    assert c._file_system_blacklist == re.compile('test|iso9660', re.I)
+    assert c._file_system_blacklist == re.compile('test|iso9660$', re.I)
     assert c._device_whitelist == re.compile('test', IGNORE_CASE)
     assert c._device_blacklist == re.compile('test', IGNORE_CASE)
     assert c._mount_point_whitelist == re.compile('test', IGNORE_CASE)
@@ -53,7 +53,7 @@ def test_ignore_empty_regex():
     c = Disk('disk', None, {}, [instance])
 
     assert c._file_system_whitelist == re.compile('test', re.I)
-    assert c._file_system_blacklist == re.compile('test|iso9660', re.I)
+    assert c._file_system_blacklist == re.compile('test|iso9660$', re.I)
     assert c._device_whitelist == re.compile('test', IGNORE_CASE)
     assert c._device_blacklist == re.compile('test', IGNORE_CASE)
     assert c._mount_point_whitelist == re.compile('test', IGNORE_CASE)
@@ -239,7 +239,7 @@ def test_legacy_config():
     }
     c = Disk('disk', None, {}, [instance])
 
-    assert c._file_system_blacklist == re.compile('iso9660|test$', re.I)
+    assert c._file_system_blacklist == re.compile('iso9660$|test$', re.I)
     assert c._device_blacklist == re.compile('test1$|test2', IGNORE_CASE)
     assert c._mount_point_blacklist == re.compile('test', IGNORE_CASE)
 

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -19,7 +19,7 @@ def test_default_options():
     assert check._use_mount is False
     assert check._all_partitions is False
     assert check._file_system_whitelist is None
-    assert check._file_system_blacklist == re.compile('iso9660', re.I)
+    assert check._file_system_blacklist == re.compile('iso9660$', re.I)
     assert check._device_whitelist is None
     assert check._device_blacklist is None
     assert check._mount_point_whitelist is None


### PR DESCRIPTION
### Motivation

Regex was too inclusive