### PR TITLE
Fix Oldest Message Age

### DIFF
--- a/ibm_mq/README.md
+++ b/ibm_mq/README.md
@@ -91,7 +91,7 @@ sudo ldconfig
 
 There are a number of ways to set up permissions in IBM MQ. Depending on how your setup works, create a `datadog` user within MQ with read only permissions.
 
-Also, queue level metric stats will need to be enabled. This can be done with a mqsc command:
+Also, queue level metric stats need to be enabled. This can be done with a mqsc command:
 
 ```
 > /opt/mqm/bin/runmqsc

--- a/ibm_mq/README.md
+++ b/ibm_mq/README.md
@@ -91,6 +91,24 @@ sudo ldconfig
 
 There are a number of ways to set up permissions in IBM MQ. Depending on how your setup works, create a `datadog` user within MQ with read only permissions.
 
+Also, queue level metric stats will need to be enabled. This can be done with a mqsc command:
+
+```
+> /opt/mqm/bin/runmqsc
+5724-H72 (C) Copyright IBM Corp. 1994, 2018.
+Starting MQSC for queue manager datadog.
+
+
+ALTER QMGR MONQ(MEDIUM) MONCHL(MEDIUM)
+     1 : ALTER QMGR MONQ(MEDIUM) MONCHL(MEDIUM)
+AMQ8005I: IBM MQ queue manager changed.
+
+       :
+One MQSC command read.
+No commands have a syntax error.
+All valid MQSC commands were processed.
+```
+
 
 ### Configuration
 

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -95,7 +95,6 @@ class IbmMqCheck(AgentCheck):
             except pymqi.Error as e:
                 self.warning("Error getting queue stats: {}".format(e))
 
-
         try:
             args = {
                 pymqi.CMQC.MQCA_Q_NAME: queue_name,

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -113,4 +113,7 @@ class IbmMqCheck(AgentCheck):
                 mname = '{}.queue.{}'.format(self.METRIC_PREFIX, mname)
                 m = int(queue_info[pymqi_value]))
 
-                self.gauge(mname, m, tags=tags)
+                if m > failure_value:
+                    self.gauge(mname, m, tags=tags)
+                else:
+                    log.debug("Unable to get {}, turn on queue level monitoring to access these metrics".format(mname))

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -100,7 +100,7 @@ class IbmMqCheck(AgentCheck):
         try:
             args = {
                 pymqi.CMQC.MQCA_Q_NAME: queue_name,
-                pymqi.CMQC.MQIA_Q_TYPE: queue_type,
+                pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_MODEL,
                 pymqi.CMQCFC.MQIACF_Q_STATUS_ATTRS: pymqi.CMQCFC.MQIACF_ALL,
             }
             pcf = pymqi.PCFExecute(queue_manager)

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -110,7 +110,7 @@ class IbmMqCheck(AgentCheck):
                 failure_value = values['failure']
                 pymqi_value = values['pymqi_value']
                 mname = '{}.queue.{}'.format(self.METRIC_PREFIX, mname)
-                m = int(queue_info[pymqi_value]))
+                m = int(queue_info[pymqi_value])
 
                 if m > failure_value:
                     self.gauge(mname, m, tags=tags)

--- a/ibm_mq/datadog_checks/ibm_mq/metrics.py
+++ b/ibm_mq/datadog_checks/ibm_mq/metrics.py
@@ -43,10 +43,12 @@ def queue_metrics():
     }
 
 
-def failure_prone_queue_metrics():
+def pcf_metrics():
     return {
-        'max_channels': pymqi.CMQC.MQIA_MAX_CHANNELS,
-        'oldest_message_age': pymqi.CMQCFC.MQIACF_OLDEST_MSG_AGE,
+        'oldest_message_age': {
+            'pymqi_value': pymqi.CMQCFC.MQIACF_OLDEST_MSG_AGE,
+            'failure': -1,
+        },
     }
 
 

--- a/ibm_mq/tox.ini
+++ b/ibm_mq/tox.ini
@@ -4,7 +4,7 @@ skip_missing_interpreters = true
 basepython = py27
 envlist =
     {py27,py36}-{8,9}
-    {py27,py36}-flake8
+    flake8
 
 [testenv]
 platform = linux|darwin

--- a/ibm_mq/tox.ini
+++ b/ibm_mq/tox.ini
@@ -3,30 +3,25 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py27
 envlist =
-    {py27,py36}-ibm_mq9
-    ibm_mq8
-    flake8
+    {py27,py36}-{8,9}
+    {py27,py36}-flake8
 
 [testenv]
 platform = linux|darwin
+skip_install =
+    flake8: true
 deps =
-    -e../datadog_checks_base[deps]
-    -rrequirements-dev.txt
+    {8,9}: -e../datadog_checks_base[deps]
+    {8,9}: -rrequirements-dev.txt
+    flake8: flake8
 passenv = *
 commands =
-    pip install -r requirements.in
-    pytest
+    {8,9}: pip install -r requirements.in
+    {8,9}: pytest
+    flake8: flake8 .
 setenv =
-  IBM_MQ_VERSION = 9
-
-[testenv:ibm_mq8]
-setenv =
-  IBM_MQ_VERSION = 8
-
-[testenv:flake8]
-skip_install = true
-deps = flake8
-commands = flake8 .
+    8: IBM_MQ_VERSION = 8
+    9: IBM_MQ_VERSION = 9
 
 [flake8]
 exclude = .eggs,.tox,build


### PR DESCRIPTION
### What does this PR do?

The oldest message age was being queried in a way that made it somewhat error prone. This should fix it.

### Motivation

it was broken 😢 

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.
