### PR TITLE
Add core and containers teams as code owners for the base check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 manifest.json         @DataDog/baklava @DataDog/agent-integrations
 
 # Container monitoring
+/datadog_checks_base/ @DataDog/container-integrations @DataDog/agent-integrations
 /docker_daemon/       @DataDog/container-integrations @DataDog/agent-integrations
 /ecs_fargate/         @DataDog/container-integrations @DataDog/agent-integrations
 /kube_dns/            @DataDog/container-integrations @DataDog/agent-integrations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,19 +6,22 @@
 *                   @DataDog/agent-integrations
 
 # Documentation
-/docs/              @DataDog/baklava @DataDog/agent-integrations
-*.md                @DataDog/baklava @DataDog/agent-integrations
-manifest.json       @DataDog/baklava @DataDog/agent-integrations
+/docs/                @DataDog/baklava @DataDog/agent-integrations
+*.md                  @DataDog/baklava @DataDog/agent-integrations
+manifest.json         @DataDog/baklava @DataDog/agent-integrations
 
 # Container monitoring
-/docker_daemon/     @DataDog/container-integrations @DataDog/agent-integrations
-/ecs_fargate/       @DataDog/container-integrations @DataDog/agent-integrations
-/kube_dns/          @DataDog/container-integrations @DataDog/agent-integrations
-/kube_proxy/        @DataDog/container-integrations @DataDog/agent-integrations
-/kubelet/           @DataDog/container-integrations @DataDog/agent-integrations
-/kubernetes/        @DataDog/container-integrations @DataDog/agent-integrations
-/kubernetes_state/  @DataDog/container-integrations @DataDog/agent-integrations
+/docker_daemon/       @DataDog/container-integrations @DataDog/agent-integrations
+/ecs_fargate/         @DataDog/container-integrations @DataDog/agent-integrations
+/kube_dns/            @DataDog/container-integrations @DataDog/agent-integrations
+/kube_proxy/          @DataDog/container-integrations @DataDog/agent-integrations
+/kubelet/             @DataDog/container-integrations @DataDog/agent-integrations
+/kubernetes/          @DataDog/container-integrations @DataDog/agent-integrations
+/kubernetes_state/    @DataDog/container-integrations @DataDog/agent-integrations
+
+# Agent core team
+/datadog_checks_base/ @DataDog/agent-core @DataDog/agent-integrations
 
 # To keep ProdSec up-to-date with changes to requirements.txt.
-requirements.in   @DataDog/prodsec
-requirements.txt  @DataDog/prodsec
+requirements.in       @DataDog/prodsec
+requirements.txt      @DataDog/prodsec


### PR DESCRIPTION
### What does this PR do?

See title

### Motivation

Changes to the base check might affect Agent nightly builds, this way the core and containers teams get notified when this happens.
