### PR TITLE
Pining pytest because of an regression in pytest-benchmark

### DIFF
--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -25,7 +25,7 @@ with open(path.join(HERE, 'README.md'), 'r', encoding='utf-8') as f:
 REQUIRES = [
     'coverage>=4.5.1',
     'mock',
-    'pytest',
+    'pytest==4.0.2',
     'pytest-benchmark',
     'pytest-cov',
     'pytest-mock',


### PR DESCRIPTION
### What does this PR do?

Pin pytest because of the following regression in pytest-banchmark https://github.com/jab/bidict/commit/2e4a9be91c603300f2161fad4c0151196f008720

### Motivation

Fix build

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
