### PR TITLE
Use original tracing mechanism

### DIFF
--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -11,12 +11,11 @@ from datetime import datetime, timedelta
 from datadog_checks.checks import AgentCheck
 from datadog_checks.config import is_affirmative
 from datadog_checks.utils.common import pattern_filter
-from datadog_checks.utils.tracing import traced
 
 from .scopes import ScopeFetcher
 from .api import ComputeApi, NeutronApi, KeystoneApi
 from .settings import DEFAULT_API_REQUEST_TIMEOUT
-from .utils import get_instance_name
+from .utils import get_instance_name, traced, add_trace_check
 from .retry import BackOffRetry
 from .exceptions import (InstancePowerOffFailure, IncompleteConfig, IncompleteIdentity, MissingNovaEndpoint,
                          MissingNeutronEndpoint, KeystoneUnreachable, AuthenticationNeeded)
@@ -132,6 +131,10 @@ class OpenStackControllerCheck(AgentCheck):
     def __init__(self, name, init_config, agentConfig, instances=None):
         super(OpenStackControllerCheck, self).__init__(name, init_config, agentConfig, instances)
         self.keystone_server_url = init_config.get("keystone_server_url")
+
+        if is_affirmative(self.init_config.get('trace_check')):
+            add_trace_check(self)
+
         if not self.keystone_server_url:
             raise IncompleteConfig()
         self.proxy_config = self.get_instance_proxy(init_config, self.keystone_server_url)

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -15,7 +15,7 @@ from datadog_checks.utils.common import pattern_filter
 from .scopes import ScopeFetcher
 from .api import ComputeApi, NeutronApi, KeystoneApi
 from .settings import DEFAULT_API_REQUEST_TIMEOUT
-from .utils import get_instance_name, traced, add_trace_check
+from .utils import get_instance_name, traced
 from .retry import BackOffRetry
 from .exceptions import (InstancePowerOffFailure, IncompleteConfig, IncompleteIdentity, MissingNovaEndpoint,
                          MissingNeutronEndpoint, KeystoneUnreachable, AuthenticationNeeded)
@@ -131,9 +131,6 @@ class OpenStackControllerCheck(AgentCheck):
     def __init__(self, name, init_config, agentConfig, instances=None):
         super(OpenStackControllerCheck, self).__init__(name, init_config, agentConfig, instances)
         self.keystone_server_url = init_config.get("keystone_server_url")
-
-        if is_affirmative(self.init_config.get('trace_check')):
-            add_trace_check(self)
 
         if not self.keystone_server_url:
             raise IncompleteConfig()

--- a/openstack_controller/datadog_checks/openstack_controller/utils.py
+++ b/openstack_controller/datadog_checks/openstack_controller/utils.py
@@ -23,19 +23,12 @@ def get_instance_name(instance):
     return name
 
 
-_tracing_config = set()
-
-
-def add_trace_check(check_object):
-    _tracing_config.add(check_object)
-
-
 @wrapt.decorator
 def traced(wrapped, instance, args, kwargs):
     if datadog_agent is None:
         return wrapped(*args, **kwargs)
 
-    trace_check = instance in _tracing_config
+    trace_check = is_affirmative(instance.init_config.get('trace_check'))
     integration_tracing = is_affirmative(datadog_agent.get_config('integration_tracing'))
 
     if integration_tracing and trace_check:

--- a/openstack_controller/datadog_checks/openstack_controller/utils.py
+++ b/openstack_controller/datadog_checks/openstack_controller/utils.py
@@ -3,6 +3,16 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from .exceptions import IncompleteConfig
+from datadog_checks.base.config import is_affirmative
+from ddtrace import tracer
+
+import wrapt
+
+try:
+    import datadog_agent
+except ImportError:
+    # Integration Tracing is only available with Agent 6
+    datadog_agent = None
 
 
 def get_instance_name(instance):
@@ -11,3 +21,25 @@ def get_instance_name(instance):
         # We need a name to identify this instance
         raise IncompleteConfig()
     return name
+
+
+_tracing_config = set()
+
+
+def add_trace_check(check_object):
+    _tracing_config.add(check_object)
+
+
+@wrapt.decorator
+def traced(wrapped, instance, args, kwargs):
+    if datadog_agent is None:
+        return wrapped(*args, **kwargs)
+
+    trace_check = instance in _tracing_config
+    integration_tracing = is_affirmative(datadog_agent.get_config('integration_tracing'))
+
+    if integration_tracing and trace_check:
+        with tracer.trace('integration.check', service='integrations-tracing', resource=instance.name):
+            return wrapped(*args, **kwargs)
+
+    return wrapped(*args, **kwargs)


### PR DESCRIPTION
### What does this PR do?

Uses the older method of tracing that was introduced in Agent 6.7 prior to the change going out with 6.8

### Motivation

Keep the upgrade path clean and allow this version of the check to support tracing with 6.7

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

