### PR TITLE
adds redis_db tag to redis.key.length

### DIFF
--- a/redisdb/datadog_checks/redisdb/data/conf.yaml.example
+++ b/redisdb/datadog_checks/redisdb/data/conf.yaml.example
@@ -33,6 +33,7 @@ instances:
     #
 
     # Collect the lengths of the following keys.
+    # Length is 1 for strings
     # Length is zero for keys that have a type other than list, set, hash, or sorted set.
     # Keys can be expressed as patterns, see https://redis.io/commands/keys
     #

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -268,12 +268,13 @@ class Redis(AgentCheck):
             databases = [db, ]
 
         # maps a key to the total length across databases
-        lengths = defaultdict(int)
+        lengths_overall = defaultdict(int)
 
         # don't overwrite the configured instance, use a copy
         tmp_instance = deepcopy(instance)
 
         for db in databases:
+            lengths = defaultdict(int)
             tmp_instance['db'] = db
             db_conn = self._get_conn(tmp_instance)
 
@@ -292,21 +293,38 @@ class Redis(AgentCheck):
                         continue
 
                     if key_type == 'list':
-                        lengths[text_key] += db_conn.llen(key)
+                        keylen = db_conn.llen(key)
+                        lengths[text_key] += keylen
+                        lengths_overall[text_key] += keylen
                     elif key_type == 'set':
-                        lengths[text_key] += db_conn.scard(key)
+                        keylen = db_conn.scard(key)
+                        lengths[text_key] += keylen
+                        lengths_overall[text_key] += keylen
                     elif key_type == 'zset':
-                        lengths[text_key] += db_conn.zcard(key)
+                        keylen = db_conn.zcard(key)
+                        lengths[text_key] += keylen
+                        lengths_overall[text_key] += keylen
                     elif key_type == 'hash':
-                        lengths[text_key] += db_conn.hlen(key)
+                        keylen = db_conn.hlen(key)
+                        lengths[text_key] += keylen
+                        lengths_overall[text_key] += keylen
                     else:
                         # If the type is unknown, it might be because the key doesn't exist,
                         # which can be because the list is empty. So always send 0 in that case.
                         lengths[text_key] += 0
+                        lengths_overall[text_key] += 0
 
-        # send the metrics
-        for key, total in iteritems(lengths):
-            self.gauge('redis.key.length', total, tags=tags + ['key:' + key])
+            # Send the metrics for each db in the redis instance.
+            for key, total in iteritems(lengths):
+                self.gauge(
+                    'redis.key.length',
+                    total,
+                    tags=tags + [
+                        'key:' + key,
+                        'redis_db:db' + str(db)])
+
+        # Warn if a key is missing from the entire redis instance.
+        for key, total in iteritems(lengths_overall):
             if total == 0 and instance.get("warn_on_missing_keys", True):
                 self.warning("{0} key not found in redis".format(key))
 

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -308,8 +308,12 @@ class Redis(AgentCheck):
                         keylen = db_conn.hlen(key)
                         lengths[text_key] += keylen
                         lengths_overall[text_key] += keylen
+                    elif key_type == 'string':
+                        # Send 1 if the key exists as a string
+                        lengths[text_key] += 1
+                        lengths_overall[text_key] += 1
                     else:
-                        # If the type is unknown, it might be because the key doesn't exist,
+                        # If the type is 'none', it might be because the key doesn't exist,
                         # which can be because the list is empty. So always send 0 in that case.
                         lengths[text_key] += 0
                         lengths_overall[text_key] += 0

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -318,8 +318,8 @@ class Redis(AgentCheck):
                         lengths[text_key]["length"] += 0
                         lengths_overall[text_key] += 0
 
-                    # Tagging with key_type since the same key
-                    #   can exist with  different key_type per db
+                    # Tagging with key_type since the same key can exist with a
+                    # different key_type in another db
                     lengths[text_key]["key_type"] = key_type
 
             # Send the metrics for each db in the redis instance.

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -330,9 +330,9 @@ class Redis(AgentCheck):
                         'redis.key.length',
                         total["length"],
                         tags=tags + [
-                            'key:' + key,
-                            'key_type:' + total["key_type"],
-                            'redis_db:db' + str(db)])
+                            'key:{}'.format(key),
+                            'key_type:{}'.format(total["key_type"]),
+                            'redis_db:db{}'.format(db)])
 
         # Warn if a key is missing from the entire redis instance.
         # Send 0 if the key is missing/empty from the entire redis instance.
