### PR TITLE
add ability to check A, CNAME and MX results

### DIFF
--- a/dns_check/datadog_checks/dns_check/dns_check.py
+++ b/dns_check/datadog_checks/dns_check/dns_check.py
@@ -115,28 +115,22 @@ class DNSCheck(NetworkCheck):
         number_of_results = len(answer.rrset.items)
 
         assert(len(ips) == number_of_results)
-        if number_of_results > 1:
-            result_ips = []
-            for rip in answer.rrset.items:
-                result = rip.to_text().lower()
-                if result.endswith('.'):
-                    result = result[:-1]
-                result_ips.append(result)
-
-            for ip in ips:
-                assert(ip in result_ips)
-        else:
-            result = answer.rrset.items[0].to_text()
+        result_ips = []
+        for rip in answer.rrset.items:
+            result = rip.to_text().lower()
             if result.endswith('.'):
                 result = result[:-1]
-            assert(result == resolves_as)
+            result_ips.append(result)
+
+        for ip in ips:
+            assert(ip in result_ips)
 
     def _get_tags(self, instance):
         hostname = instance.get('hostname')
         instance_name = instance.get('name', hostname)
         record_type = instance.get('record_type', 'A')
         custom_tags = instance.get('tags', [])
-        resolved_as = instance.get('resolves_as', None)
+        resolved_as = instance.get('resolves_as')
         tags = []
 
         try:

--- a/dns_check/datadog_checks/dns_check/dns_check.py
+++ b/dns_check/datadog_checks/dns_check/dns_check.py
@@ -65,11 +65,14 @@ class DNSCheck(NetworkCheck):
         timeout = float(instance.get('timeout', self.default_timeout))
         resolver.lifetime = timeout
         record_type = instance.get('record_type', 'A')
+        resolves_as = instance.get('resolves_as', None)
+        if resolves_as and record_type not in ['A', 'CNAME', 'MX']:
+            raise BadConfException('"resolves_as" can currently only support A, CNAME and MX records')
 
-        return hostname, timeout, nameserver, record_type, resolver
+        return hostname, timeout, nameserver, record_type, resolver, resolves_as
 
     def _check(self, instance):
-        hostname, timeout, nameserver, record_type, resolver = self._load_conf(instance)
+        hostname, timeout, nameserver, record_type, resolver, resolves_as = self._load_conf(instance)
 
         # Perform the DNS query, and report its duration as a gauge
         response_time = 0
@@ -87,6 +90,8 @@ class DNSCheck(NetworkCheck):
             else:
                 answer = resolver.query(hostname, rdtype=record_type)
                 assert(answer.rrset.items[0].to_text())
+                if resolves_as:
+                    self._check_answer(answer, resolves_as)
 
             response_time = time_func() - t0
 
@@ -105,16 +110,37 @@ class DNSCheck(NetworkCheck):
             self.log.debug('Resolved hostname: {0}'.format(hostname))
             return Status.UP, 'UP'
 
+    def _check_answer(self, answer, resolves_as):
+        ips = [x.strip().lower() for x in resolves_as.split(',')]
+        number_of_results = len(answer.rrset.items)
+
+        assert(len(ips) == number_of_results)
+        if number_of_results > 1:
+            result_ips = []
+            for rip in answer.rrset.items:
+                result = rip.to_text().lower()
+                if result.endswith('.'):
+                    result = result[:-1]
+                result_ips.append(result)
+
+            for ip in ips:
+                assert(ip in result_ips)
+        else:
+            result = answer.rrset.items[0].to_text()
+            if result.endswith('.'):
+                result = result[:-1]
+            assert(result == resolves_as)
+
     def _get_tags(self, instance):
         hostname = instance.get('hostname')
         instance_name = instance.get('name', hostname)
         record_type = instance.get('record_type', 'A')
         custom_tags = instance.get('tags', [])
+        resolved_as = instance.get('resolves_as', None)
         tags = []
 
         try:
             nameserver = instance.get('nameserver') or dns.resolver.Resolver().nameservers[0]
-            tags.append('nameserver:{0}'.format(nameserver))
         except IndexError:
             self.log.error('No DNS server was found on this host.')
 
@@ -122,6 +148,9 @@ class DNSCheck(NetworkCheck):
                               'resolved_hostname:{0}'.format(hostname),
                               'instance:{0}'.format(instance_name),
                               'record_type:{0}'.format(record_type)]
+        if resolved_as:
+            tags.append('resolved_as:{0}'.format(resolved_as))
+
         return tags
 
     def report_as_service_check(self, sc_name, status, instance, msg=None):

--- a/dns_check/tests/mocks.py
+++ b/dns_check/tests/mocks.py
@@ -11,7 +11,14 @@ class MockDNSAnswer:
 
     class MockRrset:
         def __init__(self, address):
