### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ jobs:
     - stage: test
       env: CHECK=gearmand PYTHON3=true
     - stage: test
-      env: CHECK=gitlab
+      env: CHECK=gitlab PYTHON3=true
     - stage: test
       env: CHECK=go_expvar
     - stage: test

--- a/gitlab/datadog_checks/gitlab/gitlab.py
+++ b/gitlab/datadog_checks/gitlab/gitlab.py
@@ -3,10 +3,10 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 # stdlib
-import urlparse
 from copy import deepcopy
 
 # 3rd party
+from six.moves.urllib.parse import urlparse
 import requests
 
 from datadog_checks.errors import CheckException

--- a/gitlab/datadog_checks/gitlab/gitlab.py
+++ b/gitlab/datadog_checks/gitlab/gitlab.py
@@ -95,7 +95,7 @@ class GitlabCheck(OpenMetricsBaseCheck):
         return ssl_ca_certs if ssl_cert_validation else False
 
     def _service_check_tags(self, url):
-        parsed_url = urlparse.urlparse(url)
+        parsed_url = urlparse(url)
         gitlab_host = parsed_url.hostname
         gitlab_port = 443 if parsed_url.scheme == 'https' else (parsed_url.port or 80)
         return ['gitlab_host:{}'.format(gitlab_host), 'gitlab_port:{}'.format(gitlab_port)]

--- a/gitlab/datadog_checks/gitlab/gitlab.py
+++ b/gitlab/datadog_checks/gitlab/gitlab.py
@@ -55,7 +55,7 @@ class GitlabCheck(OpenMetricsBaseCheck):
             self.service_check(
                 self.PROMETHEUS_SERVICE_CHECK_NAME,
                 OpenMetricsBaseCheck.CRITICAL,
-                message="Unable to retrieve Prometheus metrics from endpoint {}: {}".format(endpoint, e.message),
+                message="Unable to retrieve Prometheus metrics from endpoint {}: {}".format(endpoint, e),
                 tags=custom_tags,
             )
 
@@ -167,7 +167,7 @@ class GitlabCheck(OpenMetricsBaseCheck):
             self.service_check(
                 service_check_name,
                 OpenMetricsBaseCheck.CRITICAL,
-                message="Error hitting {}. Error: {}".format(check_url, e.message),
+                message="Error hitting {}. Error: {}".format(check_url, e),
                 tags=service_check_tags,
             )
             raise

--- a/gitlab/tests/conftest.py
+++ b/gitlab/tests/conftest.py
@@ -56,7 +56,7 @@ def gitlab_service(request):
         raise Exception("prometheus endpoint timed out!")
 
     # run pre-test commands
-    for i in xrange(100):
+    for i in range(100):
         requests.get(GITLAB_URL)
     sleep(2)
 
@@ -68,7 +68,7 @@ def wait_for(URL, timeout):
     Wait for specified URL
     """
 
-    for i in xrange(timeout):
+    for i in range(timeout):
         try:
             r = requests.get(URL)
             r.raise_for_status()

--- a/gitlab/tox.ini
+++ b/gitlab/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    gitlab
+    {py27,py36}-gitlab
     flake8
     bench
 


### PR DESCRIPTION
### What does this PR do?

Adds Python 3 support to gitlab. 

### Motivation

We need to move everything to python 3. 🚂 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

The container isn't working locally. I'm adding a wip label to this because I'm using travis to test this. I am uncertain if this will work.
