### PR TITLE
Support unicode for Python 3 bindings

### DIFF
--- a/datadog_checks_base/datadog_checks/base/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/__init__.py
@@ -6,7 +6,7 @@ from .checks import AgentCheck
 from .checks.openmetrics import OpenMetricsBaseCheck
 from .config import is_affirmative
 from .errors import ConfigurationError
-from .utils.common import ensure_bytes, ensure_unicode
+from .utils.common import ensure_bytes, ensure_unicode, to_string
 
 # Windows-only
 try:
@@ -23,4 +23,5 @@ __all__ = [
     'ensure_bytes',
     'ensure_unicode',
     'is_affirmative',
+    'to_string',
 ]

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -11,7 +11,7 @@ import traceback
 import unicodedata
 import inspect
 
-from six import iteritems, text_type
+from six import PY3, iteritems, text_type
 
 try:
     import datadog_agent
@@ -28,7 +28,7 @@ except ImportError:
     using_stub_aggregator = True
 
 from ..config import is_affirmative
-from ..utils.common import ensure_bytes
+from ..utils.common import ensure_bytes, ensure_unicode
 from ..utils.proxy import config_proxy_skip
 from ..utils.limiter import Limiter
 
@@ -41,7 +41,365 @@ ONE_PER_CONTEXT_METRIC_TYPES = [
 ]
 
 
