### PR TITLE
Fix context limit logic for OpenMetrics checks

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -156,7 +156,7 @@ class AgentCheck(object):
 
         return config_proxy_skip(proxies, uri, skip)
 
-    def _context_uid(mtype, name, value, tags=None, hostname=None):
+    def _context_uid(self, mtype, name, tags=None, hostname=None):
         return '{}-{}-{}-{}'.format(mtype, name, tags if tags is None else hash(frozenset(tags)), hostname)
 
     def _submit_metric(self, mtype, name, value, tags=None, hostname=None, device_name=None):

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -190,6 +190,20 @@ class LimitedCheck(AgentCheck):
 
 
 class TestLimits():
+    def test_context_uid(self, aggregator):
+        check = LimitedCheck()
+
+        # Test stability of the hash against tag ordering
+        uid = check._context_uid(aggregator.GAUGE, "test.metric", ["one", "two"], None)
+        assert uid == check._context_uid(aggregator.GAUGE, "test.metric", ["one", "two"], None)
+        assert uid == check._context_uid(aggregator.GAUGE, "test.metric", ["two", "one"], None)
+
+        # Test all fields impact the hash
+        assert uid != check._context_uid(aggregator.RATE, "test.metric", ["one", "two"], None)
+        assert uid != check._context_uid(aggregator.GAUGE, "test.metric2", ["one", "two"], None)
+        assert uid != check._context_uid(aggregator.GAUGE, "test.metric", ["two"], None)
+        assert uid != check._context_uid(aggregator.GAUGE, "test.metric", ["one", "two"], "host")
+
     def test_metric_limit_gauges(self, aggregator):
         check = LimitedCheck()
         assert check.get_warnings() == []


### PR DESCRIPTION
### What does this PR do?

The `AgentCheck._context_uid` method's signature was buggy, making it ignore the metric name in the context uid computation.

This PR fixes the signature and a unit test for the method, in order to ensure all fields impact the hash.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
