### PR TITLE
Use standalone py3 validation

### DIFF
--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -72,6 +72,7 @@ setup(
             'atomicwrites',
             'click',
             'colorama',
+            'datadog-a7',
             'docker-compose>=1.23.1,<1.24.0',
             'in-toto==0.2.3',
             'pip-tools',


### PR DESCRIPTION
### What does this PR do?

Use the standalone py3 validation from [datadog-checks-shared](https://github.com/DataDog/datadog-checks-shared) repo

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
