### PR TITLE
Postgres custom_metrics deprecated

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -4,10 +4,10 @@
 
 ## Overview
 
-Get metrics from PostgreSQL service in real time to:
+Get metrics from the PostgreSQL service in real time to:
 
 * Visualize and monitor PostgreSQL states
-* Be notified about PostgreSQL failovers and events.
+* Received notifications about PostgreSQL failovers and events
 
 ## Setup
 
@@ -21,7 +21,7 @@ Edit the `postgres.d/conf.yaml` file, in the `conf.d/` folder at the root of you
 
 #### Prepare Postgres
 
-To get started with the PostgreSQL integration, create at least a read-only Datadog user with proper access to your PostgreSQL server. Start psql on your PostgreSQL database and run:
+To get started with the PostgreSQL integration, create a read-only `datadog` user with proper access to your PostgreSQL server. Start `psql` on your PostgreSQL database and run:
 
 For PostgreSQL version 10 and above:
 ```
@@ -35,9 +35,9 @@ create user datadog with password '<PASSWORD>';
 grant SELECT ON pg_stat_database to datadog;
 ```
 
-**Note**: When generating custom metrics that require querying additional tables, you may need to grant the `CONNECT` permission on those tables to the datadog user.
+**Note**: When generating custom metrics that require querying additional tables, you may need to grant the `CONNECT` permission on those tables to the `datadog` user.
 
-To verify the correct permissions run the following command:
+To verify the permissions are correct, run the following command:
 
 ```
 psql -h localhost -U datadog postgres -c \
@@ -50,44 +50,38 @@ When it prompts for a password, enter the one used in the first command.
 
 #### Metric Collection
 
-* Edit the `postgres.d/conf.yaml` file to point to your server and port, set the masters to monitor. See the [sample postgres.d/conf.yaml][14] for all available configuration options. Configuration Options:
+* Edit the `postgres.d/conf.yaml` file to point to your server / port and set the masters to monitor. See the [sample postgres.d/conf.yaml][14] for all available configuration options.
 
-  * **`username`** (Optional) - The user account used to collect metrics, set in the [Installation section above](#installation)
-  * **`password`** (Optional) - The password for the user account.
-  * **`dbname`** (Optional) - The name of the database you want to monitor.
-  * **`ssl`** (Optional) - Defaults to False. Indicates whether to use an SSL connection.
-  * **`use_psycopg2`** (Optional) - Defaults to False. Setting this option to `True` will force the Datadog Agent to collect PostgreSQL metrics using psycopg2 instead of pg8000. Note that pyscopg2 does not support SSL connections.
-  * **`tags`** (Optional) - A list of tags applied to all metrics collected. Tags may be simple strings or key-value pairs.
-  * **`relations`** (Optional) - By default, all schemas are included. Add specific schemas here to collect metrics for schema relations. Each relation will generate 10 metrics and an additional 10 metrics per index. Use the following structure to declare relations:
+| Option                              | Required | Description                                                                                                                                                                                        |
+|-------------------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **`username`**                      | No       | The user account used to collect metrics, created in the [Installation section](#installation) above.                                                                                              |
+| **`password`**                      | No       | The password for the user account.                                                                                                                                                                 |
+| **`dbname`**                        | No       | The name of the database you want to monitor.                                                                                                                                                      |
+| **`ssl`**                           | No       | Defaults to `False`. Indicates whether to use an SSL connection.                                                                                                                                   |
+| **`use_psycopg2`**                  | No       | Defaults to `False`. Setting this option to `True` forces the Datadog Agent to collect PostgreSQL metrics using `psycopg2` instead of `pg8000`. Note: `pyscopg2` does not support SSL connections. |
+| **`tags`**                          | No       | A list of tags applied to all metrics collected. Tags may be simple strings or key-value pairs.                                                                                                    |
+| **`relations`**                     | No       | By default, all schemas are included. Add specific schemas here to collect metrics for schema relations. Each relation generates 10 metrics and an additional 10 metrics per index.                |
+| **`collect_function_metrics`**      | No       | Collect metrics regarding PL/pgSQL functions from `pg_stat_user_functions`.                                                                                                                        |
+| **`collect_count_metrics`**         | No       | Collect count metrics. The default value is `True` for backward compatibility, but this might be slow. The recommended value is `False`.                                                           |
+| **`collect_activity_metrics`**      | No       | Defaults to `False`. Collect metrics regarding transactions from `pg_stat_activity`. Make sure the user has sufficient privileges to read from `pg_stat_activity` before enabling this option.     |
+| **`collect_database_size_metrics`** | Yes      | Collect database size metrics. Default value is `True` but this might be slow with large databases.                                                                                                |
+| **`collect_default_database`**      | No       | Defaults to `False`. Include statistics from the default database `postgres` in the check metrics.                                                                                                 |
 
-    ```
-    relations:
-      - relation_name: my_relation
-        schemas:
-          - my_schema_1
-          - my_schema_2
-    ```
+For PostgreSQL versions 9.6 and below, run the following and create a `SECURITY DEFINER` to read from `pg_stat_activity`.
+```
+CREATE FUNCTION pg_stat_activity() RETURNS SETOF pg_catalog.pg_stat_activity AS 
+$$ SELECT * from pg_catalog.pg_stat_activity; $$
+LANGUAGE sql VOLATILE SECURITY DEFINER;
 
