### PR TITLE
adds the logging config to IBM MQ

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -77,9 +77,12 @@ instances:
 ##
 ## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
 
-#logs:
-#  - type: file
-#    path: /var/mqm/errors/*
-#    service: ibm_mq
-#    source: ibm_mq
-#    sourcecategory: errors
+# logs:
+#   - type: file
+#     path: /var/mqm/log/<APPNAME>/active/AMQERR01.LOG
+#     service: <APPNAME>
+#     source: ibm_mq
+#     log_processing_rules:
+#       - type: multi_line
+#         name: new_log_start_with_date
+#         pattern: "\d{2}/\d{2}/\d{4}"


### PR DESCRIPTION
### What does this PR do?

This adds the proper logging to the config for IBM MQ. 

### Motivation

I thought this was in the original PR! I was mistaken

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
