### PR TITLE
Finish Python3 Support

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -756,13 +756,11 @@ GROUP BY datid, datname
             # [(metric-map, value), (metric-map, value), ...]
             # metric-map is: (dd_name, "rate"|"gauge")
             # shift the results since the first columns will be the "descriptors"
-            values = zip([scope['metrics'][c] for c in cols], row[len(desc):])
-
             # To submit simply call the function for each value v
             # v[0] == (metric_name, submit_function)
             # v[1] == the actual value
             # tags are
-            for v in values:
+            for v in zip([scope['metrics'][c] for c in cols], row[len(desc):]):
                 v[0][1](self, v[0][0], v[1], tags=tags)
 
         return len(results)


### PR DESCRIPTION
### What does this PR do?

Finish Py3 support for postgres by only using zip when iterating. 

### Motivation

ddev validate py3 postgres was failing
PY2 bas the built in `zip` return the whole iterable, but PY3 returns an iterator. 
We were only using the return value once anyway, but this ensures it and makes the validation pass. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
