### PR TITLE
Get ready for local E2E

### DIFF
--- a/varnish/tests/conftest.py
+++ b/varnish/tests/conftest.py
@@ -4,22 +4,16 @@
 
 import pytest
 import os
-import subprocess
-import time
+
+from datadog_checks.dev import docker_run
 
 from . import common
 
 
 @pytest.fixture(scope="session")
-def spin_up_varnish():
-    env = os.environ
-    target = "varnish{}".format(env["VARNISH_VERSION"].split(".")[0])
-    args = [
-        "docker-compose",
-        "-f", os.path.join(common.HERE, 'compose', 'docker-compose.yaml')
-    ]
-    subprocess.check_call(args + ["down"], env=env)
-    subprocess.check_call(args + ["up", "-d", target], env=env)
-    time.sleep(2)
-    yield
-    subprocess.check_call(args + ["down"], env=env)
+def dd_environment():
+    target = "varnish{}".format(os.environ["VARNISH_VERSION"].split(".")[0])
+
+    compose_file = os.path.join(common.HERE, 'compose', 'docker-compose.yaml')
+    with docker_run(compose_file, service_name=target):
+        yield common.get_config_by_version(), 'local'

--- a/varnish/tests/test_varnish.py
+++ b/varnish/tests/test_varnish.py
@@ -18,7 +18,7 @@ from datadog_checks.varnish import Varnish
 pytestmark = pytest.mark.integration
 
 
-def test_check(aggregator, spin_up_varnish):
+def test_check(aggregator, dd_environment):
     check = Varnish(common.CHECK_NAME, {}, {})
     config = common.get_config_by_version()
 
@@ -27,7 +27,7 @@ def test_check(aggregator, spin_up_varnish):
         aggregator.assert_metric(mname, count=1, tags=['cluster:webs', 'varnish_name:default'])
 
 
-def test_inclusion_filter(aggregator, spin_up_varnish):
+def test_inclusion_filter(aggregator, dd_environment):
     check = Varnish(common.CHECK_NAME, {}, {})
     config = common.get_config_by_version()
     config['metrics_filter'] = ['SMA.*']
@@ -40,7 +40,7 @@ def test_inclusion_filter(aggregator, spin_up_varnish):
             aggregator.assert_metric(mname, count=0, tags=['cluster:webs', 'varnish_name:default'])
 
 
-def test_exclusion_filter(aggregator, spin_up_varnish):
+def test_exclusion_filter(aggregator, dd_environment):
     check = Varnish(common.CHECK_NAME, {}, {})
     config = common.get_config_by_version()
     config['metrics_filter'] = ['^SMA.Transient.c_req']

--- a/varnish/tests/test_varnish.py
+++ b/varnish/tests/test_varnish.py
@@ -18,7 +18,8 @@ from datadog_checks.varnish import Varnish
 pytestmark = pytest.mark.integration
 
 
-def test_check(aggregator, dd_environment):
+@pytest.mark.usefixtures('dd_environment')
+def test_check(aggregator):
     check = Varnish(common.CHECK_NAME, {}, {})
     config = common.get_config_by_version()
 
@@ -27,7 +28,8 @@ def test_check(aggregator, dd_environment):
         aggregator.assert_metric(mname, count=1, tags=['cluster:webs', 'varnish_name:default'])
 
 
-def test_inclusion_filter(aggregator, dd_environment):
+@pytest.mark.usefixtures('dd_environment')
+def test_inclusion_filter(aggregator):
     check = Varnish(common.CHECK_NAME, {}, {})
     config = common.get_config_by_version()
     config['metrics_filter'] = ['SMA.*']
@@ -40,7 +42,8 @@ def test_inclusion_filter(aggregator, dd_environment):
             aggregator.assert_metric(mname, count=0, tags=['cluster:webs', 'varnish_name:default'])
 
 
-def test_exclusion_filter(aggregator, dd_environment):
+@pytest.mark.usefixtures('dd_environment')
+def test_exclusion_filter(aggregator):
     check = Varnish(common.CHECK_NAME, {}, {})
     config = common.get_config_by_version()
     config['metrics_filter'] = ['^SMA.Transient.c_req']

--- a/varnish/tox.ini
+++ b/varnish/tox.ini
@@ -14,12 +14,12 @@ passenv =
     DOCKER*
     COMPOSE*
 setenv =
-    4.2.7: VARNISH_VERSION=4.1.7
+    4.1.7: VARNISH_VERSION=4.1.7
     5.2.1: VARNISH_VERSION=5.2.1
 commands =
     pip install -r requirements.in
     unit: pytest -m"not integration" -v
-    {4.2.7-5.2.1}: pytest -m"integration" -v
+    {4.1.7,5.2.1}: pytest -m"integration" -v
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
### What does this PR do?

Get ready for local E2E by adding the dd_environment fixture
Cleanup docker usage to use new utils provided by checks_base
Fix the tox environment, the 4.1.7 tests were broken (not being run) due to a typo in the tox file. 

### Motivation

Cleanup and test :allthethings: Also get ready for local E2E

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
