### PR TITLE
Update example config to match docs

### DIFF
--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -6,8 +6,8 @@ instances:
   # Note for RHEL and SUSE users: due to compatibility issues, the check does not make use of
   # the CPP extension to process Protocol buffer messages coming from the api. Depending
   # on the metrics volume, the check may run very slowly.
-  - istio_mesh_endpoint: http://localhost:42422/metrics
-    mixer_endpoint: http://localhost:9093/metrics
+  - istio_mesh_endpoint: http://istio-telemetry.istio-system:42422/metrics
+    mixer_endpoint: http://istio-telemetry.istio-system:9093/metrics
     send_histograms_buckets: true
     # tags:
     #   - optional_tag1


### PR DESCRIPTION
### What does this PR do?

Updates the Istio `conf.yaml.example` file to replicate the [example in the documentation](https://docs.datadoghq.com/integrations/istio/#connect-the-agent). 

### Motivation

Customer request, ticket 192695.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
