### PR TITLE
updates IBM MQ readme with much better instructions

### DIFF
--- a/ibm_mq/README.md
+++ b/ibm_mq/README.md
@@ -121,7 +121,19 @@ queues:
 
 #### Logs
 
+To set up logs, you will want to point the config file to the proper log files. You can uncomment the lines at the bottom of the config file, and amend them as you see fit:
 
+```yaml
+logs:
+  - type: file
+    path: /var/mqm/log/<APPNAME>/active/AMQERR01.LOG
+    service: <APPNAME>
+    source: ibm_mq
+    log_processing_rules:
+      - type: multi_line
+        name: new_log_start_with_date
+        pattern: "\d{2}/\d{2}/\d{4}"
+```
 
 ### Validation
 

--- a/ibm_mq/README.md
+++ b/ibm_mq/README.md
@@ -98,6 +98,8 @@ There are a number of ways to set up permissions in IBM MQ. Depending on how you
 
 2. [Restart the Agent][5]
 
+#### Metrics
+
 There are a number of options to configure IBM MQ, depending on how you're using it.
 
 `channel`: The IBM MQ channel
@@ -116,6 +118,10 @@ queues:
   - APP.QUEUE.1
   - ADMIN.QUEUE.1
 ```
+
+#### Logs
+
+
 
 ### Validation
 

--- a/ibm_mq/README.md
+++ b/ibm_mq/README.md
@@ -72,6 +72,8 @@ post-stop script
 end script
 ```
 
+Each time there is an agent update, these files are wiped and will need to be updated again.
+
 Alternatively, if you are using Linux, after the MQ Client is installed ensure the runtime linker can find the libraries. For example, using ldconfig:
 
 ```

--- a/ibm_mq/README.md
+++ b/ibm_mq/README.md
@@ -2,31 +2,112 @@
 
 ## Overview
 
-This check monitors [Ibm_mq][1].
+This check monitors [IBM MQ][1].
 
 ## Setup
 
 ### Installation
 
-The Ibm_mq check is included in the [Datadog Agent][2] package. However, in order for it to work it needs to have an IBM MQ client installed on the box.
+The IBM MQ check is included in the [Datadog Agent][2] package.
+
+In order to use the IBM MQ check, you need to install the [IBM MQ Client][3], unless the IBM MQ server is already installed on the box. Take note of where you installed it.
+
+If you are using Linux, after the MQ Client is installed ensure the runtime linker can find the libraries. For example, using ldconfig:
+
+```
+# Put the library location in an ld configuration file.
+
+sudo sh -c "echo /opt/mqm/lib64 > \
+/etc/ld.so.conf.d/mqm64.conf"
+sudo sh -c "echo /opt/mqm/lib > \
+/etc/ld.so.conf.d/mqm.conf"
+
+# Update the bindings.
+
+sudo ldconfig
+```
+
+Alternately, update your LD_LIBRARY_PATH to include the location of the libraries. For example:
+
+```
+export LD_LIBRARY_PATH=/opt/mqm/lib64:/opt/mqm/lib:$LD_LIBRARY_PATH
+```
+
+*Note*: Agent 6 uses Upstart or systemd to orchestrate the datadog-agent service. Environment variables may need to be added to the service configuration files at the default locations of /etc/init/datadog-agent.conf (Upstart) or /lib/systemd/system/datadog-agent.service (systemd). See documentation on Upstart or systemd for more information on how to configure these settings.
+
+Here's an example of the configuration that's used for Systemd:
+
+```yaml
+[Unit]
+Description="Datadog Agent"
+After=network.target
+Wants=datadog-agent-trace.service datadog-agent-process.service
+StartLimitIntervalSec=10
+StartLimitBurst=5
+
+[Service]
+Type=simple
+PIDFile=/opt/datadog-agent/run/agent.pid
+Environment="LD_LIBRARY_PATH=/opt/mqm/lib64:/opt/mqm/lib"
+User=dd-agent
+Restart=on-failure
+ExecStart=/opt/datadog-agent/bin/agent/agent run -p /opt/datadog-agent/run/agent.pid
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Here's an example of the upstart config:
+
+```
+description "Datadog Agent"
+
+start on started networking
+stop on runlevel [!2345]
+
+respawn
+respawn limit 10 5
+normal exit 0
+
+# Logging to console from the Agent is disabled since the Agent already logs using file or
+# syslog depending on its configuration. We make Upstart log what the process still outputs in order
+# to log panics/crashes to /var/log/upstart/datadog-agent.log
+console log
+env DD_LOG_TO_CONSOLE=false
+env LD_LIBRARY_PATH=/opt/mqm/lib64:/opt/mqm/lib
+
+setuid dd-agent
+
+script
+  exec /opt/datadog-agent/bin/agent/agent start -p /opt/datadog-agent/run/agent.pid
+end script
+
+post-stop script
+  rm -f /opt/datadog-agent/run/agent.pid
+end script
+```
+
+#### Permissions
+
+Once you have the library set up, you'll need to create a user with the appropriate permissions.
 
 ### Configuration
 
 1. Edit the `ibm_mq.d/conf.yaml` file, in the `conf.d/` folder at the root of your
    Agent's configuration directory to start collecting your ibm_mq performance data.
-   See the [sample ibm_mq.d/conf.yaml][3] for all available configuration options.
+   See the [sample ibm_mq.d/conf.yaml][4] for all available configuration options.
 
-2. [Restart the Agent][4]
+2. [Restart the Agent][5]
 
 ### Validation
 
-[Run the Agent's `status` subcommand][5] and look for `ibm_mq` under the Checks section.
+[Run the Agent's `status` subcommand][6] and look for `ibm_mq` under the Checks section.
 
 ## Data Collected
 
 ### Metrics
 
-Ibm_mq does not include any metrics.
+See [metadata.csv][8] for a list of metrics provided by this integration.
 
 ### Service Checks
 
@@ -38,11 +119,13 @@ Ibm_mq does not include any events.
 
 ## Troubleshooting
 
-Need help? Contact [Datadog Support][6].
+Need help? Contact [Datadog Support][7].
 
 [1]: https://www.ibm.com/products/mq
 [2]: https://app.datadoghq.com/account/settings#agent
-[3]: https://github.com/DataDog/integrations-core/blob/master/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
-[4]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
-[5]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
-[6]: https://docs.datadoghq.com/help/
+[3]: https://developer.ibm.com/messaging/mq-downloads/
+[4]: https://github.com/DataDog/integrations-core/blob/master/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+[5]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
+[6]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
+[7]: https://docs.datadoghq.com/help/
+[8]: https://github.com/DataDog/integrations-core/blob/master/oracle/metadata.csv

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -11,11 +11,6 @@ instances:
   #
     queue_manager: 'datadog'
 
-  ## @param mq_installation_dir - string - required - default: /opt/mqm
-  ## The directory where MQ is installed, required to ensure the c bindings are set correctly
-  #
-    mq_installation_dir: /opt/mqm
-
   ## @param host - string - required - default: localhost
   ## The host IBM MQ is running on.
   #


### PR DESCRIPTION
### What does this PR do?

This PR updates the IBM MQ readme with instructions that are much better

### Motivation

IBM MQ didn't have a good readme before, I had intended to do it after the merge and this is it.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [x] If PR adds a configuration option, it has been added to the configuration file.
