### PR TITLE
Add round method to checks base

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/common.py
+++ b/datadog_checks_base/datadog_checks/base/utils/common.py
@@ -25,7 +25,7 @@ to_string = ensure_unicode if PY3 else ensure_bytes
 
 
 def round_value(value, precision=0, rounding_method=ROUND_HALF_UP):
-    precision = 0 if precision == 0 else '0.{}'.format('0' * precision)
+    precision = '0.{}'.format('0' * precision)
     return float(Decimal(str(value)).quantize(Decimal(precision), rounding=rounding_method))
 
 

--- a/datadog_checks_base/datadog_checks/base/utils/common.py
+++ b/datadog_checks_base/datadog_checks/base/utils/common.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from decimal import ROUND_HALF_UP, Decimal, getcontext
 import os
 import re
 
@@ -21,6 +22,11 @@ def ensure_unicode(s):
 
 
 to_string = ensure_unicode if PY3 else ensure_bytes
+
+
+def round_value(value, sig_digits="0.01", rounding_method=ROUND_HALF_UP):
+    getcontext().rounding = rounding_method
+    return float(Decimal(value).quantize(Decimal(sig_digits)))
 
 
 def get_docker_hostname():

--- a/datadog_checks_base/datadog_checks/base/utils/common.py
+++ b/datadog_checks_base/datadog_checks/base/utils/common.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from decimal import ROUND_HALF_UP, Decimal, getcontext
+from decimal import ROUND_HALF_UP, Decimal
 import os
 import re
 
@@ -24,9 +24,9 @@ def ensure_unicode(s):
 to_string = ensure_unicode if PY3 else ensure_bytes
 
 
-def round_value(value, sig_digits="0.01", rounding_method=ROUND_HALF_UP):
-    getcontext().rounding = rounding_method
-    return float(Decimal(str(value)).quantize(Decimal(sig_digits)))
+def round_value(value, precision=0, rounding_method=ROUND_HALF_UP):
+    precision = 0 if precision == 0 else '0.{}'.format('0' * precision)
+    return float(Decimal(str(value)).quantize(Decimal(precision), rounding=rounding_method))
 
 
 def get_docker_hostname():

--- a/datadog_checks_base/datadog_checks/base/utils/common.py
+++ b/datadog_checks_base/datadog_checks/base/utils/common.py
@@ -26,7 +26,7 @@ to_string = ensure_unicode if PY3 else ensure_bytes
 
 def round_value(value, sig_digits="0.01", rounding_method=ROUND_HALF_UP):
     getcontext().rounding = rounding_method
-    return float(Decimal(value).quantize(Decimal(sig_digits)))
+    return float(Decimal(str(value)).quantize(Decimal(sig_digits)))
 
 
 def get_docker_hostname():

--- a/datadog_checks_base/tests/test_utils.py
+++ b/datadog_checks_base/tests/test_utils.py
@@ -119,4 +119,4 @@ class TestRounding():
         assert round_value(3.5, sig_digits="1") == 4.0
         assert round_value(2.555, sig_digits="0.01") == 2.560
         assert round_value(4.2345, sig_digits="0.01") == 4.23
-        assert round_value(4.2345, sig_digits="0.001", rounding_method=ROUND_HALF_UP) == 4.2350
+        assert round_value(4.2345, sig_digits="0.000") == 4.235

--- a/datadog_checks_base/tests/test_utils.py
+++ b/datadog_checks_base/tests/test_utils.py
@@ -110,13 +110,12 @@ class TestLimiter():
 
 class TestRounding():
     def test_round_half_up(self):
-        assert round_value(2.555) == 2.560
+        assert round_value(3.5) == 4.0
 
     def test_round_modify_method(self):
-        assert round_value(3.5, sig_digits="1", rounding_method=ROUND_HALF_DOWN) == 3.0
+        assert round_value(3.5, rounding_method=ROUND_HALF_DOWN) == 3.0
 
     def test_round_modify_sig_digits(self):
-        assert round_value(3.5, sig_digits="1") == 4.0
-        assert round_value(2.555, sig_digits="0.01") == 2.560
-        assert round_value(4.2345, sig_digits="0.01") == 4.23
-        assert round_value(4.2345, sig_digits="0.000") == 4.235
+        assert round_value(2.555, precision=2) == 2.560
+        assert round_value(4.2345, precision=2) == 4.23
+        assert round_value(4.2345, precision=3) == 4.235

--- a/datadog_checks_base/tests/test_utils.py
+++ b/datadog_checks_base/tests/test_utils.py
@@ -1,8 +1,9 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from decimal import ROUND_HALF_DOWN, ROUND_HALF_UP
 
-from datadog_checks.utils.common import pattern_filter
+from datadog_checks.utils.common import pattern_filter, round_value
 from datadog_checks.utils.limiter import Limiter
 
 
@@ -105,3 +106,17 @@ class TestLimiter():
         assert limiter.get_status() == (0, 10, False)
         assert limiter.is_reached("dummy1") is False
         assert limiter.get_status() == (1, 10, False)
+
+
+class TestRounding():
+    def test_round_half_up(self):
+        assert round_value(2.555) == 2.560
+
+    def test_round_modify_method(self):
+        assert round_value(3.5, sig_digits="1", rounding_method=ROUND_HALF_DOWN) == 3.0
+
+    def test_round_modify_sig_digits(self):
+        assert round_value(3.5, sig_digits="1") == 4.0
+        assert round_value(2.555, sig_digits="0.01") == 2.560
+        assert round_value(4.2345, sig_digits="0.01") == 4.23
+        assert round_value(4.2345, sig_digits="0.001", rounding_method=ROUND_HALF_UP) == 4.2350


### PR DESCRIPTION
### What does this PR do?

Creates a rounding util method in checks_base that should mostly adhere to how `round` worked in Py2

### Motivation

Python2 and 3 use different rounding strategies and could offer different results. Python 2, in the event of a tie, rounds away from zero. 

Python 3 on the other hand, breaks the tie by rounding to the closer even number

Ex:

Py2:  round(2.5) -> 3
Py3: round(2.5) -> 2

Using the Decimal library allows us to control the rounding strategy and keeps all checks using the `round` function able to return the same value as before. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
