### PR TITLE
Update templates for new integrations

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/datadog_checks/{check_name}/{check_name}.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/datadog_checks/{check_name}/{check_name}.py
@@ -1,4 +1,4 @@
-{license_header}from datadog_checks.checks import AgentCheck
+{license_header}from datadog_checks.base import AgentCheck
 
 
 class {check_class}(AgentCheck):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/manifest.json
@@ -19,5 +19,5 @@
     ""
   ],
   "type": "check",
-  "is_public": true
+  "is_public": false
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/setup.py
@@ -15,7 +15,7 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base'
+CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 
 setup(

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/manifest.json
@@ -19,5 +19,5 @@
     ""
   ],
   "type": "check",
-  "is_public": true
+  "is_public": false
 }}


### PR DESCRIPTION
### What does this PR do?

- Make `is_public` default false for docs https://github.com/DataDog/integrations-core/pull/2403
- Update imports for the base package