-  * **`collect_function_metrics`** (Optional) - Collect metrics regarding PL/pgSQL functions from pg_stat_user_functions
-  * **`collect_count_metrics`** (Optional) - Collect count metrics. The default value is `True` for backward compatibility, but this might be slow. The recommended value is `False`.
-  * **`collect_activity_metrics`** (Optional) - Collect metrics regarding transactions from pg_stat_activity, default value is `False`. Please make sure the user has sufficient privileges to read from pg_stat_activity before enabling this option.
-  
-    For PostgreSQL versions 9.6 and below, run the following and create a `SECURITY DEFINER` to read from pg_stat_activity.
-     ```
-    CREATE FUNCTION pg_stat_activity() RETURNS SETOF pg_catalog.pg_stat_activity AS 
-    $$ SELECT * from pg_catalog.pg_stat_activity; $$
-    LANGUAGE sql VOLATILE SECURITY DEFINER;
-  
-    CREATE VIEW pg_stat_activity_dd AS SELECT * FROM pg_stat_activity();
-    grant SELECT ON pg_stat_activity_dd to datadog;
-    ```
-  * **`collect_database_size_metrics`** Collect database size metrics. Default value is True but they might be slow with large databases.
-  * **`collect_default_database`** (Optional) Include statistics from the default database 'postgres' in the check metrics, default to `False`.
+CREATE VIEW pg_stat_activity_dd AS SELECT * FROM pg_stat_activity();
+grant SELECT ON pg_stat_activity_dd to datadog;
+```
+
 * [Restart the Agent][15] to start sending PostgreSQL metrics to Datadog.
 
 #### Log Collection
 
-PostgreSQL default logging is to stderr and logs do not include detailed information. This is why we suggest to log into a file with additional details specified in the log line prefix.
+PostgreSQL default logging is to `stderr` and logs do not include detailed information. It is recommended to log into a file with additional details specified in the log line prefix.
 
 * Edit your PostgreSQL configuration file `/etc/postgresql/<version>/main/postgresql.conf` and uncomment the following parameter in the log section:
 
@@ -103,7 +97,7 @@ PostgreSQL default logging is to stderr and logs do not include detailed informa
   #log_destination = 'eventlog'
   ```
 
-* Collecting logs is disabled by default in the Datadog Agent, you need to enable it in datadog.yaml:
+* Collecting logs is disabled by default in the Datadog Agent, enable it in `datadog.yaml`:
 
   ```
   logs_enabled: true
@@ -124,15 +118,15 @@ PostgreSQL default logging is to stderr and logs do not include detailed informa
         #    pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
         #    name: new_log_start_with_date
   ```
-  Change the `service` and `path` parameter values and configure them for your environment.
-  See the [sample postgres.d/conf.yaml][14] for all available configuration options.
+* Change the `service` and `path` parameter values to configure for your environment. See the [sample postgres.d/conf.yaml][14] for all available configuration options.
 
 * [Restart the Agent][15].
 
-**Learn more about log collection [in the log documentation][16]**
+**Learn more about log collection in the [log documentation][16]**
+
 ### Validation
 
-[Run the Agent's `status` subcommand][17] and look for `postgres` under the Checks section.
+[Run the Agent's status subcommand][17] and look for `postgres` under the Checks section.
 
 ## Data Collected
 ### Metrics
@@ -146,16 +140,17 @@ The PostgreSQL check does not include any events at this time.
 
 ### Service Checks
 
-**postgres.can_connect**
-
+**postgres.can_connect**  
 Returns `CRITICAL` if the Agent is unable to connect to the monitored PostgreSQL instance. Returns `OK` otherwise.
 
 ## Further Reading
+Additional helpful documentation, links, and articles:
+
 ### FAQ
 * [PostgreSQL custom metric collection explained][19]
 
 ### Blog posts
-* To get a better idea of how (or why) to have 100x faster PostgreSQL performance by changing 1 line with Datadog, check out our [series of blog posts][20] about it.
+* [100x faster Postgres performance by changing 1 line][20]
 * [Key metrics for PostgreSQL monitoring][21]
 * [Collecting metrics with PostgreSQL monitoring tools][22]
 * [How to collect and monitor PostgreSQL data with Datadog][23]

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -80,8 +80,8 @@ instances:
 #          - tester:postgresql
 
 #    /!\ DEPRECATION: Please use custom_queries instead of the now deprecated custom_metrics.
-#    Please visit our help article for a guide on collecting custom metrics from PostgreSQL:
-#    https://help.datadoghq.com/hc/en-us/articles/208385813-Postgres-custom-metric-collection-explained
+#    Please visit our FAQ article for a guide on collecting custom metrics from PostgreSQL:
+#    https://docs.datadoghq.com/integrations/faq/postgres-custom-metric-collection-explained/
 #
 #    custom_metrics:
 #    - # Londiste 3 replication lag


### PR DESCRIPTION
### What does this PR do?
- Update help article link in example yaml file
- Remove deprecated `custom_metrics` section / examples. Info on `custom_queries` will be added to https://docs.datadoghq.com/integrations/faq/postgres-custom-metric-collection-explained/
- Update wording / formatting

### Motivation
Trello request

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
~[ ] Feature or bugfix has tests~
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
~[ ] If PR adds a configuration option, it has been added to the configuration file.~

### Additional Notes
Associated documentation PR:
https://github.com/DataDog/documentation/pull/3600
