### PR TITLE
Add ability to pass state to e2e tear down

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/__init__.py
@@ -6,6 +6,6 @@ from .conditions import WaitFor
 from .docker import docker_run, get_docker_hostname
 from .env import environment_run
 from .errors import RetryError
-from .structures import EnvVars, LazyFunction
+from .structures import EnvVars, LazyFunction, TempDir
 from .subprocess import run_command
 from .utils import chdir, temp_chdir, temp_dir

--- a/datadog_checks_dev/datadog_checks/dev/_env.py
+++ b/datadog_checks_dev/datadog_checks/dev/_env.py
@@ -3,10 +3,45 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 
+from six import iteritems
+
+E2E_PREFIX = 'DDEV_E2E'
+E2E_ENV_VAR_PREFIX = '{}_ENV_'.format(E2E_PREFIX)
+E2E_SET_UP = '{}_UP'.format(E2E_PREFIX)
+E2E_TEAR_DOWN = '{}_DOWN'.format(E2E_PREFIX)
+
 E2E_FIXTURE_NAME = 'dd_environment'
-E2E_SET_UP = 'DDEV_E2E_UP'
-E2E_TEAR_DOWN = 'DDEV_E2E_DOWN'
 TESTING_PLUGIN = 'DDEV_TESTING_PLUGIN'
+
+
+def e2e_active():
+    return any(ev.startswith(E2E_PREFIX) for ev in os.environ)
+
+
+def set_env_vars(env_vars):
+    for key, value in iteritems(env_vars):
+        key = '{}{}'.format(E2E_ENV_VAR_PREFIX, key)
+        os.environ[key] = value
+
+
+def remove_env_vars(env_vars):
+    for ev in env_vars:
+        os.environ.pop('{}{}'.format(E2E_ENV_VAR_PREFIX, ev), None)
+
+
+def get_env_vars(raw=False):
+    if raw:
+        return {key: value for key, value in iteritems(os.environ) if key.startswith(E2E_ENV_VAR_PREFIX)}
+    else:
+        env_vars = {}
+
+        for key, value in iteritems(os.environ):
+            _, found, ev = key.partition(E2E_ENV_VAR_PREFIX)
+            if found:
+                # Normalize casing for Windows
+                env_vars[ev.lower()] = value
+
+        return env_vars
 
 
 def set_up_env():

--- a/datadog_checks_dev/datadog_checks/dev/plugin/plugin.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/plugin.py
@@ -7,7 +7,7 @@ from base64 import urlsafe_b64encode
 
 import pytest
 
-from .._env import E2E_FIXTURE_NAME, TESTING_PLUGIN
+from .._env import E2E_FIXTURE_NAME, TESTING_PLUGIN, e2e_active, get_env_vars
 
 try:
     from datadog_checks.base.stubs import aggregator as __aggregator
@@ -31,7 +31,7 @@ def dd_environment_runner(request):
     testing_plugin = os.getenv(TESTING_PLUGIN) == 'true'
 
     # Do nothing if no e2e action is triggered and continue with tests
-    if not testing_plugin and not any(ev.startswith('DDEV_E2E_') for ev in os.environ):  # no cov
+    if not testing_plugin and not e2e_active():  # no cov
         return
 
     try:
@@ -58,6 +58,10 @@ def dd_environment_runner(request):
 
     # Default to Docker as that is the most common
     metadata.setdefault('env_type', 'docker')
