### PR TITLE
Add description length metadata validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -188,6 +188,8 @@ PROVIDER_INTEGRATIONS = {
     'prometheus',
 }
 
+MAX_DESCRIPTION_LENGTH = 400
+
 
 @click.command(
     context_settings=CONTEXT_SETTINGS,
@@ -309,6 +311,12 @@ def metadata(check):
                 # empty description field, description is recommended
                 if not row['description']:
                     empty_warning_count['description'] += 1
+                # exceeds max allowed length of description
+                elif len(row['description']) > MAX_DESCRIPTION_LENGTH:
+                    errors = True
+                    echo_failure('{}: `{}` exceeds the max length: {} for descriptions.'.format(
+                        current_check, row['metric_name'], MAX_DESCRIPTION_LENGTH)
+                    )
 
         for header, count in iteritems(empty_count):
             errors = True


### PR DESCRIPTION
### What does this PR do?

Adds description length to the ddev validate metadata command. 

### Motivation

Description fields can actually only be up to 400 characters. Lets catch this early and during validation. 

Example output after I manually made a description more than 400 chars for an ECS metric.:
```
$ ddev validate metadata ecs_fargate
ecs_fargate: `ecs.fargate.cpu.percent` exceeds the max length: 400 for descriptions.
```

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
