### PR TITLE
Match cleanup behavior of old temp dir utility

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/structures.py
+++ b/datadog_checks_dev/datadog_checks/dev/structures.py
@@ -9,6 +9,7 @@ from tempfile import mkdtemp
 import six
 
 from ._env import e2e_active, get_env_vars, remove_env_vars, set_env_vars, tear_down_env
+from .warn import warning
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -70,6 +71,13 @@ class TempDir(object):
         self.key = key
         self.directory = os.path.realpath(directory or mkdtemp())
 
+    @classmethod
+    def _cleanup(cls, directory):
+        try:
+            rmtree(directory)
+        except Exception as e:
+            warning('Error removing temporary directory `{}`: {}'.format(directory, e))
+
     def __enter__(self):
         return self.directory
 
@@ -78,6 +86,6 @@ class TempDir(object):
             if tear_down_env():
                 TempDir.all_names.discard(self.name)
                 remove_env_vars([self.key])
-                rmtree(self.directory)
+                self._cleanup(self.directory)
         else:
-            rmtree(self.directory)
+            self._cleanup(self.directory)


### PR DESCRIPTION
### What does this PR do?

Ignore errors https://github.com/DataDog/integrations-core/blob/5a13fee8d9fcf97a6602c012a7d07e0da8452fb9/datadog_checks_dev/datadog_checks/dev/utils.py#L137-L144

### Motivation

Docker service running as sudo will often change user/group bits of bind mounts leaving them in an un-removable state on host https://travis-ci.com/DataDog/integrations-core/builds/94857581#L760

### Additional Notes

- Depends on https://github.com/DataDog/integrations-core/pull/2764
- No changelog b/c `TempDir` has not been released