### PR TITLE
Put service check behind a flag, false by default

### DIFF
--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -77,6 +77,9 @@ instances:
     # headers:
     #   key1: value1
 
+    # Enable the service check, off by default
+    # enable_service_check: False
+
 ## Log section (Available for Agent >=6.0)
 
 #logs:

--- a/haproxy/datadog_checks/haproxy/haproxy.py
+++ b/haproxy/datadog_checks/haproxy/haproxy.py
@@ -148,6 +148,10 @@ class HAProxy(AgentCheck):
             instance.get('tag_service_check_by_host', False)
         )
 
+        enable_service_check = _is_aggregate(
+            instance.get('enable_service_check', False)
+        )
+
         services_incl_filter = instance.get('services_include', [])
         services_excl_filter = instance.get('services_exclude', [])
 
@@ -173,6 +177,7 @@ class HAProxy(AgentCheck):
             custom_tags=custom_tags,
             tags_regex=tags_regex,
             active_tag=active_tag,
+            enable_service_check=enable_service_check,
         )
 
     def _fetch_url_data(self, url, username, password, verify, custom_headers):
@@ -237,7 +242,8 @@ class HAProxy(AgentCheck):
                       collect_status_metrics=False, collect_status_metrics_by_host=False,
                       tag_service_check_by_host=False, services_incl_filter=None,
                       services_excl_filter=None, collate_status_tags_per_host=False,
-                      count_status_by_service=True, custom_tags=None, tags_regex=None, active_tag=None):
+                      count_status_by_service=True, custom_tags=None, tags_regex=None, active_tag=None,
+                      enable_service_check=False):
         ''' Main data-processing loop. For each piece of useful data, we'll
         either save a metric, save an event or both. '''
 
@@ -309,13 +315,14 @@ class HAProxy(AgentCheck):
                     services_excl_filter=services_excl_filter,
                     custom_tags=line_tags,
                 )
-            self._process_service_check(
-                data_dict, url,
-                tag_by_host=tag_service_check_by_host,
-                services_incl_filter=services_incl_filter,
-                services_excl_filter=services_excl_filter,
-                custom_tags=line_tags,
-            )
+            if enable_service_check:
+                self._process_service_check(
+                    data_dict, url,
+                    tag_by_host=tag_service_check_by_host,
+                    services_incl_filter=services_incl_filter,
+                    services_excl_filter=services_excl_filter,
+                    custom_tags=line_tags,
+                )
 
         if collect_status_metrics:
             self._process_status_metric(

--- a/haproxy/datadog_checks/haproxy/haproxy.py
+++ b/haproxy/datadog_checks/haproxy/haproxy.py
@@ -148,7 +148,7 @@ class HAProxy(AgentCheck):
             instance.get('tag_service_check_by_host', False)
         )
 
-        enable_service_check = _is_aggregate(
+        enable_service_check = _is_affirmative(
             instance.get('enable_service_check', False)
         )
 

--- a/haproxy/tests/test_haproxy.py
+++ b/haproxy/tests/test_haproxy.py
@@ -72,12 +72,12 @@ def _test_service_checks(aggregator, services=None, count=1):
             tags = ['service:' + service, 'backend:' + backend]
             aggregator.assert_service_check(SERVICE_CHECK_NAME,
                                             status=HAProxy.UNKNOWN,
-                                            count=1,
+                                            count=count,
                                             tags=tags)
         tags = ['service:' + service, 'backend:BACKEND']
         aggregator.assert_service_check(SERVICE_CHECK_NAME,
                                         status=HAProxy.OK,
-                                        count=1,
+                                        count=count,
                                         tags=tags)
 
 


### PR DESCRIPTION
### What does this PR do?

The service check is not used in alerts or dashboards, and takes up a lot of backend processing power. I'm moving it behind a feature flag that's false by default. If people want to use it they can, they just have to enable it.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
