### PR TITLE
Capture metrics for ES scroll requests 

### DIFF
--- a/elastic/datadog_checks/elastic/metrics.py
+++ b/elastic/datadog_checks/elastic/metrics.py
@@ -778,6 +778,15 @@ ADDITIONAL_METRICS_5_x = {
     'elasticsearch.breakers.inflight_requests.estimated_size_in_bytes': (
         'gauge', 'breakers.in_flight_requests.estimated_size_in_bytes'
     ),
+    'elasticsearch.search.scroll.total': (
+        'gauge', 'indices.search.scroll_total'
+    ),
+    'elasticsearch.search.scroll.time': (
+        'gauge', 'indices.search.scroll_time_in_millis', lambda ms: ms_to_second(ms)
+    ),
+    'elasticsearch.search.scroll.current': (
+        'gauge', 'indices.search.scroll_current'
+    ),
 }
 
 ADDITIONAL_METRICS_PRE_6_3 = {

--- a/elastic/tests/test_metrics.py
+++ b/elastic/tests/test_metrics.py
@@ -52,11 +52,11 @@ def test_stats_for_version():
 
     # v5
     metrics = stats_for_version([5, 0, 0])
-    assert len(metrics) == 167
+    assert len(metrics) == 170
 
     # v6.3.0
     metrics = stats_for_version([6, 3, 0])
-    assert len(metrics) == 167
+    assert len(metrics) == 170
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### What does this PR do?

Adds metrics for ES [scroll requests](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cat-nodes.html) that are exposed in _indices.search_:

```javascript
    "indices": {
     ...
      "search": {
        "open_contexts": 4,
        "query_total": 795996720,
        "query_time_in_millis": 23224962799,
        "query_current": 7,
        "fetch_total": 89852997,
        "fetch_time_in_millis": 128959355,
        "fetch_current": 2,
        "scroll_total": 393249911,
        "scroll_time_in_millis": 40220899351103,
        "scroll_current": 1123,
        "suggest_total": 0,
        "suggest_time_in_millis": 0,
        "suggest_current": 0
      },
      ...
```

cc @DataDog/burrito 

### Motivation

To help differentiate between scroll requests and normal queries

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
