### PR TITLE
Remove deprecated `agentConfig` param

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -42,8 +42,8 @@ class KafkaCheck(AgentCheck):
 
     SOURCE_TYPE_NAME = 'kafka'
 
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        AgentCheck.__init__(self, name, init_config, agentConfig, instances=instances)
+    def __init__(self, name, init_config, instances=None):
+        super(KafkaCheck, self).__init__(self, name, init_config, instances)
         self._zk_timeout = int(init_config.get('zk_timeout', DEFAULT_ZK_TIMEOUT))
         self._kafka_timeout = int(init_config.get('kafka_timeout', DEFAULT_KAFKA_TIMEOUT))
         self.context_limit = int(init_config.get('max_partition_contexts', CONTEXT_UPPER_BOUND))

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -42,8 +42,8 @@ class KafkaCheck(AgentCheck):
 
     SOURCE_TYPE_NAME = 'kafka'
 
-    def __init__(self, name, init_config, instances=None):
-        super(KafkaCheck, self).__init__(self, name, init_config, instances)
+    def __init__(self, name, init_config, instances):
+        super(KafkaCheck, self).__init__(name, init_config, instances)
         self._zk_timeout = int(init_config.get('zk_timeout', DEFAULT_ZK_TIMEOUT))
         self._kafka_timeout = int(init_config.get('kafka_timeout', DEFAULT_KAFKA_TIMEOUT))
         self.context_limit = int(init_config.get('max_partition_contexts', CONTEXT_UPPER_BOUND))


### PR DESCRIPTION
### What does this PR do?

According to the [current docs](https://github.com/DataDog/datadog-agent/blob/5e9ace0240f54e3dc929bf19517bcdf4bc5af104/docs/dev/checks/python/check_api.md#base-class-methods-overriding), the `agentConfig` param is no longer required to be passed to `AgentCheck.init()`.

Also switched to using `super()`.

### Additional Notes

I am not totally clear on the compatibility story of this between v5 / v6 agents.  For example, in v5 agents, `instances` will be a list of all instances... but I'm not clear on how this list gets populated in v6 since the docs say it's a single-element list. 
