### PR TITLE
Fix ecs.fargate.cpu.system and ecs.fargate.cpu.user

### DIFF
--- a/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
@@ -147,11 +147,11 @@ class FargateCheck(AgentCheck):
 
             value_system = cpu_stats.get('system_cpu_usage')
             if value_system is not None:
-                self.rate('ecs.fargate.cpu.system', value_system, tags)
+                self.rate('ecs.fargate.cpu.system', value_system // 10**9, tags)
 
             value_total = cpu_stats.get('cpu_usage', {}).get('total_usage')
             if value_total is not None:
-                self.rate('ecs.fargate.cpu.user', value_total, tags)
+                self.rate('ecs.fargate.cpu.user', value_total // 10**9, tags)
 
             prevalue_total = prev_cpu_stats.get('cpu_usage', {}).get('total_usage')
             prevalue_system = prev_cpu_stats.get('system_cpu_usage')


### PR DESCRIPTION
### What does this PR do?

This PR will fix values of ecs.fargate.cpu.system and ecs.fargate.cpu.user.
These metrics are collected via Docker API (cf. https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v2.html) and the unit is nanoseconds as you can see in the following codes:

* https://github.com/docker/engine/blob/v18.09.1/api/types/stats.go#L18-L40
* https://github.com/docker/engine/blob/v18.09.1/daemon/stats/collector_unix.go#L27-L29


### Motivation

I want to fix the following graph, which shows CPU utilization is 2.01G%.

![image](https://user-images.githubusercontent.com/508822/51559761-2420d480-1ec6-11e9-948e-c21a8e7ea30d.png)

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.
