### PR TITLE
fix root name, fix maintainer validation for extras

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -200,22 +200,23 @@ def manifest(fix, include_extras):
                             display_queue.append((echo_failure, '  invalid `version`: {}'.format(version)))
 
             # maintainer
-            correct_maintainer = 'help@datadoghq.com'
-            maintainer = decoded.get('maintainer')
-            if maintainer != correct_maintainer:
-                file_failures += 1
-                output = '  incorrect `maintainer`: {}'.format(maintainer)
+            if root_name == 'integrations-core':
+                correct_maintainer = 'help@datadoghq.com'
+                maintainer = decoded.get('maintainer')
+                if maintainer != correct_maintainer:
+                    file_failures += 1
+                    output = '  incorrect `maintainer`: {}'.format(maintainer)
 
-                if fix:
-                    decoded['maintainer'] = correct_maintainer
+                    if fix:
+                        decoded['maintainer'] = correct_maintainer
 
-                    display_queue.append((echo_warning, output))
-                    display_queue.append((echo_success, '  new `maintainer`: {}'.format(correct_maintainer)))
+                        display_queue.append((echo_warning, output))
+                        display_queue.append((echo_success, '  new `maintainer`: {}'.format(correct_maintainer)))
 
-                    file_failures -= 1
-                    file_fixed = True
-                else:
-                    display_queue.append((echo_failure, output))
+                        file_failures -= 1
+                        file_fixed = True
+                    else:
+                        display_queue.append((echo_failure, output))
 
             # name
             correct_name = check_name
@@ -245,7 +246,7 @@ def manifest(fix, include_extras):
                 display_queue.append((echo_failure, '  should contain 80 characters maximum: short_description'))
 
             # support
-            correct_support = 'contrib' if root_name == 'extras' else 'core'
+            correct_support = 'contrib' if root_name == 'integrations-extras' else 'core'
             support = decoded.get('support')
             if support != correct_support:
                 file_failures += 1


### PR DESCRIPTION
### What does this PR do?

Fixes `ddev validate manifest` when working on -extras

### Motivation

`maintainer` validation wasn't working for integrations-extras

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