-class AgentCheck(object):
+class __AgentCheck7(object):
+    """
+    The base class for any Agent based integrations
+    """
+    OK, WARNING, CRITICAL, UNKNOWN = (0, 1, 2, 3)
+
+    """
+    DEFAULT_METRIC_LIMIT allows to set a limit on the number of metric name and tags combination
+    this check can send per run. This is useful for checks that have an unbounded
+    number of tag values that depend on the input payload.
+    The logic counts one set of tags per gauge/rate/monotonic_count call, and deduplicates
+    sets of tags for other metric types. The first N sets of tags in submission order will
+    be sent to the aggregator, the rest are dropped. The state is reset after each run.
+
+    See https://github.com/DataDog/integrations-core/pull/2093 for more information
+    """
+    DEFAULT_METRIC_LIMIT = 0
+
+    def __init__(self, *args, **kwargs):
+        """
+        args: `name`, `init_config`, `agentConfig` (deprecated), `instances`
+        """
+        self.metrics = defaultdict(list)
+        self.check_id = ''
+        self.instances = kwargs.get('instances', [])
+        self.name = kwargs.get('name', '')
+        self.init_config = kwargs.get('init_config', {})
+        self.agentConfig = kwargs.get('agentConfig', {})
+        self.warnings = []
+        self.metric_limiter = None
+
+        if len(args) > 0:
+            self.name = args[0]
+        if len(args) > 1:
+            self.init_config = args[1]
+        if len(args) > 2:
+            if len(args) > 3 or 'instances' in kwargs:
+                # old-style init: the 3rd argument is `agentConfig`
+                self.agentConfig = args[2]
+                if len(args) > 3:
+                    self.instances = args[3]
+            else:
+                # new-style init: the 3rd argument is `instances`
+                self.instances = args[2]
+
+        # `self.hostname` is deprecated, use `datadog_agent.get_hostname()` instead
+        self.hostname = datadog_agent.get_hostname()
+
+        # the agent5 'AgentCheck' setup a log attribute.
+        self.log = logging.getLogger('{}.{}'.format(__name__, self.name))
+
+        # Set proxy settings
+        self.proxies = self._get_requests_proxy()
+        if not self.init_config:
+            self._use_agent_proxy = True
+        else:
+            self._use_agent_proxy = is_affirmative(self.init_config.get('use_agent_proxy', True))
+
+        self.default_integration_http_timeout = float(self.agentConfig.get('default_integration_http_timeout', 9))
+
+        self._deprecations = {
+            'increment': [
+                False,
+                (
+                    'DEPRECATION NOTICE: `AgentCheck.increment`/`AgentCheck.decrement` are deprecated, please '
+                    'use `AgentCheck.gauge` or `AgentCheck.count` instead, with a different metric name'
+                ),
+            ],
+            'device_name': [
+                False,
+                (
+                    'DEPRECATION NOTICE: `device_name` is deprecated, please use a `device:` '
+                    'tag in the `tags` list instead'
+                ),
+            ],
+            'in_developer_mode': [
+                False,
+                'DEPRECATION NOTICE: `in_developer_mode` is deprecated, please stop using it.',
+            ],
+            'no_proxy': [
+                False,
+                (
+                    'DEPRECATION NOTICE: The `no_proxy` config option has been renamed '
+                    'to `skip_proxy` and will be removed in a future release.'
+                ),
+            ],
+        }
+
+        # Setup metric limits
+        try:
+            metric_limit = self.instances[0].get('max_returned_metrics', self.DEFAULT_METRIC_LIMIT)
+            # Do not allow to disable limiting if the class has set a non-zero default value
+            if metric_limit == 0 and self.DEFAULT_METRIC_LIMIT > 0:
+                metric_limit = self.DEFAULT_METRIC_LIMIT
+                self.warning(
+                    'Setting max_returned_metrics to zero is not allowed, reverting '
+                    'to the default of {} metrics'.format(self.DEFAULT_METRIC_LIMIT)
+                )
+        except Exception:
+            metric_limit = self.DEFAULT_METRIC_LIMIT
+        if metric_limit > 0:
+            self.metric_limiter = Limiter(self.name, 'metrics', metric_limit, self.warning)
+
+    @property
+    def in_developer_mode(self):
+        self._log_deprecation('in_developer_mode')
+        return False
+
+    def get_instance_proxy(self, instance, uri, proxies=None):
+        proxies = proxies if proxies is not None else self.proxies.copy()
+
+        deprecated_skip = instance.get('no_proxy', None)
+        skip = (
+            is_affirmative(instance.get('skip_proxy', not self._use_agent_proxy)) or is_affirmative(deprecated_skip)
+        )
+
+        if deprecated_skip is not None:
+            self._log_deprecation('no_proxy')
+
+        return config_proxy_skip(proxies, uri, skip)
+
+    def _context_uid(self, mtype, name, tags=None, hostname=None):
+        return '{}-{}-{}-{}'.format(mtype, name, tags if tags is None else hash(frozenset(tags)), hostname)
+
+    def _submit_metric(self, mtype, name, value, tags=None, hostname=None, device_name=None):
+        if value is None:
+            # ignore metric sample
+            return
+
+        tags = self._normalize_tags_type(tags, device_name)
+        if hostname is None:
+            hostname = ''
+
+        if self.metric_limiter:
+            if mtype in ONE_PER_CONTEXT_METRIC_TYPES:
+                # Fast path for gauges, rates, monotonic counters, assume one set of tags per call
+                if self.metric_limiter.is_reached():
+                    return
+            else:
+                # Other metric types have a legit use case for several calls per set of tags, track unique sets of tags
+                context = self._context_uid(mtype, name, tags, hostname)
+                if self.metric_limiter.is_reached(context):
+                    return
+
+        try:
+            value = float(value)
+        except ValueError:
+            err_msg = (
+                'Metric: {} has non float value: {}. Only float values can be submitted as metrics.'
+                .format(name, value)
+            )
+            if using_stub_aggregator:
+                raise ValueError(err_msg)
+            self.warning(err_msg)
+            return
+
+        aggregator.submit_metric(self, self.check_id, mtype, ensure_unicode(name), value, tags, hostname)
+
+    def gauge(self, name, value, tags=None, hostname=None, device_name=None):
+        self._submit_metric(aggregator.GAUGE, name, value, tags=tags, hostname=hostname, device_name=device_name)
+
+    def count(self, name, value, tags=None, hostname=None, device_name=None):
+        self._submit_metric(aggregator.COUNT, name, value, tags=tags, hostname=hostname, device_name=device_name)
+
+    def monotonic_count(self, name, value, tags=None, hostname=None, device_name=None):
+        self._submit_metric(aggregator.MONOTONIC_COUNT, name, value, tags=tags, hostname=hostname,
+                            device_name=device_name)
+
+    def rate(self, name, value, tags=None, hostname=None, device_name=None):
+        self._submit_metric(aggregator.RATE, name, value, tags=tags, hostname=hostname, device_name=device_name)
+
+    def histogram(self, name, value, tags=None, hostname=None, device_name=None):
+        self._submit_metric(aggregator.HISTOGRAM, name, value, tags=tags, hostname=hostname, device_name=device_name)
+
+    def historate(self, name, value, tags=None, hostname=None, device_name=None):
+        self._submit_metric(aggregator.HISTORATE, name, value, tags=tags, hostname=hostname, device_name=device_name)
+
+    def increment(self, name, value=1, tags=None, hostname=None, device_name=None):
+        self._log_deprecation('increment')
+        self._submit_metric(aggregator.COUNTER, name, value, tags=tags, hostname=hostname, device_name=device_name)
+
+    def decrement(self, name, value=-1, tags=None, hostname=None, device_name=None):
+        self._log_deprecation('increment')
+        self._submit_metric(aggregator.COUNTER, name, value, tags=tags, hostname=hostname, device_name=device_name)
+
+    def _log_deprecation(self, deprecation_key):
+        """
+        Logs a deprecation notice at most once per AgentCheck instance, for the pre-defined `deprecation_key`
+        """
+        if not self._deprecations[deprecation_key][0]:
+            self.log.warning(self._deprecations[deprecation_key][1])
+            self._deprecations[deprecation_key][0] = True
+
+    def service_check(self, name, status, tags=None, hostname=None, message=None):
+        tags = self._normalize_tags_type(tags)
+        if hostname is None:
+            hostname = ''
+        if message is None:
+            message = ''
+        else:
+            message = ensure_unicode(message)
+
+        aggregator.submit_service_check(self, self.check_id, ensure_unicode(name), status, tags, hostname, message)
+
+    def event(self, event):
+        # Enforce types of some fields, considerably facilitates handling in go bindings downstream
+        for key, value in list(iteritems(event)):
+            # transform any bytes objects to utf-8
+            if isinstance(value, bytes):
+                try:
+                    event[key] = event[key].decode('utf-8')
+                except UnicodeError:
+                    self.log.warning(
+                        'Error decoding unicode field `{}` to utf-8 encoded string, cannot submit event'.format(key)
+                    )
+                    return
+        if event.get('tags'):
+            event['tags'] = self._normalize_tags_type(event['tags'])
+        if event.get('timestamp'):
+            event['timestamp'] = int(event['timestamp'])
+        if event.get('aggregation_key'):
+            event['aggregation_key'] = ensure_unicode(event['aggregation_key'])
+        aggregator.submit_event(self, self.check_id, event)
+
+    # TODO(olivier): implement service_metadata if it's worth it
+    def service_metadata(self, meta_name, value):
+        pass
+
+    def check(self, instance):
+        raise NotImplementedError
+
+    def normalize(self, metric, prefix=None, fix_case=False):
+        """
+        Turn a metric into a well-formed metric name
+        prefix.b.c
+        :param metric The metric name to normalize
+        :param prefix A prefix to to add to the normalized name, default None
+        :param fix_case A boolean, indicating whether to make sure that the metric name returned is in "snake_case"
+        """
+        if isinstance(metric, text_type):
+            metric = unicodedata.normalize('NFKD', metric).encode('ascii', 'ignore')
+
+        if fix_case:
+            name = self.convert_to_underscore_separated(metric)
+            if prefix is not None:
+                prefix = self.convert_to_underscore_separated(prefix)
+        else:
+            name = re.sub(br"[,\+\*\-/()\[\]{}\s]", b"_", metric)
+        # Eliminate multiple _
+        name = re.sub(br"__+", b"_", name)
+        # Don't start/end with _
+        name = re.sub(br"^_", b"", name)
+        name = re.sub(br"_$", b"", name)
+        # Drop ._ and _.
+        name = re.sub(br"\._", b".", name)
+        name = re.sub(br"_\.", b".", name)
+
+        if prefix is not None:
+            return ensure_bytes(prefix) + b"." + name
+        else:
+            return name
+
+    FIRST_CAP_RE = re.compile(br'(.)([A-Z][a-z]+)')
+    ALL_CAP_RE = re.compile(br'([a-z0-9])([A-Z])')
+    METRIC_REPLACEMENT = re.compile(br'([^a-zA-Z0-9_.]+)|(^[^a-zA-Z]+)')
+    DOT_UNDERSCORE_CLEANUP = re.compile(br'_*\._*')
+
+    def convert_to_underscore_separated(self, name):
+        """
+        Convert from CamelCase to camel_case
+        And substitute illegal metric characters
+        """
+        metric_name = self.FIRST_CAP_RE.sub(br'\1_\2', ensure_bytes(name))
+        metric_name = self.ALL_CAP_RE.sub(br'\1_\2', metric_name).lower()
+        metric_name = self.METRIC_REPLACEMENT.sub(br'_', metric_name)
+        return self.DOT_UNDERSCORE_CLEANUP.sub(br'.', metric_name).strip(b'_')
+
+    def _normalize_tags_type(self, tags, device_name=None):
+        """
+        Normalize tags contents and type:
+        - append `device_name` as `device:` tag
+        - normalize tags type
+        - doesn't mutate the passed list, returns a new list
+        """
+        normalized_tags = []
+
+        if device_name:
+            self._log_deprecation('device_name')
+            normalized_tags.append('device:{}'.format(ensure_unicode(device_name)))
+
+        if tags is not None:
+            for tag in tags:
+                if not isinstance(tag, str):
+                    try:
+                        tag = tag.decode('utf-8')
+                    except UnicodeError:
+                        self.log.warning('Error decoding tag `{}` as utf-8, ignoring tag'.format(tag))
+                        continue
+
+                normalized_tags.append(tag)
+
+        return normalized_tags
+
+    def warning(self, warning_message):
+        warning_message = ensure_unicode(warning_message)
+
+        frame = inspect.currentframe().f_back
+        lineno = frame.f_lineno
+        # only log the last part of the filename, not the full path
+        filename = basename(frame.f_code.co_filename)
+
+        self.log.warning(warning_message, extra={'_lineno': lineno, '_filename': filename})
+        self.warnings.append(warning_message)
+
+    def get_warnings(self):
+        """
+        Return the list of warnings messages to be displayed in the info page
+        """
+        warnings = self.warnings
+        self.warnings = []
+        return warnings
+
+    def run(self):
+        try:
+            self.check(copy.deepcopy(self.instances[0]))
+            result = ''
+        except Exception as e:
+            result = json.dumps([
+                {
+                    'message': str(e),
+                    'traceback': traceback.format_exc(),
+                }
+            ])
+        finally:
+            if self.metric_limiter:
+                self.metric_limiter.reset()
+
+        return result
+
+    def _get_requests_proxy(self):
+        no_proxy_settings = {
+            'http': None,
+            'https': None,
+            'no': [],
+        }
+
+        # First we read the proxy configuration from datadog.conf
+        proxies = self.agentConfig.get('proxy', datadog_agent.get_config('proxy'))
+        if proxies:
+            proxies = proxies.copy()
+
+        # requests compliant dict
+        if proxies and 'no_proxy' in proxies:
+            proxies['no'] = proxies.pop('no_proxy')
+
+        return proxies if proxies else no_proxy_settings
+
+
+class __AgentCheck6(object):
     """
     The base class for any Agent based integrations
     """
