### PR TITLE
Support Python 3

### DIFF
--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -5,7 +5,7 @@ import socket
 import time
 
 from datadog_checks.base import ensure_unicode
-from datadog_checks.checks import NetworkCheck, Status
+from datadog_checks.base.checks import NetworkCheck, Status
 
 
 class BadConfException(Exception):

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -1,12 +1,10 @@
 # (C) Datadog, Inc. 2010-2017
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-
-# stdlib
 import socket
 import time
 
-# project
+from datadog_checks.base import ensure_unicode
 from datadog_checks.checks import NetworkCheck, Status
 
 
@@ -106,7 +104,7 @@ class TCPCheck(NetworkCheck):
         return Status.UP, "UP"
 
     def report_as_service_check(self, sc_name, status, instance, msg=None):
-        instance_name = self.normalize(instance['name'])
+        instance_name = ensure_unicode(self.normalize(instance['name']))
         host = instance.get('host', None)
         port = instance.get('port', None)
         custom_tags = instance.get('tags', [])

--- a/tcp_check/setup.py
+++ b/tcp_check/setup.py
@@ -23,7 +23,7 @@ def get_requirements(fpath):
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog_checks_base>=4.2.0'
 
 setup(
     name='datadog-tcp_check',

--- a/tcp_check/tox.ini
+++ b/tcp_check/tox.ini
@@ -2,14 +2,12 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    unit
+    {py27,py36}-unit
     flake8
 
 [testenv]
 usedevelop = true
 platform = linux2|darwin|windows
-
-[testenv:unit]
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt


### PR DESCRIPTION
### What does this PR do?

Add python 3 support to tcp_check. Mostly was supported already, but required the name to be converted to unicode.

### Motivation

🐍3️⃣ 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
