### PR TITLE
Add option to collect cluster, datacenter and datastore metrics

### DIFF
--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -113,6 +113,14 @@ instances:
   #
   #  collection_level: 1
 
+  ## @param collect_realtime_only - boolean - optional - default: true
+  ## Set to true to collect only host and VM metrics. Set to false to collect
+  ## cluster, datastore and datacenter metrics as well.
+  ## Collecting non realtime metrics will decrease performance as it
+  ## requires computation from the vCenter server.
+  #
+  #  collect_realtime_only: true
+
   ## @param use_guest_hostname - boolean - optional - default: false
   ## If true, the check will use the guest hostname for VMs instead of the VM name
   ## This requires the VM to have VMware tools installed in it. If the guest hostname is

--- a/vsphere/tests/fixtures/vsphere_topology.json
+++ b/vsphere/tests/fixtures/vsphere_topology.json
@@ -14,6 +14,11 @@
     "parent_name": "datacenter1"
   },
   {
+    "spec": "Datastore",
+    "name": "datastore",
+    "parent_name": "datacenter1"
+  },
+  {
     "spec": "HostSystem",
     "name": "host1",
     "parent_name": "compute_resource1"


### PR DESCRIPTION
### What does this PR do?

Add ability to collect cluster metrics.

This also fixes getting metrics for datastore and datacenter, which was not actually working
It won't collect this metrics by default, since getting them from vCenter considerably increase the collection time

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?