### PR TITLE
Finish Python3 Support

### DIFF
--- a/cassandra_nodetool/datadog_checks/cassandra_nodetool/cassandra_nodetool.py
+++ b/cassandra_nodetool/datadog_checks/cassandra_nodetool/cassandra_nodetool.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+# pylint: disable=W1633
+from __future__ import division
 
 import re
 import shlex


### PR DESCRIPTION
### What does this PR do?

Imports future division and ignore pylint warning about `round` function. 

### Motivation

This one was a little complicated to work through. The offending incompatible Python3 line was: https://github.com/DataDog/integrations-core/blob/master/cassandra_nodetool/datadog_checks/cassandra_nodetool/cassandra_nodetool.py#L114

The primary difference in Py2/3 `round` function is that ties are now broken in favor of the even int. 
PY2 -> round(2.5) -> 3
PY3 -> round(2.5) -> 2

Ownership in nodetool shouldn't be at 50%, so we shouldn't hit this case of a tie, so it should be safe to continue using the built in round function with this difference. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
