### PR TITLE
Add restart and container state metrics to kubelet

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -378,7 +378,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
                 for (metric_name, field_name) in [('state', 'state'), ('last_state', 'lastState')]:
                     c_state = ctr_status.get(field_name, {})
 
-                    for state_name in ['running', 'terminated', 'waiting']:
+                    for state_name in ['terminated', 'waiting']:
                         state_reasons = WHITELISTED_CONTAINER_STATE_REASONS.get(state_name, [])
                         self._submit_container_state_metric(metric_name, state_name, c_state, state_reasons, tags)
 
@@ -391,6 +391,8 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
 
             if reason.lower() in state_reasons:
                 reason_tags.append('reason:%s' % (reason))
+            else:
+                return
 
             gauge_name = '{}.containers.{}.{}'.format(self.NAMESPACE, metric_name, state_name)
             self.gauge(gauge_name, 1, tags + reason_tags)

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -50,6 +50,13 @@ FACTORS = {
     'Ei': 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
 }
 
+
+WHITELISTED_CONTAINER_STATE_REASONS = {
+    'waiting': ['errimagepull', 'imagepullbackoff', 'crashloopbackoff', 'containercreating'],
+    'terminated': ['oomkilled', 'containercannotrun', 'error']
+}
+
+
 log = logging.getLogger('collector')
 
 
@@ -158,6 +165,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
         self._report_node_metrics(self.instance_tags)
         self._report_pods_running(self.pod_list, self.instance_tags)
         self._report_container_spec_metrics(self.pod_list, self.instance_tags)
+        self._report_container_state_metrics(self.pod_list, self.instance_tags)
 
         if self.cadvisor_legacy_url:  # Legacy cAdvisor
             self.log.debug('processing legacy cadvisor metrics')
@@ -343,6 +351,46 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
                         self.gauge('{}.{}.limits'.format(self.NAMESPACE, resource), value, tags)
                 except (KeyError, AttributeError) as e:
                     self.log.debug("Unable to retrieve container limits for %s: %s", c_name, e)
+
+    def _report_container_state_metrics(self, pod_list, instance_tags):
+        """Reports container state & reasons by looking at container statuses"""
+        for pod in pod_list['items']:
+            pod_name = pod.get('metadata', {}).get('name')
+            pod_uid = pod.get('metadata', {}).get('uid')
+
+            if not pod_name or not pod_uid:
+                continue
+
+            for ctr_status in pod['status'].get('containerStatuses', []):
+                c_name = ctr_status.get('name')
+                cid = ctr_status.get('containerID')
+                if not c_name or not cid:
+                    continue
+
+                if self.pod_list_utils.is_excluded(cid, pod_uid):
+                    continue
+
+                tags = get_tags('%s' % cid, True) + instance_tags
+
+                for (metric_name, field_name) in [('state', 'state'), ('last_state', 'lastState')]:
+                    c_state = ctr_status.get(field_name, {})
+
+                    for state_name in ['running', 'terminated', 'waiting']:
+                        state_reasons = WHITELISTED_CONTAINER_STATE_REASONS.get(state_name, [])
+                        self._submit_container_state_metric(metric_name, state_name, c_state, state_reasons, tags)
+
+    def _submit_container_state_metric(self, metric_name, state_name, c_state, state_reasons, tags):
+        reason_tags = []
+
+        state_value = c_state.get(state_name)
+        if state_value:
+            reason = state_value.get('reason', '')
+
+            if reason.lower() in state_reasons:
+                reason_tags.append('reason:%s' % (reason))
+
+            gauge_name = '{}.containers.{}.{}'.format(self.NAMESPACE, metric_name, state_name)
+            self.gauge(gauge_name, 1, tags + reason_tags)
 
     @staticmethod
     def parse_quantity(string):

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -372,6 +372,9 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
 
                 tags = get_tags('%s' % cid, True) + instance_tags
 
+                restart_count = ctr_status.get('restartCount', 0)
+                self.gauge(self.NAMESPACE + '.containers.restarts', restart_count, tags)
+
                 for (metric_name, field_name) in [('state', 'state'), ('last_state', 'lastState')]:
                     c_state = ctr_status.get(field_name, {})
 

--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -1,4 +1,9 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+kubernetes.containers.last_state.terminated,gauge,,,,The number of containers that were previously terminated,0,kubelet,k8s.containers.last_state.terminated
+kubernetes.containers.restarts,gauge,,,,The number of times the container has been restarted,1,kubelet,k8s.containers.restarts
+kubernetes.containers.state.running,gauge,,,,The number of currently running containers,0,kubelet,k8s.containers.state.running
+kubernetes.containers.state.terminated,gauge,,,,The number of currently terminated containers,0,kubelet,k8s.containers.state.terminated
+kubernetes.containers.state.waiting,gauge,,,,The number of currently waiting containers,0,kubelet,k8s.containers.state.waiting
 kubernetes.cpu.load.10s.avg,gauge,,,,Container cpu load average over the last 10 seconds,0,kubelet,k8s.cpu.load.10s
 kubernetes.cpu.system.total,rate,,core,,The number of cores used for system time,0,kubelet,k8s.cpu.system
 kubernetes.cpu.user.total,rate,,core,,The number of cores used for user time,0,kubelet,k8s.cpu.user

--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -1,7 +1,6 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 kubernetes.containers.last_state.terminated,gauge,,,,The number of containers that were previously terminated,0,kubelet,k8s.containers.last_state.terminated
 kubernetes.containers.restarts,gauge,,,,The number of times the container has been restarted,1,kubelet,k8s.containers.restarts
