### PR TITLE
Add ability to debug checks with pdb

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -32,6 +32,7 @@ except ImportError:
 
 from ..config import is_affirmative
 from ..constants import ServiceCheck
+from ..utils.agent.debug import enter_pdb
 from ..utils.common import ensure_bytes, ensure_unicode
 from ..utils.proxy import config_proxy_skip
 from ..utils.limiter import Limiter
@@ -387,7 +388,13 @@ class __AgentCheckPy3(object):
 
     def run(self):
         try:
-            self.check(copy.deepcopy(self.instances[0]))
+            instance = copy.deepcopy(self.instances[0])
+
+            if 'debug_check' in self.init_config:
+                enter_pdb(self.check, line=self.init_config['debug_check'], args=(instance,))
+            else:
+                self.check(instance)
+
             result = ''
         except Exception as e:
             result = json.dumps([
@@ -773,7 +780,13 @@ class __AgentCheckPy2(object):
 
     def run(self):
         try:
-            self.check(copy.deepcopy(self.instances[0]))
+            instance = copy.deepcopy(self.instances[0])
+
+            if 'debug_check' in self.init_config:
+                enter_pdb(self.check, line=self.init_config['debug_check'], args=(instance,))
+            else:
+                self.check(instance)
+
             result = b''
         except Exception as e:
             result = json.dumps([

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -390,8 +390,8 @@ class __AgentCheckPy3(object):
         try:
             instance = copy.deepcopy(self.instances[0])
 
-            if 'debug_check' in self.init_config:
-                enter_pdb(self.check, line=self.init_config['debug_check'], args=(instance,))
+            if 'set_break_point' in self.init_config:
+                enter_pdb(self.check, line=self.init_config['set_break_point'], args=(instance,))
             else:
                 self.check(instance)
 
@@ -782,8 +782,8 @@ class __AgentCheckPy2(object):
         try:
             instance = copy.deepcopy(self.instances[0])
 
-            if 'debug_check' in self.init_config:
-                enter_pdb(self.check, line=self.init_config['debug_check'], args=(instance,))
+            if 'set_break_point' in self.init_config:
+                enter_pdb(self.check, line=self.init_config['set_break_point'], args=(instance,))
             else:
                 self.check(instance)
 

--- a/datadog_checks_base/datadog_checks/base/utils/agent/debug.py
+++ b/datadog_checks_base/datadog_checks/base/utils/agent/debug.py
@@ -1,0 +1,62 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import inspect
+import pdb
+import sys
+
+
+class Debugger(pdb.Pdb):
+    """Modified debugger that assumes the existence of predefined break points."""
+
+    def set_trace(self, frame=None):
+        """See https://github.com/python/cpython/blob/b02774f42108aaf18eb19865472c8d5cd95b5f11/Lib/bdb.py#L319-L332"""
+        self.reset()
+
+        if frame is None:
+            frame = sys._getframe().f_back
+
+        while frame:
+            frame.f_trace = self.trace_dispatch
+            self.botframe = frame
+            frame = frame.f_back
+
+        # Automatically proceed to next break point
+        self.set_continue()
+
+        sys.settrace(self.trace_dispatch)
+
+
+def enter_pdb(f, line=0, args=(), kwargs=None):
+    line = int(line)
+
+    if kwargs is None:
+        kwargs = {}
+
+    file_name = inspect.getfile(f)
+    lines, def_line = inspect.getsourcelines(f)
+
+    # Start of the function
+    if line == 0:
+        line = def_line + 1
+    # End of the function
+    elif line == -1:
+        line = def_line + len(lines) - 1
+    # Specific line number of the file where the function is defined
+    else:
+        start = def_line + 1
+        stop = def_line + len(lines)
+
+        # Ensure the line is actually within the function
+        if line not in range(start, stop):
+            raise ValueError('Line {} is not part of the check method.'.format(line))
+
+        # Ensure there is something to run or else the function will proceed normally
+        elif not lines[line - def_line].strip():
+            raise ValueError('Line {} is a blank line and therefore there is nothing to execute.'.format(line))
+
+    debugger = Debugger()
+    debugger.set_break(file_name, line)
+    debugger.set_trace()
+
+    f(*args, **kwargs)


### PR DESCRIPTION
### What this does

This makes it possible to interactively debug integrations running on Agent 6+ using the `check` command. This is enabled via an option in `init_config`, the same way we do for tracing https://github.com/DataDog/integrations-core/blob/711a6f05639001ae485897e5b56046f9130af96d/datadog_checks_base/datadog_checks/base/utils/tracing.py#L22

How this works is the caller to the check method, `run`, will set a break point on the desired line number, with `0` being a shortcut to the first line of the check method and `-1` to the last. At that point our modified debugger class will automatically execute all code up to the break point and will begin a `pdb` session at the desired place.

### Motivation

1. Being able see what's happening it real time without the need for logging, particularly for inspecting complex data structures that may be causing memory issues. Right now we do `import pdb; pdb.set_trace()` manually all the time.
2. There have been debugging sessions on numerous support calls where this would have been extremely useful to have instead of having customers navigate to `site-packages` to open the proper file in some terminal editor they don't use, just to add a print statement or 2.

### End goal

![l0](https://user-images.githubusercontent.com/9677399/49683573-5ea8ec00-fa95-11e8-813e-8cffb0c5903a.PNG)

![l1](https://user-images.githubusercontent.com/9677399/49683574-649ecd00-fa95-11e8-87ed-9dba3f2174e0.PNG)

![la](https://user-images.githubusercontent.com/9677399/49683578-6a94ae00-fa95-11e8-96a7-b539f4310763.PNG)
