### PR TITLE
Demote critical log levels to error

### DIFF
--- a/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py
+++ b/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py
@@ -279,7 +279,7 @@ class DockerDaemon(AgentCheck):
             self.capped_metrics = instance.get('capped_metrics')
 
         except Exception as e:
-            self.log.critical(e)
+            self.log.error(e)
             self.warning("Initialization failed. Will retry at next iteration")
         else:
             self.init_success = True

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -912,7 +912,7 @@ class VSphereCheck(AgentCheck):
         thread_crashed = False
         try:
             while True:
-                self.log.critical(self.exceptionq.get_nowait())
+                self.log.error(self.exceptionq.get_nowait())
                 thread_crashed = True
         except Empty:
             pass


### PR DESCRIPTION
### Motivation

Critical level is reserved for errors that force the agent to shutdown.

### Additional Notes

![capture](https://user-images.githubusercontent.com/9677399/50199568-9fb7c080-031f-11e9-9e82-21fe94e308d2.PNG)
