### PR TITLE
Edit host and port tags to fix associated check monitors

### DIFF
--- a/powerdns_recursor/service_checks.json
+++ b/powerdns_recursor/service_checks.json
@@ -4,7 +4,7 @@
         "integration":"PowerDNS Recursor",
         "check": "powerdns.recursor.can_connect",
         "statuses": ["ok", "critical"],
-        "groups": ["host", "port"],
+        "groups": ["host", "recursor_host", "recursor_port"],
         "name": "Can Connect",
         "description": "Returns `CRITICAL` if the Agent check is unable to connect to the monitored Gearman instance. Returns `OK` otherwise."
     }


### PR DESCRIPTION
### What does this PR do?

Fix for this integration's service check and related monitors. Previously the monitor would scope on `host` and port` tags and resulted in no groups being found. 

### Motivation

Issue reported by a customer. 

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.
