### PR TITLE
add note about collection interval to http check readme

### DIFF
--- a/http_check/README.md
+++ b/http_check/README.md
@@ -32,6 +32,8 @@ instances:
 
 The HTTP check has more configuration options than many checks - many more than are shown above. Most options are opt-in, e.g. the Agent will not check SSL validation unless you configure the requisite options. Notably, the Agent _will_ check for soon-to-expire SSL certificates by default.
 
+This check runs on every run of the Agent collector, which defaults to every 15 seconds. To set a custom run frequency for this check, refer to the [collection interval][11] section of the custom check documentation.
+
 See the [sample http_check.d/conf.yaml][2] for a full list and description of available options, here is a list of them:
 
 | Setting                          | Description                                                                                                                                                                                                                                                                                                                 |
@@ -117,3 +119,4 @@ Need help? Contact [Datadog support][9].
 [8]: https://app.datadoghq.com/monitors#/create
 [9]: https://docs.datadoghq.com/help/
 [10]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory
+[11]: https://docs.datadoghq.com/developers/write_agent_check/?tab=agentv6#collection-interval


### PR DESCRIPTION
### What does this PR do?

Updates http check readme with a note about collection interval

### Motivation

This was a question asked on Hotjar. Although the added paragraph is true for lots of checks, it does make sense to make a special note of it on this integration because collection interval is a natural question that would arise when configuring an http check.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.
