### PR TITLE
Update Manifest files to ship updated tests folder

### DIFF
--- a/agent_metrics/MANIFEST.in
+++ b/agent_metrics/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/ecs_fargate/MANIFEST.in
+++ b/ecs_fargate/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/etcd/MANIFEST.in
+++ b/etcd/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/fluentd/MANIFEST.in
+++ b/fluentd/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/gearmand/MANIFEST.in
+++ b/gearmand/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/go_expvar/MANIFEST.in
+++ b/go_expvar/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/gunicorn/MANIFEST.in
+++ b/gunicorn/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/kube_dns/MANIFEST.in
+++ b/kube_dns/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/mesos_master/MANIFEST.in
+++ b/mesos_master/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/mesos_slave/MANIFEST.in
+++ b/mesos_slave/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/mongo/MANIFEST.in
+++ b/mongo/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/php_fpm/MANIFEST.in
+++ b/php_fpm/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/postfix/MANIFEST.in
+++ b/postfix/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/rabbitmq/MANIFEST.in
+++ b/rabbitmq/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/riakcs/MANIFEST.in
+++ b/riakcs/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/snmp/MANIFEST.in
+++ b/snmp/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/sqlserver/MANIFEST.in
+++ b/sqlserver/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/statsd/MANIFEST.in
+++ b/statsd/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/supervisord/MANIFEST.in
+++ b/supervisord/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/system_swap/MANIFEST.in
+++ b/system_swap/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/tcp_check/MANIFEST.in
+++ b/tcp_check/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/tokumx/MANIFEST.in
+++ b/tokumx/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/twemproxy/MANIFEST.in
+++ b/twemproxy/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/win32_event_log/MANIFEST.in
+++ b/win32_event_log/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/windows_service/MANIFEST.in
+++ b/windows_service/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/wmi_check/MANIFEST.in
+++ b/wmi_check/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md

--- a/zk/MANIFEST.in
+++ b/zk/MANIFEST.in
@@ -1,5 +1,5 @@
 graft datadog_checks
-graft test
+graft tests
 
 include MANIFEST.in
 include README.md


### PR DESCRIPTION
### What does this PR do?

Properly grafts the `tests` folder for all the checks that were still shipping `test`

### Motivation

During the port of checks to pytest, it appears we missed a few and haven't been including the tests folder. 

NOTE: The only two integrations left that ship `test` are: kubernetes and docker_daemon because they still have that directory. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
