### PR TITLE
Fix links in ddev README

### DIFF
--- a/datadog_checks_dev/README.md
+++ b/datadog_checks_dev/README.md
@@ -1,18 +1,18 @@
 # Datadog Checks Dev
 
 [![Latest PyPI version][1]][2]
-[![Supported Python versions][3]][4]
-[![License][5]][6]
-[![Documentation Status][7]][8]
+[![Supported Python versions][3]][2]
+[![License][4]][5]
+[![Documentation Status][6]][7]
 
 -----
 
-This is the developer toolkit designed for use by any [Agent-based][9] check or
+This is the developer toolkit designed for use by any [Agent-based][8] check or
 integration repository.
 
 ## Installation
 
-`datadog-checks-dev` is distributed on [PyPI][10] as a universal wheel
+`datadog-checks-dev` is distributed on [PyPI][9] as a universal wheel
 and is available on Linux, macOS, and Windows, and supports Python 2.7/3.5+ and PyPy.
 
 ```console
@@ -23,16 +23,15 @@ At this point there should be a working executable, ddev, in your PATH. The help
 
 ## Documentation
 
-Dev docs are hosted on [readthedocs][11]
+Dev docs are hosted on [readthedocs][10]
 
 [1]: https://img.shields.io/pypi/v/datadog-checks-dev.svg
 [2]: https://pypi.org/project/datadog-checks-dev
 [3]: https://img.shields.io/pypi/pyversions/datadog-checks-dev.svg
-[4]: https://pypi.org/project/datadog-checks-dev
-[5]: https://img.shields.io/pypi/l/datadog-checks-dev.svg
-[6]: https://choosealicense.com/licenses
-[7]: https://readthedocs.org/projects/datadog-checks-base/badge/?version=latest
-[8]: https://datadog-checks-base.readthedocs.io/en/latest/?badge=latest
-[9]: https://github.com/DataDog/datadog-agent
-[10]: https://pypi.org
-[11]: https://datadog-checks-base.readthedocs.io/en/latest/datadog_checks_dev.html
+[4]: https://img.shields.io/pypi/l/datadog-checks-dev.svg
+[5]: https://choosealicense.com/licenses
+[6]: https://readthedocs.org/projects/datadog-checks-base/badge/?version=latest
+[7]: https://datadog-checks-base.readthedocs.io/en/latest/?badge=latest
+[8]: https://github.com/DataDog/datadog-agent
+[9]: https://pypi.org
+[10]: https://datadog-checks-base.readthedocs.io/en/latest/datadog_checks_dev.html

--- a/datadog_checks_dev/README.md
+++ b/datadog_checks_dev/README.md
@@ -1,18 +1,18 @@
 # Datadog Checks Dev
 
-[![Latest PyPI version](https://img.shields.io/pypi/v/datadog-checks-dev.svg)](https://pypi.org/project/datadog-checks-dev)
-[![Supported Python versions](https://img.shields.io/pypi/pyversions/datadog-checks-dev.svg)](https://pypi.org/project/datadog-checks-dev)
-[![License](https://img.shields.io/pypi/l/datadog-checks-dev.svg)](https://choosealicense.com/licenses)
-[![Documentation Status][19]](https://datadog-checks-base.readthedocs.io/en/latest/?badge=latest)
+[![Latest PyPI version][1]][2]
+[![Supported Python versions][3]][4]
+[![License][5]][6]
+[![Documentation Status][7]][8]
 
 -----
 
-This is the developer toolkit designed for use by any [Agent-based][1] check or
+This is the developer toolkit designed for use by any [Agent-based][9] check or
 integration repository.
 
 ## Installation
 
-`datadog-checks-dev` is distributed on [PyPI](https://pypi.org) as a universal wheel
+`datadog-checks-dev` is distributed on [PyPI][10] as a universal wheel
 and is available on Linux, macOS, and Windows, and supports Python 2.7/3.5+ and PyPy.
 
 ```console
@@ -23,4 +23,16 @@ At this point there should be a working executable, ddev, in your PATH. The help
 
 ## Documentation
 
-Dev docs are hosted on [readthedocs](https://datadog-checks-base.readthedocs.io/en/latest/datadog_checks_dev.html)
+Dev docs are hosted on [readthedocs][11]
+
+[1]: https://img.shields.io/pypi/v/datadog-checks-dev.svg
+[2]: https://pypi.org/project/datadog-checks-dev
+[3]: https://img.shields.io/pypi/pyversions/datadog-checks-dev.svg
+[4]: https://pypi.org/project/datadog-checks-dev
+[5]: https://img.shields.io/pypi/l/datadog-checks-dev.svg
+[6]: https://choosealicense.com/licenses
+[7]: https://readthedocs.org/projects/datadog-checks-base/badge/?version=latest
+[8]: https://datadog-checks-base.readthedocs.io/en/latest/?badge=latest
+[9]: https://github.com/DataDog/datadog-agent
+[10]: https://pypi.org
+[11]: https://datadog-checks-base.readthedocs.io/en/latest/datadog_checks_dev.html


### PR DESCRIPTION
### What does this PR do?

Fixes links in ddev README

### Motivation

Saw the broken links when browsing the repo.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
