### PR TITLE
Only run `top` against the admin database

### DIFF
--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -959,7 +959,7 @@ class MongoDb(AgentCheck):
         # Report the usage metrics for dbs/collections
         if 'top' in additional_metrics:
             try:
-                dbtop = db.command('top')
+                dbtop = admindb.command('top')
                 for ns, ns_metrics in iteritems(dbtop['totals']):
                     if "." not in ns:
                         continue


### PR DESCRIPTION
### What does this PR do?

Resolves #2814 

### Motivation

`top` can only be ran against the admin database