### PR TITLE
Fix unicode handling of log messages

### DIFF
--- a/http_check/datadog_checks/http_check/config.py
+++ b/http_check/datadog_checks/http_check/config.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from collections import namedtuple
 
-from datadog_checks.base import ConfigurationError, is_affirmative
+from datadog_checks.base import ConfigurationError, ensure_unicode, is_affirmative
 from datadog_checks.utils.headers import headers as agent_headers
 
 
@@ -42,7 +42,11 @@ def from_instance(instance, default_ca_certs=None):
         headers = {}
     headers.update(config_headers)
     url = instance.get('url')
+    if url is not None:
+        url = ensure_unicode(url)
     content_match = instance.get('content_match')
+    if content_match is not None:
+        content_match = ensure_unicode(content_match)
     reverse_content_match = is_affirmative(instance.get('reverse_content_match', False))
     response_time = is_affirmative(instance.get('collect_response_time', True))
     if not url:

--- a/http_check/setup.py
+++ b/http_check/setup.py
@@ -25,7 +25,7 @@ def get_requirements(fpath):
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=4.2.0'
+CHECKS_BASE_REQ = 'datadog_checks_base>=4.6.0'
 
 setup(
     name='datadog-http_check',


### PR DESCRIPTION
### What does this PR do?

Supersedes https://github.com/DataDog/integrations-core/pull/2692 to include https://github.com/DataDog/integrations-core/pull/2698

Also makes service check status messages handle unicode correctly

### Motivation

`content_match` config option was never being read as unicode, therefore for the content we were always using `response.content` which is a byte string. This is incorrect for anything other than ascii because when we then slice up to the `CONTENT_LENGTH` we may miss characters or stop in the middle of a grapheme.