### PR TITLE
Add metric for total Kafka consumer topic lag

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -51,6 +51,14 @@ instances:
     # ssl_keyfile: /path/to/key/file
     # ssl_password: password1
 
+    # Setting aggregate_consumer_lag to True will tell the check to report
+    # consumer lag metrics as a summed total across all monitored paritions per
+    # topic.
+    aggregate_consumer_lag: false
+    # Setting per_partition_consumer_lag to True (default) will tell the check
+    # to report consumer lag metrics at a partition level. Enabling this could
+    # lead to a large number of metrics being sent.
+    per_partition_consumer_lag: true
     # kafka_consumer_offsets: false
     consumer_groups:
       my_consumer:  # consumer group name

--- a/kafka_consumer/metadata.csv
+++ b/kafka_consumer/metadata.csv
@@ -1,4 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 kafka.broker_offset,gauge,,offset,,Current message offset on broker.,0,kafka,broker offset
 kafka.consumer_lag,gauge,,offset,,Lag in messages between consumer and broker.,-1,kafka,consumer lag
+kafka.consumer_lag.total,gauge,,offset,,Total lag in messages between consumer and broker.,-1,kafka,total consumer lag
 kafka.consumer_offset,gauge,,offset,,Current message offset on consumer.,0,kafka,consumer offset

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import copy
+
 import pytest
 from six import iteritems
 
@@ -17,9 +19,15 @@ BROKER_METRICS = [
     'kafka.broker_offset',
 ]
 
+CONSUMER_PARTITION_LAG_METRIC = 'kafka.consumer_lag'
+
 CONSUMER_METRICS = [
     'kafka.consumer_offset',
-    'kafka.consumer_lag',
+    CONSUMER_PARTITION_LAG_METRIC
+]
+
+CONSUMER_TOPIC_METRICS = [
+    'kafka.consumer_lag.total',
 ]
 
 
@@ -33,14 +41,80 @@ def test_check_kafka(aggregator, kafka_instance):
 
     for name, consumer_group in iteritems(kafka_instance['consumer_groups']):
         for topic, partitions in iteritems(consumer_group):
+            tags = ["topic:{}".format(topic)] + ['optional:tag1']
+            consumer_tags = ["source:kafka", "consumer_group:{}".format(name)]
+
+            for mname in CONSUMER_TOPIC_METRICS:
+                aggregator.assert_metric(mname, tags=(tags + consumer_tags), count=0)
+
             for partition in partitions:
-                tags = ["topic:{}".format(topic),
-                        "partition:{}".format(partition)] + ['optional:tag1']
+                tags += ["partition:{}".format(partition)]
                 for mname in BROKER_METRICS:
                     aggregator.assert_metric(mname, tags=tags, at_least=1)
                 for mname in CONSUMER_METRICS:
