### PR TITLE
Add missing info for SNMP/MIB

### DIFF
--- a/snmp/README.md
+++ b/snmp/README.md
@@ -152,25 +152,20 @@ C:\>dir mibdump.py /s
 In Linux, use this format for the script:
 
 ```
-export MIBSRC=<PATH_TO_MIB_FILES>
-export MIBDST=<PATH_TO_CONVERTED_MIB_PYFILES>
-
 <PATH_TO_FILE>/mibdump.py \
-  --mib-source $MIBSRC \
+  --mib-source <PATH_TO_MIB_FILES> \
   --mib-source http://mibs.snmplabs.com/asn1/@mib@ \
-  --destination-directory=$MIBDST \
+  --destination-directory=<PATH_TO_CONVERTED_MIB_PYFILES> \
   --destination-format=pysnmp <MIB_FILE_NAME>
 ```
 
 Windows Powershell example:
 
 ```
-PS> New-Variable -Name MIBSRC -Value file:///X:<PATH_TO_MIB_SOURCE>
-PS> New-Variable -Name MIBDST -Value X:<PATH_TO_MIB_DESTINATION>
 PS> & 'C:\Program Files\Datadog\Datadog Agent\embedded\python.exe' '<PATH_TO_FILE>\mibdump.py' `
-  --mib-source $MIBSRC  `
+  --mib-source <PATH_TO_MIB_SOURCE> `
   --mib-source http://mibs.snmplabs.com/asn1/@mib@ `
-  --destination-directory=$MIBDST `
+  --destination-directory=<PATH_TO_MIB_DESTINATION> `
   --destination-format=pysnmp <MIB_FILE_NAME>
 ```
 

--- a/snmp/README.md
+++ b/snmp/README.md
@@ -130,11 +130,11 @@ metrics:
 
 #### Use your own MIB
 
-To use your own MIB with the Datadog Agent, convert it to the PySNMP format. This can be done using the `build-pysnmp-mibs` script that ships with PySNMP < 4.3. `mibdump.py` replaces `build-pysnmp-mib` which was made obsolete in [PySNMP 4.3+][5].
+To use your own MIB with the Datadog Agent, convert it to the [PySNMP][14] format. This can be done using the `build-pysnmp-mibs` script that ships with PySNMP < 4.3. `mibdump.py` replaces `build-pysnmp-mib` which was made obsolete in [PySNMP 4.3+][5].
 
 Since Datadog Agent version 5.14, the Agent's PySNMP dependency has been upgraded from version 4.25 to 4.3.5 (refer to the [changelog][6]). This means that the `build-pysnmp-mib` which shipped with the Agent from version 5.13.x and earlier has also been replaced with `mibdump.py`.
  
-To find the location of `mibdump.py`, run:
+In Linux, find the location of `mibdump.py`, run:
 
 ```
 $ find /opt/datadog-agent/ -type f -name build-pysnmp-mib.py -o -name mibdump.py
@@ -149,10 +149,29 @@ C:\>dir mibdump.py /s
  Directory of C:\Program Files\Datadog\Datadog Agent\embedded\Scripts
 ```
 
-Use this format for the script:
+In Linux, use this format for the script:
 
 ```
-<PATH_TO_FILE>/mibdump.py --mib-source /path/to/mib/files/  --mib-source http://mibs.snmplabs.com/asn1/@mib@ --destination-directory=/path/to/converted/mib/pyfiles/ --destination-format=pysnmp <MIB_FILE_NAME>
+export MIBSRC=/path/to/mib/files
+export MIBDST=/path/to/converted/mib/pyfiles
+
+<PATH_TO_FILE>/mibdump.py \
+  --mib-source $MIBSRC \
+  --mib-source http://mibs.snmplabs.com/asn1/@mib@ \
+  --destination-directory=$MIBDST \
+  --destination-format=pysnmp <MIB_FILE_NAME>
+```
+
+Windows Powershell example:
+
+```
+PS> New-Variable -Name MIBSRC -Value file:///X:/path/to/mib/source
+PS> New-Variable -Name MIBDST -Value X:\path\to\mib\destination
+PS> & 'C:\Program Files\Datadog\Datadog Agent\embedded\python.exe' '<PATH_TO_FILE>\mibdump.py' `
+  --mib-source $MIBSRC  `
+  --mib-source http://mibs.snmplabs.com/asn1/@mib@ `
+  --destination-directory=$MIBDST `
+  --destination-format=pysnmp <MIB_FILE_NAME>
 ```
 
 Example using the `CISCO-TCP-MIB.my`:
