### PR TITLE
Log the correct information about snmpnext result

### DIFF
--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -257,7 +257,7 @@ class SnmpCheck(NetworkCheck):
                         lexicographicMode=False  # Don't walk through the entire MIB, stop at end of table
                     ):
 
-                        self.log.debug("Returned vars: {}".format(var_binds))
+                        self.log.debug("Returned vars: {}".format(var_binds_table))
                         # Raise on error_indication
                         self.raise_on_error_indication(error_indication, instance)
 


### PR DESCRIPTION
### What does this PR do?

This fixes the debug log line to print out the correct information about the result of the snmpnext command.

### Motivation

Investigating a support case, this will help troubleshooting.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
