### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -227,7 +227,7 @@ jobs:
     - stage: test
       env: CHECK=ssh_check
     - stage: test
-      env: CHECK=statsd
+      env: CHECK=statsd PYTHON3=true
     - stage: test
       env: CHECK=supervisord
     - stage: test

--- a/statsd/tests/test_statsd.py
+++ b/statsd/tests/test_statsd.py
@@ -6,8 +6,6 @@ import os
 
 import pytest
 
-import time
-
 from datadog_checks.dev import docker_run, get_docker_hostname
 from datadog_checks.statsd.statsd import StatsCheck, SERVICE_CHECK_NAME_HEALTH, SERVICE_CHECK_NAME
 
@@ -46,16 +44,9 @@ def get_instance():
 @pytest.fixture(scope='session', autouse=True)
 def spin_up_statsd():
     with docker_run(
-        compose_file=os.path.join(HERE, 'compose', 'statsd.yaml')
+        compose_file=os.path.join(HERE, 'compose', 'statsd.yaml'),
+        log_patterns=['server is up']
     ):
-
-        # In Python 3 the url checker does not work.
-        # It doesn't handle raw tcp connections
-        # in fact the only reason it worked in Python 2 was that it was broken
-        # The only good way to mock this would be to duplicate the logic in the check
-        # which doesn't make a very good test.
-        # Instead, just add a sleep here since the container is pretty quick to spin up
-        time.sleep(10)
         yield
 
 

--- a/statsd/tox.ini
+++ b/statsd/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    statsd
+    {py27,py36}-statsd
     flake8
 
 [testenv]


### PR DESCRIPTION
### What does this PR do?

Make Statsd support Python 3

### Motivation

🐍 🚂 

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

There's a few things to note:

This check has extensive string handling. I have done my best to ensure that, I believe, it is handled consistently between the two versions. But it's complex enough that I am not 100% positive I didn't accidentally introduce a bug.

In Python 2 we used the URL checker to ensure that the docker container spun up. However, it did not really do that. It relied on a bug in the implementation. 

There's no good way to do this for a raw tcp connection (instead of an http connection) without replicating the tcp handling logic we have in the check. So, instead, I've just put a sleep in there. This docker container is simple enough that it should always spin up in time. 

However, it does introduce a source of uncertainty that is problematic. If someone has a thought on how to better to do this, I'm open to hearing it.
