### PR TITLE
[openstack_controller] Bring back hypervisor_load metrics

### DIFF
--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -277,7 +277,7 @@ class OpenStackControllerCheck(AgentCheck):
                                                  collect_hypervisor_metrics=collect_hypervisor_metrics,
                                                  collect_hypervisor_load=collect_hypervisor_load)
         if not hypervisors:
-            self.warning("Unable to collect any hypervisors from Nova response")
+            self.warning("Unable to collect any hypervisors from Nova response.")
 
     def get_stats_for_single_hypervisor(self, hyp, custom_tags=None,
                                         use_shortname=False,

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -279,7 +279,7 @@ class OpenStackControllerCheck(AgentCheck):
                                                  collect_hypervisor_load=collect_hypervisor_load)
 
         if not hypervisors:
-            self.log.warn("Unable to collect any hypervisors from Nova response: {}".format(resp))
+            self.warning("Unable to collect any hypervisors from Nova response: {}".format(resp))
 
     def get_stats_for_single_hypervisor(self, hyp, custom_tags=None,
                                         use_shortname=False,
@@ -317,7 +317,7 @@ class OpenStackControllerCheck(AgentCheck):
 
         # This makes a request per hypervisor and only sends hypervisor_load 1/5/15
         # Disable this by default for higher performance in a large environment
-        # If the Agent is installed on the hypervisors, system.load.1/5/15 is available
+        # If the Agent is installed on the hypervisors, system.load.1/5/15 is available as a system metric
         if collect_hypervisor_load:
             try:
                 load_averages = self.get_loads_for_single_hypervisor(hyp['id'])
@@ -328,7 +328,7 @@ class OpenStackControllerCheck(AgentCheck):
                 for i, avg in enumerate([1, 5, 15]):
                     self.gauge('openstack.nova.hypervisor_load.{}'.format(avg), load_averages[i], tags=tags)
             else:
-                self.log.debug("Load Averages didn't return expected values: {}".format(load_averages))
+                self.warning("Load Averages didn't return expected values: {}".format(load_averages))
 
     def get_active_servers(self, tenant_to_name):
         servers = []
@@ -508,7 +508,7 @@ class OpenStackControllerCheck(AgentCheck):
                         tags=server_tags,
                     )
         except KeyError:
-            self.log.warn("Unexpected response, not submitting limits metrics for project id".format(project['id']))
+            self.warning("Unexpected response, not submitting limits metrics for project id {}".format(project['id']))
 
     def get_flavors(self):
         query_params = {
@@ -635,8 +635,8 @@ class OpenStackControllerCheck(AgentCheck):
                     tags=["keystone_server: {}".format(self.keystone_server_url)] + custom_tags,
                 )
             except KeystoneUnreachable as e:
-                self.log.warning("The agent could not contact the specified identity server at {} . "
-                                 "Are you sure it is up at that address?".format(self.keystone_server_url))
+                self.warning("The agent could not contact the specified identity server at {} . "
+                             "Are you sure it is up at that address?".format(self.keystone_server_url))
                 self.log.debug("Problem grabbing auth token: %s", e)
                 self.service_check(
                     self.IDENTITY_API_SC,

--- a/openstack_controller/tests/common.py
+++ b/openstack_controller/tests/common.py
@@ -23,7 +23,8 @@ MOCK_CONFIG = {
     },
     'instances': [
         {
-            'name': 'test_name', 'user': {'name': 'test_name', 'password': 'test_pass', 'domain': {'id': 'test_id'}}
+            'name': 'test_name',
+            'user': {'name': 'test_name', 'password': 'test_pass', 'domain': {'id': 'test_id'}}
         }
     ]
 }

--- a/openstack_controller/tests/fixtures/v2.1_4bfc1_os-hypervisors_uptime.json
+++ b/openstack_controller/tests/fixtures/v2.1_4bfc1_os-hypervisors_uptime.json
@@ -1,0 +1,1 @@
+{"hypervisor": {"hypervisor_hostname": "fake-mini", "id": 1, "state": "up", "status": "enabled", "uptime": " 08:32:11 up 93 days, 18:25, 12 users,  load average: 0.20, 0.12, 0.14"}}

--- a/openstack_controller/tests/test_end_to_end.py
+++ b/openstack_controller/tests/test_end_to_end.py
@@ -9,7 +9,6 @@ from datadog_checks.openstack_controller import OpenStackControllerCheck
 
 
 def make_request_responses(url, header, params=None, timeout=None):
-    mock_path = None
     if url == "http://10.0.2.15:5000/v3/projects":
         mock_path = "v3_projects.json"
     elif url == "http://10.0.2.15:9696":
@@ -32,6 +31,26 @@ def make_request_responses(url, header, params=None, timeout=None):
             mock_path = "{}_147d1.json".format(mock_path)
     elif url == "http://10.0.2.15:8774/v2.1/***************************4bfc1/os-hypervisors/detail":
         mock_path = "v2.1_4bfc1_os-hypervisors_detail.json"
