### PR TITLE
Adding the device to the tags as device_name is deprecated.

### DIFF
--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -243,6 +243,10 @@ class Network(AgentCheck):
             # Skip this network interface.
             return False
 
+        # adding the device to the tags as device_name is deprecated
+        metric_tags = [] if tags is None else tags[:]
+        metric_tags.append('device:{}'.format(iface))
+
         expected_metrics = [
             'bytes_rcvd',
             'bytes_sent',
@@ -257,7 +261,7 @@ class Network(AgentCheck):
 
         count = 0
         for metric, val in vals_by_metric.iteritems():
-            self.rate('system.net.%s' % metric, val, device_name=iface, tags=tags)
+            self.rate('system.net.%s' % metric, val, tags=metric_tags)
             count += 1
         self.log.debug("tracked %s network metrics for interface %s" % (count, iface))
 


### PR DESCRIPTION
### What does this PR do?

This PR removes a deprecation warning in the network module:

```
[ AGENT ] 2019-01-15 02:45:49 UTC | INFO | (runner.go:258 in work) | Running check network
[ AGENT ] 2019-01-15 02:45:49 UTC | WARN | (datadog_agent.go:149 in LogMessage) | (base.py:228) | DEPRECATION NOTICE: `device_name` is deprecated, please use a `device:` tag in the `tags` list instead                                    
[ AGENT ] 2019-01-15 02:45:49 UTC | INFO | (runner.go:324 in work) | Done running check network
```

### Motivation

It's been a while I haven't done anything here! :)
More seriously I am working on the migration from dd-agent 5 to 6 and saw those warnings in the logs. It's an easy enough fix so here it goes.

### Review checklist

- [X] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [X] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

