### PR TITLE
adds a --rm to agent version checking

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -69,7 +69,7 @@ class DockerInterface(object):
     def detect_agent_version(self):
         if self.agent_build and self._agent_version is None:
             command = [
-                'docker', 'run', '-e', 'DD_API_KEY={}'.format(self.api_key), self.agent_build,
+                'docker', 'run', '--rm', '-e', 'DD_API_KEY={}'.format(self.api_key), self.agent_build,
                 'head', '--lines=1', '/opt/datadog-agent/version-manifest.txt'
             ]
             result = run_command(command, capture=True)


### PR DESCRIPTION
### What does this PR do?

This container was hanging around and should be removed after it's run.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
