### PR TITLE
Support Python 3

### DIFF
--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -1,8 +1,7 @@
 # (C) Datadog, Inc. 2010-2017
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-from datadog_checks.checks import AgentCheck
-from datadog_checks.checks.win import PDHBaseCheck
+from datadog_checks.base import AgentCheck, PDHBaseCheck
 from datadog_checks.utils.containers import hash_mutable
 
 
@@ -48,7 +47,6 @@ class IIS(PDHBaseCheck):
         PDHBaseCheck.__init__(self, name, init_config, agentConfig, instances=instances, counter_list=DEFAULT_COUNTERS)
 
     def check(self, instance):
-
         sites = instance.get('sites')
         if sites is None:
             expected_sites = set()

--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2010-2017
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+from six import iteritems
+
 from datadog_checks.base import AgentCheck, PDHBaseCheck
 from datadog_checks.utils.containers import hash_mutable
 
@@ -67,7 +69,7 @@ class IIS(PDHBaseCheck):
                     self.log.error("Failed to get_all_values %s %s" % (inst_name, dd_name))
                     continue
 
-                for sitename, val in vals.iteritems():
+                for sitename, val in iteritems(vals):
                     tags = []
                     if key in self._tags:
                         tags = list(self._tags[key])

--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -114,5 +114,5 @@ class IIS(PDHBaseCheck):
             tags = []
             if key in self._tags:
                 tags = list(self._tags[key])
-            tags.append("site:{}".format(self.normalize(site)))
+            tags.append("site:{}".format(ensure_unicode(self.normalize(site))))
             self.service_check(self.SERVICE_CHECK, AgentCheck.CRITICAL, tags)

