### PR TITLE
[docs] Update correct list of default NTP hosts

### DIFF
--- a/ntp/README.md
+++ b/ntp/README.md
@@ -10,6 +10,7 @@ The Network Time Protocol (NTP) integration is enabled by default and reports th
 
 Default NTP servers reached:
 
+* `0.datadog.pool.ntp.org`
 * `1.datadog.pool.ntp.org`
 * `2.datadog.pool.ntp.org`
 * `3.datadog.pool.ntp.org`


### PR DESCRIPTION
The host starting with 0 was missing from this documentation. After seeing it blocked, and checking the agent code, this update would correct it.

* [V5 agent code](https://github.com/DataDog/dd-agent/blob/33afda662aade99500f454b33f208e8289818d7b/utils/ntp.py#L32)
* [V6 agent code](https://github.com/DataDog/datadog-agent/blob/53b8106642411f2e992acc52bf6303de22c072a8/pkg/collector/corechecks/net/ntp_test.go#L300)

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
