### PR TITLE
[supervidord] change example supervisor.sock conf

### DIFF
--- a/supervisord/datadog_checks/supervisord/data/conf.yaml.example
+++ b/supervisord/datadog_checks/supervisord/data/conf.yaml.example
@@ -18,7 +18,8 @@
 #
 #       [unix_http_server]
 #       file=/var/run/supervisor.sock
-#       chmod=777
+#       chmod=0760
+#       chown=root:dd-agent
 #
 #  Reload supervisor, specify the inet or unix socket server information
 #  in this yaml file along with an optional list of the processes you want


### PR DESCRIPTION
### What does this PR do?

Changes example supervisor.conf file to have just enough permissions for the `dd-agent` user read the socket file.

### Motivation

Reason for change: Users are usually hesitant setting files access permissions too open e.g. `777`. Not a lot follows reference links to figure out this and ownership can be changed. 

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

minor severity and does not affect the integration at all.
