### PR TITLE
Fix growing CPU and memory usage

### DIFF
--- a/kube_dns/datadog_checks/kube_dns/kube_dns.py
+++ b/kube_dns/datadog_checks/kube_dns/kube_dns.py
@@ -88,8 +88,9 @@ class KubeDNSCheck(OpenMetricsBaseCheck):
         """
         metric_name = scraper_config['namespace'] + metric_suffix
         for sample in metric.samples:
-            _tags = []
-            _tags += scraper_config['custom_tags']
+            # Explicit shallow copy of the instance tags
+            _tags = list(scraper_config['custom_tags'])
+
             for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
                 _tags.append('{}:{}'.format(label_name, label_value))
             # submit raw metric

--- a/kube_dns/datadog_checks/kube_dns/kube_dns.py
+++ b/kube_dns/datadog_checks/kube_dns/kube_dns.py
@@ -88,7 +88,8 @@ class KubeDNSCheck(OpenMetricsBaseCheck):
         """
         metric_name = scraper_config['namespace'] + metric_suffix
         for sample in metric.samples:
-            _tags = scraper_config['custom_tags']
+            _tags = []
+            _tags += scraper_config['custom_tags']
             for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
                 _tags.append('{}:{}'.format(label_name, label_value))
             # submit raw metric

--- a/kube_dns/tests/test_kube_dns.py
+++ b/kube_dns/tests/test_kube_dns.py
@@ -78,3 +78,10 @@ class TestKubeDNS:
             aggregator.assert_metric_has_tag(metric, customtag)
 
         aggregator.assert_all_metrics_covered()
+
+        # Make sure instance tags are not modified, see #3066
+        aggregator.reset()
+        check.check(instance)
+        name = self.NAMESPACE + ".request_duration.seconds.sum"
+        aggregator.assert_metric(name)
+        aggregator.assert_metric(name, tags=['custom:tag', 'system:reverse'])


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/integrations-core/pull/2299 introduced a CPU and memory unbound usage due to a bug in the handling of instance tags.

Namely, `_tags = scraper_config['custom_tags']` does not create a shallow copy, but reuses the reference to the existing slice, making it grow with every check run.

This PR ensures we are creating a shallow copy of the instance tags list, to avoid memory issues, and ensure correct tagging of the metrics.

## Backport image

Image `datadog/agent-dev:backport_3066` is available, it's a backport on top of 6.9.0-jmx