### PR TITLE
Fixed docs for the 'validate py3' command

### DIFF
--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -10,7 +10,7 @@
 * [Added] Validate checks dependencies against the embedded environment. See [#2746](https://github.com/DataDog/integrations-core/pull/2746).
 * [Added] Add constant to check if platform is Linux. See [#2782](https://github.com/DataDog/integrations-core/pull/2782).
 * [Fixed] Do not consider empty string as a version change. See [#2771](https://github.com/DataDog/integrations-core/pull/2771).
-* [Changed] Rename `ddev release freeze` to `ddev release agent_req_file`, refacor commands code. See [#2765](https://github.com/DataDog/integrations-core/pull/2765).
+* [Changed] Rename `ddev release freeze` to `ddev release agent_req_file`, refactor commands code. See [#2765](https://github.com/DataDog/integrations-core/pull/2765).
 * [Added] Add validation for configuration files. See [#2759](https://github.com/DataDog/integrations-core/pull/2759).
 * [Added] Add ability to pass state to e2e tear down. See [#2724](https://github.com/DataDog/integrations-core/pull/2724).
 * [Added] Add ability to use dev version of base package for e2e. See [#2689](https://github.com/DataDog/integrations-core/pull/2689).

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/py3.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/py3.py
@@ -21,11 +21,13 @@ from ...utils import get_valid_checks
 
 @click.command(
     context_settings=CONTEXT_SETTINGS,
-    short_help="Verify if a custom check or integration will run on python 3"
+    short_help="Verify if a custom check or integration can run on python 3"
 )
 @click.argument('check')
 def py3(check):
-    """Verify if a custom check or integration will run on python 3"""
+    """Verify if a custom check or integration can run on python 3. CHECK
+    must be a valid path to a Python module or package folder.
+    """
 
     root = get_root()
     if check == 'datadog_checks_base':

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/py3.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/py3.py
@@ -26,7 +26,7 @@ from ...utils import get_valid_checks
 @click.argument('check')
 def py3(check):
     """Verify if a custom check or integration can run on python 3. CHECK
-    must be a valid path to a Python module or package folder.
+    can be an integration name or a valid path to a Python module or package folder.
     """
 
     root = get_root()


### PR DESCRIPTION
### What does this PR do?

* Better set expectations, passing the validation doesn't imply the check will work on Py3
* Specify what the argument `CHECK` should be

### Motivation

Preparing docs for the migration guide

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Fixed an unrelated typo in an old changelog
