### PR TITLE
adds ignore_ssl_warning to rabbit file

### DIFF
--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -20,6 +20,10 @@ instances:
     #
     # ssl_verify: false
 
+    # If ssl_verify is turned on and the SSL cert is invalid, it can be very noisy. This will reduce the noise in the logs.
+    #
+    #  ignore_ssl_warning: false
+
     # The (optional) skip_proxy parameter would bypass any proxy settings enabled
     # and attempt to reach the the URL directly.
     # If no proxy is defined at any level, this flag bears no effect.


### PR DESCRIPTION
### What does this PR do?

This change was made in https://github.com/DataDog/integrations-core/pull/2472 but wasn't added to the file. I noticed it during testing. It should be in the file. This isn't a hidden config option, it's an exposed one.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
