### PR TITLE
Move tasks under 'agent' subcommand

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
 
 test_script:
   # Only test any of these that have changed for pull requests
-  - ddev test%CHANGED_ONLY_FLAG% -c datadog_checks_base active_directory aspdotnet disk dotnetclr exchange_server iis pdh_check sqlserver win32_event_log windows_service wmi_check
+  - ddev test%CHANGED_ONLY_FLAG% -c datadog_checks_base datadog_checks_dev active_directory aspdotnet disk dotnetclr exchange_server iis pdh_check sqlserver win32_event_log windows_service wmi_check
 
 # Uncomment the following to enable RDP connection into the builder and debug a build
 # on_finish:

--- a/datadog_checks_dev/datadog_checks/dev/errors.py
+++ b/datadog_checks_dev/datadog_checks/dev/errors.py
@@ -9,3 +9,10 @@ class RetryError(Exception):
 
 class SubprocessError(Exception):
     pass
+
+
+class ManifestError(Exception):
+    """
+    Raised when the manifest.json file is malformed
+    """
+    pass

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/__init__.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from .agent import agent
 from .clean import clean
 from .config import config
 from .create import create
@@ -13,6 +14,7 @@ from .test import test
 from .validate import validate
 
 ALL_COMMANDS = (
+    agent,
     clean,
     config,
     create,

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/__init__.py
@@ -1,0 +1,26 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import click
+
+from ..console import CONTEXT_SETTINGS
+from .changelog import changelog
+from .requirements import requirements
+
+
+ALL_COMMANDS = (
+    changelog,
+    requirements,
+)
+
+
+@click.group(
+    context_settings=CONTEXT_SETTINGS,
+    short_help='A collection of tasks related to the Datadog Agent'
+)
+def agent():
+    pass
+
+
+for command in ALL_COMMANDS:
+    agent.add_command(command)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/changelog.py
@@ -1,0 +1,124 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+import json
+from collections import OrderedDict
+
+import click
+from six import StringIO, iteritems
+
+from ..console import CONTEXT_SETTINGS, abort, echo_info
+from ...constants import get_root, get_agent_release_requirements
+from ...git import git_show_file, git_tag_list
+from ...release import get_folder_name, get_package_name, DATADOG_PACKAGE_PREFIX
+from ...utils import parse_agent_req_file
+from ....utils import write_file, read_file
+
+
+@click.command(
+    context_settings=CONTEXT_SETTINGS,
+    short_help="Provide a list of updated checks on a given Datadog Agent version, in changelog form"
+)
+@click.option('--since', help="Initial Agent version", default='6.3.0')
+@click.option('--to', help="Final Agent version")
+@click.option('--output', '-o', help="Path to the changelog file, if omitted contents will be printed to stdout")
+@click.option('--force', '-f', is_flag=True, default=False, help="Replace an existing file")
+def changelog(since, to, output, force):
+    """
+    Generates a markdown file containing the list of checks that changed for a
+    given Agent release. Agent version numbers are derived inspecting tags on
+    `integrations-core` so running this tool might provide unexpected results
+    if the repo is not up to date with the Agent release process.
+
+    If neither `--since` or `--to` are passed (the most common use case), the
+    tool will generate the whole changelog since Agent version 6.3.0
+    (before that point we don't have enough information to build the log).
+    """
+    agent_tags = git_tag_list(r'^\d+\.\d+\.\d+$')
+
+    # default value for --to is the latest tag
+    if not to:
+        to = agent_tags[-1]
+
+    # filter out versions according to the interval [since, to]
+    agent_tags = [t for t in agent_tags if since <= t <= to]
+
+    # reverse so we have descendant order
+    agent_tags = agent_tags[::-1]
+
+    # store the changes in a mapping {agent_version --> {check_name --> current_version}}
+    changes_per_agent = OrderedDict()
+
+    # to keep indexing easy, we run the loop off-by-one
+    for i in range(1, len(agent_tags)):
+        req_file_name = os.path.basename(get_agent_release_requirements())
+        current_tag = agent_tags[i - 1]
+        # Requirements for current tag
+        file_contents = git_show_file(req_file_name, current_tag)
+        catalog_now = parse_agent_req_file(file_contents)
+        # Requirements for previous tag
+        file_contents = git_show_file(req_file_name, agent_tags[i])
+        catalog_prev = parse_agent_req_file(file_contents)
+
+        changes_per_agent[current_tag] = OrderedDict()
+
+        for name, ver in iteritems(catalog_now):
+            # at some point in the git history, the requirements file erroneusly
+            # contained the folder name instead of the package name for each check,
+            # let's be resilient
+            old_ver = catalog_prev.get(name) \
+                or catalog_prev.get(get_folder_name(name)) \
+                or catalog_prev.get(get_package_name(name))
+
+            # normalize the package name to the check_name
+            if name.startswith(DATADOG_PACKAGE_PREFIX):
+                name = get_folder_name(name)
+
+            if old_ver and old_ver != ver:
+                # determine whether major version changed
+                breaking = old_ver.split('.')[0] < ver.split('.')[0]
+                changes_per_agent[current_tag][name] = (ver, breaking)
+
+    # store the changelog in memory
+    changelog_contents = StringIO()
+
+    # prepare the links
+    agent_changelog_url = 'https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#{}'
+    check_changelog_url = 'https://github.com/DataDog/integrations-core/blob/master/{}/CHANGELOG.md'
+
+    # go through all the agent releases
+    for agent, version_changes in iteritems(changes_per_agent):
+        url = agent_changelog_url.format(agent.replace('.', ''))  # Github removes dots from the anchor
+        changelog_contents.write('## Datadog Agent version [{}]({})\n\n'.format(agent, url))
+
+        if not version_changes:
+            changelog_contents.write('* There were no integration updates for this version of the Agent.\n\n')
+        else:
+            for name, ver in iteritems(version_changes):
+                # get the "display name" for the check
+                manifest_file = os.path.join(get_root(), name, 'manifest.json')
+                if os.path.exists(manifest_file):
+                    decoded = json.loads(read_file(manifest_file).strip(), object_pairs_hook=OrderedDict)
+                    display_name = decoded.get('display_name')
+                else:
+                    display_name = name
+
+                breaking_notice = " **BREAKING CHANGE**" if ver[1] else ""
+                changelog_url = check_changelog_url.format(name)
+                changelog_contents.write(
+                    '* {} [{}]({}){}\n'.format(display_name, ver[0], changelog_url, breaking_notice)
+                )
+            # add an extra line to separate the release block
+            changelog_contents.write('\n')
+
+    # save the changelog on disk if --output was passed
+    if output:
+        # don't overwrite an existing file
+        if os.path.exists(output) and not force:
+            msg = "Output file {} already exists, run the command again with --force to overwrite"
+            abort(msg.format(output))
+
+        write_file(output, changelog_contents.getvalue())
+    else:
+        echo_info(changelog_contents.getvalue())

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/requirements.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/requirements.py
@@ -1,0 +1,48 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import click
+
+from ..console import (
+    CONTEXT_SETTINGS, echo_failure, echo_info, echo_success
+)
+from ...constants import AGENT_V5_ONLY, get_agent_release_requirements
+from ...release import get_agent_requirement_line
+from ...utils import get_valid_checks, get_version_string
+from ....utils import write_file_lines
+
+
+@click.command(
+    context_settings=CONTEXT_SETTINGS,
+    short_help="Generate the list of integrations to ship with the Agent and save it to '{}'".format(
+        get_agent_release_requirements()
+    )
+)
+@click.pass_context
+def requirements(ctx):
+    """Write the `requirements-agent-release.txt` file at the root of the repo
+    listing all the Agent-based integrations pinned at the version they currently
+    have in HEAD.
+    """
+    echo_info('Freezing check releases')
+    checks = get_valid_checks()
+    checks.remove('datadog_checks_dev')
+
+    entries = []
+    for check in checks:
+        if check in AGENT_V5_ONLY:
+            echo_info('Check `{}` is only shipped with Agent 5, skipping'.format(check))
+            continue
+
+        try:
+            version = get_version_string(check)
+            entries.append('{}\n'.format(get_agent_requirement_line(check, version)))
+        except Exception as e:
+            echo_failure('Error generating line: {}'.format(e))
+            continue
+
+    lines = sorted(entries)
+
+    req_file = get_agent_release_requirements()
+    write_file_lines(req_file, lines)
+    echo_success('Successfully wrote to `{}`!'.format(req_file))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
@@ -19,11 +19,11 @@ from ..constants import (
     get_root, get_agent_release_requirements
 )
 from ..git import (
-    get_current_branch, parse_pr_numbers, get_commits_since, git_tag, git_commit
+    get_current_branch, get_commits_since, git_tag, git_commit
 )
 from ..github import (
     from_contributor, get_changelog_types, get_pr, get_pr_from_hash, get_pr_labels,
-    get_pr_milestone
+    get_pr_milestone, parse_pr_numbers, parse_pr_number
 )
 from ..release import (
     get_agent_requirement_line, get_release_tag_string, update_agent_requirements,
@@ -32,7 +32,7 @@ from ..release import (
 from ..trello import TrelloClient
 from ..utils import (
     get_bump_function, get_current_agent_version, get_valid_checks,
-    get_version_string, format_commit_id, parse_pr_number
+    get_version_string, format_commit_id
 )
 from ...structures import EnvVars
 from ...subprocess import run_command

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 import time
-import json
 from collections import OrderedDict, namedtuple
 from datetime import datetime
 
@@ -16,28 +15,30 @@ from .console import (
     echo_warning
 )
 from ..constants import (
-    AGENT_V5_ONLY, BETA_PACKAGES, CHANGELOG_TYPE_NONE, NOT_CHECKS, VERSION_BUMP,
+    BETA_PACKAGES, CHANGELOG_TYPE_NONE, NOT_CHECKS, VERSION_BUMP,
     get_root, get_agent_release_requirements
 )
 from ..git import (
-    get_current_branch, parse_pr_numbers, get_commits_since, git_tag, git_commit,
-    git_show_file, git_tag_list
+    get_current_branch, parse_pr_numbers, get_commits_since, git_tag, git_commit
 )
-from ..github import from_contributor, get_changelog_types, get_pr, get_pr_from_hash, get_pr_labels, get_pr_milestone
+from ..github import (
+    from_contributor, get_changelog_types, get_pr, get_pr_from_hash, get_pr_labels,
+    get_pr_milestone
+)
 from ..release import (
     get_agent_requirement_line, get_release_tag_string, update_agent_requirements,
-    update_version_module, get_folder_name, get_package_name, DATADOG_PACKAGE_PREFIX
+    update_version_module
 )
 from ..trello import TrelloClient
 from ..utils import (
     get_bump_function, get_current_agent_version, get_valid_checks,
-    get_version_string, format_commit_id, parse_pr_number, parse_agent_req_file
+    get_version_string, format_commit_id, parse_pr_number
 )
 from ...structures import EnvVars
 from ...subprocess import run_command
 from ...utils import (
     basepath, chdir, ensure_unicode, get_next, remove_path, stream_file_lines,
-    write_file, write_file_lines, read_file
+    write_file
 )
 
 ChangelogEntry = namedtuple('ChangelogEntry', 'number, title, url, author, author_url, from_contributor')
@@ -854,147 +855,3 @@ def upload(ctx, check, dry_run):
                 abort(code=result.code)
 
     echo_success('Success!')
-
-
-@release.command(
-    context_settings=CONTEXT_SETTINGS,
-    short_help="Generate the list of integrations to ship with the Agent and save it to '{}'".format(
-        get_agent_release_requirements()
-    )
-)
-@click.pass_context
-def agent_req_file(ctx):
-    """Write the `requirements-agent-release.txt` file at the root of the repo
-    listing all the Agent-based integrations pinned at the version they currently
-    have in HEAD.
-    """
-    echo_info('Freezing check releases')
-    checks = get_valid_checks()
-    checks.remove('datadog_checks_dev')
-
-    entries = []
-    for check in checks:
-        if check in AGENT_V5_ONLY:
-            echo_info('Check `{}` is only shipped with Agent 5, skipping'.format(check))
-            continue
-
-        try:
-            version = get_version_string(check)
-            entries.append('{}\n'.format(get_agent_requirement_line(check, version)))
-        except Exception as e:
-            echo_failure('Error generating line: {}'.format(e))
-            continue
-
-    lines = sorted(entries)
-
-    req_file = get_agent_release_requirements()
-    write_file_lines(req_file, lines)
-    echo_success('Successfully wrote to `{}`!'.format(req_file))
-
-
-@release.command(
-    context_settings=CONTEXT_SETTINGS,
-    short_help="Provide a list of the updated checks on a given agent version, in changelog form"
-)
-@click.option('--since', help="Initial Agent version", default='6.3.0')
-@click.option('--to', help="Final Agent version")
-@click.option('--output', '-o', help="Path to the changelog file, if omitted contents will be printed to stdout")
-@click.option('--force', '-f', is_flag=True, default=False, help="Replace an existing file")
-def agent_changelog(since, to, output, force):
-    """
-    Generates a markdown file containing the list of checks that changed for a
-    given Agent release. Agent version numbers are derived inspecting tags on
-    `integrations-core` so running this tool might provide unexpected results
-    if the repo is not up to date with the Agent release process.
-
-    If neither `--since` or `--to` are passed (the most common use case), the
-    tool will generate the whole changelog since Agent version 6.3.0
-    (before that point we don't have enough information to build the log).
-    """
-    agent_tags = git_tag_list(r'^\d+\.\d+\.\d+$')
-
-    # default value for --to is the latest tag
-    if not to:
-        to = agent_tags[-1]
-
-    # filter out versions according to the interval [since, to]
-    agent_tags = [t for t in agent_tags if since <= t <= to]
-
-    # reverse so we have descendant order
-    agent_tags = agent_tags[::-1]
-
-    # store the changes in a mapping {agent_version --> {check_name --> current_version}}
-    changes_per_agent = OrderedDict()
-
-    # to keep indexing easy, we run the loop off-by-one
-    for i in range(1, len(agent_tags)):
-        req_file_name = os.path.basename(get_agent_release_requirements())
-        current_tag = agent_tags[i - 1]
-        # Requirements for current tag
-        file_contents = git_show_file(req_file_name, current_tag)
-        catalog_now = parse_agent_req_file(file_contents)
-        # Requirements for previous tag
-        file_contents = git_show_file(req_file_name, agent_tags[i])
-        catalog_prev = parse_agent_req_file(file_contents)
-
-        changes_per_agent[current_tag] = OrderedDict()
-
-        for name, ver in iteritems(catalog_now):
-            # at some point in the git history, the requirements file erroneusly
-            # contained the folder name instead of the package name for each check,
-            # let's be resilient
-            old_ver = catalog_prev.get(name) \
-                or catalog_prev.get(get_folder_name(name)) \
-                or catalog_prev.get(get_package_name(name))
-
-            # normalize the package name to the check_name
-            if name.startswith(DATADOG_PACKAGE_PREFIX):
-                name = get_folder_name(name)
-
-            if old_ver and old_ver != ver:
-                # determine whether major version changed
-                breaking = old_ver.split('.')[0] < ver.split('.')[0]
-                changes_per_agent[current_tag][name] = (ver, breaking)
-
-    # store the changelog in memory
-    changelog_contents = StringIO()
-
-    # prepare the links
-    agent_changelog_url = 'https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#{}'
-    check_changelog_url = 'https://github.com/DataDog/integrations-core/blob/master/{}/CHANGELOG.md'
-
-    # go through all the agent releases
-    for agent, version_changes in iteritems(changes_per_agent):
-        url = agent_changelog_url.format(agent.replace('.', ''))  # Github removes dots from the anchor
-        changelog_contents.write('## Datadog Agent version [{}]({})\n\n'.format(agent, url))
-
-        if not version_changes:
-            changelog_contents.write('* There were no integration updates for this version of the Agent.\n\n')
-        else:
-            for name, ver in iteritems(version_changes):
-                # get the "display name" for the check
-                manifest_file = os.path.join(get_root(), name, 'manifest.json')
-                if os.path.exists(manifest_file):
-                    decoded = json.loads(read_file(manifest_file).strip(), object_pairs_hook=OrderedDict)
-                    display_name = decoded.get('display_name')
-                else:
-                    display_name = name
-
-                breaking_notice = " **BREAKING CHANGE**" if ver[1] else ""
-                changelog_url = check_changelog_url.format(name)
-                changelog_contents.write(
-                    '* {} [{}]({}){}\n'.format(display_name, ver[0], changelog_url, breaking_notice)
-                )
-            # add an extra line to separate the release block
-            changelog_contents.write('\n')
-
-    # save the changelog on disk if --output was passed
-    if output:
-        # don't overwrite an existing file
-        if os.path.exists(output) and not force:
-            msg = "Output file {} already exists, run the command again with --force to overwrite"
-            abort(msg.format(output))
-
-        write_file(output, changelog_contents.getvalue())
-    else:
-        echo_info(changelog_contents.getvalue())

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -5,7 +5,6 @@ import os
 import re
 
 from .constants import get_root
-from .utils import parse_pr_number
 from ..subprocess import run_command
 from ..utils import chdir
 
@@ -30,22 +29,6 @@ def files_changed():
 
     # Remove empty lines
     return [f for f in changed_files if f]
-
-
-def parse_pr_numbers(git_log_lines):
-    """
-    Parse PR numbers from commit messages. At GitHub those have the format:
-
-        `here is the message (#1234)`
-
-    being `1234` the PR number.
-    """
-    prs = []
-    for line in git_log_lines:
-        pr_number = parse_pr_number(line)
-        if pr_number:
-            prs.append(pr_number)
-    return prs
 
 
 def get_commits_since(check_name, target_tag=None):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/release.py
@@ -5,6 +5,8 @@ import re
 
 from .utils import get_version_file, load_manifest
 from ..utils import read_file, read_file_lines, write_file, write_file_lines
+from ..errors import ManifestError
+
 
 # Maps the Python platform strings to the ones we have in the manifest
 PLATFORMS_TO_PY = {
@@ -88,7 +90,7 @@ def get_agent_requirement_line(check, version):
         elif 'linux' not in platforms:
             return "{}=={}; sys_platform != 'linux2'".format(package_name, version)
 
-    raise Exception("Can't parse the `supported_os` list for the check {}: {}".format(check, platforms))
+    raise ManifestError("Can't parse the `supported_os` list for the check {}: {}".format(check, platforms))
 
 
 def update_agent_requirements(req_file, check, newline):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -14,8 +14,6 @@ from six import string_types
 from .constants import NOT_CHECKS, VERSION_BUMP, get_root
 from ..utils import file_exists, read_file
 
-# match something like `(#1234)` and return `1234` in a group
-PR_PATTERN = re.compile(r'\(#(\d+)\)')
 # match integration's version within the __about__.py module
 VERSION = re.compile(r'__version__ *= *(?:[\'"])(.+?)(?:[\'"])')
 
@@ -27,12 +25,6 @@ def format_commit_id(commit_id):
         else:
             return 'commit hash `{}`'.format(commit_id)
     return commit_id
-
-
-def parse_pr_number(log_line):
-    match = re.search(PR_PATTERN, log_line)
-    if match:
-        return match.group(1)
 
 
 def get_current_agent_version():

--- a/datadog_checks_dev/datadog_checks/dev/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/utils.py
@@ -24,8 +24,8 @@ ON_WINDOWS = NEED_SHELL = os.name == 'nt' or __platform == 'Windows'
 ON_LINUX = not (ON_MACOS or ON_WINDOWS)
 
 CI_IDENTIFIERS = {
-    'appveyor': 'APPVEYOR_',
-    'travis': 'TRAVIS_',
+    'appveyor': 'APPVEYOR',
+    'travis': 'TRAVIS',
 }
 
 

--- a/datadog_checks_dev/datadog_checks/dev/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/utils.py
@@ -30,11 +30,11 @@ CI_IDENTIFIERS = {
 
 
 def running_on_appveyor():
-    return any(ev.startswith(CI_IDENTIFIERS.get('appveyor') for ev in os.environ))
+    return any(ev.startswith(CI_IDENTIFIERS.get('appveyor')) for ev in os.environ)
 
 
 def running_on_travis():
-    return any(ev.startswith(CI_IDENTIFIERS.get('travis') for ev in os.environ))
+    return any(ev.startswith(CI_IDENTIFIERS.get('travis')) for ev in os.environ)
 
 
 def running_on_ci():

--- a/datadog_checks_dev/datadog_checks/dev/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/utils.py
@@ -38,7 +38,7 @@ def running_on_travis():
 
 
 def running_on_ci():
-    return any(ev.startswith(CI_IDENTIFIERS.values()) for ev in os.environ)
+    return any(ev.startswith(tuple(CI_IDENTIFIERS.values())) for ev in os.environ)
 
 
 if PY3:

--- a/datadog_checks_dev/datadog_checks/dev/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/utils.py
@@ -23,14 +23,22 @@ ON_MACOS = os.name == 'mac' or __platform == 'Darwin'
 ON_WINDOWS = NEED_SHELL = os.name == 'nt' or __platform == 'Windows'
 ON_LINUX = not (ON_MACOS or ON_WINDOWS)
 
-CI_IDENTIFIERS = (
-    'APPVEYOR_',
-    'TRAVIS_',
-)
+CI_IDENTIFIERS = {
+    'appveyor': 'APPVEYOR_',
+    'travis': 'TRAVIS_',
+}
+
+
+def running_on_appveyor():
+    return any(ev.startswith(CI_IDENTIFIERS.get('appveyor') for ev in os.environ))
+
+
+def running_on_travis():
+    return any(ev.startswith(CI_IDENTIFIERS.get('travis') for ev in os.environ))
 
 
 def running_on_ci():
-    return any(ev.startswith(CI_IDENTIFIERS) for ev in os.environ)
+    return any(ev.startswith(CI_IDENTIFIERS.values()) for ev in os.environ)
 
 
 if PY3:

--- a/datadog_checks_dev/tests/common.py
+++ b/datadog_checks_dev/tests/common.py
@@ -1,0 +1,9 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.dev.utils import running_on_appveyor
+
+
+not_appveyor = pytest.mark.skipif(running_on_appveyor(), reason="Test can't be run on Appveyor")

--- a/datadog_checks_dev/tests/conftest.py
+++ b/datadog_checks_dev/tests/conftest.py
@@ -3,6 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
+from datadog_checks.dev.utils import running_on_appveyor
+
 
 @pytest.fixture(scope='session')
 def mock_e2e_config():
@@ -27,3 +29,6 @@ def mock_e2e_metadata():
 @pytest.fixture(scope='session')
 def dd_environment(mock_e2e_config, mock_e2e_metadata):
     yield mock_e2e_config, mock_e2e_metadata
+
+
+not_appveyor = pytest.mark.skipif(running_on_appveyor(), reason="Test can't be run on Appveyor")

--- a/datadog_checks_dev/tests/plugin/test_environment_runner.py
+++ b/datadog_checks_dev/tests/plugin/test_environment_runner.py
@@ -1,16 +1,18 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
+import os
 import json
 from base64 import urlsafe_b64decode
 
+import pytest
 
+from datadog_checks.dev._env import TESTING_PLUGIN
+
+
+@pytest.mark.skipif(os.getenv(TESTING_PLUGIN) != 'true', reason="Plugin is not enabled, skipping plugin test...")
 def test_runner(dd_environment_runner, mock_e2e_config, mock_e2e_metadata):
     message = dd_environment_runner
-    if not message:
-        # this can happen when tests are manually run
-        pytest.skip("ddev plugin not loaded, skipping plugin test...")
 
     encoded = message.split(' ')[1]
     decoded = urlsafe_b64decode(encoded.encode('utf-8'))

--- a/datadog_checks_dev/tests/plugin/test_environment_runner.py
+++ b/datadog_checks_dev/tests/plugin/test_environment_runner.py
@@ -1,12 +1,16 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
 import json
 from base64 import urlsafe_b64decode
 
 
 def test_runner(dd_environment_runner, mock_e2e_config, mock_e2e_metadata):
     message = dd_environment_runner
+    if not message:
+        # this can happen when tests are manually run
+        pytest.skip("ddev plugin not loaded, skipping plugin test...")
 
     encoded = message.split(' ')[1]
     decoded = urlsafe_b64decode(encoded.encode('utf-8'))

--- a/datadog_checks_dev/tests/test_conditions.py
+++ b/datadog_checks_dev/tests/test_conditions.py
@@ -11,6 +11,7 @@ from datadog_checks.dev.conditions import (
 )
 from datadog_checks.dev.errors import RetryError
 from datadog_checks.dev.subprocess import run_command
+from datadog_checks.dev.utils import running_on_appveyor
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 DOCKER_DIR = os.path.join(HERE, 'docker')

--- a/datadog_checks_dev/tests/test_conditions.py
+++ b/datadog_checks_dev/tests/test_conditions.py
@@ -11,7 +11,8 @@ from datadog_checks.dev.conditions import (
 )
 from datadog_checks.dev.errors import RetryError
 from datadog_checks.dev.subprocess import run_command
-from datadog_checks.dev.utils import running_on_appveyor
+
+from .conftest import not_appveyor
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 DOCKER_DIR = os.path.join(HERE, 'docker')
@@ -78,9 +79,9 @@ class TestCheckCommandOutput:
         assert matches == 2
 
 
-@pytest.mark.docker
-@pytest.mark.skipif(running_on_appveyor(), reason="Docker is not supported on Appveyor")
 class TestCheckDockerLogs:
+    pytestmark = [pytest.mark.docker, not_appveyor]
+
     def test_no_matches(self):
         compose_file = os.path.join(DOCKER_DIR, 'test_default.yaml')
         run_command(['docker-compose', '-f', compose_file, 'down'])

--- a/datadog_checks_dev/tests/test_conditions.py
+++ b/datadog_checks_dev/tests/test_conditions.py
@@ -12,7 +12,7 @@ from datadog_checks.dev.conditions import (
 from datadog_checks.dev.errors import RetryError
 from datadog_checks.dev.subprocess import run_command
 
-from .conftest import not_appveyor
+from .common import not_appveyor
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 DOCKER_DIR = os.path.join(HERE, 'docker')

--- a/datadog_checks_dev/tests/test_conditions.py
+++ b/datadog_checks_dev/tests/test_conditions.py
@@ -78,6 +78,7 @@ class TestCheckCommandOutput:
 
 
 @pytest.mark.docker
+@pytest.mark.skipif(running_on_appveyor(), reason="Docker is not supported on Appveyor")
 class TestCheckDockerLogs:
     def test_no_matches(self):
         compose_file = os.path.join(DOCKER_DIR, 'test_default.yaml')

--- a/datadog_checks_dev/tests/test_conditions.py
+++ b/datadog_checks_dev/tests/test_conditions.py
@@ -77,6 +77,7 @@ class TestCheckCommandOutput:
         assert matches == 2
 
 
+@pytest.mark.docker
 class TestCheckDockerLogs:
     def test_no_matches(self):
         compose_file = os.path.join(DOCKER_DIR, 'test_default.yaml')

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -3,8 +3,12 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 
+import pytest
+
 from datadog_checks.dev.docker import compose_file_active, docker_run
 from datadog_checks.dev.subprocess import run_command
+
+pytestmark = pytest.mark.docker
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 DOCKER_DIR = os.path.join(HERE, 'docker')

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -8,7 +8,7 @@ import pytest
 from datadog_checks.dev.docker import compose_file_active, docker_run
 from datadog_checks.dev.subprocess import run_command
 
-from .conftest import not_appveyor
+from .common import not_appveyor
 
 pytestmark = [pytest.mark.docker, not_appveyor]
 HERE = os.path.dirname(os.path.abspath(__file__))

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -9,11 +9,9 @@ from datadog_checks.dev.docker import compose_file_active, docker_run
 from datadog_checks.dev.subprocess import run_command
 from datadog_checks.dev.utils import running_on_appveyor
 
-pytestmark = [
-    pytest.mark.docker,
-    pytest.mark.skipif(running_on_appveyor(), reason="Docker is not supported on Appveyor"),
-]
+from .conftest import not_appveyor
 
+pytestmark = [pytest.mark.docker, not_appveyor]
 HERE = os.path.dirname(os.path.abspath(__file__))
 DOCKER_DIR = os.path.join(HERE, 'docker')
 

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -7,7 +7,6 @@ import pytest
 
 from datadog_checks.dev.docker import compose_file_active, docker_run
 from datadog_checks.dev.subprocess import run_command
-from datadog_checks.dev.utils import running_on_appveyor
 
 from .conftest import not_appveyor
 

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -7,8 +7,12 @@ import pytest
 
 from datadog_checks.dev.docker import compose_file_active, docker_run
 from datadog_checks.dev.subprocess import run_command
+from datadog_checks.dev.utils import running_on_appveyor
 
-pytestmark = pytest.mark.docker
+pytestmark = [
+    pytest.mark.docker,
+    pytest.mark.skipif(running_on_appveyor(), reason="Docker is not supported on Appveyor"),
+]
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 DOCKER_DIR = os.path.join(HERE, 'docker')

--- a/datadog_checks_dev/tests/test_utils.py
+++ b/datadog_checks_dev/tests/test_utils.py
@@ -1,0 +1,22 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+import mock
+
+
+from datadog_checks.dev.utils import (
+    running_on_appveyor, running_on_travis, running_on_ci
+)
+
+
+def test_running_on_appveyor():
+    with mock.patch.dict(os.environ, {'APPVEYOR_FOO': 'foo'}):
+        assert running_on_appveyor() is True
+        assert running_on_ci() is True
+
+
+def test_running_on_travis():
+    with mock.patch.dict(os.environ, {'TRAVIS_FOO': 'foo'}):
+        assert running_on_travis() is True
+        assert running_on_ci() is True

--- a/datadog_checks_dev/tests/test_utils.py
+++ b/datadog_checks_dev/tests/test_utils.py
@@ -11,12 +11,12 @@ from datadog_checks.dev.utils import (
 
 
 def test_running_on_appveyor():
-    with mock.patch.dict(os.environ, {'APPVEYOR_FOO': 'foo'}):
+    with mock.patch.dict(os.environ, {'APPVEYOR': 'true'}):
         assert running_on_appveyor() is True
         assert running_on_ci() is True
 
 
 def test_running_on_travis():
-    with mock.patch.dict(os.environ, {'TRAVIS_FOO': 'foo'}):
+    with mock.patch.dict(os.environ, {'TRAVIS': 'true'}):
         assert running_on_travis() is True
         assert running_on_ci() is True

--- a/datadog_checks_dev/tests/tooling/test_constants.py
+++ b/datadog_checks_dev/tests/tooling/test_constants.py
@@ -1,0 +1,24 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import mock
+
+from datadog_checks.dev.tooling.constants import (
+    get_agent_release_requirements, get_agent_requirements, get_root, set_root
+)
+
+
+def test_get_agent_release_requirements():
+    with mock.patch('datadog_checks.dev.tooling.constants.get_root', return_value='/'):
+        assert get_agent_release_requirements() == '/requirements-agent-release.txt'
+
+
+def test_get_agent_requirements():
+    with mock.patch('datadog_checks.dev.tooling.constants.get_root', return_value='/'):
+        assert get_agent_requirements() == '/datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+
+
+def test_get_root():
+    assert get_root() == ''
+    set_root('foo')
+    assert get_root() == 'foo'

--- a/datadog_checks_dev/tests/tooling/test_constants.py
+++ b/datadog_checks_dev/tests/tooling/test_constants.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import os
 import mock
 
 from datadog_checks.dev.tooling.constants import (
@@ -9,13 +10,17 @@ from datadog_checks.dev.tooling.constants import (
 
 
 def test_get_agent_release_requirements():
-    with mock.patch('datadog_checks.dev.tooling.constants.get_root', return_value='/'):
-        assert get_agent_release_requirements() == '/requirements-agent-release.txt'
+    with mock.patch('datadog_checks.dev.tooling.constants.get_root', return_value='foo'):
+        expected = os.path.join('foo', 'requirements-agent-release.txt')
+        assert get_agent_release_requirements() == expected
 
 
 def test_get_agent_requirements():
-    with mock.patch('datadog_checks.dev.tooling.constants.get_root', return_value='/'):
-        assert get_agent_requirements() == '/datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+    with mock.patch('datadog_checks.dev.tooling.constants.get_root', return_value='foo'):
+        expected = os.path.join(
+            'foo', 'datadog_checks_base', 'datadog_checks', 'base', 'data', 'agent_requirements.in'
+        )
+        assert get_agent_requirements() == expected
 
 
 def test_get_root():

--- a/datadog_checks_dev/tests/tooling/test_dep.py
+++ b/datadog_checks_dev/tests/tooling/test_dep.py
@@ -63,8 +63,6 @@ def test_package_rich_comparison(package):
     if six.PY3:
         with pytest.raises(TypeError):
             package < 42
-    else:
-        assert (package < 42) is True
 
 
 def test_package__hash__(package):

--- a/datadog_checks_dev/tests/tooling/test_git.py
+++ b/datadog_checks_dev/tests/tooling/test_git.py
@@ -1,0 +1,134 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import mock
+
+from datadog_checks.dev.tooling.constants import set_root
+from datadog_checks.dev.tooling.git import (
+    get_current_branch, files_changed, get_commits_since, git_show_file,
+    git_commit, git_tag, git_tag_list
+)
+
+
+def test_get_current_branch():
+    with mock.patch('datadog_checks.dev.tooling.git.chdir') as chdir:
+        with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
+            set_root('/foo/')
+            get_current_branch()
+            chdir.assert_called_once_with('/foo/')
+            run.assert_called_once_with('git rev-parse --abbrev-ref HEAD', capture='out')
+
+
+def test_files_changed():
+    with mock.patch('datadog_checks.dev.tooling.git.chdir') as chdir:
+        with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
+            run.return_value = mock.MagicMock()
+            expected = ['foo', 'bar', 'baz']
+            run.return_value.stdout = "\n".join(expected)
+            set_root('/foo/')
+            retval = files_changed()
+            chdir.assert_called_once_with('/foo/')
+            run.assert_called_once_with('git diff --name-only master...', capture='out')
+            assert retval == expected
+
+
+def test_get_commits_since():
+    with mock.patch('datadog_checks.dev.tooling.git.chdir') as chdir:
+        with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
+            set_root('/foo/')
+            get_commits_since('my-check')
+            chdir.assert_called_once_with('/foo/')
+            get_commits_since('my-check', target_tag='the-tag')
+            run.assert_any_call('git log --pretty=%s /foo/my-check', capture=True)
+            run.assert_any_call('git log --pretty=%s the-tag... /foo/my-check', capture=True)
+
+
+def test_git_show_file():
+    with mock.patch('datadog_checks.dev.tooling.git.chdir') as chdir:
+        with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
+            set_root('/foo/')
+            git_show_file('path-string', 'git-ref-string')
+            chdir.assert_called_once_with('/foo/')
+            run.assert_called_once_with('git show git-ref-string:path-string', capture=True)
+
+
+def test_git_commit():
+    with mock.patch('datadog_checks.dev.tooling.git.chdir') as chdir:
+        with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
+            set_root('/foo/')
+            targets = ['a', 'b', 'c']
+
+            # all good
+            run.return_value = mock.MagicMock(code=0)
+            git_commit(targets, 'my message')
+            chdir.assert_called_once_with('/foo/')
+            run.assert_any_call('git add /foo/a /foo/b /foo/c')
+            run.assert_any_call('git commit -m "my message"')
+            chdir.reset_mock()
+            run.reset_mock()
+
+            # all good, more params
+            git_commit(targets, 'my message', force=True, sign=True)
+            chdir.assert_called_once_with('/foo/')
+            run.assert_any_call('git add -f /foo/a /foo/b /foo/c')
+            run.assert_any_call('git commit -S -m "my message"')
+            chdir.reset_mock()
+            run.reset_mock()
+
+            # git add fails
+            run.return_value = mock.MagicMock(code=123)
+            git_commit(targets, 'my message')
+            chdir.assert_called_once_with('/foo/')
+            # we expect only one call, git commit should not be called
+            run.assert_called_once_with('git add /foo/a /foo/b /foo/c')
+
+
+def test_git_tag():
+    with mock.patch('datadog_checks.dev.tooling.git.chdir') as chdir:
+        with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
+            set_root('/foo/')
+            run.return_value = mock.MagicMock(code=0)
+
+            # all good
+            git_tag('tagname')
+            chdir.assert_called_once_with('/foo/')
+            run.assert_called_once_with('git tag -a tagname -m "tagname"', capture=True)
+            assert run.call_count == 1
+            chdir.reset_mock()
+            run.reset_mock()
+
+            # again with push
+            git_tag('tagname', push=True)
+            chdir.assert_called_once_with('/foo/')
+            run.assert_any_call('git tag -a tagname -m "tagname"', capture=True)
+            run.assert_any_call('git push origin tagname')
+            chdir.reset_mock()
+            run.reset_mock()
+
+            # again with tag failing
+            run.return_value = mock.MagicMock(code=123)
+            git_tag('tagname', push=True)
+            chdir.assert_called_once_with('/foo/')
+            # we expect only one call, git push should be skipped
+            run.assert_called_once_with('git tag -a tagname -m "tagname"', capture=True)
+
+
+def test_git_tag_list():
+    with mock.patch('datadog_checks.dev.tooling.git.chdir') as chdir:
+        with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
+            set_root('/foo/')
+            expected = ['a', 'b', 'c']
+            run.return_value = mock.MagicMock(code=0)
+            run.return_value.stdout = '\n'.join(expected)
+
+            # no pattern
+            res = git_tag_list()
+            assert res == expected
+            chdir.assert_called_once_with('/foo/')
+            chdir.reset_mock()
+            run.reset_mock()
+
+            # pattern
+            res = git_tag_list(r'^a')
+            assert res == ['a']
+            chdir.assert_called_once_with('/foo/')

--- a/datadog_checks_dev/tests/tooling/test_release.py
+++ b/datadog_checks_dev/tests/tooling/test_release.py
@@ -1,7 +1,13 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.dev.tooling.release import get_package_name, get_folder_name
+import mock
+import pytest
+
+from datadog_checks.dev.errors import ManifestError
+from datadog_checks.dev.tooling.release import (
+    get_package_name, get_folder_name, get_agent_requirement_line
+)
 
 
 def test_get_package_name():
@@ -12,3 +18,44 @@ def test_get_package_name():
 def test_get_folder_name():
     assert get_folder_name('datadog-checks-base') == 'datadog_checks_base'
     assert get_folder_name('datadog-my-check') == 'my_check'
+
+
+def test_get_agent_requirement_line():
+    res = get_agent_requirement_line('datadog_checks_base', '1.1.0')
+    assert res == 'datadog-checks-base==1.1.0'
+
+    with mock.patch('datadog_checks.dev.tooling.release.load_manifest') as load:
+        # wrong manifest
+        load.return_value = {}
+        with pytest.raises(ManifestError):
+            get_agent_requirement_line('foo', '1.2.3')
+
+        # all platforms
+        load.return_value = {
+            "supported_os": [
+                "linux",
+                "mac_os",
+                "windows"
+            ]
+        }
+        res = get_agent_requirement_line('foo', '1.2.3')
+        assert res == 'datadog-foo==1.2.3'
+
+        # one platform
+        load.return_value = {
+            "supported_os": [
+                "linux"
+            ]
+        }
+        res = get_agent_requirement_line('foo', '1.2.3')
+        assert res == "datadog-foo==1.2.3; sys_platform == 'linux2'"
+
+        # multiple platforms
+        load.return_value = {
+            "supported_os": [
+                "linux",
+                "mac_os",
+            ]
+        }
+        res = get_agent_requirement_line('foo', '1.2.3')
+        assert res == "datadog-foo==1.2.3; sys_platform != 'win32'"

--- a/datadog_checks_dev/tests/tooling/test_utils.py
+++ b/datadog_checks_dev/tests/tooling/test_utils.py
@@ -1,0 +1,21 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import mock
+
+from datadog_checks.dev.tooling.utils import (
+    parse_agent_req_file, get_version_string
+)
+
+
+def test_parse_agent_req_file():
+    contents = "datadog-active-directory==1.1.1; sys_platform == 'win32'\nthis is garbage"
+    catalog = parse_agent_req_file(contents)
+    assert len(catalog) is 1
+    assert catalog['datadog-active-directory'] == '1.1.1'
+
+
+def test_get_version_string():
+    with mock.patch('datadog_checks.dev.tooling.utils.read_version_file') as read:
+        read.return_value = '__version__ = "2.0.0"'
+        assert get_version_string('foo_check') == '2.0.0'

--- a/datadog_checks_dev/tox.ini
+++ b/datadog_checks_dev/tox.ini
@@ -9,9 +9,7 @@ envlist =
 [testenv]
 usedevelop = true
 skip_install = true
-platform =
-    docker: linux|darwin
-    default: linux|darwin|win32
+platform = linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt

--- a/datadog_checks_dev/tox.ini
+++ b/datadog_checks_dev/tox.ini
@@ -3,13 +3,15 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py27
 envlist =
-    {py27,py36,py37}-dev
+    {py27,py36,py37}-{docker,default}
     flake8
 
 [testenv]
 usedevelop = true
 skip_install = true
-platform = linux|darwin|win32
+platform =
+    dev: linux|darwin
+    unit: linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
@@ -19,7 +21,8 @@ passenv =
 setenv =
     DDEV_TESTING_PLUGIN=true
 commands =
-    pytest tests
+    {py27,py36,py37}-default: pytest tests -m"not docker"
+    {py27,py36,py37}-docker: pytest tests -m"docker"
 
 [testenv:flake8]
 deps = flake8

--- a/datadog_checks_dev/tox.ini
+++ b/datadog_checks_dev/tox.ini
@@ -16,6 +16,8 @@ deps =
 passenv =
     DOCKER*
     COMPOSE*
+    APPVEYOR*
+    TRAVIS*
 setenv =
     DDEV_TESTING_PLUGIN=true
 commands =

--- a/datadog_checks_dev/tox.ini
+++ b/datadog_checks_dev/tox.ini
@@ -10,8 +10,8 @@ envlist =
 usedevelop = true
 skip_install = true
 platform =
-    dev: linux|darwin
-    unit: linux|darwin|win32
+    docker: linux|darwin
+    default: linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt


### PR DESCRIPTION
### What does this PR do?

Move Agent-related tasks away from `ddev release` into their own subcommand:

```
(core3) ↳ ddev agent
Usage: ddev agent [OPTIONS] COMMAND [ARGS]...

Options:
  -h, --help  Show this message and exit.

Commands:
  changelog     Provide a list of updated checks on a given Datadog Agent
                version, in changelog form
  requirements  Generate the list of integrations to ship with the Agent and
                save it to 'requirements-agent-release.txt'
```

### Motivation

Preparing the tool to accommodate another agent-related task

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Command names were slightly changed, this would be a breaking change in theory but we're not yet ready for `1.0`
