### PR TITLE
Monkey-patch the pyyaml methods defaulting to the safe methods

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -35,13 +35,19 @@ from ..utils.common import ensure_bytes, ensure_unicode
 from ..utils.proxy import config_proxy_skip
 from ..utils.limiter import Limiter
 
-
 # Metric types for which it's only useful to submit once per set of tags
 ONE_PER_CONTEXT_METRIC_TYPES = [
     aggregator.GAUGE,
     aggregator.RATE,
     aggregator.MONOTONIC_COUNT,
 ]
+
+try: # pyyaml may not be available
+    import yaml
+    from ..ddyaml import monkey_patch_pyyaml
+    monkey_patch_pyyaml()
+except ImportError:
+    pass
 
 
 class __AgentCheck7(object):

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -35,19 +35,13 @@ from ..utils.common import ensure_bytes, ensure_unicode
 from ..utils.proxy import config_proxy_skip
 from ..utils.limiter import Limiter
 
+
 # Metric types for which it's only useful to submit once per set of tags
 ONE_PER_CONTEXT_METRIC_TYPES = [
     aggregator.GAUGE,
     aggregator.RATE,
     aggregator.MONOTONIC_COUNT,
 ]
-
-try: # pyyaml may not be available
-    import yaml
-    from ..ddyaml import monkey_patch_pyyaml
-    monkey_patch_pyyaml()
-except ImportError:
-    pass
 
 
 class __AgentCheck7(object):
@@ -80,6 +74,14 @@ class __AgentCheck7(object):
         self.agentConfig = kwargs.get('agentConfig', {})
         self.warnings = []
         self.metric_limiter = None
+
+        if datadog_agent.get_config('disable_unsafe_yaml'):
+            try: # pyyaml may not be available
+                import yaml
+                from ..ddyaml import monkey_patch_pyyaml
+                monkey_patch_pyyaml()
+            except ImportError:
+                pass
 
         if len(args) > 0:
             self.name = args[0]
@@ -440,6 +442,14 @@ class __AgentCheck6(object):
         self.agentConfig = kwargs.get('agentConfig', {})
         self.warnings = []
         self.metric_limiter = None
+
+        if datadog_agent.get_config('disable_unsafe_yaml'):
+            try: # pyyaml may not be available
+                import yaml
+                from ..ddyaml import monkey_patch_pyyaml
+                monkey_patch_pyyaml()
+            except ImportError:
+                pass
 
         if len(args) > 0:
             self.name = args[0]

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -76,7 +76,8 @@ class __AgentCheck7(object):
         self.metric_limiter = None
 
         if datadog_agent.get_config('disable_unsafe_yaml'):
-            try: # pyyaml may not be available
+            # monkey-patches unsafe pyyaml methods
+            try:
                 import yaml
                 from ..ddyaml import monkey_patch_pyyaml
                 monkey_patch_pyyaml()
@@ -444,7 +445,8 @@ class __AgentCheck6(object):
         self.metric_limiter = None
 
         if datadog_agent.get_config('disable_unsafe_yaml'):
-            try: # pyyaml may not be available
+            # monkey-patches unsafe pyyaml methods
+            try:
                 import yaml
                 from ..ddyaml import monkey_patch_pyyaml
                 monkey_patch_pyyaml()

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -44,6 +44,7 @@ python-binary-memcached==0.26.1; sys_platform != 'win32'
 python3-gearman==0.1.0; sys_platform != 'win32' and python_version > '3.0'
 pyvmomi==v6.5.0.2017.5-1
 pywin32==224; sys_platform == 'win32'
+pyyaml==3.13
 redis==2.10.5
 requests==2.20.1
 requests-kerberos==0.12.0

--- a/datadog_checks_base/datadog_checks/base/ddyaml.py
+++ b/datadog_checks_base/datadog_checks/base/ddyaml.py
@@ -21,29 +21,31 @@ pyyaml_load = None
 pyyaml_load_all = None
 pyyaml_dump_all = None
 