@@ -341,7 +341,7 @@ class Redis(AgentCheck):
                 self.gauge(
                     'redis.key.length',
                     total,
-                    tags=tags + ['key:' + key])
+                    tags=tags + ['key:{}'.format(key)])
                 self.warning("{0} key not found in redis".format(key))
 
     def _check_replication(self, info, tags):

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -313,7 +313,7 @@ class Redis(AgentCheck):
                         lengths[text_key]["length"] += 1
                         lengths_overall[text_key] += 1
                     else:
-                        # If the type is 'none', it might be because the key doesn't exist,
+                        # If the type is unknown, it might be because the key doesn't exist,
                         # which can be because the list is empty. So always send 0 in that case.
                         lengths[text_key]["length"] += 0
                         lengths_overall[text_key] += 0

--- a/redisdb/tests/test_default.py
+++ b/redisdb/tests/test_default.py
@@ -203,7 +203,7 @@ def test__check_key_lengths_multi_db(aggregator, redis_instance):
     conn.lpush('test_foo', 'value4')
 
     redis_check._check_key_lengths(c, redis_instance, [])
-    aggregator.assert_metric('redis.key.length', count=3)
+    aggregator.assert_metric('redis.key.length', count=4)
     aggregator.assert_metric('redis.key.length', value=4, tags=['key:test_foo', 'key_type:list'])
     aggregator.assert_metric('redis.key.length', value=1, tags=['key:test_bar', 'key_type:list'])
     aggregator.assert_metric('redis.key.length', value=0, tags=['key:missing_key'])

--- a/redisdb/tests/test_default.py
+++ b/redisdb/tests/test_default.py
@@ -204,6 +204,7 @@ def test__check_key_lengths_multi_db(aggregator, redis_instance):
 
     redis_check._check_key_lengths(c, redis_instance, [])
     aggregator.assert_metric('redis.key.length', count=4)
-    aggregator.assert_metric('redis.key.length', value=4, tags=['key:test_foo', 'key_type:list'])
-    aggregator.assert_metric('redis.key.length', value=1, tags=['key:test_bar', 'key_type:list'])
+    aggregator.assert_metric('redis.key.length', value=2, tags=['key:test_foo', 'key_type:list', 'redis_db:db0'])
+    aggregator.assert_metric('redis.key.length', value=2, tags=['key:test_foo', 'key_type:list', 'redis_db:db3'])
+    aggregator.assert_metric('redis.key.length', value=1, tags=['key:test_bar', 'key_type:list', 'redis_db:db0'])
     aggregator.assert_metric('redis.key.length', value=0, tags=['key:missing_key'])

--- a/redisdb/tests/test_default.py
+++ b/redisdb/tests/test_default.py
@@ -57,7 +57,9 @@ def test_redis_default(aggregator, redis_auth, redis_instance):
         elif name != 'redis.key.length':
             aggregator.assert_metric(name, tags=expected)
 
-    aggregator.assert_metric('redis.key.length', 3, count=1, tags=expected + ['key:test_list'])
+    aggregator.assert_metric(
+        'redis.key.length', 3, count=1,
+        tags=expected_db + ['key:test_list', 'key_type:list'])
 
     # in the old tests these was explicitly asserted, keeping it like that
     assert 'redis.net.commands' in aggregator.metric_names
@@ -202,6 +204,6 @@ def test__check_key_lengths_multi_db(aggregator, redis_instance):
 
     redis_check._check_key_lengths(c, redis_instance, [])
     aggregator.assert_metric('redis.key.length', count=3)
-    aggregator.assert_metric('redis.key.length', value=4, tags=['key:test_foo'])
-    aggregator.assert_metric('redis.key.length', value=1, tags=['key:test_bar'])
+    aggregator.assert_metric('redis.key.length', value=4, tags=['key:test_foo', 'key_type:list'])
+    aggregator.assert_metric('redis.key.length', value=1, tags=['key:test_bar', 'key_type:list'])
     aggregator.assert_metric('redis.key.length', value=0, tags=['key:missing_key'])


### PR DESCRIPTION
### What does this PR do?

Reports redis.key.length 1 for string key type instead of 0

adds the following tags to redis.key.length
- `redis_db`
- `key_type`

### Motivation

Feature request:
[Redis] - redis.key.length should be tagged by db

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
