### PR TITLE
Add completed metric for all ES thread pools

### DIFF
--- a/elastic/datadog_checks/elastic/metrics.py
+++ b/elastic/datadog_checks/elastic/metrics.py
@@ -252,6 +252,9 @@ STATS_METRICS = {
     'elasticsearch.thread_pool.flush.rejected': (
         'rate', 'thread_pool.flush.rejected'
     ),
+    'elasticsearch.thread_pool.flush.completed': (
+        'gauge', 'thread_pool.flush.completed'
+    ),
     'elasticsearch.thread_pool.generic.active': (
         'gauge', 'thread_pool.generic.active'
     ),
@@ -263,6 +266,9 @@ STATS_METRICS = {
     ),
     'elasticsearch.thread_pool.generic.rejected': (
         'rate', 'thread_pool.generic.rejected'
+    ),
+    'elasticsearch.thread_pool.generic.completed': (
+        'gauge', 'thread_pool.generic.completed'
     ),
     'elasticsearch.thread_pool.get.active': (
         'gauge', 'thread_pool.get.active'
@@ -276,6 +282,9 @@ STATS_METRICS = {
     'elasticsearch.thread_pool.get.rejected': (
         'rate', 'thread_pool.get.rejected'
     ),
+    'elasticsearch.thread_pool.get.completed': (
+        'gauge', 'thread_pool.get.completed'
+    ),
     'elasticsearch.thread_pool.index.active': (
         'gauge', 'thread_pool.index.active'
     ),
@@ -287,6 +296,9 @@ STATS_METRICS = {
     ),
     'elasticsearch.thread_pool.index.rejected': (
         'rate', 'thread_pool.index.rejected'
+    ),
+    'elasticsearch.thread_pool.index.completed': (
+        'gauge', 'thread_pool.index.completed'
     ),
     'elasticsearch.thread_pool.management.active': (
         'gauge', 'thread_pool.management.active'
@@ -300,6 +312,9 @@ STATS_METRICS = {
     'elasticsearch.thread_pool.management.rejected': (
         'rate', 'thread_pool.management.rejected'
     ),
+    'elasticsearch.thread_pool.management.completed': (
+        'gauge', 'thread_pool.management.completed'
+    ),
     'elasticsearch.thread_pool.refresh.active': (
         'gauge', 'thread_pool.refresh.active'
     ),
@@ -311,6 +326,9 @@ STATS_METRICS = {
     ),
     'elasticsearch.thread_pool.refresh.rejected': (
         'rate', 'thread_pool.refresh.rejected'
+    ),
+    'elasticsearch.thread_pool.refresh.completed': (
+        'gauge', 'thread_pool.refresh.completed'
     ),
     'elasticsearch.thread_pool.search.active': (
         'gauge', 'thread_pool.search.active'
@@ -324,6 +342,9 @@ STATS_METRICS = {
     'elasticsearch.thread_pool.search.rejected': (
         'rate', 'thread_pool.search.rejected'
     ),
+    'elasticsearch.thread_pool.search.completed': (
+        'gauge', 'thread_pool.search.completed'
+    ),
     'elasticsearch.thread_pool.snapshot.active': (
         'gauge', 'thread_pool.snapshot.active'
     ),
@@ -336,6 +357,9 @@ STATS_METRICS = {
     'elasticsearch.thread_pool.snapshot.rejected': (
         'rate', 'thread_pool.snapshot.rejected'
     ),
+    'elasticsearch.thread_pool.snapshot.completed': (
+        'gauge', 'thread_pool.snapshot.completed'
+    ),
     'elasticsearch.thread_pool.warmer.active': (
         'gauge', 'thread_pool.warmer.active'
     ),
@@ -347,6 +371,9 @@ STATS_METRICS = {
     ),
     'elasticsearch.thread_pool.warmer.rejected': (
         'rate', 'thread_pool.warmer.rejected'
+    ),
+    'elasticsearch.thread_pool.warmer.completed': (
+        'gauge', 'thread_pool.warmer.completed'
     ),
     'elasticsearch.http.current_open': (
         'gauge', 'http.current_open'
@@ -802,6 +829,9 @@ ADDITIONAL_METRICS_PRE_6_3 = {
     'elasticsearch.thread_pool.bulk.rejected': (
         'rate', 'thread_pool.bulk.rejected'
     ),
+    'elasticsearch.thread_pool.bulk.completed': (
+        'rate', 'thread_pool.bulk.completed'
+    ),
 }
 
 ADDITIONAL_METRICS_POST_6_3 = {
@@ -816,6 +846,9 @@ ADDITIONAL_METRICS_POST_6_3 = {
     ),
     'elasticsearch.thread_pool.write.rejected': (
         'rate', 'thread_pool.write.rejected'
+    ),
+    'elasticsearch.thread_pool.write.completed': (
+        'rate', 'thread_pool.write.completed'
     ),
 }
 

--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -135,6 +135,9 @@ elasticsearch.search.fetch.total,gauge,,fetch,,The total number of search fetche
 elasticsearch.search.query.current,gauge,,query,,The number of currently active queries.,0,elasticsearch,current queries
 elasticsearch.search.query.time,gauge,,second,,The total time spent on queries.,0,elasticsearch,total query time
 elasticsearch.search.query.total,gauge,,query,,The total number of queries.,0,elasticsearch,total queries
+elasticsearch.search.scroll.current,gauge,,query,,The number of currently active scroll queries.,0,elasticsearch,current scroll queries
+elasticsearch.search.scroll.time,gauge,,second,,The total time spent on scroll queries.,0,elasticsearch,total scroll query time
+elasticsearch.search.scroll.total,gauge,,query,,The total number of scroll queries.,0,elasticsearch,total scroll queries
 elasticsearch.store.size,gauge,,byte,,The total size in bytes of the store.,0,elasticsearch,store size
 elasticsearch.thread_pool.bulk.active,gauge,,thread,,The number of active threads in the bulk pool.,0,elasticsearch,active bulk threads
 elasticsearch.thread_pool.bulk.queue,gauge,,thread,,The number of queued threads in the bulk pool.,0,elasticsearch,queued bulk threads

--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -140,6 +140,7 @@ elasticsearch.thread_pool.bulk.active,gauge,,thread,,The number of active thread
 elasticsearch.thread_pool.bulk.queue,gauge,,thread,,The number of queued threads in the bulk pool.,0,elasticsearch,queued bulk threads
 elasticsearch.thread_pool.bulk.threads,gauge,,thread,,The total number of threads in the bulk pool.,0,elasticsearch,total bulk threads
 elasticsearch.thread_pool.bulk.rejected,gauge,,thread,,The number of rejected threads in the bulk pool.,0,elasticsearch,rejected bulk threads
+elasticsearch.thread_pool.bulk.completed,gauge,,thread,,The number of completed threads in the bulk pool.,0,elasticsearch,completed bulk threads
 elasticsearch.thread_pool.fetch_shard_started.active,gauge,,thread,,The number of active threads in the fetch shard started pool.,0,elasticsearch,active fetch shard started threads
 elasticsearch.thread_pool.fetch_shard_started.threads,gauge,,thread,,The total number of threads in the fetch shard started pool.,0,elasticsearch,total fetch shard started threads
 elasticsearch.thread_pool.fetch_shard_started.queue,gauge,,thread,,The number of queued threads in the fetch shard started pool.,0,elasticsearch,total fetch shard started threads
@@ -152,6 +153,7 @@ elasticsearch.thread_pool.flush.active,gauge,,thread,,The number of active threa
 elasticsearch.thread_pool.flush.queue,gauge,,thread,,The number of queued threads in the flush pool.,0,elasticsearch,queued flush threads
 elasticsearch.thread_pool.flush.threads,gauge,,thread,,The total number of threads in the flush pool.,0,elasticsearch,total flush threads
 elasticsearch.thread_pool.flush.rejected,gauge,,thread,,The number of rejected threads in the flush pool.,0,elasticsearch,rejected flush threads
+elasticsearch.thread_pool.flush.completed,gauge,,thread,,The number of completed threads in the flush pool.,0,elasticsearch,completed flush threads
 elasticsearch.thread_pool.force_merge.active,gauge,,thread,,The number of active threads for force merge operations.,0,elasticsearch,active force merge threads
 elasticsearch.thread_pool.force_merge.threads,gauge,,thread,,The total number of threads for force merge operations.,0,elasticsearch,total force merge threads
 elasticsearch.thread_pool.force_merge.queue,gauge,,thread,,The number of queued threads for force merge operations.,0,elasticsearch,rejected force merge threads
@@ -160,22 +162,27 @@ elasticsearch.thread_pool.generic.active,gauge,,thread,,The number of active thr
 elasticsearch.thread_pool.generic.queue,gauge,,thread,,The number of queued threads in the generic pool.,0,elasticsearch,queued generic threads
 elasticsearch.thread_pool.generic.threads,gauge,,thread,,The total number of threads in the generic pool.,0,elasticsearch,total generic threads
 elasticsearch.thread_pool.generic.rejected,gauge,,thread,,The number of rejected threads in the generic pool.,0,elasticsearch,rejected generic threads
+elasticsearch.thread_pool.generic.completed,gauge,,thread,,The number of completed threads in the generic pool.,0,elasticsearch,completed generic threads
 elasticsearch.thread_pool.get.active,gauge,,thread,,The number of active threads in the get pool.,0,elasticsearch,active get threads
 elasticsearch.thread_pool.get.queue,gauge,,thread,,The number of queued threads in the get pool.,0,elasticsearch,queued get threads
 elasticsearch.thread_pool.get.threads,gauge,,thread,,The total number of threads in the get pool.,0,elasticsearch,total get threads
 elasticsearch.thread_pool.get.rejected,gauge,,thread,,The number of rejected threads in the get pool.,0,elasticsearch,rejected get threads
+elasticsearch.thread_pool.get.completed,gauge,,thread,,The number of completed threads in the get pool.,0,elasticsearch,completed get threads
 elasticsearch.thread_pool.index.active,gauge,,thread,,The number of active threads in the index pool.,0,elasticsearch,active index threads
 elasticsearch.thread_pool.index.queue,gauge,,thread,,The number of queued threads in the index pool.,0,elasticsearch,queued index threads
 elasticsearch.thread_pool.index.threads,gauge,,thread,,The total number of threads in the index pool.,0,elasticsearch,total index threads
 elasticsearch.thread_pool.index.rejected,gauge,,thread,,The number of rejected threads in the index pool.,0,elasticsearch,rejected index threads
+elasticsearch.thread_pool.index.completed,gauge,,thread,,The number of completed threads in the index pool.,0,elasticsearch,completed index threads
 elasticsearch.thread_pool.listener.active,gauge,,thread,,The number of active threads in the listener pool.,0,elasticsearch,active listener threads
 elasticsearch.thread_pool.listener.queue,gauge,,thread,,The number of queued threads in the listener pool.,0,elasticsearch,queued listener threads
 elasticsearch.thread_pool.listener.threads,gauge,,thread,,The total number of threads in the listener pool.,0,elasticsearch,total listener threads
 elasticsearch.thread_pool.listener.rejected,gauge,,thread,,The number of rejected threads in the listener pool.,0,elasticsearch,rejected listener threads
+elasticsearch.thread_pool.listener.completed,gauge,,thread,,The number of completed threads in the listener pool.,0,elasticsearch,completed listener threads
 elasticsearch.thread_pool.management.active,gauge,,thread,,The number of active threads in the management pool.,0,elasticsearch,active management threads
 elasticsearch.thread_pool.management.queue,gauge,,thread,,The number of queued threads in the management pool.,0,elasticsearch,queued management threads
 elasticsearch.thread_pool.management.threads,gauge,,thread,,The total number of threads in the management pool.,0,elasticsearch,total management threads
 elasticsearch.thread_pool.management.rejected,gauge,,thread,,The number of rejected threads in the management pool.,0,elasticsearch,rejected management threads
+elasticsearch.thread_pool.management.completed,gauge,,thread,,The number of completed threads in the management pool.,0,elasticsearch,completed management threads
 elasticsearch.thread_pool.merge.active,gauge,,thread,,The number of active threads in the merge pool.,0,elasticsearch,active merge threads
 elasticsearch.thread_pool.merge.queue,gauge,,thread,,The number of queued threads in the merge pool.,0,elasticsearch,queued merge threads
 elasticsearch.thread_pool.merge.threads,gauge,,thread,,The total number of threads in the merge pool.,0,elasticsearch,total merge threads
@@ -188,18 +195,22 @@ elasticsearch.thread_pool.refresh.active,gauge,,thread,,The number of active thr
 elasticsearch.thread_pool.refresh.queue,gauge,,thread,,The number of queued threads in the refresh pool.,0,elasticsearch,queued refresh threads
 elasticsearch.thread_pool.refresh.threads,gauge,,thread,,The total number of threads in the refresh pool.,0,elasticsearch,total refresh threads
 elasticsearch.thread_pool.refresh.rejected,gauge,,thread,,The number of rejected threads in the refresh pool.,0,elasticsearch,rejected refresh threads
+elasticsearch.thread_pool.refresh.completed,gauge,,thread,,The number of completed threads in the refresh pool.,0,elasticsearch,completed refresh threads
 elasticsearch.thread_pool.search.active,gauge,,thread,,The number of active threads in the search pool.,0,elasticsearch,active search threads
 elasticsearch.thread_pool.search.queue,gauge,,thread,,The number of queued threads in the search pool.,0,elasticsearch,queued search threads
 elasticsearch.thread_pool.search.threads,gauge,,thread,,The total number of threads in the search pool.,0,elasticsearch,total search threads
 elasticsearch.thread_pool.search.rejected,gauge,,thread,,The number of rejected threads in the search pool.,0,elasticsearch,rejected search threads
+elasticsearch.thread_pool.search.completed,gauge,,thread,,The number of completed threads in the search pool.,0,elasticsearch,completed search threads
 elasticsearch.thread_pool.snapshot.active,gauge,,thread,,The number of active threads in the snapshot pool.,0,elasticsearch,active snapshot threads
 elasticsearch.thread_pool.snapshot.queue,gauge,,thread,,The number of queued threads in the snapshot pool.,0,elasticsearch,queued snapshot threads
 elasticsearch.thread_pool.snapshot.threads,gauge,,thread,,The total number of threads in the snapshot pool.,0,elasticsearch,total snapshot threads
 elasticsearch.thread_pool.snapshot.rejected,gauge,,thread,,The number of rejected threads in the snapshot pool.,0,elasticsearch,rejected snapshot threads
+elasticsearch.thread_pool.snapshot.completed,gauge,,thread,,The number of completed threads in the snapshot pool.,0,elasticsearch,completed snapshot threads
 elasticsearch.thread_pool.write.active,gauge,,thread,,The number of active threads in the write pool.,0,elasticsearch,active write threads
 elasticsearch.thread_pool.write.queue,gauge,,thread,,The number of queued threads in the write pool.,0,elasticsearch,queued write threads
 elasticsearch.thread_pool.write.threads,gauge,,thread,,The total number of threads in the write pool.,0,elasticsearch,total write threads
 elasticsearch.thread_pool.write.rejected,gauge,,thread,,The number of rejected threads in the write pool.,0,elasticsearch,rejected write threads
+elasticsearch.thread_pool.write.completed,gauge,,thread,,The number of completed threads in the write pool.,0,elasticsearch,completed write threads
 elasticsearch.transport.rx_count,gauge,,packet,,The total number of packets received in cluster communication.,0,elasticsearch,transport packets received
 elasticsearch.transport.rx_size,gauge,,byte,,The total size of data received in cluster communication.,0,elasticsearch,transport bytes received
 elasticsearch.transport.server_open,gauge,,connection,,The number of connections opened for cluster communication.,0,elasticsearch,transport open connections

--- a/elastic/tests/test_metrics.py
+++ b/elastic/tests/test_metrics.py
@@ -12,51 +12,51 @@ from datadog_checks.elastic.metrics import (
 def test_stats_for_version():
     # v0.90
     metrics = stats_for_version([0, 90, 0])
-    assert len(metrics) == 123
+    assert len(metrics) == 133
 
     # v0.90.5
     metrics = stats_for_version([0, 90, 5])
-    assert len(metrics) == 124
+    assert len(metrics) == 134
 
     # v0.90.10
     metrics = stats_for_version([0, 90, 10])
-    assert len(metrics) == 122
+    assert len(metrics) == 132
 
     # v1
     metrics = stats_for_version([1, 0, 0])
-    assert len(metrics) == 130
+    assert len(metrics) == 140
 
     # v1.3.0
     metrics = stats_for_version([1, 3, 0])
-    assert len(metrics) == 132
+    assert len(metrics) == 142
 
     # v1.4.0
     metrics = stats_for_version([1, 4, 0])
-    assert len(metrics) == 152
+    assert len(metrics) == 162
 
     # v1.5.0
     metrics = stats_for_version([1, 5, 0])
-    assert len(metrics) == 155
+    assert len(metrics) == 165
 
     # v1.6.0
     metrics = stats_for_version([1, 6, 0])
-    assert len(metrics) == 163
+    assert len(metrics) == 173
 
     # v2
     metrics = stats_for_version([2, 0, 0])
-    assert len(metrics) == 162
+    assert len(metrics) == 172
 
     # v2.1.0
     metrics = stats_for_version([2, 1, 0])
-    assert len(metrics) == 167
+    assert len(metrics) == 177
 
     # v5
     metrics = stats_for_version([5, 0, 0])
-    assert len(metrics) == 170
+    assert len(metrics) == 180
 
     # v6.3.0
     metrics = stats_for_version([6, 3, 0])
-    assert len(metrics) == 170
+    assert len(metrics) == 180
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### What does this PR do?

This PR captures the `completed` metric for all of the elastic thread pools.  This value is useful to determine the rate at which threads are completing in the pool.  The other metrics, `active` and `queued` can miss data depending on when the values were sampled as they only report the current value, not the total over time

### Motivation

To determine the rate at which requests (searches in particular) are serviced through the thread pool

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

cc @DataDog/burrito 
