### PR TITLE
[postgres] adds pg_instance tag to metrics

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -1045,6 +1045,9 @@ GROUP BY datid, datname
         else:
             tags = list(set(tags))
 
+        # preset tags to host (if using socket) or host-port
+        tags.extend(["pginstance:%s" % (host if host.startswith('/') else "{}-{}".format(host,port))])
+
         # preset tags to the database name
         tags.extend(["db:%s" % dbname])
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -1046,7 +1046,7 @@ GROUP BY datid, datname
             tags = list(set(tags))
 
         # preset tags to host (if using socket) or host-port
-        tags.extend(["pg_instance:%s" % (host if host.startswith('/') else "{}-{}".format(host,port))])
+        tags.extend(["pg_instance:%s" % (host if host.startswith('/') else "{}-{}".format(host, port))])
 
         # preset tags to the database name
         tags.extend(["db:%s" % dbname])

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -838,7 +838,7 @@ GROUP BY datid, datname
             "host:%s" % host,
             "port:%s" % port,
         ]
-        service_check_tags.extend([t for t in tags if not t.startswith('pginstance')])
+        service_check_tags.extend([t for t in tags if not t.startswith('pg_instance')])
         service_check_tags = list(set(service_check_tags))
         return service_check_tags
 
@@ -1046,7 +1046,7 @@ GROUP BY datid, datname
             tags = list(set(tags))
 
         # preset tags to host (if using socket) or host-port
-        tags.extend(["pginstance:%s" % (host if host.startswith('/') else "{}-{}".format(host,port))])
+        tags.extend(["pg_instance:%s" % (host if host.startswith('/') else "{}-{}".format(host,port))])
 
         # preset tags to the database name
         tags.extend(["db:%s" % dbname])

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -838,7 +838,7 @@ GROUP BY datid, datname
             "host:%s" % host,
             "port:%s" % port,
         ]
-        service_check_tags.extend(tags)
+        service_check_tags.extend([t for t in tags if not t.startswith('pginstance')])
         service_check_tags = list(set(service_check_tags))
         return service_check_tags
 

--- a/postgres/tests/test_common.py
+++ b/postgres/tests/test_common.py
@@ -118,10 +118,11 @@ def test_schema_metrics(aggregator, check, pg_instance):
 def test_connections_metrics(aggregator, check, pg_instance):
     check.check(pg_instance)
 
+    expected_tags = pg_instance['tags'] + ['pg_instance:{}-{}'.format(HOST, PORT)]
     for name in CONNECTION_METRICS:
-        aggregator.assert_metric(name, count=1, tags=pg_instance['tags'])
-    tags = pg_instance['tags'] + ['db:datadog_test', 'pg_instance:{}-{}'.format(HOST, PORT)]
-    aggregator.assert_metric('postgresql.connections', count=1, tags=tags)
+        aggregator.assert_metric(name, count=1, tags=expected_tags)
+    expected_tags += ['db:datadog_test']
+    aggregator.assert_metric('postgresql.connections', count=1, tags=expected_tags)
 
 
 @pytest.mark.integration

--- a/postgres/tests/test_common.py
+++ b/postgres/tests/test_common.py
@@ -78,7 +78,9 @@ def check_bgw_metrics(aggregator, expected_tags):
 def test_common_metrics(aggregator, check, pg_instance):
     check.check(pg_instance)
 
-    expected_tags = pg_instance['tags'] + ['pg_instance:{}-{}'.format(HOST, PORT)]
+    expected_tags = pg_instance['tags'] + [
+        'pg_instance:{}-{}'.format(HOST, PORT),
+    ]
     check_bgw_metrics(aggregator, expected_tags)
 
     expected_tags += ['db:{}'.format(DB_NAME)]
@@ -110,8 +112,12 @@ def test_can_connect_service_check(aggregator, check, pg_instance):
 def test_schema_metrics(aggregator, check, pg_instance):
     check.check(pg_instance)
 
+    expected_tags = pg_instance['tags'] + [
+        'pg_instance:{}-{}'.format(HOST, PORT),
+        'schema:public',
+    ]
     aggregator.assert_metric('postgresql.table.count', value=1, count=1,
-                             tags=pg_instance['tags'] + ['schema:public', 'pg_instance:{}-{}'.format(HOST, PORT)])
+                             tags=expected_tags)
     aggregator.assert_metric('postgresql.db.count', value=2, count=1)
 
 
@@ -135,8 +141,12 @@ def test_locks_metrics(aggregator, check, pg_instance):
             cur.execute('LOCK persons')
             check.check(pg_instance)
 
-    tags = pg_instance['tags'] + ['lock_mode:AccessExclusiveLock', 'table:persons', 'db:datadog_test', 'pg_instance:{}-{}'.format(HOST, PORT)]
-    aggregator.assert_metric('postgresql.locks', count=1, tags=tags)
+    expected_tags = pg_instance['tags'] + [
+        'pg_instance:{}-{}'.format(HOST, PORT),
+        'db:datadog_test',
+        'lock_mode:AccessExclusiveLock', 'table:persons',
+    ]
+    aggregator.assert_metric('postgresql.locks', count=1, tags=expected_tags)
 
 
 @pytest.mark.integration
