### PR TITLE
[Release] Bumped datadog_checks_dev version to 0.14.1

### DIFF
--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - Datadog Checks Dev
 
+## 0.14.1 / 2018-11-22
+
+* [Fixed] Increase gpg timeout to give time to developers to interact with Yubikeys. See [#2613](https://github.com/DataDog/integrations-core/pull/2613).
+* [Fixed] Fix requirements-agent-release.txt updating. See [#2617](https://github.com/DataDog/integrations-core/pull/2617).
+
 ## 0.14.0 / 2018-11-16
 
 * [Added] Support agent repo. See [#2600](https://github.com/DataDog/integrations-core/pull/2600).

--- a/datadog_checks_dev/datadog_checks/dev/__about__.py
+++ b/datadog_checks_dev/datadog_checks/dev/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '0.14.0'
+__version__ = '0.14.1'


### PR DESCRIPTION
### What does this PR do?

See title