### PR TITLE
Provide example to enable Containerd integration on Kubernetes

### DIFF
--- a/containerd/README.md
+++ b/containerd/README.md
@@ -12,7 +12,33 @@ Containerd is a core Agent 6 check and thus needs to be configured in both in `d
 
 In `datadog.yaml`, configure your `cri_socket_path` for the Agent to query Containerd. In `containerd.d/conf.yaml`, configure the Check instance settings (such as `filters`) for the events.
 
-**Note**: If you are using the Agent in a container, setting the `DD_CRI_SOCKET_PATH` environment variable automatically enables the `Containerd` Check with the default configuration.
+#### Installation on containers
+
+If you are using the Agent in a container, setting the `DD_CRI_SOCKET_PATH` environment variable to the Containerd socket automatically enables the `Containerd` Check with the default configuration.
+
+For example, to install the integration on Kubernetes, edit your `datadog-agent.yaml` to map the Containerd socket from the host node to the daemonset and set the `DD_CRI_SOCKET_PATH` to the daemonset mountPath:
+
+```
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: datadog-agent
+spec:
+  template:
+    spec:
+      containers:
+        - name: datadog-agent
+          env:
+            - name: DD_CRI_SOCKET_PATH
+              value: "/var/run/containerd/containerd.sock"
+          volumeMounts:
+            - name: containerdsocket
+              mountPath: /var/run/containerd/containerd.sock
+          volumes:
+            - hostPath:
+                path: /var/run/containerd/containerd.sock
+              name: containerdsocket
+```
 
 ### Configuration
 

--- a/containerd/README.md
+++ b/containerd/README.md
@@ -28,6 +28,7 @@ spec:
     spec:
       containers:
         - name: datadog-agent
+          ...
           env:
             - name: DD_CRI_SOCKET_PATH
               value: "/var/run/containerd/containerd.sock"


### PR DESCRIPTION
### What does this PR do?

Provides a better example of how to enable this on Kubernetes.
 
### Motivation

The existing documentation is extremely lacking in details.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.
