### PR TITLE
Add validation for configuration files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,21 +47,23 @@ jobs:
   include:
     - stage: test_changed
       script:
+        - ddev validate agent-reqs
+        - ddev validate config
         - ddev validate dep
         - ddev validate manifest --include-extras
         - ddev validate metadata
         - ddev validate service-checks
-        - ddev validate agent-reqs
         - ddev test --cov
         - ddev test --bench || true
     - stage: test
       env: CHECK=datadog_checks_base PYTHON3=true
       script:
+        - ddev validate agent-reqs
+        - ddev validate config
         - ddev validate dep
         - ddev validate manifest --include-extras
         - ddev validate metadata
         - ddev validate service-checks
-        - ddev validate agent-reqs
         - travis_retry ddev test --cov ${CHECK}
         - ddev test ${CHECK} --bench || true
     - stage: test

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
@@ -3,19 +3,21 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import click
 
-from ..utils import CONTEXT_SETTINGS
+from .agent_reqs import agent_reqs
+from .config import config
 from .dep import dep
 from .manifest import manifest
 from .metadata import metadata
 from .service_checks import service_checks
-from .agent_reqs import agent_reqs
+from ..utils import CONTEXT_SETTINGS
 
 ALL_COMMANDS = (
+    agent_reqs,
+    config,
     dep,
     manifest,
     metadata,
     service_checks,
-    agent_reqs,
 )
 
 @click.group(

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -45,6 +45,7 @@ def config(check):
         for config_file in config_files:
             num_files += 1
             file_display_queue = []
+            file_name = basepath(config_file)
 
             try:
                 config_data = yaml.safe_load(read_file(config_file))
@@ -54,7 +55,7 @@ def config(check):
                 # We must convert to text here to free Exception object before it goes out of scope
                 error = str(e)
 
-                check_display_queue.append(lambda: echo_info('{}:'.format(basepath(config_file)), indent=True))
+                check_display_queue.append(lambda: echo_info('{}:'.format(file_name), indent=True))
                 check_display_queue.append(lambda: echo_failure('Invalid YAML -', indent=FILE_INDENT))
                 check_display_queue.append(lambda: echo_info(error, indent=FILE_INDENT * 2))
                 continue
@@ -72,7 +73,7 @@ def config(check):
                     file_display_queue.append(lambda: echo_failure('No default instance', indent=FILE_INDENT))
 
             if file_display_queue:
-                check_display_queue.append(lambda: echo_info('{}:'.format(basepath(config_file)), indent=True))
+                check_display_queue.append(lambda: echo_info('{}:'.format(file_name), indent=True))
                 check_display_queue.extend(file_display_queue)
 
         if check_display_queue:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -1,0 +1,103 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import click
+import yaml
+
+from ..utils import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_waiting, echo_warning
+from ...utils import get_config_files, get_valid_checks
+from ....utils import basepath, read_file
+
+FILE_INDENT = ' ' * 8
+
+IGNORE_DEFAULT_INSTANCE = {
+    'ceph',
+    'dotnetclr',
+    'gunicorn',
+    'marathon',
+    'pgbouncer',
+    'process',
+    'supervisord',
+}
+
+
+@click.command(
+    context_settings=CONTEXT_SETTINGS,
+    short_help='Validate default configuration files'
+)
+@click.argument('check', required=False)
+def config(check):
+    """Validate default configuration files."""
+    if check:
+        checks = [check]
+    else:
+        checks = sorted(get_valid_checks())
+
+    files_failed = {}
+    files_warned = {}
+    num_files = 0
+
+    echo_waiting('Validating default configuration files...')
+    for check in checks:
+        check_display_queue = []
+
+        config_files = get_config_files(check)
+        for config_file in config_files:
+            num_files += 1
+            file_display_queue = []
+
+            try:
+                config_data = yaml.safe_load(read_file(config_file))
+            except Exception as e:
+                files_failed[config_file] = True
+
+                # We must convert to text here to free Exception object before it goes out of scope
+                error = str(e)
+
+                check_display_queue.append(lambda: echo_info('{}:'.format(basepath(config_file)), indent=True))
+                check_display_queue.append(lambda: echo_failure('Invalid YAML -', indent=FILE_INDENT))
+                check_display_queue.append(lambda: echo_info(error, indent=FILE_INDENT * 2))
+                continue
+
+            # Verify there is an `instances` section
+            if 'instances' not in config_data:
+                files_failed[config_file] = True
+                file_display_queue.append(lambda: echo_failure('Missing `instances` section', indent=FILE_INDENT))
+
+            # Verify there is a default instance
+            else:
+                instances = config_data['instances']
+                if check not in IGNORE_DEFAULT_INSTANCE and not isinstance(instances, list):
+                    files_failed[config_file] = True
+                    file_display_queue.append(lambda: echo_failure('No default instance', indent=FILE_INDENT))
+
+            if file_display_queue:
+                check_display_queue.append(lambda: echo_info('{}:'.format(basepath(config_file)), indent=True))
+                check_display_queue.extend(file_display_queue)
+
+        if check_display_queue:
+            echo_success('{}:'.format(check))
+            for display in check_display_queue:
+                display()
+
+    files_failed = len(files_failed)
+    files_warned = len(files_warned)
+    files_passed = num_files - (files_failed + files_warned)
+
+    if files_failed or files_warned:
+        click.echo()
+
+    if files_failed:
+        echo_failure('Files with errors: {}'.format(files_failed))
+
+    if files_warned:
+        echo_warning('Files with warnings: {}'.format(files_warned))
+
+    if files_passed:
+        if files_failed or files_warned:
+            echo_success('Files valid: {}'.format(files_passed))
+        else:
+            echo_success('All {} configuration files are valid!'.format(num_files))
+
+    if files_failed:
+        abort()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -11,7 +11,7 @@ import requests
 import semver
 from six import string_types
 
-from .constants import VERSION_BUMP, get_root
+from .constants import NOT_CHECKS, VERSION_BUMP, get_root
 from ..utils import file_exists, read_file
 
 # match something like `(#1234)` and return `1234` in a group
@@ -85,6 +85,23 @@ def get_tox_file(check_name):
 
 def get_metadata_file(check_name):
     return os.path.join(get_root(), check_name, 'metadata.csv')
+
+
+def get_config_files(check_name):
+    files = []
+
+    if check_name in NOT_CHECKS:
+        return files
+
+    default_yaml = os.path.join(get_root(), check_name, 'datadog_checks', check_name, 'data', 'conf.yaml.default')
+    if file_exists(default_yaml):
+        files.append(default_yaml)
+
+    example_yaml = os.path.join(get_root(), check_name, 'datadog_checks', check_name, 'data', 'conf.yaml.example')
+    if file_exists(example_yaml):
+        files.append(example_yaml)
+
+    return sorted(files)
 
 
 def get_valid_checks():

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -93,11 +93,17 @@ def get_config_files(check_name):
     if check_name in NOT_CHECKS:
         return files
 
-    default_yaml = os.path.join(get_root(), check_name, 'datadog_checks', check_name, 'data', 'conf.yaml.default')
+    root = get_root()
+
+    auto_conf = os.path.join(root, check_name, 'datadog_checks', check_name, 'data', 'auto_conf.yaml')
+    if file_exists(auto_conf):
+        files.append(auto_conf)
+
+    default_yaml = os.path.join(root, check_name, 'datadog_checks', check_name, 'data', 'conf.yaml.default')
     if file_exists(default_yaml):
         files.append(default_yaml)
 
-    example_yaml = os.path.join(get_root(), check_name, 'datadog_checks', check_name, 'data', 'conf.yaml.example')
+    example_yaml = os.path.join(root, check_name, 'datadog_checks', check_name, 'data', 'conf.yaml.example')
     if file_exists(example_yaml):
         files.append(example_yaml)
 


### PR DESCRIPTION
### What does this PR do?

Adds validation of every `conf.yaml.default`, `conf.yaml.example`, and `auto_conf.yaml` to Travis. Initially, we verify:

- YAML is valid
- `instances` key exists
- if `instances` key exists, that there is a default instance

### Motivation

No default instance may cause unexpected behavior

### Additional Notes

- For now, I've ignored the few checks that already have no default instance. Let me know if we want to change those in separate PRs.
- This paves the way for us to do other checks on the configs like ensuring proper doc comments.

### Example

![capture](https://user-images.githubusercontent.com/9677399/49981936-55ea6700-ff28-11e8-8402-d30f7ee4d087.PNG)
