### PR TITLE
Finish Py3 support

### DIFF
--- a/btrfs/datadog_checks/btrfs/btrfs.py
+++ b/btrfs/datadog_checks/btrfs/btrfs.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2010-2017
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+from __future__ import division
 
 import array
 from collections import defaultdict
@@ -11,8 +12,10 @@ import struct
 
 import psutil
 from six import iteritems
+from six.moves import xrange
 
 from datadog_checks.checks import AgentCheck
+
 
 MIXED = "mixed"
 DATA = "data"
@@ -185,7 +188,7 @@ class BTRFS(AgentCheck):
                 tags.extend(custom_tags)
 
                 free = total_bytes - used_bytes
-                usage = float(used_bytes) / float(total_bytes)
+                usage = used_bytes / total_bytes
 
                 self.gauge('system.disk.btrfs.total', total_bytes, tags=tags)
                 self.gauge('system.disk.btrfs.used', used_bytes, tags=tags)


### PR DESCRIPTION
### What does this PR do?

Make ddev validate py3 pass and finish supporting PY3

Decided to keep `xrange` here because [in the place its used](https://github.com/DataDog/integrations-core/blob/576925cfcbb898b5afeee36d97ff49e531421ddc/btrfs/datadog_checks/btrfs/btrfs.py#L148), it iterates through all devices found, so a generator seems ideal. 

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
