### PR TITLE
Use Cloudfront instead of direct-to-S3

### DIFF
--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -46,7 +46,7 @@ REPOSITORIES_DIR = os.path.join(here, 'data')
 REPOSITORY_DIR = 'repo'
 REPOSITORY_MIRRORS = {
     'repo': {
-        'url_prefix': 'https://dd-integrations-core-wheels-build-stable.s3.amazonaws.com',
+        'url_prefix': 'https://dd-integrations-core-wheels-build-stable.datadoghq.com',
         'metadata_path': 'metadata.staged',
         'targets_path': 'targets',
         'confined_target_dirs': ['']

--- a/datadog_checks_downloader/tests/test_downloader.py
+++ b/datadog_checks_downloader/tests/test_downloader.py
@@ -13,7 +13,7 @@ log = logging.getLogger('test_downloader')
 
 
 def test_downloader():
-    r = requests.get('https://dd-integrations-core-wheels-build-stable.s3.amazonaws.com/targets/simple/index.html')
+    r = requests.get('https://dd-integrations-core-wheels-build-stable.datadoghq.com/targets/simple/index.html')
     r.raise_for_status()
 
     for line in r.text.split('\n'):


### PR DESCRIPTION
### What does this PR do?

Point our downloader to our Cloudfront distribution instead of our S3 bucket directly.

### Motivation

Some customers have blacklisted `amazonaws.com` but not `datadoghq.com` on their firewalls. This should fix that issue.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
