### PR TITLE
Pin Docker Image to 4.1.6

### DIFF
--- a/mongo/tox.ini
+++ b/mongo/tox.ini
@@ -23,7 +23,7 @@ setenv =
     3.2.10: MONGO_VERSION=3.2.10
     3.4: MONGO_VERSION=3.4
     3.5: MONGO_VERSION=3.5
-    4.1: MONGO_VERSION=4.1
+    4.1: MONGO_VERSION=4.1.6
 
 [testenv:unit]
 commands =


### PR DESCRIPTION
### What does this PR do?

Pins the mongo docker image to be 4.1.6 instead of 4.1

### Motivation

Master CI is failing because the Mongo 4.1 tag was recently updated to be the new bugfix 4.1.7
The check is breaking on this and we'll have to investigate why. But for now keep the master CI green. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
