### PR TITLE
Rework tagging to be consistent with the live container view and Autodiscovery

### DIFF
--- a/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
+++ b/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
@@ -7,6 +7,3 @@ instances:
 
     # Add additional custom tags to the metrics
     # tags: ['custom:tag']
-
-    # Whitelist some containers label if you want to collect them
-    # label_whitelist: ['']

--- a/ecs_fargate/tests/test_unit.py
+++ b/ecs_fargate/tests/test_unit.py
@@ -20,7 +20,6 @@ def instance():
     return {
         'timeout': '2',
         'tags': INSTANCE_TAGS,
-        'label_whitelist': ['com.amazonaws.ecs.container-name'],
     }
 
 
@@ -50,6 +49,55 @@ def mocked_requests_get(*args, **kwargs):
         return MockResponse(json.loads(f.read()), 200)
 
 
+def mocked_get_tags(entity, _):
+    # Values taken from Agent6's TestParseMetadataV10 test
+    tag_store = {
+        "docker://e8d4a9a20a0d931f8f632ec166b3f71a6ff00450aa7e99607f650e586df7d068": [
+            "docker_image:datadog/docker-dd-agent:latest",
+            "image_name:datadog/docker-dd-agent",
+            "short_image:docker-dd-agent",
+            "image_tag:latest",
+            "cluster_name:pierrem-test-fargate",
+            "task_family:redis-datadog",
+            "task_version:1",
+            "ecs_container_name:dd-agent",
+            "container_id:e8d4a9a20a0d931f8f632ec166b3f71a6ff00450aa7e99607f650e586df7d068",
+            "container_name:ecs-redis-datadog-1-dd-agent-8085fa82d1d3ada5a601",
+            "task_arn:arn:aws:ecs:eu-west-1:172597598159:task/648ca535-cbe0-4de7-b102-28e50b81e888",
+        ],
+        "docker://c912d0f0f204360ee90ce67c0d083c3514975f149b854f38a48deac611e82e48": [
+            "docker_image:redis:latest",
+            "image_name:redis",
+            "short_image:redis",
+            "image_tag:latest",
+            "cluster_name:pierrem-test-fargate",
+            "task_family:redis-datadog",
+            "task_version:1",
+            "ecs_container_name:redis",
+            "container_id:c912d0f0f204360ee90ce67c0d083c3514975f149b854f38a48deac611e82e48",
+            "container_name:ecs-redis-datadog-1-redis-ce99d29f8ce998ed4a00",
+            "task_arn:arn:aws:ecs:eu-west-1:172597598159:task/648ca535-cbe0-4de7-b102-28e50b81e888",
+        ],
+        "docker://39e13ccc425e7777187a603fe33f466a18515030707c4063de1dc1b63d14d411": [
+            "docker_image:amazon/amazon-ecs-pause:0.1.0",
+            "image_name:amazon/amazon-ecs-pause",
+            "short_image:amazon-ecs-pause",
+            "image_tag:0.1.0",
+            "cluster_name:pierrem-test-fargate",
+            "task_family:redis-datadog",
+            "task_version:1",
+            "ecs_container_name:~internal~ecs~pause",
+            "container_id:39e13ccc425e7777187a603fe33f466a18515030707c4063de1dc1b63d14d411",
+            "container_name:ecs-redis-datadog-1-internalecspause-a2df9cefc2938ec19e01",
+            "task_arn:arn:aws:ecs:eu-west-1:172597598159:task/648ca535-cbe0-4de7-b102-28e50b81e888",
+        ],
+    }
+    # Match agent 6.5 behaviour of not accepting None
+    if entity is None:
+        raise ValueError("None is not a valid entity id")
+    return tag_store.get(entity, [])
+
+
 def test_failing_check(check, instance, aggregator):
     """
     Testing fargate metadata endpoint error.
@@ -75,34 +123,60 @@ def test_successful_check(check, instance, aggregator):
     Testing successful fargate check.
     """
     with mock.patch('datadog_checks.ecs_fargate.ecs_fargate.requests.get', side_effect=mocked_requests_get):
