### PR TITLE
Remove dependency on pymqi

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -31,7 +31,6 @@ pyasn1==0.4.2
 pycparser==2.18
 pycryptodomex==3.4.7
 pymongo==3.5.1
-pymqi==1.8.0; sys_platform != 'win32' and sys_platform != 'darwin'
 pymysql==0.8.0
 pyodbc==4.0.13
 pyro4==4.73; sys_platform == 'win32'


### PR DESCRIPTION
### What does this PR do?

Removes dependency on pymqi, added in https://github.com/DataDog/integrations-core/pull/2668

### Motivation

The dep currently breaks the datadog-agent build, which blocks 6.8.0-rc.1

This dep is required by the ibmmq integration, so removing it breaks that integration in the packaged agent

cc @gmmeyer @ofek 
