### PR TITLE
Allow pre-release tags to trigger pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,7 @@
 test:
   only:
     - master
+    # e.g.: any_check-X.Y.Z-rc.N
+    - /-\d\.\d\.\d-(rc|pre|alpha|beta)\.\d+$/
   script: if [ -n "$DD_TEST_CMD" ] ; then eval "$DD_TEST_CMD" ; else echo "skipping, DD_TEST_CMD is not set" ; fi
   tags: [ "runner:main", "size:large" ]


### PR DESCRIPTION
### What does this PR do?

Allows this example workflow to trigger build pipeline on a branch:

```console
$ ddev release make mysql minor,rc
$ ddev release tag mysql
```

### Motivation

Need way to build development releases for customers