### PR TITLE
Always ensure_unicode for out/err

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
+++ b/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
@@ -64,9 +64,7 @@ def get_subprocess_output(command, log, raise_on_empty_output=True, log_debug=Tr
         )
     )
 
-    if out:
-        out = ensure_unicode(out)
-    if err:
-        err = ensure_unicode(err)
+    out = ensure_unicode(out)
+    err = ensure_unicode(err)
 
     return out, err, returncode

--- a/varnish/tests/common.py
+++ b/varnish/tests/common.py
@@ -67,7 +67,6 @@ COMMON_METRICS = [
     "varnish.n_purgesps",
 ]
 
-VARNISH_DEFAULT_VERSION = "4.1.7"
 VARNISHADM_PATH = "varnishadm"
 SECRETFILE_PATH = "secretfile"
 DAEMON_ADDRESS = "localhost:6082"
@@ -90,5 +89,4 @@ def get_config_by_version(name=None):
 
 
 def get_varnish_stat_path():
-    varnish_version = os.environ.get("VARNISH_VERSION", VARNISH_DEFAULT_VERSION).split(".")[0]
-    return "docker exec ci_varnish{} varnishstat".format(varnish_version)
+    return "docker exec ci_varnish varnishstat"

--- a/varnish/tests/compose/docker-compose.yaml
+++ b/varnish/tests/compose/docker-compose.yaml
@@ -1,14 +1,8 @@
 version: '3.5'
 services:
 
-  varnish4:
-    image: datadog/docker-library:varnish_4_1_7
-    container_name: ci_varnish4
-    ports:
-    - "80"
-
-  varnish5:
-    image: datadog/docker-library:varnish_5_2_1
-    container_name: ci_varnish5
+  varnish:
+    image: datadog/docker-library:varnish_${VARNISH_VERSION}
+    container_name: ci_varnish
     ports:
     - "80"

--- a/varnish/tests/conftest.py
+++ b/varnish/tests/conftest.py
@@ -4,22 +4,26 @@
 
 import pytest
 import os
-import subprocess
-import time
 
+from datadog_checks.dev import docker_run
+from datadog_checks.varnish import Varnish
 from . import common
 
 
-@pytest.fixture(scope="session")
-def spin_up_varnish():
-    env = os.environ
-    target = "varnish{}".format(env["VARNISH_VERSION"].split(".")[0])
-    args = [
-        "docker-compose",
-        "-f", os.path.join(common.HERE, 'compose', 'docker-compose.yaml')
-    ]
-    subprocess.check_call(args + ["down"], env=env)
-    subprocess.check_call(args + ["up", "-d", target], env=env)
-    time.sleep(2)
-    yield
-    subprocess.check_call(args + ["down"], env=env)
+@pytest.fixture
+def check():
+    return Varnish(common.CHECK_NAME, {}, {})
+
+
+@pytest.fixture(scope='session')
+def dd_environment():
+    with docker_run(
+            compose_file=os.path.join(common.HERE, 'compose', 'docker-compose.yaml'),
+            sleep=2,
+    ):
+        yield common.get_config_by_version()
+
+
+@pytest.fixture
+def instance():
+    return common.get_config_by_version()

--- a/varnish/tests/test_varnish.py
+++ b/varnish/tests/test_varnish.py
@@ -2,21 +2,13 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import os
-import re
-import shlex
-import subprocess
 import pytest
-
-from datadog_checks.base import ensure_unicode
 
 from . import common
 
 
-pytestmark = pytest.mark.integration
-
-
 @pytest.mark.usefixtures('dd_environment')
+@pytest.mark.integration
 def test_check(aggregator, check, instance):
 
     check.check(instance)
@@ -25,6 +17,7 @@ def test_check(aggregator, check, instance):
 
 
 @pytest.mark.usefixtures('dd_environment')
+@pytest.mark.integration
 def test_inclusion_filter(aggregator, check, instance):
     instance['metrics_filter'] = ['SMA.*']
 
@@ -37,6 +30,7 @@ def test_inclusion_filter(aggregator, check, instance):
 
 
 @pytest.mark.usefixtures('dd_environment')
+@pytest.mark.integration
 def test_exclusion_filter(aggregator, check, instance):
     instance['metrics_filter'] = ['^SMA.Transient.c_req']
 

--- a/varnish/tests/test_varnish.py
+++ b/varnish/tests/test_varnish.py
@@ -2,37 +2,33 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-# stdlib
 import os
 import re
 import shlex
 import subprocess
-
 import pytest
 
-from . import common
 from datadog_checks.base import ensure_unicode
-from datadog_checks.varnish import Varnish
+
+from . import common
 
 
 pytestmark = pytest.mark.integration
 
 
