### PR TITLE
Collect age(datfrozenxid) to measure the distance to transaction wraparound

### DIFF
--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -52,3 +52,4 @@ postgresql.toast_index_blocks_read,gauge,,block,second,The number of disk blocks
 postgresql.toast_index_blocks_hit,gauge,,block,second,The number of buffer hits in this table's TOAST table index.,0,postgres,toast idx blks hit
 postgresql.transactions.open,gauge,,transaction,,The number of open transactions in this database.,0,postgres,transactions open
 postgresql.transactions.idle_in_transaction,gauge,,transaction,,The number of 'idle in transaction' transactions in this database.,0,postgres,transactions idle_in_transaction
+postgresql.before_xid_wraparound,gauge,,transaction,,The number of transactions that can occur until a transaction wraparound.,0,postgres,tx before xid wraparound

--- a/postgres/tests/test_common.py
+++ b/postgres/tests/test_common.py
@@ -10,6 +10,7 @@ from .common import HOST, PORT, DB_NAME
 
 
 COMMON_METRICS = [
+    'postgresql.before_xid_wraparound',
     'postgresql.connections',
     'postgresql.commits',
     'postgresql.rollbacks',

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -61,11 +61,11 @@ def test_get_instance_with_default(check):
     """
     collect_default_db = False
     res = check._get_instance_metrics(KEY, 'dbname', False, collect_default_db)
-    assert "  AND datname not ilike 'postgres'" in res['query']
+    assert "  AND psd.datname not ilike 'postgres'" in res['query']
 
     collect_default_db = True
     res = check._get_instance_metrics(KEY, 'dbname', False, collect_default_db)
-    assert "  AND datname not ilike 'postgres'" not in res['query']
+    assert "  AND psd.datname not ilike 'postgres'" not in res['query']
 
 
 def test_get_instance_metrics_instance(check):


### PR DESCRIPTION
### What does this PR do?

Postgres can run out of transaction IDs `(2**31)` if autovacuum or `VACUUM` are not run regularly. In order to detect this condition, the postgres check is now collecting `postgresql.before_xid_wraparound` on a per-database basis. When that number reaches 1 million (i.e. the difference between the oldest transaction and the newest transaction is > `2**31` - `10**6`, the database will typically stop accepting new transactions.

### Motivation

This is an occasional but painful way to discover that autovacuum has not run.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

It passes all tests but I have not had a chance to do a live test... Also, first commit in ages for me ;)
