### PR TITLE
Upgrade pytest plugins

### DIFF
--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -25,9 +25,9 @@ with open(path.join(HERE, 'README.md'), 'r', encoding='utf-8') as f:
 REQUIRES = [
     'coverage>=4.5.1',
     'mock',
-    'pytest<4.1',
-    'pytest-benchmark',
-    'pytest-cov',
+    'pytest',
+    'pytest-benchmark>=3.2.0',
+    'pytest-cov>=2.6.1',
     'pytest-mock',
     'requests>=2.20.0',
     'six',


### PR DESCRIPTION
### Motivation

pytest 4.1 introduced changes that broke a few plugins and now fixes are released:

https://github.com/pytest-dev/pytest-cov/pull/253#issuecomment-451792355
https://github.com/ionelmc/pytest-benchmark/issues/124#issuecomment-451989104