-                    aggregator.assert_metric(mname, tags=tags +
-                                             ["source:kafka", "consumer_group:{}".format(name)], at_least=1)
+                    aggregator.assert_metric(mname, tags=(tags + consumer_tags), at_least=1)
+
+    # let's reassert for the __consumer_offsets - multiple partitions
+    aggregator.assert_metric('kafka.broker_offset', at_least=1)
+
+
+@pytest.mark.usefixtures('dd_environment', 'kafka_consumer', 'kafka_producer')
+def test_aggregate_lag_kafka(aggregator, kafka_instance):
+    """
+    Testing Kafka_consumer check.
+    """
+    aggregate_lag_kafka_instance = copy.deepcopy(kafka_instance)
+    aggregate_lag_kafka_instance['aggregate_consumer_lag'] = True
+
+    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, {})
+    kafka_consumer_check.check(aggregate_lag_kafka_instance)
+
+    for name, consumer_group in iteritems(aggregate_lag_kafka_instance['consumer_groups']):
+        for topic, partitions in iteritems(consumer_group):
+            tags = ["topic:{}".format(topic)] + ['optional:tag1']
+            consumer_tags = ["source:kafka", "consumer_group:{}".format(name)]
+
+            for mname in CONSUMER_TOPIC_METRICS:
+                aggregator.assert_metric(mname, tags=(tags + consumer_tags), at_least=1)
+
+            for partition in partitions:
+                tags += ["partition:{}".format(partition)]
+                for mname in BROKER_METRICS:
+                    aggregator.assert_metric(mname, tags=tags, at_least=1)
+                for mname in CONSUMER_METRICS:
+                    aggregator.assert_metric(mname, tags=(tags + consumer_tags), at_least=1)
+
+    # let's reassert for the __consumer_offsets - multiple partitions
+    aggregator.assert_metric('kafka.broker_offset', at_least=1)
+
+
+@pytest.mark.usefixtures('dd_environment', 'kafka_consumer', 'kafka_producer')
+def test_no_partition_lag_kafka(aggregator, kafka_instance):
+    """
+    Testing Kafka_consumer check.
+    """
+    no_partition_lag_kafka_instance = copy.deepcopy(kafka_instance)
+    no_partition_lag_kafka_instance['aggregate_consumer_lag'] = True
+    no_partition_lag_kafka_instance['per_partition_consumer_lag'] = False
+
+    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, {})
+    kafka_consumer_check.check(no_partition_lag_kafka_instance)
+
+    for name, consumer_group in iteritems(no_partition_lag_kafka_instance['consumer_groups']):
+        for topic, partitions in iteritems(consumer_group):
+            tags = ["topic:{}".format(topic)] + ['optional:tag1']
+            consumer_tags = ["source:kafka", "consumer_group:{}".format(name)]
+
+            for mname in CONSUMER_TOPIC_METRICS:
+                aggregator.assert_metric(mname, tags=(tags + consumer_tags), at_least=1)
+
+            for partition in partitions:
+                tags += ["partition:{}".format(partition)]
+                for mname in BROKER_METRICS:
+                    aggregator.assert_metric(mname, tags=tags, at_least=1)
+                for mname in CONSUMER_METRICS:
+                    assertion = {'count': 0} if mname == CONSUMER_PARTITION_LAG_METRIC else {'at_least': 1}
+                    aggregator.assert_metric(mname, tags=(tags + consumer_tags), **assertion)
 
     # let's reassert for the __consumer_offsets - multiple partitions
     aggregator.assert_metric('kafka.broker_offset', at_least=1)

--- a/kafka_consumer/tests/test_kafka_consumer_zk.py
+++ b/kafka_consumer/tests/test_kafka_consumer_zk.py
@@ -19,9 +19,15 @@ BROKER_METRICS = [
     'kafka.broker_offset',
 ]
 
+CONSUMER_PARTITION_LAG_METRIC = 'kafka.consumer_lag'
+
 CONSUMER_METRICS = [
     'kafka.consumer_offset',
-    'kafka.consumer_lag',
+    CONSUMER_PARTITION_LAG_METRIC
+]
+
+CONSUMER_TOPIC_METRICS = [
+    'kafka.consumer_lag.total',
 ]
 
 
@@ -35,14 +41,18 @@ def test_check_zk(aggregator, zk_instance):
 
     for name, consumer_group in iteritems(zk_instance['consumer_groups']):
         for topic, partitions in iteritems(consumer_group):
+            tags = ["topic:{}".format(topic)]
+            consumer_tags = ["source:zk", "consumer_group:{}".format(name)]
+
+            for mname in CONSUMER_TOPIC_METRICS:
+                aggregator.assert_metric(mname, tags=(tags + consumer_tags), count=0)
+
             for partition in partitions:
-                tags = ["topic:{}".format(topic),
-                        "partition:{}".format(partition)]
+                tags += ["partition:{}".format(partition)]
                 for mname in BROKER_METRICS:
                     aggregator.assert_metric(mname, tags=tags, at_least=1)
                 for mname in CONSUMER_METRICS:
-                    aggregator.assert_metric(mname, tags=tags +
-                                             ["source:zk", "consumer_group:{}".format(name)], at_least=1)
+                    aggregator.assert_metric(mname, tags=(tags + consumer_tags), at_least=1)
 
     # let's reassert for the __consumer_offsets - multiple partitions
     aggregator.assert_metric('kafka.broker_offset', at_least=1)
@@ -97,3 +107,65 @@ def test_check_nogroups_zk(aggregator, zk_instance):
         else:
             for mname in BROKER_METRICS + CONSUMER_METRICS:
                 aggregator.assert_metric(mname, at_least=1)
