### PR TITLE
Add `consul.can_connect` service check for every HTTP request to consul

### DIFF
--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -50,6 +50,7 @@ class ConsulCheckInstanceState(object):
 
 class ConsulCheck(AgentCheck):
     CONSUL_CHECK = 'consul.up'
+    CONSUL_CAN_CONNECT = 'consul.can_connect'
     HEALTH_CHECK = 'consul.check'
 
     CONSUL_CATALOG_CHECK = 'consul.catalog'
@@ -83,6 +84,7 @@ class ConsulCheck(AgentCheck):
 
     def consul_request(self, instance, endpoint):
         url = urljoin(instance.get('url'), endpoint)
+        service_check_tags = ["url:{}".format(url)] + instance.get("tags", [])
         try:
 
             clientcertfile = instance.get('client_cert_file', self.init_config.get('client_cert_file', False))
@@ -103,11 +105,19 @@ class ConsulCheck(AgentCheck):
             else:
                 resp = requests.get(url, verify=cabundlefile, headers=headers)
 
+            resp.raise_for_status()
+
         except requests.exceptions.Timeout:
             self.log.exception('Consul request to {} timed out'.format(url))
+            self.service_check(self.CONSUL_CAN_CONNECT, self.CRITICAL, tags=service_check_tags)
             raise
+        except Exception:
+            self.log.exception("Consul request to {} failed".format(url))
+            self.service_check(self.CONSUL_CAN_CONNECT, self.CRITICAL, tags=service_check_tags)
+            raise
+        else:
+            self.service_check(self.CONSUL_CAN_CONNECT, self.OK, tags=service_check_tags)
 
-        resp.raise_for_status()
         return resp.json()
 
     # Consul Config Accessors

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -107,13 +107,25 @@ class ConsulCheck(AgentCheck):
 
             resp.raise_for_status()
 
-        except requests.exceptions.Timeout:
-            self.log.exception('Consul request to {} timed out'.format(url))
-            self.service_check(self.CONSUL_CAN_CONNECT, self.CRITICAL, tags=service_check_tags)
+        except requests.exceptions.Timeout as e:
+            msg = 'Consul request to {} timed out'.format(url)
+            self.log.exception(msg)
+            self.service_check(
+                self.CONSUL_CAN_CONNECT,
+                self.CRITICAL,
+                tags=service_check_tags,
+                message="{}: {}".format(msg, e)
+            )
             raise
-        except Exception:
-            self.log.exception("Consul request to {} failed".format(url))
-            self.service_check(self.CONSUL_CAN_CONNECT, self.CRITICAL, tags=service_check_tags)
+        except Exception as e:
+            msg = "Consul request to {} failed".format(url)
+            self.log.exception(msg)
+            self.service_check(
+                self.CONSUL_CAN_CONNECT,
+                self.CRITICAL,
+                tags=service_check_tags,
+                message="{}: {}".format(msg, e)
+            )
             raise
         else:
             self.service_check(self.CONSUL_CAN_CONNECT, self.OK, tags=service_check_tags)

--- a/consul/service_checks.json
+++ b/consul/service_checks.json
@@ -16,5 +16,14 @@
         "statuses": ["ok", "critical"],
         "name": "Up",
         "description": "Returns OK if the consul server is up, CRITICAL otherwise."
+    },
+    {
+        "agent_version": "5.5.0",
+        "integration":"consul",
+        "groups": ["host", "url"],
+        "check": "consul.can_connect",
+        "statuses": ["ok", "critical"],
+        "name": "Can Connect",
+        "description": "Returns OK if the Agent can make HTTP requests to consul, CRITICAL otherwise."
     }
 ]

--- a/consul/tests/conftest.py
+++ b/consul/tests/conftest.py
@@ -48,10 +48,6 @@ def dd_environment(instance_single_node_install):
 
 
 @pytest.fixture
-def check():
-    return ConsulCheck(common.CHECK_NAME, {}, {})
-
-@pytest.fixture
 def instance():
     return {
         'url': common.URL,

--- a/consul/tests/conftest.py
+++ b/consul/tests/conftest.py
@@ -48,6 +48,10 @@ def dd_environment(instance_single_node_install):
 
 
 @pytest.fixture
+def check():
+    return ConsulCheck(common.CHECK_NAME, {}, {})
+
+@pytest.fixture
 def instance():
     return {
         'url': common.URL,

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -119,20 +119,24 @@ def test_consul_request(aggregator, instance):
     consul_check = ConsulCheck(common.CHECK_NAME, {}, {})
     with mock.patch("datadog_checks.consul.consul.requests") as mock_requests:
         consul_check.consul_request(instance, "foo")
+        url = "{}/{}".format(instance["url"], "foo")
         aggregator.assert_service_check(
             "consul.can_connect",
             ConsulCheck.OK,
-            tags=['url:{}/{}'.format(instance["url"], "foo")]
+            tags=["url:{}".format(url)],
+            count=1,
         )
 
         aggregator.reset()
-        mock_requests.get.side_effect = Exception
+        mock_requests.get.side_effect = Exception("message")
         with pytest.raises(Exception):
             consul_check.consul_request(instance, "foo")
         aggregator.assert_service_check(
             "consul.can_connect",
             ConsulCheck.CRITICAL,
-            tags=['url:{}/{}'.format(instance["url"], "foo")]
+            tags=["url:{}".format(url)],
+            count=1,
+            message="Consul request to {} failed: message".format(url)
         )
 
 

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -3,6 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
 
+import mock
+import pytest
+
 from datadog_checks.consul import ConsulCheck
 from datadog_checks.utils.containers import hash_mutable
 from . import common
@@ -110,6 +113,27 @@ def test_get_nodes_with_service_critical(aggregator):
     aggregator.assert_metric('consul.catalog.services_passing', value=0, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.services_warning', value=0, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.services_critical', value=6, tags=expected_tags)
+
+
+def test_consul_request(aggregator, instance):
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, {})
+    with mock.patch("datadog_checks.consul.consul.requests") as mock_requests:
+        consul_check.consul_request(instance, "foo")
+        aggregator.assert_service_check(
+            "consul.can_connect",
+            ConsulCheck.OK,
+            tags=['url:{}/{}'.format(instance["url"], "foo")]
+        )
+
+        aggregator.reset()
+        mock_requests.get.side_effect = Exception
+        with pytest.raises(Exception):
+            consul_check.consul_request(instance, "foo")
+        aggregator.assert_service_check(
+            "consul.can_connect",
+            ConsulCheck.CRITICAL,
+            tags=['url:{}/{}'.format(instance["url"], "foo")]
+        )
 
 
 def test_service_checks(aggregator):


### PR DESCRIPTION
### What does this PR do?

Add a service check around every consul request, tagged by URL.

### Motivation

the check could fail to make some HTTP requests at the beginning of the check, before sending any service check, so the only way to monitor would be with a `no data` trigger. With this, it will be possible to monitor with a `critical` service check trigger on `consul.can_connect`.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?