### PR TITLE
Add panic_count_total metric to CoreDNS integration

### DIFF
--- a/coredns/datadog_checks/coredns/coredns.py
+++ b/coredns/datadog_checks/coredns/coredns.py
@@ -16,6 +16,7 @@ DEFAULT_METRICS = {
     'coredns_proxy_request_count_total': 'proxy_request_count',
     'coredns_proxy_request_duration_seconds': 'proxy_request_duration.seconds',
     'coredns_cache_size': 'cache_size.count',
+    'coredns_panic_count_total': 'panic_count.count',
 }
 
 


### PR DESCRIPTION
### What does this PR do?

CoreDNS exposes `coredns_panic_count_total` metric now, which is highly interesting as it will report total Golang panics of the CoreDNS server