-        check.check(instance)
+        with mock.patch("datadog_checks.ecs_fargate.ecs_fargate.get_tags", side_effect=mocked_get_tags):
+            check.check(instance)
 
     aggregator.assert_service_check("fargate_check", status=FargateCheck.OK, tags=INSTANCE_TAGS, count=1)
 
     common_tags = INSTANCE_TAGS + [
-        'ecs_cluster:pierrem-test-fargate', 'ecs_task_family:redis-datadog', 'ecs_task_version:1'
+        # Tagger
+        'cluster_name:pierrem-test-fargate',
+        'task_family:redis-datadog',
+        'task_version:1',
+        # Compat
+        'ecs_cluster:pierrem-test-fargate',
+        'ecs_task_family:redis-datadog',
+        'ecs_task_version:1',
     ]
 
     container_tags = [
         [
-            'docker_image:datadog/docker-dd-agent:latest',
-            'image_name:datadog/docker-dd-agent',
-            'image_tag:latest',
-            'com.amazonaws.ecs.container-name:dd-agent',
+            # Tagger
+            "docker_image:datadog/docker-dd-agent:latest",
+            "image_name:datadog/docker-dd-agent",
+            "short_image:docker-dd-agent",
+            "image_tag:latest",
+            "ecs_container_name:dd-agent",
+            "container_id:e8d4a9a20a0d931f8f632ec166b3f71a6ff00450aa7e99607f650e586df7d068",
+            "container_name:ecs-redis-datadog-1-dd-agent-8085fa82d1d3ada5a601",
+            "task_arn:arn:aws:ecs:eu-west-1:172597598159:task/648ca535-cbe0-4de7-b102-28e50b81e888",
+            # Compat
             'docker_name:ecs-redis-datadog-1-dd-agent-8085fa82d1d3ada5a601'
         ],
         [
-            'docker_image:redis:latest',
-            'image_name:redis',
-            'image_tag:latest',
-            'com.amazonaws.ecs.container-name:redis',
+            # Tagger
+            "docker_image:redis:latest",
+            "image_name:redis",
+            "short_image:redis",
+            "image_tag:latest",
+            "ecs_container_name:redis",
+            "container_id:c912d0f0f204360ee90ce67c0d083c3514975f149b854f38a48deac611e82e48",
+            "container_name:ecs-redis-datadog-1-redis-ce99d29f8ce998ed4a00",
+            "task_arn:arn:aws:ecs:eu-west-1:172597598159:task/648ca535-cbe0-4de7-b102-28e50b81e888",
+            # Compat
             'docker_name:ecs-redis-datadog-1-redis-ce99d29f8ce998ed4a00'
         ],
         [
-            'docker_image:amazon/amazon-ecs-pause:0.1.0',
-            'image_name:amazon/amazon-ecs-pause',
-            'image_tag:0.1.0',
-            'com.amazonaws.ecs.container-name:~internal~ecs~pause',
+            # Tagger
+            "docker_image:amazon/amazon-ecs-pause:0.1.0",
+            "image_name:amazon/amazon-ecs-pause",
+            "short_image:amazon-ecs-pause",
+            "image_tag:0.1.0",
+            "ecs_container_name:~internal~ecs~pause",
+            "container_id:39e13ccc425e7777187a603fe33f466a18515030707c4063de1dc1b63d14d411",
+            "container_name:ecs-redis-datadog-1-internalecspause-a2df9cefc2938ec19e01",
+            "task_arn:arn:aws:ecs:eu-west-1:172597598159:task/648ca535-cbe0-4de7-b102-28e50b81e888",
+            # Compat
             'docker_name:ecs-redis-datadog-1-internalecspause-a2df9cefc2938ec19e01'
         ]
     ]


### PR DESCRIPTION
### What does this PR do?

Sister PR for https://github.com/DataDog/datadog-agent/pull/2675 , using the tagger for container tagging.

- New tags from the tagger: `task_version`, `task_family`, `cluster_name`, `ecs_container_name`, `task_arn`, `container_id`, `container_name`
- Compatibility layer is added to keep the aliased `ecs_task_family`, `ecs_task_version`, `ecs_cluster`, `docker_name`
- `label_whitelist` option is removed, users should migrate to the agent's `docker_labels_as_tags` that works with fargate task labels

### Motivation

Consistent tagging

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
