### PR TITLE
Allow multi-line aggregation for cassandra logs

### DIFF
--- a/cassandra/datadog_checks/cassandra/data/conf.yaml.example
+++ b/cassandra/datadog_checks/cassandra/data/conf.yaml.example
@@ -113,6 +113,10 @@ instances:
 #    source: cassandra
 #    sourcecategory: database
 #    service: myapplication
+#    log_processing_rules:
+#      - type: "multi_line"
+#        name: "new_log_start_with_date"
+#        pattern: "\\w+\\s+\\[.*\\]\\s+\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])"
 
 
 init_config:


### PR DESCRIPTION
Allow multi-line aggregation for Cassandra logs

### What does this PR do?

This PR adds multi-line log aggregation to Cassandra configuration example.

### Motivation

We were getting stack-traces from Cassandra , but since multi-line log aggregation was not enabled, every line was sent as a separate event. Adding this configuration helped us to get stack traces as a single log event.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [x] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

N/A
