### PR TITLE
Add validation for new `library` type

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -43,6 +43,11 @@ OPTIONAL_ATTRIBUTES = {
 
 ALL_ATTRIBUTES = REQUIRED_ATTRIBUTES | OPTIONAL_ATTRIBUTES
 
+INTEGRATION_TYPE = {
+    "check",
+    "library",
+}
+
 
 @click.command(
     context_settings=CONTEXT_SETTINGS,
@@ -321,20 +326,10 @@ def manifest(fix, include_extras):
                         file_fixed = True
                     else:
                         display_queue.append((echo_failure, output))
-                elif integration_type != correct_integration_type:
+                elif integration_type not in INTEGRATION_TYPE:
                     file_failures += 1
                     output = '  invalid `type`: {}'.format(integration_type)
-
-                    if fix:
-                        decoded['type'] = correct_integration_type
-
-                        display_queue.append((echo_warning, output))
-                        display_queue.append((echo_success, '  new `type`: {}'.format(correct_integration_type)))
-
-                        file_failures -= 1
-                        file_fixed = True
-                    else:
-                        display_queue.append((echo_failure, output))
+                    display_queue.append((echo_failure, output))
 
                 # is_public
                 correct_is_public = True


### PR DESCRIPTION
### What does this PR do?

A new type `library` is available. This adds the validation for it.

### Motivation

Tests were failing after #2983 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
