### PR TITLE
Remove KSM deprecated pod phase service checks

### DIFF
--- a/kubernetes_state/README.md
+++ b/kubernetes_state/README.md
@@ -53,10 +53,6 @@ Returns `OK` otherwise.
 Returns `CRITICAL` if a cluster node is in a network unavailable state.
 Returns `OK` otherwise.
 
-**kubernetes_state.pod.phase**
-
-Returns `CRITICAL` if the pod is in phase `Failed`, `WARNING` if it is `Pending`, `UNKNOWN` if it is `Unknown` or `OK` otherwise.
-
 ## Troubleshooting
 Need help? Contact [Datadog Support][5].
 

--- a/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
@@ -24,7 +24,3 @@ instances:
     # overriden by the value of the label, this can be deactivated (all metrics
     # will be attached to the host running KSM)
     # hostname_override: true
-    #
-    # Send (deprecated) pod.phase service checks (default false)
-    # We recommend using the corresponding gauges instead, which benefit from historical data unlike service checks
-    # send_pod_phase_service_checks: false

--- a/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
@@ -25,10 +25,6 @@ instances:
     # overriden by the value of the label, this can be deactivated (all metrics
     # will be attached to the host running KSM)
     # hostname_override: true
-    #
-    # Send (deprecated) pod.phase service checks (default true, will be turned off in future versions)
-    # We recommend using the corresponding gauges instead, which benefit from historical data unlike service checks
-    # send_pod_phase_service_checks: false
 
     # You can also specify here custom tags to be added to all metrics reported by this integration
     #  tags:

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -41,19 +41,6 @@ class KubernetesState(OpenMetricsBaseCheck):
         generic_instances = [kubernetes_state_instance]
         super(KubernetesState, self).__init__(name, init_config, agentConfig, instances=generic_instances)
 
-        self.send_pod_phase_service_checks = is_affirmative(instance.get('send_pod_phase_service_checks', False))
-        if self.send_pod_phase_service_checks:
-            self.warning("DEPRECATION NOTICE: pod phase service checks are deprecated. Please set "
-                         "`send_pod_phase_service_checks` to false and rely on corresponding gauges instead")
-
-        self.pod_phase_to_status = {
-            'Pending':   self.WARNING,
-            'Running':   self.OK,
-            'Succeeded': self.OK,
-            'Failed':    self.CRITICAL,
-            'Unknown':   self.UNKNOWN
-        }
-
         self.condition_to_status_positive = {
             'true':      self.OK,
             'false':     self.CRITICAL,
@@ -324,14 +311,9 @@ class KubernetesState(OpenMetricsBaseCheck):
         service_check_name = condition_map['service_check_name']
         mapping = condition_map['mapping']
 
-        if base_sc_name == 'kubernetes_state.pod.phase':
-            pod = self._label_to_tag('pod', sample[self.SAMPLE_LABELS], scraper_config)
-            phase = self._label_to_tag('phase', sample[self.SAMPLE_LABELS], scraper_config)
-            message = "{} is currently reporting {}".format(pod, phase)
-        else:
-            node = self._label_to_tag('node', sample[self.SAMPLE_LABELS], scraper_config)
-            condition = self._label_to_tag('condition', sample[self.SAMPLE_LABELS], scraper_config)
-            message = "{} is currently reporting {} = {}".format(node, condition, label_value)
+        node = self._label_to_tag('node', sample[self.SAMPLE_LABELS], scraper_config)
+        condition = self._label_to_tag('condition', sample[self.SAMPLE_LABELS], scraper_config)
+        message = "{} is currently reporting {} = {}".format(node, condition, label_value)
 
         if condition_map['service_check_name'] is None:
             self.log.debug("Unable to handle {} - unknown condition {}".format(service_check_name, label_value))
@@ -364,9 +346,6 @@ class KubernetesState(OpenMetricsBaseCheck):
             }
             return (labels.get('status'), switch.get(labels.get('condition'),
                     {'service_check_name': None, 'mapping': None}))
