### PR TITLE
Document `resolves_as` and migrate conf file

### DIFF
--- a/dns_check/datadog_checks/dns_check/data/conf.yaml.example
+++ b/dns_check/datadog_checks/dns_check/data/conf.yaml.example
@@ -1,37 +1,58 @@
 init_config:
-    default_timeout: 4
+  ## @param default_timeout - string - optional - default: 5
+  ## Timeout to use as a default for all your instances.
+  #
+  #  default_timeout: 5
 
 instances:
-    - name: example
-      hostname: www.example.org
-      # please notice: nameserver must be a valid IP address
-      nameserver: 127.0.0.1
-      
-      # Optionally specify your nameserver's port
-      # nameserver_port: 53
-      
-      timeout: 8
+  ## @param name - string - required
+  ## Name of your DNS check instance
+  ## To create multiple DNS checks, create multiple instances with unique names
+  #
+  - name: My first instance
 
-      # Specify an (optional) `record_type` to customize the record type
-      # queried by the check (default: "A")
-      # record_type: A
+  ## @param hostname - string - required
+  ## Hostname to resolve
+  #
+    hostname: www.example.org
 
-      # The check will automatically tag `nameserver` and `resolved_hostname`
-      # Use this section to add additional tags
-      #
-      # tags:
-      #   - tag:one
-      #   - tag:two
+  ## @param nameserver - string - required
+  ## IP address of the name server to query
+  #
+    nameserver: 127.0.0.1
 
-    # If you use NXDOMAIN as the `record_type`, an NXDOMAIN result is expected from the query,
-    # and the check instance will report response time data.
-    # In many DNS systems, NXDOMAIN results are uncached. Further a query for a unqualified domain
-    # name that one expects to return an NXDOMAIN result can result in many dns queries, depending
-    # on the resolver's configured search domain.
-    # For these reasons, these queries are good candidates to monitor the worst-case performance of a DNS lookup.
-    # See https://github.com/DataDog/dd-agent/pull/2849 for more details.
+  ## @param nameserver_port - string - optional - default: 53
+  ## Port for the name server
+  #
+  # nameserver_port: 53
 
-    # - name: nxdomain_example
-    #   hostname: nxdomain.example.org
-    #   nameserver: 127.0.0.1
-    #   record_type: NXDOMAIN
+  ## @param resolves_as - string - optional
+  ## A comma separated list of IP addresses that the hostname is expected to resolve as.
+  ## Useful to ensure that the name hasn't been hijacked and points to the expected servers.
+  #
+  # resolves_as: <IP_ADDRESSES>
+
+  ## @param timeout - string - optional - default: default_timeout
+  ## Timeout to honor for this instance of the check
+  #
+  # timeout: 5
+
+  ## @param record_type - string - optional - default: A
+  ## The record type to be queried to the name server
+  ## If you use NXDOMAIN as the `record_type`, an NXDOMAIN result is expected from the query,
+  ## and the check instance will report response time data.
+  ## In many DNS systems, NXDOMAIN results are uncached. Further a query for a unqualified domain
+  ## name that one expects to return an NXDOMAIN result can result in many dns queries, depending
+  ## on the resolver's configured search domain.
+  ## For these reasons, these queries are good candidates to monitor the worst-case performance of a DNS lookup.
+  #
+  # record_type: A
+
+  ## @param tags  - list of key:value element - optional
+  ## List of tags to attach to every metric, event and service check emitted by this integration.
+  ##
+  ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+  #
+  #  tags:
+  #    - <KEY_1>:<VALUE_1>
+  #    - <KEY_2>:<VALUE_2>

--- a/dns_check/datadog_checks/dns_check/data/conf.yaml.example
+++ b/dns_check/datadog_checks/dns_check/data/conf.yaml.example
@@ -1,52 +1,54 @@
 init_config:
+  
   ## @param default_timeout - string - optional - default: 5
   ## Timeout to use as a default for all your instances.
   #
   #  default_timeout: 5
 
 instances:
+  
   ## @param name - string - required
-  ## Name of your DNS check instance
-  ## To create multiple DNS checks, create multiple instances with unique names
+  ## Name of your DNS check instance.
+  ## To create multiple DNS checks, create multiple instances with unique names.
   #
-  - name: My first instance
+  - name: <INSTANCE_NAME>
 
   ## @param hostname - string - required
-  ## Hostname to resolve
+  ## Hostname to resolve.
   #
-    hostname: www.example.org
+    hostname: <HOSTNAME>
 
   ## @param nameserver - string - required
-  ## IP address of the name server to query
+  ## IP address of the name server to query.
   #
     nameserver: 127.0.0.1
 
   ## @param nameserver_port - string - optional - default: 53
-  ## Port for the name server
+  ## Port for the name server.
   #
-  # nameserver_port: 53
+  #  nameserver_port: 53
 
   ## @param resolves_as - string - optional
   ## A comma separated list of IP addresses that the hostname is expected to resolve as.
   ## Useful to ensure that the name hasn't been hijacked and points to the expected servers.
   #
-  # resolves_as: <IP_ADDRESSES>
+  #  resolves_as: <IP_ADDRESSES>
 
   ## @param timeout - string - optional - default: default_timeout
   ## Timeout to honor for this instance of the check
   #
-  # timeout: 5
+  #  timeout: 5
 
   ## @param record_type - string - optional - default: A
   ## The record type to be queried to the name server
   ## If you use NXDOMAIN as the `record_type`, an NXDOMAIN result is expected from the query,
-  ## and the check instance will report response time data.
+  ## and the check instance reports response time data.
   ## In many DNS systems, NXDOMAIN results are uncached. Further a query for a unqualified domain
   ## name that one expects to return an NXDOMAIN result can result in many dns queries, depending
   ## on the resolver's configured search domain.
   ## For these reasons, these queries are good candidates to monitor the worst-case performance of a DNS lookup.
   #
-  # record_type: A
+  #  record_type: A
 
   ## @param tags  - list of key:value element - optional
   ## List of tags to attach to every metric, event and service check emitted by this integration.


### PR DESCRIPTION
### What does this PR do?

Document option introduced in #2615 and migrate file.

### Motivation

New option was not documented

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
