### PR TITLE
Fix not_asserted aggregator stub function

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -221,11 +221,12 @@ class AggregatorStub(object):
         assert self.metrics_asserted_pct >= 100.0
 
     def not_asserted(self):
-        not_asserted = []
-        for mname, metric in iteritems(self._metrics):
-            if mname not in self._asserted:
-                not_asserted.append(metric)
-        return not_asserted
+        metrics_not_asserted = []
+        for metric in self._metrics:
+            metric = ensure_unicode(metric)
+            if metric not in self._asserted:
+                metrics_not_asserted.append(metric)
+        return metrics_not_asserted
 
     def assert_metric_has_tag_prefix(self, metric_name, tag_prefix, count=None, at_least=1):
         candidates = []


### PR DESCRIPTION
### Motivation

Python 3 compatibility

### Additional Notes

Also made it return the more useful metric names instead of list of list of metric stubs. This function is only used in mysql tests and it won't be affected