### PR TITLE
Use 'format()' function to create device tag

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -318,11 +318,11 @@ class AgentCheck(object):
         - normalize tags to type `str`
         - always return a list
         """
-        normalized_tags = self._normalize_tags_type(tags)
-
         if device_name:
             self._log_deprecation("device_name")
-            normalized_tags.append("device:{}".format(device_name))
+            tags.append("device:{}".format(device_name))
+
+        normalized_tags = self._normalize_tags_type(tags)
 
         return normalized_tags
 

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -322,7 +322,7 @@ class AgentCheck(object):
 
         if device_name:
             self._log_deprecation("device_name")
-            normalized_tags.append("device:%s" % device_name)
+            normalized_tags.append("device:{}".format(device_name))
 
         return normalized_tags
 

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -157,6 +157,17 @@ class TestTags:
         assert normalized_tags is not tags
         assert normalized_tag == tag.encode('utf-8')
 
+    def test_unicode_device_name(self):
+        check = AgentCheck()
+        tags = ['test:tag']
+        device_name = u'unicode_string'
+
+        normalized_tags = check._normalize_tags(tags, device_name)
+        normalized_device_tag = normalized_tags[0]
+
+        assert len(normalized_tags) is 2
+        assert normalized_device_tag == tag.encode('utf-8')
+
 
 class LimitedCheck(AgentCheck):
     DEFAULT_METRIC_LIMIT = 10

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -163,7 +163,7 @@ class TestTags:
         device_name = u'unicode_string'
 
         normalized_tags = check._normalize_tags(tags, device_name)
-        normalized_device_tag = normalized_tags[0]
+        normalized_device_tag = normalized_tags[1]
 
         assert len(normalized_tags) is 2
         assert isinstance(normalized_device_tag, str)

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -165,7 +165,7 @@ class TestTags:
         normalized_tags = check._normalize_tags(tags, device_name)
         normalized_device_tag = normalized_tags[0]
 
-        assert isinstance(normalized_device_tag, bytes)
+        assert isinstance(normalized_device_tag, str)
 
 
 class LimitedCheck(AgentCheck):

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -159,14 +159,13 @@ class TestTags:
 
     def test_unicode_device_name(self):
         check = AgentCheck()
-        tags = ['test:tag']
+        tags = []
         device_name = u'unicode_string'
 
         normalized_tags = check._normalize_tags(tags, device_name)
-        normalized_device_tag = normalized_tags[1]
+        normalized_device_tag = normalized_tags[0]
 
-        assert len(normalized_tags) is 2
-        assert isinstance(normalized_device_tag, str)
+        assert isinstance(normalized_device_tag, bytes)
 
 
 class LimitedCheck(AgentCheck):

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -166,7 +166,7 @@ class TestTags:
         normalized_device_tag = normalized_tags[0]
 
         assert len(normalized_tags) is 2
-        assert normalized_device_tag == tag.encode('utf-8')
+        assert isinstance(normalized_device_tag, str)
 
 
 class LimitedCheck(AgentCheck):

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -165,7 +165,7 @@ class TestTags:
         normalized_tags = check._normalize_tags(tags, device_name)
         normalized_device_tag = normalized_tags[0]
 
-        assert isinstance(normalized_device_tag, str)
+        assert isinstance(normalized_device_tag, bytes)
 
 
 class LimitedCheck(AgentCheck):


### PR DESCRIPTION
### What does this PR do?

Uses `.format()` to create the device tag since using `%s` with a unicode string [can result in the entire object being turn into a unicode type](https://bugs.python.org/issue9196)

### Motivation

User reported the Agent logs being filled with [this line](https://github.com/DataDog/datadog-agent/blob/6.8.x/pkg/collector/py/api.go#L231) from the Agent's `extractTags()` function that warned about a tag being a unicode type and therefore getting ignored. Full output from the logs here:

```
2018-12-20 22:50:35 UTC | INFO | (api.go:231 in extractTags) | One of the submitted tags for the check with ID couchbase:<id> is not a string but a unicode: u'device:<device-tag>', ignoring it
2018-12-20 22:50:36 UTC | INFO | (api.go:231 in extractTags) | One of the submitted tags for the check with ID couchbase:<id> is not a string but a unicode: u'device:<device-tag>', ignoring it
2018-12-20 22:50:36 UTC | INFO | (api.go:231 in extractTags) | One of the submitted tags for the check with ID couchbase:<id> is not a string but a unicode: u'device:<device-tag>', ignoring it
```

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Code snippet from running a simple demonstration in a Python shell to show the difference in behavior from `.format()` and `%s` when unicode is included

```
>>> bucket = u"test"
>>> test = "yo:{}".format(bucket)
>>> print test
yo:test
>>> print type(test)
<type 'str'>
```

```
>>> test = "yo %s" % bucket
>>> print test
yo test
>>> print type(test)
<type 'unicode'>
```