### PR TITLE
Finish Python 3 Support

### DIFF
--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import division
+
 from collections import defaultdict
 import time
 import os
@@ -334,8 +336,7 @@ class ProcessCheck(AgentCheck):
             self.log.debug('error getting proc stats: file_to_string failed',
                            'for /{}/{}/stat'.format(psutil.PROCFS_PATH, pid))
             return None
-
-        return map(lambda i: int(i), data.split()[9:13])
+        return (int(i) for i in data.split()[9:13])
 
     def _get_child_processes(self, pids):
         children_pids = set()


### PR DESCRIPTION
### What does this PR do?

Map in Py3 returns iterator, so this PR removes the use of map and just creates a tuple instead. Its a 5  element length object, so shouldn't be any performance issues. 

### Motivation

`ddev validate py3 process` was failing since we use built in type map as not an iterator. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
