### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -245,7 +245,7 @@ jobs:
     - stage: test
       env: CHECK=twemproxy
     - stage: test
-      env: CHECK=varnish
+      env: CHECK=varnish PYTHON3=true
     - stage: test
       env: CHECK=vault PYTHON3=true
     - stage: test

--- a/varnish/datadog_checks/varnish/varnish.py
+++ b/varnish/datadog_checks/varnish/varnish.py
@@ -123,7 +123,6 @@ class Varnish(AgentCheck):
             tags = custom_tags + [u'varnish_name:default']
 
         output, _, _ = get_subprocess_output(cmd, self.log)
-        output = output
 
         self._parse_varnishstat(output, varnishstat_format, tags)
 
@@ -171,7 +170,6 @@ class Varnish(AgentCheck):
     def _get_version_info(self, varnishstat_path):
         # Get the varnish version from varnishstat
         output, error, _ = get_subprocess_output(varnishstat_path + ["-V"], self.log, raise_on_empty_output=False)
-        output = output
 
         # Assumptions regarding varnish's version
         varnishstat_format = "json"

--- a/varnish/datadog_checks/varnish/varnish.py
+++ b/varnish/datadog_checks/varnish/varnish.py
@@ -123,7 +123,7 @@ class Varnish(AgentCheck):
             tags = custom_tags + [u'varnish_name:default']
 
         output, _, _ = get_subprocess_output(cmd, self.log)
-        output = ensure_unicode(output)
+        output = output
 
         self._parse_varnishstat(output, varnishstat_format, tags)
 
@@ -171,7 +171,7 @@ class Varnish(AgentCheck):
     def _get_version_info(self, varnishstat_path):
         # Get the varnish version from varnishstat
         output, error, _ = get_subprocess_output(varnishstat_path + ["-V"], self.log, raise_on_empty_output=False)
-        output = ensure_unicode(output)
+        output = output
 
         # Assumptions regarding varnish's version
         varnishstat_format = "json"

--- a/varnish/tests/conftest.py
+++ b/varnish/tests/conftest.py
@@ -7,14 +7,7 @@ import os
 import subprocess
 import time
 
-import common
-
-
-@pytest.fixture
-def aggregator():
-    from datadog_checks.stubs import aggregator
-    aggregator.reset()
-    return aggregator
+from . import common
 
 
 @pytest.fixture(scope="session")

--- a/varnish/tests/test_unit.py
+++ b/varnish/tests/test_unit.py
@@ -7,6 +7,7 @@ import os
 from distutils.version import LooseVersion
 
 from . import common
+from datadog_checks.base import ensure_unicode
 from datadog_checks.varnish import Varnish
 
 
@@ -15,11 +16,11 @@ def debug_health_mock(*args, **kwargs):
     if common.VARNISHADM_PATH in args[0]:
         fpath = os.path.join(common.FIXTURE_DIR, "debug_health_output")
         with open(fpath) as f:
-            return f.read(), "", 0
+            return ensure_unicode(f.read()), u"", 0
     else:
         fpath = os.path.join(common.FIXTURE_DIR, "stats_output")
         with open(fpath) as f:
-            return f.read(), "", 0
+            return ensure_unicode(f.read()), u"", 0
 
 
 # Varnish >= 4.x && <= 5.x varnishadm output
@@ -27,11 +28,11 @@ def backend_list_mock(*args, **kwargs):
     if common.VARNISHADM_PATH in args[0]:
         fpath = os.path.join(common.FIXTURE_DIR, "backend_list_output")
         with open(fpath) as f:
-            return f.read(), "", 0
+            return ensure_unicode(f.read()), u"", 0
     else:
         fpath = os.path.join(common.FIXTURE_DIR, "stats_output")
         with open(fpath) as f:
-            return f.read(), "", 0
+            return ensure_unicode(f.read()), u"", 0
 
 
 # Varnish >= 5.x varnishadm output
@@ -39,11 +40,11 @@ def backend_list_mock_v5(*args, **kwargs):
     if common.VARNISHADM_PATH in args[0]:
         fpath = os.path.join(common.FIXTURE_DIR, "backend_list_output")
         with open(fpath) as f:
-            return f.read(), "", 0
+            return ensure_unicode(f.read()), u"", 0
     else:
         fpath = os.path.join(common.FIXTURE_DIR, "stats_output_json")
         with open(fpath) as f:
-            return f.read(), "", 0
+            return ensure_unicode(f.read()), u"", 0
 
 
 # Varnish >= 4.x && <= 5.x Varnishadm manually set backend to sick
