### PR TITLE
Revert trace decorator changes

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/tracing.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tracing.py
@@ -14,12 +14,19 @@ except ImportError:
     datadog_agent = None
 
 
+_tracing_config = set()
+
+
+def add_trace_check(check_object):
+    _tracing_config.add(check_object)
+
+
 @wrapt.decorator
 def traced(wrapped, instance, args, kwargs):
     if datadog_agent is None:
         return wrapped(*args, **kwargs)
 
-    trace_check = is_affirmative(instance.init_config.get('trace_check'))
+    trace_check = instance in _tracing_config
     integration_tracing = is_affirmative(datadog_agent.get_config('integration_tracing'))
 
     if integration_tracing and trace_check:


### PR DESCRIPTION
### What does this PR do?

Essentially a revert of - https://github.com/DataDog/integrations-core/pull/2515

### Motivation

Lets make the upgrade path of the Agent seamless for users that may be using a check with the original method of tracing. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
