### PR TITLE
Fix e2e package install order

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -139,20 +139,20 @@ falling back to latest docker image"
         'the environment is torn down. Would you like to proceed?'
     )
 
-    if dev:
-        echo_waiting('Upgrading `{}` check to the development version... '.format(check), nl=False)
-        if environment.ENV_TYPE == 'local' and not click.confirm(editable_warning.format(environment.check)):
-            echo_success('skipping')
-        else:
-            environment.update_check()
-            echo_success('success!')
-
     if base:
         echo_waiting('Upgrading the base package to the development version... ', nl=False)
         if environment.ENV_TYPE == 'local' and not click.confirm(editable_warning.format('base')):
             echo_success('skipping')
         else:
             environment.update_base_package()
+            echo_success('success!')
+
+    if dev:
+        echo_waiting('Upgrading `{}` check to the development version... '.format(check), nl=False)
+        if environment.ENV_TYPE == 'local' and not click.confirm(editable_warning.format(environment.check)):
+            echo_success('skipping')
+        else:
+            environment.update_check()
             echo_success('success!')
 
     click.echo()


### PR DESCRIPTION
### Motivation

Any base package upgrades should come before check upgrades so the development version of checks can depend on newer/unreleased base package versions