### PR TITLE
Do not consider empty string as a change

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
@@ -936,7 +936,7 @@ def agent_changelog(since, to, output, force):
 
         for name, ver in iteritems(catalog_to):
             old_ver = catalog_from.get(name, "")
-            if old_ver != ver:
+            if old_ver and old_ver != ver:
                 # determine whether major version changed
                 breaking = old_ver.split('.')[0] < ver.split('.')[0]
                 version_changes[name] = (ver, breaking)


### PR DESCRIPTION
### What does this PR do?

Fixes the agent changelog command

### Motivation

If there's not change bewteen two agent releases, everything was considered as a change

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

