### PR TITLE
Autodiscover queues

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -17,6 +17,16 @@ class IBMMQConfig:
     No need to parse the instance more than once in the check run
     """
 
+    DISALLOWED_QUEUES = [
+        'SYSTEM.MQSC.REPLY.QUEUE',
+        'SYSTEM.DEFAULT.MODEL.QUEUE',
+        'SYSTEM.DURABLE.MODEL.QUEUE',
+        'SYSTEM.JMS.TEMPQ.MODEL',
+        'SYSTEM.MQEXPLORER.REPLY.MODEL',
+        'SYSTEM.NDURABLE.MODEL.QUEUE',
+        'SYSTEM.CLUSTER.TRANSMIT.MODEL.QUEUE',
+    ]
+
     def __init__(self, instance):
         self.channel = instance.get('channel')
         self.queue_manager_name = instance.get('queue_manager', 'default')
@@ -50,9 +60,13 @@ class IBMMQConfig:
             msg = "channel, queue_manager, host and port are all required configurations"
             raise ConfigurationError(msg)
 
-    def add_queues(self, queues):
+    def add_queues(self, new_queues):
         # add queues without duplication
-        self.queues = list(set(self.queues + queues))
+
+        for queue in self.DISALLOWED_QUEUES:
+            new_queues = new_queues.remove(queue)
+
+        self.queues = list(set(self.queues + new_queues))
 
     @property
     def tags(self):

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import logging
 from datadog_checks.config import is_affirmative
 
 # compatability layer for agents under 6.6.0
@@ -10,8 +9,6 @@ try:
     from datadog_checks.errors import ConfigurationError
 except ImportError:
     ConfigurationError = Exception
-
-log = logging.getLogger(__file__)
 
 
 class IBMMQConfig:

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -29,7 +29,7 @@ class IBMMQConfig:
         self.password = instance.get('password')
 
         self.queues = instance.get('queues', [])
-        self.queue_regexes = instance.get('queue_regexes', [])
+        self.queue_patterns = instance.get('queue_patterns', [])
 
         self.custom_tags = instance.get('tags', [])
 

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -20,16 +20,6 @@ class IBMMQConfig:
     No need to parse the instance more than once in the check run
     """
 
-    DISALLOWED_QUEUES = [
-        'SYSTEM.MQSC.REPLY.QUEUE',
-        'SYSTEM.DEFAULT.MODEL.QUEUE',
-        'SYSTEM.DURABLE.MODEL.QUEUE',
-        'SYSTEM.JMS.TEMPQ.MODEL',
-        'SYSTEM.MQEXPLORER.REPLY.MODEL',
-        'SYSTEM.NDURABLE.MODEL.QUEUE',
-        'SYSTEM.CLUSTER.TRANSMIT.MODEL.QUEUE',
-    ]
-
     def __init__(self, instance):
         self.channel = instance.get('channel')
         self.queue_manager_name = instance.get('queue_manager', 'default')
@@ -64,14 +54,8 @@ class IBMMQConfig:
             raise ConfigurationError(msg)
 
     def add_queues(self, new_queues):
-        # remove disallowed system queues from the discovered queues
-        for queue in self.DISALLOWED_QUEUES:
-            new_queues.remove(queue)
-
-        log.info(new_queues)
         # add queues without duplication
         self.queues = list(set(self.queues + new_queues))
-        log.info(self.queues)
 
     @property
     def tags(self):

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -61,11 +61,11 @@ class IBMMQConfig:
             raise ConfigurationError(msg)
 
     def add_queues(self, new_queues):
-        # add queues without duplication
-
+        # remove disallowed system queues from the discovered queues
         for queue in self.DISALLOWED_QUEUES:
             new_queues.remove(queue)
 
+        # add queues without duplication
         self.queues = list(set(self.queues + new_queues))
 
     @property

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -29,7 +29,11 @@ class IBMMQConfig:
         self.password = instance.get('password')
 
         self.queues = instance.get('queues', [])
+        self.queue_regexes = instance.get('queue_regexes', [])
+
         self.custom_tags = instance.get('tags', [])
+
+        self.auto_discover_queues = instance.get('auto_discover_queues', False)
 
         self.ssl = is_affirmative(instance.get('ssl_auth', False))
         self.ssl_cipher_spec = instance.get('ssl_cipher_spec', 'TLS_RSA_WITH_AES_256_CBC_SHA')
@@ -45,6 +49,10 @@ class IBMMQConfig:
         if not self.channel or not self.queue_manager_name or not self.host or not self.port:
             msg = "channel, queue_manager, host and port are all required configurations"
             raise ConfigurationError(msg)
