### PR TITLE
make warning logging optional

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -347,9 +347,10 @@ class AgentCheck(object):
 
         return normalized_tags
 
-    def warning(self, warning_message):
+    def warning(self, warning_message, log=True):
         warning_message = str(warning_message)
-        self.log.warning(warning_message)
+        if log:
+            self.log.warning(warning_message)
         self.warnings.append(warning_message)
 
     def get_warnings(self):

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -347,10 +347,16 @@ class AgentCheck(object):
 
         return normalized_tags
 
-    def warning(self, warning_message, log=True):
+    def warning(self, warning_message):
         warning_message = str(warning_message)
-        if log:
-            self.log.warning(warning_message)
+
+        frame = inspect.currentframe().f_back
+        lineno = frame.f_lineno
+        filename = frame.f_code.co_filename
+        # only log the last part of the filename, not the full path
+        filename = filename.split('/')[-1]
+
+        self.log.warning(warning_message, extra={'_lineno': lineno, '_filename': filename})
         self.warnings.append(warning_message)
 
     def get_warnings(self):

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from collections import defaultdict
+from os.path import basename
 import logging
 import re
 import json
@@ -354,7 +355,7 @@ class AgentCheck(object):
         lineno = frame.f_lineno
         filename = frame.f_code.co_filename
         # only log the last part of the filename, not the full path
-        filename = filename.split('/')[-1]
+        filename = basename(filename)
 
         self.log.warning(warning_message, extra={'_lineno': lineno, '_filename': filename})
         self.warnings.append(warning_message)

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -9,6 +9,7 @@ import json
 import copy
 import traceback
 import unicodedata
+import inspect
 
 from six import iteritems, text_type
 

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -15,7 +15,11 @@ class AgentLogHandler(logging.Handler):
     log message within the main agent logging system.
     """
     def emit(self, record):
-        msg = "({}:{}) | {}".format(record.filename, record.lineno, self.format(record))
+        msg = "({}:{}) | {}".format(
+            getattr(record, '_filename', record.filename),
+            getattr(record, '_lineno', record.lineno),
+            self.format(record)
+        )
         datadog_agent.log(msg, record.levelno)
 
 


### PR DESCRIPTION
### What does this PR do?

Right now, when you log from warning, it says that the warning log is on line 382 of base.py. This is not so great. I want it to show me the line in the check not the line of base. So, I want to make logging in warning optional and be able to log in the check instead, making warnings easier to track down. This means that we'll just add warning to the warnings without logging it.

### Motivation

Found this frustrating :(
