### PR TITLE
Refactor validations under `validate` command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,17 +43,19 @@ jobs:
   include:
     - stage: test_changed
       script:
-        - ddev dep verify
-        - ddev manifest verify --include-extras
-        - ddev metadata verify
+        - ddev validate dep
+        - ddev validate manifest --include-extras
+        - ddev validate metadata
+        - ddev validate service-checks
         - ddev test --cov
         - ddev test --bench || true
     - stage: test
       env: CHECK=datadog_checks_base PYTHON3=true
       script:
-        - ddev dep verify
-        - ddev manifest verify --include-extras
-        - ddev metadata verify
+        - ddev validate dep
+        - ddev validate manifest --include-extras
+        - ddev validate metadata
+        - ddev validate service-checks
         - travis_retry ddev test --cov ${CHECK}
         - ddev test ${CHECK} --bench || true
     - stage: test

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/__init__.py
@@ -6,13 +6,11 @@ from .config import config
 from .create import create
 from .dep import dep
 from .env import env
-from .manifest import manifest
 from .meta import meta
-from .metadata import metadata
 from .release import release
 from .run import run
-from .service_checks import service_checks
 from .test import test
+from .validate import validate
 
 ALL_COMMANDS = (
     clean,
@@ -20,11 +18,9 @@ ALL_COMMANDS = (
     create,
     dep,
     env,
-    manifest,
     meta,
-    metadata,
     release,
     run,
-    service_checks,
     test,
+    validate,
 )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -56,56 +56,9 @@ def display_package_changes(pre_packages, post_packages, indent=''):
             ))
 
 
-def display_multiple_attributes(attributes, message):
-    echo_failure(message)
-    for attribute, checks in sorted(iteritems(attributes)):
-        if len(checks) == 1:
-            echo_info('    {}: {}'.format(attribute, checks[0]))
-        elif len(checks) == 2:
-            echo_info('    {}: {} and {}'.format(attribute, checks[0], checks[1]))
-        else:
-            remaining = len(checks) - 2
-            echo_info('    {}: {}, {}, and {} other{}'.format(
-                attribute,
-                checks[0],
-                checks[1],
-                remaining,
-                's' if remaining > 1 else ''
-            ))
-
-
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Manage dependencies')
 def dep():
     pass