@@ -237,3 +256,4 @@ Additional helpful documentation, links, and articles:
 [11]: https://docs.datadoghq.com/integrations/faq/for-snmp-does-datadog-have-a-list-of-commonly-used-compatible-oids
 [12]: https://docs.datadoghq.com/agent/faq/how-to-monitor-snmp-devices
 [13]: https://medium.com/server-guides/monitoring-unifi-devices-using-snmp-and-datadog-c8093a7d54ca
+[14]: http://snmplabs.com/pysnmp/index.html

--- a/snmp/README.md
+++ b/snmp/README.md
@@ -17,7 +17,7 @@ The SNMP check doesn't collect anything by default. Specify metrics to collect b
 
 ```
 init_config:
-  mibs_folder: /path/to/your/additional/mibs
+  mibs_folder: <PATH_TO_ADDITIONAL_MIBS>
 
 instances:
    - ip_address: localhost
@@ -59,7 +59,7 @@ instances:
 
 ```
 init_config:
-   - mibs_folder: /path/to/your/additional/mibs
+   - mibs_folder: <PATH_TO_ADDITIONAL_MIBS>
 
 instances:
    - ip_address: 192.168.34.10
@@ -152,8 +152,8 @@ C:\>dir mibdump.py /s
 In Linux, use this format for the script:
 
 ```
-export MIBSRC=/path/to/mib/files
-export MIBDST=/path/to/converted/mib/pyfiles
+export MIBSRC=<PATH_TO_MIB_FILES>
+export MIBDST=<PATH_TO_CONVERTED_MIB_PYFILES>
 
 <PATH_TO_FILE>/mibdump.py \
   --mib-source $MIBSRC \
@@ -165,8 +165,8 @@ export MIBDST=/path/to/converted/mib/pyfiles
 Windows Powershell example:
 
 ```
-PS> New-Variable -Name MIBSRC -Value file:///X:/path/to/mib/source
-PS> New-Variable -Name MIBDST -Value X:\path\to\mib\destination
+PS> New-Variable -Name MIBSRC -Value file:///X:<PATH_TO_MIB_SOURCE>
+PS> New-Variable -Name MIBDST -Value X:<PATH_TO_MIB_DESTINATION>
 PS> & 'C:\Program Files\Datadog\Datadog Agent\embedded\python.exe' '<PATH_TO_FILE>\mibdump.py' `
   --mib-source $MIBSRC  `
   --mib-source http://mibs.snmplabs.com/asn1/@mib@ `
@@ -177,9 +177,9 @@ PS> & 'C:\Program Files\Datadog\Datadog Agent\embedded\python.exe' '<PATH_TO_FIL
 Example using the `CISCO-TCP-MIB.my`:
 
 ```
- # /opt/datadog-agent/embedded/bin/mibdump.py --mib-source /path/to/mib/files/  --mib-source http://mibs.snmplabs.com/asn1/@mib@ --destination-directory=/opt/datadog-agent/pysnmp/custom_mibpy/ --destination-format=pysnmp CISCO-TCP-MIB
+ # /opt/datadog-agent/embedded/bin/mibdump.py --mib-source <PATH_TO_MIB_FILE>  --mib-source http://mibs.snmplabs.com/asn1/@mib@ --destination-directory=/opt/datadog-agent/pysnmp/custom_mibpy/ --destination-format=pysnmp CISCO-TCP-MIB
 
- Source MIB repositories: /path/to/mib/files/, http://mibs.snmplabs.com/asn1/@mib@
+ Source MIB repositories: <PATH_TO_MIB_FILE>, http://mibs.snmplabs.com/asn1/@mib@
  Borrow missing/failed MIBs from: http://mibs.snmplabs.com/pysnmp/notexts/@mib@
  Existing/compiled MIB locations: pysnmp.smi.mibs, pysnmp_mibs
  Compiled MIBs destination directory: /opt/datadog-agent/pysnmp/custom_mibpy/
@@ -209,8 +209,6 @@ CISCO-SMI.py CISCO-SMI.pyc CISCO-TCP-MIB.py CISCO-TCP-MIB.pyc
 ```
 
 The Agent looks for the converted MIB Python files by specifying the destination path with `mibs_folder` in the [SNMP YAML configuration][7].
-
----
 
 [Restart the Agent][8] to start sending SNMP metrics to Datadog.
 


### PR DESCRIPTION
### What does this PR do?
- Add missing info for SNMP/MIB from KB: https://help.datadoghq.com/hc/en-us/articles/115003480071-Using-your-own-MIB-with-Datadog-agent-v5-14-x-onwards
- Update wording

### Motivation
KB site migration

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes
Redirect KB article after merge
