### PR TITLE
Support agent repo

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
@@ -16,11 +16,12 @@ from ..utils import dir_exists
 @click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
 @click.option('--core', '-c', is_flag=True, help='Work on `integrations-core`.')
 @click.option('--extras', '-e', is_flag=True, help='Work on `integrations-extras`.')
+@click.option('--agent', '-a', is_flag=True, help='Work on `datadog-agent`.')
 @click.option('--here', '-x', is_flag=True, help='Work on the current location.')
 @click.option('--quiet', '-q', is_flag=True)
 @click.version_option()
 @click.pass_context
-def ddev(ctx, core, extras, here, quiet):
+def ddev(ctx, core, extras, agent, here, quiet):
     if not quiet and not config_file_exists():
         echo_waiting(
             'No config file found, creating one with default settings now...'
@@ -41,6 +42,7 @@ def ddev(ctx, core, extras, here, quiet):
     repo_choice = (
         'core' if core
         else 'extras' if extras
+        else 'agent' if agent
         else config.get('repo', 'core')
     )
 
@@ -50,10 +52,9 @@ def ddev(ctx, core, extras, here, quiet):
     root = os.path.expanduser(config.get(repo_choice, ''))
     if here or not dir_exists(root):
         if not here and not quiet:
-            echo_warning(
-                '`integrations-{}` directory `{}` does not exist, defaulting '
-                'to the current location.'.format(repo_choice, root)
-            )
+            repo = 'datadog-agent' if repo_choice == 'agent' else 'integrations-{}'.format(repo_choice)
+            echo_warning('`{}` directory `{}` does not exist, defaulting to the current location.'.format(repo, root))
+
         root = os.getcwd()
 
     set_root(root)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/config.py
@@ -97,7 +97,7 @@ def set_value(ctx, key, value):
             hide_input=scrubbing
         )
 
-    if key in ('core', 'extras') and not value.startswith('~'):
+    if key in ('core', 'extras', 'agent') and not value.startswith('~'):
         value = os.path.abspath(value)
 
     user_config = new_config = ctx.obj

--- a/datadog_checks_dev/datadog_checks/dev/tooling/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/config.py
@@ -27,6 +27,7 @@ SECRET_KEYS = {
 DEFAULT_CONFIG = OrderedDict([
     ('core', os.path.join('~', 'dd', 'integrations-core')),
     ('extras', os.path.join('~', 'dd', 'integrations-extras')),
+    ('agent', os.path.join('~', 'dd', 'datadog-agent')),
     ('repo', 'core'),
     ('agent6', 'datadog/agent-dev:master'),
     ('agent5', 'datadog/dev-dd-agent:master'),


### PR DESCRIPTION
### Motivation

- Easier Trello releasing for agent teams (no more `ddev -x ...`)
- Everyone will have access to `ddev run` to easily grep, run invoke tasks, etc. for agent from anywhere