### PR TITLE
Test gitlab regex for pre releases

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,6 @@ test:
   only:
     - master
     # e.g.: any_check-X.Y.Z-rc.N
-    - /-\d\.\d\.\d-(rc|pre|alpha|beta)\.\d+$/
+    - /.*-\d\.\d\.\d-(rc|pre|alpha|beta)\.\d+$/
   script: if [ -n "$DD_TEST_CMD" ] ; then eval "$DD_TEST_CMD" ; else echo "skipping, DD_TEST_CMD is not set" ; fi
   tags: [ "runner:main", "size:large" ]


### PR DESCRIPTION
### What does this PR do?

Try to be more lenient with the gitlab `only` regex to allow pre commit tags to be picked up by the pipeline

### Motivation

Currently tagging a pre release isn't triggering the pipeline. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