+
+
+@pytest.mark.usefixtures('dd_environment', 'kafka_producer', 'zk_consumer')
+def test_aggregate_lag_zk(aggregator, zk_instance):
+    """
+    Testing Kafka_consumer check.
+    """
+    aggregate_lag_zk_instance = copy.deepcopy(zk_instance)
+    aggregate_lag_zk_instance['aggregate_consumer_lag'] = True
+
+    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, {})
+    kafka_consumer_check.check(aggregate_lag_zk_instance)
+
+    for name, consumer_group in iteritems(aggregate_lag_zk_instance['consumer_groups']):
+        for topic, partitions in iteritems(consumer_group):
+            tags = ["topic:{}".format(topic)]
+            consumer_tags = ["source:zk", "consumer_group:{}".format(name)]
+
+            for mname in CONSUMER_TOPIC_METRICS:
+                aggregator.assert_metric(mname, tags=(tags + consumer_tags), at_least=1)
+
+            for partition in partitions:
+                tags += ["partition:{}".format(partition)]
+                for mname in BROKER_METRICS:
+                    aggregator.assert_metric(mname, tags=tags, at_least=1)
+                for mname in CONSUMER_METRICS:
+                    aggregator.assert_metric(mname, tags=(tags + consumer_tags), at_least=1)
+
+    # let's reassert for the __consumer_offsets - multiple partitions
+    aggregator.assert_metric('kafka.broker_offset', at_least=1)
+
+
+@pytest.mark.usefixtures('dd_environment', 'kafka_producer', 'zk_consumer')
+def test_no_partition_lag_zk(aggregator, zk_instance):
+    """
+    Testing Kafka_consumer check.
+    """
+    no_partition_lag_zk_instance = copy.deepcopy(zk_instance)
+    no_partition_lag_zk_instance['aggregate_consumer_lag'] = True
+    no_partition_lag_zk_instance['per_partition_consumer_lag'] = False
+
+    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, {})
+    kafka_consumer_check.check(no_partition_lag_zk_instance)
+
+    for name, consumer_group in iteritems(no_partition_lag_zk_instance['consumer_groups']):
+        for topic, partitions in iteritems(consumer_group):
+            tags = ["topic:{}".format(topic)]
+            consumer_tags = ["source:zk", "consumer_group:{}".format(name)]
+
+            for mname in CONSUMER_TOPIC_METRICS:
+                aggregator.assert_metric(mname, tags=(tags + consumer_tags), at_least=1)
+
+            for partition in partitions:
+                tags += ["partition:{}".format(partition)]
+                for mname in BROKER_METRICS:
+                    aggregator.assert_metric(mname, tags=tags, at_least=1)
+                for mname in CONSUMER_METRICS:
+                    assertion = {'count': 0} if mname == CONSUMER_PARTITION_LAG_METRIC else {'at_least': 1}
+                    aggregator.assert_metric(mname, tags=(tags + consumer_tags), **assertion)
+
+    # let's reassert for the __consumer_offsets - multiple partitions
+    aggregator.assert_metric('kafka.broker_offset', at_least=1)


### PR DESCRIPTION
### What does this PR do?

- Add a metric for the sum total lag across all monitored partitions
  for a topic
- Add a configuration flag to enable/disable total lag and
  per-partition lag

### Motivation

Per-partition consumer lag metrics generates a large volume of metrics for any reasonable number of topics and partitions. In many cases, all you really want to track is the total consumer lag across all partitions. While you can calculate the sum across all partitions through Datadog graphing, you quickly run into issues if the check runs on multiple hosts (e.g. on all Kafka brokers or consumers) as you can only perform one level of aggregation.

Collecting a metric that represents the sum total consumer lag across all partitions solves both problems. It limits the consumer lag metric to a single metric per consumer group and topic. It also allows aggregations across hosts or other tags. 

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

When making the change, I was faced with a dilemma. The current check only collects offset metrics for partitions that have been explicitly listed (or all partitions if no partitions are listed). In order to limit the amount of refactoring, the simplest thing to do was simply calculate total lag across the partitions for which offset metrics were being collected. This can be confusing at first, but seems more correct. If you've limited collection to a set of partitions, then total lag should only be calculated against those partitions. It's also more flexible as you can always define multiple instances with different configurations.

Also, the check defaults to enabling per partition lag and disabling total lag. This ensures the default behavior of the check remains the same. However, I adjusted the example config to favor enabling the total lag and disabling per partition lag. This is based on the assumption that this would reduce the number of times people hit the partition context limit.
