### PR TITLE
Add unix socket support in php_fpm plugin

### DIFF
--- a/php_fpm/README.md
+++ b/php_fpm/README.md
@@ -69,6 +69,20 @@ server {
 
 If you find this approach too tedious at scale, setting `use_fastcgi` to `true` instructs the check to bypass any proxy servers and communicate directly with PHP-FPM using FastCGI. The default port is `9000` for when omitted from `status_url` or `ping_url`.
 
+### Unix sockets
+
+If your php-fpm installation uses unix sockets, you have to use the below syntax for `status_url`, `ping_url` and enable `use_fastcgi`:
+
+```
+init_config:
+
+instances:
+  - status_url: unix:///path/to/file.sock/status 
+    ping_url: unix:///path/to/file.sock/ping    
+    ping_reply: pong                   
+    use_fastcgi: true
+```
+
 ### Validation
 
 [Run the Agent's `status` subcommand][4] and look for `php_fpm` under the Checks section.

--- a/php_fpm/datadog_checks/php_fpm/php_fpm.py
+++ b/php_fpm/datadog_checks/php_fpm/php_fpm.py
@@ -189,13 +189,22 @@ class PHPFPMCheck(AgentCheck):
     @classmethod
     def request_fastcgi(cls, url, query=''):
         parsed_url = urlparse(url)
-
-        hostname = parsed_url.hostname
-        if hostname == 'localhost':
-            hostname = '127.0.0.1'
-
-        port = str(parsed_url.port or 9000)
-        route = parsed_url.path
+        
+        if parsed_url.scheme == "unix":
+          # Example of expected format: unix:///path/to/file.sock/ping
+          sock = parsed_url.path.split('.sock')[0]+'.sock'
+          route =  parsed_url.path.split('.sock')[1]
+          hostname = 'localhost'
+          port = '80'
+          fcgi = FCGIApp(connect=sock)
+        else:
+        
+          hostname = parsed_url.hostname
+          if hostname == 'localhost':
+              hostname = '127.0.0.1'
+          port = str(parsed_url.port or 9000)
+          route = parsed_url.path
+          fcgi = FCGIApp(host=hostname, port=port)
 
         env = {
             'CONTENT_LENGTH': '0',
@@ -218,8 +227,6 @@ class PHPFPMCheck(AgentCheck):
             'wsgi.errors': StringIO(),
             'wsgi.input': StringIO(),
         }
-
-        fcgi = FCGIApp(host=hostname, port=port)
 
         # Return first response
         return fcgi(env, lambda *args, **kwargs: '')[0]

--- a/php_fpm/datadog_checks/php_fpm/php_fpm.py
+++ b/php_fpm/datadog_checks/php_fpm/php_fpm.py
@@ -189,16 +189,15 @@ class PHPFPMCheck(AgentCheck):
     @classmethod
     def request_fastcgi(cls, url, query=''):
         parsed_url = urlparse(url)
-        
+
         if parsed_url.scheme == "unix":
             # Example of expected format: unix:///path/to/file.sock/ping
             sock = parsed_url.path.split('.sock')[0]+'.sock'
-            route =  parsed_url.path.split('.sock')[1]
+            route = parsed_url.path.split('.sock')[1]
             hostname = 'localhost'
             port = '80'
             fcgi = FCGIApp(connect=sock)
         else:
-        
             hostname = parsed_url.hostname
             if hostname == 'localhost':
                 hostname = '127.0.0.1'

--- a/php_fpm/datadog_checks/php_fpm/php_fpm.py
+++ b/php_fpm/datadog_checks/php_fpm/php_fpm.py
@@ -192,8 +192,8 @@ class PHPFPMCheck(AgentCheck):
 
         if parsed_url.scheme == "unix":
             # Example of expected format: unix:///path/to/file.sock/ping
-            sock = parsed_url.path.split('.sock')[0]+'.sock'
-            route = parsed_url.path.split('.sock')[1]
+            sock_file, _, route = parsed_url.path.partition('.sock')
+            sock_file += '.sock'
             hostname = 'localhost'
             port = '80'
             fcgi = FCGIApp(connect=sock)

--- a/php_fpm/datadog_checks/php_fpm/php_fpm.py
+++ b/php_fpm/datadog_checks/php_fpm/php_fpm.py
@@ -191,20 +191,20 @@ class PHPFPMCheck(AgentCheck):
         parsed_url = urlparse(url)
         
         if parsed_url.scheme == "unix":
-          # Example of expected format: unix:///path/to/file.sock/ping
-          sock = parsed_url.path.split('.sock')[0]+'.sock'
-          route =  parsed_url.path.split('.sock')[1]
-          hostname = 'localhost'
-          port = '80'
-          fcgi = FCGIApp(connect=sock)
+            # Example of expected format: unix:///path/to/file.sock/ping
+            sock = parsed_url.path.split('.sock')[0]+'.sock'
+            route =  parsed_url.path.split('.sock')[1]
+            hostname = 'localhost'
+            port = '80'
+            fcgi = FCGIApp(connect=sock)
         else:
         
-          hostname = parsed_url.hostname
-          if hostname == 'localhost':
-              hostname = '127.0.0.1'
-          port = str(parsed_url.port or 9000)
-          route = parsed_url.path
-          fcgi = FCGIApp(host=hostname, port=port)
+            hostname = parsed_url.hostname
+            if hostname == 'localhost':
+                hostname = '127.0.0.1'
+            port = str(parsed_url.port or 9000)
+            route = parsed_url.path
+            fcgi = FCGIApp(host=hostname, port=port)
 
         env = {
             'CONTENT_LENGTH': '0',

--- a/php_fpm/datadog_checks/php_fpm/php_fpm.py
+++ b/php_fpm/datadog_checks/php_fpm/php_fpm.py
@@ -196,7 +196,7 @@ class PHPFPMCheck(AgentCheck):
             sock_file += '.sock'
             hostname = 'localhost'
             port = '80'
-            fcgi = FCGIApp(connect=sock)
+            fcgi = FCGIApp(connect=sock_file)
         else:
             hostname = parsed_url.hostname
             if hostname == 'localhost':


### PR DESCRIPTION
### What does this PR do?

It adds unix sockets support to php_fpm plugin

### Motivation

Company PHP fpm setup which does not use plain sockets.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

This is our first contribution, do not hesitate to contact us ! 
