### PR TITLE
Support Python 3

### DIFF
--- a/hdfs_datanode/tests/test_hdfs_datanode.py
+++ b/hdfs_datanode/tests/test_hdfs_datanode.py
@@ -4,6 +4,8 @@
 
 from datadog_checks.hdfs_datanode import HDFSDataNode
 
+from six import iteritems
+
 from .common import (
     CUSTOM_TAGS, HDFS_DATANODE_CONFIG, HDFS_DATANODE_AUTH_CONFIG, HDFS_DATANODE_METRICS_VALUES,
     HDFS_DATANODE_METRIC_TAGS
@@ -25,7 +27,7 @@ def test_check(aggregator, mocked_request):
         HDFSDataNode.JMX_SERVICE_CHECK, status=HDFSDataNode.OK, tags=HDFS_DATANODE_METRIC_TAGS + CUSTOM_TAGS, count=1
     )
 
-    for metric, value in HDFS_DATANODE_METRICS_VALUES.iteritems():
+    for metric, value in iteritems(HDFS_DATANODE_METRICS_VALUES):
         aggregator.assert_metric(metric, value=value, tags=HDFS_DATANODE_METRIC_TAGS + CUSTOM_TAGS, count=1)
 
     aggregator.assert_all_metrics_covered()

--- a/hdfs_datanode/tox.ini
+++ b/hdfs_datanode/tox.ini
@@ -2,25 +2,22 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    hdfs_datanode
-    flake8
+    {py27,py36}-unit
+    {py27,py36}-flake8
 
 [testenv]
 usedevelop = true
 platform = linux|darwin|win32
-
-[testenv:hdfs_datanode]
+skip_install =
+    flake8: true
 deps =
-    -e../datadog_checks_base[deps]
-    -rrequirements-dev.txt
+    unit: -e../datadog_checks_base[deps]
+    unit: -rrequirements-dev.txt
+    flake8: flake8
 commands =
-    pip install -r requirements.in
-    pytest -v
-
-[testenv:flake8]
-skip_install = true
-deps = flake8
-commands = flake8 .
+    unit: pip install -r requirements.in
+    unit: pytest -v
+    flake8: flake8 .
 
 [flake8]
 exclude = .eggs,.tox


### PR DESCRIPTION
### What does this PR do?

This moves HDFS Datanode to python 3.

It just moves the tests and fixes test support. The check already supported Python 3.

### Motivation

🐍 3️⃣ 🚂 

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