@@ -408,3 +766,11 @@ class AgentCheck(object):
             proxies['no'] = proxies.pop('no_proxy')
 
         return proxies if proxies else no_proxy_settings
+
+
+if PY3:
+    AgentCheck = __AgentCheck7
+    del __AgentCheck6
+else:
+    AgentCheck = __AgentCheck6
+    del __AgentCheck7

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -10,7 +10,7 @@ except ImportError:
     from .stubs import datadog_agent
     running_on_agent = False
 
-from .utils.common import ensure_bytes
+from .utils.common import to_string
 
 # Arbitrary number less than 10 (DEBUG)
 TRACE_LEVEL = 7
@@ -35,7 +35,7 @@ class AgentLogHandler(logging.Handler):
         msg = "({}:{}) | {}".format(
             getattr(record, '_filename', record.filename),
             getattr(record, '_lineno', record.lineno),
-            ensure_bytes(self.format(record))
+            to_string(self.format(record))
         )
         datadog_agent.log(msg, record.levelno)
 
@@ -75,7 +75,7 @@ def init_logging():
     rootLogger.setLevel(_get_py_loglevel(datadog_agent.get_config('log_level')))
 
     # `requests` (used in a lot of checks) imports `urllib3`, which logs a bunch of stuff at the info level
-    # Therefore, pre-emptively increase the default level of that logger to `WARN`
+    # Therefore, pre emptively increase the default level of that logger to `WARN`
     urllib_logger = logging.getLogger("requests.packages.urllib3")
     urllib_logger.setLevel(logging.WARN)
     urllib_logger.propagate = True

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -7,7 +7,7 @@ from collections import defaultdict, namedtuple
 
 from six import binary_type, iteritems
 
