### PR TITLE
Fix unicode handling of log messages

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -350,7 +350,7 @@ class AgentCheck(object):
         return normalized_tags
 
     def warning(self, warning_message):
-        warning_message = str(warning_message)
+        warning_message = ensure_bytes(warning_message)
 
         frame = inspect.currentframe().f_back
         lineno = frame.f_lineno

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -8,6 +8,8 @@ try:
 except ImportError:
     from .stubs import datadog_agent
 
+from .utils.common import ensure_bytes
+
 
 class AgentLogHandler(logging.Handler):
     """
@@ -18,7 +20,7 @@ class AgentLogHandler(logging.Handler):
         msg = "({}:{}) | {}".format(
             getattr(record, '_filename', record.filename),
             getattr(record, '_lineno', record.lineno),
-            self.format(record)
+            ensure_bytes(self.format(record))
         )
         datadog_agent.log(msg, record.levelno)
 


### PR DESCRIPTION
### Motivation

Since the Go bindings require byte string log messages, we must `ensure_bytes(...)` everywhere. This does it for us at emission time.