### PR TITLE
Properly check if tenant name is in cache

### DIFF
--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -350,7 +350,7 @@ class OpenStackControllerCheck(AgentCheck):
 
             if updated_server_status == 'ACTIVE':
                 # Add or update the cache
-                if tenant_to_name[updated_server.get('tenant_id')]:
+                if tenant_to_name.get(updated_server.get('tenant_id')):
                     servers[updated_server_id] = self.create_server_object(updated_server, tenant_to_name)
             else:
                 # Remove from the cache if it exists

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -332,7 +332,7 @@ class OpenStackControllerCheck(AgentCheck):
             servers.extend(resp)
 
         return {server.get('id'): self.create_server_object(server, tenant_to_name) for server in servers
-                if tenant_to_name[server.get('tenant_id')]}
+                if tenant_to_name.get(server.get('tenant_id'))}
 
     def update_servers_cache(self, cached_servers, tenant_to_name, changes_since):
         servers = copy.deepcopy(cached_servers)
@@ -366,7 +366,7 @@ class OpenStackControllerCheck(AgentCheck):
             'hypervisor_hostname': server.get('OS-EXT-SRV-ATTR:hypervisor_hostname'),
             'tenant_id': server.get('tenant_id'),
             'availability_zone': server.get('OS-EXT-AZ:availability_zone'),
-            'project_name': tenant_to_name[server.get('tenant_id')]
+            'project_name': tenant_to_name.get(server.get('tenant_id'))
         }
         # starting version 2.47, flavors infos are contained within the `servers/detail` endpoint
         # See https://developer.openstack.org/api-ref/compute/


### PR DESCRIPTION
### What does this PR do?

Properly check if tenant name is in cache before accessing

### Motivation

KeyError if the server's tenant id isn't there. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
