### PR TITLE
Don't send leader tag with health service check

### DIFF
--- a/etcd/datadog_checks/etcd/etcd.py
+++ b/etcd/datadog_checks/etcd/etcd.py
@@ -167,18 +167,12 @@ class Etcd(OpenMetricsBaseCheck):
                 )
             )
 
-        custom_tags = list(scraper_config['custom_tags'])
-        tags = list(custom_tags)
-
+        tags = []
         self.add_leader_state_tag(scraper_config, tags)
 
-        # Add leader tag for the duration of this run
-        scraper_config['custom_tags'][:] = tags
+        scraper_config['_metric_tags'][:] = tags
 
-        try:
-            self.process(scraper_config)
-        finally:
-            scraper_config['custom_tags'][:] = custom_tags
+        self.process(scraper_config)
 
     def check_pre_v3(self, instance):
         if 'url' not in instance:

--- a/etcd/tests/test_etcd.py
+++ b/etcd/tests/test_etcd.py
@@ -39,9 +39,13 @@ def test_check(aggregator, instance):
     check = Etcd('etcd', {}, {}, [instance])
     check.check(instance)
 
+    tags = [
+        'is_leader:{}'.format('true' if is_leader(URL) else 'false')
+    ]
+
     for metric in itervalues(METRIC_MAP):
         try:
-            aggregator.assert_metric(metric)
+            aggregator.assert_metric(metric, tags=tags)
         except AssertionError:
             pass
 
@@ -55,7 +59,6 @@ def test_service_check(aggregator, instance):
 
     tags = [
         'endpoint:{}'.format(instance['prometheus_url']),
-        'is_leader:{}'.format('true' if is_leader(URL) else 'false')
     ]
 
     aggregator.assert_service_check('etcd.prometheus.health', Etcd.OK, tags=tags, count=1)


### PR DESCRIPTION
### Motivation

So health state changes aren't flaky due to inconsistent tags e.g. if critical when leader true then becomes ok with leader changed it's still critical in backend

No changelog since new version is not yet released