-kubernetes.containers.state.running,gauge,,,,The number of currently running containers,0,kubelet,k8s.containers.state.running
 kubernetes.containers.state.terminated,gauge,,,,The number of currently terminated containers,0,kubelet,k8s.containers.state.terminated
 kubernetes.containers.state.waiting,gauge,,,,The number of currently waiting containers,0,kubelet,k8s.containers.state.waiting
 kubernetes.cpu.load.10s.avg,gauge,,,,Container cpu load average over the last 10 seconds,0,kubelet,k8s.cpu.load.10s

--- a/kubelet/tests/fixtures/pods_crashed.json
+++ b/kubelet/tests/fixtures/pods_crashed.json
@@ -1,0 +1,1255 @@
+{
+    "items": [
+        {
+            "status": {
+                "phase": "Pending",
+                "conditions": [
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "PodScheduled",
+                        "lastTransitionTime": "2018-02-13T16:10:24Z"
+                    }
+                ]
+            },
+            "spec": {
+                "dnsPolicy": "ClusterFirst",
+                "securityContext": {},
+                "nodeName": "gke-haissam-default-pool-be5066f1-wnvn",
+                "schedulerName": "default-scheduler",
+                "hostNetwork": true,
+                "terminationGracePeriodSeconds": 30,
+                "restartPolicy": "Always",
+                "volumes": [
+                    {
+                        "hostPath": {
+                            "path": "/usr/share/ca-certificates",
+                            "type": ""
+                        },
+                        "name": "usr-ca-certs"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/etc/ssl/certs",
+                            "type": ""
+                        },
+                        "name": "etc-ssl-certs"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/var/lib/kube-proxy/kubeconfig",
+                            "type": "FileOrCreate"
+                        },
+                        "name": "kubeconfig"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/var/log",
+                            "type": ""
+                        },
+                        "name": "varlog"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/run/xtables.lock",
+                            "type": "FileOrCreate"
+                        },
+                        "name": "iptableslock"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/lib/modules",
+                            "type": ""
+                        },
+                        "name": "lib-modules"
+                    }
+                ],
+                "tolerations": [
+                    {
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    }
+                ],
+                "containers": [
+                    {
+                        "terminationMessagePath": "/dev/termination-log",
+                        "name": "kube-proxy",
+                        "image": "gcr.io/google_containers/kube-proxy:v1.9.2-gke.1",
+                        "volumeMounts": [
+                            {
+                                "readOnly": true,
+                                "mountPath": "/etc/ssl/certs",
+                                "name": "etc-ssl-certs"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/usr/share/ca-certificates",
+                                "name": "usr-ca-certs"
+                            },
+                            {
+                                "mountPath": "/var/log",
+                                "name": "varlog"
+                            },
+                            {
+                                "mountPath": "/var/lib/kube-proxy/kubeconfig",
+                                "name": "kubeconfig"
+                            },
+                            {
+                                "mountPath": "/run/xtables.lock",
+                                "name": "iptableslock"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/lib/modules",
+                                "name": "lib-modules"
+                            }
+                        ],
+                        "terminationMessagePolicy": "File",
+                        "command": [
+                            "/bin/sh",
+                            "-c",
+                            "exec kube-proxy --master=https://35.189.248.80 --kubeconfig=/var/lib/kube-proxy/kubeconfig --cluster-cidr=10.8.0.0/14 --resource-container=\"\" --oom-score-adj=-998 --v=2 --feature-gates=ExperimentalCriticalPodAnnotation=true --iptables-sync-period=1m --iptables-min-sync-period=10s --ipvs-sync-period=1m --ipvs-min-sync-period=10s 1>>/var/log/kube-proxy.log 2>&1"
+                        ],
+                        "imagePullPolicy": "IfNotPresent",
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "resources": {
+                            "requests": {
+                                "cpu": "100m"
+                            }
+                        }
+                    }
+                ]
+            },
+            "metadata": {
+                "name": "kube-proxy-gke-haissam-default-pool-be5066f1-wnvn",
+                "labels": {
+                    "tier": "node",
+                    "component": "kube-proxy"
+                },
+                "namespace": "kube-system",
+                "creationTimestamp": null,
+                "annotations": {
+                    "scheduler.alpha.kubernetes.io/critical-pod": "",
+                    "kubernetes.io/config.hash": "260c2b1d43b094af6d6b4ccba082c2db",
+                    "kubernetes.io/config.source": "file",
+                    "kubernetes.io/config.seen": "2018-02-13T16:10:19.507814572Z"
+                },
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-proxy-gke-haissam-default-pool-be5066f1-wnvn",
+                "uid": "260c2b1d43b094af6d6b4ccba082c2db"
+            }
+        },
+        {
+            "status": {
+                "qosClass": "Burstable",
+                "containerStatuses": [
+                    {
+                        "restartCount": 1,
+                        "name": "fluentd-gcp",
+                        "image": "asia.gcr.io/google-containers/fluentd-gcp:2.0.10",
+                        "imageID": "docker-pullable://asia.gcr.io/google-containers/fluentd-gcp@sha256:a81a2c0137aee9f8a3e870898773976df9b63b27809bed2a4b9297531fb3c3c9",
+                        "state": {
+                            "running": {
+                                "startedAt": "2018-02-13T16:10:45Z"
+                            }
+                        },
+                        "ready": true,
+                        "lastState": {
+                          "terminated": {
+                            "containerID": "docker://3eca48f90f5203547bc1f08fc0e3ee50cb3d82d6014d666075d5d9d1ee6efc16",
+                            "exitCode": 2,
+                            "finishedAt": "2018-02-13T16:05:48Z",
+                            "reason": "OOMKilled",
+                            "startedAt": "2018-02-13T16:01:13Z"
+                          }
+                        },
+                        "containerID": "docker://5741ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76561"
+                    },
+                    {
+                        "restartCount": 0,
+                        "name": "prometheus-to-sd-exporter",
+                        "image": "asia.gcr.io/google-containers/prometheus-to-sd:v0.2.2",
+                        "imageID": "docker-pullable://asia.gcr.io/google-containers/prometheus-to-sd@sha256:5831390762c790b0375c202579fd41dd5f40c71950f7538adbe14b0c16f35d56",
+                        "state": {
+                          "waiting": {
+                            "message": "Back-off 5m0s restarting failed container=prometheus-to-sd-exporter pod=kube-proxy-gke-haissam-default-pool-be5066f1-wnvn_prometheus-to-sd-exporter(986b21ed-d64d-11e8-a227-0adb9c53b1aa)",
+                            "reason": "CrashLoopBackOff"
+                          }
+                        },
+                        "ready": true,
+                        "lastState": {},
+                        "containerID": "docker://580cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b05"
+                    }
+                ],
+                "podIP": "10.8.2.4",
+                "startTime": "2018-02-13T14:57:17Z",
+                "hostIP": "10.132.0.4",
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "Initialized",
+                        "lastTransitionTime": "2018-02-13T14:57:17Z"
+                    },
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "Ready",
+                        "lastTransitionTime": "2018-02-13T16:10:47Z"
+                    },
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "PodScheduled",
+                        "lastTransitionTime": "2018-02-13T14:57:27Z"
+                    }
+                ]
+            },
+            "spec": {
+                "dnsPolicy": "Default",
+                "securityContext": {},
+                "serviceAccountName": "fluentd-gcp",
+                "schedulerName": "default-scheduler",
+                "serviceAccount": "fluentd-gcp",
+                "nodeSelector": {
+                    "beta.kubernetes.io/fluentd-ds-ready": "true"
+                },
+                "terminationGracePeriodSeconds": 30,
+                "restartPolicy": "Always",
+                "volumes": [
+                    {
+                        "hostPath": {
+                            "path": "/var/log",
+                            "type": ""
+                        },
+                        "name": "varlog"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/var/lib/docker/containers",
+                            "type": ""
+                        },
+                        "name": "varlibdockercontainers"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/usr/lib64",
+                            "type": ""
+                        },
+                        "name": "libsystemddir"
+                    },
+                    {
+                        "configMap": {
+                            "name": "fluentd-gcp-config-v1.2.3",
+                            "defaultMode": 420
+                        },
+                        "name": "config-volume"
+                    },
+                    {
+                        "secret": {
+                            "defaultMode": 420,
+                            "secretName": "fluentd-gcp-token-vcd8d"
+                        },
+                        "name": "fluentd-gcp-token-vcd8d"
+                    }
+                ],
+                "tolerations": [
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.alpha.kubernetes.io/ismaster"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/disk-pressure"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/memory-pressure"
+                    }
+                ],
+                "containers": [
+                    {
+                        "livenessProbe": {
+                            "timeoutSeconds": 1,
+                            "exec": {
+                                "command": [
+                                    "/bin/sh",
+                                    "-c",
+                                    "LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300}; STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900}; if [ ! -e /var/log/fluentd-buffers ]; then\n  exit 1;\nfi; LAST_MODIFIED_DATE=`stat /var/log/fluentd-buffers | grep Modify | sed -r \"s/Modify: (.*)/\\1/\"`; LAST_MODIFIED_TIMESTAMP=`date -d \"$LAST_MODIFIED_DATE\" +%s`; if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $STUCK_THRESHOLD_SECONDS` ]; then\n  rm -rf /var/log/fluentd-buffers;\n  exit 1;\nfi; if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $LIVENESS_THRESHOLD_SECONDS` ]; then\n  exit 1;\nfi;\n"
+                                ]
+                            },
+                            "initialDelaySeconds": 600,
+                            "periodSeconds": 60,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "name": "fluentd-gcp",
+                        "image": "gcr.io/google-containers/fluentd-gcp:2.0.10",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/var/log",
+                                "name": "varlog"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/var/lib/docker/containers",
+                                "name": "varlibdockercontainers"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/host/lib",
+                                "name": "libsystemddir"
+                            },
+                            {
+                                "mountPath": "/etc/fluent/config.d",
+                                "name": "config-volume"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "fluentd-gcp-token-vcd8d"
+                            }
+                        ],
+                        "terminationMessagePolicy": "File",
+                        "env": [
+                            {
+                                "name": "FLUENTD_ARGS",
+                                "value": "--no-supervisor -q"
+                            }
+                        ],
+                        "imagePullPolicy": "IfNotPresent",
+                        "resources": {
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "200Mi"
+                            },
+                            "limits": {
+                                "memory": "300Mi"
+                            }
+                        }
+                    },
+                    {
+                        "terminationMessagePath": "/dev/termination-log",
+                        "name": "prometheus-to-sd-exporter",
+                        "image": "gcr.io/google-containers/prometheus-to-sd:v0.2.2",
+                        "volumeMounts": [
+                            {
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "fluentd-gcp-token-vcd8d"
+                            }
+                        ],
+                        "terminationMessagePolicy": "File",
+                        "command": [
+                            "/monitor",
+                            "--stackdriver-prefix=container.googleapis.com/internal/addons",
+                            "--api-override=https://monitoring.googleapis.com/",
+                            "--source=fluentd:http://localhost:31337?whitelisted=stackdriver_successful_requests_count,stackdriver_failed_requests_count,stackdriver_ingested_entries_count,stackdriver_dropped_entries_count",
+                            "--pod-id=$(POD_NAME)",
+                            "--namespace-id=$(POD_NAMESPACE)"
+                        ],
+                        "env": [
+                            {
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "fieldPath": "metadata.name",
+                                        "apiVersion": "v1"
+                                    }
+                                },
+                                "name": "POD_NAME"
+                            },
+                            {
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "fieldPath": "metadata.namespace",
+                                        "apiVersion": "v1"
+                                    }
+                                },
+                                "name": "POD_NAMESPACE"
+                            }
+                        ],
+                        "imagePullPolicy": "IfNotPresent",
+                        "resources": {}
+                    }
+                ],
+                "nodeName": "gke-haissam-default-pool-be5066f1-wnvn"
+            },
+            "metadata": {
+                "name": "fluentd-gcp-v2.0.10-9q9t4",
+                "labels": {
+                    "k8s-app": "fluentd-gcp",
+                    "version": "v2.0.10",
+                    "pod-template-generation": "1",
+                    "kubernetes.io/cluster-service": "true",
+                    "controller-revision-hash": "1108666223"
+                },
+                "namespace": "kube-system",
+                "ownerReferences": [
+                    {
+                        "kind": "DaemonSet",
+                        "name": "fluentd-gcp-v2.0.10",
+                        "apiVersion": "extensions/v1beta1",
+                        "controller": true,
+                        "blockOwnerDeletion": true,
+                        "uid": "77585c76-10cc-11e8-bd5a-42010af00137"
+                    }
+                ],
+                "resourceVersion": "30704838",
+                "generateName": "fluentd-gcp-v2.0.10-",
+                "creationTimestamp": "2018-02-13T14:57:17Z",
+                "annotations": {
+                    "scheduler.alpha.kubernetes.io/critical-pod": "",
+                    "kubernetes.io/config.source": "api",
+                    "kubernetes.io/config.seen": "2018-02-13T16:10:19.509264637Z"
+                },
+                "selfLink": "/api/v1/namespaces/kube-system/pods/fluentd-gcp-v2.0.10-9q9t4",
+                "uid": "2edfd4d9-10ce-11e8-bd5a-42010af00137"
+            }
+        },
+        {
+            "status": {
+                "qosClass": "Burstable",
+                "containerStatuses": [
+                    {
+                        "restartCount": 0,
+                        "name": "fluentd-gcp",
+                        "image": "asia.gcr.io/google-containers/fluentd-gcp:2.0.10",
+                        "imageID": "docker-pullable://asia.gcr.io/google-containers/fluentd-gcp@sha256:a81a2c0137aee9f8a3e870898773976df9b63b27809bed2a4b9297531fb3c3c9",
+                        "state": {
+                            "running": {
+                                "startedAt": "2018-02-13T16:10:45Z"
+                            }
+                        },
+                        "ready": true,
+                        "lastState": {},
+                        "containerID": "docker://6941ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76561"
+                    },
+                    {
+                        "restartCount": 0,
+                        "name": "prometheus-to-sd-exporter",
+                        "image": "asia.gcr.io/google-containers/prometheus-to-sd:v0.2.2",
+                        "imageID": "docker-pullable://asia.gcr.io/google-containers/prometheus-to-sd@sha256:5831390762c790b0375c202579fd41dd5f40c71950f7538adbe14b0c16f35d56",
+                        "state": {
+                            "running": {
+                                "startedAt": "2018-02-13T16:10:46Z"
+                            }
+                        },
+                        "ready": true,
+                        "lastState": {},
+                        "containerID": "docker://690cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b05"
+                    }
+                ],
+                "podIP": "10.8.2.4",
+                "startTime": "2018-02-13T14:57:17Z",
+                "hostIP": "10.132.0.4",
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "Initialized",
+                        "lastTransitionTime": "2018-02-13T14:57:17Z"
+                    },
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "Ready",
+                        "lastTransitionTime": "2018-02-13T16:10:47Z"
+                    },
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "PodScheduled",
+                        "lastTransitionTime": "2018-02-13T14:57:27Z"
+                    }
+                ]
+            },
+            "spec": {
+                "dnsPolicy": "Default",
+                "securityContext": {},
+                "serviceAccountName": "fluentd-gcp",
+                "schedulerName": "default-scheduler",
+                "serviceAccount": "fluentd-gcp",
+                "nodeSelector": {
+                    "beta.kubernetes.io/fluentd-ds-ready": "true"
+                },
+                "terminationGracePeriodSeconds": 30,
+                "restartPolicy": "Always",
+                "volumes": [
+                    {
+                        "hostPath": {
+                            "path": "/var/log",
+                            "type": ""
+                        },
+                        "name": "varlog"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/var/lib/docker/containers",
+                            "type": ""
+                        },
+                        "name": "varlibdockercontainers"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/usr/lib64",
+                            "type": ""
+                        },
+                        "name": "libsystemddir"
+                    },
+                    {
+                        "configMap": {
+                            "name": "fluentd-gcp-config-v1.2.3",
+                            "defaultMode": 420
+                        },
+                        "name": "config-volume"
+                    },
+                    {
+                        "secret": {
+                            "defaultMode": 420,
+                            "secretName": "fluentd-gcp-token-vcd8d"
+                        },
+                        "name": "fluentd-gcp-token-vcd8d"
+                    }
+                ],
+                "tolerations": [
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.alpha.kubernetes.io/ismaster"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/disk-pressure"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/memory-pressure"
+                    }
+                ],
+                "containers": [
+                    {
+                        "livenessProbe": {
+                            "timeoutSeconds": 1,
+                            "exec": {
+                                "command": [
+                                    "/bin/sh",
+                                    "-c",
+                                    "LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300}; STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900}; if [ ! -e /var/log/fluentd-buffers ]; then\n  exit 1;\nfi; LAST_MODIFIED_DATE=`stat /var/log/fluentd-buffers | grep Modify | sed -r \"s/Modify: (.*)/\\1/\"`; LAST_MODIFIED_TIMESTAMP=`date -d \"$LAST_MODIFIED_DATE\" +%s`; if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $STUCK_THRESHOLD_SECONDS` ]; then\n  rm -rf /var/log/fluentd-buffers;\n  exit 1;\nfi; if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $LIVENESS_THRESHOLD_SECONDS` ]; then\n  exit 1;\nfi;\n"
+                                ]
+                            },
+                            "initialDelaySeconds": 600,
+                            "periodSeconds": 60,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "name": "fluentd-gcp",
+                        "image": "gcr.io/google-containers/fluentd-gcp:2.0.10",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/var/log",
+                                "name": "varlog"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/var/lib/docker/containers",
+                                "name": "varlibdockercontainers"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/host/lib",
+                                "name": "libsystemddir"
+                            },
+                            {
+                                "mountPath": "/etc/fluent/config.d",
+                                "name": "config-volume"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "fluentd-gcp-token-vcd8d"
+                            }
+                        ],
+                        "terminationMessagePolicy": "File",
+                        "env": [
+                            {
+                                "name": "FLUENTD_ARGS",
+                                "value": "--no-supervisor -q"
+                            }
+                        ],
+                        "imagePullPolicy": "IfNotPresent",
+                        "resources": {
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "200Mi"
+                            },
+                            "limits": {
+                                "memory": "300Mi"
+                            }
+                        }
+                    },
+                    {
+                        "terminationMessagePath": "/dev/termination-log",
+                        "name": "prometheus-to-sd-exporter",
+                        "image": "gcr.io/google-containers/prometheus-to-sd:v0.2.2",
+                        "volumeMounts": [
+                            {
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "fluentd-gcp-token-vcd8d"
+                            }
+                        ],
+                        "terminationMessagePolicy": "File",
+                        "command": [
+                            "/monitor",
+                            "--stackdriver-prefix=container.googleapis.com/internal/addons",
+                            "--api-override=https://monitoring.googleapis.com/",
+                            "--source=fluentd:http://localhost:31337?whitelisted=stackdriver_successful_requests_count,stackdriver_failed_requests_count,stackdriver_ingested_entries_count,stackdriver_dropped_entries_count",
+                            "--pod-id=$(POD_NAME)",
+                            "--namespace-id=$(POD_NAMESPACE)"
+                        ],
+                        "env": [
+                            {
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "fieldPath": "metadata.name",
+                                        "apiVersion": "v1"
+                                    }
+                                },
+                                "name": "POD_NAME"
+                            },
+                            {
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "fieldPath": "metadata.namespace",
+                                        "apiVersion": "v1"
+                                    }
+                                },
+                                "name": "POD_NAMESPACE"
+                            }
+                        ],
+                        "imagePullPolicy": "IfNotPresent",
+                        "resources": {}
+                    }
+                ],
+                "nodeName": "gke-haissam-default-pool-be5066f1-wnvn"
+            },
+            "metadata": {
+                "name": "fluentd-gcp-v2.0.10-9q9t4",
+                "labels": {
+                    "k8s-app": "fluentd-gcp",
+                    "version": "v2.0.10",
+                    "pod-template-generation": "1",
+                    "kubernetes.io/cluster-service": "true",
+                    "controller-revision-hash": "1108666223"
+                },
+                "namespace": "kube-system",
+                "ownerReferences": [
+                    {
+                        "kind": "DaemonSet",
+                        "name": "fluentd-gcp-v2.0.10",
+                        "apiVersion": "extensions/v1beta1",
+                        "controller": true,
+                        "blockOwnerDeletion": true,
+                        "uid": "77585c76-10cc-11e8-bd5a-42010af00137"
+                    }
+                ],
+                "resourceVersion": "30704838",
+                "generateName": "fluentd-gcp-v2.0.10-",
+                "creationTimestamp": "2018-02-13T14:57:17Z",
+                "annotations": {
+                    "scheduler.alpha.kubernetes.io/critical-pod": "",
+                    "kubernetes.io/config.source": "api",
+                    "kubernetes.io/config.seen": "2018-02-13T16:10:19.509264637Z"
+                },
+                "selfLink": "/api/v1/namespaces/kube-system/pods/fluentd-gcp-v2.0.10-9q9t4",
+                "uid": "2fdfd4d9-10ce-11e8-bd5a-42010af00137"
+            }
+        },
+        {
+            "status": {
+                "qosClass": "Burstable",
+                "containerStatuses": [
+                    {
+                        "restartCount": 0,
+                        "name": "datadog-agent",
+                        "image": "datadog/agent-dev:haissam-tagger-pod-entity",
+                        "imageID": "docker-pullable://datadog/agent-dev@sha256:894fb66f89be0332a47388d7219ab8b365520ff0e3bbf597bd0a378b19efa7ee",
+                        "state": {
+                            "running": {
+                                "startedAt": "2018-02-13T16:11:19Z"
+                            }
+                        },
+                        "ready": true,
+                        "lastState": {},
+                        "containerID": "docker://a335589109ce5506aa69ba7481fc3e6c943abd23c5277016c92dac15d0f40479"
+                    }
+                ],
+                "podIP": "10.8.2.3",
+                "startTime": "2018-02-13T15:15:43Z",
+                "hostIP": "10.132.0.4",
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "Initialized",
+                        "lastTransitionTime": "2018-02-13T15:15:43Z"
+                    },
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "Ready",
+                        "lastTransitionTime": "2018-02-13T16:11:19Z"
+                    },
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "PodScheduled",
+                        "lastTransitionTime": "2018-02-13T15:15:46Z"
+                    }
+                ]
+            },
+            "spec": {
+                "dnsPolicy": "ClusterFirst",
+                "securityContext": {},
+                "serviceAccountName": "datadog",
+                "schedulerName": "default-scheduler",
+                "serviceAccount": "datadog",
+                "terminationGracePeriodSeconds": 30,
+                "restartPolicy": "Always",
+                "volumes": [
+                    {
+                        "hostPath": {
+                            "path": "/var/run/docker.sock",
+                            "type": ""
+                        },
+                        "name": "dockersocket"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/proc",
+                            "type": ""
+                        },
+                        "name": "procdir"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/sys/fs/cgroup",
+                            "type": ""
+                        },
+                        "name": "cgroups"
+                    },
+                    {
+                        "secret": {
+                            "defaultMode": 420,
+                            "secretName": "datadog-token-bbjjv"
+                        },
+                        "name": "datadog-token-bbjjv"
+                    }
+                ],
+                "tolerations": [
+                    {
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/disk-pressure"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/memory-pressure"
+                    }
+                ],
+                "containers": [
+                    {
+                        "terminationMessagePath": "/dev/termination-log",
+                        "name": "datadog-agent",
+                        "image": "datadog/agent-dev:haissam-tagger-pod-entity",
+                        "volumeMounts": [
+                            {
+                                "readOnly": true,
+                                "mountPath": "/var/run/docker.sock",
+                                "name": "dockersocket"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/host/proc",
+                                "name": "procdir"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/host/sys/fs/cgroup",
+                                "name": "cgroups"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "datadog-token-bbjjv"
+                            }
+                        ],
+                        "terminationMessagePolicy": "File",
+                        "command": [
+                            "/bin/bash",
+                            "-c",
+                            "apt-get update ; apt-get install -y libpython2.7 vim; sleep 6000000"
+                        ],
+                        "env": [
+                            {
+                                "name": "DD_API_KEY",
+                                "value": "foobarbazz"
+                            },
+                            {
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "fieldPath": "status.hostIP",
+                                        "apiVersion": "v1"
+                                    }
+                                },
+                                "name": "DD_KUBERNETES_KUBELET_HOST"
+                            }
+                        ],
+                        "imagePullPolicy": "Always",
+                        "resources": {
+                            "requests": {
+                                "cpu": "100m"
+                            }
+                        }
+                    }
+                ],
+                "nodeName": "gke-haissam-default-pool-be5066f1-wnvn"
+            },
+            "metadata": {
+                "name": "datadog-agent-jbm2k",
+                "labels": {
+                    "app": "datadog-node-agent",
+                    "pod-template-generation": "1",
+                    "controller-revision-hash": "4047775714"
+                },
+                "namespace": "default",
+                "ownerReferences": [
+                    {
+                        "kind": "DaemonSet",
+                        "name": "datadog-agent",
+                        "apiVersion": "extensions/v1beta1",
+                        "controller": true,
+                        "blockOwnerDeletion": true,
+                        "uid": "c22d1552-10d0-11e8-bd5a-42010af00137"
+                    }
+                ],
+                "resourceVersion": "30704834",
+                "generateName": "datadog-agent-",
+                "creationTimestamp": "2018-02-13T15:15:43Z",
+                "annotations": {
+                    "kubernetes.io/config.source": "api",
+                    "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container datadog-agent",
+                    "kubernetes.io/config.seen": "2018-02-13T16:10:19.509271892Z"
+                },
+                "selfLink": "/api/v1/namespaces/default/pods/datadog-agent-jbm2k",
+                "uid": "c2319815-10d0-11e8-bd5a-42010af00137"
+            }
+        },
+        {
+            "status": {
+                "qosClass": "Burstable",
+                "containerStatuses": [
+                    {
+                        "restartCount": 0,
+                        "name": "dd-agent",
+                        "image": "datadog/dev-dd-agent:beta",
+                        "imageID": "docker-pullable://datadog/dev-dd-agent@sha256:1672a9c8741813070b5fac803d598c379e37e678e989582c55b7659b01f36eb4",
+                        "state": {
+                            "running": {
+                                "startedAt": "2018-02-13T16:11:00Z"
+                            }
+                        },
+                        "ready": true,
+                        "lastState": {},
+                        "containerID": "docker://326b384481ca95204018e3e837c61e522b64a3b86c3804142a22b2d1db9dbd7b"
+                    }
+                ],
+                "podIP": "10.8.2.2",
+                "startTime": "2018-02-13T15:16:11Z",
+                "hostIP": "10.132.0.4",
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "Initialized",
+                        "lastTransitionTime": "2018-02-13T15:16:11Z"
+                    },
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "Ready",
+                        "lastTransitionTime": "2018-02-13T16:11:00Z"
+                    },
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "PodScheduled",
+                        "lastTransitionTime": "2018-02-13T15:16:35Z"
+                    }
+                ]
+            },
+            "spec": {
+                "dnsPolicy": "ClusterFirst",
+                "securityContext": {},
+                "serviceAccountName": "default",
+                "schedulerName": "default-scheduler",
+                "serviceAccount": "default",
+                "terminationGracePeriodSeconds": 30,
+                "restartPolicy": "Always",
+                "volumes": [
+                    {
+                        "hostPath": {
+                            "path": "/var/run/docker.sock",
+                            "type": ""
+                        },
+                        "name": "dockersocket"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/proc",
+                            "type": ""
+                        },
+                        "name": "procdir"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/sys/fs/cgroup",
+                            "type": ""
+                        },
+                        "name": "cgroups"
+                    },
+                    {
+                        "secret": {
+                            "defaultMode": 420,
+                            "secretName": "default-token-zkdf2"
+                        },
+                        "name": "default-token-zkdf2"
+                    }
+                ],
+                "tolerations": [
+                    {
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/disk-pressure"
+                    },
+                    {
+                        "operator": "Exists",
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/memory-pressure"
+                    }
+                ],
+                "containers": [
+                    {
+                        "terminationMessagePath": "/dev/termination-log",
+                        "name": "dd-agent",
+                        "image": "datadog/dev-dd-agent:beta",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/var/run/docker.sock",
+                                "name": "dockersocket"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/host/proc",
+                                "name": "procdir"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/host/sys/fs/cgroup",
+                                "name": "cgroups"
+                            },
+                            {
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "default-token-zkdf2"
+                            }
+                        ],
+                        "terminationMessagePolicy": "File",
+                        "env": [
+                            {
+                                "name": "API_KEY",
+                                "value": "foobarbazz"
+                            },
+                            {
+                                "name": "KUBERNETES",
+                                "value": "yes"
+                            },
+                            {
+                                "name": "SD_BACKEND",
+                                "value": "docker"
+                            },
+                            {
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "fieldPath": "status.hostIP",
+                                        "apiVersion": "v1"
+                                    }
+                                },
+                                "name": "KUBERNETES_KUBELET_HOST"
+                            }
+                        ],
+                        "imagePullPolicy": "Always",
+                        "ports": [
+                            {
+                                "protocol": "UDP",
+                                "name": "dogstatsdport",
+                                "containerPort": 8125
+                            }
+                        ],
+                        "resources": {
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "128Mi"
+                            },
+                            "limits": {
+                                "cpu": "250m",
+                                "memory": "512Mi"
+                            }
+                        }
+                    }
+                ],
+                "nodeName": "gke-haissam-default-pool-be5066f1-wnvn"
+            },
+            "metadata": {
+                "name": "dd-agent-q6hpw",
+                "labels": {
+                    "app": "dd-agent",
+                    "pod-template-generation": "1",
+                    "controller-revision-hash": "3964071385"
+                },
+                "namespace": "default",
+                "ownerReferences": [
+                    {
+                        "kind": "DaemonSet",
+                        "name": "dd-agent",
+                        "apiVersion": "extensions/v1beta1",
+                        "controller": true,
+                        "blockOwnerDeletion": true,
+                        "uid": "d2e3ee56-10d0-11e8-bd5a-42010af00137"
+                    }
+                ],
+                "resourceVersion": "30704836",
+                "generateName": "dd-agent-",
+                "creationTimestamp": "2018-02-13T15:16:11Z",
+                "annotations": {
+                    "kubernetes.io/config.source": "api",
+                    "kubernetes.io/config.seen": "2018-02-13T16:10:19.509269848Z"
+                },
+                "selfLink": "/api/v1/namespaces/default/pods/dd-agent-q6hpw",
+                "uid": "d2e71e36-10d0-11e8-bd5a-42010af00137"
+            }
+        },
+        {
+            "status": {
+                "qosClass": "Burstable",
+                "containerStatuses": [
+                    {
+                        "restartCount": 0,
+                        "name": "demo-app",
+                        "image": "hkaj/demo-app:latest",
+                        "imageID": "docker-pullable://hkaj/demo-app@sha256:0b638d574b905c853c67f69801677d219ae177c38d7fab25292934ec5564642f",
+                        "state": {
+                            "running": {
+                                "startedAt": "2018-02-13T16:11:44Z"
+                            }
+                        },
+                        "ready": true,
+                        "lastState": {},
+                        "containerID": "docker://5f93d91c7aee0230f77fbe9ec642dd60958f5098e76de270a933285c24dfdc6f"
+                    }
+                ],
+                "podIP": "10.8.2.5",
+                "startTime": "2018-02-13T16:11:38Z",
+                "hostIP": "10.132.0.4",
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "Initialized",
+                        "lastTransitionTime": "2018-02-13T16:11:38Z"
+                    },
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "Ready",
+                        "lastTransitionTime": "2018-02-13T16:11:45Z"
+                    },
+                    {
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "type": "PodScheduled",
+                        "lastTransitionTime": "2018-02-13T16:11:38Z"
+                    }
+                ]
+            },
+            "spec": {
+                "dnsPolicy": "ClusterFirst",
+                "securityContext": {},
+                "serviceAccountName": "default",
+                "schedulerName": "default-scheduler",
+                "serviceAccount": "default",
+                "terminationGracePeriodSeconds": 30,
+                "restartPolicy": "Always",
+                "volumes": [
+                    {
+                        "secret": {
+                            "defaultMode": 420,
+                            "secretName": "default-token-zkdf2"
+                        },
+                        "name": "default-token-zkdf2"
+                    }
+                ],
+                "tolerations": [
+                    {
+                        "operator": "Exists",
+                        "tolerationSeconds": 300,
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready"
+                    },
+                    {
+                        "operator": "Exists",
+                        "tolerationSeconds": 300,
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable"
+                    }
+                ],
+                "containers": [
+                    {
+                        "terminationMessagePath": "/dev/termination-log",
+                        "name": "demo-app",
+                        "image": "hkaj/demo-app:latest",
+                        "volumeMounts": [
+                            {
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "default-token-zkdf2"
+                            }
+                        ],
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always",
+                        "ports": [
+                            {
+                                "protocol": "TCP",
+                                "containerPort": 80
+                            }
+                        ],
+                        "resources": {
+                            "requests": {
+                                "cpu": "100m"
+                            }
+                        }
+                    }
+                ],
+                "nodeName": "gke-haissam-default-pool-be5066f1-wnvn"
+            },
+            "metadata": {
+                "name": "demo-app-success-c485bc67b-klj45",
+                "labels": {
+                    "pod-template-hash": "704167236",
+                    "project": "cncf",
+                    "app": "demo-app",
+                    "version": "1"
+                },
+                "namespace": "default",
+                "ownerReferences": [
+                    {
+                        "kind": "ReplicaSet",
+                        "name": "demo-app-success-c485bc67b",
+                        "apiVersion": "extensions/v1beta1",
+                        "controller": true,
+                        "blockOwnerDeletion": true,
+                        "uid": "390ee05e-0c3d-11e8-a231-42010af000a9"
+                    }
+                ],
+                "resourceVersion": "30705944",
+                "generateName": "demo-app-success-c485bc67b-",
+                "creationTimestamp": "2018-02-13T16:08:35Z",
+                "annotations": {
+                    "kubernetes.io/config.seen": "2018-02-13T16:11:38.235504619Z",
+                    "service-discovery.datadoghq.com/demo-app.init_configs": "[{}]",
+                    "service-discovery.datadoghq.com/demo-app.check_names": "[\"go_expvar\"]",
+                    "kubernetes.io/config.source": "api",
+                    "service-discovery.datadoghq.com/demo-app.instances": "[{\"expvar_url\": \"http://%%host%%:8080\", \"metrics\": [{\"path\": \"demo.requests.failures\", \"type\": \"counter\"}, {\"path\": \"demo.requests.success\", \"type\": \"counter\"}], \"tags\": [\"%%tags%%\"]}]",
+                    "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container demo-app"
+                },
+                "selfLink": "/api/v1/namespaces/default/pods/demo-app-success-c485bc67b-klj45",
+                "uid": "24d6daa3-10d8-11e8-bd5a-42010af00137"
+            }
+        }
+    ],
+    "kind": "PodList",
+    "apiVersion": "v1",
+    "metadata": {}
+}