@@ -51,11 +52,11 @@ def backend_manual_unhealthy_mock(*args, **kwargs):
     if common.VARNISHADM_PATH in args[0]:
         fpath = os.path.join(common.FIXTURE_DIR, "backend_manually_unhealthy")
         with open(fpath) as f:
-            return f.read(), "", 0
+            return ensure_unicode(f.read()), u"", 0
     else:
         fpath = os.path.join(common.FIXTURE_DIR, "stats_output")
         with open(fpath) as f:
-            return f.read(), "", 0
+            return ensure_unicode(f.read()), u"", 0
 
 
 @mock.patch('datadog_checks.varnish.varnish.geteuid')

--- a/varnish/tests/test_unit.py
+++ b/varnish/tests/test_unit.py
@@ -6,7 +6,7 @@ import mock
 import os
 from distutils.version import LooseVersion
 
-import common
+from . import common
 from datadog_checks.varnish import Varnish
 
 

--- a/varnish/tests/test_varnish.py
+++ b/varnish/tests/test_varnish.py
@@ -10,8 +10,10 @@ import subprocess
 
 import pytest
 
-import common
+from . import common
+from datadog_checks.base import ensure_unicode
 from datadog_checks.varnish import Varnish
+
 
 pytestmark = pytest.mark.integration
 
@@ -60,7 +62,7 @@ def test_version():
 
     # Version info is printed to stderr
     output = subprocess.check_output(shlex.split(varnishstat) + ["-V"], stderr=subprocess.STDOUT)
-    res = re.search(r"varnish-(\d+\.\d\.\d)", output)
+    res = re.search(r"varnish-(\d+\.\d\.\d)", ensure_unicode(output))
     if res is None:
         raise Exception("Could not retrieve varnish version from docker")
 

--- a/varnish/tox.ini
+++ b/varnish/tox.ini
@@ -3,9 +3,7 @@ minversion = 2.0
 basepython = py27
 envlist =
     flake8
-    unit
-    varnish4
-    varnish5
+    {py27,py36}-{unit,varnish4,varnish5}
 
 [testenv]
 platform = linux|darwin|win32
@@ -15,25 +13,13 @@ deps =
 passenv =
     DOCKER*
     COMPOSE*
+setenv =
+    varnish4: VARNISH_VERSION=4.1.7
+    varnish5: VARNISH_VERSION=5.2.1
 commands =
     pip install --require-hashes -r requirements.txt
-
-[testenv:varnish4]
-setenv = VARNISH_VERSION=4.1.7
-commands =
-    {[testenv]commands}
-    pytest -m"integration" -v
-
-[testenv:varnish5]
-setenv = VARNISH_VERSION=5.2.1
-commands =
-    {[testenv]commands}
-    pytest -m"integration" -v
-
-[testenv:unit]
-commands =
-    {[testenv]commands}
-	pytest -m"not integration" -v
+    unit: pytest -m"not integration" -v
+    {varnish4-varnish5}: pytest -m"integration" -v
 
 [testenv:flake8]
 skip_install = true

--- a/varnish/tox.ini
+++ b/varnish/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 basepython = py27
 envlist =
     flake8
-    {py27,py36}-{unit,varnish4,varnish5}
+    {py27,py36}-{unit,4.1.7,5.2.1}
 
 [testenv]
 platform = linux|darwin|win32
@@ -14,12 +14,12 @@ passenv =
     DOCKER*
     COMPOSE*
 setenv =
-    varnish4: VARNISH_VERSION=4.1.7
-    varnish5: VARNISH_VERSION=5.2.1
+    4.2.7: VARNISH_VERSION=4.1.7
+    5.2.1: VARNISH_VERSION=5.2.1
 commands =
     pip install --require-hashes -r requirements.txt
     unit: pytest -m"not integration" -v
-    {varnish4-varnish5}: pytest -m"integration" -v
+    {4.2.7-5.2.1}: pytest -m"integration" -v
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
### What does this PR do?

Adds support for Python3 for Varnish

### Motivation

Support 🐍 3️⃣ for more checks

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

`filter` in Python3 returns an iterator and not a list like Python2 does. To reduce too much functionality changes to the check, and because the output is ultimately going to be small, I convert it to a list. We have core functionality in the check that depends on the length of the filter, so it's needed to be a list. 

The get_subprocess_output function already ensures_unicode, but the mocks don't, so this PR updates the mocks and not the check code. 