### PR TITLE
fix service check name

### DIFF
--- a/couchbase/service_checks.json
+++ b/couchbase/service_checks.json
@@ -20,10 +20,10 @@
     {
         "agent_version": "6.2.1",
         "integration":"couchbase",
-        "check": "couchbase.by_node.health_status",
+        "check": "couchbase.by_node.health",
         "statuses": ["ok", "critical"],
         "groups": ["node"],
-        "name": "Node Health Status",
+        "name": "Node Health",
         "description": "Returns `CRITICAL` if the node is unhealthy. Returns `OK` otherwise."
     }
 ]


### PR DESCRIPTION
### What does this PR do?

Fix the service check name for health status. 
The correct name is defined https://github.com/DataDog/integrations-core/blob/16afef311cbeddaec340ca739296c07a1ac92a1c/couchbase/datadog_checks/couchbase/couchbase.py#L34