-from ..utils.common import ensure_bytes, ensure_unicode
+from ..utils.common import ensure_unicode, to_string
 
 MetricStub = namedtuple('MetricStub', 'name type value tags hostname')
 ServiceCheckStub = namedtuple('ServiceCheckStub', 'check_id name status tags hostname message')
@@ -59,7 +59,7 @@ class AggregatorStub(object):
                 normalize_tags(stub.tags),
                 ensure_unicode(stub.hostname)
             )
-            for stub in self._metrics.get(ensure_bytes(name), [])
+            for stub in self._metrics.get(to_string(name), [])
         ]
 
     def service_checks(self, name):
@@ -75,7 +75,7 @@ class AggregatorStub(object):
                 ensure_unicode(stub.hostname),
                 ensure_unicode(stub.message)
             )
-            for stub in self._service_checks.get(ensure_bytes(name), [])
+            for stub in self._service_checks.get(to_string(name), [])
         ]
 
     @property

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -4,7 +4,7 @@
 
 
 def get_hostname():
-    return b'stubbed.hostname'
+    return 'stubbed.hostname'
 
 
 def log(*args, **kwargs):

--- a/datadog_checks_base/datadog_checks/base/utils/common.py
+++ b/datadog_checks_base/datadog_checks/base/utils/common.py
@@ -4,6 +4,7 @@
 import os
 import re
 
