### PR TITLE
Handle unicode characters in urls and response content

### DIFF
--- a/http_check/datadog_checks/http_check/config.py
+++ b/http_check/datadog_checks/http_check/config.py
@@ -48,7 +48,7 @@ def from_instance(instance, default_ca_certs=None):
     if not url:
         raise ConfigurationError("Bad configuration. You must specify a url")
     if not url.startswith("http"):
-        raise ConfigurationError("The url {} must start with the scheme http or https".format(url))
+        raise ConfigurationError(b"The url {} must start with the scheme http or https".format(url))
     include_content = is_affirmative(instance.get('include_content', False))
     disable_ssl_validation = is_affirmative(instance.get('disable_ssl_validation', True))
     ssl_expire = is_affirmative(instance.get('check_certificate_expiration', True))


### PR DESCRIPTION
### What does this PR do?

Additional handling of unicode characters to complete #2435.

### Motivation

this was still breaking with the following configuration
```
instances:
  - name: fr.wikipedia.org/wiki/Wikipedia:Accueil_principal
    url: https://fr.wikipedia.org/wiki/Wikipédia:Accueil_principal
    timeout: 1
    content_match: officier supérieur
    reverse_content_match: true
    include_content: true
```
### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?