+
 def safe_yaml_dump_all(documents, stream=None, Dumper=yDumper,
-        default_style=None, default_flow_style=None,
-        canonical=None, indent=None, width=None,
-        allow_unicode=None, line_break=None,
-        encoding='utf-8', explicit_start=None, explicit_end=None,
-        version=None, tags=None):
+                       default_style=None, default_flow_style=None,
+                       canonical=None, indent=None, width=None,
+                       allow_unicode=None, line_break=None,
+                       encoding='utf-8', explicit_start=None, explicit_end=None,
+                       version=None, tags=None):
     if Dumper != yDumper:
         log.warning("Unsafe dumping of YAML has been disabled - using safe dumper instead")
 
     if pyyaml_dump_all:
         return pyyaml_dump_all(documents, stream, yDumper,
-            default_style, default_flow_style,
-            canonical, indent, width,
-            allow_unicode, line_break,
-            encoding, explicit_start, explicit_end,
-            version, tags)
+                               default_style, default_flow_style,
+                               canonical, indent, width,
+                               allow_unicode, line_break,
+                               encoding, explicit_start, explicit_end,
+                               version, tags)
 
     return yaml.dump_all(documents, stream, yDumper,
-        default_style, default_flow_style,
-        canonical, indent, width,
-        allow_unicode, line_break,
-        encoding, explicit_start, explicit_end,
-        version, tags)
+                         default_style, default_flow_style,
+                         canonical, indent, width,
+                         allow_unicode, line_break,
+                         encoding, explicit_start, explicit_end,
+                         version, tags)
+
 
 def safe_yaml_load(stream, Loader=yLoader):
     if Loader != yLoader:
@@ -54,6 +56,7 @@ def safe_yaml_load(stream, Loader=yLoader):
 
     return yaml.load(stream, Loader=yLoader)
 
+
 def safe_yaml_load_all(stream, Loader=yLoader):
     if Loader != yLoader:
         log.warning("Unsafe loading of YAML has been disabled - using safe loader instead")
@@ -62,6 +65,7 @@ def safe_yaml_load_all(stream, Loader=yLoader):
         return pyyaml_load_all(stream, Loader=yLoader)
 
     return yaml.load_all(stream, Loader=yLoader)
+
 
 def monkey_patch_pyyaml():
     global pyyaml_load
@@ -80,6 +84,7 @@ def monkey_patch_pyyaml():
         log.info("monkey patching yaml.dump_all... (affects all yaml dump operations)")
         pyyaml_dump_all = yaml.dump_all
         yaml.dump_all = safe_yaml_dump_all
+
 
 def monkey_patch_pyyaml_reverse():
     global pyyaml_load

