### PR TITLE
Add elasticsearch-oss as an auto_conf.yaml Elasticsearch identifier

### DIFF
--- a/elastic/datadog_checks/elastic/data/auto_conf.yaml
+++ b/elastic/datadog_checks/elastic/data/auto_conf.yaml
@@ -1,5 +1,6 @@
 ad_identifiers:
   - elasticsearch
+  - elasticsearch-oss
 
 init_config:
 


### PR DESCRIPTION
### What does this PR do?

The open source Elasticsearch image is named `elasticsearch-oss`, so this should enable autodiscovery for it.

### Motivation

An Elasticsearch deployment was not autodiscovered.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
