### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ jobs:
     - stage: test
       env: CHECK=fluentd
     - stage: test
-      env: CHECK=gearmand
+      env: CHECK=gearmand PYTHON3=true
     - stage: test
       env: CHECK=gitlab
     - stage: test

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -10,6 +10,7 @@ dnspython==1.12.0
 enum34==1.1.6
 flup==1.0.3.dev-20110405; python_version < '3.0'
 gearman==2.0.2; sys_platform != 'win32' and python_version < '3.0'
+python3-gearman==0.1.0; sys_platform != 'win32' and python_version > '3.0'
 google-compute-engine==2.8.3
 httplib2==0.10.3
 ipaddress==1.0.22

--- a/gearmand/datadog_checks/gearmand/gearmand.py
+++ b/gearmand/datadog_checks/gearmand/gearmand.py
@@ -3,12 +3,17 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-# 3rd party
-import gearman
+from six import PY2
 
-# project
 from datadog_checks.checks import AgentCheck
 
+# Python 3 compatability is a different library
+# It's a drop in replacement but has a different name
+# This will enable the check to use the new library
+if PY2:
+    import gearman
+else:
+    import python3_gearman as gearman
 
 MAX_NUM_TASKS = 200
 

--- a/gearmand/requirements.in
+++ b/gearmand/requirements.in
@@ -1,1 +1,2 @@
 gearman==2.0.2; sys_platform != 'win32' and python_version < '3.0'
+python3-gearman==0.1.0; sys_platform != 'win32' and python_version > '3.0'

--- a/gearmand/requirements.txt
+++ b/gearmand/requirements.txt
@@ -4,5 +4,10 @@
 #
 #    pip-compile --generate-hashes --output-file requirements.txt requirements.in
 #
-gearman==2.0.2 \
+
+gearman==2.0.2 ; sys_platform != "win32" and python_version < "3.0" \
     --hash=sha256:2b1876a60e32e24bed4c6d187898274de6409bbfa942bcbe3512efdf2aed0ec9
+
+python3-gearman==0.1.0 ; sys_platform != "win32" and python_version > "3.0" \
+    --hash=sha256:3ee44df221587c76ff13f0bebf4923b02b31b1b069ffda07416658be0614865c \
+    --hash=sha256:4a5808d3a0bfc6c243548ad57e7aab4bee62c9cba2b1c3a860fdd292d46a112d

--- a/gearmand/tox.ini
+++ b/gearmand/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py27
 envlist =
-  gearmand
+  {py27,py36}-gearmand
   flake8
 
 [testenv]
@@ -14,8 +14,6 @@ deps =
 passenv =
     COMPOSE*
     DOCKER*
-
-[testenv:gearmand]
 commands =
     pip install --require-hashes -r requirements.txt
     pytest -v


### PR DESCRIPTION
### What does this PR do?

This moves Gearmand to Python3. Python 3 support for the library is a new drop in replacement library: https://github.com/josiahmwalton/python3-gearman

We can use that, we just need to amend the requirements files and make the import conditional

### Motivation

 We need to move everything to python3

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
