### PR TITLE
Add debug log line printing the external_host_tags payload

### DIFF
--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -332,6 +332,8 @@ class VSphereCheck(AgentCheck):
                 if hostname:
                     external_host_tags.append((hostname, {SOURCE_TYPE: mor.get('tags')}))
 
+        self.log.debug(b"External host tags payload: %s", external_host_tags)
+
         return external_host_tags
 
     def _get_parent_tags(self, mor, all_objects):


### PR DESCRIPTION
### What does this PR do?

Add a debug log line to print the entire payload of external host tags that are sent to the agent.

### Motivation

Information needed for debugging a customer issue

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
