### PR TITLE
tcp scheme support for stats socket

### DIFF
--- a/haproxy/datadog_checks/haproxy/haproxy.py
+++ b/haproxy/datadog_checks/haproxy/haproxy.py
@@ -588,6 +588,8 @@ class HAProxy(AgentCheck):
 
         if back_or_front == Services.BACKEND:
             tags.append('backend:%s' % hostname)
+            if data.get('addr'):
+                tags.append('server_address:{}'.format(data.get('addr')))
 
         for key, value in data.items():
             if HAProxy.METRICS.get(key):

--- a/haproxy/tests/common.py
+++ b/haproxy/tests/common.py
@@ -53,6 +53,12 @@ BACKEND_SERVICES = ['anotherbackend', 'datadog']
 
 BACKEND_LIST = ['singleton:8080', 'singleton:8081', 'otherserver']
 
+BACKEND_TO_ADDR = {
+    'singleton:8080': '127.0.0.1:8080',
+    'singleton:8081': '127.0.0.1:8081',
+    'otherserver': '127.0.0.1:1234'
+}
+
 FRONTEND_CHECK_GAUGES = [
     'haproxy.frontend.session.current',
     'haproxy.frontend.session.limit',

--- a/haproxy/tests/common.py
+++ b/haproxy/tests/common.py
@@ -20,16 +20,24 @@ CHECK_NAME = 'haproxy'
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(os.path.dirname(HERE))
 HOST = get_docker_hostname()
+SOCKET_PORT = '13834'
 PORT = '13835'
 PORT_OPEN = '13836'
 BASE_URL = "http://{0}:{1}".format(HOST, PORT)
 BASE_URL_OPEN = "http://{0}:{1}".format(HOST, PORT_OPEN)
 STATS_URL = "{0}/stats".format(BASE_URL)
 STATS_URL_OPEN = "{0}/stats".format(BASE_URL_OPEN)
+STATS_SOCKET = "tcp://{0}:{1}".format(HOST, SOCKET_PORT)
 USERNAME = 'datadog'
 PASSWORD = 'isdevops'
 
 CONFIG_UNIXSOCKET = {
+    'collect_aggregates_only': False,
+}
+
+
+CONFIG_TCPSOCKET = {
+    'url': STATS_SOCKET,
     'collect_aggregates_only': False,
 }
 

--- a/haproxy/tests/compose/haproxy-1_7.cfg
+++ b/haproxy/tests/compose/haproxy-1_7.cfg
@@ -1,0 +1,42 @@
+# Basic configuration
+global
+    log 127.0.0.1 local0
+    maxconn 4096
+    stats socket /tmp/datadog-haproxy-stats.sock
+    stats socket "ipv4@0.0.0.0:13834"
+
+defaults
+    log     global
+    mode    http
+    option  httplog
+    option  dontlognull
+    retries 3
+    option  redispatch
+    option  forwardfor
+    timeout client 1000
+    timeout server 1000
+    timeout connect 1000
+
+frontend public
+    bind 0.0.0.0:13835 # DTDG
+    default_backend datadog
+
+backend datadog
+    stats uri /stats
+    stats auth datadog:isdevops
+    stats refresh 5s
+
+    balance roundrobin
+    server singleton:8080 127.0.0.1:8080
+    server singleton:8081 127.0.0.1:8081
+    server otherserver 127.0.0.1:1234
+
+backend anotherbackend
+    stats uri /stats
+    stats auth datadog:isdevops
+    stats refresh 5s
+
+    balance roundrobin
+    server singleton:8080 127.0.0.1:8080
+    server singleton:8081 127.0.0.1:8081
+    server otherserver 127.0.0.1:1234

--- a/haproxy/tests/compose/haproxy.yaml
+++ b/haproxy/tests/compose/haproxy.yaml
@@ -7,6 +7,7 @@ services:
       - ${HAPROXY_CONFIG}:/usr/local/etc/haproxy/haproxy.cfg
       - ${HAPROXY_SOCKET_DIR}:/tmp
     ports:
+      - "13834:13834"
       - "13835:13835"
     networks:
       - network1

--- a/haproxy/tests/conftest.py
+++ b/haproxy/tests/conftest.py
@@ -67,6 +67,8 @@ def haproxy_container():
 
         env['HAPROXY_CONFIG_DIR'] = os.path.join(common.HERE, 'compose')
         env['HAPROXY_CONFIG'] = os.path.join(common.HERE, 'compose', 'haproxy.cfg')
+        if os.environ.get('HAPROXY_VERSION', '1.5.11').split('.')[:2] >= ['1', '7']:
+            env['HAPROXY_CONFIG'] = os.path.join(common.HERE, 'compose', 'haproxy-1_7.cfg')
         env['HAPROXY_CONFIG_OPEN'] = os.path.join(common.HERE, 'compose', 'haproxy-open.cfg')
         env['HAPROXY_SOCKET_DIR'] = host_socket_dir
 


### PR DESCRIPTION
### What does this PR do?

Allow tcp scheme in url for haproxy stats socket.

### Motivation

Since haproxy 1.7, some informations are only available with operator or admin access (like addr, see https://www.haproxy.org/download/1.7/doc/management.txt).

When using http stats page, you only have admin or standard access. 
So, to get more informations without providing remote admin access to the agent, one solution is to use a socket with the operator level access.

This PR adds the possibility to define a remote tcp socket. 

Related PR https://github.com/DataDog/integrations-core/pull/2727

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

The tests depends on the additional tags added in https://github.com/DataDog/integrations-core/pull/2727, so this PR includes all the changes.
