### PR TITLE
Improve performance by querying only necessary columns from a table

### DIFF
--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -309,6 +309,32 @@ class SnmpCheck(NetworkCheck):
         self.log.debug("Raw results: {}".format(results))
         return results
 
+    def parse_metrics(self, metrics, enforce_constraints):
+        if not metrics:
+            raise Exception('Metrics list must contain at least one metric')
+        raw_oids = []
+        table_oids = []
+        mibs_to_load = set()
+        # Check the metrics completely defined
+        for metric in metrics:
+            if 'MIB' in metric:
+                if not("table" in metric or "symbol" in metric):
+                    raise Exception("When specifying a MIB, you must specify either table or symbol")
+                if not enforce_constraints:
+                    # We need this only if we don't enforce constraints to be able to lookup MIBs manually
+                    mibs_to_load.add(metric["MIB"])
+                to_query = metric.get("table", metric.get("symbol"))
+                try:
+                    table_oids.append(hlapi.ObjectType(hlapi.ObjectIdentity(metric["MIB"], to_query)))
+                except Exception as e:
+                    self.warning("Can't generate MIB object for variable : %s\nException: %s", metric, e)
+            elif 'OID' in metric:
+                raw_oids.append(hlapi.ObjectType(hlapi.ObjectIdentity(metric['OID'])))
+            else:
+                raise Exception('Unsupported metric in config file: {}'.format(metric))
+
+        return table_oids, raw_oids, mibs_to_load
+
     def _check(self, instance):
         '''
         Perform two series of SNMP requests, one for all that have MIB asociated
@@ -318,32 +344,9 @@ class SnmpCheck(NetworkCheck):
         (snmp_engine, mib_view_controller, ip_address,
          tags, metrics, timeout, retries, enforce_constraints) = self._load_conf(instance)
 
-        if not metrics:
-            raise Exception('Metrics list must contain at least one metric')
-
         tags += ['snmp_device:{}'.format(ip_address)]
 
-        table_oids = []
-        raw_oids = []
-        mibs_to_load = set()
-
-        # Check the metrics completely defined
-        for metric in metrics:
-            if 'MIB' in metric:
-                try:
-                    assert "table" in metric or "symbol" in metric
-                    if not enforce_constraints:
-                        # We need this only if we don't enforce constraints to be able to lookup MIBs manually
-                        mibs_to_load.add(metric["MIB"])
-                    to_query = metric.get("table", metric.get("symbol"))
-                    table_oids.append(hlapi.ObjectType(hlapi.ObjectIdentity(metric["MIB"], to_query)))
-                except Exception as e:
-                    self.log.warning("Can't generate MIB object for variable : %s\n"
-                                     "Exception: %s", metric, e)
-            elif 'OID' in metric:
-                raw_oids.append(hlapi.ObjectType(hlapi.ObjectIdentity(metric['OID'])))
-            else:
-                raise Exception('Unsupported metric in config file: {}'.format(metric))
+        table_oids, raw_oids, mibs_to_load = self.parse_metrics(metrics, enforce_constraints)
         try:
             if table_oids:
                 self.log.debug("Querying device %s for %s oids", ip_address, len(table_oids))

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -159,7 +159,7 @@ INVALID_METRICS = [
     {
         'MIB': "IF-MIB",
         'table': "noIdeaWhatIAmDoingHere",
-        'symbols': ["ifInOctets", "ifOutOctets"],
+        'symbols': ["ImWrong", "MeToo"],
     }
 ]
 

--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -13,7 +13,7 @@ from .common import (
 )
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope='session')
 def dd_environment():
     env = {
         'COMPOSE_DIR': COMPOSE_DIR

--- a/snmp/tests/test_bench.py
+++ b/snmp/tests/test_bench.py
@@ -1,7 +1,12 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pytest
+
 from .common import TABULAR_OBJECTS, generate_instance_config
+
+pytestmark = pytest.mark.usefixtures("dd_environment")
 
 
 def test_tabular_enforce(benchmark, check):

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -3,10 +3,13 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 import mock
+import pytest
 
 from . import common
 
 from datadog_checks.snmp import SnmpCheck
+
+pytestmark = pytest.mark.usefixtures("dd_environment")
 
 
 def test_command_generator(aggregator):

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -52,14 +52,75 @@ def test_parse_metrics(hlapi_mock, check):
     hlapi_mock.ObjectIdentity.assert_called_once_with("foo_mib", "foo")
     hlapi_mock.reset_mock()
 
-    # MIB with table
+    # MIB with table, no symbols
     metrics = [{
         "MIB": "foo_mib",
         "table": "foo",
     }]
+    with pytest.raises(Exception):
+        check.parse_metrics(metrics, False)
+
+    # MIB with table and symbols
+    metrics = [{
+        "MIB": "foo_mib",
+        "table": "foo",
+        "symbols": ["foo", "bar"],
+    }]
     table, raw, mibs = check.parse_metrics(metrics, True)
     assert raw == []
     assert mibs == set()
-    assert len(table) == 1
-    hlapi_mock.ObjectIdentity.assert_called_once_with("foo_mib", "foo")
+    assert len(table) == 2
+    hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "foo")
+    hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "bar")
+    hlapi_mock.reset_mock()
+
+    # MIB with table, symbols, bad metrics_tags
+    metrics = [{
+        "MIB": "foo_mib",
+        "table": "foo",
+        "symbols": ["foo", "bar"],
+        "metric_tags": [{}]
+    }]
+    with pytest.raises(Exception):
+        check.parse_metrics(metrics, False)
+
+    # MIB with table, symbols, bad metrics_tags
+    metrics = [{
+        "MIB": "foo_mib",
+        "table": "foo",
+        "symbols": ["foo", "bar"],
+        "metric_tags": [{"tag": "foo"}]
+    }]
+    with pytest.raises(Exception):
+        check.parse_metrics(metrics, False)
+
+    # MIB with table, symbols, metrics_tags index
+    metrics = [{
+        "MIB": "foo_mib",
+        "table": "foo",
+        "symbols": ["foo", "bar"],
+        "metric_tags": [{"tag": "foo", "index": "1"}]
+    }]
+    table, raw, mibs = check.parse_metrics(metrics, True)
+    assert raw == []
+    assert mibs == set()
+    assert len(table) == 2
+    hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "foo")
+    hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "bar")
+    hlapi_mock.reset_mock()
+
+    # MIB with table, symbols, metrics_tags column
+    metrics = [{
+        "MIB": "foo_mib",
+        "table": "foo",
+        "symbols": ["foo", "bar"],
+        "metric_tags": [{"tag": "foo", "column": "baz"}]
+    }]
+    table, raw, mibs = check.parse_metrics(metrics, True)
+    assert raw == []
+    assert mibs == set()
+    assert len(table) == 3
+    hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "foo")
+    hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "bar")
+    hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "baz")
     hlapi_mock.reset_mock()

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -1,0 +1,65 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+import mock
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@mock.patch("datadog_checks.snmp.snmp.hlapi")
+def test_parse_metrics(hlapi_mock, check):
+    # No metrics
+    metrics = []
+    with pytest.raises(Exception):
+        check.parse_metrics(metrics, False)
+
+    # Unsupported metric
+    metrics = [{
+        "foo": "bar"
+    }]
+    with pytest.raises(Exception):
+        check.parse_metrics(metrics, False)
+
+    # Simple OID
+    metrics = [{
+        "OID": "1.2.3"
+    }]
+    table, raw, mibs = check.parse_metrics(metrics, False)
+    assert table == []
+    assert mibs == set()
+    assert len(raw) == 1
+    hlapi_mock.ObjectIdentity.assert_called_once_with("1.2.3")
+    hlapi_mock.reset_mock()
+
+    # MIB with no symbol or table
+    metrics = [{
+        "MIB": "foo_mib"
+    }]
+    with pytest.raises(Exception):
+        check.parse_metrics(metrics, False)
+
+    # MIB with symbol
+    metrics = [{
+        "MIB": "foo_mib",
+        "symbol": "foo",
+    }]
+    table, raw, mibs = check.parse_metrics(metrics, False)
+    assert raw == []
+    assert mibs == {"foo_mib"}
+    assert len(table) == 1
+    hlapi_mock.ObjectIdentity.assert_called_once_with("foo_mib", "foo")
+    hlapi_mock.reset_mock()
+
+    # MIB with table
+    metrics = [{
+        "MIB": "foo_mib",
+        "table": "foo",
+    }]
+    table, raw, mibs = check.parse_metrics(metrics, True)
+    assert raw == []
+    assert mibs == set()
+    assert len(table) == 1
+    hlapi_mock.ObjectIdentity.assert_called_once_with("foo_mib", "foo")
+    hlapi_mock.reset_mock()

--- a/snmp/tox.ini
+++ b/snmp/tox.ini
@@ -3,6 +3,7 @@ minversion = 2.0
 basepython = py27
 envlist =
   {py27,py36}-snmp
+  {py27,py36}-unit
   bench
   flake8
 
@@ -14,7 +15,8 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install -r requirements.in
-    pytest
+    unit: pytest -v -munit
+    snmp: pytest -v -m"not unit"
 
 [testenv:bench]
 commands =


### PR DESCRIPTION
### What does this PR do?

Previously, we were querying for the entire table, which can be large, even if we wanted only a few columns. This will help a lot with performance, and can be further improved by making bulk requests, but that'll come in another PR.

### Motivation

Check was too slow for large `ifTable` tables.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?