### PR TITLE
[http_check] adds instance tag to metrics

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -74,6 +74,8 @@ class HTTPCheck(NetworkCheck):
 
         # Store tags in a temporary list so that we don't modify the global tags data structure
         tags_list = list(tags)
+        instance_name = ensure_unicode(self.normalize(instance['name']))
+        tags_list.append("instance:{}".format(instance_name))
         service_checks = []
         r = None
         try:

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -227,6 +227,7 @@ class HTTPCheck(NetworkCheck):
                                                                               check_hostname, client_cert, client_key)
             tags_list = list(tags)
             tags_list.append('url:{}'.format(addr))
+            tags_list.append("instance:{}".format(instance_name))
             self.gauge('http.ssl.days_left', days_left, tags=tags_list)
             self.gauge('http.ssl.seconds_left', seconds_left, tags=tags_list)
 

--- a/http_check/tests/test_http_check.py
+++ b/http_check/tests/test_http_check.py
@@ -294,9 +294,9 @@ def test_data_methods(aggregator, http_check):
         instance_tag = ['instance:{}'.format(instance.get('name'))]
 
         aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=url_tag + instance_tag, count=1)
-        aggregator.assert_metric('network.http.can_connect', tags=url_tag, value=1, count=1)
-        aggregator.assert_metric('network.http.cant_connect', tags=url_tag, value=0, count=1)
-        aggregator.assert_metric('network.http.response_time', tags=url_tag, count=1)
+        aggregator.assert_metric('network.http.can_connect', tags=url_tag + instance_tag, value=1, count=1)
+        aggregator.assert_metric('network.http.cant_connect', tags=url_tag + instance_tag, value=0, count=1)
+        aggregator.assert_metric('network.http.response_time', tags=url_tag + instance_tag, count=1)
 
         # Assert coverage for this check on this instance
         aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

adds the instance tag (already included in service checks) to the metrics

### Motivation

For consistency especially when recommending metric monitor over status check monitors

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Not sure if there was a reason not tag metrics with the instance.
