### PR TITLE
Add conntrack basic metrics to the network integration.

### DIFF
--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -439,6 +439,7 @@ class Network(AgentCheck):
                 # Starting at 0 as the last line has a line return
                 conntrack_count = 0
                 while 1:
+                    # Reading the file by chucks (64k being a randomly chosen buffer size)
                     conntrack_buffer = conntrack_file.read(65536)
                     if not conntrack_buffer:
                         break

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -450,7 +450,7 @@ class Network(AgentCheck):
         try:
             with open(proc_conntrack_max_path, 'r') as conntrack_max_file:
                 # Starting at 0 as the last line has a line return
-                conntrack_max=f.read()
+                conntrack_max=conntrack_max_file.read()
                 self.gauge('system.net.conntrack.max', conntrack_max, tags=custom_tags)
         except IOError:
             self.log.debug("Unable to read %s. Skipping nf_conntrack_max metrics pull.", proc_conntrack_max_path)

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -440,7 +440,8 @@ class Network(AgentCheck):
                 conntrack_count = 0
                 while 1:
                     conntrack_buffer = conntrack_file.read(65536)
-                    if not conntrack_buffer: break
+                    if not conntrack_buffer:
+                        break
                     conntrack_count += conntrack_buffer.count('\n')
                 self.gauge('system.net.conntrack.count', conntrack_count, tags=custom_tags)
         except IOError:
@@ -450,7 +451,7 @@ class Network(AgentCheck):
         try:
             with open(proc_conntrack_max_path, 'r') as conntrack_max_file:
                 # Starting at 0 as the last line has a line return
-                conntrack_max=conntrack_max_file.read()
+                conntrack_max = conntrack_max_file.read()
                 self.gauge('system.net.conntrack.max', conntrack_max, tags=custom_tags)
         except IOError:
             self.log.debug("Unable to read %s. Skipping nf_conntrack_max metrics pull.", proc_conntrack_max_path)

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -433,6 +433,28 @@ class Network(AgentCheck):
                     self._submit_netmetric(nstat_metrics_names[k][met], self._parse_value(netstat_data[k][met]),
                                            tags=custom_tags)
 
