### PR TITLE
Finish Python 3 Support

### DIFF
--- a/cacti/datadog_checks/cacti/cacti.py
+++ b/cacti/datadog_checks/cacti/cacti.py
@@ -230,5 +230,5 @@ class Cacti(AgentCheck):
         ''' Add any special case transformations here '''
         # Report memory in MB
         if m_name[0:11] in ('system.mem.', 'system.disk'):
-            return float(val) / 1024
+            return val / 1024
         return val

--- a/cacti/datadog_checks/cacti/cacti.py
+++ b/cacti/datadog_checks/cacti/cacti.py
@@ -1,21 +1,19 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import division
 
-# stdlib
 from collections import namedtuple
 from fnmatch import fnmatch
 import os
 import time
 
-# 3rd party
 try:
     import rrdtool
 except ImportError:
     rrdtool = None
 import pymysql
 
-# project
 from datadog_checks.checks import AgentCheck
 
 CFUNC_TO_AGGR = {'AVERAGE': 'avg', 'MAXIMUM': 'max', 'MINIMUM': 'min'}
@@ -232,5 +230,5 @@ class Cacti(AgentCheck):
         ''' Add any special case transformations here '''
         # Report memory in MB
         if m_name[0:11] in ('system.mem.', 'system.disk'):
-            return val / 1024
+            return float(val) / 1024
         return val


### PR DESCRIPTION
### What does this PR do?

Imports division from __future__ to make sure we fully support Py3 here. 

Right now the division in the check occurs with values that could be a float or int. In Py2 this means that the resulting value being submitted could be a float or int depending on operators. 

By importing division from future, keeping single division, we do gain a slight granularity increase for any returned `val` from cacti that is a float, now we get a decimal instead of flooring. 

### Motivation

ddev validate py3 was failing. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
