### PR TITLE
Fix MQ client install script

### DIFF
--- a/.travis/install_ibm_mq.sh
+++ b/.travis/install_ibm_mq.sh
@@ -7,7 +7,7 @@ MQ_URL=http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/m
 MQ_PACKAGES="MQSeriesRuntime-*.rpm MQSeriesServer-*.rpm MQSeriesMsg*.rpm MQSeriesJava*.rpm MQSeriesJRE*.rpm MQSeriesGSKit*.rpm"
 
 if [ -z "$CHECK" ]; then
-    OUT=$(ddev test --list)i
+    OUT=$(ddev test --list)
     if [[ "$OUT" != *"ibm_mq"* ]]; then
         exit 0
     fi

--- a/.travis/install_ibm_mq.sh
+++ b/.travis/install_ibm_mq.sh
@@ -6,8 +6,15 @@ TMP_DIR=/tmp/mq
 MQ_URL=http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev90_linux_x86-64.tar.gz
 MQ_PACKAGES="MQSeriesRuntime-*.rpm MQSeriesServer-*.rpm MQSeriesMsg*.rpm MQSeriesJava*.rpm MQSeriesJRE*.rpm MQSeriesGSKit*.rpm"
 
-if [ "$CHECK" != "ibm_mq" -a -n `ddev test --list` =~ "ibm_mq" ]; then
-  exit 0
+if [ -z "$CHECK" ]; then
+    OUT=$(ddev test --list)i
+    if [[ "$OUT" != *"ibm_mq"* ]]; then
+        exit 0
+    fi
+else
+    if [ $CHECK != "ibm_mq" ]; then
+        exit 0
+    fi
 fi
 
 if [ -e /opt/mqm/inc/cmqc.h ]; then


### PR DESCRIPTION
### What does this PR do?

Only installs MQ client when the `ibm_mq` check is involved

### Motivation

Installation always happens because of a bash error

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
