### PR TITLE
[kubernetes_state] add phase tag to pod metrics

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -300,6 +300,12 @@ class OpenMetricsScraperMixin(object):
         if metric.name in scraper_config['label_joins']:
             matching_label = scraper_config['label_joins'][metric.name]['label_to_match']
             for sample in metric.samples:
+                # metadata-only metrics that are used for label joins are always equal to 1
+                # this is required for metrics where all combinations of a state are sent
+                # but only the active one is set to 1 (others are set to 0)
+                # example: kube_pod_status_phase in kube-state-metrics
+                if sample[self.SAMPLE_VALUE] != 1:
+                    continue
                 labels_list = []
                 matching_value = None
                 for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -248,6 +248,10 @@ class KubernetesState(OpenMetricsBaseCheck):
                     'label_to_match': 'pod',
                     'labels_to_get': ['node']
                 },
+                'kube_pod_status_phase': {
+                    'label_to_match': 'pod',
+                    'labels_to_get': ['phase']
+                },
                 'kube_persistentvolume_info': {
                     'label_to_match': 'persistentvolume',
                     'labels_to_get': ['storageclass']


### PR DESCRIPTION
### What does this PR do?

Add pod phase to metrics from KSM with a label join.

### Motivation

requested by several users (several support tickets + #2521 + https://github.com/DataDog/datadog-agent/issues/2692)

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

I checked the label_joins bit in our codebase, it doesn't break anything. I'm willing to re-evaluate and put it behind an option if someone thinks of something that would break. As usual, if you see something, say something.

Also:
closes #2521 