### PR TITLE
Make service check statuses available as constants

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -28,6 +28,7 @@ except ImportError:
     using_stub_aggregator = True
 
 from ..config import is_affirmative
+from ..constants import ServiceCheck
 from ..utils.common import ensure_bytes, ensure_unicode
 from ..utils.proxy import config_proxy_skip
 from ..utils.limiter import Limiter
@@ -45,7 +46,7 @@ class __AgentCheck7(object):
     """
     The base class for any Agent based integrations
     """
-    OK, WARNING, CRITICAL, UNKNOWN = (0, 1, 2, 3)
+    OK, WARNING, CRITICAL, UNKNOWN = ServiceCheck
 
     """
     DEFAULT_METRIC_LIMIT allows to set a limit on the number of metric name and tags combination
@@ -403,7 +404,7 @@ class __AgentCheck6(object):
     """
     The base class for any Agent based integrations
     """
-    OK, WARNING, CRITICAL, UNKNOWN = (0, 1, 2, 3)
+    OK, WARNING, CRITICAL, UNKNOWN = ServiceCheck
 
     """
     DEFAULT_METRIC_LIMIT allows to set a limit on the number of metric name and tags combination

--- a/datadog_checks_base/datadog_checks/base/constants.py
+++ b/datadog_checks_base/datadog_checks/base/constants.py
@@ -1,0 +1,6 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from collections import namedtuple
+
+ServiceCheck = namedtuple('ServiceCheck', 'OK WARNING CRITICAL UNKNOWN')(0, 1, 2, 3)


### PR DESCRIPTION
### Motivation

Easier access for utility functions that map product statuses to service check statuses