### PR TITLE
Failure to reconnect to PGBouncer when using database URL

### DIFF
--- a/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
+++ b/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
@@ -225,7 +225,8 @@ class PgBouncer(AgentCheck):
             self._collect_stats(db, tags)
         except ShouldRestartException:
             self.log.info("Resetting the connection")
-            db = self._get_connection(key, host, port, user, password, tags=tags, use_cached=False)
+            db = self._get_connection(key, host, port, user, password, tags=tags,
+                                      database_url=database_url, use_cached=False)
             self._collect_stats(db, tags)
 
         redacted_dsn = self._get_redacted_dsn(host, port, user, database_url)


### PR DESCRIPTION
See support case 171619

### What does this PR do?

Fixes an issue with the PGBouncer integration. If the connection is closed (for example when PGBouncer is retarted).

This seems to be specifically when using a database URL to connect instead of the alternative syntax.

Sample logs:-

```
Nov 09 13:30:33 ip-10-0-10-198 agent[1513]: 2018-11-09 13:30:33 UTC | ERROR | (datadog_agent.go:147 in LogMessage) | (pgbouncer.py:111) | Not all metrics may be available
Nov 09 13:30:33 ip-10-0-10-198 agent[1513]: Traceback (most recent call last):
Nov 09 13:30:33 ip-10-0-10-198 agent[1513]: File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/pgbouncer/pgbouncer.py", line 106, in _collect_stats
Nov 09 13:30:33 ip-10-0-10-198 agent[1513]: cursor.execute(query)
Nov 09 13:30:33 ip-10-0-10-198 agent[1513]: File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/psycopg2/extras.py", line 144, in execute
Nov 09 13:30:33 ip-10-0-10-198 agent[1513]: return super(DictCursor, self).execute(query, vars)
Nov 09 13:30:33 ip-10-0-10-198 agent[1513]: OperationalError: server closed the connection unexpectedly
Nov 09 13:30:33 ip-10-0-10-198 agent[1513]: This probably means the server terminated abnormally
Nov 09 13:30:33 ip-10-0-10-198 agent[1513]: before or while processing the request.
Nov 09 13:30:33 ip-10-0-10-198 agent[1513]: 2018-11-09 13:30:33 UTC | ERROR | (datadog_agent.go:147 in LogMessage) | (pgbouncer.py:111) | Not all metrics may be available
Nov 09 13:30:33 ip-10-0-10-198 agent[1513]: Traceback (most recent call last):
Nov 09 13:30:33 ip-10-0-10-198 agent[1513]: File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/pgbouncer/pgbouncer.py", line 106, in _collect_stats
Nov 09 13:30:33 ip-10-0-10-198 agent[1513]: cursor.execute(query)
Nov 09 13:30:33 ip-10-0-10-198 agent[1513]: File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/psycopg2/extras.py", line 144, in execute
Nov 09 13:30:33 ip-10-0-10-198 agent[1513]: return super(DictCursor, self).execute(query, vars)
Nov 09 13:30:33 ip-10-0-10-198 agent[1513]: InterfaceError: cursor already closed
Nov 09 13:30:48 ip-10-0-10-198 agent[1513]: 2018-11-09 13:30:48 UTC | ERROR | (datadog_agent.go:147 in LogMessage) | (pgbouncer.py:131) | Connection error
Nov 09 13:30:48 ip-10-0-10-198 agent[1513]: Traceback (most recent call last):
Nov 09 13:30:48 ip-10-0-10-198 agent[1513]: File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/pgbouncer/pgbouncer.py", line 98, in _collect_stats
Nov 09 13:30:48 ip-10-0-10-198 agent[1513]: with db.cursor(cursor_factory=pgextras.DictCursor) as cursor:
Nov 09 13:30:48 ip-10-0-10-198 agent[1513]: InterfaceError: connection already closed
Nov 09 13:30:48 ip-10-0-10-198 agent[1513]: 2018-11-09 13:30:48 UTC | INFO | (datadog_agent.go:151 in LogMessage) | (pgbouncer.py:227) | Resetting the connection
Nov 09 13:30:48 ip-10-0-10-198 agent[1513]: 2018-11-09 13:30:48 UTC | ERROR | (runner.go:289 in work) | Error running check pgbouncer: [{"message": "Please specify a PgBouncer host to connect to.", "traceback": "Traceback (most recent call last):\n File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/base.py\", line 366, in run\n self.check(copy.deepcopy(self.instances[0]))\n File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/pgbouncer/pgbouncer.py\", line 228, in check\n db = self._get_connection(key, host, port, user, password, tags=tags, use_cached=False)\n File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/pgbouncer/pgbouncer.py\", line 171, in _get_connection\n password=password, database_url=database_url\n File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/pgbouncer/pgbouncer.py\", line 145, in _get_connect_kwargs\n \"Please specify a PgBouncer host to connect to.\")\nCheckException: Please specify a PgBouncer host to connect to.\n"}]
Nov 09 13:31:03 ip-10-0-10-198 agent[1513]: 2018-11-09 13:31:03 UTC | ERROR | (datadog_agent.go:147 in LogMessage) | (pgbouncer.py:131) | Connection error
Nov 09 13:31:03 ip-10-0-10-198 agent[1513]: Traceback (most recent call last):
Nov 09 13:31:03 ip-10-0-10-198 agent[1513]: File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/pgbouncer/pgbouncer.py", line 98, in _collect_stats
Nov 09 13:31:03 ip-10-0-10-198 agent[1513]: with db.cursor(cursor_factory=pgextras.DictCursor) as cursor:
Nov 09 13:31:03 ip-10-0-10-198 agent[1513]: InterfaceError: connection already closed
Nov 09 13:31:03 ip-10-0-10-198 agent[1513]: 2018-11-09 13:31:03 UTC | INFO | (datadog_agent.go:151 in LogMessage) | (pgbouncer.py:227) | Resetting the connection
Nov 09 13:31:03 ip-10-0-10-198 agent[1513]: 2018-11-09 13:31:03 UTC | ERROR | (runner.go:289 in work) | Error running check pgbouncer: [{"message": "Please specify a PgBouncer host to connect to.", "traceback": "Traceback (most recent call last):\n File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/base.py\", line 366, in run\n self.check(copy.deepcopy(self.instances[0]))\n File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/pgbouncer/pgbouncer.py\", line 228, in check\n db = self._get_connection(key, host, port, user, password, tags=tags, use_cached=False)\n File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/pgbouncer/pgbouncer.py\", line 171, in _get_connection\n password=password, database_url=database_url\n File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/pgbouncer/pgbouncer.py\", line 145, in _get_connect_kwargs\n \"Please specify a PgBouncer host to connect to.\")\nCheckException: Please specify a PgBouncer host to connect to.\n"}]
Nov 09 13:31:18 ip-10-0-10-198 agent[1513]: 2018-11-09 13:31:18 UTC | ERROR | (datadog_agent.go:147 in LogMessage) | (pgbouncer.py:131) | Connection error
Nov 09 13:31:18 ip-10-0-10-198 agent[1513]: Traceback (most recent call last):
Nov 09 13:31:18 ip-10-0-10-198 agent[1513]: File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/pgbouncer/pgbouncer.py", line 98, in _collect_stats
Nov 09 13:31:18 ip-10-0-10-198 agent[1513]: with db.cursor(cursor_factory=pgextras.DictCursor) as cursor:
Nov 09 13:31:18 ip-10-0-10-198 agent[1513]: InterfaceError: connection already closed
Nov 09 13:31:18 ip-10-0-10-198 agent[1513]: 2018-11-09 13:31:18 UTC | INFO | (datadog_agent.go:151 in LogMessage) | (pgbouncer.py:227) | Resetting the connection
Nov 09 13:31:18 ip-10-0-10-198 agent[1513]: 2018-11-09 13:31:18 UTC | ERROR | (runner.go:289 in work) | Error running check pgbouncer: [{"message": "Please specify a PgBouncer host to connect to.", "traceback": "Traceback (most recent call last):\n File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/base.py\", line 366, in run\n self.check(copy.deepcopy(self.instances[0]))\n File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/pgbouncer/pgbouncer.py\", line 228, in check\n db = self._get_connection(key, host, port, user, password, tags=tags, use_cached=False)\n File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/pgbouncer/pgbouncer.py\", line 171, in _get_connection\n password=password, database_url=database_url\n File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/pgbouncer/pgbouncer.py\", line 145, in _get_connect_kwargs\n \"Please specify a PgBouncer host to connect to.\")\nCheckException: Please specify a PgBouncer host to connect to.\n"}]
```

The error is caused by a missing parameter in the retry path in the code.

### Motivation

This bug is affecting my use of the product.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
