### PR TITLE
Fix regression on 'dep pin' command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -16,10 +16,6 @@ from ..requirements import (
 from ...utils import write_file_lines
 
 
-def transform_package_data(packages):
-    return {package.name: package for package in packages}
-
-
 def display_package_changes(pre_packages, post_packages, indent=''):
     """
     Print packages that've been added, removed or changed
@@ -125,7 +121,7 @@ def pin(package, version, checks, marker, resolving, lazy, quiet):
         resolved_reqs_file = os.path.join(root, check_name, 'requirements.txt')
 
         if os.path.isfile(pinned_reqs_file):
-            pinned_packages = transform_package_data(read_packages(pinned_reqs_file))
+            pinned_packages = {package.name: package for package in read_packages(pinned_reqs_file)}
             if package not in pinned_packages and check_name not in checks:
                 continue
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -138,7 +138,8 @@ def pin(package, version, checks, marker, resolving, lazy, quiet):
             else:
                 pinned_packages[package_name] = Package(package_name, version, marker)
 
-            write_file_lines(pinned_reqs_file, ('{}\n'.format(package) for package in sorted(itervalues(pinned_packages))))
+            package_list = sorted(itervalues(pinned_packages))
+            write_file_lines(pinned_reqs_file, ('{}\n'.format(package) for package in package_list))
 
             if not quiet:
                 echo_waiting('    Resolving dependencies...')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -117,7 +117,7 @@ def pin(package, version, checks, marker, resolving, lazy, quiet):
     pin for via arguments.
     """
     root = get_root()
-    package = package.lower()
+    package_name = package.lower()
     version = version.lower()
 
     for check_name in sorted(os.listdir(root)):
@@ -138,11 +138,11 @@ def pin(package, version, checks, marker, resolving, lazy, quiet):
                 echo_info('Check `{}`:'.format(check_name))
 
             if version == 'none':
-                del pinned_packages[package]
+                del pinned_packages[package_name]
             else:
-                pinned_packages[package] = Package(package, version, marker)
+                pinned_packages[package_name] = Package(package_name, version, marker)
 
-            write_file_lines(pinned_reqs_file, ('{}\n'.format(package) for package in sorted(pinned_packages)))
+            write_file_lines(pinned_reqs_file, ('{}\n'.format(package) for package in sorted(itervalues(pinned_packages))))
 
             if not quiet:
                 echo_waiting('    Resolving dependencies...')


### PR DESCRIPTION
### What does this PR do?

Fix `ddev dep pin` command, it was losing package versions on the way.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.
