### PR TITLE
Revamp PR body template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,14 +6,14 @@ A brief description of the change being made with this pull request.
 
 What inspired you to submit this pull request?
 
-### Review checklist
-
-- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
-- [ ] Feature or bugfix has tests
-- [ ] Git history is clean
-- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
-- [ ] If PR adds a configuration option, it has been added to the configuration file.
-
 ### Additional Notes
 
 Anything else we should know when reviewing?
+
+### Review checklist (to be filled by reviewers)
+
+- [ ] PR title is written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
+- [ ] PR has the `changelog/` and `integration/` labels attached
+- [ ] Feature or bugfix has tests
+- [ ] Git history [is clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
+- [ ] If PR adds a configuration option, it has been added to the configuration file.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,7 @@ Anything else we should know when reviewing?
 ### Review checklist (to be filled by reviewers)
 
 - [ ] PR title is written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
+- [ ] Files changes correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
 - [ ] PR has the `changelog/` and `integration/` labels attached
 - [ ] Feature or bugfix has tests
 - [ ] Git history [is clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,9 +12,9 @@ Anything else we should know when reviewing?
 
 ### Review checklist (to be filled by reviewers)
 
-- [ ] PR title is written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
-- [ ] Files changes correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
-- [ ] PR has the `changelog/` and `integration/` labels attached
-- [ ] Feature or bugfix has tests
-- [ ] Git history [is clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
-- [ ] If PR adds a configuration option, it has been added to the configuration file.
+- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
+- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
+- [ ] PR must have `changelog/` and `integration/` labels attached
+- [ ] Feature or bugfix must have tests
+- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
+- [ ] If PR adds a configuration option, it must be added to the configuration file.


### PR DESCRIPTION
### What does this PR do?

Adjust a bit the PR body template to make the review checklist more effective

### Motivation

Review checklist is often ignored by reviewers, or mistakenly filled by PR authors

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.
