### PR TITLE
Add constant to check if platform is Linux

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/utils.py
@@ -17,6 +17,7 @@ from .structures import EnvVars
 __platform = platform.system()
 ON_MACOS = os.name == 'mac' or __platform == 'Darwin'
 ON_WINDOWS = NEED_SHELL = os.name == 'nt' or __platform == 'Windows'
+ON_LINUX = not (ON_MACOS or ON_WINDOWS)
 
 CI_IDENTIFIERS = (
     'APPVEYOR_',


### PR DESCRIPTION
### Motivation

Some tests need it

https://github.com/DataDog/integrations-core/blob/9303ad9e311fc2007bd82c29c0d12b748fbb3171/mcache/tests/test_integration.py#L86