### PR TITLE
Properly check required server fields exist

### DIFF
--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -863,8 +863,12 @@ class OpenStackControllerCheck(AgentCheck):
             new_server['availability_zone'] = server.get('OS-EXT-AZ:availability_zone')
 
             # Confirm that the new server has all the required fields
-            if not all(key in new_server for key in SERVER_FIELDS_REQ):
-                self.log.debug("Server {} is missing one of the required keys. Not adding to cache".format(new_server))
+            if not all(new_server[key] is not None for key in SERVER_FIELDS_REQ):
+                self.log.debug(
+                    "Server {} has None for one of the required keys."
+                    "Not collecting server metrics for this server."
+                    .format(new_server)
+                )
                 continue
 
             # Update our cached list of servers


### PR DESCRIPTION
### What does this PR do?

Checks that the value of the required server fields returned by Nova aren't empty before adding them to the server cache. 

### Motivation

There may be orphaned servers that can't have data collected. The solution for that was to have a set of required server attributes that must be present in order for the check to consider it a server we can collect metrics from. This fixes that approach by not just checking that the key exists (because it always will) but that the value itself is not None. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
