### PR TITLE
[postgres] Adds an option to tag metrics with replication_role

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - postgres
 
+## Unreleased
+
+* [Added] Adds option to tag metrics with replication_role. See [#2929](https://github.com/DataDog/integrations-core/pull/2929)
+
 ## 2.4.0 / 2019-01-04
 
 * [Added] Bump psycopg2-binary version to 2.7.5. See [#2799](https://github.com/DataDog/integrations-core/pull/2799).

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -1,7 +1,5 @@
 # CHANGELOG - postgres
 
-* [Added] Adds option to tag metrics with replication_role. See [#2929](https://github.com/DataDog/integrations-core/pull/2929)
-
 ## 2.4.0 / 2019-01-04
 
 * [Added] Bump psycopg2-binary version to 2.7.5. See [#2799](https://github.com/DataDog/integrations-core/pull/2799).

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -1,7 +1,5 @@
 # CHANGELOG - postgres
 
-## Unreleased
-
 * [Added] Adds option to tag metrics with replication_role. See [#2929](https://github.com/DataDog/integrations-core/pull/2929)
 
 ## 2.4.0 / 2019-01-04

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -117,6 +117,10 @@ instances:
 #    collect_default_database: False
 #
 
+#    Tag metrics and checks with `replication_role:<master|standby>`, default to false
+#    tag_replication_role: False
+#
+
 ## log Section (Available for Agent >=6.0)
 #logs:
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -422,6 +422,7 @@ GROUP BY datid, datname
         cursor = db.cursor()
         cursor.execute('SELECT pg_is_in_recovery();')
         role = cursor.fetchone()[0]
+        # value fetched for role is of <type 'bool'> 
         return "standby" if role else "master"
 
     def _get_version(self, key, db):

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -422,7 +422,7 @@ GROUP BY datid, datname
         cursor = db.cursor()
         cursor.execute('SELECT pg_is_in_recovery();')
         role = cursor.fetchone()[0]
-        # value fetched for role is of <type 'bool'> 
+        # value fetched for role is of <type 'bool'>
         return "standby" if role else "master"
 
     def _get_version(self, key, db):

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -1067,7 +1067,7 @@ GROUP BY datid, datname
             version = self._get_version(key, db)
             self.log.debug("Running check against version %s" % version)
             if tag_replication_role:
-                tags.extend(["replication_role:%s" % self._get_replication_role(key, db)])
+                tags.extend(["replication_role:{}".format(self._get_replication_role(key, db))])
             self._collect_stats(key, db, tags, relations, custom_metrics, collect_function_metrics,
                                 collect_count_metrics, collect_activity_metrics, collect_database_size_metrics,
                                 collect_default_db, interface_error, programming_error)

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -418,6 +418,12 @@ GROUP BY datid, datname
         # Let's use pg8000
         return pg8000.connect, pg8000.InterfaceError, pg8000.ProgrammingError
 
+    def _get_replication_role(self, key, db):
+        cursor = db.cursor()
+        cursor.execute('SELECT pg_is_in_recovery();')
+        role = cursor.fetchone()[0]
+        return "standby" if role else "master"
+        
     def _get_version(self, key, db):
         if key not in self.versions:
             cursor = db.cursor()
@@ -1026,6 +1032,7 @@ GROUP BY datid, datname
         collect_activity_metrics = is_affirmative(instance.get('collect_activity_metrics', False))
         collect_database_size_metrics = is_affirmative(instance.get('collect_database_size_metrics', True))
         collect_default_db = is_affirmative(instance.get('collect_default_database', False))
+        tag_replication_role = is_affirmative(instance.get('tag_replication_role', False))
 
         if relations and not dbname:
             self.warning('"dbname" parameter must be set when using the "relations" parameter.')
@@ -1058,6 +1065,8 @@ GROUP BY datid, datname
             db = self.get_connection(key, host, port, user, password, dbname, ssl, connect_fct, tags)
             version = self._get_version(key, db)
             self.log.debug("Running check against version %s" % version)
+            if tag_replication_role:
+                tags.extend(["replication_role:%s" % self._get_replication_role(key, db)])
             self._collect_stats(key, db, tags, relations, custom_metrics, collect_function_metrics,
                                 collect_count_metrics, collect_activity_metrics, collect_database_size_metrics,
                                 collect_default_db, interface_error, programming_error)

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -423,7 +423,7 @@ GROUP BY datid, datname
         cursor.execute('SELECT pg_is_in_recovery();')
         role = cursor.fetchone()[0]
         return "standby" if role else "master"
-        
+
     def _get_version(self, key, db):
         if key not in self.versions:
             cursor = db.cursor()


### PR DESCRIPTION
### What does this PR do?

This is to determine if the metrics are coming from a master or replica PG instance.

### Motivation

customer request. We already have a way to determine the replication role, just need to add it as a tag.
https://datadog.zendesk.com/agent/tickets/190965

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
