### PR TITLE
Bump kafka-python and kazoo

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -16,8 +16,8 @@ httplib2==0.10.3
 ipaddress==1.0.22
 jaydebeapi==1.1.1
 jpype1==0.6.3
-kafka-python==1.4.3; sys_platform != 'win32'
-kazoo==2.4.0; sys_platform != 'win32'
+kafka-python==1.4.4; sys_platform != 'win32'
+kazoo==2.6.0; sys_platform != 'win32'
 ldap3==2.5
 meld3==1.0.2
 ntplib==0.3.3


### PR DESCRIPTION
### What does this PR do?

Per `kafka_consumer` check requirements.

Sister PRs (hold until those are merged):

- [ ] https://github.com/DataDog/dd-agent/pull/3801
- [ ] https://github.com/DataDog/omnibus-software/pull/279

### Motivation

Requirements bumped in #2728 and #2729 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

