### PR TITLE
Change example config from "localhost" to "."

### DIFF
--- a/aspdotnet/datadog_checks/aspdotnet/data/conf.yaml.example
+++ b/aspdotnet/datadog_checks/aspdotnet/data/conf.yaml.example
@@ -4,8 +4,9 @@ instances:
 
   ## @param host - string - required
   ## ASP .NET host to connect to.
+  ## "." means the current host
   #
-  - host: localhost
+  - host: .
   
   ## @param port - integer - required
   ## ASP .NET port to connect to. 

--- a/aspdotnet/datadog_checks/aspdotnet/data/conf.yaml.example
+++ b/aspdotnet/datadog_checks/aspdotnet/data/conf.yaml.example
@@ -4,7 +4,8 @@ instances:
 
   ## @param host - string - required
   ## ASP .NET host to connect to.
-  ## "." means the current host, any other value will have the Agent attempt to connect to a remote host. 
+  ## "." means the current host, any other value will have the Agent attempt to connect to a remote host.
+  ## Note: Remote access requires additional permissions - https://support.microsoft.com/en-us/help/922775/how-to-troubleshoot-monitoring-and-logging-issues-for-performance-coun
   #
   - host: .
   

--- a/aspdotnet/datadog_checks/aspdotnet/data/conf.yaml.example
+++ b/aspdotnet/datadog_checks/aspdotnet/data/conf.yaml.example
@@ -4,7 +4,7 @@ instances:
 
   ## @param host - string - required
   ## ASP .NET host to connect to.
-  ## "." means the current host
+  ## "." means the current host, any other value will have the Agent attempt to connect to a remote host. 
   #
   - host: .
   

--- a/dotnetclr/datadog_checks/dotnetclr/data/conf.yaml.example
+++ b/dotnetclr/datadog_checks/dotnetclr/data/conf.yaml.example
@@ -6,6 +6,7 @@ instances:
   #   a set of customizable tags and other parameters we might need to
   #   configure the behavior of our check.
   #
-  # "." means the current host, any other value will have the Agent attempt to connect to a remote host. 
+  # "." means the current host, any other value will have the Agent attempt to connect to a remote host.
+  # Note: Remote access requires additional permissions - https://support.microsoft.com/en-us/help/922775/how-to-troubleshoot-monitoring-and-logging-issues-for-performance-coun
   # - host: .
   #   tags: ['custom:tag']

--- a/dotnetclr/datadog_checks/dotnetclr/data/conf.yaml.example
+++ b/dotnetclr/datadog_checks/dotnetclr/data/conf.yaml.example
@@ -6,5 +6,6 @@ instances:
   #   a set of customizable tags and other parameters we might need to
   #   configure the behavior of our check.
   #
-  # - host: localhost
+  # "." means the current host, any other value will have the Agent attempt to connect to a remote host. 
+  # - host: .
   #   tags: ['custom:tag']

--- a/exchange_server/datadog_checks/exchange_server/data/conf.yaml.example
+++ b/exchange_server/datadog_checks/exchange_server/data/conf.yaml.example
@@ -1,7 +1,7 @@
 init_config:
 
 instances:
-  # "." means the current host
+  # "." means the current host, any other value will have the Agent attempt to connect to a remote host. 
   - host: .
   #
   #   The additional metrics is a list of additional counters to collect.  The

--- a/exchange_server/datadog_checks/exchange_server/data/conf.yaml.example
+++ b/exchange_server/datadog_checks/exchange_server/data/conf.yaml.example
@@ -1,7 +1,8 @@
 init_config:
 
 instances:
-  # "." means the current host, any other value will have the Agent attempt to connect to a remote host. 
+  # "." means the current host, any other value will have the Agent attempt to connect to a remote host.
+  # Note: Remote access requires additional permissions - https://support.microsoft.com/en-us/help/922775/how-to-troubleshoot-monitoring-and-logging-issues-for-performance-coun
   - host: .
   #
   #   The additional metrics is a list of additional counters to collect.  The

--- a/iis/datadog_checks/iis/data/conf.yaml.example
+++ b/iis/datadog_checks/iis/data/conf.yaml.example
@@ -22,7 +22,7 @@ instances:
   # only pulling metrics from the default site.
   #
 
-  # "." means the current host
+  # "." means the current host, any other value will have the Agent attempt to connect to a remote host. 
   - host: .
   #   tags:
   #     - myapp1

--- a/iis/datadog_checks/iis/data/conf.yaml.example
+++ b/iis/datadog_checks/iis/data/conf.yaml.example
@@ -22,7 +22,8 @@ instances:
   # only pulling metrics from the default site.
   #
 
-  # "." means the current host, any other value will have the Agent attempt to connect to a remote host. 
+  # "." means the current host, any other value will have the Agent attempt to connect to a remote host.
+  # Note: Remote access requires additional permissions - https://support.microsoft.com/en-us/help/922775/how-to-troubleshoot-monitoring-and-logging-issues-for-performance-coun
   - host: .
   #   tags:
   #     - myapp1


### PR DESCRIPTION
### What does this PR do?

Changes the example configuration of all PDH based integrations to use `.` instead of `localhost` for its default configuration parameter along with adding a quick message about this being the appropriate value to collect metrics from counters on the local machine. 

### Motivation

If the host param is present, and its not a `.`, then the PDH Base class attempts to make a remote connection instead of local. The common case should be to collect metrics from counters on the local machine, which I believe was the original intent. This allows that to be the default. 

See here for that logic - https://github.com/DataDog/integrations-core/blob/6bbb3be48bb8831a6ed3a6398d6338aa6a06ac61/datadog_checks_base/datadog_checks/base/checks/win/winpdh_base.py#L55

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Verbiage taken from existing active_directory check here - https://github.com/DataDog/integrations-core/blob/master/active_directory/datadog_checks/active_directory/data/conf.yaml.example#L7
