### PR TITLE
Revert #2773 Fix ntp conf.yaml typo

### DIFF
--- a/ntp/datadog_checks/ntp/data/conf.yaml.default
+++ b/ntp/datadog_checks/ntp/data/conf.yaml.default
@@ -1,6 +1,6 @@
 # This file is overwritten upon Agent upgrade.
 # To make modifications to the check configuration, please copy this file
-# to `conf.yaml` and make your changes on that file.
+# to `ntp.yaml` and make your changes on that file.
 
 init_config:
 


### PR DESCRIPTION
Reverts DataDog/integrations-core#2773
This does not work for agent 5. And the python ntp check is a5 only