### PR TITLE
Fix metric types by changing rates to gauges or counts

### DIFF
--- a/spark/datadog_checks/spark/spark.py
+++ b/spark/datadog_checks/spark/spark.py
@@ -63,76 +63,75 @@ SUCCESS_STATUS = ['SUCCEEDED', 'COMPLETE']
 SOURCE_TYPE_NAME = 'spark'
 
 # Metric types
-INCREMENT = 'increment'
 GAUGE = 'gauge'
 COUNT = 'count'
 MONOTONIC_COUNT = 'monotonic_count'
 
 # Metrics to collect
 SPARK_JOB_METRICS = {
-    'numTasks': ('spark.job.num_tasks', INCREMENT),
-    'numActiveTasks': ('spark.job.num_active_tasks', INCREMENT),
-    'numCompletedTasks': ('spark.job.num_completed_tasks', INCREMENT),
-    'numSkippedTasks': ('spark.job.num_skipped_tasks', INCREMENT),
-    'numFailedTasks': ('spark.job.num_failed_tasks', INCREMENT),
-    'numActiveStages': ('spark.job.num_active_stages', INCREMENT),
-    'numCompletedStages': ('spark.job.num_completed_stages', INCREMENT),
-    'numSkippedStages': ('spark.job.num_skipped_stages', INCREMENT),
-    'numFailedStages': ('spark.job.num_failed_stages', INCREMENT)
+    'numTasks': ('spark.job.num_tasks', COUNT),
+    'numActiveTasks': ('spark.job.num_active_tasks', COUNT),
+    'numCompletedTasks': ('spark.job.num_completed_tasks', COUNT),
+    'numSkippedTasks': ('spark.job.num_skipped_tasks', COUNT),
+    'numFailedTasks': ('spark.job.num_failed_tasks', COUNT),
+    'numActiveStages': ('spark.job.num_active_stages', COUNT),
+    'numCompletedStages': ('spark.job.num_completed_stages', COUNT),
+    'numSkippedStages': ('spark.job.num_skipped_stages', COUNT),
+    'numFailedStages': ('spark.job.num_failed_stages', COUNT)
 }
 
 SPARK_STAGE_METRICS = {
-    'numActiveTasks': ('spark.stage.num_active_tasks', INCREMENT),
-    'numCompleteTasks': ('spark.stage.num_complete_tasks', INCREMENT),
-    'numFailedTasks': ('spark.stage.num_failed_tasks', INCREMENT),
-    'executorRunTime': ('spark.stage.executor_run_time', INCREMENT),
-    'inputBytes': ('spark.stage.input_bytes', INCREMENT),
-    'inputRecords': ('spark.stage.input_records', INCREMENT),
-    'outputBytes': ('spark.stage.output_bytes', INCREMENT),
-    'outputRecords': ('spark.stage.output_records', INCREMENT),
-    'shuffleReadBytes': ('spark.stage.shuffle_read_bytes', INCREMENT),
-    'shuffleReadRecords': ('spark.stage.shuffle_read_records', INCREMENT),
-    'shuffleWriteBytes': ('spark.stage.shuffle_write_bytes', INCREMENT),
-    'shuffleWriteRecords': ('spark.stage.shuffle_write_records', INCREMENT),
-    'memoryBytesSpilled': ('spark.stage.memory_bytes_spilled', INCREMENT),
-    'diskBytesSpilled': ('spark.stage.disk_bytes_spilled', INCREMENT)
+    'numActiveTasks': ('spark.stage.num_active_tasks', COUNT),
+    'numCompleteTasks': ('spark.stage.num_complete_tasks', COUNT),
+    'numFailedTasks': ('spark.stage.num_failed_tasks', COUNT),
+    'executorRunTime': ('spark.stage.executor_run_time', COUNT),
+    'inputBytes': ('spark.stage.input_bytes', COUNT),
+    'inputRecords': ('spark.stage.input_records', COUNT),
+    'outputBytes': ('spark.stage.output_bytes', COUNT),
+    'outputRecords': ('spark.stage.output_records', COUNT),
+    'shuffleReadBytes': ('spark.stage.shuffle_read_bytes', COUNT),
+    'shuffleReadRecords': ('spark.stage.shuffle_read_records', COUNT),
+    'shuffleWriteBytes': ('spark.stage.shuffle_write_bytes', COUNT),
+    'shuffleWriteRecords': ('spark.stage.shuffle_write_records', COUNT),
+    'memoryBytesSpilled': ('spark.stage.memory_bytes_spilled', COUNT),
+    'diskBytesSpilled': ('spark.stage.disk_bytes_spilled', COUNT)
 }
 
 SPARK_DRIVER_METRICS = {
-    'rddBlocks': ('spark.driver.rdd_blocks', INCREMENT),
-    'memoryUsed': ('spark.driver.memory_used', INCREMENT),
-    'diskUsed': ('spark.driver.disk_used', INCREMENT),
-    'activeTasks': ('spark.driver.active_tasks', INCREMENT),
-    'failedTasks': ('spark.driver.failed_tasks', INCREMENT),
-    'completedTasks': ('spark.driver.completed_tasks', INCREMENT),
-    'totalTasks': ('spark.driver.total_tasks', INCREMENT),
-    'totalDuration': ('spark.driver.total_duration', INCREMENT),
-    'totalInputBytes': ('spark.driver.total_input_bytes', INCREMENT),
-    'totalShuffleRead': ('spark.driver.total_shuffle_read', INCREMENT),
-    'totalShuffleWrite': ('spark.driver.total_shuffle_write', INCREMENT),
-    'maxMemory': ('spark.driver.max_memory', INCREMENT)
+    'rddBlocks': ('spark.driver.rdd_blocks', COUNT),
+    'memoryUsed': ('spark.driver.memory_used', COUNT),
+    'diskUsed': ('spark.driver.disk_used', COUNT),
+    'activeTasks': ('spark.driver.active_tasks', COUNT),
+    'failedTasks': ('spark.driver.failed_tasks', COUNT),
+    'completedTasks': ('spark.driver.completed_tasks', COUNT),
+    'totalTasks': ('spark.driver.total_tasks', COUNT),
+    'totalDuration': ('spark.driver.total_duration', COUNT),
+    'totalInputBytes': ('spark.driver.total_input_bytes', COUNT),
+    'totalShuffleRead': ('spark.driver.total_shuffle_read', COUNT),
+    'totalShuffleWrite': ('spark.driver.total_shuffle_write', COUNT),
+    'maxMemory': ('spark.driver.max_memory', COUNT)
 }
 
 SPARK_EXECUTOR_METRICS = {
-    'rddBlocks': ('spark.executor.rdd_blocks', INCREMENT),
-    'memoryUsed': ('spark.executor.memory_used', INCREMENT),
-    'diskUsed': ('spark.executor.disk_used', INCREMENT),
-    'activeTasks': ('spark.executor.active_tasks', INCREMENT),
-    'failedTasks': ('spark.executor.failed_tasks', INCREMENT),
-    'completedTasks': ('spark.executor.completed_tasks', INCREMENT),
-    'totalTasks': ('spark.executor.total_tasks', INCREMENT),
-    'totalDuration': ('spark.executor.total_duration', INCREMENT),
-    'totalInputBytes': ('spark.executor.total_input_bytes', INCREMENT),
-    'totalShuffleRead': ('spark.executor.total_shuffle_read', INCREMENT),
-    'totalShuffleWrite': ('spark.executor.total_shuffle_write', INCREMENT),
-    'maxMemory': ('spark.executor.max_memory', INCREMENT)
+    'rddBlocks': ('spark.executor.rdd_blocks', COUNT),
+    'memoryUsed': ('spark.executor.memory_used', COUNT),
+    'diskUsed': ('spark.executor.disk_used', COUNT),
+    'activeTasks': ('spark.executor.active_tasks', COUNT),
+    'failedTasks': ('spark.executor.failed_tasks', COUNT),
+    'completedTasks': ('spark.executor.completed_tasks', COUNT),
+    'totalTasks': ('spark.executor.total_tasks', COUNT),
+    'totalDuration': ('spark.executor.total_duration', COUNT),
+    'totalInputBytes': ('spark.executor.total_input_bytes', COUNT),
+    'totalShuffleRead': ('spark.executor.total_shuffle_read', COUNT),
+    'totalShuffleWrite': ('spark.executor.total_shuffle_write', COUNT),
+    'maxMemory': ('spark.executor.max_memory', COUNT)
 }
 
 SPARK_RDD_METRICS = {
-    'numPartitions': ('spark.rdd.num_partitions', INCREMENT),
-    'numCachedPartitions': ('spark.rdd.num_cached_partitions', INCREMENT),
-    'memoryUsed': ('spark.rdd.memory_used', INCREMENT),
-    'diskUsed': ('spark.rdd.disk_used', INCREMENT)
+    'numPartitions': ('spark.rdd.num_partitions', COUNT),
+    'numCachedPartitions': ('spark.rdd.num_cached_partitions', COUNT),
+    'memoryUsed': ('spark.rdd.memory_used', COUNT),
+    'diskUsed': ('spark.rdd.disk_used', COUNT)
 }
 
 SPARK_STREAMING_STATISTICS_METRICS = {
@@ -504,7 +503,7 @@ class SparkCheck(AgentCheck):
                 tags.append('status:%s' % str(status).lower())
 
                 self._set_metrics_from_json(tags, job, SPARK_JOB_METRICS)
-                self._set_metric('spark.job.count', INCREMENT, 1, tags)
+                self._set_metric('spark.job.count', COUNT, 1, tags)
 
     def _spark_stage_metrics(self, instance, running_apps, addl_tags, requests_config):
         """
@@ -527,7 +526,7 @@ class SparkCheck(AgentCheck):
                 tags.append('status:%s' % str(status).lower())
 
                 self._set_metrics_from_json(tags, stage, SPARK_STAGE_METRICS)
-                self._set_metric('spark.stage.count', INCREMENT, 1, tags)
+                self._set_metric('spark.stage.count', COUNT, 1, tags)
 
     def _spark_executor_metrics(self, instance, running_apps, addl_tags, requests_config):
         """
@@ -551,7 +550,7 @@ class SparkCheck(AgentCheck):
                     self._set_metrics_from_json(tags, executor, SPARK_EXECUTOR_METRICS)
 
             if len(response):
-                self._set_metric('spark.executor.count', INCREMENT, len(response), tags)
+                self._set_metric('spark.executor.count', COUNT, len(response), tags)
 
     def _spark_rdd_metrics(self, instance, running_apps, addl_tags, requests_config):
         """
@@ -572,7 +571,7 @@ class SparkCheck(AgentCheck):
                 self._set_metrics_from_json(tags, rdd, SPARK_RDD_METRICS)
 
             if len(response):
-                self._set_metric('spark.rdd.count', INCREMENT, len(response), tags)
+                self._set_metric('spark.rdd.count', COUNT, len(response), tags)
 
     def _spark_streaming_statistics_metrics(self, instance, running_apps, addl_tags, requests_config):
         """
@@ -620,9 +619,7 @@ class SparkCheck(AgentCheck):
         """
         if tags is None:
             tags = []
-        if metric_type == INCREMENT:
-            self.increment(metric_name, value, tags=tags)
-        elif metric_type == GAUGE:
+        if metric_type == GAUGE:
             self.gauge(metric_name, value, tags=tags)
         elif metric_type == COUNT:
             self.count(metric_name, value, tags=tags)

--- a/spark/metadata.csv
+++ b/spark/metadata.csv
@@ -1,70 +1,70 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-spark.job.count,rate,,task,,Number of jobs,0,spark,jb count
-spark.job.num_tasks,rate,,task,second,Number of tasks in the application,0,spark,jb nm tsk
-spark.job.num_active_tasks,rate,,task,second,Number of active tasks in the application,0,spark,jb nm act tsk
-spark.job.num_skipped_tasks,rate,,task,second,Number of skipped tasks in the application,0,spark,jb nm skp tsk
-spark.job.num_failed_tasks,rate,,task,second,Number of failed tasks in the application,0,spark,jb nm fld tsk
-spark.job.num_completed_tasks,rate,,task,second,Number of completed tasks in the application,0,spark,jb nm completed tsk
-spark.job.num_active_stages,rate,,stage,second,Number of active stages in the application,0,spark,jb act stg
-spark.job.num_completed_stages,rate,,stage,second,Number of completed stages in the application,0,spark,jb nm cmp stg
-spark.job.num_skipped_stages,rate,,stage,second,Number of skipped stages in the application,0,spark,jb nm skp stg
-spark.job.num_failed_stages,rate,,stage,second,Number of failed stages in the application,0,spark,jb nm fld stg
-spark.stage.count,rate,,task,,Number of stages,0,spark,stg count
-spark.stage.num_active_tasks,rate,,task,second,Number of active tasks in the application's stages,0,spark,stg nm act tsk
-spark.stage.num_complete_tasks,rate,,task,second,Number of complete tasks in the application's stages,0,spark,stg nm cmp tsk
-spark.stage.num_failed_tasks,rate,,task,second,Number of failed tasks in the application's stages,0,spark,stg nm fld tsk
-spark.stage.executor_run_time,gauge,,fraction,,Fraction of time (ms/s) spent by the executor in the application's stages,0,spark,stg exe rn tm
-spark.stage.input_bytes,rate,,byte,second,Input bytes in the application's stages,0,spark,stg in byt
-spark.stage.input_records,rate,,record,second,Input records in the application's stages,0,spark,stg in rec
-spark.stage.output_bytes,rate,,byte,second,Output bytes in the application's stages,0,spark,stg out byt
-spark.stage.output_records,rate,,record,second,Output records in the application's stages,0,spark,stg out rec
-spark.stage.shuffle_read_bytes,rate,,byte,second,Number of bytes read during a shuffle in the application's stages,0,spark,stg shfl rd byt
-spark.stage.shuffle_read_records,rate,,record,second,Number of records read during a shuffle in the application's stages,0,spark,stg shfl rd rec
-spark.stage.shuffle_write_bytes,rate,,byte,second,Number of shuffled bytes in the application's stages,0,spark,stg shfl wrt byt
-spark.stage.shuffle_write_records,rate,,record,second,Number of shuffled records in the application's stages,0,spark,stg shfl wrt rec
-spark.stage.memory_bytes_spilled,rate,,byte,second,Number of bytes spilled to disk in the application's stages,0,spark,stg mem byt spld
-spark.stage.disk_bytes_spilled,rate,,byte,second,Max size on disk of the spilled bytes in the application's stages,0,spark,stg dsk byt spld
-spark.driver.rdd_blocks,rate,,block,second,Number of RDD blocks in the driver,0,spark,dvr rdd blk
-spark.driver.memory_used,rate,,byte,second,Amount of memory used in the driver,0,spark,dvr mem usd
-spark.driver.disk_used,rate,,byte,second,Amount of disk used in the driver,0,spark,dvr dsk usd
-spark.driver.active_tasks,rate,,task,second,Number of active tasks in the driver,0,spark,dvr act tsk
-spark.driver.failed_tasks,rate,,task,second,Number of failed tasks in the driver,0,spark,dvr fld tsk
-spark.driver.completed_tasks,rate,,task,second,Number of completed tasks in the driver,0,spark,dvr comp tsk
-spark.driver.total_tasks,rate,,task,second,Number of total tasks in the driver,0,spark,dvr tot task
-spark.driver.total_duration,gauge,,fraction,,Fraction of time (ms/s) spent by the driver,0,spark,dvr tot dur
-spark.driver.total_input_bytes,rate,,byte,second,Number of input bytes in the driver,0,spark,dvr tot in byt
-spark.driver.total_shuffle_read,rate,,byte,second,Number of bytes read during a shuffle in the driver,0,spark,dvr tot shfl rd
-spark.driver.total_shuffle_write,rate,,byte,second,Number of shuffled bytes in the driver,0,spark,dvr tot shfl wrt
-spark.driver.max_memory,rate,,byte,second,Maximum memory used in the driver,0,spark,dvr max mem
-spark.executor.count,rate,,task,,Number of executors,0,spark,exe count
-spark.executor.rdd_blocks,rate,,block,second,Number of persisted RDD blocks in the application's executors,0,spark,exe rdd blk
-spark.executor.memory_used,rate,,byte,second,Amount of memory used for cached RDDs in the application's executors,0,spark,exe mem usd
-spark.executor.max_memory,rate,,byte,second,Max memory across all executors working for a particular application,0,spark,exe mem max
-spark.executor.disk_used,rate,,byte,second,Amount of disk space used by persisted RDDs in the application's executors,0,spark,exe dsk usd
-spark.executor.active_tasks,rate,,task,second,Number of active tasks in the application's executors,0,spark,exe act tsk
-spark.executor.failed_tasks,rate,,task,second,Number of failed tasks in the application's executors,0,spark,exe fld tsk
-spark.executor.completed_tasks,rate,,task,second,Number of completed tasks in the application's executors,0,spark,exe comp tsk
-spark.executor.total_tasks,rate,,task,second,Total number of tasks in the application's executors,0,spark,exe tot tsk
-spark.executor.total_duration,gauge,,fraction,,Fraction of time (ms/s) spent by the application's executors executing tasks,0,spark,exe tot dur
-spark.executor.total_input_bytes,rate,,byte,second,Total number of input bytes in the application's executors,0,spark,exe in byt
-spark.executor.total_shuffle_read,rate,,byte,second,Total number of bytes read during a shuffle in the application's executors,0,spark,exe tot shfl rd
-spark.executor.total_shuffle_write,rate,,byte,second,Total number of shuffled bytes in the application's executors,0,spark,exe tot shfl wrt
-spark.executor_memory,rate,,byte,second,Maximum memory available for caching RDD blocks in the application's executors,0,spark,exe max mem
-spark.rdd.count,rate,,,,Number of RDDs,0,spark,rdd count
-spark.rdd.num_partitions,rate,,,second,Number of persisted RDD partitions in the application,0,spark,rdd num part
-spark.rdd.num_cached_partitions,rate,,,second,Number of in-memory cached RDD partitions in the application,0,spark,rdd num ch part
-spark.rdd.memory_used,rate,,byte,second,Amount of memory used in the application's persisted RDDs,0,spark,rdd mem usd
-spark.rdd.disk_used,rate,,byte,second,Amount of disk space used by persisted RDDs in the application,0,spark,rdd dsk usd
-spark.streaming.statistics.avg_input_rate,rate,,byte,second,Average streaming input data rate,0,spark,streaming avg input rate
+spark.job.count,count,,task,,Number of jobs,0,spark,jb count
+spark.job.num_tasks,count,,task,,Number of tasks in the application,0,spark,jb nm tsk
+spark.job.num_active_tasks,count,,task,,Number of active tasks in the application,0,spark,jb nm act tsk
+spark.job.num_skipped_tasks,count,,task,,Number of skipped tasks in the application,0,spark,jb nm skp tsk
+spark.job.num_failed_tasks,count,,task,,Number of failed tasks in the application,0,spark,jb nm fld tsk
+spark.job.num_completed_tasks,count,,task,,Number of completed tasks in the application,0,spark,jb nm completed tsk
+spark.job.num_active_stages,count,,stage,,Number of active stages in the application,0,spark,jb act stg
+spark.job.num_completed_stages,count,,stage,,Number of completed stages in the application,0,spark,jb nm cmp stg
+spark.job.num_skipped_stages,count,,stage,,Number of skipped stages in the application,0,spark,jb nm skp stg
+spark.job.num_failed_stages,count,,stage,,Number of failed stages in the application,0,spark,jb nm fld stg
+spark.stage.count,count,,task,,Number of stages,0,spark,stg count
+spark.stage.num_active_tasks,count,,task,,Number of active tasks in the application's stages,0,spark,stg nm act tsk
+spark.stage.num_complete_tasks,count,,task,,Number of complete tasks in the application's stages,0,spark,stg nm cmp tsk
+spark.stage.num_failed_tasks,count,,task,,Number of failed tasks in the application's stages,0,spark,stg nm fld tsk
+spark.stage.executor_run_time,count,,millisecond,,Time spent by the executor in the application's stages,0,spark,stg exe rn tm
+spark.stage.input_bytes,count,,byte,,Input bytes in the application's stages,0,spark,stg in byt
+spark.stage.input_records,count,,record,,Input records in the application's stages,0,spark,stg in rec
+spark.stage.output_bytes,count,,byte,,Output bytes in the application's stages,0,spark,stg out byt
+spark.stage.output_records,count,,record,,Output records in the application's stages,0,spark,stg out rec
+spark.stage.shuffle_read_bytes,count,,byte,,Number of bytes read during a shuffle in the application's stages,0,spark,stg shfl rd byt
+spark.stage.shuffle_read_records,count,,record,,Number of records read during a shuffle in the application's stages,0,spark,stg shfl rd rec
+spark.stage.shuffle_write_bytes,count,,byte,,Number of shuffled bytes in the application's stages,0,spark,stg shfl wrt byt
+spark.stage.shuffle_write_records,count,,record,,Number of shuffled records in the application's stages,0,spark,stg shfl wrt rec
+spark.stage.memory_bytes_spilled,count,,byte,,Number of bytes spilled to disk in the application's stages,0,spark,stg mem byt spld
+spark.stage.disk_bytes_spilled,count,,byte,,Max size on disk of the spilled bytes in the application's stages,0,spark,stg dsk byt spld
+spark.driver.rdd_blocks,count,,block,,Number of RDD blocks in the driver,0,spark,dvr rdd blk
+spark.driver.memory_used,count,,byte,,Amount of memory used in the driver,0,spark,dvr mem usd
+spark.driver.disk_used,count,,byte,,Amount of disk used in the driver,0,spark,dvr dsk usd
+spark.driver.active_tasks,count,,task,,Number of active tasks in the driver,0,spark,dvr act tsk
+spark.driver.failed_tasks,count,,task,,Number of failed tasks in the driver,0,spark,dvr fld tsk
+spark.driver.completed_tasks,count,,task,,Number of completed tasks in the driver,0,spark,dvr comp tsk
+spark.driver.total_tasks,count,,task,,Number of total tasks in the driver,0,spark,dvr tot task
+spark.driver.total_duration,count,,millisecond,,Time spent in the driver,0,spark,dvr tot dur
+spark.driver.total_input_bytes,count,,byte,,Number of input bytes in the driver,0,spark,dvr tot in byt
+spark.driver.total_shuffle_read,count,,byte,,Number of bytes read during a shuffle in the driver,0,spark,dvr tot shfl rd
+spark.driver.total_shuffle_write,count,,byte,,Number of shuffled bytes in the driver,0,spark,dvr tot shfl wrt
+spark.driver.max_memory,count,,byte,,Maximum memory used in the driver,0,spark,dvr max mem
+spark.executor.count,count,,task,,Number of executors,0,spark,exe count
+spark.executor.rdd_blocks,count,,block,,Number of persisted RDD blocks in the application's executors,0,spark,exe rdd blk
+spark.executor.memory_used,count,,byte,,Amount of memory used for cached RDDs in the application's executors,0,spark,exe mem usd
+spark.executor.max_memory,count,,byte,,Max memory across all executors working for a particular application,0,spark,exe mem max
+spark.executor.disk_used,count,,byte,,Amount of disk space used by persisted RDDs in the application's executors,0,spark,exe dsk usd
+spark.executor.active_tasks,count,,task,,Number of active tasks in the application's executors,0,spark,exe act tsk
+spark.executor.failed_tasks,count,,task,,Number of failed tasks in the application's executors,0,spark,exe fld tsk
+spark.executor.completed_tasks,count,,task,,Number of completed tasks in the application's executors,0,spark,exe comp tsk
+spark.executor.total_tasks,count,,task,,Total number of tasks in the application's executors,0,spark,exe tot tsk
+spark.executor.total_duration,count,,millisecond,,Time spent by the application's executors executing tasks,0,spark,exe tot dur
+spark.executor.total_input_bytes,count,,byte,,Total number of input bytes in the application's executors,0,spark,exe in byt
+spark.executor.total_shuffle_read,count,,byte,,Total number of bytes read during a shuffle in the application's executors,0,spark,exe tot shfl rd
+spark.executor.total_shuffle_write,count,,byte,,Total number of shuffled bytes in the application's executors,0,spark,exe tot shfl wrt
+spark.executor_memory,count,,byte,,Maximum memory available for caching RDD blocks in the application's executors,0,spark,exe max mem
+spark.rdd.count,count,,,,Number of RDDs,0,spark,rdd count
+spark.rdd.num_partitions,count,,,,Number of persisted RDD partitions in the application,0,spark,rdd num part
+spark.rdd.num_cached_partitions,count,,,,Number of in-memory cached RDD partitions in the application,0,spark,rdd num ch part
+spark.rdd.memory_used,count,,byte,,Amount of memory used in the application's persisted RDDs,0,spark,rdd mem usd
+spark.rdd.disk_used,count,,byte,,Amount of disk space used by persisted RDDs in the application,0,spark,rdd dsk usd
+spark.streaming.statistics.avg_input_rate,gauge,,byte,,Average streaming input data rate,0,spark,streaming avg input rate
 spark.streaming.statistics.avg_processing_time,gauge,,millisecond,,Average application's streaming batch processing time,0,spark,streaming avg processing time
 spark.streaming.statistics.avg_scheduling_delay,gauge,,millisecond,,Average application's streaming batch scheduling delay,0,spark,streaming avg scheduling delay
 spark.streaming.statistics.avg_total_delay,gauge,,millisecond,,Average application's streaming batch total delay,0,spark,streaming avg total delay
 spark.streaming.statistics.batch_duration,gauge,,millisecond,,Application's streaming batch duration,0,spark,streaming batch duration
-spark.streaming.statistics.num_active_batches,rate,,job,second, Number of active streaming batches,0,spark,num active batches
-spark.streaming.statistics.num_active_receivers,rate,,object,second,Number of active streaming receivers,0,spark,num active receivers
-spark.streaming.statistics.num_inactive_receivers,rate,,object,second,Number of inactive streaming receivers,0,spark,num inactive receivers
-spark.streaming.statistics.num_processed_records,rate,,record,second,Number of processed streaming records ,0,spark,num processed records
-spark.streaming.statistics.num_received_records,rate,,record,second,Number of received streaming records,0,spark,num received records
-spark.streaming.statistics.num_receivers,rate,,object,second,Number of streaming application's receivers,0,spark,num receivers
-spark.streaming.statistics.num_retained_completed_batches,rate,,job,second,Number of retained completed application's streaming batches,0,spark,num retained completed batches
-spark.streaming.statistics.num_total_completed_batches,rate,,job,second,Total number of completed application's streaming batches,0,spark,num total completed batches
+spark.streaming.statistics.num_active_batches,gauge,,job,,Number of active streaming batches,0,spark,num active batches
+spark.streaming.statistics.num_active_receivers,gauge,,object,,Number of active streaming receivers,0,spark,num active receivers
+spark.streaming.statistics.num_inactive_receivers,gauge,,object,,Number of inactive streaming receivers,0,spark,num inactive receivers
+spark.streaming.statistics.num_processed_records,count,,record,,Number of processed streaming records ,0,spark,num processed records
+spark.streaming.statistics.num_received_records,count,,record,,Number of received streaming records,0,spark,num received records
+spark.streaming.statistics.num_receivers,gauge,,object,,Number of streaming application's receivers,0,spark,num receivers
+spark.streaming.statistics.num_retained_completed_batches,count,,job,,Number of retained completed application's streaming batches,0,spark,num retained completed batches
+spark.streaming.statistics.num_total_completed_batches,count,,job,,Total number of completed application's streaming batches,0,spark,num total completed batches

--- a/spark/tests/conftest.py
+++ b/spark/tests/conftest.py
@@ -13,6 +13,7 @@ from .common import HERE, HOST
 def dd_environment(instance_standalone):
     with docker_run(
         compose_file=os.path.join(HERE, 'docker', 'docker-compose.yaml'),
+        build=True,
         endpoints='http://{}:4040/api/v1/applications'.format(HOST),
         sleep=5,
     ):

--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -591,12 +591,6 @@ def test_yarn(aggregator):
         c = SparkCheck('spark', None, {}, [YARN_CONFIG])
         c.check(YARN_CONFIG)
 
-        # Check the running job metrics
-        for metric, value in iteritems(SPARK_JOB_RUNNING_METRIC_VALUES):
-            aggregator.assert_metric(
-                metric,
-                tags=SPARK_JOB_RUNNING_METRIC_TAGS + CUSTOM_TAGS, value=value)
-
         # Check the succeeded job metrics
         for metric, value in iteritems(SPARK_JOB_SUCCEEDED_METRIC_VALUES):
             aggregator.assert_metric(


### PR DESCRIPTION
### What does this PR do?

Metrics that were previously submitted as increments (rate) are now being submitted as counts since Spark itself already does the aggregation.

### Motivation

Feedback from customers

### Additional Notes

Some resources used:

https://spark.apache.org/docs/latest/monitoring.html
https://jaceklaskowski.gitbooks.io/mastering-apache-spark/spark-metrics.html
https://docs.datadoghq.com/developers/metrics