### PR TITLE
Add e2e support

### DIFF
--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -1,0 +1,94 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import os
+import sys
+
+from datadog_checks.sqlserver import SQLServer
+from datadog_checks.dev import get_docker_hostname
+
+
+def lib_tds_path():
+    """
+    This is definitely ugly but should do the trick most of the times. On OSX
+    we can point unixODBC directly to the FreeTDS client library. On linux instead
+    we need to define the 'FreeTDS' driver in odbcinst.ini
+    """
+    if sys.platform == 'darwin':
+        return '/usr/local/lib/libtdsodbc.so'
+    return 'FreeTDS'
+
+
+HOST = get_docker_hostname()
+PORT = 1433
+HERE = os.path.dirname(os.path.abspath(__file__))
+CHECK_NAME = "sqlserver"
+
+EXPECTED_METRICS = [m[0] for m in SQLServer.METRICS]
+
+INSTANCE_DOCKER = {
+    'host': '{},1433'.format(HOST),
+    'connector': 'odbc',
+    'driver': lib_tds_path(),
+    'username': 'sa',
+    'password': 'Password123',
+    'tags': ['optional:tag1'],
+}
+
+INSTANCE_SQL2008 = {
+    'host': r'(local)\SQL2008R2SP2',
+    'username': 'sa',
+    'password': 'Password12!',
+}
+
+INIT_CONFIG = {
+    'custom_metrics': [
+        {
+            'name': 'sqlserver.clr.execution',
+            'type': 'gauge',
+            'counter_name': 'CLR Execution',
+        },
+        {
+            'name': 'sqlserver.exec.in_progress',
+            'type': 'gauge',
+            'counter_name': 'OLEDB calls',
+            'instance_name': 'Cumulative execution time (ms) per second',
+        },
+        {
+            'name': 'sqlserver.db.commit_table_entries',
+            'type': 'gauge',
+            'counter_name': 'Log Flushes/sec',
+            'instance_name': 'ALL',
+            'tag_by': 'db',
+        },
+    ],
+}
+
+INIT_CONFIG_OBJECT_NAME = {
+    'custom_metrics': [
+        {
+            'name': 'sqlserver.cache.hit_ratio',
+            'counter_name': 'Cache Hit Ratio',
+            'instance_name': 'SQL Plans',
+            'object_name': 'SQLServer:Plan Cache',
+            'tags': [
+                'optional_tag:tag1'
+            ]
+        },
+        {
+            'name': 'sqlserver.active_requests',
+            'counter_name': 'Active requests',
+            'instance_name': 'default',
+            'object_name': 'SQLServer:Workload Group Stats',
+            'tags': [
+                'optional_tag:tag1'
+            ]
+        }
+    ]
+}
+
+FULL_CONFIG = {
+    "init_config": INIT_CONFIG,
+    "instances": [INSTANCE_DOCKER]
+}

--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -1,9 +1,9 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
 import os
-import time
-import sys
+from copy import deepcopy
 
 import pytest
 try:
@@ -11,95 +11,44 @@ try:
 except ImportError:
     pyodbc = None
 
-from datadog_checks.dev import docker_run, get_docker_hostname, RetryError
+from datadog_checks.dev import docker_run, WaitFor
 
-
-HOST = get_docker_hostname()
-PORT = 1433
-HERE = os.path.dirname(os.path.abspath(__file__))
-
-
-def lib_tds_path():
-    """
-    This is definitely ugly but should do the trick most of the times. On OSX
-    we can point unixODBC directly to the FreeTDS client library. On linux instead
-    we need to define the 'FreeTDS' driver in odbcinst.ini
-    """
-    if sys.platform == 'darwin':
-        return '/usr/local/lib/libtdsodbc.so'
-    return 'FreeTDS'
+from .common import (
+    INIT_CONFIG, INIT_CONFIG_OBJECT_NAME, INSTANCE_SQL2008, INSTANCE_DOCKER, HOST, PORT, HERE, FULL_CONFIG, lib_tds_path
+)
 
 
 @pytest.fixture
 def init_config():
-    return {
-        'custom_metrics': [
-            {
-                'name': 'sqlserver.clr.execution',
-                'type': 'gauge',
-                'counter_name': 'CLR Execution',
-            },
-            {
-                'name': 'sqlserver.exec.in_progress',
-                'type': 'gauge',
-                'counter_name': 'OLEDB calls',
-                'instance_name': 'Cumulative execution time (ms) per second',
-            },
-            {
-                'name': 'sqlserver.db.commit_table_entries',
-                'type': 'gauge',
-                'counter_name': 'Log Flushes/sec',
-                'instance_name': 'ALL',
-                'tag_by': 'db',
-            },
-        ],
-    }
+    return deepcopy(INIT_CONFIG)
+
+
+@pytest.fixture
+def init_config_object_name():
+    return deepcopy(INIT_CONFIG_OBJECT_NAME)
 
 
 @pytest.fixture
 def instance_sql2008():
-    return {
-        'host': r'(local)\SQL2008R2SP2',
-        'username': 'sa',
-        'password': 'Password12!',
-    }
+    return deepcopy(INSTANCE_SQL2008)
 
 
 @pytest.fixture
 def instance_docker():
-    return {
-        'host': '{},1433'.format(HOST),
-        'connector': 'odbc',
-        'driver': lib_tds_path(),
-        'username': 'sa',
-        'password': 'Password123',
-        'tags': ['optional:tag1'],
-    }
+    return deepcopy(INSTANCE_DOCKER)
 
 
 @pytest.fixture(scope='session')
-def sqlserver():
+def dd_environment():
     if pyodbc is None:
         raise Exception("pyodbc is not installed!")
 
-    compose_file = os.path.join(HERE, 'compose', 'docker-compose.yaml')
-    conn = 'DRIVER={};Server={},{};Database=master;UID=sa;PWD=Password123;'
-    conn = conn.format(lib_tds_path(), HOST, PORT)
+    def sqlserver():
+        conn = 'DRIVER={};Server={},{};Database=master;UID=sa;PWD=Password123;'.format(lib_tds_path(), HOST, PORT)
+        pyodbc.connect(conn, timeout=30)
 
-    def condition():
-        sys.stderr.write("Waiting for SQLServer to boot...\n")
-        booted = False
-        for _ in xrange(10):
-            try:
-                pyodbc.connect(conn, timeout=30)
-                booted = True
-            except pyodbc.Error as e:
-                sys.stderr.write(str(e)+'\n')
-                time.sleep(3)
-
-        if not booted:
-            raise RetryError("SQLServer failed to boot!")
-        sys.stderr.write("SQLServer boot complete.\n")
-
-    with docker_run(compose_file=compose_file, conditions=[condition]):
-        yield
+    with docker_run(
+        compose_file=os.path.join(HERE, 'compose', 'docker-compose.yaml'),
+        conditions=[WaitFor(sqlserver, wait=3, attempts=10)]
+    ):
+        yield FULL_CONFIG


### PR DESCRIPTION
### What does this PR do?

^
`ddev env check sqlserver` won't work though because the needed libraries are not in the datadog-agent container. Still useful for spinning up the container.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?