### PR TITLE
Support custom certificates

### DIFF
--- a/vault/datadog_checks/vault/data/conf.yaml.example
+++ b/vault/datadog_checks/vault/data/conf.yaml.example
@@ -20,11 +20,25 @@ instances:
   # username: USERNAME
   # password: PASSWORD
 
+  # If Vault setup uses SSL, you might need to set the following options as well.
+
+  # You can specify a local cert to use as client side certificate
+  # as a single file (containing the private key and the certificate concatenated)
+  # client_cert_file: '/path/to/client.concatenated.pem'
+
+  # Or as two separate files (for certificate and key):
+  # client_cert_file: '/path/to/client.cert.pem'
+  # private_key_file: '/path/to/private.key.pem'
+
   # The (optional) ssl_verify parameter will instruct the check to validate SSL
   # certificates when connecting to Vault. Defaulting to true, set to false if
   # you want to disable SSL certificate validation.
   #
   # ssl_verify: true
+  #
+  # If ssl_verify is enabled, optionally specify a path to
+  # a ca bundle file or directory to trust additional roots
+  # ca_bundle_path: '/path/to/trusted_ca_bundle_file'
   #
   # If you disable the ssl_verify above, you will still receive security
   # warnings in logs. You can disable those too using the flag below.

--- a/vault/datadog_checks/vault/data/conf.yaml.example
+++ b/vault/datadog_checks/vault/data/conf.yaml.example
@@ -24,11 +24,11 @@ instances:
 
   # You can specify a local cert to use as client side certificate
   # as a single file (containing the private key and the certificate concatenated)
-  # client_cert_file: '/path/to/client.concatenated.pem'
+  # ssl_cert: '/path/to/client.concatenated.pem'
 
   # Or as two separate files (for certificate and key):
-  # client_cert_file: '/path/to/client.cert.pem'
-  # private_key_file: '/path/to/private.key.pem'
+  # ssl_cert: '/path/to/client.cert.pem'
+  # ssl_private_key: '/path/to/private.key.pem'
 
   # The (optional) ssl_verify parameter will instruct the check to validate SSL
   # certificates when connecting to Vault. Defaulting to true, set to false if
@@ -36,11 +36,12 @@ instances:
   #
   # ssl_verify: true
   #
-  # If ssl_verify is enabled, optionally specify a path to
-  # a ca bundle file or directory to trust additional roots
-  # ca_bundle_path: '/path/to/trusted_ca_bundle_file'
+  # Alternatively, setting ssl_ca_cert to the path of a trusted ca bundle file or directory
+  # will both enable ssl_verify and use the specified path during validation.
   #
-  # If you disable the ssl_verify above, you will still receive security
+  # ssl_ca_cert: '/path/to/trusted_ca_bundle_file'
+  #
+  # If you disable ssl_verify above, you will still receive security
   # warnings in logs. You can disable those too using the flag below.
   #
   # ssl_ignore_warning: false

--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -161,7 +161,7 @@ class Vault(AgentCheck):
                 if config['ssl_ignore_warning']:
                     warnings.simplefilter('ignore', InsecureRequestWarning)
 
