### PR TITLE
Ensure unicode for subprocess output

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
+++ b/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
@@ -19,8 +19,7 @@ except ImportError:
         from ..stubs._util import subprocess_output
         from ..stubs._util import SubprocessOutputEmptyError  # noqa
 
-from datadog_checks.base import ensure_unicode
-
+from .. import ensure_unicode
 
 log = logging.getLogger(__name__)
 
@@ -67,5 +66,7 @@ def get_subprocess_output(command, log, raise_on_empty_output=True, log_debug=Tr
 
     if out:
         out = ensure_unicode(out)
+    if err:
+        err = ensure_unicode(err)
 
     return out, err, returncode

--- a/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
+++ b/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
@@ -19,6 +19,9 @@ except ImportError:
         from ..stubs._util import subprocess_output
         from ..stubs._util import SubprocessOutputEmptyError  # noqa
 
+from datadog_checks.base import ensure_unicode
+
+
 log = logging.getLogger(__name__)
 
 
@@ -61,5 +64,8 @@ def get_subprocess_output(command, log, raise_on_empty_output=True, log_debug=Tr
             len(out), len(err), returncode
         )
     )
+
+    if out:
+        out = ensure_unicode(out)
 
     return out, err, returncode


### PR DESCRIPTION
### What does this PR do?

Runs `ensure_unicode` on the result of get_subprocess_output before returning it. 

### Motivation

When porting checks to Python3, we do a lot of literal string comparison between some hardcoded expected strings and the output from get_subprocess_output. Due to this and other similar scenarios, its expected/required that the output from get_subprocess_output is an appropriate non `bytes` format. This uses the `ensure_unicode` helper function to perform this action for us. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes
