### PR TITLE
Remove metric that is no longer sent

### DIFF
--- a/zk/README.md
+++ b/zk/README.md
@@ -119,7 +119,6 @@ for a list of metrics provided by this check.
 Following metrics are still sent but will be removed eventually:
  * `zookeeper.bytes_received`
  * `zookeeper.bytes_sent`
- * `zookeeper.bytes_outstanding`
 
 ### Events
 The Zookeeper check does not include any events at this time.


### PR DESCRIPTION
### What does this PR do?

Metric is no longer being sent as of this PR - https://github.com/DataDog/integrations-core/pull/2476/files

### Motivation

Keeps docs up to date. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
