### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -220,7 +220,7 @@ jobs:
     - stage: test
       env: CHECK=process PYTHON3=true
     - stage: test
-      env: CHECK=prometheus
+      env: CHECK=prometheus PYTHON3=true
     - stage: test
       env: CHECK=rabbitmq PYTHON3=true
     - stage: test

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -16,7 +16,6 @@ from prometheus_client.parser import text_fd_to_metric_families
 from six import PY3, iteritems, string_types
 
 from .. import AgentCheck
-from datadog_checks.base import ensure_unicode
 
 if PY3:
     long = int

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -16,6 +16,7 @@ from prometheus_client.parser import text_fd_to_metric_families
 from six import PY3, iteritems, string_types
 
 from .. import AgentCheck
+from datadog_checks.base import ensure_unicode
 
 if PY3:
     long = int

--- a/prometheus/tests/test_prometheus.py
+++ b/prometheus/tests/test_prometheus.py
@@ -1,15 +1,14 @@
 # (C) Datadog, Inc. 2010-2018
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-
 import pytest
 import mock
 
-# 3p
 from prometheus_client import generate_latest, CollectorRegistry, Gauge, Counter
 
-# project
+from datadog_checks.base import ensure_unicode
 from datadog_checks.prometheus import PrometheusCheck
+
 
 instance = {
     'prometheus_url': 'http://localhost:10249/metrics',
@@ -50,7 +49,7 @@ def poll_mock():
         'requests.get',
         return_value=mock.MagicMock(
             status_code=200,
-            iter_lines=lambda **kwargs: generate_latest(registry).split("\n"),
+            iter_lines=lambda **kwargs: ensure_unicode(generate_latest(registry)).split("\n"),
             headers={'Content-Type': "text/plain"}
         )
     )

--- a/prometheus/tox.ini
+++ b/prometheus/tox.ini
@@ -2,14 +2,12 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    prometheus
+    {py27,py36}-prometheus
     flake8
 
 [testenv]
 usedevelop = true
 platform = linux2|darwin
-
-[testenv:prometheus]
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt


### PR DESCRIPTION
### What does this PR do?

Add python3 support for the prometheus check
The tests that mock iteritems were returning bytes, so needed to change to strings. 

### Motivation

🐍 3️⃣ 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