--- a/kubelet/tests/fixtures/pods_crashed.json
+++ b/kubelet/tests/fixtures/pods_crashed.json
@@ -915,7 +915,11 @@
                         "image": "datadog/dev-dd-agent:beta",
                         "imageID": "docker-pullable://datadog/dev-dd-agent@sha256:1672a9c8741813070b5fac803d598c379e37e678e989582c55b7659b01f36eb4",
                         "state": {
-                            "running": {
+                            "terminated": {
+                                "containerID": "docker://326b384481ca95204018e3e837c61e522b64a3b86c3804142a22b2d1db9dbd7b",
+                                "exitCode": 0,
+                                "finishedAt": "2018-02-13T16:12:00Z",
+                                "reason": "TransientReason",
                                 "startedAt": "2018-02-13T16:11:00Z"
                             }
                         },

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -37,6 +37,7 @@ NODE_SPEC = {
 }
 
 EXPECTED_METRICS_COMMON = [
+    'kubernetes.containers.restarts',
     'kubernetes.containers.state.running',
     'kubernetes.cpu.capacity',
     'kubernetes.cpu.usage.total',
@@ -464,6 +465,14 @@ def test_report_container_state_metrics(monkeypatch):
             'kube_deployment:fluentd-gcp-v2.0.10'
         ] + instance_tags),
         mock.call('kubernetes.containers.state.running', 1, [
+            'kube_container_name:prometheus-to-sd-exporter',
+            'kube_deployment:fluentd-gcp-v2.0.10'
+        ] + instance_tags),
+        mock.call('kubernetes.containers.restarts', 1, [
+            'kube_container_name:fluentd-gcp',
+            'kube_deployment:fluentd-gcp-v2.0.10'
+        ] + instance_tags),
+        mock.call('kubernetes.containers.restarts', 0, [
             'kube_container_name:prometheus-to-sd-exporter',
             'kube_deployment:fluentd-gcp-v2.0.10'
         ] + instance_tags),


### PR DESCRIPTION
### What does this PR do?

This PR adds some metrics that would normally come from `kube-state-metrics` to the `kubelet` check.  We (airbnb) were having problems getting `kube-state-metrics` integration to work on our very large clusters.  The specific metrics that we want are available in the kubelet podlist and are similar to other metrics that are already being collected here.

* Reports `kubernetes.containers.restarts` from the `restartCount` of the container status
* Reports `kubernetes.containers.{state,last_state}.{running,waiting,terminated}` with reasons from the container status fields of the same name.  The `running` metric is pretty redundant and included only for completeness.

### Motivation

We were running into issues similar to https://github.com/DataDog/integrations-core/issues/1346#issuecomment-400293835 .  The response size of the metrics endpoint on kube-state-metrics was too large to submit through DataDog.  Sharding by namespace was not possible for our use case because we use a large number of dynamic and variably sized namespaces.  We are most interested in being able to detect containers in erroneous or crashloop states. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
