### PR TITLE
Fixed docs with the new base package layout

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -269,8 +269,7 @@ class AgentCheck(object):
         prefix.b.c
         :param metric The metric name to normalize
         :param prefix A prefix to to add to the normalized name, default None
-        :param fix_case A boolean, indicating whether to make sure that
-                        the metric name returned is in underscore_case
+        :param fix_case A boolean, indicating whether to make sure that the metric name returned is in underscore_case
         """
         if isinstance(metric, text_type):
             metric_name = unicodedata.normalize('NFKD', metric).encode('ascii', 'ignore')

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -269,7 +269,7 @@ class AgentCheck(object):
         prefix.b.c
         :param metric The metric name to normalize
         :param prefix A prefix to to add to the normalized name, default None
-        :param fix_case A boolean, indicating whether to make sure that the metric name returned is in underscore_case
+        :param fix_case A boolean, indicating whether to make sure that the metric name returned is in "snake_case"
         """
         if isinstance(metric, text_type):
             metric_name = unicodedata.normalize('NFKD', metric).encode('ascii', 'ignore')

--- a/datadog_checks_base/datadog_checks/base/checks/libs/thread_pool.py
+++ b/datadog_checks_base/datadog_checks/base/checks/libs/thread_pool.py
@@ -321,7 +321,7 @@ class ApplyResult(object):
     the Job didn't process yet. It's possible to use this object to
     wait for the result/exception of the job to be available.
 
-    The result objects returns by the Pool::*_async() methods are of
+    The result objects returns by the `Pool::*_async()` methods are of
     this type"""
     def __init__(self, collector=None, callback=None):
         """

--- a/datadog_checks_base/datadog_checks/base/checks/libs/thread_pool.py
+++ b/datadog_checks_base/datadog_checks/base/checks/libs/thread_pool.py
@@ -321,7 +321,7 @@ class ApplyResult(object):
     the Job didn't process yet. It's possible to use this object to
     wait for the result/exception of the job to be available.
 
-    The result objects returns by the `Pool::*_async()` methods are of
+    The result object(s) returned by the `Pool::*_async()` methods are of
     this type"""
     def __init__(self, collector=None, callback=None):
         """

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -14,7 +14,7 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
     Minimal example configuration::
 
         instances:
-        - prometheus_url: http://foobar/endpoint
+        - prometheus_url: http://example.com/endpoint
             namespace: "foobar"
             metrics:
             - bar

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -10,15 +10,15 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
     """
     OpenMetricsBaseCheck is a class that helps instantiating PrometheusCheck only
     with YAML configurations. As each check has it own states it maintains a map
-    of all checks so that the one corresponding to the instance is executed
+    of all checks so that the one corresponding to the instance is executed.
+    Minimal example configuration::
 
-    Minimal example configuration:
-    instances:
-    - prometheus_url: http://foobar/endpoint
-        namespace: "foobar"
-        metrics:
-        - bar
-        - foo
+        instances:
+        - prometheus_url: http://foobar/endpoint
+            namespace: "foobar"
+            metrics:
+            - bar
+            - foo
     """
     DEFAULT_METRIC_LIMIT = 2000
 

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
@@ -74,15 +74,15 @@ class GenericPrometheusCheck(AgentCheck):
     """
     GenericPrometheusCheck is a class that helps instantiating PrometheusCheck only
     with YAML configurations. As each check has it own states it maintains a map
-    of all checks so that the one corresponding to the instance is executed
+    of all checks so that the one corresponding to the instance is executed.
+    Minimal example configuration::
 
-    Minimal example configuration:
-    instances:
-    - prometheus_url: http://foobar/endpoint
-        namespace: "foobar"
-        metrics:
-        - bar
-        - foo
+        instances:
+        - prometheus_url: http://foobar/endpoint
+            namespace: "foobar"
+            metrics:
+            - bar
+            - foo
     """
     DEFAULT_METRIC_LIMIT = 2000
 

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
@@ -78,7 +78,7 @@ class GenericPrometheusCheck(AgentCheck):
     Minimal example configuration::
 
         instances:
-        - prometheus_url: http://foobar/endpoint
+        - prometheus_url: http://example.com/endpoint
             namespace: "foobar"
             metrics:
             - bar

--- a/datadog_checks_base/datadog_checks/base/utils/proxy.py
+++ b/datadog_checks_base/datadog_checks/base/utils/proxy.py
@@ -9,7 +9,7 @@ def config_proxy_skip(proxies, uri, skip_proxy=False):
     """
     Returns an amended copy of the proxies dictionary - used by `requests`,
     it will disable the proxy if the uri provided is to be reached directly.
-    :param proxies dict with existing proxies: 'https', 'http', 'no' as pontential keys
+    :param proxies A dict with existing proxies: `https`, `http`, and `no` are potential keys.
     :param uri URI to determine if a proxy is necessary or not.
     :param skip_proxy If `True`, the returned proxy dictionary will disable all proxies.
     """