+    elif url == "http://10.0.2.15:8774/v2.1/***************************4bfc1/os-hypervisors/1/uptime":
+        mock_path = "v2.1_4bfc1_os-hypervisors_uptime.json"
+    elif url == "http://10.0.2.15:8774/v2.1/***************************4bfc1/os-hypervisors/2/uptime":
+        mock_path = "v2.1_4bfc1_os-hypervisors_uptime.json"
+    elif url == "http://10.0.2.15:8774/v2.1/***************************4bfc1/os-hypervisors/8/uptime":
+        mock_path = "v2.1_4bfc1_os-hypervisors_uptime.json"
+    elif url == "http://10.0.2.15:8774/v2.1/***************************4bfc1/os-hypervisors/9/uptime":
+        mock_path = "v2.1_4bfc1_os-hypervisors_uptime.json"
+    elif url == "http://10.0.2.15:8774/v2.1/***************************4bfc1/os-hypervisors/10/uptime":
+        mock_path = "v2.1_4bfc1_os-hypervisors_uptime.json"
+    elif url == "http://10.0.2.15:8774/v2.1/***************************4bfc1/os-hypervisors/11/uptime":
+        mock_path = "v2.1_4bfc1_os-hypervisors_uptime.json"
+    elif url == "http://10.0.2.15:8774/v2.1/***************************4bfc1/os-hypervisors/12/uptime":
+        mock_path = "v2.1_4bfc1_os-hypervisors_uptime.json"
+    elif url == "http://10.0.2.15:8774/v2.1/***************************4bfc1/os-hypervisors/13/uptime":
+        mock_path = "v2.1_4bfc1_os-hypervisors_uptime.json"
+    elif url == "http://10.0.2.15:8774/v2.1/***************************4bfc1/os-hypervisors/14/uptime":
+        mock_path = "v2.1_4bfc1_os-hypervisors_uptime.json"
+    elif url == "http://10.0.2.15:8774/v2.1/***************************4bfc1/os-hypervisors/15/uptime":
+        mock_path = "v2.1_4bfc1_os-hypervisors_uptime.json"
     elif url == "http://10.0.2.15:8774/v2.1/***************************4bfc1/os-aggregates":
         mock_path = "v2.1_4bfc1_os-aggregates.json"
     elif url == "http://10.0.2.15:8774/v2.1/***************************4bfc1/servers/detail":
@@ -76,6 +95,8 @@ def make_request_responses(url, header, params=None, timeout=None):
         mock_path = "v2.1_4bfc1_servers_57030997-f1b5-4f79-9429-8cb285318633_diagnostics.json"
     elif url == "http://10.0.2.15:9696/v2.0/networks":
         mock_path = "v2.0_networks.json"
+    else:
+        raise RuntimeError()
 
     mock_path = os.path.join(common.FIXTURES_DIR, mock_path)
     with open(mock_path, 'r') as f:
@@ -2760,6 +2781,127 @@ def test_scenario(make_request, aggregator):
                                            'hypervisor:compute2.openstack.local',
                                            'server_name:jnrgjoner', 'availability_zone:nova'],
                                      hostname=u'b3c8eee3-7e22-4a7c-9745-759073673cbe')
+
+            aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
+                                     tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
+                                     tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
+                                           'virt_type:QEMU', 'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
+                                     tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
+                                     tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
+                                           'virt_type:QEMU', 'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
+                                     tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
+                                     tags=['hypervisor:compute6.openstack.local', 'hypervisor_id:11', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
+                                     tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
+                                     tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
+                                     tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
+                                     tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
+                                     tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
+                                     tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
+                                           'virt_type:QEMU', 'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
+                                     tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
+                                     tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
+                                           'virt_type:QEMU', 'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
+                                     tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
+                                     tags=['hypervisor:compute6.openstack.local', 'hypervisor_id:11', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
+                                     tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
+                                     tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
+                                     tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
+                                     tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
+                                     tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
+                                     tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
+                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
+                                     tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
+                                     tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
+                                           'virt_type:QEMU', 'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
+                                     tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+
+            aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
+                                     tags=['hypervisor:compute6.openstack.local', 'hypervisor_id:11', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
+                                     tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
+                                     tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
+                                     tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
+            aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
+                                     tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15', 'virt_type:QEMU',
+                                           'status:enabled'],
+                                     hostname='')
 
         # Assert coverage for this check on this instance
         aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

Bring hypervisor loads metrics back.
This issue was introduced in https://github.com/DataDog/integrations-core/pull/2718
The reason why it was unnoticed is because `collect_hypervisor_load` initially defaulted to `false`.
Unit tests were not testing this config.
Added unit tests coverage this time :)

### Motivation

Fix regression

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
