### PR TITLE
Increase gpg timeout to give time to developers to interact with Yubikeys

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
@@ -3,6 +3,13 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import shutil
 
+# NOTE: Set one minute for any GPG subprocess to timeout in in-toto.  Should be
+# enough time for developers to find and enter their PIN and / or touch their
+# Yubikey. We do this before we load the rest of in-toto, so that this setting
+# takes effect.
+import in_toto.settings
+in_toto.settings.SUBPROCESS_TIMEOUT = 60
+
 from in_toto import runlib
 from in_toto.gpg.constants import GPG_COMMAND
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+# flake8: noqa
 import shutil
 
 # NOTE: Set one minute for any GPG subprocess to timeout in in-toto.  Should be


### PR DESCRIPTION
### What does this PR do?

Increase the timeout value for any GPG subprocess to run from in-toto.

### Motivation

Developers find the current timeout value (3 seconds) to short to successfully find and enter their PINs.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

@zippolyte and @ofek should test this to make sure that the PR is satisfactory.