+
+    # Save any environment variables
+    metadata.setdefault('env_vars', {})
+    metadata['env_vars'].update(get_env_vars(raw=True))
 
     data = {
         'config': config,

--- a/datadog_checks_dev/datadog_checks/dev/structures.py
+++ b/datadog_checks_dev/datadog_checks/dev/structures.py
@@ -3,8 +3,12 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import abc
 import os
+from shutil import rmtree
+from tempfile import mkdtemp
 
 import six
+
+from ._env import e2e_active, get_env_vars, remove_env_vars, set_env_vars, tear_down_env
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -35,3 +39,45 @@ class EnvVars(dict):
     def __exit__(self, exc_type, exc_value, traceback):
         os.environ.clear()
         os.environ.update(self.old_env)
+
+
+class TempDir(object):
+    all_names = set()
+
+    def __init__(self, name='default'):
+        key = None
+        directory = None
+
+        if e2e_active():
+            name = name.lower()
+
+            if name in TempDir.all_names:
+                raise Exception(
+                    'Temporary directory name {} has already been used, choose a different one.'.format(name)
+                )
+            TempDir.all_names.add(name)
+
+            key = 'temp_dir_{}'.format(name)
+            env_vars = get_env_vars()
+
+            if key in env_vars:
+                directory = env_vars[key]
+            else:
+                directory = mkdtemp()
+                set_env_vars({key: directory})
+
+        self.name = name
+        self.key = key
+        self.directory = os.path.realpath(directory or mkdtemp())
+
+    def __enter__(self):
+        return self.directory
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if e2e_active():
+            if tear_down_env():
+                TempDir.all_names.discard(self.name)
+                remove_env_vars([self.key])
+                rmtree(self.directory)
+        else:
+            rmtree(self.directory)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env_commands/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env_commands/start.py
@@ -71,7 +71,7 @@ def start(ctx, check, env, agent, dev, base):
     if error:
         echo_failure('failed!')
         echo_waiting('Stopping the environment...')
-        stop_environment(check, env)
+        stop_environment(check, env, metadata=metadata)
         abort(error)
     echo_success('success!')
 
@@ -80,13 +80,13 @@ def start(ctx, check, env, agent, dev, base):
     if interface is None:
         echo_failure('`{}` is an unsupported environment type.'.format(env_type))
         echo_waiting('Stopping the environment...')
-        stop_environment(check, env)
+        stop_environment(check, env, metadata=metadata)
         abort()
 
     if env_type != 'docker' and agent.isdigit():
         echo_failure('Configuration for default Agents are only for Docker. You must specify the full build.')
         echo_waiting('Stopping the environment...')
-        stop_environment(check, env)
+        stop_environment(check, env, metadata=metadata)
         abort()
 
     environment = interface(check, env, base_package, config, metadata, agent_build, api_key)
@@ -110,7 +110,7 @@ def start(ctx, check, env, agent, dev, base):
         echo_info(result.stdout + result.stderr)
         echo_failure('An error occurred.')
         echo_waiting('Stopping the environment...')
-        stop_environment(check, env)
+        stop_environment(check, env, metadata=metadata)
         environment.remove_config()
         abort()
     echo_success('success!')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env_commands/stop.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env_commands/stop.py
@@ -46,7 +46,7 @@ def stop(check, env):
             echo_success('success!')
 
             echo_waiting('Stopping the environment... ', nl=False, indent=status_indent)
-            _, _, error = stop_environment(check, env)
+            _, _, error = stop_environment(check, env, metadata=environment.metadata)
             if error:
                 echo_failure('failed!')
                 abort(error)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/run.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/run.py
@@ -5,7 +5,7 @@ from .format import parse_config_from_result
 from ..constants import get_root
 from ...subprocess import run_command
 from ...utils import chdir, path_join
-from ..._env import E2E_SET_UP, E2E_TEAR_DOWN
+from ..._env import E2E_ENV_VAR_PREFIX, E2E_SET_UP, E2E_TEAR_DOWN
 
 
 def start_environment(check, env):
@@ -22,13 +22,14 @@ def start_environment(check, env):
     return parse_config_from_result(env, result)
 
 
-def stop_environment(check, env):
+def stop_environment(check, env, metadata=None):
     command = 'tox --develop -e {}'.format(env)
     env_vars = {
         E2E_SET_UP: 'false',
         'PYTEST_ADDOPTS': '--benchmark-skip',
-        'TOX_TESTENV_PASSENV': '{} PYTEST_ADDOPTS'.format(E2E_SET_UP),
+        'TOX_TESTENV_PASSENV': '{}* {} PYTEST_ADDOPTS'.format(E2E_ENV_VAR_PREFIX, E2E_SET_UP),
     }
+    env_vars.update((metadata or {}).get('env_vars', {}))
 
     with chdir(path_join(get_root(), check), env_vars=env_vars):
         result = run_command(command, capture=True)

--- a/datadog_checks_dev/tests/conftest.py
+++ b/datadog_checks_dev/tests/conftest.py
@@ -20,6 +20,7 @@ def mock_e2e_metadata():
     return {
         'env_type': 'vagrant',
         'future': 'now',
+        'env_vars': {},
     }
 
 


### PR DESCRIPTION
### What does this PR do?

Allow one to pass state from when environments start to the stage when they stop using the metadata file (planned use case) and env vars. The first method implemented is for temporary directories.

### Motivation

Some checks use objects that can only be known at start time, like names of temp files or results of Docker commands. This makes it so checks like mcache and openldap can use e2e.