### PR TITLE
Add ability to log warnings during pytest

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/warn.py
+++ b/datadog_checks_dev/datadog_checks/dev/warn.py
@@ -1,0 +1,28 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import warnings
+
+from ._env import e2e_active
+
+_original_formatwarning = warnings.formatwarning
+
+
+def warning(message):
+    # We disable caching of this helper so it can be used multiple times.
+    # https://github.com/python/cpython/blob/9a4758550d96030ee7e7f7c7c68b435db1a2a825/Lib/warnings.py#L362
+    with warnings.catch_warnings():
+        warnings.warn(message, stacklevel=2)
+
+
+def _formatwarning(message, category, filename, lineno, line=None):
+    # Shorten output for occurrences during E2E to just what is necessary for a nice display.
+    if e2e_active():
+        return '{}\n'.format(message)
+
+    return _original_formatwarning(message, category, filename, lineno, line=line)
+
+
+# We can't override `showwarning` as usual because pytest already overrides that for logs.
+# https://github.com/pytest-dev/pytest/blob/b76104e722f41ce367765cd988ee8314d45b20b5/src/_pytest/warnings.py#L75
+warnings.formatwarning = _formatwarning


### PR DESCRIPTION
### Motivation

We need a way to output messages even for passing tests, such as when temporary directories could not be cleaned up. However, pytest captures output by default, so logs only get displayed upon failure or when using extra flags. Therefore we use their built-in warnings mechanism to elicit this behavior by default https://docs.pytest.org/en/latest/warnings.html. We also can output condensed messages so these look just as nice in terminal when not running tests.

### Additional Notes

This needs to be merged before https://github.com/DataDog/integrations-core/pull/2762, which in turn is required for https://github.com/DataDog/integrations-core/pull/2760