### PR TITLE
Refactor Docker Utils used for integration testing

### DIFF
--- a/cassandra_nodetool/tests/conftest.py
+++ b/cassandra_nodetool/tests/conftest.py
@@ -7,51 +7,22 @@ import stat
 import os
 import logging
 import pytest
-import time
 
 from . import common
-from datadog_checks.dev import TempDir
+from datadog_checks.dev import docker_run, TempDir
 from datadog_checks.dev.utils import copy_path
+from datadog_checks.dev.docker import get_container_ip
 
 log = logging.getLogger(__file__)
 
 
-def wait_on_docker_logs(container_name, max_wait, sentences):
-    args = [
-        'docker',
-        'logs',
-        container_name
-    ]
-    log.info("Waiting for {} to come up".format(container_name))
-    for _ in range(max_wait):
-        out = subprocess.check_output(args)
-        if any(str.encode(s) in out for s in sentences):
-            log.info('{} is up!'.format(container_name))
-            return True
-        time.sleep(1)
-
-    log.info(out)
-    return False
-
-
-def get_container_ip(container_id_or_name):
-    """
-    Get a docker container's IP address from its id or name
-    """
-    args = [
-        'docker', 'inspect',
-        '-f', '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}', container_id_or_name
-    ]
-
-    return subprocess.check_output(args).strip()
-
-
 @pytest.fixture(scope="session")
-def cassandra_cluster():
+def dd_environment():
     """
         Start the cassandra cluster with required configuration
     """
     env = os.environ
+    compose_file = os.path.join(common.HERE, 'compose', 'docker-compose.yaml')
     env['CONTAINER_PORT'] = common.PORT
 
     # We need to restrict permission on the password file
@@ -63,34 +34,24 @@ def cassandra_cluster():
         temp_jmx_file = os.path.join(tmpdir, 'jmxremote.password')
         env['JMX_PASS_FILE'] = temp_jmx_file
         os.chmod(temp_jmx_file, stat.S_IRWXU)
-        docker_compose_args = [
-            "docker-compose",
-            "-f", os.path.join(common.HERE, 'compose', 'docker-compose.yaml')
-        ]
-        subprocess.check_call(docker_compose_args + ["up", "-d", common.CASSANDRA_CONTAINER_NAME])
-        # wait for the cluster to be up before yielding
-        if not wait_on_docker_logs(
-                common.CASSANDRA_CONTAINER_NAME,
-                20,
-                ['Listening for thrift clients', "Created default superuser role 'cassandra'"]
+        with docker_run(
+            compose_file,
+            service_name=common.CASSANDRA_CONTAINER_NAME,
+            log_patterns=['Listening for thrift clients']
         ):
-            raise Exception("Cassandra cluster dd-test-cassandra boot timed out!")
-        cassandra_seed = get_container_ip("{}".format(common.CASSANDRA_CONTAINER_NAME))
-        env['CASSANDRA_SEEDS'] = cassandra_seed.decode('utf-8')
-        subprocess.check_call(docker_compose_args + ["up", "-d", common.CASSANDRA_CONTAINER_NAME_2])
-        if not wait_on_docker_logs(
-                common.CASSANDRA_CONTAINER_NAME_2,
-                50,
-                ['Listening for thrift clients', 'Not starting RPC server as requested']
-        ):
-            raise Exception("Cassandra cluster {} boot timed out!".format(common.CASSANDRA_CONTAINER_NAME_2))
-        subprocess.check_call([
-            "docker",
-            "exec", common.CASSANDRA_CONTAINER_NAME,
-            "cqlsh",
-            "-e",
-            "CREATE KEYSPACE IF NOT EXISTS test WITH REPLICATION={'class':'SimpleStrategy', 'replication_factor':2}"
-        ])
-        yield
-
-    subprocess.check_call(docker_compose_args + ["down"])
+            cassandra_seed = get_container_ip("{}".format(common.CASSANDRA_CONTAINER_NAME))
+            env['CASSANDRA_SEEDS'] = cassandra_seed
+            with docker_run(
+                compose_file,
+                service_name=common.CASSANDRA_CONTAINER_NAME_2,
+                log_patterns=['All sessions completed']
+            ):
+                subprocess.check_call([
+                    "docker",
+                    "exec", common.CASSANDRA_CONTAINER_NAME,
+                    "cqlsh",
+                    "-e",
+                    "CREATE KEYSPACE IF NOT EXISTS test \
+                    WITH REPLICATION={'class':'SimpleStrategy', 'replication_factor':2}"
+                ])
+                yield

--- a/cassandra_nodetool/tests/conftest.py
+++ b/cassandra_nodetool/tests/conftest.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__file__)
 
 
 @pytest.fixture(scope="session")
-def dd_environment():
+def cassandra_cluster():
     """
         Start the cassandra cluster with required configuration
     """
@@ -54,4 +54,4 @@ def dd_environment():
                     "CREATE KEYSPACE IF NOT EXISTS test \
                     WITH REPLICATION={'class':'SimpleStrategy', 'replication_factor':2}"
                 ])
-                yield
+                yield common.CONFIG_INSTANCE

--- a/cassandra_nodetool/tests/test_integration.py
+++ b/cassandra_nodetool/tests/test_integration.py
@@ -9,7 +9,7 @@ from datadog_checks.cassandra_nodetool import CassandraNodetoolCheck
 
 
 @pytest.mark.integration
-def test_integration(aggregator, cassandra_cluster):
+def test_integration(aggregator, dd_environment):
     """
     Testing Cassandra Nodetool Integration
     """

--- a/cassandra_nodetool/tests/test_integration.py
+++ b/cassandra_nodetool/tests/test_integration.py
@@ -9,7 +9,7 @@ from datadog_checks.cassandra_nodetool import CassandraNodetoolCheck
 
 
 @pytest.mark.integration
-def test_integration(aggregator, dd_environment):
+def test_integration(aggregator, cassandra_cluster):
     """
     Testing Cassandra Nodetool Integration
     """


### PR DESCRIPTION
### What does this PR do?

Refactors the docker compose setup for the cassandra_nodetool tests. 

### Motivation

Use the docker utilities from datadog_checks_dev to help standardize how test containers are being spun up. 

Only impacts/modifies test files. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

E2E currently doesn't work for environments that need to call subprocess output to access a binary on the host. This is because E2E relies on running the Agent container, which doesn't have access to the binary in something like the nodetool container. When we have the ability to support this, enabling E2E on this check would be a matter of changing the function that spins up the env to `dd_environment`