@@ -145,5 +155,9 @@ def test_activity_metrics(aggregator, check, pg_instance):
     pg_instance['collect_activity_metrics'] = True
     check.check(pg_instance)
 
+    expected_tags = pg_instance['tags'] + [
+        'pg_instance:{}-{}'.format(HOST, PORT),
+        'db:datadog_test',
+    ]
     for name in ACTIVITY_METRICS:
-        aggregator.assert_metric(name, count=1, tags=pg_instance['tags'] + ['db:datadog_test', 'pg_instance:{}-{}'.format(HOST, PORT)])
+        aggregator.assert_metric(name, count=1, tags=expected_tags)

--- a/postgres/tests/test_common.py
+++ b/postgres/tests/test_common.py
@@ -76,7 +76,7 @@ def check_bgw_metrics(aggregator, expected_tags):
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_common_metrics(aggregator, check, pg_instance):
-    expected_tags = pg_instance['tags'] + ['db:{}'.format(DB_NAME)]
+    expected_tags = pg_instance['tags'] + ['db:{}'.format(DB_NAME), 'pg_instance:{}'.format((HOST if HOST.startswith('/') else "{}-{}".format(HOST,PORT)))]
 
     check.check(pg_instance)
     check_common_metrics(aggregator, expected_tags)

--- a/postgres/tests/test_common.py
+++ b/postgres/tests/test_common.py
@@ -76,11 +76,13 @@ def check_bgw_metrics(aggregator, expected_tags):
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_common_metrics(aggregator, check, pg_instance):
-    expected_tags = pg_instance['tags'] + ['pg_instance:{}-{}'.format(HOST, PORT)]
-
     check.check(pg_instance)
-    check_common_metrics(aggregator, expected_tags=expected_tags + ['db:{}'.format(DB_NAME)])
+
+    expected_tags = pg_instance['tags'] + ['pg_instance:{}-{}'.format(HOST, PORT)]
     check_bgw_metrics(aggregator, expected_tags)
+
+    expected_tags += ['db:{}'.format(DB_NAME)]
+    check_common_metrics(aggregator, expected_tags=expected_tags)
 
 
 @pytest.mark.integration

--- a/postgres/tests/test_custom_metrics.py
+++ b/postgres/tests/test_custom_metrics.py
@@ -23,10 +23,10 @@ def test_custom_metrics(aggregator, pg_instance):
     postgres_check = PostgreSql('postgres', {}, {})
     postgres_check.check(pg_instance)
 
-    tags = pg_instance['tags'] + [
-        'pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port']),
-        'customdb:a',
-    ]
+    tags = ['customdb:a']
+    tags.append('pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port']))
+    tags.extend(pg_instance['tags'])
+
     aggregator.assert_metric('custom.num', value=21, tags=tags)
 
 

--- a/postgres/tests/test_custom_metrics.py
+++ b/postgres/tests/test_custom_metrics.py
@@ -68,6 +68,7 @@ def test_custom_queries(aggregator, pg_instance):
     postgres_check = PostgreSql('postgres', {}, {})
     postgres_check.check(pg_instance)
     tags = ['db:{}'.format(pg_instance['dbname'])]
+    tags.extend('pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port']))
     tags.extend(pg_instance['tags'])
 
     for tag in ('a', 'b', 'c'):

--- a/postgres/tests/test_custom_metrics.py
+++ b/postgres/tests/test_custom_metrics.py
@@ -68,7 +68,7 @@ def test_custom_queries(aggregator, pg_instance):
     postgres_check = PostgreSql('postgres', {}, {})
     postgres_check.check(pg_instance)
     tags = ['db:{}'.format(pg_instance['dbname'])]
-    tags.extend('pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port']))
+    tags.append('pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port']))
     tags.extend(pg_instance['tags'])
 
     for tag in ('a', 'b', 'c'):

--- a/postgres/tests/test_custom_metrics.py
+++ b/postgres/tests/test_custom_metrics.py
@@ -23,7 +23,10 @@ def test_custom_metrics(aggregator, pg_instance):
     postgres_check = PostgreSql('postgres', {}, {})
     postgres_check.check(pg_instance)
 
-    tags = ['customdb:a', 'pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port'])] + pg_instance['tags']
+    tags = pg_instance['tags'] + [
+        'pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port']),
+        'customdb:a',
+    ]
     aggregator.assert_metric('custom.num', value=21, tags=tags)
 
 

--- a/postgres/tests/test_custom_metrics.py
+++ b/postgres/tests/test_custom_metrics.py
@@ -23,7 +23,8 @@ def test_custom_metrics(aggregator, pg_instance):
     postgres_check = PostgreSql('postgres', {}, {})
     postgres_check.check(pg_instance)
 