-            self.items = [MockDNSAnswer.MockItem(address)]
+            addresses = [x.strip().lower() for x in address.split(',')]
+            if addresses > 1:
+                items = []
+                for address in addresses:
+                    items.append(MockDNSAnswer.MockItem(address))
+                    self.items = items
+            else:
+                self.items = [MockDNSAnswer.MockItem(address)]
 
     class MockItem:
         def __init__(self, address):
@@ -35,7 +42,9 @@ class MockTime(object):
 
 def success_query_mock(d_name, rdtype):
     if rdtype == 'A':
-        return MockDNSAnswer('127.0.0.1')
+        if d_name == 'my.example.org':
+            return MockDNSAnswer('127.0.0.2,127.0.0.3,127.0.0.4')
+        return MockDNSAnswer('127.0.0.2')
     elif rdtype == 'CNAME':
         return MockDNSAnswer('alias.example.org')
 

--- a/dns_check/tests/mocks.py
+++ b/dns_check/tests/mocks.py
@@ -16,7 +16,7 @@ class MockDNSAnswer:
                 items = []
                 for address in addresses:
                     items.append(MockDNSAnswer.MockItem(address))
-                    self.items = items
+                self.items = items
             else:
                 self.items = [MockDNSAnswer.MockItem(address)]
 

--- a/dns_check/tests/test_dns_check.py
+++ b/dns_check/tests/test_dns_check.py
@@ -16,12 +16,28 @@ CONFIG_SUCCESS = {
     'instances': [{
         'name': 'success',
         'hostname': 'www.example.org',
-        'nameserver': '127.0.0.1'
+        'nameserver': '127.0.0.1',
     }, {
         'name': 'cname',
         'hostname': 'www.example.org',
         'nameserver': '127.0.0.1',
         'record_type': 'CNAME'
+    }, {
+        'name': 'check_response_ip',
+        'hostname': 'www.example.org',
+        'nameserver': '127.0.0.1',
+        'resolves_as': '127.0.0.2'
+    }, {
+        'name': 'check_response_multiple_ips',
+        'hostname': 'my.example.org',
+        'nameserver': '127.0.0.1',
+        'resolves_as': '127.0.0.2,127.0.0.3,127.0.0.4'
+    }, {
+        'name': 'check_response_CNAME',
+        'hostname': 'www.example.org',
+        'nameserver': '127.0.0.1',
+        'record_type': 'CNAME',
+        'resolves_as': 'alias.example.org'
     }]
 }
 
@@ -78,7 +94,27 @@ def test_success(mocked_query, mocked_time, aggregator):
     tags = ['instance:success', 'resolved_hostname:www.example.org', 'nameserver:127.0.0.1', 'record_type:A']
     aggregator.assert_service_check(DNSCheck.SERVICE_CHECK_NAME, status=DNSCheck.OK,
                                     tags=tags, count=1)
+    aggregator.assert_metric('dns.response_time', tags=tags, count=1, value=1)
 
+    integration.check(CONFIG_SUCCESS['instances'][2])
+    tags = ['instance:check_response_ip', 'resolved_hostname:www.example.org', 'nameserver:127.0.0.1', 'record_type:A',
+            'resolved_as:127.0.0.2']
+    aggregator.assert_service_check(DNSCheck.SERVICE_CHECK_NAME, status=DNSCheck.OK,
+                                    tags=tags, count=1)
+    aggregator.assert_metric('dns.response_time', tags=tags, count=1, value=1)
+
+    integration.check(CONFIG_SUCCESS['instances'][3])
+    tags = ['instance:check_response_multiple_ips', 'resolved_hostname:my.example.org', 'nameserver:127.0.0.1',
+            'record_type:A', 'resolved_as:127.0.0.2,127.0.0.3,127.0.0.4']
+    aggregator.assert_service_check(DNSCheck.SERVICE_CHECK_NAME, status=DNSCheck.OK,
+                                    tags=tags, count=1)
+    aggregator.assert_metric('dns.response_time', tags=tags, count=1, value=1)
+
+    integration.check(CONFIG_SUCCESS['instances'][4])
+    tags = ['instance:check_response_CNAME', 'resolved_hostname:www.example.org', 'nameserver:127.0.0.1',
+            'record_type:CNAME', 'resolved_as:alias.example.org']
+    aggregator.assert_service_check(DNSCheck.SERVICE_CHECK_NAME, status=DNSCheck.OK,
+                                    tags=tags, count=1)
     aggregator.assert_metric('dns.response_time', tags=tags, count=1, value=1)
 
     integration.check(CONFIG_SUCCESS['instances'][1])


### PR DESCRIPTION
### What does this PR do?

Adds the option to check the results of a dns_check. Meaning if we expect www.example.org to resolve to 127.0.0.1 then the dns_check will ensure that not only does it resolve but it resolves to that IP.

### Motivation

It was lacking from dns_check. Needed the ability to ensure that the name hadn't be hijacked and was pointing to our server(s).

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

None!
