### PR TITLE
Finish supporting Py3

### DIFF
--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import division
+
 from collections import defaultdict
 from datetime import datetime, timedelta
 from itertools import islice
@@ -460,7 +462,7 @@ class ConsulCheck(AgentCheck):
                     tags = main_tags + ['source_datacenter:{}'.format(name),
                                         'dest_datacenter:{}'.format(other_name)]
                     n = len(latencies)
-                    half_n = int(n // 2)
+                    half_n = n // 2
                     if n % 2:
                         median = latencies[half_n]
                     else:
@@ -487,7 +489,7 @@ class ConsulCheck(AgentCheck):
                     latencies.append(distance(node, other))
                 latencies.sort()
                 n = len(latencies)
-                half_n = int(n // 2)
+                half_n = n // 2
                 if n % 2:
                     median = latencies[half_n]
                 else:


### PR DESCRIPTION
### What does this PR do?

Imports division from future

### Motivation

Finish supporting Py3

There are two places where division occurs here. 

1) https://github.com/DataDog/integrations-core/blob/master/consul/datadog_checks/consul/consul.py#L463 Since this is based on the `len` of a list it should always be integer on integer division, so we no longer need to cast to an int here. 

2) https://github.com/DataDog/integrations-core/blob/master/consul/datadog_checks/consul/consul.py#L467 This is based off a value in computed from the `distance` function which would always return a float. So single `/` division would still return a float based value. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