-    aggregator.assert_metric('custom.num', value=21, tags=['customdb:a'] + pg_instance['tags'])
+    tags = ['customdb:a', 'pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port'])] + pg_instance['tags']
+    aggregator.assert_metric('custom.num', value=21, tags=tags)
 
 
 @pytest.mark.integration

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -52,8 +52,8 @@ def test_relations_metrics(aggregator, pg_instance):
     posgres_check = PostgreSql('postgres', {}, {})
     posgres_check.check(pg_instance)
 
-    expected_tags = pg_instance['tags'] + ['db:%s' % pg_instance['dbname'], 'table:persons', 'schema:public']
-    expected_size_tags = pg_instance['tags'] + ['db:%s' % pg_instance['dbname'], 'table:persons']
+    expected_tags = pg_instance['tags'] + ['db:%s' % pg_instance['dbname'], 'table:persons', 'schema:public', 'pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port'])]
+    expected_size_tags = pg_instance['tags'] + ['db:%s' % pg_instance['dbname'], 'table:persons', 'pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port'])]
     for name in RELATION_METRICS:
         aggregator.assert_metric(name, count=1, tags=expected_tags)
 
@@ -74,7 +74,7 @@ def test_index_metrics(aggregator, pg_instance):
     posgres_check = PostgreSql('postgres', {}, {})
     posgres_check.check(pg_instance)
 
-    expected_tags = ['db:dogs', 'table:breed', 'index:breed_names', 'schema:public']
+    expected_tags = ['db:dogs', 'table:breed', 'index:breed_names', 'schema:public', 'pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port'])]
     expected_tags += pg_instance['tags']
     for name in IDX_METRICS:
         aggregator.assert_metric(name, count=1, tags=expected_tags)

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -52,8 +52,18 @@ def test_relations_metrics(aggregator, pg_instance):
     posgres_check = PostgreSql('postgres', {}, {})
     posgres_check.check(pg_instance)
 
-    expected_tags = pg_instance['tags'] + ['db:%s' % pg_instance['dbname'], 'table:persons', 'schema:public', 'pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port'])]
-    expected_size_tags = pg_instance['tags'] + ['db:%s' % pg_instance['dbname'], 'table:persons', 'pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port'])]
+    expected_tags = pg_instance['tags'] + [
+        'pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port']),
+        'db:%s' % pg_instance['dbname'],
+        'table:persons', 'schema:public',
+    ]
+
+    expected_size_tags = pg_instance['tags'] + [
+        'pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port']),
+        'db:%s' % pg_instance['dbname'],
+        'table:persons',
+    ]
+
     for name in RELATION_METRICS:
         aggregator.assert_metric(name, count=1, tags=expected_tags)
 
@@ -74,7 +84,10 @@ def test_index_metrics(aggregator, pg_instance):
     posgres_check = PostgreSql('postgres', {}, {})
     posgres_check.check(pg_instance)
 
-    expected_tags = ['db:dogs', 'table:breed', 'index:breed_names', 'schema:public', 'pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port'])]
-    expected_tags += pg_instance['tags']
+    expected_tags = pg_instance['tags'] + [
+        'pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port']),
+        'db:dogs', 'table:breed', 'index:breed_names', 'schema:public',
+    ]
+
     for name in IDX_METRICS:
         aggregator.assert_metric(name, count=1, tags=expected_tags)


### PR DESCRIPTION
### What does this PR do?

adds pg_instance:<host|host-port> tag to metrics to distinguish which instance the metric came from.

Given a host (e.g. `dd-host1`) that connects to multiple remote PG instances:

```
instances:
  - host: /var/run/postgresql/.s.PGSQL.5432
  - host: pg01
    port: 5432
  - host: pg02
    port: 5433
```

metric submitted from each instance are identical and has no reference to which pg instance they were queried from.

```
{
  "metric": "postgresql.table.count",  "points": [[ 1547173475, 1]],
  "tags": [
    "schema:public"
  ],
  "host": "dd-host1",
  "type": "gauge", "interval": 0, "source_type_name": "System"
}
```

With the pg_instance tag, it would look like:

```
[
  {
    "metric": "postgresql.table.count", "points": [[ 1547173475, 1]],
    "tags": [
      "pg_instance:/var/run/postgresql/.s.PGSQL.5432",
      "schema:public"
    ],
    "host": "dd-host1",
    "type": "gauge", "interval": 0, "source_type_name": "System"
  },
  {
    "metric": "postgresql.table.count", "points": [[ 1547173475, 1]],
    "tags": [
      "pg_instance:pg01-5432",
      "schema:public"
    ],
    "host": "dd-host1",
    "type": "gauge", "interval": 0, "source_type_name": "System"
  },
  {
    "metric": "postgresql.table.count", "points": [[ 1547173475, 1]],
    "tags": [
      "pg_instance:pg02-5433",
      "schema:public"
    ],
    "host": "dd-host1",
    "type": "gauge", "interval": 0, "source_type_name": "System"
  }
]
```

### Motivation

Realized that i could not distinguish which metrics are coming from what instance.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
