### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ jobs:
     - stage: test
       env: CHECK=disk PYTHON3=true
     - stage: test
-      env: CHECK=dns_check
+      env: CHECK=dns_check PYTHON3=true
     - stage: test
       env: CHECK=dotnetclr
     - stage: test

--- a/dns_check/requirements.in
+++ b/dns_check/requirements.in
@@ -1,1 +1,1 @@
-dnspython==1.12.0
+dnspython==1.16.0

--- a/dns_check/requirements.txt
+++ b/dns_check/requirements.txt
@@ -4,5 +4,6 @@
 #
 #    pip-compile --generate-hashes --output-file requirements.txt requirements.in
 #
-dnspython==1.12.0 \
-    --hash=sha256:63bd1fae61809eedb91f84b2185816fac1270ae51494fbdd36ea25f904a8502f
+dnspython==1.16.0 \
+    --hash=sha256:36c5e8e38d4369a08b6780b7f27d790a292b2b08eea01607865bf0936c558e01 \
+    --hash=sha256:f69c21288a962f4da86e56c4905b49d11aba7938d3d740e80d9e366ee4f1632d

--- a/dns_check/tox.ini
+++ b/dns_check/tox.ini
@@ -8,8 +8,6 @@ envlist =
 [testenv]
 usedevelop = true
 platform = linux|darwin|win32
-
-[testenv:dns_check]
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt

--- a/dns_check/tox.ini
+++ b/dns_check/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    dns_check
+    {py27,py36}-dns_check
     flake8
 
 [testenv]


### PR DESCRIPTION
### What does this PR do?

The DNS Check appears to already support python 3, so I'm just adding a test for it to ensure we don't break python 3 support.

### Motivation

We gotta move everything to python 3

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

I added no changelog since there are no changes