### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -225,7 +225,7 @@ jobs:
     - stage: test
       env: CHECK=sqlserver
     - stage: test
-      env: CHECK=ssh_check
+      env: CHECK=ssh_check PYTHON3=true
     - stage: test
       env: CHECK=statsd PYTHON3=true
     - stage: test

--- a/ssh_check/tests/test_ssh.py
+++ b/ssh_check/tests/test_ssh.py
@@ -62,7 +62,7 @@ class TestSshCheck:
 
         # Check that we've closed all connections, if not we're leaking threads
         # It seems Python3 takes a small amount of time to finish closing threads
-        time.sleep(2)
+        time.sleep(5)
         assert nb_threads == threading.active_count()
 
     def test_ssh_bad_config(self, aggregator):

--- a/ssh_check/tests/test_ssh.py
+++ b/ssh_check/tests/test_ssh.py
@@ -54,12 +54,8 @@ class TestSshCheck:
             for tag in sc.tags:
                 assert tag in ('instance:io.netgarage.org-22', 'optional:tag1')
 
-        for thread in threading.enumerate():
-            try:
-                thread.join(self.THREAD_TIMEOUT)
-            except RuntimeError:
-                pass
-
+        # Check that we've closed all connections, if not we're leaking threads
+        self.wait_for_threads()
         assert nb_threads == threading.active_count()
 
     def test_ssh_bad_config(self, aggregator):
@@ -77,4 +73,12 @@ class TestSshCheck:
             assert sc.status == CheckSSH.CRITICAL
 
         # Check that we've closed all connections, if not we're leaking threads
+        self.wait_for_threads()
         assert nb_threads == threading.active_count()
+
+    def wait_for_threads(self):
+        for thread in threading.enumerate():
+            try:
+                thread.join(self.THREAD_TIMEOUT)
+            except RuntimeError:
+                pass

--- a/ssh_check/tests/test_ssh.py
+++ b/ssh_check/tests/test_ssh.py
@@ -4,6 +4,7 @@
 import threading
 
 import pytest
+import time
 
 from datadog_checks.ssh_check import CheckSSH
 
@@ -60,6 +61,8 @@ class TestSshCheck:
                 assert tag in ('instance:io.netgarage.org-22', 'optional:tag1')
 
         # Check that we've closed all connections, if not we're leaking threads
+        # It seems Python3 takes a small amount of time to finish closing threads
+        time.sleep(2)
         assert nb_threads == threading.active_count()
 
     def test_ssh_bad_config(self, aggregator):

--- a/ssh_check/tox.ini
+++ b/ssh_check/tox.ini
@@ -2,14 +2,12 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    ssh_check
+    {py27,py36}-latest
     flake8
 
 [testenv]
 usedevelop = true
 platform = linux|darwin|win32
-
-[testenv:ssh_check]
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt


### PR DESCRIPTION
### What does this PR do?

The check already seems to support Py3, the tests needed to be updated slightly though. 

Removes redundant stub aggregator fixture. 

### Motivation

Support Py3 for more things. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

The close method on the SSH Client in Python3 seems to require a really brief period of time to finish closing the associated threads, so a sleep was added there. 