### PR TITLE
Don't raise Exception when No NFS mounts could be found

### DIFF
--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -38,11 +38,14 @@ class NfsStatCheck(AgentCheck):
         all_devices = []
         this_device = []
         custom_tags = instance.get("tags", [])
-        for l in stat_out.splitlines():
-            if l.find(b'No NFS mount point') >= 0:
-                self.warning("No NFS mount points were found")
-                return
-            elif not l:
+        stats = stat_out.splitlines()
+
+        if b'No NFS mount point' in stats[0]:
+            self.warning("No NFS mount points were found")
+            return
+
+        for l in stats:
+            if not l:
                 continue
             elif l.find(b'mounted on') >= 0 and len(this_device) > 0:
                 # if it's a new device, create the device and add it to the array

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -38,9 +38,11 @@ class NfsStatCheck(AgentCheck):
         all_devices = []
         this_device = []
         custom_tags = instance.get("tags", [])
-
         for l in stat_out.splitlines():
-            if not l:
+            if l.find(b'No NFS mount point') >= 0:
+                self.log.warning("No NFS mount points were found")
+                return
+            if not l or l.find(b'No NFS mount point') >= 0:
                 continue
             elif l.find(b'mounted on') >= 0 and len(this_device) > 0:
                 # if it's a new device, create the device and add it to the array

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -42,7 +42,7 @@ class NfsStatCheck(AgentCheck):
             if l.find(b'No NFS mount point') >= 0:
                 self.warning("No NFS mount points were found")
                 return
-            if not l:
+            elif not l:
                 continue
             elif l.find(b'mounted on') >= 0 and len(this_device) > 0:
                 # if it's a new device, create the device and add it to the array

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -42,7 +42,7 @@ class NfsStatCheck(AgentCheck):
             if l.find(b'No NFS mount point') >= 0:
                 self.warning("No NFS mount points were found")
                 return
-            if not l or l.find(b'No NFS mount point') >= 0:
+            if not l:
                 continue
             elif l.find(b'mounted on') >= 0 and len(this_device) > 0:
                 # if it's a new device, create the device and add it to the array

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -40,7 +40,7 @@ class NfsStatCheck(AgentCheck):
         custom_tags = instance.get("tags", [])
         for l in stat_out.splitlines():
             if l.find(b'No NFS mount point') >= 0:
-                self.log.warning("No NFS mount points were found")
+                self.warning("No NFS mount points were found")
                 return
             if not l or l.find(b'No NFS mount point') >= 0:
                 continue

--- a/nfsstat/tests/test_nfsstat.py
+++ b/nfsstat/tests/test_nfsstat.py
@@ -44,6 +44,13 @@ class TestNfsstat:
         'nfsiostat_path': '/opt/datadog-agent/embedded/sbin/nfsiostat',
     }
 
+    def test_no_devices(self, aggregator):
+        instance = self.INSTANCES['main']
+        c = NfsStatCheck(self.CHECK_NAME, self.INIT_CONFIG, {}, [instance])
+        with mock.patch('datadog_checks.nfsstat.nfsstat.get_subprocess_output',
+                        return_value=(b'No NFS mount points were found', '', 0)):
+            c.check(instance)
+
     def test_check(self, aggregator):
         instance = self.INSTANCES['main']
         c = NfsStatCheck(self.CHECK_NAME, self.INIT_CONFIG, {}, [instance])


### PR DESCRIPTION
### What does this PR do?

When no nfs mount points are on the host, we now simply return from the check and emit a warning message to the user

Also creates a test that before would raise an exception and now successfully allows the check to finish. 

### Motivation

Previously, the check would raise an exception when there were no mount points:

```
    def _parse_device_header(self):
>       self._device_header = self._device_data[0]
E       IndexError: list index out of range
```

Because the device array was simply `[[u'No', u'NFS', u'mount', u'points', u'were', u'found']]`

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
