### PR TITLE
Change the prometheus example to use prometheus_url

### DIFF
--- a/prometheus/datadog_checks/prometheus/data/conf.yaml.example
+++ b/prometheus/datadog_checks/prometheus/data/conf.yaml.example
@@ -5,7 +5,7 @@ instances:
   ## @param prometheus_url - string - required
   ## The URL where your application metrics are exposed by Prometheus.
   #
-  - prometheus_endpoint: http://localhost:10055/metrics
+  - prometheus_url: http://localhost:10055/metrics
 
   ## @param namespace - string - required
   ## The namespace to be appended before all metrics namespace


### PR DESCRIPTION
The example prometheus config is not using the correct parameter name.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
