### PR TITLE
Always ensure_unicode for subprocess output

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
+++ b/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
@@ -64,7 +64,7 @@ def get_subprocess_output(command, log, raise_on_empty_output=True, log_debug=Tr
         )
     )
 
-    out = ensure_unicode(out)
-    err = ensure_unicode(err)
+    out = ensure_unicode(out) if out is not None else None
+    err = ensure_unicode(err) if err is not None else None
 
     return out, err, returncode

--- a/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
+++ b/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
@@ -64,9 +64,7 @@ def get_subprocess_output(command, log, raise_on_empty_output=True, log_debug=Tr
         )
     )
 
-    if out:
-        out = ensure_unicode(out)
-    if err:
-        err = ensure_unicode(err)
+    out = ensure_unicode(out)
+    err = ensure_unicode(err)
 
     return out, err, returncode


### PR DESCRIPTION
### What does this PR do?

Remove unnecessary `if` branches for ensuring unicode around the output from subprocess. 

### Motivation

If the response from subprocess is empty, python3 will return a byte and not be converted to unicode, which can break some checks that don't require subproccess_out returns a non empty value. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
