### PR TITLE
Add linux as supported OS

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -32,7 +32,7 @@ pycparser==2.18
 pycryptodomex==3.4.7
 pymongo==3.5.1
 pymysql==0.8.0
-pyodbc==4.0.13; sys_platform == 'win32'
+pyodbc==4.0.13
 pyro4==4.73; sys_platform == 'win32'
 pysmi==0.2.2
 pysnmp==4.4.3

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -114,7 +114,7 @@ instances:
 
     # Optional, change the connection method from adodbapi (the default) to
     # odbc (valid connector names are 'odbc' and 'adodbapi')
-    # odbc is only available on Windows
+    # 'adodbapi` is only available on Windows
     # connector: odbc
 
     # Optional, if using odbc, use the named driver.  If none is specified,

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -15,6 +15,7 @@
   "short_description": "Collect important SQL Server performance and health metrics.",
   "support": "core",
   "supported_os": [
+    "linux",
     "windows"
   ],
   "type": "check"

--- a/sqlserver/requirements-dev.txt
+++ b/sqlserver/requirements-dev.txt
@@ -1,2 +1,1 @@
 -e ../datadog_checks_dev
-pyodbc; sys_platform != 'win32'

--- a/sqlserver/requirements.in
+++ b/sqlserver/requirements.in
@@ -1,5 +1,5 @@
 adodbapi==2.6.0.7; sys_platform == 'win32'
-pyodbc==4.0.13; sys_platform == 'win32'
+pyodbc==4.0.13
 pyro4==4.73; sys_platform == 'win32'
 pywin32==224; sys_platform == 'win32'
 selectors34==1.2.0; sys_platform == 'win32' and python_version < '3.4'

--- a/sqlserver/requirements.txt
+++ b/sqlserver/requirements.txt
@@ -6,7 +6,7 @@
 #
 adodbapi==2.6.0.7 ; sys_platform == "win32" \
     --hash=sha256:7aa5f79136a757cbeac8ea00f554e541fbd59c7f6be87443127bf0319c4bb0a3
-pyodbc==4.0.13 ; sys_platform == "win32" \
+pyodbc==4.0.13 \
     --hash=sha256:05da16d4f6464498d78a4618db4d888a8528f0a03a9b1a17d62a2d0e84c424a4 \
     --hash=sha256:174580250fb76d75b214f1d47c0a9bdc7196f421ba44ca62226698e0ccd72fa9 \
     --hash=sha256:26b719271c8676578d5732f517ef56438669f90fbb6a33f16b0825b8311156af \


### PR DESCRIPTION
### What does this PR do?

Adds Linux support in the manifest file.
Add the pyodbc dependency to all platforms, not just Windows
Updates the conf.yaml file to reflect that adbobapi is only on Windows

This lets the Agent build the integration on Linux platforms. 

### Motivation

Customer request, and travis testing is currently done in Linux. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

I made a custom build of the Agent and confirmed that the sqlserver wheel and the pyodbc dep is properly shipped with the deb package.  EDIT: re testing with the latest dep changes