--- a/iis/setup.py
+++ b/iis/setup.py
@@ -23,7 +23,7 @@ def get_requirements(fpath):
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog_checks_base>=4.2.0'
 
 setup(
     name='datadog-iis',

--- a/iis/tests/common.py
+++ b/iis/tests/common.py
@@ -1,0 +1,27 @@
+# (C) Datadog, Inc. 2010-2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+CHECK_NAME = 'iis'
+MINIMAL_INSTANCE = {
+    'host': '.',
+}
+
+INSTANCE = {
+    'host': '.',
+    'sites': ['Default Web Site', 'Exchange Back End', 'Non Existing Website'],
+}
+
+INVALID_HOST_INSTANCE = {
+    'host': 'nonexistinghost'
+}
+
+WIN_SERVICES_MINIMAL_CONFIG = {
+    'host': ".",
+    'tags': ["mytag1", "mytag2"]
+}
+
+WIN_SERVICES_CONFIG = {
+    'host': ".",
+    'tags': ["mytag1", "mytag2"],
+    'sites': ["Default Web Site", "Exchange Back End", "Failing site"]
+}

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -1,0 +1,11 @@
+# (C) Datadog, Inc. 2010-2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+import pytest
+
+from datadog_test_libs.win.pdh_mocks import pdh_mocks_fixture, initialize_pdh_tests  # noqa: F401
+
+
+@pytest.fixture(scope="function", autouse=True)
+def setup_check():
+    initialize_pdh_tests()

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -82,7 +82,7 @@ def test_check(aggregator, pdh_mocks_fixture):
     instance = WIN_SERVICES_CONFIG
     c = IIS(CHECK_NAME, {}, {}, [instance])
     c.check(instance)
-
+    raise Exception("Metrics: {}".format(aggregator._metrics))
     # Test metrics
     # ... normalize site-names
     default_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", WIN_SERVICES_CONFIG['sites'][0])

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -1,42 +1,28 @@
 # (C) Datadog, Inc. 2010-2017
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-
 import pytest
 import re
-from datadog_checks.stubs import aggregator
+
 from datadog_checks.iis import IIS
 from datadog_checks.iis.iis import DEFAULT_COUNTERS
 # for reasons unknown, flake8 says that pdh_mocks_fixture is unused, even though
 # it's used below.  noqa to suppress that error.
-from datadog_test_libs.win.pdh_mocks import pdh_mocks_fixture, initialize_pdh_tests  # noqa: F401
+from datadog_test_libs.win.pdh_mocks import pdh_mocks_fixture  # noqa: F401
 
-
-@pytest.fixture
-def Aggregator():
-    aggregator.reset()
-    return aggregator
-
-
-CHECK_NAME = 'iis'
-MINIMAL_INSTANCE = {
-    'host': '.',
-}
-
-INSTANCE = {
-    'host': '.',
-    'sites': ['Default Web Site', 'Exchange Back End', 'Non Existing Website'],
-}
-
-INVALID_HOST_INSTANCE = {
-    'host': 'nonexistinghost'
-}
+from .common import (
+    CHECK_NAME,
+    MINIMAL_INSTANCE,
+    INSTANCE,
+    INVALID_HOST_INSTANCE,
+    WIN_SERVICES_MINIMAL_CONFIG,
+    WIN_SERVICES_CONFIG
+)
 
 
 # flake8 then says this is a redefinition of unused, which it's not.
 @pytest.mark.usefixtures("pdh_mocks_fixture")  # noqa: F811
-def test_basic_check(Aggregator, pdh_mocks_fixture):
-    initialize_pdh_tests()
+def test_basic_check(aggregator, pdh_mocks_fixture):
     instance = MINIMAL_INSTANCE
     c = IIS(CHECK_NAME, {}, {}, [instance])
     c.check(instance)
@@ -45,19 +31,18 @@ def test_basic_check(Aggregator, pdh_mocks_fixture):
     for metric_def in DEFAULT_COUNTERS:
         metric = metric_def[3]
         for site_tag in site_tags:
-            Aggregator.assert_metric(metric, tags=["site:{0}".format(site_tag)], count=1)
+            aggregator.assert_metric(metric, tags=["site:{0}".format(site_tag)], count=1)
 
     for site_tag in site_tags:
-        Aggregator.assert_service_check('iis.site_up', IIS.OK,
+        aggregator.assert_service_check('iis.site_up', IIS.OK,
                                         tags=["site:{0}".format(site_tag)], count=1)
 
-    Aggregator.assert_all_metrics_covered()
+    aggregator.assert_all_metrics_covered()
 
 
 # flake8 then says this is a redefinition of unused, which it's not.
 @pytest.mark.usefixtures("pdh_mocks_fixture")  # noqa: F811
-def test_check_on_specific_websites(Aggregator, pdh_mocks_fixture):
-    initialize_pdh_tests()
+def test_check_on_specific_websites(aggregator, pdh_mocks_fixture):
     instance = INSTANCE
     c = IIS(CHECK_NAME, {}, {}, [instance])
     c.check(instance)
@@ -66,87 +51,68 @@ def test_check_on_specific_websites(Aggregator, pdh_mocks_fixture):
     for metric_def in DEFAULT_COUNTERS:
         metric = metric_def[3]
         for site_tag in site_tags:
-            Aggregator.assert_metric(metric, tags=["site:{0}".format(site_tag)], count=1)
+            aggregator.assert_metric(metric, tags=["site:{0}".format(site_tag)], count=1)
 
     for site_tag in site_tags:
-        Aggregator.assert_service_check('iis.site_up', IIS.OK,
+        aggregator.assert_service_check('iis.site_up', IIS.OK,
                                         tags=["site:{0}".format(site_tag)], count=1)
 
-    Aggregator.assert_service_check('iis.site_up', IIS.CRITICAL,
+    aggregator.assert_service_check('iis.site_up', IIS.CRITICAL,
                                     tags=["site:{0}".format('Non_Existing_Website')], count=1)
 
-    Aggregator.assert_all_metrics_covered()
+    aggregator.assert_all_metrics_covered()
 
 
 # flake8 then says this is a redefinition of unused, which it's not.
 @pytest.mark.usefixtures("pdh_mocks_fixture")  # noqa: F811
-def test_service_check_with_invalid_host(Aggregator, pdh_mocks_fixture):
-    initialize_pdh_tests()
+def test_service_check_with_invalid_host(aggregator, pdh_mocks_fixture):
     instance = INVALID_HOST_INSTANCE
     c = IIS(CHECK_NAME, {}, {}, [instance])
     c.check(instance)
 
-    Aggregator.assert_service_check('iis.site_up', IIS.CRITICAL, tags=["site:{0}".format('Total')])
-
-
-WIN_SERVICES_MINIMAL_CONFIG = {
-    'host': ".",
-    'tags': ["mytag1", "mytag2"]
-}
-
-WIN_SERVICES_CONFIG = {
-    'host': ".",
-    'tags': ["mytag1", "mytag2"],
-    'sites': ["Default Web Site", "Exchange Back End", "Failing site"]
-}
+    aggregator.assert_service_check('iis.site_up', IIS.CRITICAL, tags=["site:{0}".format('Total')])
 
 
 # flake8 then says this is a redefinition of unused, which it's not.
 @pytest.mark.usefixtures("pdh_mocks_fixture")  # noqa: F811
-def test_check(Aggregator, pdh_mocks_fixture):
+def test_check(aggregator, pdh_mocks_fixture):
     """
     Returns the right metrics and service checks
     """
-    # Set up & run the check
-    config = {
-        'instances': [WIN_SERVICES_CONFIG]
-    }
-    initialize_pdh_tests()
     instance = WIN_SERVICES_CONFIG
     c = IIS(CHECK_NAME, {}, {}, [instance])
     c.check(instance)
 
     # Test metrics
     # ... normalize site-names
-    default_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][0])
-    ok_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][1])
-    fail_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][2])
+    default_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", WIN_SERVICES_CONFIG['sites'][0])
+    ok_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", WIN_SERVICES_CONFIG['sites'][1])
+    fail_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", WIN_SERVICES_CONFIG['sites'][2])
 
     for site_name in [default_site_name, ok_site_name, 'Total']:
         for metric_def in DEFAULT_COUNTERS:
             mname = metric_def[3]
