### PR TITLE
Fix agent_changelog command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/release.py
@@ -13,8 +13,8 @@ PLATFORMS_TO_PY = {
     'linux': 'linux2',
 }
 ALL_PLATFORMS = sorted(PLATFORMS_TO_PY)
-
 VERSION = re.compile(r'__version__ *= *(?:[\'"])(.+?)(?:[\'"])')
+DATADOG_PACKAGE_PREFIX = 'datadog-'
 
 
 def get_release_tag_string(check_name, version_string):
@@ -36,11 +36,26 @@ def update_version_module(check_name, old_ver, new_ver):
     write_file(version_file, contents)
 
 
-def get_package_name(check_name):
-    if check_name == 'datadog_checks_base':
-        return check_name.replace('_', '-')
+def get_package_name(folder_name):
+    """
+    Given a folder name for a check, return the name of the
+    corresponding Python package
+    """
+    if folder_name == 'datadog_checks_base':
+        return 'datadog-checks-base'
 
-    return 'datadog-{}'.format(check_name.replace('_', '-'))
+    return '{}{}'.format(DATADOG_PACKAGE_PREFIX, folder_name.replace('_', '-'))
+
+
+def get_folder_name(package_name):
+    """
+    Given a Python package name for a check, return the corresponding folder
+    name in the git repo
+    """
+    if package_name == 'datadog-checks-base':
+        return 'datadog_checks_base'
+
+    return package_name.replace('-', '_')[len(DATADOG_PACKAGE_PREFIX):]
 
 
 def get_agent_requirement_line(check, version):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -160,10 +160,10 @@ def get_bump_function(changelog_types):
 
 def parse_agent_req_file(contents):
     """
-    Returns a dictionary mapping {check_name --> pinned_version} from the
+    Returns a dictionary mapping {check-package-name --> pinned_version} from the
     given file contents. We can assume lines are in the form:
 
-        active_directory==1.1.1; sys_platform == 'win32'
+        active-directory==1.1.1; sys_platform == 'win32'
 
     """
     catalog = OrderedDict()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -163,7 +163,7 @@ def parse_agent_req_file(contents):
     Returns a dictionary mapping {check-package-name --> pinned_version} from the
     given file contents. We can assume lines are in the form:
 
-        active-directory==1.1.1; sys_platform == 'win32'
+        datadog-active-directory==1.1.1; sys_platform == 'win32'
 
     """
     catalog = OrderedDict()

--- a/datadog_checks_dev/tests/tooling/test_release.py
+++ b/datadog_checks_dev/tests/tooling/test_release.py
@@ -1,0 +1,16 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.dev.tooling.release import get_package_name, get_folder_name
+
+
+def test_get_package_name():
+    assert get_package_name('datadog_checks_base') == 'datadog-checks-base'
+    assert get_package_name('my_check') == 'datadog-my-check'
+
+
+def test_get_folder_name():
+    assert get_folder_name('datadog-checks-base') == 'datadog_checks_base'
+    assert get_folder_name('datadog-my-check') == 'my_check'

--- a/datadog_checks_dev/tests/tooling/test_release.py
+++ b/datadog_checks_dev/tests/tooling/test_release.py
@@ -1,8 +1,6 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.tooling.release import get_package_name, get_folder_name
 
 


### PR DESCRIPTION
### What does this PR do?

The `requirements-agent-release.txt` file we parse to generate the changelog has a weird git history and the generation command wasn't working correctly. This PR fixes the logic and adds a fair bunch of comments/docstrings so the process is better documented now.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.
