### PR TITLE
Update conf.yaml example with SSL params

### DIFF
--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -11,12 +11,12 @@ instances:
   #
   # ssl_cert: <path_to_cert.pem>
 
-  ## @param ssl_private_key - string - required 
+  ## @param ssl_private_key - string - optional
   ## Needed if the certificate does not include the private key. Currently, Requests does not support using encrypted keys.
   #
    ssl_private_key: <path_to_cert.key>
 
-  ## @param ssl_ca_cert - string - required
+  ## @param ssl_ca_cert - string - optional
   ## The path to the trusted CA used for generating custom certificates
   #
    ssl_ca_cert: <path_to_cert.pem>

--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -5,16 +5,21 @@ instances:
   ## The Prometheus endpoint to query.
   #
   - prometheus_url: http://localhost:8080/_status/vars
-    # Can either be only the path to the certificate and thus you should specify the private key
-      # or it can be the path to a file containing both the certificate & the private key
-    # ssl_cert: /path/to/cert.pem
-    
-    # Needed if the certificate does not include the private key
-      # Currently, Requests does not support using encrypted keys.
-    # ssl_private_key: /path/to/cert.key
-    
-    # The path to the trusted CA used for generating custom certificates
-    # ssl_ca_cert: /path/to/cert.pem
+  
+  ## @param ssl_cert - string - optional 
+  ## If the certificate contains the ssl_private_key you can use this optional param instead of ssl_private_key and ssl_ca_cert
+  #
+  # ssl_cert: <path_to_cert.pem>
+
+  ## @param ssl_private_key - string - required 
+  ## Needed if the certificate does not include the private key. Currently, Requests does not support using encrypted keys.
+  #
+   ssl_private_key: <path_to_cert.key>
+
+  ## @param ssl_ca_cert - string - required
+  ## The path to the trusted CA used for generating custom certificates
+  #
+   ssl_ca_cert: <path_to_cert.pem>
 
   ## @param prometheus_timeout - integer - optional - default: 10
   ## The timeout for connecting to the prometheus_url.

--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -5,6 +5,16 @@ instances:
   ## The Prometheus endpoint to query.
   #
   - prometheus_url: http://localhost:8080/_status/vars
+    # Can either be only the path to the certificate and thus you should specify the private key
+      # or it can be the path to a file containing both the certificate & the private key
+    # ssl_cert: /path/to/cert.pem
+    
+    # Needed if the certificate does not include the private key
+      # Currently, Requests does not support using encrypted keys.
+    # ssl_private_key: /path/to/cert.key
+    
+    # The path to the trusted CA used for generating custom certificates
+    # ssl_ca_cert: /path/to/cert.pem
 
   ## @param prometheus_timeout - integer - optional - default: 10
   ## The timeout for connecting to the prometheus_url.

--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -9,17 +9,17 @@ instances:
   ## @param ssl_cert - string - optional 
   ## If the certificate contains the ssl_private_key you can use this optional param instead of ssl_private_key and ssl_ca_cert
   #
-  # ssl_cert: <path_to_cert.pem>
+  #  ssl_cert: <PATH_TO_CERT_PEM>
 
   ## @param ssl_private_key - string - optional
   ## Needed if the certificate does not include the private key. Currently, Requests does not support using encrypted keys.
   #
-   ssl_private_key: <path_to_cert.key>
+  #  ssl_private_key: <PATH_TO_CERT_KEY>
 
   ## @param ssl_ca_cert - string - optional
   ## The path to the trusted CA used for generating custom certificates
   #
-   ssl_ca_cert: <path_to_cert.pem>
+  #  ssl_ca_cert: <PATH_TO_CERT_PEM>
 
   ## @param prometheus_timeout - integer - optional - default: 10
   ## The timeout for connecting to the prometheus_url.


### PR DESCRIPTION
### What does this PR do?

Adds ssl parameters necessary to run the integration 

### Motivation

I ran into a case where the customer had several SSL errors. When we added `ssl_private_key​` and `ssl_ca_cert​` params the integration worked as expected. It appears as if this check is looking for these paramters per this check: 
https://github.com/DataDog/integrations-core/blob/cc873c7eff1d86b5aca2293fc012bd89608f2b39/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L179

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
