### PR TITLE
Reduce test cluster complexity

### DIFF
--- a/spark/tests/docker/docker-compose.yaml
+++ b/spark/tests/docker/docker-compose.yaml
@@ -22,16 +22,7 @@ services:
     environment:
       - ENABLE_INIT_DAEMON=false
       - "SPARK_MASTER=spark://spark-master:7077"
-  spark-worker-2:
-    image: bde2020/spark-worker:${SPARK_VERSION}-hadoop2.7
-    container_name: spark-worker-2
-    depends_on:
-      - spark-master
-    ports:
-      - "8082:8081"
-    environment:
-      - ENABLE_INIT_DAEMON=false
-      - "SPARK_MASTER=spark://spark-master:7077"
+      - SPARK_WORKER_CORES=1
   spark-app-1:
     build:
       context: .


### PR DESCRIPTION
### What does this PR do?

Removes the worker2 container
Sets the number of worker cores to 1 on the worker container

We don't lose any metrics by having only one worker, and reducing the number of cores per worker should keep resource utilization 

### Motivation

Test Cluster uses a lot of resources/time when its spun up. Since this supports E2E (and to keep CI ⏩ ) lets only keep what we need. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
