### PR TITLE
Add support for e2e testing

### DIFF
--- a/ibm_mq/tests/conftest.py
+++ b/ibm_mq/tests/conftest.py
@@ -90,7 +90,7 @@ def consume():
 
 
 @pytest.fixture(scope='session')
-def spin_up_ibmmq():
+def dd_environment():
 
     if common.MQ_VERSION == '9':
         log_pattern = "AMQ5026I: The listener 'DEV.LISTENER.TCP' has started. ProcessId"

--- a/ibm_mq/tests/conftest.py
+++ b/ibm_mq/tests/conftest.py
@@ -107,4 +107,4 @@ def dd_environment():
         log_patterns=log_pattern,
         sleep=10
     ):
-        yield
+        yield common.INSTANCE

--- a/ibm_mq/tests/test_ibm_mq.py
+++ b/ibm_mq/tests/test_ibm_mq.py
@@ -4,6 +4,8 @@
 
 import logging
 
+import pytest
+
 from datadog_checks.ibm_mq import IbmMqCheck
 
 log = logging.getLogger(__file__)
@@ -53,7 +55,8 @@ OPTIONAL_METRICS = [
 ]
 
 
-def test_check(aggregator, instance, spin_up_ibmmq, seed_data):
+@pytest.mark.usefixtures("dd_environment")
+def test_check(aggregator, instance, seed_data):
     check = IbmMqCheck('ibm_mq', {}, {})
     check.check(instance)
 


### PR DESCRIPTION
### What does this PR do?

This allows the `dev env start` command to launch the container. Since the check needs proprietary libs, it is not possible to use `ddev env check` though. 

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?