### PR TITLE
Add watt unit to metadata validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate_commands/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate_commands/metadata.py
@@ -174,6 +174,11 @@ VALID_UNIT_NAMES = {
     'exacore',
     'build',
     'prediction',
+    'watt',
+    'kilowatt',
+    'megawatt',
+    'gigawatt',
+    'terawatt',
 }
 
 PROVIDER_INTEGRATIONS = {


### PR DESCRIPTION
### What does this PR do?

title

### Motivation

vSphere sends a metric with this unit

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
