### PR TITLE
Introduce compatibility layer for `version` detection

### DIFF
--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -12,7 +12,11 @@ try:
 except ImportError:
     from datadog_checks.config import _is_affirmative
 
-from datadog_checks.utils.headers import headers
+# compatability layer
+try:
+    from util import headers
+except ImportError:
+    from datadog_checks.utils.headers import headers
 
 
 class Apache(AgentCheck):

--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -12,11 +12,7 @@ try:
 except ImportError:
     from datadog_checks.config import _is_affirmative
 
-# compatability layer
-try:
-    from util import headers
-except ImportError:
-    from datadog_checks.utils.headers import headers
+from datadog_checks.utils.headers import headers
 
 
 class Apache(AgentCheck):

--- a/datadog_checks_base/datadog_checks/base/utils/headers.py
+++ b/datadog_checks_base/datadog_checks/base/utils/headers.py
@@ -9,15 +9,20 @@ except ImportError:
 
 def headers(agentConfig, **kwargs):
     # Build the request headers
-    if datadog_agent:
-        version = datadog_agent.get_version() or '0.0.0'
-    else:
-        version = agentConfig.get('version', '0.0.0')
+    version = __get_version(agentConfig)
     res = {
-        'User-Agent': 'Datadog Agent/%s' % agentConfig.get('version', version),
+        'User-Agent': 'Datadog Agent/{}'.format(version),
         'Content-Type': 'application/x-www-form-urlencoded',
         'Accept': 'text/html, */*',
     }
     if 'http_host' in kwargs:
         res['Host'] = kwargs['http_host']
     return res
+
+
+def __get_version(agentConfig):
+    if datadog_agent:
+        version = datadog_agent.get_version() or '0.0.0'
+    else:
+        version = agentConfig.get('version', '0.0.0')
+    return version

--- a/datadog_checks_base/datadog_checks/base/utils/headers.py
+++ b/datadog_checks_base/datadog_checks/base/utils/headers.py
@@ -1,12 +1,20 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+try:
+    import datadog_agent
+except ImportError:
+    datadog_agent = None
 
 
 def headers(agentConfig, **kwargs):
     # Build the request headers
+    if datadog_agent:
+        version = datadog_agent.get_version() or '0.0.0'
+    else:
+        version = agentConfig.get('version', '0.0.0')
     res = {
-        'User-Agent': 'Datadog Agent/%s' % agentConfig.get('version', '0.0.0'),
+        'User-Agent': 'Datadog Agent/%s' % agentConfig.get('version', version),
         'Content-Type': 'application/x-www-form-urlencoded',
         'Accept': 'text/html, */*',
     }


### PR DESCRIPTION
### What does this PR do?

Add a compatibility layer in the util/headers file to properly detect agent version between A5 and A6
Side note - Remove the compatibility import from apache

### Motivation

agentConfig is deprecated in Agent 6, and `datadog_agent` should be used instead. 
See https://github.com/DataDog/datadog-agent/blob/6a0668670fe37784b09073556fd198027e477e2d/docs/dev/checks/python/datadog_agent.md for more info. (The use of `from util import headers` is deprecated in A6)

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Its unclear to me if I should use the `datadog_agent.headers()` function directly if available and if that is something we'd want to keep in the Agent instead of checks_base. 