--- a/datadog_checks_base/datadog_checks/base/ddyaml.py
+++ b/datadog_checks_base/datadog_checks/base/ddyaml.py
@@ -1,0 +1,100 @@
+# (C) Datadog, Inc. 2011-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+import logging
+
+# 3p
+import yaml  # noqa, let's guess, probably imported somewhere
+try:
+    from yaml import CSafeLoader as yLoader
+    from yaml import CSafeDumper as yDumper
+except ImportError:
+    # On source install C Extensions might have not been built
+    from yaml import SafeLoader as yLoader  # noqa, imported from here elsewhere
+    from yaml import SafeDumper as yDumper  # noqa, imported from here elsewhere
+
+log = logging.getLogger(__name__)
+
+pyyaml_load = None
+pyyaml_load_all = None
+pyyaml_dump_all = None
+
+def safe_yaml_dump_all(documents, stream=None, Dumper=yDumper,
+        default_style=None, default_flow_style=None,
+        canonical=None, indent=None, width=None,
+        allow_unicode=None, line_break=None,
+        encoding='utf-8', explicit_start=None, explicit_end=None,
+        version=None, tags=None):
+    if Dumper != yDumper:
+        log.warning("Unsafe dumping of YAML has been disabled - using safe dumper instead")
+
+    if pyyaml_dump_all:
+        return pyyaml_dump_all(documents, stream, yDumper,
+            default_style, default_flow_style,
+            canonical, indent, width,
+            allow_unicode, line_break,
+            encoding, explicit_start, explicit_end,
+            version, tags)
+
+    return yaml.dump_all(documents, stream, yDumper,
+        default_style, default_flow_style,
+        canonical, indent, width,
+        allow_unicode, line_break,
+        encoding, explicit_start, explicit_end,
+        version, tags)
+
+def safe_yaml_load(stream, Loader=yLoader):
+    if Loader != yLoader:
+        log.warning("Unsafe loading of YAML has been disabled - using safe loader instead")
+
+    if pyyaml_load:
+        return pyyaml_load(stream, Loader=yLoader)
+
+    return yaml.load(stream, Loader=yLoader)
+
+def safe_yaml_load_all(stream, Loader=yLoader):
+    if Loader != yLoader:
+        log.warning("Unsafe loading of YAML has been disabled - using safe loader instead")
+
+    if pyyaml_load_all:
+        return pyyaml_load_all(stream, Loader=yLoader)
+
+    return yaml.load_all(stream, Loader=yLoader)
+
+def monkey_patch_pyyaml():
+    global pyyaml_load
+    global pyyaml_load_all
+    global pyyaml_dump_all
+
+    if not pyyaml_load:
+        log.info("monkey patching yaml.load...")
+        pyyaml_load = yaml.load
+        yaml.load = safe_yaml_load
+    if not pyyaml_load_all:
+        log.info("monkey patching yaml.load_all...")
+        pyyaml_load_all = yaml.load_all
+        yaml.load_all = safe_yaml_load_all
+    if not pyyaml_dump_all:
+        log.info("monkey patching yaml.dump_all... (affects all yaml dump operations)")
+        pyyaml_dump_all = yaml.dump_all
+        yaml.dump_all = safe_yaml_dump_all
+
+def monkey_patch_pyyaml_reverse():
+    global pyyaml_load
+    global pyyaml_load_all
+    global pyyaml_dump_all
+
+    if pyyaml_load:
+        log.info("reversing monkey patch for yaml.load...")
+        yaml.load = pyyaml_load
+        pyyaml_load = None
+    if pyyaml_load_all:
+        log.info("reversing monkey patch for yaml.load_all...")
+        yaml.load_all = pyyaml_load_all
+        pyyaml_load_all = None
+    if pyyaml_dump_all:
+        log.info("reversing monkey patch for yaml.dump_all... (affects all yaml dump operations)")
+        yaml.dump_all = pyyaml_dump_all
+        pyyaml_dump_all = None

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -1,4 +1,5 @@
 ddtrace==0.13.0
+pyyaml==3.13
 prometheus-client==0.3.0
 protobuf==3.5.1
 pywin32==224; sys_platform == 'win32'

--- a/datadog_checks_base/tests/fixtures/ddyaml/valid_conf.yaml
+++ b/datadog_checks_base/tests/fixtures/ddyaml/valid_conf.yaml
@@ -1,0 +1,4 @@
+init_config:
+
+instances:
+  - host: localhost

