### PR TITLE
Check that files are tracked by git before signing them

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -113,3 +113,13 @@ def git_tag_list(pattern=None):
 
     regex = re.compile(pattern)
     return list(filter(regex.search, result))
+
+
+def git_ls_files(filename):
+    """
+    Return a boolean value for whether the given file is tracked by git.
+    """
+    with chdir(get_root()):
+        # https://stackoverflow.com/a/2406813
+        result = run_command('git ls-files --error-unmatch {}'.format(filename))
+        return result.code == 0

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -121,5 +121,5 @@ def git_ls_files(filename):
     """
     with chdir(get_root()):
         # https://stackoverflow.com/a/2406813
-        result = run_command('git ls-files --error-unmatch {}'.format(filename))
+        result = run_command('git ls-files --error-unmatch {}'.format(filename), capture=True)
         return result.code == 0

--- a/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
@@ -110,6 +110,8 @@ def update_link_metadata(checks):
         run_in_toto(key_id, products)
 
         # Check whether each signed product is being tracked by git.
+        # NOTE: We have to check now *AFTER* signing the tag link file, so that
+        # we can check against the actual complete list of products.
         with open(tag_link) as tag_json:
             tag = json.load(tag_json)
             products = tag['signed']['products']

--- a/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 # flake8: noqa
 import json
+import os
 import shutil
 
 # NOTE: Set one minute for any GPG subprocess to timeout in in-toto.  Should be
@@ -116,9 +117,10 @@ def update_link_metadata(checks):
             tag = json.load(tag_json)
             products = tag['signed']['products']
 
-            for product in products:
-                if not git_ls_files(product):
-                    raise UntrackedFileException(product)
+        for product in products:
+            if not git_ls_files(product):
+                os.remove(tag_link)
+                raise UntrackedFileException(product)
 
         # Tell pipeline which tag link metadata to use.
         write_file(metadata_file_tracker, tag_link)


### PR DESCRIPTION
### What does this PR do?

Before signing files with `in-toto`, we check whether each file has been tracked by `git`.

### Motivation

To prevent untracked files from being signed, which prevents us from releasing checks.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

N/A