### PR TITLE
Fixing NoneType error arount hypervisor hostname

### DIFF
--- a/openstack_controller/datadog_checks/openstack_controller/api.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api.py
@@ -83,7 +83,8 @@ class ComputeApi(AbstractApi):
 
     def get_os_hypervisors_detail(self):
         url = '{}/os-hypervisors/detail'.format(self.endpoint)
-        return self._make_request(url, self.headers)
+        hypervisors = self._make_request(url, self.headers)
+        return hypervisors.get('hypervisors', [])
 
     def get_servers_detail(self, query_params, timeout=None):
         url = '{}/servers/detail'.format(self.endpoint)

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -378,6 +378,9 @@ class OpenStackControllerCheck(AgentCheck):
         if 'disk' in flavor:
             # New in version 2.47
             result['flavor'] = self.create_flavor_object(flavor)
+        if not all(key in result for key in SERVER_FIELDS_REQ):
+            self.warning("Server {} is missing a required field. Unable to collect all metrics for this server"
+                         .format(result))
         return result
 
     # Get all of the server IDs and their metadata and cache them

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -270,16 +270,14 @@ class OpenStackControllerCheck(AgentCheck):
         Submits stats for all hypervisors registered to this control plane
         Raises specific exceptions based on response code
         """
-        resp = self.get_os_hypervisors_detail()
-        hypervisors = resp.get('hypervisors', [])
+        hypervisors = self.get_os_hypervisors_detail()
         for hyp in hypervisors:
             self.get_stats_for_single_hypervisor(hyp, custom_tags=custom_tags,
                                                  use_shortname=use_shortname,
                                                  collect_hypervisor_metrics=collect_hypervisor_metrics,
                                                  collect_hypervisor_load=collect_hypervisor_load)
-
-        if not hypervisors:
-            self.log.warn("Unable to collect any hypervisors from Nova response: {}".format(resp))
+        else:
+            self.log.warn("Unable to collect any hypervisors from Nova response.")
 
     def get_stats_for_single_hypervisor(self, hyp, custom_tags=None,
                                         use_shortname=False,
@@ -796,6 +794,9 @@ class OpenStackControllerCheck(AgentCheck):
 
     def _get_host_aggregate_tag(self, hyp_hostname, use_shortname=False):
         tags = []
+        if not hyp_hostname:
+            return tags
+
         hyp_hostname = hyp_hostname.split('.')[0] if use_shortname else hyp_hostname
         if hyp_hostname in self._get_and_set_aggregate_list():
             tags.append('aggregate:{}'.format(self._aggregate_list[hyp_hostname].get('aggregate', "unknown")))

--- a/openstack_controller/tests/test_compute_api.py
+++ b/openstack_controller/tests/test_compute_api.py
@@ -199,108 +199,91 @@ def test_get_os_hypervisors_detail(aggregator):
     with mock.patch('datadog_checks.openstack_controller.api.AbstractApi._make_request',
                     side_effect=get_os_hypervisors_detail_post_v2_33_response):
         compute_api = ComputeApi(None, False, None, "foo", "foo")
-        assert compute_api.get_os_hypervisors_detail() == {
-            "hypervisors": [
-                {
-                    "cpu_info": {
-                        "arch": "x86_64",
-                        "model": "Nehalem",
-                        "vendor": "Intel",
-                        "features": [
-                            "pge",
-                            "clflush"
-                        ],
-                        "topology": {
-                            "cores": 1,
-                            "threads": 1,
-                            "sockets": 4
-                        }
-                    },
-                    "current_workload": 0,
-                    "status": "enabled",
-                    "state": "up",
-                    "disk_available_least": 0,
-                    "host_ip": "1.1.1.1",
-                    "free_disk_gb": 1028,
-                    "free_ram_mb": 7680,
-                    "hypervisor_hostname": "host1",
-                    "hypervisor_type": "fake",
-                    "hypervisor_version": 1000,
-                    "id": 2,
-                    "local_gb": 1028,
-                    "local_gb_used": 0,
-                    "memory_mb": 8192,
-                    "memory_mb_used": 512,
-                    "running_vms": 0,
-                    "service": {
-                        "host": "host1",
-                        "id": 7,
-                        "disabled_reason": None
-                    },
-                    "vcpus": 2,
-                    "vcpus_used": 0
-                }
-            ],
-            "hypervisors_links": [
-                {
-                    "href": "http://openstack.example.com/v2.1/6f70656e737461636b20342065766572/hypervisors/detail?limit=1&marker=2",  # noqa: E501
-                    "rel": "next"
-                }
-            ]
-        }
+        assert compute_api.get_os_hypervisors_detail() == [
+            {
+                "cpu_info": {
+                    "arch": "x86_64",
+                    "model": "Nehalem",
+                    "vendor": "Intel",
+                    "features": [
+                        "pge",
+                        "clflush"
+                    ],
+                    "topology": {
+                        "cores": 1,
+                        "threads": 1,
+                        "sockets": 4
+                    }
+                },
+                "current_workload": 0,
+                "status": "enabled",
+                "state": "up",
+                "disk_available_least": 0,
+                "host_ip": "1.1.1.1",
+                "free_disk_gb": 1028,
+                "free_ram_mb": 7680,
+                "hypervisor_hostname": "host1",
+                "hypervisor_type": "fake",
+                "hypervisor_version": 1000,
+                "id": 2,
+                "local_gb": 1028,
+                "local_gb_used": 0,
+                "memory_mb": 8192,
+                "memory_mb_used": 512,
+                "running_vms": 0,
+                "service": {
+                    "host": "host1",
+                    "id": 7,
+                    "disabled_reason": None
+                },
+                "vcpus": 2,
+                "vcpus_used": 0
+            }
+        ]
 
     with mock.patch('datadog_checks.openstack_controller.api.AbstractApi._make_request',
                     side_effect=get_os_hypervisors_detail_post_v2_53_response):
         compute_api = ComputeApi(None, False, None, "foo", "foo")
-        assert compute_api.get_os_hypervisors_detail() == {
-            "hypervisors": [
-                {
-                    "cpu_info": {
-                        "arch": "x86_64",
-                        "model": "Nehalem",
-                        "vendor": "Intel",
-                        "features": [
-                            "pge",
-                            "clflush"
-                        ],
-                        "topology": {
-                            "cores": 1,
-                            "threads": 1,
-                            "sockets": 4
-                        }
-                    },
-                    "current_workload": 0,
-                    "status": "enabled",
-                    "state": "up",
-                    "disk_available_least": 0,
-                    "host_ip": "1.1.1.1",
-                    "free_disk_gb": 1028,
-                    "free_ram_mb": 7680,
-                    "hypervisor_hostname": "host2",
-                    "hypervisor_type": "fake",
-                    "hypervisor_version": 1000,
-                    "id": "1bb62a04-c576-402c-8147-9e89757a09e3",
-                    "local_gb": 1028,
-                    "local_gb_used": 0,
-                    "memory_mb": 8192,
-                    "memory_mb_used": 512,
-                    "running_vms": 0,
-                    "service": {
-                        "host": "host1",
-                        "id": "62f62f6e-a713-4cbe-87d3-3ecf8a1e0f8d",
-                        "disabled_reason": None
-                    },
-                    "vcpus": 2,
-                    "vcpus_used": 0
-                }
-            ],
-            "hypervisors_links": [
-                {
-                    "href": "http://openstack.example.com/v2.1/6f70656e737461636b20342065766572/hypervisors/detail?limit=1&marker=1bb62a04-c576-402c-8147-9e89757a09e3",  # noqa: E501
-                    "rel": "next"
-                }
-            ]
-        }
+        assert compute_api.get_os_hypervisors_detail() == [
+            {
+                "cpu_info": {
+                    "arch": "x86_64",
+                    "model": "Nehalem",
+                    "vendor": "Intel",
+                    "features": [
+                        "pge",
+                        "clflush"
+                    ],
+                    "topology": {
+                        "cores": 1,
+                        "threads": 1,
+                        "sockets": 4
+                    }
+                },
+                "current_workload": 0,
+                "status": "enabled",
+                "state": "up",
+                "disk_available_least": 0,
+                "host_ip": "1.1.1.1",
+                "free_disk_gb": 1028,
+                "free_ram_mb": 7680,
+                "hypervisor_hostname": "host2",
+                "hypervisor_type": "fake",
+                "hypervisor_version": 1000,
+                "id": "1bb62a04-c576-402c-8147-9e89757a09e3",
+                "local_gb": 1028,
+                "local_gb_used": 0,
+                "memory_mb": 8192,
+                "memory_mb_used": 512,
+                "running_vms": 0,
+                "service": {
+                    "host": "host1",
+                    "id": "62f62f6e-a713-4cbe-87d3-3ecf8a1e0f8d",
+                    "disabled_reason": None
+                },
+                "vcpus": 2,
+                "vcpus_used": 0
+            }]
 
 
 def get_servers_detail_post_v2_63_response(url, headers, params=None, timeout=None):


### PR DESCRIPTION
### What does this PR do?

Fixes the following stack trace
```
Traceback (most recent call last):
 File "/etc/datadog-agent/checks.d/openstack_controller/utils.py", line 36, in traced
   return wrapped(*args, **kwargs)
 File "/etc/datadog-agent/checks.d/openstack_controller/openstack_controller.py", line 758, in check
   use_shortname=use_shortname)
 File "/etc/datadog-agent/checks.d/openstack_controller/openstack_controller.py", line 522, in collect_server_flavor_metrics
   host_tags = self._get_host_aggregate_tag(hypervisor_hostname, use_shortname=use_shortname)
 File "/etc/datadog-agent/checks.d/openstack_controller/openstack_controller.py", line 799, in _get_host_aggregate_tag
   hyp_hostname = hyp_hostname.split('.')[0] if use_shortname else hyp_hostname
AttributeError: 'NoneType' object has no attribute 'split'
```

### Motivation

Bug fix

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
