### PR TITLE
Finish Python 3 Support

### DIFF
--- a/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
@@ -7,7 +7,7 @@ import requests
 from six import iteritems
 
 from datadog_checks.checks import AgentCheck
-
+from datadog_checks.base.utils.common import round_value
 
 try:
     from tagger import get_tags
@@ -168,7 +168,7 @@ class FargateCheck(AgentCheck):
             cpu_percent = 0.0
             if system_delta > 0 and cpu_delta > 0 and active_cpus > 0:
                 cpu_percent = (cpu_delta / system_delta) * active_cpus * 100.0
-                cpu_percent = round(cpu_percent, 2)
+                cpu_percent = round_value(cpu_percent, 2)
                 self.gauge('ecs.fargate.cpu.percent', cpu_percent, tags)
 
             # Memory metrics

--- a/ecs_fargate/setup.py
+++ b/ecs_fargate/setup.py
@@ -23,7 +23,7 @@ def get_requirements(fpath):
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog_checks_base>=5.1.0'
 
 setup(
     name='datadog-ecs_fargate',


### PR DESCRIPTION
### What does this PR do?

Finish Python3 support by using the new round_value util from checks_base instead of the build in round

### Motivation

Py2/3 build in `round` uses different rounding strategies, so pylint fails when you use it (ddev validate py3 ecs_fargate was failing)

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
