### PR TITLE
Make the check robust to an unresponsive kubelet

### DIFF
--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -90,6 +90,9 @@ class PodListUtils(object):
         self.pod_uid_by_name_tuple = {}
         self.container_id_by_name_tuple = {}
 
+        if podlist is None:
+            return
+
         pods = podlist.get('items') or []
 
         for pod in pods:


### PR DESCRIPTION
### What does this PR do?

- Move the kubelet health check at the very top of the check
- Make the `PodListUtils` not break the check when the podlist response is `None`

### Motivation

The current logic does not send the `critical` service check if the kubelet is stopped after the agent is started

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [x] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
