### PR TITLE
Fix indentation for end of .example file

### DIFF
--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -64,6 +64,7 @@ instances:
   #    - <KEY_2>:<VALUE_2>
 
 
+  ## Note: the following configuration params are only available when the `use_preview` param is set to False
   #  API endpoint of your etcd instance
   #  url: "https://server:port"
 

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -67,22 +67,22 @@ instances:
   #  API endpoint of your etcd instance
   #  url: "https://server:port"
 
-    # Change the time to wait on an etcd API request
-    # timeout: 5
+  # Change the time to wait on an etcd API request
+  # timeout: 5
 
-    # If certificate-based authentication of clients is enabled on your etcd server,
-    # specify the key file and the certificate file that the check should use.
-    # ssl_keyfile: /path/to/key/file
-    # ssl_certfile: /path/to/certificate/file
+  # If certificate-based authentication of clients is enabled on your etcd server,
+  # specify the key file and the certificate file that the check should use.
+  # ssl_keyfile: /path/to/key/file
+  # ssl_certfile: /path/to/certificate/file
 
-    # Set to `false` to disable the validation of the server's SSL certificates (default: true).
-    # ssl_cert_validation: true
+  # Set to `false` to disable the validation of the server's SSL certificates (default: true).
+  # ssl_cert_validation: true
 
-    # If ssl_cert_validation is enabled, you can provide a custom file
-    # that lists trusted CA certificates (optional).
-    # ssl_ca_certs: /path/to/CA/certificate/file
+  # If ssl_cert_validation is enabled, you can provide a custom file
+  # that lists trusted CA certificates (optional).
+  # ssl_ca_certs: /path/to/CA/certificate/file
 
-    # optionally, add tags:
-    # tags:
-    # - foo
-    # - bar
+  # optionally, add tags:
+  # tags:
+  # - foo
+  # - bar


### PR DESCRIPTION
Fixes the indentation for etcd conf.yaml.example file starting from line 70 to the end.

See related ticket: https://datadog.zendesk.com/agent/tickets/189108