### PR TITLE
Correctly catch LDAP exception when failing to connect to server

### DIFF
--- a/openldap/datadog_checks/openldap/openldap.py
+++ b/openldap/datadog_checks/openldap/openldap.py
@@ -38,8 +38,8 @@ class OpenLDAP(AgentCheck):
             res = conn.bind()
             if not res:
                 raise ldap3.core.exceptions.LDAPBindError("Error binding to server: {}".format(conn.result))
-        except ldap3.core.exceptions.LDAPBindError:
-            self.log.exception("Could not connect to server at %s: %s", url, conn.result)
+        except ldap3.core.exceptions.LDAPExceptionError as e:
+            self.log.exception("Could not connect to server at %s: %s", url, e)
             self.service_check("{}.can_connect".format(METRIC_PREFIX), self.CRITICAL, tags=tags)
             raise
 


### PR DESCRIPTION
### What does this PR do?

Before that, when failing to connect to the server, the exception would not always be caught, thus not sending any Critical service check.
