### PR TITLE
Validate checks dependencies against the embedded environment

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
@@ -17,7 +17,7 @@ from .utils import (
     echo_warning
 )
 from ..constants import (
-    AGENT_REQ_FILE, AGENT_V5_ONLY, BETA_PACKAGES, CHANGELOG_TYPE_NONE, NOT_CHECKS, VERSION_BUMP, get_root
+    AGENT_RELEASE_REQ_FILE, AGENT_V5_ONLY, BETA_PACKAGES, CHANGELOG_TYPE_NONE, NOT_CHECKS, VERSION_BUMP, get_root
 )
 from ..git import (
     get_current_branch, parse_pr_numbers, get_commits_since, git_tag, git_commit,
@@ -670,8 +670,8 @@ def make(ctx, check, version, initial_release, skip_sign, sign_only):
 
         # update the global requirements file
         if check not in NOT_CHECKS:
-            commit_targets.append(AGENT_REQ_FILE)
-            req_file = os.path.join(root, AGENT_REQ_FILE)
+            commit_targets.append(AGENT_RELEASE_REQ_FILE)
+            req_file = os.path.join(root, AGENT_RELEASE_REQ_FILE)
             echo_waiting('Updating the Agent requirements file... ', nl=False)
             update_agent_requirements(req_file, check, get_agent_requirement_line(check, version))
             echo_success('success!')
@@ -887,7 +887,7 @@ def freeze(ctx, no_deps):
 
     lines = sorted(entries)
 
-    req_file = os.path.join(get_root(), AGENT_REQ_FILE)
+    req_file = os.path.join(get_root(), AGENT_RELEASE_REQ_FILE)
     write_file_lines(req_file, lines)
     echo_success('Successfully wrote to `{}`!'.format(req_file))
 
@@ -930,10 +930,10 @@ def agent_changelog(since, to, output, force):
     changes_per_agent = OrderedDict()
 
     for i in range(1, len(agent_tags)):
-        contents_from = git_show_file(AGENT_REQ_FILE, agent_tags[i - 1])
+        contents_from = git_show_file(AGENT_RELEASE_REQ_FILE, agent_tags[i - 1])
         catalog_from = parse_agent_req_file(contents_from)
 
-        contents_to = git_show_file(AGENT_REQ_FILE, agent_tags[i])
+        contents_to = git_show_file(AGENT_RELEASE_REQ_FILE, agent_tags[i])
         catalog_to = parse_agent_req_file(contents_to)
 
         version_changes = OrderedDict()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_reqs.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_reqs.py
@@ -5,7 +5,7 @@ import click
 import os
 
 from ..utils import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_warning
-from ...constants import get_root, AGENT_REQ_FILE, AGENT_V5_ONLY, NOT_CHECKS
+from ...constants import get_root, AGENT_RELEASE_REQ_FILE, AGENT_V5_ONLY, NOT_CHECKS
 from ...utils import get_valid_checks, parse_agent_req_file, get_version_string
 from ...release import get_package_name
 from ....utils import read_file
@@ -21,7 +21,7 @@ def agent_reqs():
 
     root = get_root()
     echo_info("Validating requirements-agent-release.txt...")
-    agent_reqs_content = parse_agent_req_file(read_file(os.path.join(root, AGENT_REQ_FILE)))
+    agent_reqs_content = parse_agent_req_file(read_file(os.path.join(root, AGENT_RELEASE_REQ_FILE)))
     ok_checks = 0
     unreleased_checks = 0
     failed_checks = 0

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
@@ -1,11 +1,14 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+
 import click
 from six import iteritems
 
 from ..utils import CONTEXT_SETTINGS, abort, echo_failure, echo_info
-from ...dep import collect_packages
+from ...constants import get_root, AGENT_REQUIREMENTS
+from ...dep import collect_packages, read_packages
 from ....utils import get_next
 
 
@@ -29,15 +32,23 @@ def display_multiple_attributes(attributes, message):
 
 @click.command(
     context_settings=CONTEXT_SETTINGS,
-    short_help='Verify the uniqueness of dependency versions'
+    short_help='Verify dependencies across all checks'
 )
 def dep():
-    """Verify the uniqueness of dependency versions across all checks."""
-    all_packages, _ = collect_packages()
+    """
+    This command will:
+
+    * Verify the uniqueness of dependency versions across all checks.
+    * Verify all the dependencies are pinned.
+    * Verify the embedded Python environment defined in the base check and requirements
+      listed in every integration are compatible.
+    """
+    catalog = collect_packages()
     failed = False
 
-    for package, package_data in sorted(iteritems(all_packages)):
-        versions = package_data['versions']
+    # Check uniqueness and unpinned
+    for package in catalog.packages:
+        versions = catalog.get_package_versions(package)
         if len(versions) > 1:
             failed = True
             display_multiple_attributes(versions, 'Multiple versions found for package `{}`:'.format(package))
@@ -47,10 +58,28 @@ def dep():
                 failed = True
                 echo_failure('Unpinned dependency `{}` in the `{}` check.'.format(package, checks[0]))
 
-        markers = package_data['markers']
+        markers = catalog.get_package_markers(package)
         if len(markers) > 1:
             failed = True
             display_multiple_attributes(markers, 'Multiple markers found for package `{}`:'.format(package))
+
+    # Check embedded env compatibility
+    agent_req_file = os.path.join(get_root(), AGENT_REQUIREMENTS)
+    embedded_deps = {p.name: p for p in read_packages(agent_req_file)}
+    for check_name in sorted(os.listdir(get_root())):
+        for package in catalog.get_check_packages(check_name):
+            if package.name not in embedded_deps:
+                failed = True
+                echo_failure('Dependency `{}` for check `{}` missing from the embedded environment'.format(
+                    package.name, check_name
+                ))
+            elif embedded_deps[package.name] != package:
+                failed = True
+                echo_failure('Dependency `{}` mismatch for check `{}` in the embedded environment'.format(
+                    package.name, check_name
+                ))
+                echo_failure('    have: {}'.format(embedded_deps[package.name]))
+                echo_failure('    want: {}'.format(package))
 
     if failed:
         abort()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -30,7 +30,7 @@ VERSION_BUMP = OrderedDict([
 AGENT_RELEASE_REQ_FILE = 'requirements-agent-release.txt'
 # The requirements file listing dependencies needed by the embedded Python environment
 AGENT_REQUIREMENTS = os.path.join(
-    'datadog_checks_base', 'base', 'data', 'agent_requirements.in'
+    'datadog_checks_base', 'datadog_checks', 'base', 'data', 'agent_requirements.in'
 )
 AGENT_V5_ONLY = {
     'agent_metrics',

--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import os
 from collections import OrderedDict
 
 import semver
@@ -25,8 +26,10 @@ VERSION_BUMP = OrderedDict([
     ('beta', lambda v: semver.bump_prerelease(v, 'beta')),
 ])
 
-# The checks requirement file used by the agent
-AGENT_REQ_FILE = 'requirements-agent-release.txt'
+# The requirements file listing integrations to be included in the Agent package
+AGENT_RELEASE_REQ_FILE = 'requirements-agent-release.txt'
+# The requirements file listing dependencies needed by the embedded Python environment
+AGENT_REQUIREMENTS = 'agent_requirements.in'
 
 AGENT_V5_ONLY = {
     'agent_metrics',

--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -29,8 +29,9 @@ VERSION_BUMP = OrderedDict([
 # The requirements file listing integrations to be included in the Agent package
 AGENT_RELEASE_REQ_FILE = 'requirements-agent-release.txt'
 # The requirements file listing dependencies needed by the embedded Python environment
-AGENT_REQUIREMENTS = 'agent_requirements.in'
-
+AGENT_REQUIREMENTS = os.path.join(
+    'datadog_checks_base', 'base', 'data', 'agent_requirements.in'
+)
 AGENT_V5_ONLY = {
     'agent_metrics',
     'docker_daemon',


### PR DESCRIPTION
### What does this PR do?

Adds an extra step to `ddev validate dep`: now the tool will ensure a certain dependency in a local `requirements.txt` file for an integration has a match in the requirements file that defines the Python env embedded in the Agent.

### Motivation

Consistency

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Also added a bit of refactoring:

* `Package` is now a full fledged class with utility methods
* added a `PackageCatalog` class to wrap a bunch of complex nested dicts 
