### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -177,7 +177,7 @@ jobs:
     - stage: test
       env: CHECK=mysql PYTHON3=true
     - stage: test
-      env: CHECK=nagios
+      env: CHECK=nagios PYTHON3=true
     - stage: test
       env: CHECK=network
     - stage: test

--- a/datadog_checks_base/datadog_checks/base/utils/tailfile.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tailfile.py
@@ -5,6 +5,8 @@ import binascii
 import os
 from stat import ST_INO, ST_SIZE
 
+from datadog_checks.utils.common import ensure_bytes
+
 
 class TailFile(object):
 
@@ -36,7 +38,7 @@ class TailFile(object):
         crc = None
         if size >= self.CRC_SIZE:
             tmp_file = open(self._path, 'r')
-            data = tmp_file.read(self.CRC_SIZE)
+            data = ensure_bytes(tmp_file.read(self.CRC_SIZE))
             crc = binascii.crc32(data)
 
         if already_open:

--- a/datadog_checks_base/datadog_checks/base/utils/tailfile.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tailfile.py
@@ -5,7 +5,7 @@ import binascii
 import os
 from stat import ST_INO, ST_SIZE
 
-from datadog_checks.utils.common import ensure_bytes
+from .common import ensure_bytes
 
 
 class TailFile(object):

--- a/nagios/datadog_checks/nagios/nagios.py
+++ b/nagios/datadog_checks/nagios/nagios.py
@@ -14,8 +14,7 @@ from datadog_checks.base.utils.tailfile import TailFile
 if not PY3:
     from inspect import getargspec
 else:
-    from inspect import getfullargspec
-    getargspec = getfullargspec
+    from inspect import getfullargspec as getargspec
 
 
 # fields order for each event type, as named tuples

--- a/nagios/datadog_checks/nagios/nagios.py
+++ b/nagios/datadog_checks/nagios/nagios.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import division
 
 from collections import namedtuple
 import json

--- a/nagios/datadog_checks/nagios/nagios.py
+++ b/nagios/datadog_checks/nagios/nagios.py
@@ -6,7 +6,6 @@ from collections import namedtuple
 import json
 import re
 from six import next, PY3
-from six.moves import map
 
 from datadog_checks.checks import AgentCheck
 from datadog_checks.utils.tailfile import TailFile
@@ -326,7 +325,7 @@ class NagiosEventLogTailer(NagiosTailer):
                 return False
 
             # and parse the rest of the line
-            parts = list(map(lambda p: p.strip(), remainder.split(';')))
+            parts = [p.strip() for p in remainder.split(';')]
             # Chop parts we don't recognize
             parts = parts[: len(fields._fields)]
 

--- a/nagios/datadog_checks/nagios/nagios.py
+++ b/nagios/datadog_checks/nagios/nagios.py
@@ -7,8 +7,8 @@ import json
 import re
 from six import next, PY3
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.utils.tailfile import TailFile
+from datadog_checks.base import AgentCheck
+from datadog_checks.base.utils.tailfile import TailFile
 
 if not PY3:
     from inspect import getargspec

