### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -253,7 +253,7 @@ jobs:
     - stage: test
       env: CHECK=yarn
     - stage: test
-      env: CHECK=zk
+      env: CHECK=zk PYTHON3=true
 before_install:
   - bash .travis/prepare.sh
   - PATH="$PATH:$(pyenv root)/versions/3.6/bin"

--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -59,11 +59,10 @@ zk_max_file_descriptor_count    4096
 # stdlib
 from collections import defaultdict
 from distutils.version import LooseVersion  # pylint: disable=E0611,E0401
-from six import PY3, iteritems
+from six import iteritems, PY3, StringIO
 import re
 import socket
 import struct
-from six import StringIO
 
 from datadog_checks.base import ensure_bytes, ensure_unicode
 from datadog_checks.checks import AgentCheck

--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -63,15 +63,13 @@ from six import PY3, iteritems
 import re
 import socket
 import struct
+from six import StringIO
 
-# project
+from datadog_checks.dev.utils import ensure_bytes, ensure_unicode
 from datadog_checks.checks import AgentCheck
 
 if PY3:
-    from io import StringIO
     long = int
-else:
-    from StringIO import StringIO
 
 
 class ZKConnectionFailure(Exception):
@@ -243,10 +241,10 @@ class ZookeeperCheck(AgentCheck):
             try:
                 # Connect to the zk client port and send the stat command
                 sock.connect((host, port))
-                sock.sendall(command.encode("UTF-8"))
+                sock.sendall(ensure_bytes(command))
 
                 # Read the response into a StringIO buffer
-                chunk = sock.recv(chunk_size).decode("UTF-8")
+                chunk = ensure_unicode(sock.recv(chunk_size))
                 buf.write(chunk)
                 num_reads = 1
                 max_reads = 10000
@@ -255,7 +253,7 @@ class ZookeeperCheck(AgentCheck):
                         # Safeguard against an infinite loop
                         raise Exception("Read %s bytes before exceeding max reads of %s. "
                                         % (buf.tell(), max_reads))
-                    chunk = sock.recv(chunk_size).decode("UTF-8")
+                    chunk = ensure_unicode(sock.recv(chunk_size))
                     buf.write(chunk)
                     num_reads += 1
             except (socket.timeout, socket.error):

--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -65,7 +65,7 @@ import socket
 import struct
 from six import StringIO
 
-from datadog_checks.base.utils.common import ensure_bytes, ensure_unicode
+from datadog_checks.base import ensure_bytes, ensure_unicode
 from datadog_checks.checks import AgentCheck
 
 if PY3:

--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -65,7 +65,7 @@ import socket
 import struct
 from six import StringIO
 
-from datadog_checks.dev.utils import ensure_bytes, ensure_unicode
+from datadog_checks.base.utils.common import ensure_bytes, ensure_unicode
 from datadog_checks.checks import AgentCheck
 
 if PY3:

--- a/zk/tests/conftest.py
+++ b/zk/tests/conftest.py
@@ -104,7 +104,7 @@ def spin_up_zk():
     def condition():
         sys.stderr.write("Waiting for ZK to boot...\n")
         booted = False
-        for _ in xrange(10):
+        for _ in range(10):
             try:
                 out = ZookeeperCheck._send_command('ruok', HOST, PORT, 500)
                 out.seek(0)

--- a/zk/tests/conftest.py
+++ b/zk/tests/conftest.py
@@ -62,7 +62,7 @@ STATUS_TYPES = [
 ]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def get_instance():
     return {
         'host': HOST,
@@ -101,7 +101,7 @@ def get_version():
 
 
 @pytest.fixture(scope="session")
-def spin_up_zk():
+def dd_environment(get_instance):
     def condition():
         sys.stderr.write("Waiting for ZK to boot...\n")
         booted = False
@@ -125,4 +125,4 @@ def spin_up_zk():
         compose_file = os.path.join(HERE, 'compose', 'zk35plus.yaml')
 
     with docker_run(compose_file, conditions=[condition]):
-        yield
+        yield get_instance

--- a/zk/tests/conftest.py
+++ b/zk/tests/conftest.py
@@ -5,6 +5,7 @@ import os
 import sys
 import time
 import pytest
+
 from datadog_checks.dev import docker_run, RetryError
 from datadog_checks.utils.common import get_docker_hostname
 from datadog_checks.zk import ZookeeperCheck

--- a/zk/tests/test_zk.py
+++ b/zk/tests/test_zk.py
@@ -8,7 +8,7 @@ import pytest
 
 # project
 from datadog_checks.zk import ZookeeperCheck
-import conftest
+from . import conftest
 
 
 def test_check(aggregator, spin_up_zk, get_instance):

--- a/zk/tests/test_zk.py
+++ b/zk/tests/test_zk.py
@@ -10,7 +10,7 @@ from datadog_checks.zk import ZookeeperCheck
 from . import conftest
 
 
-def test_check(aggregator, spin_up_zk, get_instance):
+def test_check(aggregator, dd_environment, get_instance):
     """
     Collect ZooKeeper metrics.
     """
@@ -37,7 +37,7 @@ def test_check(aggregator, spin_up_zk, get_instance):
     aggregator.assert_all_metrics_covered()
 
 
-def test_wrong_expected_mode(aggregator, spin_up_zk, get_invalid_mode_instance):
+def test_wrong_expected_mode(aggregator, dd_environment, get_invalid_mode_instance):
     """
     Raise a 'critical' service check when ZooKeeper is not in the expected mode.
     """
@@ -48,7 +48,7 @@ def test_wrong_expected_mode(aggregator, spin_up_zk, get_invalid_mode_instance):
     aggregator.assert_service_check("zookeeper.mode", status=zk_check.CRITICAL)
 
 
-def test_error_state(aggregator, spin_up_zk, get_conn_failure_config):
+def test_error_state(aggregator, dd_environment, get_conn_failure_config):
     """
     Raise a 'critical' service check when ZooKeeper is in an error state.
     Report status as down.

--- a/zk/tests/test_zk.py
+++ b/zk/tests/test_zk.py
@@ -6,7 +6,6 @@ import os
 from distutils.version import LooseVersion  # pylint: disable=E0611,E0401
 import pytest
 
-# project
 from datadog_checks.zk import ZookeeperCheck
 from . import conftest
 

--- a/zk/tox.ini
+++ b/zk/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    {py27,py36}-{3.4,3.5}
+    {py36}-{3.4,3.5}
     flake8
 
 [testenv]

--- a/zk/tox.ini
+++ b/zk/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    {py36}-{3.4,3.5}
+    {py27,py36}-{3.4,3.5}
     flake8
 
 [testenv]

--- a/zk/tox.ini
+++ b/zk/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    zk-{3.4,3.5}
+    {py27,py36}-{3.4,3.5}
     flake8
 
 [testenv]
@@ -14,17 +14,12 @@ deps =
 commands =
     pip install --require-hashes -r requirements.txt
     pytest -v
+setenv = 
+    3.4: ZK_VERSION=3.4.11
+    3.5: ZK_VERSION=3.5
 passenv =
     DOCKER*
     COMPOSE*
-
-[testenv:zk-3.4]
-setenv =
-    ZK_VERSION=3.4.11
-
-[testenv:zk-3.5]
-setenv =
-    ZK_VERSION=3.5
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
### What does this PR do?

Add support for Python 3 to zookeeper integration
Also make E2E work

### Motivation

Efforts to support both Python2 and 3 for all integrations. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