-
-
-@dep.command(
-    context_settings=CONTEXT_SETTINGS,
-    short_help='Verify the uniqueness of dependency versions across all checks'
-)
-def verify():
-    """Verify the uniqueness of dependency versions across all checks."""
-    all_packages, _ = collect_packages()
-    failed = False
-
-    for package, package_data in sorted(iteritems(all_packages)):
-        versions = package_data['versions']
-        if len(versions) > 1:
-            failed = True
-            display_multiple_attributes(versions, 'Multiple versions found for package `{}`:'.format(package))
-        else:
-            version, checks = get_next(iteritems(versions))
-            if version is None:
-                failed = True
-                echo_failure('Unpinned dependency `{}` in the `{}` check.'.format(package, checks[0]))
-
-        markers = package_data['markers']
-        if len(markers) > 1:
-            failed = True
-            display_multiple_attributes(markers, 'Multiple markers found for package `{}`:'.format(package))
-
-    if failed:
-        abort()
 
 
 @dep.command(

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate.py
@@ -1,0 +1,19 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import click
+
+from .utils import CONTEXT_SETTINGS
+from .validate_commands import ALL_COMMANDS
+
+
+@click.group(
+    context_settings=CONTEXT_SETTINGS,
+    short_help='Verify certain aspects of the repo'
+)
+def validate():
+    pass
+
+
+for command in ALL_COMMANDS:
+    validate.add_command(command)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate_commands/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate_commands/__init__.py
@@ -1,0 +1,14 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from .dep import dep
+from .manifest import manifest
+from .metadata import metadata
+from .service_checks import service_checks
+
+ALL_COMMANDS = (
+    dep,
+    manifest,
+    metadata,
+    service_checks,
+)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate_commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate_commands/dep.py
@@ -1,0 +1,56 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import click
+from six import iteritems
+
+from ..utils import CONTEXT_SETTINGS, abort, echo_failure, echo_info
+from ...dep import collect_packages
+from ....utils import get_next
+
+
+def display_multiple_attributes(attributes, message):
+    echo_failure(message)
+    for attribute, checks in sorted(iteritems(attributes)):
+        if len(checks) == 1:
+            echo_info('    {}: {}'.format(attribute, checks[0]))
+        elif len(checks) == 2:
+            echo_info('    {}: {} and {}'.format(attribute, checks[0], checks[1]))
+        else:
+            remaining = len(checks) - 2
+            echo_info('    {}: {}, {}, and {} other{}'.format(
+                attribute,
+                checks[0],
+                checks[1],
+                remaining,
+                's' if remaining > 1 else ''
+            ))
+
+
+@click.command(
+    context_settings=CONTEXT_SETTINGS,
+    short_help='Verify the uniqueness of dependency versions'
+)
+def dep():
+    """Verify the uniqueness of dependency versions across all checks."""
+    all_packages, _ = collect_packages()
+    failed = False
+
+    for package, package_data in sorted(iteritems(all_packages)):
+        versions = package_data['versions']
+        if len(versions) > 1:
+            failed = True
+            display_multiple_attributes(versions, 'Multiple versions found for package `{}`:'.format(package))
+        else:
+            version, checks = get_next(iteritems(versions))
+            if version is None:
+                failed = True
+                echo_failure('Unpinned dependency `{}` in the `{}` check.'.format(package, checks[0]))
+
+        markers = package_data['markers']
+        if len(markers) > 1:
+            failed = True
+            display_multiple_attributes(markers, 'Multiple markers found for package `{}`:'.format(package))
+
+    if failed:
+        abort()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate_commands/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate_commands/metadata.py
@@ -8,8 +8,8 @@ from io import open
 import click
 from six import PY2, iteritems
 
-from .utils import CONTEXT_SETTINGS, abort, echo_failure, echo_warning
-from ..utils import get_metadata_file, get_metric_sources, load_manifest
+from ..utils import CONTEXT_SETTINGS, abort, echo_failure, echo_warning
+from ...utils import get_metadata_file, get_metric_sources, load_manifest
 
 REQUIRED_HEADERS = {
     'metric_name',
@@ -182,20 +182,12 @@ PROVIDER_INTEGRATIONS = {
 }
 
 
-@click.group(
-    context_settings=CONTEXT_SETTINGS,
-    short_help='Manage metadata files'
-)
-def metadata():
-    pass
-
-
-@metadata.command(
+@click.command(
     context_settings=CONTEXT_SETTINGS,
     short_help='Validate `metadata.csv` files'
 )
 @click.argument('check', required=False)
-def verify(check):
+def metadata(check):
     """Validates metadata.csv files
 
     If `check` is specified, only the check will be validated,

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate_commands/service_checks.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate_commands/service_checks.py
@@ -8,11 +8,11 @@ from collections import OrderedDict
 import click
 from six import string_types
 
-from .utils import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
-from ..constants import get_root
-from ..utils import parse_version_parts
-from ...compat import JSONDecodeError
-from ...utils import file_exists, read_file
+from ..utils import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
+from ...constants import get_root
+from ...utils import parse_version_parts
+from ....compat import JSONDecodeError
+from ....utils import file_exists, read_file
 
 REQUIRED_ATTRIBUTES = {
     'agent_version',
@@ -25,21 +25,13 @@ REQUIRED_ATTRIBUTES = {
 }
 
 
-@click.group(
+@click.command(
+    'service-checks',
     context_settings=CONTEXT_SETTINGS,
-    short_help='Manage service checks files'
+    short_help='Validate `service_checks.json` files'
 )
 def service_checks():
-    pass
-
-
-@service_checks.command(
-    context_settings=CONTEXT_SETTINGS,
-    short_help='Validate all `service_checks.json` files'
-)
-def verify():
     """Validate all `service_checks.json` files."""
-
     root = get_root()
     echo_info("Validating all service_checks.json files...")
     failed_checks = 0


### PR DESCRIPTION
### Motivation

Root was getting unwieldy

### Additional Notes

- Added service check validation to ci
- Got rid of `manifest set` for now, we'll add back as separate command in future if there is any desire