### PR TITLE
Use our IBM MQ mirror

### DIFF
--- a/.travis/install_ibm_mq.sh
+++ b/.travis/install_ibm_mq.sh
@@ -3,7 +3,7 @@
 set -ex
 
 TMP_DIR=/tmp/mq
-MQ_URL=http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev90_linux_x86-64.tar.gz
+MQ_URL=https://s3.amazonaws.com/dd-agent-tarball-mirror/mqadv_dev90_linux_x86-64.tar.gz
 MQ_PACKAGES="MQSeriesRuntime-*.rpm MQSeriesServer-*.rpm MQSeriesMsg*.rpm MQSeriesJava*.rpm MQSeriesJRE*.rpm MQSeriesGSKit*.rpm"
 
 if [ -z "$CHECK" ]; then


### PR DESCRIPTION
### What does this PR do?

This changes the download location to our own IBM MQ mirror instead of using the official one (which is very slow)

### Motivation

The IBM download would fail and break the tests

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
