### PR TITLE
add exchange filtering options to the default rabbitmq config yaml file

### DIFF
--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -58,6 +58,17 @@ instances:
     #   - thisqueue-.*
     #   - another_\d+queue
     #   - (lepidorae)-\d+   # to tag queues in the lepidorae queue_family
+    
+    # Use the `exchanges` or `exchanges_regexes` parameters to specify the exchanges you'd like to
+    # collect metrics on (up to 50 exchanges).
+    # If you have less than 50 exchanges, you don't have to set this parameter,
+    # the metrics will be collected on all the exchanges by default.
+    #
+    # exchanges:
+    #   - exchange1
+    #   - exchange2
+    # exchanges_regexes:
+    #   - thisexchange-.*
 
     # Service checks and `rabbitmq.connections` metric:
     # By default a list of all vhosts is fetched and each one will be checked


### PR DESCRIPTION
### What does this PR do?
Add exchange filtering options such as exchanges and exchanges_regexes

### Motivation
Client reached maximum exchange limit and wanted to filter Rabbitmq exchanges and raise exchange limit, didn't know what to do because the options are not present in the sample conf file

https://datadog.zendesk.com/agent/tickets/186296 
https://trello.com/c/0Dldjr1D/650-add-exchange-limiting-options-to-the-example-rabbitmq-config-file 

What inspired you to submit this pull request?
Add these options in the conf file can help users to better solve this problem in the future

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [x] If PR adds a configuration option, it has been added to the configuration file.