### PR TITLE
Wait for jobs to finish before returning from check function

### DIFF
--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -897,12 +897,6 @@ class VSphereCheck(AgentCheck):
     def check(self, instance):
         self.start_pool()
 
-        custom_tags = instance.get('tags', [])
-
-        # ## <TEST-INSTRUMENTATION>
-        self.gauge('datadog.agent.vsphere.queue_size', self.pool._workq.qsize(), tags=['instant:initial'] + custom_tags)
-        # ## </TEST-INSTRUMENTATION>
-
         # First part: make sure our object repository is neat & clean
         if self._should_cache(instance, CacheConfig.Metadata):
             self._cache_metrics_metadata(instance)
@@ -936,7 +930,3 @@ class VSphereCheck(AgentCheck):
             set_external_tags(self.get_external_host_tags())
 
         self.stop_pool()
-
-        # ## <TEST-INSTRUMENTATION>
-        self.gauge('datadog.agent.vsphere.queue_size', self.pool._workq.qsize(), tags=['instant:final'] + custom_tags)
-        # ## </TEST-INSTRUMENTATION>

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -151,11 +151,12 @@ class VSphereCheck(AgentCheck):
         self.latest_event_query = {}
 
     def start_pool(self):
-        self.log.info("Starting Thread Pool")
-        self.pool_size = int(self.init_config.get('threads_count', DEFAULT_SIZE_POOL))
+        if not self.pool_started:
+            self.log.info("Starting Thread Pool")
+            self.pool_size = int(self.init_config.get('threads_count', DEFAULT_SIZE_POOL))
 
-        self.pool = Pool(self.pool_size)
-        self.pool_started = True
+            self.pool = Pool(self.pool_size)
+            self.pool_started = True
 
     def terminate_pool(self):
         self.log.info("Terminating Thread Pool")

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -149,6 +149,9 @@ class VSphereCheck(AgentCheck):
         self.exception_printed = 0
 
     def print_exception(self, msg):
+        """ Print exceptions happening in separate threads
+        Prevent from logging a ton of them if a potentially big number of them fail the same way
+        """
         if self.exception_printed < 10:
             self.log.error(msg)
             self.exception_printed += 1

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -623,7 +623,6 @@ class VSphereCheck(AgentCheck):
         include_only_marked = is_affirmative(instance.get('include_only_marked', False))
 
         # Discover hosts and virtual machines
