### PR TITLE
Gently handle Yubikey exceptions

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
@@ -577,7 +577,7 @@ def make(ctx, check, version, initial_release, skip_sign, sign_only):
       - Ensure you did `gpg --import <YOUR_KEY_ID>.gpg.pub`
     """
     # Import lazily since in-toto runs a subprocess to check for gpg2 on load
-    from ..signing import update_link_metadata
+    from ..signing import update_link_metadata, YubikeyException
 
     root = get_root()
     releasing_all = check == 'all'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
@@ -690,9 +690,11 @@ def make(ctx, check, version, initial_release, skip_sign, sign_only):
     if sign_only or not skip_sign:
         echo_waiting('Updating release metadata...')
         echo_info('Please touch your Yubikey immediately after entering your PIN!')
-        commit_targets = update_link_metadata(checks)
-
-        git_commit(commit_targets, '[Release] Update metadata', force=True)
+        try:
+            commit_targets = update_link_metadata(checks)
+            git_commit(commit_targets, '[Release] Update metadata', force=True)
+        except YubikeyException as e:
+            abort('A problem occurred while signing metadata: {}'.format(e))
 
     # done
     echo_success('All done, remember to push to origin and open a PR to merge these changes on master')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
@@ -24,6 +24,10 @@ LINK_DIR = '.links'
 STEP_NAME = 'tag'
 
 
+class YubikeyException(Exception):
+    pass
+
+
 def read_gitignore_patterns():
     exclude_patterns = []
 
@@ -42,7 +46,7 @@ def get_key_id(gpg_exe):
         if line.startswith('Signature key ....:'):
             return line.split(':')[1].replace(' ', '')
     else:
-        raise Exception('Could not find private signing key on Yubikey!')
+        raise YubikeyException('Could not find private signing key on Yubikey!')
 
 
 def run_in_toto(key_id, products):


### PR DESCRIPTION
### What does this PR do?

See title

### Motivation

If the Yubikey is not properly setup, `ddev` fails with a traceback instead of handling the error.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Make use of a specific error type to avoid catching `Exception`