### PR TITLE
Add logs section

### DIFF
--- a/postfix/README.md
+++ b/postfix/README.md
@@ -78,6 +78,41 @@ List of users who are authorized to view the queue.
 
 [Restart the Agent][5] to start sending Postfix metrics to Datadog.
 
+#### Log Collection
+
+**Available for Agent >6.0**
+
+Postfix logs activity to the syslog daemon that then gets sent to logfiles.
+
+By default, the naming convention and log files can by configured in your syslog file:
+
+```
+/etc/syslog.conf:
+    mail.err                                    /dev/console
+    mail.debug                                  /var/log/maillog
+```
+
+
+* Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file with:
+
+  ```
+  logs_enabled: true
+  ```
+
+* Add the following configuration block to your `postfix.d/conf.yaml` file. Change the `path` and `service` parameter values based on your environment. See the [sample postfix.d/conf.yaml][5] for all available configuration options.
+
+  ```
+  logs:
+    - type: file
+      path: /var/log/mail.log
+      source: postfix
+  ```
+
+* [Restart the Agent][9].
+
+**Learn more about log collection [in the log documentation][10]**
+
+
 ### Validation
 
 [Run the Agent's `status` subcommand][6] and look for `postfix` under the Checks section.
@@ -109,3 +144,4 @@ Need help? Contact [Datadog support][8].
 [7]: https://github.com/DataDog/integrations-core/blob/master/postfix/metadata.csv
 [8]: https://docs.datadoghq.com/help
 [9]: https://www.datadoghq.com/blog/monitor-postfix-queues
+[10]: https://docs.datadoghq.com/logs

--- a/postfix/README.md
+++ b/postfix/README.md
@@ -106,6 +106,7 @@ By default, the naming convention and log files can by configured in your syslog
     - type: file
       path: /var/log/mail.log
       source: postfix
+      service: myapp
   ```
 
 * [Restart the Agent][9].

--- a/postfix/README.md
+++ b/postfix/README.md
@@ -82,9 +82,9 @@ List of users who are authorized to view the queue.
 
 **Available for Agent >6.0**
 
-Postfix logs activity to the syslog daemon that then gets sent to logfiles.
+Postfix sends logs to the syslog daemon, which then writes logs to the file system.
 
-By default, the naming convention and log files can by configured in your syslog file:
+The naming convention and log file destinations are configurable:
 
 ```
 /etc/syslog.conf:
@@ -93,7 +93,7 @@ By default, the naming convention and log files can by configured in your syslog
 ```
 
 
-* Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file with:
+* Collecting logs is disabled by default in the Datadog Agent. Enable it in your `datadog.yaml` file:
 
   ```
   logs_enabled: true

--- a/postfix/datadog_checks/postfix/data/conf.yaml.example
+++ b/postfix/datadog_checks/postfix/data/conf.yaml.example
@@ -62,10 +62,10 @@ instances:
 ## Log Section (Available for Agent >=6.0)
 ##
 ## type - mandatory - Type of log input source (tcp / udp / file / windows_event)
-## port / path / channel - mandatory - Set port if type is tcp or udp. Set path if type is file and channel if windows_event
-## service - mandatory - Name of the service owning the log
-## source  - mandatory - Attribute that defines which Integration is sending the logs
-## sourcecategory - optional - Multiple value attribute. Can be used to refine the source attribtue
+## port / path / channel - mandatory - Set port if type is tcp or udp. Set path if type is file. Set channel if type is windows_event
+## service - mandatory - Name of the service that generated the log
+## source  - mandatory - Attribute that defines which Integration sent the logs
+## sourcecategory - optional - Multiple value attribute. Used to refine the source attribute
 ## tags: - optional - Add tags to the collected logs
 ##
 ## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/

--- a/postfix/datadog_checks/postfix/data/conf.yaml.example
+++ b/postfix/datadog_checks/postfix/data/conf.yaml.example
@@ -64,9 +64,9 @@ instances:
 ## type - mandatory - Type of log input source (tcp / udp / file / windows_event)
 ## port / path / channel - mandatory - Set port if type is tcp or udp. Set path if type is file and channel if windows_event
 ## service - mandatory - Name of the service owning the log
-## source  - mandatory - Attribute that defines which integration is sending the logs
+## source  - mandatory - Attribute that defines which Integration is sending the logs
 ## sourcecategory - optional - Multiple value attribute. Can be used to refine the source attribtue
-## tags: - optional - Add tags to each logs collected
+## tags: - optional - Add tags to the collected logs
 ##
 ## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
 

--- a/postfix/datadog_checks/postfix/data/conf.yaml.example
+++ b/postfix/datadog_checks/postfix/data/conf.yaml.example
@@ -57,3 +57,21 @@ instances:
     tags:
       - optional_tag3
       - optional_tag4
+
+
+## Log Section (Available for Agent >=6.0)
+##
+## type - mandatory - Type of log input source (tcp / udp / file / windows_event)
+## port / path / channel - mandatory - Set port if type is tcp or udp. Set path if type is file and channel if windows_event
+## service - mandatory - Name of the service owning the log
+## source  - mandatory - Attribute that defines which integration is sending the logs
+## sourcecategory - optional - Multiple value attribute. Can be used to refine the source attribtue
+## tags: - optional - Add tags to each logs collected
+##
+## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
+
+#logs:
+#  - type: file
+#    path: /var/log/mail.log
+#    service: myapp
+#    source: postfix

--- a/postfix/manifest.json
+++ b/postfix/manifest.json
@@ -1,6 +1,7 @@
 {
   "categories": [
-    "Collaboration"
+    "Collaboration",
+    "log collection"
   ],
   "creates_events": false,
   "display_name": "Postfix",


### PR DESCRIPTION
### What does this PR do?

Adds logs section to readme and example yaml file. 
Adds the log collection category to the manifest file

Most of this info came from here - http://www.postfix.org/BASIC_CONFIGURATION_README.html#syslog_howto

### Motivation

We now have an OOTB logs pipeline for postfix so update the docs and yaml to reflect that. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