+        proc_conntrack_path = "{}/net/nf_conntrack".format(proc_location)
+        try:
+            with open(proc_conntrack_path, 'r') as conntrack_file:
+                # Starting at 0 as the last line has a line return
+                conntrack_count = 0
+                while 1:
+                    conntrack_buffer = conntrack_file.read(65536)
+                    if not conntrack_buffer: break
+                    conntrack_count += conntrack_buffer.count('\n')
+                self.gauge('system.net.conntrack.count', conntrack_count, tags=custom_tags)
+        except IOError:
+            self.log.debug("Unable to read %s. Skipping conntrack metrics pull.", proc_conntrack_path)
+
+        proc_conntrack_max_path = "{}/sys/net/nf_conntrack_max".format(proc_location)
+        try:
+            with open(proc_conntrack_max_path, 'r') as conntrack_max_file:
+                # Starting at 0 as the last line has a line return
+                conntrack_max=f.read()
+                self.gauge('system.net.conntrack.max', conntrack_max, tags=custom_tags)
+        except IOError:
+            self.log.debug("Unable to read %s. Skipping nf_conntrack_max metrics pull.", proc_conntrack_max_path)
+
     def _parse_linux_cx_state(self, lines, tcp_states, state_col, protocol=None, ip_version=None):
         """
         Parse the output of the command that retrieves the connection state (either `ss` or `netstat`)

--- a/network/metadata.csv
+++ b/network/metadata.csv
@@ -1,8 +1,8 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 system.net.bytes_rcvd,gauge,,byte,second,The number of bytes received on a device per second.,0,system,bytes rcvd
 system.net.bytes_sent,gauge,,byte,second,The number of bytes sent from a device per second.,0,system,bytes sent
-system.net.conntrack.count,gauge,,count,connections,The number of connections present in the conntrack table.,0,system,connections
-system.net.conntrack.max,gauge,,count,entries,Conntrack table max capacity.,0,system,table entries
+system.net.conntrack.count,gauge,,connections,connection,The number of connections present in the conntrack table.,0,system,connections
+system.net.conntrack.max,gauge,,entries,entry,Conntrack table max capacity.,0,system,table entries
 system.net.packets_in.count,gauge,,packet,second,The number of packets of data received by the interface.,0,system,packets in
 system.net.packets_in.error,gauge,,error,second,The number of packet receive errors detected by the device driver.,-1,system,pkts in err
 system.net.packets_out.count,gauge,,packet,second,The number of packets of data transmitted by the interface.,0,system,packets out

--- a/network/metadata.csv
+++ b/network/metadata.csv
@@ -1,8 +1,8 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 system.net.bytes_rcvd,gauge,,byte,second,The number of bytes received on a device per second.,0,system,bytes rcvd
 system.net.bytes_sent,gauge,,byte,second,The number of bytes sent from a device per second.,0,system,bytes sent
-system.net.conntrack.count,gauge,,connections,connection,The number of connections present in the conntrack table.,0,system,connections
-system.net.conntrack.max,gauge,,entries,entry,Conntrack table max capacity.,0,system,table entries
+system.net.conntrack.count,gauge,,connection,connection,The number of connections present in the conntrack table.,0,system,connections
+system.net.conntrack.max,gauge,,connection,entry,Conntrack table max capacity.,0,system,table entries
 system.net.packets_in.count,gauge,,packet,second,The number of packets of data received by the interface.,0,system,packets in
 system.net.packets_in.error,gauge,,error,second,The number of packet receive errors detected by the device driver.,-1,system,pkts in err
 system.net.packets_out.count,gauge,,packet,second,The number of packets of data transmitted by the interface.,0,system,packets out

--- a/network/metadata.csv
+++ b/network/metadata.csv
@@ -1,6 +1,8 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 system.net.bytes_rcvd,gauge,,byte,second,The number of bytes received on a device per second.,0,system,bytes rcvd
 system.net.bytes_sent,gauge,,byte,second,The number of bytes sent from a device per second.,0,system,bytes sent
+system.net.conntrack.count,,gauge,,count,The number of connections present in the conntrack table.,0,system,connections
+system.net.conntrack.max,,gauge,,count,Conntrack table max capacity.,0,system,table entries
 system.net.packets_in.count,gauge,,packet,second,The number of packets of data received by the interface.,0,system,packets in
 system.net.packets_in.error,gauge,,error,second,The number of packet receive errors detected by the device driver.,-1,system,pkts in err
 system.net.packets_out.count,gauge,,packet,second,The number of packets of data transmitted by the interface.,0,system,packets out

--- a/network/metadata.csv
+++ b/network/metadata.csv
@@ -1,8 +1,8 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 system.net.bytes_rcvd,gauge,,byte,second,The number of bytes received on a device per second.,0,system,bytes rcvd
 system.net.bytes_sent,gauge,,byte,second,The number of bytes sent from a device per second.,0,system,bytes sent
-system.net.conntrack.count,,gauge,,count,The number of connections present in the conntrack table.,0,system,connections
-system.net.conntrack.max,,gauge,,count,Conntrack table max capacity.,0,system,table entries
+system.net.conntrack.count,gauge,,count,connections,The number of connections present in the conntrack table.,0,system,connections
+system.net.conntrack.max,gauge,,count,entries,Conntrack table max capacity.,0,system,table entries
 system.net.packets_in.count,gauge,,packet,second,The number of packets of data received by the interface.,0,system,packets in
 system.net.packets_in.error,gauge,,error,second,The number of packet receive errors detected by the device driver.,-1,system,pkts in err
 system.net.packets_out.count,gauge,,packet,second,The number of packets of data transmitted by the interface.,0,system,packets out


### PR DESCRIPTION
### What does this PR do?

Adds the conntrack count and the conntrack table max capacity metrics in the standard network integration.

### Motivation

This is something that we have been doing in custom and that was started a while back in https://github.com/DataDog/dd-agent/pull/1904 by someone else but never finished.
We need those metrics in general to monitor our conntrack tables that sometimes get full and start generating issues.

### Review checklist

- [X] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [X] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.


Thanks for your time,
Joseph