-                 response = requests.get(
+                response = requests.get(
                     url,
                     auth=config['auth'],
                     cert=config['ssl_cert'],

--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -5,6 +5,7 @@ import warnings
 from time import time as timestamp
 
 import requests
+from six import string_types
 from urllib3.exceptions import InsecureRequestWarning
 
 from datadog_checks.checks import AgentCheck
@@ -126,10 +127,21 @@ class Vault(AgentCheck):
             password = instance.get('password')
             config['auth'] = (username, password) if username and password else None
 
-            config['client_cert_file'] = instance.get('client_cert_file', False)
-            config['private_key_file'] = instance.get('private_key_file', False)
-            config['ssl_verify'] = is_affirmative(instance.get('ssl_verify', True))
-            config['ca_bundle_path'] = instance.get('ca_bundle_path', False)
+            ssl_cert = instance.get('ssl_cert')
+            ssl_private_key = instance.get('ssl_private_key')
+            if isinstance(ssl_cert, string_types):
+                if isinstance(ssl_private_key, string_types):
+                    config['ssl_cert'] = (ssl_cert, ssl_private_key)
+                else:
+                    config['ssl_cert'] = ssl_cert
+            else:
+                config['ssl_cert'] = None
+
+            if isinstance(instance.get('ssl_ca_cert'), string_types):
+                config['ssl_verify'] = instance['ssl_ca_cert']
+            else:
+                config['ssl_verify'] = is_affirmative(instance.get('ssl_verify', True))
+
             config['ssl_ignore_warning'] = is_affirmative(instance.get('ssl_ignore_warning', False))
             config['proxies'] = self.get_instance_proxy(instance, config['api_url'])
             config['timeout'] = int(instance.get('timeout', 20))
@@ -149,44 +161,15 @@ class Vault(AgentCheck):
                 if config['ssl_ignore_warning']:
                     warnings.simplefilter('ignore', InsecureRequestWarning)
 
-                # if ssl_verify is enabled
-                # optionally use the ca_bundle_path, if specified
-                ssl_verify_or_bundle = config['ssl_verify']
-                if ssl_verify_or_bundle and config['ca_bundle_path']:
-                    ssl_verify_or_bundle = config['ca_bundle_path']
-
-                if config['client_cert_file']:
-                    if config['private_key_file']:
-                        response = requests.get(
-                            url,
-                            cert=(
-                                config['client_cert_file'],
-                                config['private_key_file']),
-                            auth=config['auth'],
-                            verify=ssl_verify_or_bundle,
-                            proxies=config['proxies'],
-                            timeout=config['timeout'],
-                            headers=config['headers']
-                        )
-                    else:
-                        response = requests.get(
-                            url,
-                            cert=config['client_cert_file'],
-                            auth=config['auth'],
-                            verify=ssl_verify_or_bundle,
-                            proxies=config['proxies'],
-                            timeout=config['timeout'],
-                            headers=config['headers']
-                        )
-                else:
-                    response = requests.get(
-                        url,
-                        auth=config['auth'],
-                        verify=ssl_verify_or_bundle,
-                        proxies=config['proxies'],
-                        timeout=config['timeout'],
-                        headers=config['headers']
-                    )
+                 response = requests.get(
+                    url,
+                    auth=config['auth'],
+                    cert=config['ssl_cert'],
+                    verify=config['ssl_verify'],
+                    proxies=config['proxies'],
+                    timeout=config['timeout'],
+                    headers=config['headers']
+                )
         except requests.exceptions.Timeout:
             msg = 'Vault endpoint `{}` timed out after {} seconds'.format(url, config['timeout'])
             self.service_check(


### PR DESCRIPTION
### What does this PR do?

For the hashicorp vault integration:

Adds the ability to optionally specify a client cert, private key file, and/or ca bundle file or directory used when making requests to the vault endpoint.

The implementation is based off the existing working implementation used for the [consul check](https://github.com/DataDog/integrations-core/blob/master/consul/datadog_checks/consul/consul.py#L86-L102).

### Motivation

The need to support client-certificate based authentication for vault (such as when [tls_require_and_verify_client_cert](https://www.vaultproject.io/docs/configuration/listener/tcp.html#tls_require_and_verify_client_cert) is enabled)

As well as specify a custom ca bundle file or directory

Closes #2320 

### Review checklist

- [X] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [X] Feature or bugfix has tests (see below)
- [X] Git history is clean
- [X] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new) -- I don't think so?

### Additional Notes

This is my first attempt at contributing to integrations-core.

I based these changes on the behavior used by the consul integration, which also uses the python requests library with support for client certs and ca bundles.

I checked the consul project and was unable to find any tests that exercise the ssl configuration, so I similarly did not implement any explicit tests for this behavior.

Existing tests pass.

Additional help or commits from maintainers to get this across the line are more than welcome!