-def test_check(aggregator, spin_up_varnish):
-    check = Varnish(common.CHECK_NAME, {}, {})
-    config = common.get_config_by_version()
+@pytest.mark.usefixtures('dd_environment')
+def test_check(aggregator, check, instance):
 
-    check.check(config)
+    check.check(instance)
     for mname in common.COMMON_METRICS:
         aggregator.assert_metric(mname, count=1, tags=['cluster:webs', 'varnish_name:default'])
 
 
-def test_inclusion_filter(aggregator, spin_up_varnish):
-    check = Varnish(common.CHECK_NAME, {}, {})
-    config = common.get_config_by_version()
-    config['metrics_filter'] = ['SMA.*']
+@pytest.mark.usefixtures('dd_environment')
+def test_inclusion_filter(aggregator, check, instance):
+    instance['metrics_filter'] = ['SMA.*']
 
-    check.check(config)
+    check.check(instance)
     for mname in common.COMMON_METRICS:
         if 'SMA.' in mname:
             aggregator.assert_metric(mname, count=1, tags=['cluster:webs', 'varnish_name:default'])
@@ -40,31 +36,13 @@ def test_inclusion_filter(aggregator, spin_up_varnish):
             aggregator.assert_metric(mname, count=0, tags=['cluster:webs', 'varnish_name:default'])
 
 
-def test_exclusion_filter(aggregator, spin_up_varnish):
-    check = Varnish(common.CHECK_NAME, {}, {})
-    config = common.get_config_by_version()
-    config['metrics_filter'] = ['^SMA.Transient.c_req']
+@pytest.mark.usefixtures('dd_environment')
+def test_exclusion_filter(aggregator, check, instance):
+    instance['metrics_filter'] = ['^SMA.Transient.c_req']
 
-    check.check(config)
+    check.check(instance)
     for mname in common.COMMON_METRICS:
         if 'SMA.Transient.c_req' in mname:
             aggregator.assert_metric(mname, count=0, tags=['cluster:webs', 'varnish_name:default'])
         elif 'varnish.uptime' not in mname:
             aggregator.assert_metric(mname, count=1, tags=['cluster:webs', 'varnish_name:default'])
-
-
-def test_version():
-    """
-    If the docker image is in a different repository, we check that the
-    version requested in the VARNISH_VERSION env var is the one running inside the container.
-    """
-    varnishstat = common.get_varnish_stat_path()
-
-    # Version info is printed to stderr
-    output = subprocess.check_output(shlex.split(varnishstat) + ["-V"], stderr=subprocess.STDOUT)
-    res = re.search(r"varnish-(\d+\.\d\.\d)", ensure_unicode(output))
-    if res is None:
-        raise Exception("Could not retrieve varnish version from docker")
-
-    version = res.groups()[0]
-    assert version == os.environ.get('VARNISH_VERSION', common.VARNISH_DEFAULT_VERSION)

--- a/varnish/tox.ini
+++ b/varnish/tox.ini
@@ -2,31 +2,40 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    flake8
-    {py27,py36}-{unit,4.1.7,5.2.1}
+    {py27,py36}-417
+    {py27,py36}-521
+    {py27,py36}-unit
+    {py27,py36}-flake8
 
 [testenv]
+usedevelop = true
 platform = linux|darwin|win32
-deps =
-    -e../datadog_checks_base[deps]
-    -rrequirements-dev.txt
+skip_install =
+    flake8: true
 passenv =
     DOCKER*
     COMPOSE*
+deps =
+    {417,521,unit}: -e../datadog_checks_base[deps]
+    -rrequirements-dev.txt
+
 setenv =
-    4.2.7: VARNISH_VERSION=4.1.7
-    5.2.1: VARNISH_VERSION=5.2.1
+    417: VARNISH_VERSION=4_1_7
+    521: VARNISH_VERSION=5_2_1
+    unit: VARNISH_VERSION=5_2_1
 commands =
-    pip install -r requirements.in
+    {417,521}: pip install -r requirements.in
+    {417,521}: pytest -m"integration" -v
+
+[testenv:unit]
+commands =
+    unit: pip install -r requirements.in
     unit: pytest -m"not integration" -v
-    {4.2.7-5.2.1}: pytest -m"integration" -v
 
 [testenv:flake8]
 skip_install = true
 deps = flake8
-commands =
-    flake8 .
+commands = flake8 .
 
 [flake8]
 exclude = .eggs,.tox,build
-max-line-length = 120


### PR DESCRIPTION
### What does this PR do?

Remove unnecessary `if` branches for ensuring unicode around the output from subprocess. 

### Motivation

If the response from subprocess is empty, python3 will return a byte and not be converted to unicode, which can break some checks that don't require subproccess_out returns a non empty value. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
