### PR TITLE
remove unicode character from MyCheck example

### DIFF
--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -125,7 +125,7 @@ class MyCheck(AgentCheck):
                 # Page is accessible but the string was not found.
                 self.service_check('my_check.all_good', self.WARNING)
         except Exception as e:
-            # Something went horribly wrong. Ideally we'd be more specific…
+            # Something went horribly wrong. Ideally we'd be more specific...
             self.service_check('my_check.all_good', self.CRITICAL, e)
 ```
 


### PR DESCRIPTION
invalid `…` unicode symbol cause python check to not compile when copy/pasted

### What does this PR do?

replace `…` with `...`

### Motivation

I spent an hour debugging my check while trying to follow along. This will avoid future users having the same issue

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
