### PR TITLE
Stop using deprecated 'device_name' parameter.

### DIFF
--- a/couchbase/datadog_checks/couchbase/couchbase.py
+++ b/couchbase/datadog_checks/couchbase/couchbase.py
@@ -290,7 +290,7 @@ class Couchbase(AgentCheck):
 
         # Get node metrics
         for node_name, node_stats in data['nodes'].items():
-            metric_tags = tags[:] or []
+            metric_tags = [] if tags is None else tags[:]
             metric_tags.append('node:{}'.format(node_name))
             metric_tags.append('device:{}'.format(node_name))
             for metric_name, val in node_stats['interestingStats'].items():

--- a/couchbase/datadog_checks/couchbase/couchbase.py
+++ b/couchbase/datadog_checks/couchbase/couchbase.py
@@ -278,23 +278,25 @@ class Couchbase(AgentCheck):
 
         # Get bucket metrics
         for bucket_name, bucket_stats in data['buckets'].items():
-            metric_tags = list(tags)
+            metric_tags = tags[:] or []
             metric_tags.append('bucket:{}'.format(bucket_name))
+            metric_tags.append('device:{}'.format(bucket_name))
             for metric_name, val in bucket_stats.items():
                 if val is not None:
                     norm_metric_name = self.camel_case_to_joined_lower(metric_name)
                     if norm_metric_name in self.BUCKET_STATS:
                         full_metric_name = 'couchbase.by_bucket.{}'.format(norm_metric_name)
-                        self.gauge(full_metric_name, val[0], tags=metric_tags, device_name=bucket_name)
+                        self.gauge(full_metric_name, val[0], tags=metric_tags)
 
         # Get node metrics
         for node_name, node_stats in data['nodes'].items():
-            metric_tags = list(tags)
+            metric_tags = tags[:] or []
             metric_tags.append('node:{}'.format(node_name))
+            metric_tags.append('device:{}'.format(node_name))
             for metric_name, val in node_stats['interestingStats'].items():
                 if val is not None:
                     metric_name = 'couchbase.by_node.{}'.format(self.camel_case_to_joined_lower(metric_name))
-                    self.gauge(metric_name, val, tags=metric_tags, device_name=node_name)
+                    self.gauge(metric_name, val, tags=metric_tags)
 
             # Get cluster health data
             self._process_cluster_health_data(node_name, node_stats, tags)

--- a/couchbase/datadog_checks/couchbase/couchbase.py
+++ b/couchbase/datadog_checks/couchbase/couchbase.py
@@ -278,7 +278,7 @@ class Couchbase(AgentCheck):
 
         # Get bucket metrics
         for bucket_name, bucket_stats in data['buckets'].items():
-            metric_tags = tags[:] or []
+            metric_tags = [] if tags is None else tags[:]
             metric_tags.append('bucket:{}'.format(bucket_name))
             metric_tags.append('device:{}'.format(bucket_name))
             for metric_name, val in bucket_stats.items():

--- a/couchbase/tests/common.py
+++ b/couchbase/tests/common.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
 import os
 
 from datadog_checks.utils.common import get_docker_hostname
@@ -11,38 +10,9 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 # Networking
 HOST = get_docker_hostname()
 PORT = '8091'
-SYSTEM_VITALS_PORT = '8093'
-URL = 'http://{}:{}'.format(HOST, PORT)
-SYSTEM_VITALS_URL = 'http://{}:{}'.format(HOST, SYSTEM_VITALS_PORT)
-
-CB_CONTAINER_NAME = 'couchbase-standalone'
-
-# Authentication
-USER = 'Administrator'
-PASSWORD = 'password'
+QUERY_PORT = '8093'
 
 # Tags and common bucket name
 CUSTOM_TAGS = ['optional:tag1']
 CHECK_TAGS = CUSTOM_TAGS + ['instance:http://{}:{}'.format(HOST, PORT)]
 BUCKET_NAME = 'cb_bucket'
-
-CONFIG = {
-    'instances': [{
-        'server': URL,
-        'user': USER,
-        'password': PASSWORD,
-        'timeout': 0.5,
-        'tags': list(CUSTOM_TAGS),
-    }]
-}
-
-CONFIG_QUERY = {
-    'instances': [{
-        'server': URL,
-        'user': USER,
-        'password': PASSWORD,
-        'timeout': 0.5,
-        'tags': list(CUSTOM_TAGS),
-        'query_monitoring_url': SYSTEM_VITALS_URL,
-    }]
-}

--- a/couchbase/tests/compose/standalone.compose
+++ b/couchbase/tests/compose/standalone.compose
@@ -2,12 +2,7 @@ version: '3.5'
 
 services:
   couchbase-standalone:
-    image: "couchbase/server"
+    image: "couchbase/server:5.5.3"
     ports:
-      - 8091:8091
-      - 8092:8092
-      - 8093:8093
-      - 8094:8094
-      - 11210:11210
-      - 11211:11211
+      - 8091-8094:8091-8094
     container_name: ${CB_CONTAINER_NAME}

