### PR TITLE
pgBouncer: add support for database metrics

### DIFF
--- a/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
+++ b/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
@@ -65,6 +65,18 @@ class PgBouncer(AgentCheck):
         'query': """SHOW POOLS""",
     }
 
+    DATABASES_METRICS = {
+        'descriptors': [
+            ('database', 'db'),
+        ],
+        'metrics': [
+            ('pool_size',            ('pgbouncer.databases.pool_size', GAUGE)),
+            ('max_connections',      ('pgbouncer.databases.max_connections', GAUGE)),
+            ('current_connections',  ('pgbouncer.databases.current_connections', GAUGE)),
+        ],
+        'query': """SHOW DATABASES""",
+    }
+
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
         self.dbs = {}
@@ -92,7 +104,7 @@ class PgBouncer(AgentCheck):
         """Query pgbouncer for various metrics
         """
 
-        metric_scope = [self.STATS_METRICS, self.POOLS_METRICS]
+        metric_scope = [self.STATS_METRICS, self.POOLS_METRICS, self.DATABASES_METRICS]
 
         try:
             with db.cursor(cursor_factory=pgextras.DictCursor) as cursor:

--- a/pgbouncer/metadata.csv
+++ b/pgbouncer/metadata.csv
@@ -22,3 +22,6 @@ pgbouncer.pools.sv_used,gauge,,connection,,"Server connections idle more than se
 pgbouncer.pools.sv_tested,gauge,,connection,,Server connections currently running either server_reset_query or server_check_query,0,pgbouncer,server tested conns
 pgbouncer.pools.sv_login,gauge,,connection,,Server connections currently in the process of logging in,0,pgbouncer,server login conns
 pgbouncer.pools.maxwait,gauge,,second,,Age of oldest unserved client connection,-1,pgbouncer,max client wait
+pgbouncer.databases.pool_size,gauge,,connection,,Maximum number of server connections,0,pgbouncer,database pool size
+pgbouncer.databases.max_connections,gauge,,connection,,Maximum number of allowed connections,0,pgbouncer,database max conns
+pgbouncer.databases.current_connections,gauge,,connection,,Current number of connections for this database,0,pgbouncer,database current conns

--- a/pgbouncer/tests/test_pgbouncer.py
+++ b/pgbouncer/tests/test_pgbouncer.py
@@ -52,6 +52,10 @@ def test_check(instance, aggregator):
     aggregator.assert_metric('pgbouncer.stats.bytes_received_per_second')
     aggregator.assert_metric('pgbouncer.stats.bytes_sent_per_second')
 
+    aggregator.assert_metric('pgbouncer.databases.pool_size')
+    aggregator.assert_metric('pgbouncer.databases.max_connections')
+    aggregator.assert_metric('pgbouncer.databases.current_connections')
+
     # Service checks
     sc_tags = [
         'host:{}'.format(common.HOST),


### PR DESCRIPTION
### What does this PR do?

This PR adds per database metrics to the pgBouncer check.
See SHOW DATABASES on https://pgbouncer.github.io/usage.html

### Motivation

These metrics are vital for monitoring pgBouncer, especially when having more than one database configured in one instance.