### PR TITLE
Finish Python 3 support

### DIFF
--- a/mcache/datadog_checks/mcache/mcache.py
+++ b/mcache/datadog_checks/mcache/mcache.py
@@ -158,7 +158,7 @@ class Memcache(AgentCheck):
             try:
                 self.gauge(
                     "memcache.get_hit_percent",
-                    100.0 * stats["get_hits"] / stats["cmd_get"],
+                    100.0 * float(stats["get_hits"]) / float(stats["cmd_get"]),
                     tags=tags,
                 )
             except ZeroDivisionError:
@@ -167,7 +167,7 @@ class Memcache(AgentCheck):
             try:
                 self.gauge(
                     "memcache.fill_percent",
-                    100.0 * stats["bytes"] / stats["limit_maxbytes"],
+                    100.0 * float(stats["bytes"]) / float(stats["limit_maxbytes"]),
                     tags=tags,
                 )
             except ZeroDivisionError:
@@ -176,7 +176,7 @@ class Memcache(AgentCheck):
             try:
                 self.gauge(
                     "memcache.avg_item_size",
-                    stats["bytes"] / stats["curr_items"],
+                    float(stats["bytes"]) / float(stats["curr_items"]),
                     tags=tags,
                 )
             except ZeroDivisionError:

--- a/mcache/datadog_checks/mcache/mcache.py
+++ b/mcache/datadog_checks/mcache/mcache.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+from __future__ import division
+
 import pkg_resources
 
 import bmemcached
@@ -156,7 +158,7 @@ class Memcache(AgentCheck):
             try:
                 self.gauge(
                     "memcache.get_hit_percent",
-                    100.0 * float(stats["get_hits"]) / float(stats["cmd_get"]),
+                    100.0 * stats["get_hits"] / stats["cmd_get"],
                     tags=tags,
                 )
             except ZeroDivisionError:
@@ -165,7 +167,7 @@ class Memcache(AgentCheck):
             try:
                 self.gauge(
                     "memcache.fill_percent",
-                    100.0 * float(stats["bytes"]) / float(stats["limit_maxbytes"]),
+                    100.0 * stats["bytes"] / stats["limit_maxbytes"],
                     tags=tags,
                 )
             except ZeroDivisionError:
@@ -174,7 +176,7 @@ class Memcache(AgentCheck):
             try:
                 self.gauge(
                     "memcache.avg_item_size",
-                    float(stats["bytes"]) / float(stats["curr_items"]),
+                    stats["bytes"] / stats["curr_items"],
                     tags=tags,
                 )
             except ZeroDivisionError:


### PR DESCRIPTION
### What does this PR do?

 imports future division

I had to keep the float casting around division because the values returned from mcache are strings. 

### Motivation

ddev validate py3 was failing on using division without future import

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