--- a/couchbase/tests/test_couchbase.py
+++ b/couchbase/tests/test_couchbase.py
@@ -6,16 +6,16 @@
 import pytest
 
 from datadog_checks.couchbase import Couchbase
-from .common import CONFIG, CONFIG_QUERY, CHECK_TAGS, BUCKET_NAME, PORT
+from .common import CHECK_TAGS, BUCKET_NAME, PORT
 
 
 @pytest.mark.integration
-def test_service_check(aggregator, couchbase_container_ip):
+def test_service_check(aggregator, instance, couchbase_container_ip):
     """
     Assert the OK service check
     """
     couchbase = Couchbase('couchbase', {}, {})
-    couchbase.check(CONFIG['instances'][0])
+    couchbase.check(instance)
 
     NODE_HOST = '{}:{}'.format(couchbase_container_ip, PORT)
     NODE_TAGS = ['node:{}'.format(NODE_HOST)]
@@ -28,30 +28,23 @@ def test_service_check(aggregator, couchbase_container_ip):
 
 
 @pytest.mark.integration
-def test_metrics(aggregator, couchbase_container_ip):
+def test_metrics(aggregator, instance, couchbase_container_ip):
     """
     Test couchbase metrics not including 'couchbase.query.'
     """
-
     couchbase = Couchbase('couchbase', {}, {})
-    couchbase.check(CONFIG['instances'][0])
-
+    couchbase.check(instance)
     assert_basic_couchbase_metrics(aggregator, couchbase_container_ip)
 
 
 @pytest.mark.integration
-def test_query_monitoring_metrics(aggregator, couchbase_container_ip):
+def test_query_monitoring_metrics(aggregator, instance_query, couchbase_container_ip):
     """
     Test system vitals metrics (prefixed "couchbase.query.")
     """
-
-    # Add query monitoring endpoint
     couchbase = Couchbase('couchbase', {}, {})
-    couchbase.check(CONFIG_QUERY['instances'][0])
+    couchbase.check(instance_query)
 
-    assert_basic_couchbase_metrics(aggregator, couchbase_container_ip)
-
-    # Assert 'couchbase.query.' metrics
     for mname in Couchbase.QUERY_STATS:
         aggregator.assert_metric('couchbase.query.{}'.format(mname), tags=CHECK_TAGS, count=1)
 
@@ -60,23 +53,28 @@ def assert_basic_couchbase_metrics(aggregator, couchbase_container_ip):
     """
     Assert each type of metric (buckets, nodes, totals) except query
     """
-
     # Assert 'couchbase.by_bucket.' metrics
     #  Because some metrics are deprecated, we can just see if we get an arbitrary number
     #  of bucket metrics. If there are more than that number, we assume that we're getting
     #  all the bucket metrics we should be getting
-    BUCKET_TAGS = ['device:{}'.format(BUCKET_NAME), 'bucket:{}'.format(BUCKET_NAME)]
+    tags = CHECK_TAGS + [
+        'device:{}'.format(BUCKET_NAME),
+        'bucket:{}'.format(BUCKET_NAME)
+    ]
     bucket_metric_count = 0
     for bucket_metric in aggregator.metric_names:
         if bucket_metric.find('couchbase.by_bucket.') == 0:
-            aggregator.assert_metric(bucket_metric, tags=CHECK_TAGS + BUCKET_TAGS, count=1)
+            aggregator.assert_metric(bucket_metric, tags=tags, count=1)
             bucket_metric_count += 1
 
     assert(bucket_metric_count > 10)
 
     # Assert 'couchbase.by_node.' metrics
-    NODE_HOST = '{}:{}'.format(couchbase_container_ip, PORT)
-    NODE_TAGS = ['device:{}'.format(NODE_HOST), 'node:{}'.format(NODE_HOST)]
+    tags = CHECK_TAGS + [
+        'device:{}:{}'.format(couchbase_container_ip, PORT),
+        'node:{}:{}'.format(couchbase_container_ip, PORT)
+    ]
+
     NODE_STATS = [
         'curr_items',
         'curr_items_tot',
@@ -87,7 +85,7 @@ def assert_basic_couchbase_metrics(aggregator, couchbase_container_ip):
         'vb_replica_curr_items'
     ]
     for mname in NODE_STATS:
-        aggregator.assert_metric('couchbase.by_node.{}'.format(mname), tags=CHECK_TAGS + NODE_TAGS, count=1)
+        aggregator.assert_metric('couchbase.by_node.{}'.format(mname), tags=tags, count=1)
 
     # Assert 'couchbase.' metrics
     TOTAL_STATS = [


### PR DESCRIPTION
### What does this PR do?

Fix tests by:

* Removing deprecated and buggy `device_name` parameter for `self.gauge`. (bug found in the base check will be addressed in a dedicated PR).
* Pin couchbase version for integration tests
* Rearrange tests so they're more consistent with the rest of this repo

### Motivation

`master` build broken

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

