### PR TITLE
Update NTLM auth comments

### DIFF
--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -66,7 +66,9 @@ instances:
 
   ## @param ntlm_domain - string - optional
   ## If your service uses NTLM authentication, you can optionally
-  ## specify a domain that will be used in the check.
+  ## specify a domain that will be used in the check. For NTLM Auth,
+  ## append the username to domain, not as a seperate @param.
+  ## Example: example_ntlm_domain\example_username
   #
   #  ntlm_domain: <DOMAIN>
 


### PR DESCRIPTION
### What does this PR do?

Currently, the way auth is handled in [http_check.py](https://github.com/DataDog/integrations-core/blob/a212694c74644b01ecdc69b084a82d7cc423aff4/http_check/datadog_checks/http_check/http_check.py#L104) if a `username` param is supplied in `http.d/conf.yaml` , then NTLM authentication never gets called.  

```
auth = None
if password is not None:
    if username is not None:
        auth = (username, password)
    elif ntlm_domain is not None:
        auth = HttpNtlmAuth(ntlm_domain, password)
```

Further, it's unclear that the format of the ntlm_domain key should include the username appended to the domain with `\`, and not as a separate param, which is the format expected by the [request-ntlm](https://github.com/requests/requests-ntlm) package underlying it.

Adding a comment here to clarify the proper formatting of the `ntlm_domain` file and `http_check.d/conf.yaml` config.

### Motivation

A number of customers have reached out experiencing issues with NTLM Authentication and the ambiguity here seems like the root cause.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)


### Additional Notes

Issue opened in documentation repo: https://github.com/DataDog/documentation/issues/3561
Apologies if the formatting is off here, still getting acquainted with conventions here as I'm new to the team.
