### PR TITLE
Add disclaimer on new metric names

### DIFF
--- a/vsphere/README.md
+++ b/vsphere/README.md
@@ -13,7 +13,7 @@ The vSphere check is included in the [Datadog Agent][1] package, so you don't ne
 
 ### Configuration
 
-In the Administration section of vCenter, add a read-only user called datadog-readonly.
+In the **Administration** section of vCenter, add a read-only user called `datadog-readonly`.
 
 Then, edit the `vsphere.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][9]. See the [sample vsphere.d/conf.yaml][2] for all available configuration options:
 
@@ -21,7 +21,7 @@ Then, edit the `vsphere.d/conf.yaml` file in the `conf.d/` folder at the root of
 init_config:
 
 instances:
-  - name: main-vcenter # how metrics will be tagged, i.e. 'vcenter_server:main-vcenter'
+  - name: main-vcenter # how metrics are tagged, i.e. 'vcenter_server:main-vcenter'
     host: <VCENTER_HOSTNAME>          # e.g. myvcenter.example.com
     username: <USER_YOU_JUST_CREATED> # e.g. datadog-readonly@vsphere.local
     password: <PASSWORD>
@@ -29,36 +29,38 @@ instances:
 
 [Restart the Agent][3] to start sending vSphere metrics and events to Datadog.
 
-**Note**: The Datadog Agent doesn't need to be on the same server as the vSphere appliance software. An Agent with the vSphere check enabled can be set up -no matter what OS it's running on- to point to a vSphere appliance server. You will have to update your `<VCENTER_HOSTNAME>` accordingly.
+**Note**: The Datadog Agent doesn't need to be on the same server as the vSphere appliance software. An Agent with the vSphere check enabled can be set up -no matter what OS it's running on- to point to a vSphere appliance server. Update your `<VCENTER_HOSTNAME>` accordingly.
 
 ### Compatibility
 
-Starting with version 3.3.0 of the check, shipped in agent version 6.5.0/5.27.0, a new optional parameter `collection_level` was introduced to select which metrics to collect from vCenter, and the optional parameter `all_metrics` was deprecated. Along with this change, the names of the metrics sent to Datadog by the integration have changed, with the addition of a suffix specifying the rollup type of the metric exposed by vCenter (`.avg`, `.sum`, etc.).
+Starting with version 3.3.0 of the check, shipped in Agent version 6.5.0/5.27.0, a new optional parameter `collection_level` is available to select which metrics to collect from vCenter, and the optional parameter `all_metrics` was deprecated. Along with this change, the names of the metrics sent to Datadog by the integration have changed, with the addition of a suffix specifying the rollup type of the metric exposed by vCenter (`.avg`, `.sum`, etc.).
 
 By default, starting with version 3.3.0, the `collection_level` is set to 1 and the new metric names with the additional suffix are sent by the integration.
-The following scenarios are possible when using the vSphere integration:
-1. You never used the integration before, and you just installed an agent newer than 6.5.0/5.27.0. Nothing specific in that case, you can just use the integration, configure the `collection_level` as you wish and view your metrics in Datadog.
 
-1. You used the integration with an agent older than 6.5.0/5.27.0, and upgraded to a newer version.
-    1. If your configuration specifically set the `all_metrics` parameter to either `true` or `false`, nothing changes for you, you the same metrics are sent to Datadog. You should then update your dashboards and monitors to use the new metric names before switching to the new `collection_level` parameter, since `all_metrics` is deprecated and will eventually be removed.
-    1. If your configuration did not specify the `all_metrics` parameter, upon upgrade, the integration will default to the `collection_level` parameter set to 1 and send the metrics with the new name to Datadog. \
-    **Warning**: this will break your dashboard graphs and monitors scoped on the deprecated metrics, which will stop being sent.
-    To prevent this, you should explicitely set `all_metrics: false` in your configuration to continue reporting the same metrics, then update your dashboards and monitors to use the new metrics before switching back to using `collection_level`.
+The following scenarios are possible when using the vSphere integration:  
+1. You never used the integration before, and you just installed an Agent with version 6.5.0+ / 5.27.0+. There is nothing specific in this case. Use the integration, configure the `collection_level`, and view your metrics in Datadog.
+
+2. You used the integration with an Agent older than 6.5.0/5.27.0, and upgraded to a newer version.
+    - If your configuration specifically set the `all_metrics` parameter to either `true` or `false`, nothing changes (the same metrics are sent to Datadog). You should then update your dashboards and monitors to use the new metric names before switching to the new `collection_level` parameter, since `all_metrics` is deprecated and will eventually be removed.
+    - If your configuration did not specify the `all_metrics` parameter, upon upgrade the integration defaults to the `collection_level` parameter set to 1 and sends the metrics with the new name to Datadog.  
+    **Warning**: this breaks your dashboard graphs and monitors scoped on the deprecated metrics, which stop being sent. To prevent this, you should explicitly set `all_metrics: false` in your configuration to continue reporting the same metrics, then update your dashboards and monitors to use the new metrics before switching back to using `collection_level`.
 
 #### Configuration Options
 
-* `ssl_verify` (Optional) - Set to false to disable SSL verification, when connecting to vCenter
-* `ssl_capath` (Optional) - Set to the absolute file path of a directory containing CA certificates in PEM format
-* `host_include_only_regex` (Optional) - Use a regex like this if you want only the check to fetch metrics for these ESXi hosts and the VMs running on it
-* `vm_include_only_regex` (Optional) - Use a regex to include only the VMs that are matching this pattern.
-* `include_only_marked` (Optional) - Set to true if you'd like to only collect metrics on vSphere VMs which are marked by a custom field with the value 'DatadogMonitored'. To set this custom field with PowerCLI, use the follow command: `Get-VM <MyVMName> | Set-CustomField -Name "DatadogMonitored" -Value "DatadogMonitored"`
-* `collection_level` (Optional) - A number between 1 and 4 to specify how many metrics will be sent, 1 meaning only important monitoring metrics and 4 meaning every metric available.
-* `all_metrics` (Deprecated, Optional) - When set to true, this will collect EVERY metric from vCenter, which means a LOT of metrics you probably do not care about. We have selected a set of metrics that are interesting to monitor for you if false.
-* `event_config` (Optional) - Event config is a dictionary. For now the only switch you can flip is collect_vcenter_alarms which will send as events the alarms set in vCenter.
+| Options                   | Required | Description                                                                                                                                                                                                                                                                               |
+|---------------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ssl_verify`              | No       | Set to false to disable SSL verification, when connecting to vCenter.                                                                                                                                                                                                                     |
+| `ssl_capath`              | No       | Set to the absolute file path of a directory containing CA certificates in PEM format.                                                                                                                                                                                                    |
+| `host_include_only_regex` | No       | Use a regex like this if you want the check to only fetch metrics for these ESXi hosts and the VMs running on it.                                                                                                                                                                         |
+| `vm_include_only_regex`   | No       | Use a regex to include only the VMs that are matching this pattern.                                                                                                                                                                                                                       |
+| `include_only_marked`     | No       | Set to true if you'd like to only collect metrics on vSphere VMs which are marked by a custom field with the value 'DatadogMonitored'. To set this custom field with PowerCLI, use the command: <code>Get-VM <MyVMName> \| Set-CustomField -Name "DatadogMonitored" -Value "DatadogMonitored"</code>. |
+| `collection_level`        | No       | A number between 1 and 4 to specify how many metrics are sent, 1 meaning only important monitoring metrics and 4 meaning every metric available.                                                                                                                                          |
+| `all_metrics`             | No       | (Deprecated) When set to true, this collects EVERY metric from vCenter, which means a LOT of metrics. When set to false, this collects a subset of metrics we selected that are interesting to monitor                                                                                    |
+| `event_config`            | No       | Event config is a dictionary. For now the only switch you can flip is `collect_vcenter_alarms` which sends the alarms set in vCenter as events.                                                                                                                                           |
 
 ### Validation
 
