### PR TITLE
Add query activity metrics

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -340,7 +340,7 @@ SELECT s.schemaname,
         "SUM(CASE WHEN current_query LIKE '<IDLE> in transaction' THEN 1 ELSE 0 END)",
         "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', 'datadog'))"
         "THEN 1 ELSE null END )",
-        "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' THEN 1 ELSE null END )", 
+        "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
     ]
 
     # The metrics we collect from pg_stat_activity that we zip with one of the lists above

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -53,3 +53,5 @@ postgresql.toast_index_blocks_hit,gauge,,block,second,The number of buffer hits 
 postgresql.transactions.open,gauge,,transaction,,The number of open transactions in this database.,0,postgres,transactions open
 postgresql.transactions.idle_in_transaction,gauge,,transaction,,The number of 'idle in transaction' transactions in this database.,0,postgres,transactions idle_in_transaction
 postgresql.before_xid_wraparound,gauge,,transaction,,The number of transactions that can occur until a transaction wraparound.,0,postgres,tx before xid wraparound
+postgresql.active_queries,gauge,,,,The number of active queries in this database.,0,postgres,active queries
+postgresql.waiting_queries,gauge,,,,The number of waiting queries in this database.,0,postgres,transactions waiting queries

--- a/postgres/tests/test_common.py
+++ b/postgres/tests/test_common.py
@@ -53,6 +53,8 @@ CONNECTION_METRICS = [
 ACTIVITY_METRICS = [
     'postgresql.transactions.open',
     'postgresql.transactions.idle_in_transaction',
+    'postgresql.active_queries',
+    'postgresql.waiting_queries',
 ]
 
 


### PR DESCRIPTION
### What does this PR do?

Adds `postgresql.active_queries` and `postgresql.waiting_queries` to postgres integration. 

Also adds version check for 9.6 and after because the `waiting` column in `pg_stat_activity` was changed to `wait_event` and `wait_event_type`.

### Motivation

The query counts are useful, especially for versions prior to 9.6 when exceeding core count made performance drop by 50%.
### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