+from six import PY3
 from six.moves.urllib.parse import urlparse
 
 
@@ -17,6 +18,9 @@ def ensure_unicode(s):
     if isinstance(s, bytes):
         s = s.decode('utf-8')
     return s
+
+
+to_string = ensure_unicode if PY3 else ensure_bytes
 
 
 def get_docker_hostname():

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -3,17 +3,11 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
 import mock
+import pytest
+from six import PY3
 
-from datadog_checks.checks import AgentCheck
-
-
-@pytest.fixture
-def aggregator():
-    from datadog_checks.stubs import aggregator
-    aggregator.reset()
-    return aggregator
+from datadog_checks.base import AgentCheck
 
 
 def test_instance():
@@ -133,7 +127,8 @@ class TestTags:
         normalized_tag = normalized_tags[0]
 
         assert normalized_tags is not tags
-        assert normalized_tag == tag.encode('utf-8')
+        # Ensure no new allocation occurs
+        assert normalized_tag is tag
 
     def test_bytes_string(self):
         check = AgentCheck()
@@ -144,8 +139,12 @@ class TestTags:
         normalized_tag = normalized_tags[0]
 
         assert normalized_tags is not tags
-        # Ensure no new allocation occurs
-        assert normalized_tag is tag
+
+        if PY3:
+            assert normalized_tag == tag.decode('utf-8')
+        else:
+            # Ensure no new allocation occurs
+            assert normalized_tag is tag
 
     def test_unicode_string(self):
         check = AgentCheck()
@@ -156,7 +155,12 @@ class TestTags:
         normalized_tag = normalized_tags[0]
 
         assert normalized_tags is not tags
-        assert normalized_tag == tag.encode('utf-8')
+
+        if PY3:
+            # Ensure no new allocation occurs
+            assert normalized_tag is tag
+        else:
+            assert normalized_tag == tag.encode('utf-8')
 
     def test_unicode_device_name(self):
         check = AgentCheck()
@@ -166,7 +170,7 @@ class TestTags:
         normalized_tags = check._normalize_tags_type(tags, device_name)
         normalized_device_tag = normalized_tags[0]
 
-        assert isinstance(normalized_device_tag, bytes)
+        assert isinstance(normalized_device_tag, str if PY3 else bytes)
 
     def test_duplicated_device_name(self):
         check = AgentCheck()
@@ -177,6 +181,8 @@ class TestTags:
         assert len(normalized_tags) == 1
 
     def test__to_bytes(self):
