### PR TITLE
Collect APM Traces using original decorator

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/tracing.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tracing.py
@@ -14,12 +14,19 @@ except ImportError:
     datadog_agent = None
 
 
+_tracing_config = set()
+
+
+def add_trace_check(check_object):
+    _tracing_config.add(check_object)
+
+
 @wrapt.decorator
 def traced(wrapped, instance, args, kwargs):
     if datadog_agent is None:
         return wrapped(*args, **kwargs)
 
-    trace_check = is_affirmative(instance.init_config.get('trace_check'))
+    trace_check = instance in _tracing_config
     integration_tracing = is_affirmative(datadog_agent.get_config('integration_tracing'))
 
     if integration_tracing and trace_check:

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 from datadog_checks.checks import AgentCheck
 from datadog_checks.config import is_affirmative
 from datadog_checks.utils.common import pattern_filter
-from datadog_checks.utils.tracing import traced
+from datadog_checks.utils.tracing import traced, add_trace_check
 
 from .scopes import ScopeFetcher
 from .api import ComputeApi, NeutronApi, KeystoneApi
@@ -134,6 +134,10 @@ class OpenStackControllerCheck(AgentCheck):
         self.keystone_server_url = init_config.get("keystone_server_url")
         if not self.keystone_server_url:
             raise IncompleteConfig()
+
+        if is_affirmative(self.init_config.get('trace_check')):
+            add_trace_check(self)
+
         self.proxy_config = self.get_instance_proxy(init_config, self.keystone_server_url)
 
         self.ssl_verify = is_affirmative(init_config.get("ssl_verify", True))


### PR DESCRIPTION
### What does this PR do?

Keeps the openstack_collector using the original tracing decorator code. 

Relies on this PR - https://github.com/DataDog/integrations-core/pull/2710

### Motivation

Make the upgrade process seamless for users since the original decorator was released with an Agent. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

