### PR TITLE
Disable pytest output capturing when debugging

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/test.py
@@ -148,7 +148,7 @@ def construct_pytest_options(verbose=0, enter_pdb=False, debug=False, bench=Fals
         pytest_options += ' --pdb -x'
 
     if debug:
-        pytest_options += ' --log-level=debug'
+        pytest_options += ' --log-level=debug -s'
 
     if bench:
         pytest_options += ' --benchmark-only --benchmark-cprofile=tottime'


### PR DESCRIPTION
Use the `s` flag when invoking pytest to avoid capturing stdout/err https://docs.pytest.org/en/latest/capture.html

It's helpful to log things in tests when debugging something (including in Travis where we can't pdb)