### PR TITLE
Fix tablespace metrics

### DIFF
--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -13,6 +13,7 @@ import cx_Oracle
 
 # project
 from datadog_checks.checks import AgentCheck
+from . import queries
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'oracle'
 
@@ -230,9 +231,9 @@ class Oracle(AgentCheck):
     def _get_sys_metrics(self, con, tags):
         if tags is None:
             tags = []
-        query = "SELECT METRIC_NAME, VALUE, BEGIN_TIME FROM GV$SYSMETRIC ORDER BY BEGIN_TIME"
+
         with closing(con.cursor()) as cur:
-            cur.execute(query)
+            cur.execute(queries.SYSTEM)
             for row in cur.fetchall():
                 metric_name = row[0]
                 metric_value = row[1]
@@ -243,9 +244,8 @@ class Oracle(AgentCheck):
         if tags is None:
             tags = []
 
-        query = "SELECT PROGRAM, {} FROM GV$PROCESS".format(','.join(self.PROCESS_METRICS.keys()))
         with closing(con.cursor()) as cur:
-            cur.execute(query)
+            cur.execute(queries.PROCESS.format(','.join(self.PROCESS_METRICS.keys())))
             for row in cur.fetchall():
 
                 # Oracle program name
@@ -259,28 +259,26 @@ class Oracle(AgentCheck):
     def _get_tablespace_metrics(self, con, tags):
         if tags is None:
             tags = []
-        query = "SELECT TABLESPACE_NAME, sum(BYTES), sum(MAXBYTES) FROM sys.dba_data_files GROUP BY TABLESPACE_NAME"
+
         with closing(con.cursor()) as cur:
-            cur.execute(query)
-            for row in cur.fetchall():
-                tablespace_tag = 'tablespace:%s' % row[0]
-                if row[1] is None:
-                    # mark tablespace as offline if sum(BYTES) is null
-                    offline = True
+            cur.execute(queries.TABLESPACE)
+            for tablespace_name, used_bytes, max_bytes, used_percent in cur.fetchall():
+                tablespace_tag = 'tablespace:{}'.format(tablespace_name)
+                if used_bytes is None:
+                    # mark tablespace as offline if null
+                    offline = 1
                     used = 0
                 else:
-                    offline = False
-                    used = float(row[1])
-                if row[2] is None:
+                    offline = 0
+                    used = float(used_bytes)
+                if max_bytes is None:
                     size = 0
                 else:
-                    size = float(row[2])
-                if (used >= size):
-                    in_use = 100
-                elif (used == 0) or (size == 0):
+                    size = float(max_bytes)
+                if used_percent is None:
                     in_use = 0
                 else:
-                    in_use = used / size * 100
+                    in_use = float(used_percent)
 
                 self.gauge('oracle.tablespace.used', used, tags=tags + [tablespace_tag])
                 self.gauge('oracle.tablespace.size', size, tags=tags + [tablespace_tag])

--- a/oracle/datadog_checks/oracle/queries.py
+++ b/oracle/datadog_checks/oracle/queries.py
@@ -11,5 +11,5 @@ select
   m.used_percent
 from
   dba_tablespace_usage_metrics m
-  join dba_tablespaces t on m.tablespace_name = t.tablespace_name;
+  join dba_tablespaces t on m.tablespace_name = t.tablespace_name
 """

--- a/oracle/datadog_checks/oracle/queries.py
+++ b/oracle/datadog_checks/oracle/queries.py
@@ -1,0 +1,15 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+PROCESS = 'SELECT PROGRAM, {} FROM GV$PROCESS'
+SYSTEM = 'SELECT METRIC_NAME, VALUE, BEGIN_TIME FROM GV$SYSMETRIC ORDER BY BEGIN_TIME'
+TABLESPACE = """\
+select
+  m.tablespace_name,
+  m.used_space * t.block_size as used_bytes,
+  m.tablespace_size * t.block_size as max_bytes,
+  m.used_percent
+from
+  dba_tablespace_usage_metrics m
+  join dba_tablespaces t on m.tablespace_name = t.tablespace_name;
+"""

--- a/oracle/tests/test_metrics.py
+++ b/oracle/tests/test_metrics.py
@@ -1,12 +1,13 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
 import mock
+
+from datadog_checks.oracle import queries
 
 
 def test__get_sys_metrics(aggregator, check):
-    query = "SELECT METRIC_NAME, VALUE, BEGIN_TIME FROM GV$SYSMETRIC ORDER BY BEGIN_TIME"
+    query = queries.SYSTEM
     con = mock.MagicMock()
     cur = mock.MagicMock()
     con.cursor.return_value = cur
@@ -20,7 +21,7 @@ def test__get_sys_metrics(aggregator, check):
 
 
 def test__get_process_metrics(aggregator, check):
-    query = "SELECT PROGRAM, {} FROM GV$PROCESS".format(','.join(check.PROCESS_METRICS.keys()))
+    query = queries.PROCESS.format(','.join(check.PROCESS_METRICS.keys()))
     con = mock.MagicMock()
     cur = mock.MagicMock()
     con.cursor.return_value = cur
@@ -42,15 +43,15 @@ def test__get_process_metrics(aggregator, check):
 
 
 def test__get_tablespace_metrics(aggregator, check):
-    query = "SELECT TABLESPACE_NAME, sum(BYTES), sum(MAXBYTES) FROM sys.dba_data_files GROUP BY TABLESPACE_NAME"
+    query = queries.TABLESPACE
 
     con = mock.MagicMock()
     cur = mock.MagicMock()
     cur.fetchall.return_value = [
-        ["offline", None, 100],
-        ["normal", 50, 100],
-        ["full", 100, 100],
-        ["size_0", 1, None]
+        ["offline", None, 100, 0],
+        ["normal", 50, 100, 50],
+        ["full", 100, 100, 100],
+        ["size_0", 1, None, 100]
     ]
     con.cursor.return_value = cur
 


### PR DESCRIPTION
### What does this PR do?

Query tablespace metrics directly instead of computing our own

### Motivation

Previously,

- `size` was the maximum possible size of the tablespace and not the current datafile size. Also this value could be inaccurate if autoextend is disabled.
- `used` was the current size of all the datafiles for a tablespace. The term "used" is accurate from an OS perspective (a tablespace with one 16GB datafile takes up 16GB of disk space) however, the actual object sizes in the tablespace can be much smaller (e.g. a 16GB tablespace could only have 100MB of actual data).
- `in_use` could be inaccurate if autoextend is disabled.

### Additional Notes

I don't know if this table actually reports null for offline tables like our previous computation did. If not, then we should eventually remove the offline metric.