-
-        elif base_sc_name == 'kubernetes_state.pod.phase':
-            return labels.get('phase'), {'service_check_name': base_sc_name, 'mapping': self.pod_phase_to_status}
 
     def _format_tag(self, name, value, scraper_config):
         """
@@ -402,18 +381,9 @@ class KubernetesState(OpenMetricsBaseCheck):
     def kube_pod_status_phase(self, metric, scraper_config):
         """ Phase a pod is in. """
         metric_name = scraper_config['namespace'] + '.pod.status_phase'
-        # Will submit a service check which status is given by its phase.
-        # More details about the phase in the message of the check.
-        check_basename = scraper_config['namespace'] + '.pod.phase'
         status_phase_counter = Counter()
 
         for sample in metric.samples:
-            if self.send_pod_phase_service_checks:
-                pod_tag = self._label_to_tag('pod', sample[self.SAMPLE_LABELS], scraper_config)
-                namespace_tag = self._label_to_tag('namespace', sample[self.SAMPLE_LABELS], scraper_config)
-                self._condition_to_tag_check(sample, check_basename, self.pod_phase_to_status, scraper_config,
-                                             tags=[pod_tag, namespace_tag] + scraper_config['custom_tags'])
-
             # Counts aggregated cluster-wide to avoid no-data issues on pod churn,
             # pod granularity available in the service checks
             tags = [

--- a/kubernetes_state/service_checks.json
+++ b/kubernetes_state/service_checks.json
@@ -43,14 +43,5 @@
         "groups": ["host", "node"],
         "name": "Node Network Unavailable",
         "description": "Returns `CRITICAL` if a cluster node is in a network unavailable state. Returns `OK` otherwise."
-    },
-    {
-        "agent_version": "5.6.0",
-        "integration":"kubernetes",
-        "check": "kubernetes_state.pod.phase",
-        "statuses": ["ok", "critical", "warning", "unknown"],
-        "groups": ["host", "pod"],
-        "name": "Pod Phase",
-        "description": "Returns `CRITICAL` if the pod is in phase `Failed`, `WARNING` if it is `Pending`, `UNKNOWN` if it is `Unknown` or `OK` otherwise."
     }
 ]

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -354,28 +354,10 @@ def test_disabling_hostname_override(instance):
     assert scraper_config['label_to_hostname'] is None
 
 
-def test_add_pod_phase_service_checks(aggregator, instance, check):
-    check.send_pod_phase_service_checks = True
+def test_pod_phase_gauges(aggregator, instance, check):
     for _ in range(2):
         check.check(instance)
-    # We should still send gauges
     aggregator.assert_metric(NAMESPACE + '.pod.status_phase',
                              tags=['namespace:default', 'phase:Running', 'optional:tag1'], value=3)
     aggregator.assert_metric(NAMESPACE + '.pod.status_phase',
                              tags=['namespace:default', 'phase:Failed', 'optional:tag1'], value=2)
-    # the service checks should be sent as well
-    # Running
-    aggregator.assert_service_check(NAMESPACE + '.pod.phase', check.OK,
-                                    tags=['namespace:default', 'pod:task-pv-pod', 'optional:tag1'])
-    # Pending
-    aggregator.assert_service_check(NAMESPACE + '.pod.phase', check.WARNING,
-                                    tags=['namespace:default', 'pod:failingtest-f585bbd4-2fsml', 'optional:tag1'])
-    # Succeeded
-    aggregator.assert_service_check(NAMESPACE + '.pod.phase', check.OK,
-                                    tags=['namespace:default', 'pod:hello-1509998340-k4f8q', 'optional:tag1'])
-    # Failed
-    aggregator.assert_service_check(NAMESPACE + '.pod.phase', check.CRITICAL,
-                                    tags=['namespace:default', 'pod:should-run-once', 'optional:tag1'])
-    # Unknown
-    aggregator.assert_service_check(NAMESPACE + '.pod.phase', check.UNKNOWN,
-                                    tags=['namespace:default', 'pod:hello-1509998460-tzh8k', 'optional:tag1'])


### PR DESCRIPTION
### What does this PR do?

Remove pod phase service checks that were deprecated.

### Motivation

Cleanup

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