+
+    def add_queues(self, queues):
+        # add queues without duplication
+        self.queues = list(set(self.queues + queues))
 
     @property
     def tags(self):

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -20,6 +20,16 @@ class IBMMQConfig:
     No need to parse the instance more than once in the check run
     """
 
+    DISALLOWED_QUEUES = [
+        'SYSTEM.MQSC.REPLY.QUEUE',
+        'SYSTEM.DEFAULT.MODEL.QUEUE',
+        'SYSTEM.DURABLE.MODEL.QUEUE',
+        'SYSTEM.JMS.TEMPQ.MODEL',
+        'SYSTEM.MQEXPLORER.REPLY.MODEL',
+        'SYSTEM.NDURABLE.MODEL.QUEUE',
+        'SYSTEM.CLUSTER.TRANSMIT.MODEL.QUEUE',
+    ]
+
     def __init__(self, instance):
         self.channel = instance.get('channel')
         self.queue_manager_name = instance.get('queue_manager', 'default')

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -64,7 +64,7 @@ class IBMMQConfig:
         # add queues without duplication
 
         for queue in self.DISALLOWED_QUEUES:
-            new_queues = new_queues.remove(queue)
+            new_queues.remove(queue)
 
         self.queues = list(set(self.queues + new_queues))
 

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import logging
 from datadog_checks.config import is_affirmative
 
 # compatability layer for agents under 6.6.0
@@ -9,6 +10,8 @@ try:
     from datadog_checks.errors import ConfigurationError
 except ImportError:
     ConfigurationError = Exception
+
+log = logging.getLogger(__file__)
 
 
 class IBMMQConfig:
@@ -65,8 +68,10 @@ class IBMMQConfig:
         for queue in self.DISALLOWED_QUEUES:
             new_queues.remove(queue)
 
+        log.info(new_queues)
         # add queues without duplication
         self.queues = list(set(self.queues + new_queues))
+        log.info(self.queues)
 
     @property
     def tags(self):

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -46,6 +46,7 @@ instances:
 
   ## @param auto_discover_queues - string - optional - default: false
   ## Autodiscover the queues to monitor
+  ## Warning: this will lead to some warnings in your
   #
   #  auto_discover_queues: '<PASSWORD>'
 

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -37,6 +37,18 @@ instances:
   #  queues:
   #    - '<QUEUE_NAME>'
 
+  ## @param queue_patterns - list of string - optional
+  ## Collect from queues that match a pattern
+  #
+  #  queue_patterns:
+  #    - 'DEV.*'
+  #    - 'SYSTEM.*'
+
+  ## @param auto_discover_queues - string - optional - default: false
+  ## Autodiscover the queues to monitor
+  #
+  #  auto_discover_queues: '<PASSWORD>'
+
   ## @param ssl_auth - string - optional
   ## Whether or not to use SSL auth while connecting to the channel.
   #

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -118,7 +118,7 @@ class IbmMqCheck(AgentCheck):
                 m = queue.inquire(pymqi_value)
                 self.gauge(mname, m, tags=tags)
             except pymqi.Error as e:
-                self.warning("Error getting queue stats: {}".format(e))
+                self.warning("Error getting queue stats for {}: {}".format(queue, e))
 
         for mname, func in iteritems(metrics.queue_metrics_functions()):
             try:
@@ -126,7 +126,7 @@ class IbmMqCheck(AgentCheck):
                 m = func(queue)
                 self.gauge(mname, m, tags=tags)
             except pymqi.Error as e:
-                self.warning("Error getting queue stats: {}".format(e))
+                self.warning("Error getting queue stats for {}: {}".format(queue, e))
 
     def get_pcf_queue_metrics(self, queue_manager, queue_name, tags):
         try:
@@ -151,5 +151,6 @@ class IbmMqCheck(AgentCheck):
                     if m > failure_value:
                         self.gauge(mname, m, tags=tags)
                     else:
-                        msg = "Unable to get {}, turn on queue level monitoring to access these metrics".format(mname)
+                        msg = "Unable to get {}, turn on queue level monitoring to access these metrics for {}"
+                        msg = msg.format(mname, queue_name)
                         log.debug(msg)

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -138,7 +138,7 @@ class IbmMqCheck(AgentCheck):
             pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_INQUIRE_Q_STATUS(args)
         except pymqi.MQMIError as e:
-            self.warning("Error getting queue stats: {}".format(e))
+            self.warning("Error getting queue stats for {}: {}".format(queue_name, e))
         else:
             # Response is a list. It likely has only one member in it.
             for queue_info in response:

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -54,7 +54,8 @@ class IbmMqCheck(AgentCheck):
                 try:
                     queue = pymqi.Queue(queue_manager, queue_name)
                     self.queue_stats(queue, queue_tags)
-                    self.get_pcf_queue_metrics(queue_manager, queue_name, queue_tags)
+                    if queue not in config.DISALLOWED_QUEUES:
+                        self.get_pcf_queue_metrics(queue_manager, queue_name, queue_tags)
                     self.service_check(self.QUEUE_SERVICE_CHECK, AgentCheck.OK, queue_tags)
                     queue.close()
                 except Exception as e:
@@ -130,24 +131,6 @@ class IbmMqCheck(AgentCheck):
                 self.warning("Error getting queue stats for {}: {}".format(queue, e))
 
     def get_pcf_queue_metrics(self, queue_manager, queue_name, tags):
-        response = self._pcf_queue_metrics(queue_manager, queue_name)
-        # Response is a list. It likely has only one member in it.
-        for queue_info in response:
-            for mname, values in iteritems(metrics.pcf_metrics()):
-                failure_value = values['failure']
-                pymqi_value = values['pymqi_value']
-                mname = '{}.queue.{}'.format(self.METRIC_PREFIX, mname)
-                m = int(queue_info[pymqi_value])
-
-                if m > failure_value:
-                    self.gauge(mname, m, tags=tags)
-                else:
-                    msg = "Unable to get {}, turn on queue level monitoring to access these metrics for {}"
-                    msg = msg.format(mname, queue_name)
-                    log.debug(msg)
-
-    def _pcf_queue_metrics(self, queue_manager, queue_name):
-        response = []
         try:
             args = {
                 pymqi.CMQC.MQCA_Q_NAME: queue_name,
@@ -157,14 +140,19 @@ class IbmMqCheck(AgentCheck):
             pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_INQUIRE_Q_STATUS(args)
         except pymqi.MQMIError as e:
-            try:
-                args = {
-                    pymqi.CMQC.MQCA_Q_NAME: queue_name,
-                    pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_MODEL
-                }
-                pcf = pymqi.PCFExecute(queue_manager)
-                response = pcf.MQCMD_INQUIRE_Q_STATUS(args)
-            except pymqi.MQMIError as e:
-                self.warning("Error getting queue stats for {}: {}".format(queue_name, e))
+            self.warning("Error getting queue stats for {}: {}".format(queue_name, e))
+        else:
+            # Response is a list. It likely has only one member in it.
+            for queue_info in response:
+                for mname, values in iteritems(metrics.pcf_metrics()):
+                    failure_value = values['failure']
+                    pymqi_value = values['pymqi_value']
+                    mname = '{}.queue.{}'.format(self.METRIC_PREFIX, mname)
+                    m = int(queue_info[pymqi_value])
 
-        return response
+                    if m > failure_value:
+                        self.gauge(mname, m, tags=tags)
+                    else:
+                        msg = "Unable to get {}, turn on queue level monitoring to access these metrics for {}"
+                        msg = msg.format(mname, queue_name)
+                        log.debug(msg)

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -89,7 +89,9 @@ class IbmMqCheck(AgentCheck):
             self.warning("Error getting queue stats: {}".format(e))
         else:
             for queue_info in response:
-                queues.append(queue_info[pymqi.CMQC.MQCA_Q_NAME])
+                queue = queue_info[pymqi.CMQC.MQCA_Q_NAME]
+                queue = queue.strip()
+                queues.append(queue)
 
         return queues
 

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -74,7 +74,6 @@ class IbmMqCheck(AgentCheck):
 
         config.add_queues(queues)
 
-
     def _discover_queues(self, queue_manager, regex):
         args = {
             pymqi.CMQC.MQCA_Q_NAME: regex,

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -78,7 +78,7 @@ class IbmMqCheck(AgentCheck):
     def _discover_queues(self, queue_manager, regex):
         args = {
             pymqi.CMQC.MQCA_Q_NAME: regex,
-            pymqi.CMQC.MQIA_Q_TYPE: queue_type
+            pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_MODEL
         }
         queues = []
 

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -54,8 +54,7 @@ class IbmMqCheck(AgentCheck):
                 try:
                     queue = pymqi.Queue(queue_manager, queue_name)
                     self.queue_stats(queue, queue_tags)
-                    self.log.info("{} {} {}".format(queue, config.DISALLOWED_QUEUES, queue not in config.DISALLOWED_QUEUES))
-                    if queue not in config.DISALLOWED_QUEUES:
+                    if queue_name not in config.DISALLOWED_QUEUES:
                         self.get_pcf_queue_metrics(queue_manager, queue_name, queue_tags)
                     self.service_check(self.QUEUE_SERVICE_CHECK, AgentCheck.OK, queue_tags)
                     queue.close()

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -146,25 +146,25 @@ class IbmMqCheck(AgentCheck):
                     msg = msg.format(mname, queue_name)
                     log.debug(msg)
 
-def _pcf_queue_metrics(self, queue_manager, queue_name):
-    response = []
-    try:
-        args = {
-            pymqi.CMQC.MQCA_Q_NAME: queue_name,
-            pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_MODEL,
-            pymqi.CMQCFC.MQIACF_Q_STATUS_ATTRS: pymqi.CMQCFC.MQIACF_ALL,
-        }
-        pcf = pymqi.PCFExecute(queue_manager)
-        response = pcf.MQCMD_INQUIRE_Q_STATUS(args)
-    except pymqi.MQMIError as e:
+    def _pcf_queue_metrics(self, queue_manager, queue_name):
+        response = []
         try:
             args = {
                 pymqi.CMQC.MQCA_Q_NAME: queue_name,
-                pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_MODEL
+                pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_MODEL,
+                pymqi.CMQCFC.MQIACF_Q_STATUS_ATTRS: pymqi.CMQCFC.MQIACF_ALL,
             }
             pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_INQUIRE_Q_STATUS(args)
         except pymqi.MQMIError as e:
-            self.warning("Error getting queue stats for {}: {}".format(queue_name, e))
+            try:
+                args = {
+                    pymqi.CMQC.MQCA_Q_NAME: queue_name,
+                    pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_MODEL
+                }
+                pcf = pymqi.PCFExecute(queue_manager)
+                response = pcf.MQCMD_INQUIRE_Q_STATUS(args)
+            except pymqi.MQMIError as e:
+                self.warning("Error getting queue stats for {}: {}".format(queue_name, e))
 
-    return response
+        return response

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -4,6 +4,8 @@
 
 from datadog_checks.checks import AgentCheck
 
+from datadog_checks.base import ensure_bytes
+
 from six import iteritems
 import logging
 
@@ -79,7 +81,7 @@ class IbmMqCheck(AgentCheck):
 
     def _discover_queues(self, queue_manager, regex):
         args = {
-            pymqi.CMQC.MQCA_Q_NAME: regex,
+            pymqi.CMQC.MQCA_Q_NAME: ensure_bytes(regex),
             pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_MODEL
         }
         queues = []
@@ -135,7 +137,7 @@ class IbmMqCheck(AgentCheck):
     def get_pcf_queue_metrics(self, queue_manager, queue_name, tags):
         try:
             args = {
-                pymqi.CMQC.MQCA_Q_NAME: queue_name,
+                pymqi.CMQC.MQCA_Q_NAME: ensure_bytes(queue_name),
                 pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_MODEL,
                 pymqi.CMQCFC.MQIACF_Q_STATUS_ATTRS: pymqi.CMQCFC.MQIACF_ALL,
             }

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -54,6 +54,8 @@ class IbmMqCheck(AgentCheck):
                 try:
                     queue = pymqi.Queue(queue_manager, queue_name)
                     self.queue_stats(queue, queue_tags)
+                    # some system queues don't have PCF metrics
+                    # so we don't collect those metrics from those queues
                     if queue_name not in config.DISALLOWED_QUEUES:
                         self.get_pcf_queue_metrics(queue_manager, queue_name, queue_tags)
                     self.service_check(self.QUEUE_SERVICE_CHECK, AgentCheck.OK, queue_tags)

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -54,6 +54,7 @@ class IbmMqCheck(AgentCheck):
                 try:
                     queue = pymqi.Queue(queue_manager, queue_name)
                     self.queue_stats(queue, queue_tags)
+                    self.log.info("{} {} {}".format(queue, config.DISALLOWED_QUEUES, queue not in config.DISALLOWED_QUEUES))
                     if queue not in config.DISALLOWED_QUEUES:
                         self.get_pcf_queue_metrics(queue_manager, queue_name, queue_tags)
                     self.service_check(self.QUEUE_SERVICE_CHECK, AgentCheck.OK, queue_tags)

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -83,7 +83,7 @@ class IbmMqCheck(AgentCheck):
         queues = []
 
         try:
-            pcf = pymqi.PCFExecute(qmgr)
+            pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_INQUIRE_Q(args)
         except pymqi.MQMIError as e:
             self.warning("Error getting queue stats: {}".format(e))

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -68,8 +68,8 @@ class IbmMqCheck(AgentCheck):
         if config.auto_discover_queues:
             queues.extend(self._discover_queues(queue_manager, '*'))
 
-        if len(config.queue_regexes) > 0:
-            for regex in config.queue_regexes:
+        if len(config.queue_patterns) > 0:
+            for regex in config.queue_patterns:
                 queues.extend(self._discover_queues(queue_manager, regex))
 
         config.add_queues(queues)

--- a/ibm_mq/tests/common.py
+++ b/ibm_mq/tests/common.py
@@ -37,3 +37,26 @@ INSTANCE = {
         QUEUE
     ]
 }
+
+INSTANCE_PATTERN = {
+    'channel': CHANNEL,
+    'queue_manager': QUEUE_MANAGER,
+    'host': HOST,
+    'port': PORT,
+    'username': USERNAME,
+    'password': PASSWORD,
+    'queue_patterns': [
+        'DEV.*',
+        'SYSTEM.*'
+    ]
+}
+
+INSTANCE_COLLECT_ALL = {
+    'channel': CHANNEL,
+    'queue_manager': QUEUE_MANAGER,
+    'host': HOST,
+    'port': PORT,
+    'username': USERNAME,
+    'password': PASSWORD,
+    'auto_discover_queues': True,
+}

--- a/ibm_mq/tests/conftest.py
+++ b/ibm_mq/tests/conftest.py
@@ -34,6 +34,18 @@ def instance():
 
 
 @pytest.fixture
+def instance_pattern():
+    inst = copy.deepcopy(common.INSTANCE_PATTERN)
+    return inst
+
+
+@pytest.fixture
+def instance_collect_all():
+    inst = copy.deepcopy(common.INSTANCE_COLLECT_ALL)
+    return inst
+
+
+@pytest.fixture
 def seed_data():
     publish()
     consume()

--- a/ibm_mq/tests/test_ibm_mq.py
+++ b/ibm_mq/tests/test_ibm_mq.py
@@ -68,6 +68,7 @@ def test_check(aggregator, instance, seed_data):
 
     aggregator.assert_all_metrics_covered()
 
+
 @pytest.mark.usefixtures("dd_environment")
 def test_check_pattern(aggregator, instance_pattern, seed_data):
     check = IbmMqCheck('ibm_mq', {}, {})
@@ -80,6 +81,7 @@ def test_check_pattern(aggregator, instance_pattern, seed_data):
         aggregator.assert_metric(metric, at_least=0)
 
     aggregator.assert_all_metrics_covered()
+
 
 @pytest.mark.usefixtures("dd_environment")
 def test_check_all(aggregator, instance_collect_all, seed_data):

--- a/ibm_mq/tests/test_ibm_mq.py
+++ b/ibm_mq/tests/test_ibm_mq.py
@@ -67,3 +67,29 @@ def test_check(aggregator, instance, seed_data):
         aggregator.assert_metric(metric, at_least=0)
 
     aggregator.assert_all_metrics_covered()
+
+@pytest.mark.usefixtures("dd_environment")
+def test_check_pattern(aggregator, instance_pattern, seed_data):
+    check = IbmMqCheck('ibm_mq', {}, {})
+    check.check(instance_pattern)
+
+    for metric in METRICS:
+        aggregator.assert_metric(metric)
+
+    for metric in OPTIONAL_METRICS:
+        aggregator.assert_metric(metric, at_least=0)
+
+    aggregator.assert_all_metrics_covered()
+
+@pytest.mark.usefixtures("dd_environment")
+def test_check_all(aggregator, instance_collect_all, seed_data):
+    check = IbmMqCheck('ibm_mq', {}, {})
+    check.check(instance_collect_all)
+
+    for metric in METRICS:
+        aggregator.assert_metric(metric)
+
+    for metric in OPTIONAL_METRICS:
+        aggregator.assert_metric(metric, at_least=0)
+
+    aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

This will allow the IBM MQ check to autodiscover queues. I thought I would take a long time to do this but discovered that I had done the work to set this up a month ago, so it was just a matter of translating that into a full fledged thing.

### Motivation

It's a request from a customer

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

I am calling it a pattern instead of regex because as far as I understand it is not actually a regex, it's a simpler pattern. I think it's just a prefix and then you can select under that prefix. However, I could be wrong about this. As usual, the docs aren't that great