-            Aggregator.assert_metric(mname, tags=["mytag1", "mytag2", "site:{0}".format(site_name)], count=1)
+            aggregator.assert_metric(mname, tags=["mytag1", "mytag2", "site:{0}".format(site_name)], count=1)
 
-        Aggregator.assert_service_check('iis.site_up', status=IIS.OK,
+        aggregator.assert_service_check('iis.site_up', status=IIS.OK,
                                         tags=["mytag1", "mytag2", "site:{0}".format(site_name)], count=1)
 
-    Aggregator.assert_service_check('iis.site_up', status=IIS.CRITICAL,
+    aggregator.assert_service_check('iis.site_up', status=IIS.CRITICAL,
                                     tags=["mytag1", "mytag2", "site:{0}".format(fail_site_name)], count=1)
 
     # Check completed with no warnings
     # self.assertFalse(logger.warning.called)
 
-    Aggregator.assert_all_metrics_covered()
+    aggregator.assert_all_metrics_covered()
 
 
 # flake8 then says this is a redefinition of unused, which it's not.
 @pytest.mark.usefixtures("pdh_mocks_fixture")  # noqa: F811
-def test_check_without_sites_specified(Aggregator, pdh_mocks_fixture):
+def test_check_without_sites_specified(aggregator, pdh_mocks_fixture):
     """
     Returns the right metrics and service checks for the `_Total` site
     """
     # Run check
-    initialize_pdh_tests()
     instance = WIN_SERVICES_MINIMAL_CONFIG
     c = IIS(CHECK_NAME, {}, {}, [instance])
     c.check(instance)
@@ -156,9 +122,9 @@ def test_check_without_sites_specified(Aggregator, pdh_mocks_fixture):
         mname = metric_def[3]
 
         for site_tag in site_tags:
-            Aggregator.assert_metric(mname, tags=["mytag1", "mytag2", "site:{0}".format(site_tag)], count=1)
+            aggregator.assert_metric(mname, tags=["mytag1", "mytag2", "site:{0}".format(site_tag)], count=1)
 
     for site_tag in site_tags:
-        Aggregator.assert_service_check('iis.site_up', status=IIS.OK,
+        aggregator.assert_service_check('iis.site_up', status=IIS.OK,
                                         tags=["mytag1", "mytag2", "site:{0}".format(site_tag)], count=1)
-    Aggregator.assert_all_metrics_covered()
+    aggregator.assert_all_metrics_covered()

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -82,7 +82,7 @@ def test_check(aggregator, pdh_mocks_fixture):
     instance = WIN_SERVICES_CONFIG
     c = IIS(CHECK_NAME, {}, {}, [instance])
     c.check(instance)
-    raise Exception("Metrics: {}".format(aggregator._metrics))
+
     # Test metrics
     # ... normalize site-names
     default_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", WIN_SERVICES_CONFIG['sites'][0])

--- a/iis/tox.ini
+++ b/iis/tox.ini
@@ -2,14 +2,12 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    iis
+    {py27,py36}-iis
     flake8
 
 [testenv]
 usedevelop = true
 platform = win32
-
-[testenv:iis]
 deps =
     -e../datadog_checks_base[deps]
     ../datadog_checks_tests_helper


### PR DESCRIPTION
### What does this PR do?

This test already supported PY3. Mainly adds py3 testing to tox file, cleanup imports and pin checks_base, and cleans up the test folder.
 
### Motivation

Test on 🐍 3️⃣ and cleanup. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