--- a/datadog_checks_base/datadog_checks/base/utils/proxy.py
+++ b/datadog_checks_base/datadog_checks/base/utils/proxy.py
@@ -9,10 +9,9 @@ def config_proxy_skip(proxies, uri, skip_proxy=False):
     """
     Returns an amended copy of the proxies dictionary - used by `requests`,
     it will disable the proxy if the uri provided is to be reached directly.
-    Keyword Arguments:
-        proxies -- dict with existing proxies: 'https', 'http', 'no' as pontential keys
-        uri -- uri to determine if proxy is necessary or not.
-        skip_proxy -- if True, the proxy dictionary returned will disable all proxies
+    :param proxies dict with existing proxies: 'https', 'http', 'no' as pontential keys
+    :param uri uri to determine if proxy is necessary or not.
+    :param skip_proxy if True, the proxy dictionary returned will disable all proxies
     """
     parsed_uri = urlparse(uri)
 

--- a/datadog_checks_base/datadog_checks/base/utils/proxy.py
+++ b/datadog_checks_base/datadog_checks/base/utils/proxy.py
@@ -10,7 +10,7 @@ def config_proxy_skip(proxies, uri, skip_proxy=False):
     Returns an amended copy of the proxies dictionary - used by `requests`,
     it will disable the proxy if the uri provided is to be reached directly.
     :param proxies dict with existing proxies: 'https', 'http', 'no' as pontential keys
-    :param uri uri to determine if proxy is necessary or not.
+    :param uri URI to determine if a proxy is necessary or not.
     :param skip_proxy if True, the proxy dictionary returned will disable all proxies
     """
     parsed_uri = urlparse(uri)

--- a/datadog_checks_base/datadog_checks/base/utils/proxy.py
+++ b/datadog_checks_base/datadog_checks/base/utils/proxy.py
@@ -11,7 +11,7 @@ def config_proxy_skip(proxies, uri, skip_proxy=False):
     it will disable the proxy if the uri provided is to be reached directly.
     :param proxies dict with existing proxies: 'https', 'http', 'no' as pontential keys
     :param uri URI to determine if a proxy is necessary or not.
-    :param skip_proxy if True, the proxy dictionary returned will disable all proxies
+    :param skip_proxy If `True`, the returned proxy dictionary will disable all proxies.
     """
     parsed_uri = urlparse(uri)
 

--- a/docs/datadog_checks.checks.libs.rst
+++ b/docs/datadog_checks.checks.libs.rst
@@ -12,7 +12,7 @@ Subpackages
 datadog\_checks.checks.libs.thread\_pool
 ----------------------------------------
 
-.. automodule:: datadog_checks.checks.libs.thread_pool
+.. automodule:: datadog_checks.base.checks.libs.thread_pool
     :members:
     :undoc-members:
     :show-inheritance:
@@ -20,7 +20,7 @@ datadog\_checks.checks.libs.thread\_pool
 datadog\_checks.checks.libs.timer
 ---------------------------------
 
-.. automodule:: datadog_checks.checks.libs.timer
+.. automodule:: datadog_checks.base.checks.libs.timer
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/datadog_checks.checks.libs.vmware.rst
+++ b/docs/datadog_checks.checks.libs.vmware.rst
@@ -4,7 +4,7 @@ datadog\_checks.checks.libs.vmware
 datadog\_checks.checks.libs.vmware.all\_metrics
 -----------------------------------------------
 
-.. automodule:: datadog_checks.checks.libs.vmware.all_metrics
+.. automodule:: datadog_checks.base.checks.libs.vmware.all_metrics
     :members:
     :undoc-members:
     :show-inheritance:
@@ -12,7 +12,7 @@ datadog\_checks.checks.libs.vmware.all\_metrics
 datadog\_checks.checks.libs.vmware.basic\_metrics
 -------------------------------------------------
 
-.. automodule:: datadog_checks.checks.libs.vmware.basic_metrics
+.. automodule:: datadog_checks.base.checks.libs.vmware.basic_metrics
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/datadog_checks.checks.openmetrics.rst
+++ b/docs/datadog_checks.checks.openmetrics.rst
@@ -6,7 +6,7 @@ datadog\_checks.checks.openmetrics
 datadog\_checks.checks.openmetrics.base\_check
 ----------------------------------------------
 
