### PR TITLE
Remove spurious tab from config file

### DIFF
--- a/openldap/datadog_checks/openldap/data/conf.yaml.example
+++ b/openldap/datadog_checks/openldap/data/conf.yaml.example
@@ -3,7 +3,7 @@ init_config:
 # List of instances describing your OpenLDAP servers to monitor.
 instances:
   - url: ldaps://localhost:636  # Mandatory: full URL of your ldap server. Use `ldaps` or `ldap` as the scheme to use TLS or not, or `ldapi` to connect to a UNIX socket.
-  	#
+    #
     # username: dc=monitor,dc=yourdomain  # Optional: the DN of the user that can read the monitor database.
     # password: pass  # Optional: the password of the above user.
     #


### PR DESCRIPTION
### Motivation

```
...
  File "C:\Users\ofek.lev\Desktop\q\Miniconda3\lib\site-packages\yaml\scanner.py", line 257, in fetch_more_tokens
    self.get_mark())
yaml.scanner.ScannerError: while scanning for the next token
found character '\t' that cannot start any token
  in "<unicode string>", line 6, column 3:
        #
      ^
```