### PR TITLE
haproxy: Only send 'haproxy.backend_hosts' metrics for backend

### DIFF
--- a/haproxy/tests/common.py
+++ b/haproxy/tests/common.py
@@ -61,6 +61,7 @@ CHECK_CONFIG = {
 CHECK_CONFIG_OPEN = {
     'url': STATS_URL_OPEN,
     'collect_aggregates_only': False,
+    'collect_status_metrics': True,
 }
 
 BACKEND_SERVICES = ['anotherbackend', 'datadog']
@@ -87,6 +88,10 @@ BACKEND_CHECK_GAUGES = [
     'haproxy.backend.queue.current',
     'haproxy.backend.session.current',
 ]
+
+BACKEND_HOSTS_METRIC = 'haproxy.backend_hosts'
+BACKEND_STATUS_METRIC = 'haproxy.count_per_status'
+
 
 BACKEND_CHECK_GAUGES_POST_1_5 = [
     'haproxy.backend.queue.time',


### PR DESCRIPTION
### What does this PR do?

Don't send `haproxy.backend_hosts` metrics for frontends since it will always be 0.

### Motivation

I need to create monitors checking we have unavailable backends always > 0 to check we always have available slots for haproxy using dns resolution and server template. 
Currently, I need to exclude all frontends from the monitor since they are always at 0.
With this patch, I will be able to create a generic monitors for all our haproxy using dns resolution.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
