### PR TITLE
Add server_address tag when available

### DIFF
--- a/haproxy/datadog_checks/haproxy/haproxy.py
+++ b/haproxy/datadog_checks/haproxy/haproxy.py
@@ -588,6 +588,8 @@ class HAProxy(AgentCheck):
 
         if back_or_front == Services.BACKEND:
             tags.append('backend:%s' % hostname)
+            if data.get('addr'):
+                tags.append('server_address:{}'.format(data.get('addr')))
 
         for key, value in data.items():
             if HAProxy.METRICS.get(key):

--- a/haproxy/tests/common.py
+++ b/haproxy/tests/common.py
@@ -53,6 +53,12 @@ BACKEND_SERVICES = ['anotherbackend', 'datadog']
 
 BACKEND_LIST = ['singleton:8080', 'singleton:8081', 'otherserver']
 
+BACKEND_TO_ADDR = {
+    'singleton:8080': '127.0.0.1:8080',
+    'singleton:8081': '127.0.0.1:8081',
+    'otherserver': '127.0.0.1:1234'
+}
+
 FRONTEND_CHECK_GAUGES = [
     'haproxy.frontend.session.current',
     'haproxy.frontend.session.limit',


### PR DESCRIPTION
### What does this PR do?

Add a server_address tag to haproxy metric when available.

### Motivation

When using server template and hostname resolution in haproxy, we lose the information linked to the backend name (backend-1 in one haproxy can be backend-15 in another one)

The addr information is available in the stats since haproxy 1.7 (see https://www.haproxy.org/download/1.7/doc/management.txt).

Related PR https://github.com/DataDog/integrations-core/pull/2731

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