-.. automodule:: datadog_checks.checks.openmetrics.base_check
+.. automodule:: datadog_checks.base.checks.openmetrics.base_check
     :members:
     :undoc-members:
     :show-inheritance:
@@ -14,7 +14,7 @@ datadog\_checks.checks.openmetrics.base\_check
 datadog\_checks.checks.openmetrics.mixins
 -----------------------------------------
 
-.. automodule:: datadog_checks.checks.openmetrics.mixins
+.. automodule:: datadog_checks.base.checks.openmetrics.mixins
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/datadog_checks.checks.prometheus.rst
+++ b/docs/datadog_checks.checks.prometheus.rst
@@ -6,7 +6,7 @@ datadog\_checks.checks.prometheus
 datadog\_checks.checks.prometheus.base\_check
 ---------------------------------------------
 
-.. automodule:: datadog_checks.checks.prometheus.base_check
+.. automodule:: datadog_checks.base.checks.prometheus.base_check
     :members:
     :undoc-members:
     :show-inheritance:
@@ -14,7 +14,7 @@ datadog\_checks.checks.prometheus.base\_check
 datadog\_checks.checks.prometheus.mixins
 ----------------------------------------
 
-.. automodule:: datadog_checks.checks.prometheus.mixins
+.. automodule:: datadog_checks.base.checks.prometheus.mixins
     :members:
     :undoc-members:
     :show-inheritance:
@@ -22,7 +22,7 @@ datadog\_checks.checks.prometheus.mixins
 datadog\_checks.checks.prometheus.prometheus\_base
 --------------------------------------------------
 
-.. automodule:: datadog_checks.checks.prometheus.prometheus_base
+.. automodule:: datadog_checks.base.checks.prometheus.prometheus_base
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/datadog_checks.checks.rst
+++ b/docs/datadog_checks.checks.rst
@@ -15,7 +15,7 @@ Subpackages
 datadog\_checks.checks.base
 ---------------------------
 
-.. automodule:: datadog_checks.checks.base
+.. automodule:: datadog_checks.base.checks.base
     :members:
     :undoc-members:
     :show-inheritance:
@@ -23,7 +23,7 @@ datadog\_checks.checks.base
 datadog\_checks.checks.network
 ------------------------------
 
-.. automodule:: datadog_checks.checks.network
+.. automodule:: datadog_checks.base.checks.network
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/datadog_checks.checks.win.rst
+++ b/docs/datadog_checks.checks.win.rst
@@ -11,7 +11,7 @@ Subpackages
 datadog\_checks.checks.win.winpdh
 ---------------------------------
 
-.. automodule:: datadog_checks.checks.win.winpdh
+.. automodule:: datadog_checks.base.checks.win.winpdh
     :members:
     :undoc-members:
     :show-inheritance:
@@ -19,7 +19,7 @@ datadog\_checks.checks.win.winpdh
 datadog\_checks.checks.win.winpdh\_base
 ---------------------------------------
 
-.. automodule:: datadog_checks.checks.win.winpdh_base
+.. automodule:: datadog_checks.base.checks.win.winpdh_base
     :members:
     :undoc-members:
     :show-inheritance:
@@ -27,7 +27,7 @@ datadog\_checks.checks.win.winpdh\_base
 datadog\_checks.checks.win.winpdh\_stub
 ---------------------------------------
 
-.. automodule:: datadog_checks.checks.win.winpdh_stub
+.. automodule:: datadog_checks.base.checks.win.winpdh_stub
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/datadog_checks.checks.win.wmi.rst
+++ b/docs/datadog_checks.checks.win.wmi.rst
@@ -4,7 +4,7 @@ datadog\_checks.checks.win.wmi
 datadog\_checks.checks.win.wmi.counter\_type
 --------------------------------------------
 
-.. automodule:: datadog_checks.checks.win.wmi.counter_type
+.. automodule:: datadog_checks.base.checks.win.wmi.counter_type
     :members:
     :undoc-members:
     :show-inheritance:
@@ -12,7 +12,7 @@ datadog\_checks.checks.win.wmi.counter\_type
 datadog\_checks.checks.win.wmi.sampler
 --------------------------------------
 
-.. automodule:: datadog_checks.checks.win.wmi.sampler
+.. automodule:: datadog_checks.base.checks.win.wmi.sampler
     :members:
     :undoc-members:
     :show-inheritance:
@@ -21,7 +21,7 @@ datadog\_checks.checks.win.wmi.sampler
 Module contents
 ---------------
 
