### PR TITLE
Rework Postgres wait_for_healthy function

### DIFF
--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -48,6 +48,19 @@ def postgres_standalone():
 
         output = subprocess.check_output([
             "docker",
+            "-v"
+        ])
+        print "\n Docker version {} \n".format(output)
+
+        output = subprocess.check_output([
+            "docker",
+            "inspect --help"
+        ])
+        
+        print "\n Docker inspect help {} \n".format(output)
+
+        output = subprocess.check_output([
+            "docker",
             "inspect",
             "--format='{{json .State.Health.Status}}'",
             "compose_postgres_1"])

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -5,6 +5,8 @@ import subprocess
 import os
 import time
 
+import psycopg2
+
 import pytest
 import mock
 from datadog_checks.postgres import PostgreSql
@@ -46,38 +48,12 @@ def postgres_standalone():
             subprocess.check_call(args + ["down"], env=env)
             raise Exception("PostgreSQL boot timed out!")
 
-        output = subprocess.check_output([
-            "docker",
-            "-v"
-        ])
-        print "\n Docker version {} \n".format(output)
-
-        output = subprocess.check_output([
-            "docker",
-            "inspect",
-            "--help"
-        ])
-
-        print "\n Docker inspect help {} \n".format(output)
-
-        output =  subprocess.check_output([
-            "docker",
-            "ps"
-        ])
-
-        print "\n Docker ps {} \n".format(output)
-
-        output = subprocess.check_output([
-            "docker",
-            "inspect",
-            "--format='{{json .State.Health.Status}}'",
-            "compose_postgres_1"])
-
-        # we get a json string output from docker
-        if output.strip() == "'\"healthy\"'":
+        try:
+            psycopg2.connect(host=HOST, dbname=DB_NAME, user=USER, password=PASSWORD)
             break
-        attempts += 1
-        time.sleep(1)
+        except psycopg2.OperationalError:
+            attempts += 1
+            time.sleep(1)
 
     yield
     subprocess.check_call(args + ["down"], env=env)

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -65,6 +65,8 @@ def postgres_standalone():
             "ps"
         ])
 
+        print "\n Docker ps {} \n".format(output)
+
         output = subprocess.check_output([
             "docker",
             "inspect",

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -60,6 +60,11 @@ def postgres_standalone():
 
         print "\n Docker inspect help {} \n".format(output)
 
+        output =  subprocess.check_output([
+            "docker",
+            "ps"
+        ])
+
         output = subprocess.check_output([
             "docker",
             "inspect",

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -54,9 +54,10 @@ def postgres_standalone():
 
         output = subprocess.check_output([
             "docker",
-            "inspect --help"
+            "inspect",
+            "--help"
         ])
-        
+
         print "\n Docker inspect help {} \n".format(output)
 
         output = subprocess.check_output([

--- a/postgres/tox.ini
+++ b/postgres/tox.ini
@@ -14,7 +14,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt
-    pytest -v -m"integration"
+    pytest -v -m"integration" -s
 
 [testenv:unit]
 commands =

--- a/postgres/tox.ini
+++ b/postgres/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.0
 basepython = py27
-envlist = postgres{11}-psycopg2, flake8
+envlist = unit, postgres{93,94,95,96,10,11}-pg8000, postgres{93,94,95,96,10,11}-psycopg2, flake8
 
 [testenv]
 usedevelop = true

--- a/postgres/tox.ini
+++ b/postgres/tox.ini
@@ -14,7 +14,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install --require-hashes -r requirements.txt
-    pytest -v -m"integration" -s
+    pytest -v -m"integration"
 
 [testenv:unit]
 commands =

--- a/postgres/tox.ini
+++ b/postgres/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.0
 basepython = py27
-envlist = unit, postgres{93,94,95,96,10,11}-pg8000, postgres{93,94,95,96,10,11}-psycopg2, flake8
+envlist = postgres{11}-psycopg2, flake8
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
### What does this PR do?

Rely on making a connection via psycopg2 instead of using docker inspect when confirming the docker pg env is ready for integration tests.

### Motivation

CI was failing

Docker-compose upgrade made the container name include a hash at the end. This broke the postgres tests because the docker inspect wasn't including the hash at the end of the container name. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
