### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -239,7 +239,7 @@ jobs:
     - stage: test
       env: CHECK=tcp_check
     - stage: test
-      env: CHECK=teamcity
+      env: CHECK=teamcity PYTHON3=true
     - stage: test
       env: CHECK=tokumx
     - stage: test

--- a/teamcity/tests/test_teamcity.py
+++ b/teamcity/tests/test_teamcity.py
@@ -49,7 +49,7 @@ def test_build_event(aggregator):
     assert events[0]['msg_text'] == "Build Number: 2\nDeployed To: buildhost42.dtdg.co\n\nMore Info: " + \
                                     "http://localhost:8111/viewLog.html?buildId=2&buildTypeId=TestProject_TestBuild"
     assert events[0]['tags'] == ['build', 'one:tag', 'one:test']
-    assert events[0]['host'] == "buildhost42.dtdg.co"
+    assert events[0]['host'] == b"buildhost42.dtdg.co"
     aggregator.reset()
 
     # One more check should not create any more events

--- a/teamcity/tests/test_unit.py
+++ b/teamcity/tests/test_unit.py
@@ -5,6 +5,8 @@
 # project
 from datadog_checks.teamcity import TeamCityCheck
 
+from six import iteritems
+
 # A path regularly used in the TeamCity Check
 COMMON_PATH = "guestAuth/app/rest/builds/?locator=buildType:TestProject_TestBuild,sinceBuild:id:1,status:SUCCESS"
 
@@ -38,7 +40,7 @@ def test_server_normalization():
 
     teamcity = TeamCityCheck("teamcity", {}, {})
 
-    for server, expected_server in TEAMCITY_SERVER_VALUES.iteritems():
+    for server, expected_server in iteritems(TEAMCITY_SERVER_VALUES):
         normalized_server = teamcity._normalize_server_url(server)
 
         assert expected_server == normalized_server

--- a/teamcity/tox.ini
+++ b/teamcity/tox.ini
@@ -2,8 +2,8 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    unit
-    teamcity
+    {py27,py36}-unit
+    {py27,py36}-teamcity
     flake8
 
 [testenv]
@@ -12,16 +12,10 @@ platform = linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
-
-[testenv:teamcity]
 commands =
     pip install -r requirements.in
-    pytest -m"integration" -v
-
-[testenv:unit]
-commands =
-    pip install -r requirements.in
-    pytest -m"not integration" -v
+    teamcity: pytest -m"integration" -v
+    unit: pytest -m"not integration" -v
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
### What does this PR do?

This moves teamcity to python 3.

I tried to ensure that the hosts element was unicode instead of bytes, but could not. For some reason the way that the aggregator stub works makes this impossible to do. (I didn't dig into it all the way, but it seems to treat some events differently and only decodes them sometimes.)

### Motivation

Python 3 is on its way

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
