### PR TITLE
Publish list of GPG public key fingerprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,35 @@ and [knowledge base][12]. You can also visit our
 [18]: https://codecov.io/github/DataDog/integrations-core?branch=master
 [19]: https://readthedocs.org/projects/datadog-checks-base/badge/?version=latest
 [20]: https://datadog-checks-base.readthedocs.io/en/latest/?badge=latest
+
+## GPG public keys
+
+For those whom it may concern, the following is a list of GPG public key
+fingerprints known to correspond to our developers at the time of writing (Nov
+20 2018):
+
+* [Christine Chen](ihttps://api.github.com/users/ChristineTChen/gpg_keys)
+  * `57CE 2495 EA48 D456 B9C4  BA4F 66E8 2239 9141 D9D3`
+  * `36C0 82E7 38C7 B4A1 E169  11C0 D633 59C4 875A 1A9A`
+* [Dave Coleman](https://api.github.com/users/dcoleman17/gpg_keys)
+  * `8278 C406 C1BB F1F2 DFBB  5AD6 0AE7 E246 4F8F D375`
+  * `98A5 37CD CCA2 8DFF B35B  0551 5D50 0742 90F6 422F`
+* [Hippolyte Henry](https://api.github.com/users/zippolyte/gpg_keys)
+  * `87D5 2666 ECBF 2459 9D5A  594F F7AC E411 B85D 518C`
+  * `31EE F81D 7F71 6E35 83F2  4095 55D1 30B4 49D2 BD26`
+* [Ofek Lev](https://api.github.com/users/ofek/gpg_keys)
+  * `C295 CF63 B355 DFEB 3316  02F7 F426 A944 35BE 6F99`
+  * `D009 8861 8057 D2F4 D855  5A62 B472 442C B7D3 AF42`
+* [Greg Meyer](https://api.github.com/users/gmmeyer/gpg_keys)
+  * `989A 83AA 3C99 E86D DB9E  EE69 598E 38E0 370E B759`
+  * `E145 39B1 BE48 615B FFE5  E7D2 4EA8 2631 E127 97FC`
+* [Nicholas Muesch](https://api.github.com/users/nmuesch/gpg_keys)
+  * `6E09 1A53 0468 B148 54BB  6CCE 831C 23C4 9BBE 61F8`
+  * `BACE F480 6D0B 4FBE D227  DC3B C0E2 8E5E 241E D25A`
+* [Massimiliano Pippi](https://api.github.com/users/masci/gpg_keys)
+  * `BE9C 5131 8EED C03F E901  F256 C2C8 965F 07D0 A23D`
+  * `69CA DE35 4030 5312 54AF  170C 50A7 66D9 4DFC 27CC`
+* [Greg Zussa](https://api.github.com/users/gzussa/gpg_keys)
+  * `D24D 57CE 96BD F8C2 9BB0  BEAB C783 0ECB 08F8 8C74`
+  * `3936 7937 7466 5878 C67A  50E9 3C67 09D5 583F B57C`
+

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For those whom it may concern, the following is a list of GPG public key
 fingerprints known to correspond to our developers at the time of writing (Nov
 20 2018):
 
-* [Christine Chen](ihttps://api.github.com/users/ChristineTChen/gpg_keys)
+* [Christine Chen](https://api.github.com/users/ChristineTChen/gpg_keys)
   * `57CE 2495 EA48 D456 B9C4  BA4F 66E8 2239 9141 D9D3`
   * `36C0 82E7 38C7 B4A1 E169  11C0 D633 59C4 875A 1A9A`
 * [Dave Coleman](https://api.github.com/users/dcoleman17/gpg_keys)


### PR DESCRIPTION
### What does this PR do?

Publish the list of GPG fingerprints known to belong to developers at the time of writing (Nov 20 2018).

### Motivation

So that interested end-users, if they so desire, can manually verify for themselves whether checks (source code, or wheels) have been signed by one of the developers.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Everyone who is listed here _should_ verify that the listed fingerprints of their keys are correct.
