### PR TITLE
Move text for docs site build

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -129,9 +129,10 @@ PostgreSQL default logging is to `stderr` and logs do not include detailed infor
 [Run the Agent's status subcommand][17] and look for `postgres` under the Checks section.
 
 ## Data Collected
-### Metrics
 
 Some of the metrics listed below require additional configuration, see the [sample postgres.d/conf.yaml][14] for all configurable options.
+
+### Metrics
 
 See [metadata.csv][18] for a list of metrics provided by this integration.
 


### PR DESCRIPTION
### What does this PR do?
- Move text so it is included on docs site

### Motivation
- Build steps prevent this text from being seen on the docs site

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
~[ ] Feature or bugfix has tests~
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes
Docs build site process will be evaluated