-[Run the Agent's `status` subcommand][4] and look for `vsphere` under the Checks section.
+[Run the Agent's status subcommand][4] and look for `vsphere` under the Checks section.
 
 ## Data Collected
 ### Metrics
@@ -88,8 +90,7 @@ This check watches vCenter's Event Manager for events and emits them to Datadog.
 
 ### Service Checks
 
-`vcenter.can_connect`:
-
+`vcenter.can_connect`:  
 Returns CRITICAL if the Agent cannot connect to vCenter to collect metrics, otherwise OK.
 
 ## Troubleshooting

--- a/vsphere/README.md
+++ b/vsphere/README.md
@@ -33,17 +33,17 @@ instances:
 
 ### Compatibility
 
-Starting with version 3.3.0 of the check, shipped in agent version 6.5.0/5.27.0, we introduced a new optional parameter `collection_level` to select which metrics to collect from vCenter, and deprecated the optional parameter `all_metrics`. Along with this change, the names of the metrics sent to Datadog by the integration have changed, with the addition of a suffix specifying the rollup type of the metric exposed by vCenter (`.avg`, `.sum`, etc.).
+Starting with version 3.3.0 of the check, shipped in agent version 6.5.0/5.27.0, a new optional parameter `collection_level` was introduced to select which metrics to collect from vCenter, and the optional parameter `all_metrics` was deprecated. Along with this change, the names of the metrics sent to Datadog by the integration have changed, with the addition of a suffix specifying the rollup type of the metric exposed by vCenter (`.avg`, `.sum`, etc.).
 
 By default, starting with version 3.3.0, the `collection_level` is set to 1 and the new metric names with the additional suffix are sent by the integration.
 The following scenarios are possible when using the vSphere integration:
-1. You never used the integration before, and you just install an agent newer than 6.5.0/5.27.0. Nothing specific in that case, you can just use the integration, configure the `collection_level` as you wish and view your metrics in Datadog.
+1. You never used the integration before, and you just installed an agent newer than 6.5.0/5.27.0. Nothing specific in that case, you can just use the integration, configure the `collection_level` as you wish and view your metrics in Datadog.
 
 1. You used the integration with an agent older than 6.5.0/5.27.0, and upgraded to a newer version.
-    1. If your configuration specifically set the `all_metrics` parameter to either `true` or `false`, nothing changes for you, you will still see the same metrics in Datadog. You should then change your dashboards and monitors to use the new metric names and then switch to the new `collection_level` parameter.
+    1. If your configuration specifically set the `all_metrics` parameter to either `true` or `false`, nothing changes for you, you the same metrics are sent to Datadog. You should then update your dashboards and monitors to use the new metric names before switching to the new `collection_level` parameter, since `all_metrics` is deprecated and will eventually be removed.
     1. If your configuration did not specify the `all_metrics` parameter, upon upgrade, the integration will default to the `collection_level` parameter set to 1 and send the metrics with the new name to Datadog. \
     **Warning**: this will break your dashboard graphs and monitors scoped on the deprecated metrics, which will stop being sent.
-    To prevent this, you should explicitely set `all_metrics: false` in your configuration to continue reporting the same metrics, then change your dashboards and monitors to use the new metrics before switching back to using `collection_level`.
+    To prevent this, you should explicitely set `all_metrics: false` in your configuration to continue reporting the same metrics, then update your dashboards and monitors to use the new metrics before switching back to using `collection_level`.
 
 #### Configuration Options
 
@@ -52,7 +52,8 @@ The following scenarios are possible when using the vSphere integration:
 * `host_include_only_regex` (Optional) - Use a regex like this if you want only the check to fetch metrics for these ESXi hosts and the VMs running on it
 * `vm_include_only_regex` (Optional) - Use a regex to include only the VMs that are matching this pattern.
 * `include_only_marked` (Optional) - Set to true if you'd like to only collect metrics on vSphere VMs which are marked by a custom field with the value 'DatadogMonitored'. To set this custom field with PowerCLI, use the follow command: `Get-VM <MyVMName> | Set-CustomField -Name "DatadogMonitored" -Value "DatadogMonitored"`
-* `all_metrics` (Optional) - When set to true, this will collect EVERY metric from vCenter, which means a LOT of metrics you probably do not care about. We have selected a set of metrics that are interesting to monitor for you if false.
+* `collection_level` (Optional) - A number between 1 and 4 to specify how many metrics will be sent, 1 meaning only important monitoring metrics and 4 meaning every metric available.
+* `all_metrics` (Deprecated, Optional) - When set to true, this will collect EVERY metric from vCenter, which means a LOT of metrics you probably do not care about. We have selected a set of metrics that are interesting to monitor for you if false.
 * `event_config` (Optional) - Event config is a dictionary. For now the only switch you can flip is collect_vcenter_alarms which will send as events the alarms set in vCenter.
 
 ### Validation

--- a/vsphere/README.md
+++ b/vsphere/README.md
@@ -31,6 +31,20 @@ instances:
 
 **Note**: The Datadog Agent doesn't need to be on the same server as the vSphere appliance software. An Agent with the vSphere check enabled can be set up -no matter what OS it's running on- to point to a vSphere appliance server. You will have to update your `<VCENTER_HOSTNAME>` accordingly.
 
+### Compatibility
+
+Starting with version 3.3.0 of the check, shipped in agent version 6.5.0/5.27.0, we introduced a new optional parameter `collection_level` to select which metrics to collect from vCenter, and deprecated the optional parameter `all_metrics`. Along with this change, the names of the metrics sent to Datadog by the integration have changed, with the addition of a suffix specifying the rollup type of the metric exposed by vCenter (`.avg`, `.sum`, etc.).
+
+By default, starting with version 3.3.0, the `collection_level` is set to 1 and the new metric names with the additional suffix are sent by the integration.
+The following scenarios are possible when using the vSphere integration:
+1. You never used the integration before, and you just install an agent newer than 6.5.0/5.27.0. Nothing specific in that case, you can just use the integration, configure the `collection_level` as you wish and view your metrics in Datadog.
+
+1. You used the integration with an agent older than 6.5.0/5.27.0, and upgraded to a newer version.
+    1. If your configuration specifically set the `all_metrics` parameter to either `true` or `false`, nothing changes for you, you will still see the same metrics in Datadog. You should then change your dashboards and monitors to use the new metric names and then switch to the new `collection_level` parameter.
+    1. If your configuration did not specify the `all_metrics` parameter, upon upgrade, the integration will default to the `collection_level` parameter set to 1 and send the metrics with the new name to Datadog. \
+    **Warning**: this will break your dashboard graphs and monitors scoped on the deprecated metrics, which will stop being sent.
+    To prevent this, you should explicitely set `all_metrics: false` in your configuration to continue reporting the same metrics, then change your dashboards and monitors to use the new metrics before switching back to using `collection_level`.
+
 #### Configuration Options
 
 * `ssl_verify` (Optional) - Set to false to disable SSL verification, when connecting to vCenter


### PR DESCRIPTION
### What does this PR do?

Document the possible cases regarding the change in metrics names with version 3.3.0 of the vsphere integration

### Motivation

The implications weren't clear

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?