### PR TITLE
Do not append duplicates when using `device_name` parameter.

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -322,7 +322,7 @@ class AgentCheck(object):
 
         if device_name:
             self._log_deprecation("device_name")
-            device_tag = self._normalize_type("device:{}".format(device_name))
+            device_tag = self._to_bytes("device:{}".format(device_name))
             if device_tag is None:
                 self.log.warning('Error encoding device tag to utf-8 encoded string, ignoring')
             else:
@@ -330,7 +330,7 @@ class AgentCheck(object):
 
         if tags is not None:
             for tag in tags:
-                tag = self._normalize_type(tag)
+                tag = self._to_bytes(tag)
                 if tag is None:
                     self.log.warning('Error encoding tag to utf-8 encoded string, ignoring tag')
                     continue
@@ -338,7 +338,7 @@ class AgentCheck(object):
 
         return normalized_tags
 
-    def _normalize_type(self, data):
+    def _to_bytes(self, data):
         """
         Normalize a text data to bytes (type `bytes`) so that the go bindings can
         handle it easily.

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -320,7 +320,9 @@ class AgentCheck(object):
         """
         if device_name:
             self._log_deprecation("device_name")
-            tags.append("device:{}".format(device_name))
+            device_tag = "device:{}".format(device_name)
+            if device_tag not in tags:
+                tags.append(device_tag)
 
         normalized_tags = self._normalize_tags_type(tags)
 

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -318,15 +318,12 @@ class AgentCheck(object):
         - normalize tags to type `str`
         - always return a list
         """
+        out_tags = [] if tags is None else tags[:]
         if device_name:
             self._log_deprecation("device_name")
-            device_tag = "device:{}".format(device_name)
-            if device_tag not in tags:
-                tags.append(device_tag)
+            out_tags.append("device:{}".format(device_name))
 
-        normalized_tags = self._normalize_tags_type(tags)
-
-        return normalized_tags
+        return self._normalize_tags_type(out_tags)
 
     def _normalize_tags_type(self, tags):
         """

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -167,6 +167,14 @@ class TestTags:
 
         assert isinstance(normalized_device_tag, bytes)
 
+    def test_duplicated_device_name(self):
+        check = AgentCheck()
+        tags = []
+        device_name = 'foo'
+        check._normalize_tags(tags, device_name)
+        normalized_tags = check._normalize_tags(tags, device_name)
+        assert len(normalized_tags) == 1
+
 
 class LimitedCheck(AgentCheck):
     DEFAULT_METRIC_LIMIT = 10

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -5,7 +5,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 import mock
-from six import string_types
 
 from datadog_checks.checks import AgentCheck
 
@@ -177,12 +176,10 @@ class TestTags:
         normalized_tags = check._normalize_tags_type(tags, device_name)
         assert len(normalized_tags) == 1
 
-    def test__normalize_type(self):
+    def test__to_bytes(self):
         check = AgentCheck()
-        in_str = bytes("tag:☣")
-        assert check._normalize_type(in_str) == bytes("tag:☣")
-        in_str = u"tag:☣"
-        assert check._normalize_type(in_str) == bytes("tag:☣")
+        assert isinstance(check._normalize_type(b"tag:foo"), bytes)
+        assert isinstance(check._normalize_type(u"tag:☣"), bytes)
         in_str = mock.MagicMock(side_effect=Exception)
         in_str.encode.side_effect = Exception
         assert check._normalize_type(in_str) is None

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -178,11 +178,11 @@ class TestTags:
 
     def test__to_bytes(self):
         check = AgentCheck()
-        assert isinstance(check._normalize_type(b"tag:foo"), bytes)
-        assert isinstance(check._normalize_type(u"tag:☣"), bytes)
+        assert isinstance(check._to_bytes(b"tag:foo"), bytes)
+        assert isinstance(check._to_bytes(u"tag:☣"), bytes)
         in_str = mock.MagicMock(side_effect=Exception)
         in_str.encode.side_effect = Exception
-        assert check._normalize_type(in_str) is None
+        assert check._to_bytes(in_str) is None
 
 
 class LimitedCheck(AgentCheck):

--- a/datadog_checks_base/tox.ini
+++ b/datadog_checks_base/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 skip_missing_interpreters = true
 envlist =
-    py{27,36}
+    py{27,36,37}
     flake8
 
 [testenv]


### PR DESCRIPTION
### What does this PR do?

Avoids appending multiple times the same tag when the (deprecated) `device_name` param is used. This will also fix tests on `master`.

PR is marked as `no-changelog` because the commit that introduced the bug (https://github.com/DataDog/integrations-core/pull/2822) hasn't been released yet.

### Motivation

Avoid sending fatter payloads because of duplicates

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.
