### PR TITLE
document kubernetes.pods.running and kubernetes.containers.running

### DIFF
--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -1,5 +1,7 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 kubernetes.containers.last_state.terminated,gauge,,,,The number of containers that were previously terminated,0,kubelet,k8s.containers.last_state.terminated
+kubernetes.pods.running,gauge,,,,The number of running pods,1,kubelet,k8s.pods.running
+kubernetes.containers.running,gauge,,,,The number of running containers,1,kubelet,k8s.containers.running
 kubernetes.containers.restarts,gauge,,,,The number of times the container has been restarted,1,kubelet,k8s.containers.restarts
 kubernetes.containers.state.terminated,gauge,,,,The number of currently terminated containers,0,kubelet,k8s.containers.state.terminated
 kubernetes.containers.state.waiting,gauge,,,,The number of currently waiting containers,0,kubelet,k8s.containers.state.waiting


### PR DESCRIPTION
adds `kubernetes.pods.running` and `kubernetes.containers.running` to metadata.csv
Ref: https://github.com/DataDog/integrations-core/pull/2191/files

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