-        i_key = self._instance_key(instance)
         server_instance = self._get_server_instance(instance)
         use_guest_hostname = is_affirmative(instance.get("use_guest_hostname", False))
         all_objs = self._get_all_objs(server_instance, regexes, include_only_marked, tags,

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -166,7 +166,7 @@ class VSphereCheck(AgentCheck):
             self.pool_started = False
 
     def stop_pool(self):
-        self.log.info("Stopping Thread Pool")
+        self.log.info("Stopping Thread Pool, waiting for queued jobs to finish")
         if self.pool_started:
             for _ in self.pool._workers:
                 self.pool._workq.put(SENTINEL)
@@ -628,6 +628,7 @@ class VSphereCheck(AgentCheck):
         use_guest_hostname = is_affirmative(instance.get("use_guest_hostname", False))
         all_objs = self._get_all_objs(server_instance, regexes, include_only_marked, tags,
                                       use_guest_hostname=use_guest_hostname)
+
         self.mor_objects_queue.fill(i_key, dict(all_objs))
         self.cache_config.set_last(CacheConfig.Morlist, i_key, time.time())
 

--- a/vsphere/tests/test_vsphere.py
+++ b/vsphere/tests/test_vsphere.py
@@ -37,7 +37,6 @@ def test__init__(instance):
     i_key = check._instance_key(instance)
 
     assert check.time_started > 0
-    assert check.pool_started is False
     assert len(check.server_instances) == 0
     assert check.cache_config.get_interval(CacheConfig.Morlist, i_key) == 42
     assert check.cache_config.get_interval(CacheConfig.Metadata, i_key) == -42

--- a/vsphere/tests/test_vsphere.py
+++ b/vsphere/tests/test_vsphere.py
@@ -178,7 +178,7 @@ def test__collect_mors_and_attributes(vsphere, instance):
         assert len(mor_attrs) == 1
 
 
-def test__cache_morlist_raw_async(vsphere, instance):
+def test__cache_morlist_raw(vsphere, instance):
     """
     Explore the vCenter infrastructure to discover hosts, virtual machines.
 
@@ -201,16 +201,12 @@ def test__cache_morlist_raw_async(vsphere, instance):
     """
     # Samples
     with mock.patch('datadog_checks.vsphere.vsphere.vmodl'):
-        tags = ["toto", "optional:tag1"]
-        include_regexes = {
-            'host_include': "host[2-9]",
-            'vm_include': "vm[^2]",
-        }
-        include_only_marked = True
-        instance["tags"] = ["optional:tag1"]
+        instance["host_include_only_regex"] = "host[2-9]"
+        instance["vm_include_only_regex"] = "vm[^2]"
+        instance["include_only_marked"] = True
 
         # Discover hosts and virtual machines
-        vsphere._cache_morlist_raw_async(instance, tags, include_regexes, include_only_marked)
+        vsphere._cache_morlist_raw(instance)
 
         # Assertions: 1 labeled+monitored VM + 2 hosts + 2 datacenters + 2 clusters + 1 datastore.
         assertMOR(vsphere, instance, count=8)
@@ -218,24 +214,24 @@ def test__cache_morlist_raw_async(vsphere, instance):
         # ...on hosts
         assertMOR(vsphere, instance, spec="host", count=2)
         tags = [
-            "toto", "vsphere_folder:rootFolder", "vsphere_datacenter:datacenter1",
+            "vcenter_server:vsphere_mock", "vsphere_folder:rootFolder", "vsphere_datacenter:datacenter1",
             "vsphere_compute:compute_resource1", "vsphere_cluster:compute_resource1",
-            "vsphere_type:host", "optional:tag1"
+            "vsphere_type:host"
         ]
         assertMOR(vsphere, instance, name="host2", spec="host", tags=tags)
         tags = [
-            "toto", "vsphere_folder:rootFolder", "vsphere_folder:folder1",
+            "vcenter_server:vsphere_mock", "vsphere_folder:rootFolder", "vsphere_folder:folder1",
             "vsphere_datacenter:datacenter2", "vsphere_compute:compute_resource2",
-            "vsphere_cluster:compute_resource2", "vsphere_type:host", "optional:tag1"
+            "vsphere_cluster:compute_resource2", "vsphere_type:host"
         ]
         assertMOR(vsphere, instance, name="host3", spec="host", tags=tags)
 
         # ...on VMs
         assertMOR(vsphere, instance, spec="vm", count=1)
         tags = [
-            "toto", "vsphere_folder:folder1", "vsphere_datacenter:datacenter2",
+            "vcenter_server:vsphere_mock", "vsphere_folder:folder1", "vsphere_datacenter:datacenter2",
             "vsphere_compute:compute_resource2", "vsphere_cluster:compute_resource2",
-            "vsphere_host:host3", "vsphere_type:vm", "optional:tag1"
+            "vsphere_host:host3", "vsphere_type:vm"
         ]
         assertMOR(vsphere, instance, name="vm4", spec="vm", subset=True, tags=tags)
 
@@ -244,20 +240,20 @@ def test_use_guest_hostname(vsphere, instance):
     # Default value
     with mock.patch("datadog_checks.vsphere.VSphereCheck._get_all_objs") as mock_get_all_objs, \
          mock.patch("datadog_checks.vsphere.vsphere.vmodl"):
-        vsphere._cache_morlist_raw_async(instance, [])
+        vsphere._cache_morlist_raw(instance)
         # Default value
         mock_get_all_objs.call_args[1]["use_guest_hostname"] is False
 
         # use guest hostname
         instance["use_guest_hostname"] = True
-        vsphere._cache_morlist_raw_async(instance, [])
+        vsphere._cache_morlist_raw(instance)
         mock_get_all_objs.call_args[1]["use_guest_hostname"] is True
 
     with mock.patch("datadog_checks.vsphere.vsphere.vmodl"):
 
         # Discover hosts and virtual machines
         instance["use_guest_hostname"] = True
-        vsphere._cache_morlist_raw_async(instance, [])
+        vsphere._cache_morlist_raw(instance)
         assertMOR(vsphere, instance, spec="vm", count=3)
         # Fallback on VM name when guest hostname not available
         assertMOR(vsphere, instance, name="vm1", spec="vm", subset=True)

--- a/vsphere/tests/utils.py
+++ b/vsphere/tests/utils.py
@@ -118,6 +118,7 @@ def disable_thread_pool(check):
     """
     check.pool = MagicMock(apply_async=lambda func, args: func(*args))
     check.pool._workq.qsize.return_value = 0
+    check.pool.get_nworkers.return_value = 0
     check.pool_started = True  # otherwise the mock will be overwritten
     return check
 

--- a/vsphere/tests/utils.py
+++ b/vsphere/tests/utils.py
@@ -116,10 +116,10 @@ def disable_thread_pool(check):
     """
     Disable the thread pool on the check instance
     """
+    check.start_pool = MagicMock()
     check.pool = MagicMock(apply_async=lambda func, args: func(*args))
     check.pool._workq.qsize.return_value = 0
     check.pool.get_nworkers.return_value = 0
-    check.pool_started = True  # otherwise the mock will be overwritten
     return check
 
 


### PR DESCRIPTION
### What does this PR do?

The check now makes a join on the thread pool at the end of the check function so that it only returns once everything has been processed and all the metrics have been sent.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
