### PR TITLE
IBM MQ shouldn't send bad service checks

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -82,7 +82,6 @@ class IbmMqCheck(AgentCheck):
         for mname, pymqi_value in iteritems(metrics.queue_metrics()):
             try:
                 mname = '{}.queue.{}'.format(self.METRIC_PREFIX, mname)
-                log.info('collecting: {}'.format(mname))
                 m = queue.inquire(pymqi_value)
                 self.gauge(mname, m, tags=tags)
             except pymqi.Error as e:
@@ -91,8 +90,17 @@ class IbmMqCheck(AgentCheck):
         for mname, func in iteritems(metrics.queue_metrics_functions()):
             try:
                 mname = '{}.queue.{}'.format(self.METRIC_PREFIX, mname)
-                log.info('collecting: {}'.format(mname))
                 m = func(queue)
                 self.gauge(mname, m, tags=tags)
             except pymqi.Error as e:
                 self.warning("Error getting queue stats: {}".format(e))
+
+        for mname, value_dict in iteritems(metrics.failure_prone_queue_metrics()):
+            mname = '{}.queue.{}'.format(self.METRIC_PREFIX, mname)
+            pymqi_value = value_dict['value']
+            default_value = value_dict['value']
+            try:
+                m = queue.inquire(pymqi_value)
+            except pymqi.Error as e:
+                m = default_value
+            self.gauge(mname, m, tags=tags)

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -81,16 +81,18 @@ class IbmMqCheck(AgentCheck):
         """
         for mname, pymqi_value in iteritems(metrics.queue_metrics()):
             try:
-                m = queue.inquire(pymqi_value)
                 mname = '{}.queue.{}'.format(self.METRIC_PREFIX, mname)
+                log.info('collecting: {}'.format(mname))
+                m = queue.inquire(pymqi_value)
                 self.gauge(mname, m, tags=tags)
             except pymqi.Error as e:
                 self.warning("Error getting queue stats: {}".format(e))
 
         for mname, func in iteritems(metrics.queue_metrics_functions()):
             try:
-                m = func(queue)
                 mname = '{}.queue.{}'.format(self.METRIC_PREFIX, mname)
+                log.info('collecting: {}'.format(mname))
+                m = func(queue)
                 self.gauge(mname, m, tags=tags)
             except pymqi.Error as e:
                 self.warning("Error getting queue stats: {}".format(e))

--- a/ibm_mq/datadog_checks/ibm_mq/metrics.py
+++ b/ibm_mq/datadog_checks/ibm_mq/metrics.py
@@ -40,8 +40,19 @@ def queue_metrics():
         'retention_interval': pymqi.CMQC.MQIA_RETENTION_INTERVAL,
         'open_output_count': pymqi.CMQC.MQIA_OPEN_OUTPUT_COUNT,
         'trigger_type': pymqi.CMQC.MQIA_TRIGGER_TYPE,
-        'max_channels': pymqi.CMQC.MQIA_MAX_CHANNELS,
-        'oldest_message_age': pymqi.CMQCFC.MQIACF_OLDEST_MSG_AGE,
+    }
+
+
+def failure_prone_queue_metrics():
+    return {
+        'max_channels': {
+            'value': pymqi.CMQC.MQIA_MAX_CHANNELS,
+            'default_value': 0,
+        },
+        'oldest_message_age': {
+            'value': pymqi.CMQCFC.MQIACF_OLDEST_MSG_AGE,
+            'default_value': 0,
+        }
     }
 
 


### PR DESCRIPTION
### What does this PR do?

We use failure to get a metric to determine if a service check should be sent. However, some metrics fail when they are simply not available (and should be 0). We shouldn't send these as 0 metrics. We should, first, send these as 0 metrics. And, we should also not send a bad service check. 

### Motivation

@dsahni found this in his testing of the check

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
