### PR TITLE
typo for the critical sshd example - process integration

### DIFF
--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -48,7 +48,7 @@ instances:
 #      - env:staging
 #      - cluster:big-data
 #    thresholds:
-#      critical if no sshd or more than 8 sshd are running
+#      critical if no sshd or more than 7 sshd are running
 #      critical: [1, 7]
 #      warning if 1, 2, 6, 7 sshd processes are running
 #      warning: [3, 5]


### PR DESCRIPTION
### What does this PR do?

It put 7 instead of 8 in the sentence of the critical sshd example. It's a little typo.

### Motivation

Seen by a client