### PR TITLE
Support Python 3 Base WMI

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
@@ -254,7 +254,7 @@ class WinWMICheck(AgentCheck):
         """
         Create and cache a WMISampler for the given (class, properties)
         """
-        properties = properties + [tag_by] if tag_by else properties
+        properties = list(properties) + [tag_by] if tag_by else list(properties)
 
         if instance_key not in self.wmi_samplers:
             wmi_sampler = WMISampler(self.log, wmi_class, properties, **kwargs)

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -27,7 +27,7 @@ from copy import deepcopy
 
 import pythoncom
 import pywintypes
-from six import iteritems, string_types
+from six import iteritems, string_types, with_metaclass
 from six.moves import zip
 from win32com.client import Dispatch
 
@@ -60,12 +60,10 @@ class ProviderArchitectureMeta(type):
         return provider in cls._AVAILABLE_PROVIDER_ARCHITECTURES
 
 
-class ProviderArchitecture(object):
+class ProviderArchitecture(with_metaclass(ProviderArchitectureMeta, object)):
     """
     Enumerate WMI Provider Architectures.
     """
-    __metaclass__ = ProviderArchitectureMeta
-
     # Available Provider Architecture(s)
     DEFAULT = 0
     _32BIT = 32


### PR DESCRIPTION
### What does this PR do?

Supports Python3 for the base classes of the WMI check

The biggest change here is the way the metaclass is defined. In Python3, you can no longer do the __metaclass__ approach and need to put it in the declaration of the class itself. Six provides a way to be compatible with both, so I used that. 

PEP that changes this - https://www.python.org/dev/peps/pep-3115/

Also, `map` was returning the map type, so you couldn't add a map to a list, this casts the map to the underlying type of list. 

### Motivation

🐍3️⃣ 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