-.. automodule:: datadog_checks.checks.win.wmi
+.. automodule:: datadog_checks.base.checks.win.wmi
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/datadog_checks.rst
+++ b/docs/datadog_checks.rst
@@ -16,7 +16,7 @@ Subpackages
 datadog\_checks.config
 ----------------------
 
-.. automodule:: datadog_checks.config
+.. automodule:: datadog_checks.base.config
     :members:
     :undoc-members:
     :show-inheritance:
@@ -24,7 +24,7 @@ datadog\_checks.config
 datadog\_checks.errors
 ----------------------
 
-.. automodule:: datadog_checks.errors
+.. automodule:: datadog_checks.base.errors
     :members:
     :undoc-members:
     :show-inheritance:
@@ -32,7 +32,7 @@ datadog\_checks.errors
 datadog\_checks.log
 -------------------
 
-.. automodule:: datadog_checks.log
+.. automodule:: datadog_checks.base.log
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/datadog_checks.stubs.rst
+++ b/docs/datadog_checks.stubs.rst
@@ -4,7 +4,7 @@ datadog\_checks.stubs
 datadog\_checks.stubs.aggregator
 --------------------------------
 
-.. automodule:: datadog_checks.stubs.aggregator
+.. automodule:: datadog_checks.base.stubs.aggregator
     :members:
     :undoc-members:
     :show-inheritance:
@@ -12,7 +12,7 @@ datadog\_checks.stubs.aggregator
 datadog\_checks.stubs.datadog\_agent
 ------------------------------------
 
-.. automodule:: datadog_checks.stubs.datadog_agent
+.. automodule:: datadog_checks.base.stubs.datadog_agent
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/datadog_checks.utils.rst
+++ b/docs/datadog_checks.utils.rst
@@ -4,7 +4,7 @@ datadog\_checks.utils
 datadog\_checks.utils.common
 ----------------------------
 
-.. automodule:: datadog_checks.utils.common
+.. automodule:: datadog_checks.base.utils.common
     :members:
     :undoc-members:
     :show-inheritance:
@@ -12,7 +12,7 @@ datadog\_checks.utils.common
 datadog\_checks.utils.containers
 --------------------------------
 
-.. automodule:: datadog_checks.utils.containers
+.. automodule:: datadog_checks.base.utils.containers
     :members:
     :undoc-members:
     :show-inheritance:
@@ -20,7 +20,7 @@ datadog\_checks.utils.containers
 datadog\_checks.utils.headers
 -----------------------------
 
-.. automodule:: datadog_checks.utils.headers
+.. automodule:: datadog_checks.base.utils.headers
     :members:
     :undoc-members:
     :show-inheritance:
@@ -28,7 +28,7 @@ datadog\_checks.utils.headers
 datadog\_checks.utils.limiter
 -----------------------------
 
-.. automodule:: datadog_checks.utils.limiter
+.. automodule:: datadog_checks.base.utils.limiter
     :members:
     :undoc-members:
     :show-inheritance:
@@ -36,7 +36,7 @@ datadog\_checks.utils.limiter
 datadog\_checks.utils.platform
 ------------------------------
 
-.. automodule:: datadog_checks.utils.platform
+.. automodule:: datadog_checks.base.utils.platform
     :members:
     :undoc-members:
     :show-inheritance:
@@ -44,7 +44,7 @@ datadog\_checks.utils.platform
 datadog\_checks.utils.proxy
 ---------------------------
 
-.. automodule:: datadog_checks.utils.proxy
+.. automodule:: datadog_checks.base.utils.proxy
     :members:
     :undoc-members:
     :show-inheritance:
@@ -52,7 +52,7 @@ datadog\_checks.utils.proxy
 datadog\_checks.utils.subprocess\_output
 ----------------------------------------
 
-.. automodule:: datadog_checks.utils.subprocess_output
+.. automodule:: datadog_checks.base.utils.subprocess_output
     :members:
     :undoc-members:
     :show-inheritance:
@@ -60,7 +60,7 @@ datadog\_checks.utils.subprocess\_output
 datadog\_checks.utils.tailfile
 ------------------------------
 
-.. automodule:: datadog_checks.utils.tailfile
+.. automodule:: datadog_checks.base.utils.tailfile
     :members:
     :undoc-members:
     :show-inheritance:
@@ -68,7 +68,7 @@ datadog\_checks.utils.tailfile
 datadog\_checks.utils.timeout
 -----------------------------
 
-.. automodule:: datadog_checks.utils.timeout
+.. automodule:: datadog_checks.base.utils.timeout
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
### What does this PR do?

Fixes the build on readthedocs

### Motivation

moving stuff down to the `datadog_checks.base` package broke automodule docs generation

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

