### PR TITLE
add consul.up service check

### DIFF
--- a/consul/service_checks.json
+++ b/consul/service_checks.json
@@ -4,8 +4,17 @@
         "integration":"consul",
         "groups": ["host", "check", "service", "consul_service_id"],
         "check": "consul.check",
-        "statuses": ["ok", "warning", "critical"],
-        "name": "Health check",
-        "description": "Returns ok if the service is up, warning if there is an issue and critical when down."
+        "statuses": ["ok", "warning", "critical", "unknown"],
+        "name": "Health Check",
+        "description": "Returns OK if the service is up, WARNING if there is an issue and CRITICAL when down."
+    },
+    {
+        "agent_version": "5.5.0",
+        "integration":"consul",
+        "groups": ["host", "consul_url"],
+        "check": "consul.up",
+        "statuses": ["ok", "critical"],
+        "name": "Up",
+        "description": "Returns OK if the consul server is up, CRITICAL otherwise."
     }
 ]


### PR DESCRIPTION
### What does this PR do?

`consul.up` definition was missing in `service_checks.json`. This adds it.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?