+        if PY3:
+            pytest.skip('Method only exists on Python 2')
         check = AgentCheck()
         assert isinstance(check._to_bytes(b"tag:foo"), bytes)
         assert isinstance(check._to_bytes(u"tag:☣"), bytes)

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -8,7 +8,7 @@ import requests
 from six import iteritems, itervalues
 from six.moves.urllib.parse import urljoin
 
-from datadog_checks.base import AgentCheck
+from datadog_checks.base import AgentCheck, to_string
 from datadog_checks.base.utils.headers import headers
 
 from .config import from_instance
@@ -374,7 +374,7 @@ class ESCheck(AgentCheck):
         )
 
     def _create_event(self, status, tags=None):
-        hostname = self.hostname.decode('utf-8')
+        hostname = to_string(self.hostname)
         if status == "red":
             alert_type = "error"
             msg_title = "{} is {}".format(hostname, status)

--- a/haproxy/datadog_checks/haproxy/haproxy.py
+++ b/haproxy/datadog_checks/haproxy/haproxy.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 from six import iteritems, PY2
 from six.moves.urllib.parse import urlparse
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base import AgentCheck, to_string
 from datadog_checks.config import _is_affirmative
 from datadog_checks.utils.headers import headers
 
@@ -705,7 +705,7 @@ class HAProxy(AgentCheck):
         custom_tags = [] if custom_tags is None else custom_tags
         service_name = data['pxname']
         status = data['status']
-        haproxy_hostname = self.hostname.decode('utf-8')
+        haproxy_hostname = to_string(self.hostname)
         check_hostname = haproxy_hostname if tag_by_host else ''
 
         if self._is_service_excl_filtered(service_name, services_incl_filter,

--- a/mongo/tests/test_mongo.py
+++ b/mongo/tests/test_mongo.py
@@ -6,7 +6,7 @@ from . import common
 import pytest
 from six import itervalues
 
-from datadog_checks.dev.utils import ensure_bytes
+from datadog_checks.base import to_string
 
 METRIC_VAL_CHECKS = {
     'mongodb.asserts.msgps': lambda x: x >= 0,
@@ -75,12 +75,12 @@ def test_mongo2(aggregator, check, instance_user):
     assert len(service_checks[0]) == 1
     # Assert that all service checks have the proper tags: host and port
     for sc in service_checks[0]:
-        assert ensure_bytes('host:{}'.format(common.HOST)) in sc.tags
+        assert to_string('host:{}'.format(common.HOST)) in sc.tags
         assert (
-            ensure_bytes('port:{}'.format(common.PORT1)) in sc.tags
-            or ensure_bytes('port:{}'.format(common.PORT2)) in sc.tags
+            to_string('port:{}'.format(common.PORT1)) in sc.tags
+            or to_string('port:{}'.format(common.PORT2)) in sc.tags
         )
-        assert b'db:test' in sc.tags
+        assert 'db:test' in sc.tags
 
     # Metric assertions
     metrics = list(itervalues(aggregator._metrics))

--- a/teamcity/tests/test_teamcity.py
+++ b/teamcity/tests/test_teamcity.py
@@ -22,13 +22,6 @@ CONFIG = {
 }
 
 
-@pytest.fixture
-def aggregator():
-    from datadog_checks.stubs import aggregator
-    aggregator.reset()
-    return aggregator
-
-
 @pytest.mark.integration
 def test_build_event(aggregator):
     teamcity = TeamCityCheck('teamcity', {}, {})
@@ -49,7 +42,7 @@ def test_build_event(aggregator):
     assert events[0]['msg_text'] == "Build Number: 2\nDeployed To: buildhost42.dtdg.co\n\nMore Info: " + \
                                     "http://localhost:8111/viewLog.html?buildId=2&buildTypeId=TestProject_TestBuild"
     assert events[0]['tags'] == ['build', 'one:tag', 'one:test']
-    assert events[0]['host'] == b"buildhost42.dtdg.co"
+    assert events[0]['host'] == "buildhost42.dtdg.co"
     aggregator.reset()
 
     # One more check should not create any more events


### PR DESCRIPTION
### Motivation

Our new Go bindings require unicode

Note: the Python 2 base class is unchanged