### PR TITLE
Add kube_leader mixin to monitor leader elections

### DIFF
--- a/datadog_checks_base/datadog_checks/base/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/__init__.py
@@ -4,6 +4,8 @@
 from .__about__ import __version__
 from .checks import AgentCheck
 from .checks.openmetrics import OpenMetricsBaseCheck
+from .checks.kube_leader import KubeLeaderElectionMixin, KubeLeaderElectionBaseCheck
+
 from .config import is_affirmative
 from .errors import ConfigurationError
 from .utils.common import ensure_bytes, ensure_unicode
@@ -17,6 +19,8 @@ except ImportError:
 __all__ = [
     '__version__',
     'AgentCheck',
+    'KubeLeaderElectionMixin',
+    'KubeLeaderElectionBaseCheck',
     'OpenMetricsBaseCheck',
     'PDHBaseCheck',
     'ConfigurationError',

--- a/datadog_checks_base/datadog_checks/base/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/__init__.py
@@ -4,7 +4,6 @@
 from .__about__ import __version__
 from .checks import AgentCheck
 from .checks.openmetrics import OpenMetricsBaseCheck
-from .checks.kube_leader import KubeLeaderElectionMixin, KubeLeaderElectionBaseCheck
 
 from .config import is_affirmative
 from .errors import ConfigurationError
@@ -16,10 +15,15 @@ try:
 except ImportError:
     PDHBaseCheck = None
 
+# Kubernetes dep will not always be installed
+try:
+    from .checks.kube_leader import KubeLeaderElectionBaseCheck
+except ImportError:
+    KubeLeaderElectionBaseCheck = None
+
 __all__ = [
     '__version__',
     'AgentCheck',
-    'KubeLeaderElectionMixin',
     'KubeLeaderElectionBaseCheck',
     'OpenMetricsBaseCheck',
     'PDHBaseCheck',

--- a/datadog_checks_base/datadog_checks/base/checks/kube_leader/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/kube_leader/__init__.py
@@ -1,0 +1,9 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+
+from .mixins import KubeLeaderElectionMixin
+from .record import ElectionRecord
+
+__all__ = ['KubeLeaderElectionMixin', 'ElectionRecord']

--- a/datadog_checks_base/datadog_checks/base/checks/kube_leader/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/kube_leader/__init__.py
@@ -2,8 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-
+from .base_check import KubeLeaderElectionBaseCheck
 from .mixins import KubeLeaderElectionMixin
 from .record import ElectionRecord
 
-__all__ = ['KubeLeaderElectionMixin', 'ElectionRecord']
+__all__ = ['KubeLeaderElectionMixin', 'ElectionRecord', 'KubeLeaderElectionBaseCheck']

--- a/datadog_checks_base/datadog_checks/base/checks/kube_leader/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/kube_leader/base_check.py
@@ -1,0 +1,23 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from .mixins import KubeLeaderElectionMixin
+from .. import AgentCheck
+from ...errors import CheckException
+
+
+class KubeLeaderElectionBaseCheck(KubeLeaderElectionMixin, AgentCheck):
+    """
+    KubeLeaderElectioBaseCheck is a class that helps instantiating a Kube Leader
+    Election mixin only with YAML configurations.
+    Example configuration::
+
+        instances:
+        - namespace (prefix for the metrics and check)
+          record_kind (endpoints or configmap)
+          record_name
+          record_namespace
+          tags (optional)
+    """
+    def check(self, instance):
+        self.check_election_status(instance)

--- a/datadog_checks_base/datadog_checks/base/checks/kube_leader/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/kube_leader/mixins.py
@@ -96,8 +96,8 @@ class KubeLeaderElectionMixin(object):
             self.service_check(prefix + ".status", AgentCheck.CRITICAL, tags=tags, message=reason)
             return  # Stop here
 
-        # Report gauges
-        self.gauge(prefix + ".transitions", record.transitions, tags)
+        # Report metrics
+        self.monotonic_count(prefix + ".transitions", record.transitions, tags)
         self.gauge(prefix + ".lease_duration", record.lease_duration, tags)
 
         leader_status = AgentCheck.OK

--- a/datadog_checks_base/datadog_checks/base/checks/kube_leader/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/kube_leader/mixins.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from kubernetes import client, config
-from six import iteritems, string_types
 
 try:
     import datadog_agent

--- a/datadog_checks_base/datadog_checks/base/checks/kube_leader/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/kube_leader/mixins.py
@@ -1,0 +1,106 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from kubernetes import client, config
+from six import iteritems, string_types
+
+try:
+    import datadog_agent
+except ImportError:
+    from ...stubs import datadog_agent
+
+from .. import AgentCheck
+from .record import ElectionRecord
+
+# Known names of the leader election annotation,
+# will be tried in the order of the list
+ELECTION_ANNOTATION_NAMES = ["control-plane.alpha.kubernetes.io/leader"]
+
+
+class KubeLeaderElectionMixin(object):
+    """
+    This mixin uses the facilities of the AgentCheck class
+    """
+
+    def check_election_status(self, config):
+        """
+        Retrieves the leader-election annotation from a given object, and
+        submits metrics and a service check.
+
+        An integration warning is sent if the object is not retrievable,
+        or no record is found. Monitors on the service-check should have
+        no-data alerts enabled to account for this.
+
+        The config objet requires the following fields:
+            namespace (prefix for the metrics and check)
+            record_kind (endpoints or configmap)
+            record_name
+            record_namespace
+            tags (optional)
+
+        It reads the following agent configuration:
+            kubernetes_kubeconfig_path: defaut is to use in-cluster config
+        """
+        try:
+            record = self._get_record(
+                config.get("record_kind", ""), config.get("record_name", ""), config.get("record_namespace", "")
+            )
+            self._report_status(config, record)
+        except Exception as e:
+            self.warning("Cannot retrieve leader election record {}: {}".format(config.get("record_name", ""), e))
+
+    @staticmethod
+    def _get_record(kind, name, namespace):
+        kubeconfig_path = datadog_agent.get_config('kubernetes_kubeconfig_path')
+        if kubeconfig_path:
+            config.load_kube_config(config_file=kubeconfig_path)
+        else:
+            config.load_incluster_config()
+        v1 = client.CoreV1Api()
+
+        obj = None
+        if kind.lower() in ["endpoints", "endpoint", "ep"]:
+            obj = v1.read_namespaced_endpoints(name, namespace)
+        elif kind.lower() in ["configmap", "cm"]:
+            obj = v1.read_namespaced_config_map(name, namespace)
+        else:
+            raise ValueError("Unknown kind {}".format(kind))
+
+        if not obj:
+            return ValueError("Empty input object")
+
+        # Can raise AttributeError if object is not a v1 kube object
+        annotations = obj.metadata.annotations
+
+        for name in ELECTION_ANNOTATION_NAMES:
+            if name in annotations:
+                return ElectionRecord(annotations[name])
+
+        # Could not find annotation
+        raise ValueError("Object has no leader election annotation")
+
+    def _report_status(self, config, record):
+        # Compute prefix for gauges and service check
+        prefix = config.get("namespace") + ".leader_election"
+
+        # Compute tags for gauges and service check
+        tags = config.get("tags", [])
+        for n in ["record_kind", "record_name", "record_namespace"]:
+            if n in config:
+                tags.append("{}:{}".format(n, config[n]))
+
+        # Sanity check on the record
+        valid, reason = record.validate()
+        if not valid:
+            self.service_check(prefix, AgentCheck.CRITICAL, tags=tags, message=reason)
+            return  # Stop here
+
+        # Report gauges
+        self.gauge(prefix + ".transitions", record.transitions, tags)
+        self.gauge(prefix + ".lease_duration", record.lease_duration, tags)
+
+        leader_status = AgentCheck.OK
+        if record.seconds_until_renew + record.lease_duration < 0:
+            leader_status = AgentCheck.CRITICAL
+        self.service_check(prefix + ".status", leader_status, tags=tags, message=record.summary)

--- a/datadog_checks_base/datadog_checks/base/checks/kube_leader/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/kube_leader/mixins.py
@@ -85,15 +85,16 @@ class KubeLeaderElectionMixin(object):
         prefix = config.get("namespace") + ".leader_election"
 
         # Compute tags for gauges and service check
-        tags = config.get("tags", [])
+        tags = []
         for n in ["record_kind", "record_name", "record_namespace"]:
             if n in config:
                 tags.append("{}:{}".format(n, config[n]))
+        tags += config.get("tags", [])
 
         # Sanity check on the record
         valid, reason = record.validate()
         if not valid:
-            self.service_check(prefix, AgentCheck.CRITICAL, tags=tags, message=reason)
+            self.service_check(prefix + ".status", AgentCheck.CRITICAL, tags=tags, message=reason)
             return  # Stop here
 
         # Report gauges

--- a/datadog_checks_base/datadog_checks/base/checks/kube_leader/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/kube_leader/mixins.py
@@ -67,10 +67,12 @@ class KubeLeaderElectionMixin(object):
             raise ValueError("Unknown kind {}".format(kind))
 
         if not obj:
-            return ValueError("Empty input object")
+            raise ValueError("Empty input object")
 
-        # Can raise AttributeError if object is not a v1 kube object
-        annotations = obj.metadata.annotations
+        try:
+            annotations = obj.metadata.annotations
+        except AttributeError:
+            raise ValueError("Invalid input object type")
 
         for name in ELECTION_ANNOTATION_NAMES:
             if name in annotations:

--- a/datadog_checks_base/datadog_checks/base/checks/kube_leader/record.py
+++ b/datadog_checks_base/datadog_checks/base/checks/kube_leader/record.py
@@ -1,0 +1,79 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import json
+from datetime import datetime, timedelta
+
+from six import iteritems
+from kubernetes.config.dateutil import parse_rfc3339
+
+# If these fields are missing or empty, the service check
+# will fail inconditionnaly. Fields taken from
+# https://godoc.org/k8s.io/client-go/tools/leaderelection/resourcelock#LeaderElectionRecord
+REQUIRED_FIELDS = [
+    ("holderIdentity", "no current leader recorded"),
+    ("leaseDurationSeconds", "no lease duration set"),
+    ("renewTime", "no renew time set"),
+    ("acquireTime", "no acquire time recorded"),
+]
+
+
+class ElectionRecord(object):
+    def __init__(self, record_string):
+        self._record = json.loads(record_string)
+
+    def validate(self):
+        reason_prefix = "Invalid record: "
+        # Test for required fields
+        for field, message in REQUIRED_FIELDS:
+            if field not in self._record or not self._record[field]:
+                return False, reason_prefix + message
+
+        if not self.renew_time:
+            return False, reason_prefix + "bad format for renewTime field"
+        if not self.acquire_time:
+            return False, reason_prefix + "bad format for acquireTime field"
+
+        # No issue, record is valid
+        return True, None
+
+    @property
+    def leader_name(self):
+        return self._record["holderIdentity"]
+
+    @property
+    def lease_duration(self):
+        return int(self._record["leaseDurationSeconds"])
+
+    @property
+    def renew_time(self):
+        try:
+            return parse_rfc3339(self._record.get("renewTime"))
+        except Exception:
+            return None
+
+    @property
+    def acquire_time(self):
+        try:
+            return parse_rfc3339(self._record.get("acquireTime"))
+        except Exception:
+            return None
+
+    @property
+    def transitions(self):
+        return self._record.get("leaderTransitions", 0)
+
+    @property
+    def seconds_until_renew(self):
+        """
+        Returns the number of seconds between the current time
+        and the set renew time. It can be negative if the
+        leader election is running late.
+        """
+        delta = self.renew_time - datetime.now(self.renew_time.tzinfo)
+        return delta.total_seconds()
+
+    @property
+    def summary(self):
+        return "Leader: {} since {}, next renew {}".format(self.leader_name, self.acquire_time, self.renew_time)

--- a/datadog_checks_base/datadog_checks/base/checks/kube_leader/record.py
+++ b/datadog_checks_base/datadog_checks/base/checks/kube_leader/record.py
@@ -3,9 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import json
-from datetime import datetime, timedelta
+from datetime import datetime
 
-from six import iteritems
 from kubernetes.config.dateutil import parse_rfc3339
 
 # If these fields are missing or empty, the service check

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -11,7 +11,6 @@ dnspython==1.12.0
 enum34==1.1.6
 flup==1.0.3.dev-20110405; python_version < '3.0'
 gearman==2.0.2; sys_platform != 'win32' and python_version < '3.0'
-python3-gearman==0.1.0; sys_platform != 'win32' and python_version > '3.0'
 google-compute-engine==2.8.3
 httplib2==0.10.3
 ipaddress==1.0.22
@@ -19,6 +18,7 @@ jaydebeapi==1.1.1
 jpype1==0.6.3
 kafka-python==1.4.4; sys_platform != 'win32'
 kazoo==2.6.0; sys_platform != 'win32'
+kubernetes==8.0.0
 ldap3==2.5
 meld3==1.0.2
 ntplib==0.3.3
@@ -41,6 +41,7 @@ pysmi==0.2.2
 pysnmp==4.4.3
 pysnmp-mibs==0.1.6
 python-binary-memcached==0.26.1; sys_platform != 'win32'
+python3-gearman==0.1.0; sys_platform != 'win32' and python_version > '3.0'
 pyvmomi==v6.5.0.2017.5-1
 pywin32==224; sys_platform == 'win32'
 redis==2.10.5

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -1,4 +1,5 @@
 ddtrace==0.13.0
+kubernetes==8.0.0
 prometheus-client==0.3.0
 protobuf==3.5.1
 pywin32==224; sys_platform == 'win32'

--- a/datadog_checks_base/setup.py
+++ b/datadog_checks_base/setup.py
@@ -18,9 +18,18 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     LONG_DESC = f.read()
 
 
-def get_requirements(fpath):
+def get_requirements(fpath, exclude=[], only=[]):
     with open(path.join(HERE, fpath), encoding='utf-8') as f:
-        return f.readlines()
+        requirements = []
+        for line in f:
+            name = line.split("==")[0]
+            if only:
+                if name in only:
+                    requirements.append(line.rstrip())
+            else:
+                if name not in exclude:
+                    requirements.append(line.rstrip())
+        return requirements
 
 
 setup(
@@ -51,6 +60,7 @@ setup(
     include_package_data=True,
 
     extras_require={
-        'deps': get_requirements('requirements.in'),
+        'deps': get_requirements('requirements.in', exclude=['kubernetes']),
+        'kube': get_requirements('requirements.in', only=['kubernetes']),
     },
 )

--- a/datadog_checks_base/tests/test_kube_leader.py
+++ b/datadog_checks_base/tests/test_kube_leader.py
@@ -1,0 +1,258 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import json
+from datetime import datetime, timedelta
+
+import mock
+import pytest
+from six import iteritems, string_types
+from kubernetes.config.dateutil import format_rfc3339
+from kubernetes.client import ApiClient
+
+from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks.kube_leader import ElectionRecord, KubeLeaderElectionMixin
+
+
+RAW_VALID_RECORD = ('{"holderIdentity":"dd-cluster-agent-568f458dd6-kj6vt",'
+                    '"leaseDurationSeconds":60,'
+                    '"acquireTime":"2018-12-17T11:53:07Z",'
+                    '"renewTime":"2018-12-18T12:32:22Z",'
+                    '"leaderTransitions":7}')
+
+
+@pytest.fixture
+def aggregator():
+    from datadog_checks.stubs import aggregator
+
+    aggregator.reset()
+    return aggregator
+
+
+@pytest.fixture()
+def mock_incluster():
+    with mock.patch('datadog_checks.base.checks.kube_leader.mixins.config.load_incluster_config'):
+        yield
+
+
+@pytest.fixture()
+def mock_read_endpoints():
+    with mock.patch(
+        'datadog_checks.base.checks.kube_leader.mixins.client.CoreV1Api.read_namespaced_endpoints',
+    ) as m:
+        yield m
+
+
+@pytest.fixture()
+def mock_read_configmap():
+    with mock.patch(
+        'datadog_checks.base.checks.kube_leader.mixins.client.CoreV1Api.read_namespaced_config_map',
+    ) as m:
+        yield m
+
+
+class SimpleLeaderCheck(AgentCheck, KubeLeaderElectionMixin):
+    def check(self, instance):
+        self.check_election_status(instance)
+
+
+def make_record(holder=None, duration=None, transitions=None, acquire=None, renew=None):
+    def format_time(date_time):
+        if isinstance(date_time, string_types):
+            return date_time
+        return format_rfc3339(date_time)
+
+    record = {}
+    if holder:
+        record["holderIdentity"] = holder
+    if duration:
+        record["leaseDurationSeconds"] = duration
+    if transitions:
+        record["leaderTransitions"] = transitions
+    if acquire:
+        record["acquireTime"] = format_time(acquire)
+    if renew:
+        record["renewTime"] = format_time(renew)
+
+    return json.dumps(record)
+
+
+def make_fake_object(record=None):
+    obj = type('', (), {})()
+    obj.metadata = type('', (), {})()
+    obj.metadata.annotations = {}
+
+    if record:
+        obj.metadata.annotations["control-plane.alpha.kubernetes.io/leader"] = record
+
+    return obj
+
+
+class TestElectionRecord:
+    def test_parse_raw(self):
+        record = ElectionRecord(RAW_VALID_RECORD)
+
+        valid, reason = record.validate()
+        assert valid is True
+        assert reason is None
+
+        assert record.leader_name == "dd-cluster-agent-568f458dd6-kj6vt"
+        assert record.lease_duration == 60
+        assert record.transitions == 7
+        assert record.renew_time > record.acquire_time
+        assert record.seconds_until_renew < 0
+        assert record.summary == ("Leader: dd-cluster-agent-568f458dd6-kj6vt "
+                                  "since 2018-12-17 11:53:07+00:00, "
+                                  "next renew 2018-12-18 12:32:22+00:00")
+
+    def test_validation(self):
+        cases = {
+            make_record(): "Invalid record: no current leader recorded",
+            make_record(holder="me"): "Invalid record: no lease duration set",
+            make_record(holder="me", duration=30): "Invalid record: no renew time set",
+            make_record(
+                holder="me", duration=30, renew="2018-12-18T12:32:22Z"
+            ): "Invalid record: no acquire time recorded",
+            make_record(holder="me", duration=30, renew=datetime.now(), acquire="2018-12-18T12:32:22Z"): None,
+            make_record(
+                holder="me", duration=30, renew="invalid", acquire="2018-12-18T12:32:22Z"
+            ): "Invalid record: bad format for renewTime field",
+            make_record(
+                holder="me", duration=30, renew="2018-12-18T12:32:22Z", acquire="0000-12-18T12:32:22Z"
+            ): "Invalid record: bad format for acquireTime field",
+        }
+
+        for raw, expected_reason in iteritems(cases):
+            valid, reason = ElectionRecord(raw).validate()
+            assert reason == expected_reason
+            if expected_reason is None:
+                assert valid is True
+            else:
+                assert valid is False
+
+    def test_seconds_until_renew(self):
+        raw = make_record(
+            holder="me", duration=30, acquire="2018-12-18T12:32:22Z", renew=datetime.now() + timedelta(seconds=20)
+        )
+
+        record = ElectionRecord(raw)
+        assert record.seconds_until_renew > 19
+        assert record.seconds_until_renew < 21
+
+        raw = make_record(
+            holder="me", duration=30, acquire="2018-12-18T12:32:22Z", renew=datetime.now() - timedelta(seconds=5)
+        )
+
+        record = ElectionRecord(raw)
+        assert record.seconds_until_renew > -6
+        assert record.seconds_until_renew < -4
+
+
+@mock.patch('datadog_checks.base.checks.kube_leader.mixins.config')
+class TestClientConfig:
+    def test_config_incluster(self, config):
+        c = SimpleLeaderCheck()
+        c.check({})
+        config.load_incluster_config.assert_called_once()
+
+    @mock.patch('datadog_checks.base.checks.kube_leader.mixins.datadog_agent')
+    def test_config_kubeconfig(self, datadog_agent, config):
+        datadog_agent.get_config.return_value = "/file/path"
+        c = SimpleLeaderCheck()
+        c.check({})
+        datadog_agent.get_config.assert_called_once_with('kubernetes_kubeconfig_path')
+        config.load_kube_config.assert_called_once_with(config_file="/file/path")
+
+
+class TestMixin:
+    def test_valid_endpoints(self, aggregator, mock_read_endpoints, mock_incluster):
+        instance = {
+            "namespace": "base",
+            "record_kind": "ep",
+            "record_name": "thisrecord",
+            "record_namespace": "myns",
+            "tags": ["custom:tag"],
+        }
+        expected_tags = [
+            "record_kind:ep",
+            "record_name:thisrecord",
+            "record_namespace:myns",
+            "custom:tag",
+        ]
+        mock_read_endpoints.return_value = make_fake_object(RAW_VALID_RECORD)
+        c = SimpleLeaderCheck()
+        c.check(instance)
+
+        assert c.get_warnings() == []
+        mock_read_endpoints.assert_called_once_with("thisrecord", "myns")
+
+        aggregator.assert_metric("base.leader_election.transitions", value=7, tags=expected_tags)
+        aggregator.assert_metric("base.leader_election.lease_duration", value=60, tags=expected_tags)
+        aggregator.assert_service_check("base.leader_election.status", status=AgentCheck.CRITICAL, tags=expected_tags)
+
+    def test_valid_configmap(self, aggregator, mock_read_configmap, mock_incluster):
+        instance = {
+            "namespace": "base",
+            "record_kind": "configmap",
+            "record_name": "thisrecord",
+            "record_namespace": "myns",
+            "tags": ["custom:tag"],
+        }
+        expected_tags = [
+            "record_kind:configmap",
+            "record_name:thisrecord",
+            "record_namespace:myns",
+            "custom:tag",
+        ]
+        mock_read_configmap.return_value = make_fake_object(RAW_VALID_RECORD)
+        c = SimpleLeaderCheck()
+        c.check(instance)
+
+        assert c.get_warnings() == []
+        mock_read_configmap.assert_called_once_with("thisrecord", "myns")
+
+        aggregator.assert_metric("base.leader_election.transitions", value=7, tags=expected_tags)
+        aggregator.assert_metric("base.leader_election.lease_duration", value=60, tags=expected_tags)
+        aggregator.assert_service_check("base.leader_election.status", status=AgentCheck.CRITICAL, tags=expected_tags)
+
+    def test_invalid_configmap(self, aggregator, mock_read_configmap, mock_incluster):
+        instance = {
+            "namespace": "base",
+            "record_kind": "configmap",
+            "record_name": "thisrecord",
+            "record_namespace": "myns",
+        }
+        mock_read_configmap.return_value = make_fake_object()
+        c = SimpleLeaderCheck()
+        c.check(instance)
+
+        assert len(c.get_warnings()) == 1
+        mock_read_configmap.assert_called_once_with("thisrecord", "myns")
+
+    def test_ok_configmap(self, aggregator, mock_read_configmap, mock_incluster):
+        instance = {
+            "namespace": "base",
+            "record_kind": "configmap",
+            "record_name": "thisrecord",
+            "record_namespace": "myns",
+            "tags": ["custom:tag"],
+        }
+        expected_tags = [
+            "record_kind:configmap",
+            "record_name:thisrecord",
+            "record_namespace:myns",
+            "custom:tag",
+        ]
+        mock_read_configmap.return_value = make_fake_object(
+            make_record(holder="me", duration=30, renew=datetime.now(), acquire="2018-12-18T12:32:22Z")
+        )
+        c = SimpleLeaderCheck()
+        c.check(instance)
+
+        assert c.get_warnings() == []
+        mock_read_configmap.assert_called_once_with("thisrecord", "myns")
+
+        aggregator.assert_metric("base.leader_election.transitions", value=0, tags=expected_tags)
+        aggregator.assert_metric("base.leader_election.lease_duration", value=30, tags=expected_tags)
+        aggregator.assert_service_check("base.leader_election.status", status=AgentCheck.OK, tags=expected_tags)

--- a/datadog_checks_base/tests/test_kube_leader.py
+++ b/datadog_checks_base/tests/test_kube_leader.py
@@ -53,6 +53,7 @@ CM_TAGS = [
     "custom:tag",
 ]
 
+
 @pytest.fixture
 def aggregator():
     from datadog_checks.stubs import aggregator


### PR DESCRIPTION
### What does this PR do?

The upcoming `kube_scheduler` and `kube_controller_manager` need to monitor the status of the leader-election for these components, in order to ensure there is a healthy leader at all times. This PR introduces this logic as a mixin in the base package. It can be tested with the following custom class:

```
from checks import AgentCheck
from datadog_checks.base_kube.kube_leader import KubeLeaderElectionMixin

class KubeLeaderCheck(AgentCheck, KubeLeaderElectionMixin):
    def check(self, instance):
        self.check_election_status(instance)
```

and these instances:

```
init_config:
instances:
  - namespace: "kube_controller_manager"
    record_kind: "endpoints"
    record_name: "kube-controller-manager"
    record_namespace: "kube-system"
    tags:
      - "test:tag"
  - namespace: "cluster_agent"
    record_kind: "configmap"
    record_name: "datadog-leader-election"
    record_namespace: "default"
```

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- ~[ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)~
- ~[ ] If PR adds a configuration option, it has been added to the configuration file.~

### Additional Notes

This PR uses the [official python kube client library](https://github.com/kubernetes-client/python) as it provides:
  - the in-cluster and from-file configuration logics, mirroring the behavior we have on the go side
  - facilities for rfc3339 date parsing