--- a/datadog_checks_base/tests/test_ddyaml.py
+++ b/datadog_checks_base/tests/test_ddyaml.py
@@ -19,6 +19,7 @@ from datadog_checks.base.ddyaml import (
 
 FIXTURE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtures', 'ddyaml')
 
+
 class Dummy(object):
     def __init__(self):
         self.foo = 1

--- a/datadog_checks_base/tests/test_ddyaml.py
+++ b/datadog_checks_base/tests/test_ddyaml.py
@@ -1,0 +1,96 @@
+# stdlib
+import os
+import unittest
+import tempfile
+
+# project
+import yaml
+
+import json
+
+from datadog_checks.base.ddyaml import (
+    monkey_patch_pyyaml,
+    monkey_patch_pyyaml_reverse,
+    safe_yaml_dump_all,
+    safe_yaml_load_all,
+    safe_yaml_load,
+    yDumper,
+)
+
+FIXTURE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtures', 'ddyaml')
+
+class Dummy(object):
+    def __init__(self):
+        self.foo = 1
+        self.bar = 'a'
+        self.qux = {self.foo: self.bar}
+
+    def get_foo(self):
+        return self.foo
+
+    def get_bar(self):
+        return self.bar
+
+    def get_qux(self):
+        return self.qux
+
+
+class UtilsYAMLTest(unittest.TestCase):
+
+    def setUp(self):
+        monkey_patch_pyyaml()
+
+    def tearDown(self):
+        monkey_patch_pyyaml_reverse()
+
+    def test_monkey_patch(self):
+        self.assertTrue(yaml.dump_all == safe_yaml_dump_all)
+        self.assertTrue(yaml.load_all == safe_yaml_load_all)
+        self.assertTrue(yaml.load == safe_yaml_load)
+
+    def test_load(self):
+        conf = os.path.join(FIXTURE_PATH, "valid_conf.yaml")
+        with open(conf) as f:
+            stream = f.read()
+
+            yaml_config_safe = safe_yaml_load(stream)
+            yaml_config_native = yaml.load(stream)
+            self.assertTrue(yaml_config_safe is not None)
+            self.assertTrue(yaml_config_native is not None)
+            self.assertTrue(yaml_config_native == yaml_config_safe)
+
+            yaml_config_safe = [entry for entry in safe_yaml_load_all(stream)]
+            yaml_config_native = [entry for entry in yaml.load_all(stream)]
+            self.assertTrue(yaml_config_safe is not [])
+            self.assertTrue(yaml_config_native is not [])
+            self.assertTrue(len(yaml_config_safe) == len(yaml_config_native))
+            for safe, native in zip(yaml_config_safe, yaml_config_native):
+                self.assertTrue(safe == native)
+
+    def test_unsafe(self):
+        dummy = Dummy()
+
+        with self.assertRaises(yaml.representer.RepresenterError):
+            yaml.dump_all([dummy])
+
+        with self.assertRaises(yaml.representer.RepresenterError):
+            yaml.dump(dummy, Dumper=yDumper)
+
+        # reverse monkey patch and try again
+        monkey_patch_pyyaml_reverse()
+
+        with tempfile.TemporaryFile(suffix='.yaml', mode='w+t') as f:
+            yaml.dump_all([dummy], stream=f)
+            f.seek(0)  # rewind
+
+            doc_unsafe = yaml.load(f)
+            self.assertTrue(type(doc_unsafe) is Dummy)
+
+            monkey_patch_pyyaml()
+            with self.assertRaises(yaml.constructor.ConstructorError):
+                f.seek(0)  # rewind
+                safe_yaml_load(f)
+
+            with self.assertRaises(yaml.constructor.ConstructorError):
+                f.seek(0)  # rewind
+                yaml.load(f)


### PR DESCRIPTION
### What does this PR do?

This PR applies a monkey-patch on the pyyaml methods for custom checks to use the safe methods by default unless they set the `disable_unsafe_yaml` flag to `false` in the Datadog Agent configuration.

### Motivation
With the [CVE-2017-18342](https://nvd.nist.gov/vuln/detail/CVE-2017-18342), we prefer the custom checks to use the safe methods of pyyaml by default.

### Review checklist
* [x]  PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
* [x]  Feature or bugfix has tests
* [x]  Git history is clean
* [ ]  If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
* [ ]  If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes
A big chunk of the code comes from this PR in Agent 5: [DataDog/dd-agent#3808](https://github.com/DataDog/dd-agent/pull/3808)