### PR TITLE
Remove extra log about error encoding tag

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -718,7 +718,6 @@ class __AgentCheck6(object):
             try:
                 return data.encode('utf-8')
             except Exception:
-                self.log.warning('Error encoding tag to utf-8 encoded string, ignoring tag')
                 return None
 
         return data


### PR DESCRIPTION
### What does this PR do?

_to_bytes is logging a message when it can't encode. However, the calling function of `_to_bytes` has more context and prints a more useful message. 

### Motivation

No need to log multiple times for the same error. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
