### PR TITLE
Remove PYTHON3 env var for tokumx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -252,7 +252,7 @@ jobs:
     - stage: test
       env: CHECK=teamcity PYTHON3=true
     - stage: test
-      env: CHECK=tokumx PYTHON3=true
+      env: CHECK=tokumx
     - stage: test
       env: CHECK=twemproxy PYTHON3=true
     - stage: test


### PR DESCRIPTION
### What does this PR do?

Pymongo didn't support PY3 until 3.7 - http://api.mongodb.com/python/current/changelog.html#changes-in-version-3-7-0

The PR that vendored pymongo 3.5.1 into tokumx broke the `ddev validate py3 tokumx` because the version of the vendored lib doesn't support PY3 - https://travis-ci.com/DataDog/integrations-core/jobs/175225174

### Motivation 

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
