### PR TITLE
Fix supported_os for kube_controller_manager

### DIFF
--- a/kube_controller_manager/manifest.json
+++ b/kube_controller_manager/manifest.json
@@ -10,7 +10,9 @@
   "guid": "34156dda-9288-4968-962b-6b29e1753d33",
   "support": "core",
   "supported_os": [
-    "linux"
+    "linux",
+    "mac_os",
+    "windows"
   ],
   "public_title": "Datadog-Kubernetes Controller Manager Integration",
   "categories": [


### PR DESCRIPTION
### Motivation

k8s has cross-platform support