### PR TITLE
Keep running the check when one endpoint fails

### DIFF
--- a/couchbase/tests/test_unit.py
+++ b/couchbase/tests/test_unit.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
 from datadog_checks.couchbase import Couchbase
 
 
@@ -42,3 +41,12 @@ def test_extract_seconds_value():
         test_output = couchbase.extract_seconds_value(test_input)
         assert test_output == expected_output, 'Input was {}, expected output was {}, actual output was {}'.format(
             test_input, expected_output, test_output)
+
+
+def test__get_query_monitoring_data():
+    """
+    `query_monitoring_url` can potentially fail, be sure we don't raise when the
+    endpoint is not reachable
+    """
+    couchbase = Couchbase('couchbase', {}, {})
+    couchbase._get_query_monitoring_data({'query_monitoring_url': 'http://foo/bar'})


### PR DESCRIPTION
### What does this PR do?

Catch a broader exception when hitting the query data monitoring endpoint so that we don't stop the check if the endpoint isn't reachable.

### Motivation

Sometimes the endpoint is expected to fail, for example when you have multiple pods in a k8s cluster and only some of them actually exposes the url configured with `query_monitoring_url`, so failure is expected.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional notes

The logic was isolated in a class method to ease testing and make the code more readable.