--- a/nagios/setup.py
+++ b/nagios/setup.py
@@ -23,7 +23,7 @@ def get_requirements(fpath):
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog_checks_base>=4.2.0'
 
 setup(
     name='datadog-nagios',

--- a/nagios/tests/test_nagios.py
+++ b/nagios/tests/test_nagios.py
@@ -7,6 +7,7 @@ import time
 import pytest
 
 from datadog_checks.nagios import Nagios
+from datadog_checks.utils.common import ensure_bytes
 from .common import (
     CHECK_NAME, CUSTOM_TAGS, NAGIOS_TEST_LOG, NAGIOS_TEST_HOST, NAGIOS_TEST_ALT_HOST_TEMPLATE,
     NAGIOS_TEST_HOST_TEMPLATE, NAGIOS_TEST_SVC, NAGIOS_TEST_SVC_TEMPLATE, NAGIOS_TEST_ALT_SVC_TEMPLATE,
@@ -21,7 +22,10 @@ class TestEventLogTailer:
         """
 
         # Get the config
-        config, nagios_cfg = get_config("log_file={}\n".format(NAGIOS_TEST_LOG), events=True, tags=CUSTOM_TAGS)
+        config, nagios_cfg = get_config(
+            ensure_bytes("log_file={}\n".format(NAGIOS_TEST_LOG)),
+            events=True, tags=CUSTOM_TAGS
+        )
 
         # Set up the check
         nagios = Nagios(CHECK_NAME, {}, {}, config['instances'])
@@ -87,7 +91,7 @@ class TestEventLogTailer:
         """
         Make sure the tailer continues to parse nagios as the file grows
         """
-        test_data = open(NAGIOS_TEST_LOG).read()
+        test_data = ensure_bytes(open(NAGIOS_TEST_LOG).read())
         ITERATIONS = 1
         log_file = tempfile.NamedTemporaryFile(mode="a+b")
 
@@ -312,7 +316,7 @@ class TestPerfDataTailer:
         nagios.check(config['instances'][0])
 
         with open(NAGIOS_TEST_SVC, "r") as f:
-            nagios_perf = f.read()
+            nagios_perf = ensure_bytes(f.read())
 
         perfdata_file.write(nagios_perf)
         perfdata_file.flush()
@@ -377,7 +381,7 @@ class TestPerfDataTailer:
         nagios.check(config['instances'][0])
 
         with open(NAGIOS_TEST_HOST, "r") as f:
-            nagios_perf = f.read()
+            nagios_perf = ensure_bytes(f.read())
 
         perfdata_file.write(nagios_perf)
         perfdata_file.flush()
@@ -411,7 +415,7 @@ class TestPerfDataTailer:
         """
         Write log data to log file
         """
-        self.log_file.write(log_data + "\n")
+        self.log_file.write(ensure_bytes(log_data + "\n"))
         self.log_file.flush()
 
 
@@ -419,6 +423,7 @@ def get_config(nagios_conf, events=False, service_perf=False, host_perf=False, t
     """
     Helper to generate a valid Nagios configuration
     """
+    nagios_conf = ensure_bytes(nagios_conf)
     tags = [] if tags is None else tags
 
     NAGIOS_CFG = tempfile.NamedTemporaryFile(mode="a+b")

--- a/nagios/tests/test_nagios.py
+++ b/nagios/tests/test_nagios.py
@@ -7,7 +7,7 @@ import time
 import pytest
 
 from datadog_checks.nagios import Nagios
-from datadog_checks.utils.common import ensure_bytes
+from datadog_checks.base import ensure_bytes
 from .common import (
     CHECK_NAME, CUSTOM_TAGS, NAGIOS_TEST_LOG, NAGIOS_TEST_HOST, NAGIOS_TEST_ALT_HOST_TEMPLATE,
     NAGIOS_TEST_HOST_TEMPLATE, NAGIOS_TEST_SVC, NAGIOS_TEST_SVC_TEMPLATE, NAGIOS_TEST_ALT_SVC_TEMPLATE,

--- a/nagios/tox.ini
+++ b/nagios/tox.ini
@@ -2,8 +2,8 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    unit
-    nagios
+    {py27,py36}-unit
+    {py27,py36}-nagios
     flake8
 
 [testenv]
@@ -12,16 +12,10 @@ deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 platform = linux|darwin|win32
-
-[testenv:unit]
 commands =
     pip install -r requirements.in
-    pytest -m"not integration" -v
-
-[testenv:nagios]
-commands =
-    pip install -r requirements.in
-    pytest -m"integration" -v
+    unit: pytest -m"not integration" -v
+    nagios: pytest -m"integration" -v
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
### What does this PR do?

Supports Python3 for Nagios

Additionally, tailfile in datadog_checks_base needed to be updated to support Py3 

### Motivation

Moving closer to supporting Python3

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

A couple of warnings needed to be addressed:
1) getargspec has been deprecated in Py3 in favor of getfullargspec
2) There was a warning about regexing that simply required an escape char:

```
  integrations-core/nagios/datadog_checks/nagios/nagios.py:270: FutureWarning: Possible nested set at position 1
    regex = re.sub(r'[[\]*]', r'.', file_template)
```