### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -181,7 +181,7 @@ jobs:
     - stage: test
       env: CHECK=network
     - stage: test
-      env: CHECK=nfsstat
+      env: CHECK=nfsstat PYTHON3=true
     - stage: test
       env: CHECK=nginx PYTHON3=true
     - stage: test

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -40,7 +40,7 @@ class NfsStatCheck(AgentCheck):
         for l in stat_out.splitlines():
             if not l:
                 continue
-            elif l.find('mounted on') >= 0 and len(this_device) > 0:
+            elif l.find(b'mounted on') >= 0 and len(this_device) > 0:
                 # if it's a new device, create the device and add it to the array
                 device = Device(this_device, self.log)
                 all_devices.append(device)
@@ -77,8 +77,8 @@ class Device(object):
         self.log.info(self._device_header)
         self.device_name = self._device_header[0]
         self.mount = self._device_header[-1][:-1]
-        self.nfs_server = self.device_name.split(':')[0]
-        self.nfs_export = self.device_name.split(':')[1]
+        self.nfs_server = self.device_name.split(b':')[0]
+        self.nfs_export = self.device_name.split(b':')[1]
 
     def _parse_ops(self):
         ops = self._device_data[2]
@@ -91,7 +91,7 @@ class Device(object):
         self.read_kb_per_s = float(read_data[1])
         self.read_kb_per_op = float(read_data[2])
         self.read_retrans = float(read_data[3])
-        self.read_retrans_pct = read_data[4].strip('(').strip(')').strip('%')
+        self.read_retrans_pct = read_data[4].strip(b'(').strip(b')').strip(b'%')
         self.read_retrans_pct = float(self.read_retrans_pct)
         self.read_avg_rtt = float(read_data[5])
         self.read_avg_exe = float(read_data[6])
@@ -102,7 +102,7 @@ class Device(object):
         self.write_kb_per_s = float(write_data[1])
         self.write_kb_per_op = float(write_data[2])
         self.write_retrans = float(write_data[3])
-        self.write_retrans_pct = write_data[4].strip('(').strip(')').strip('%')
+        self.write_retrans_pct = write_data[4].strip(b'(').strip(b')').strip(b'%')
         self.write_retrans_pct = float(self.write_retrans_pct)
         self.write_avg_rtt = float(write_data[5])
         self.write_avg_exe = float(write_data[6])

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -3,6 +3,8 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import os
 
+from datadog_checks.base import ensure_unicode
+
 from datadog_checks.checks import AgentCheck
 from datadog_checks.utils.subprocess_output import get_subprocess_output
 
@@ -109,9 +111,9 @@ class Device(object):
 
     def _parse_tags(self):
         self.tags = []
-        self.tags.append('nfs_server:{0}'.format(self.nfs_server))
-        self.tags.append('nfs_export:{0}'.format(self.nfs_export))
-        self.tags.append('nfs_mount:{0}'.format(self.mount))
+        self.tags.append('nfs_server:{0}'.format(ensure_unicode(self.nfs_server)))
+        self.tags.append('nfs_export:{0}'.format(ensure_unicode(self.nfs_export)))
+        self.tags.append('nfs_mount:{0}'.format(ensure_unicode(self.mount)))
 
     def send_metrics(self, gauge, tags):
         metric_prefix = 'system.nfs.'

--- a/nfsstat/tests/test_nfsstat.py
+++ b/nfsstat/tests/test_nfsstat.py
@@ -5,8 +5,6 @@ import os
 import logging
 
 import mock
-import pytest
-from datadog_checks.stubs import aggregator
 
 from datadog_checks.nfsstat import NfsStatCheck
 
@@ -34,12 +32,6 @@ FIXTURE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'fixtures
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture
-def Aggregator():
-    aggregator.reset()
-    return aggregator
-
-
 class TestNfsstat:
     CHECK_NAME = 'nfsstat'
     INSTANCES = {
@@ -52,7 +44,7 @@ class TestNfsstat:
         'nfsiostat_path': '/opt/datadog-agent/embedded/sbin/nfsiostat',
     }
 
-    def test_check(self, Aggregator):
+    def test_check(self, aggregator):
         instance = self.INSTANCES['main']
         c = NfsStatCheck(self.CHECK_NAME, self.INIT_CONFIG, {}, [instance])
 
@@ -70,11 +62,7 @@ class TestNfsstat:
             'nfs_mount:/mnt/datadog/two'
         ])
 
-        from six import iteritems
-        for name, metric in iteritems(Aggregator._metrics):
-            log.warning("{} {}".format(name, metric))
-
         for metric in metrics:
-            Aggregator.assert_metric(metric, tags=tags)
+            aggregator.assert_metric(metric, tags=tags)
 
-        assert Aggregator.metrics_asserted_pct == 100.0
+        assert aggregator.metrics_asserted_pct == 100.0

--- a/nfsstat/tests/test_nfsstat.py
+++ b/nfsstat/tests/test_nfsstat.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+import logging
 
 import mock
 import pytest
@@ -29,6 +30,8 @@ metrics = [
 ]
 
 FIXTURE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'fixtures')
+
+log = logging.getLogger(__name__)
 
 
 @pytest.fixture
@@ -66,6 +69,10 @@ class TestNfsstat:
             'nfs_export:/exports/nfs/datadog/two',
             'nfs_mount:/mnt/datadog/two'
         ])
+
+        from six import iteritems
+        for name, metric in iteritems(Aggregator._metrics):
+            log.warning("{} {}".format(name, metric))
 
         for metric in metrics:
             Aggregator.assert_metric(metric, tags=tags)

--- a/nfsstat/tox.ini
+++ b/nfsstat/tox.ini
@@ -2,14 +2,12 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    nfsstat
+    {py27,py36}-nfsstat
     flake8
 
 [testenv]
 usedevelop = true
 platform = linux|darwin|win32
-
-[testenv:nfsstat]
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt


### PR DESCRIPTION
### What does this PR do?

Adds Python 3 support to the NFS Stat check.

It mostly just had some string handling issues. I think I fixed them in a good and consistent way. I used binary strings on the internal string handling and use unicode on strings that would be sent externally.

I also removed an old aggregator implementation from the test.

### Motivation

All aboard the Python 3 🚂 . We're leaving the station!

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
