### PR TITLE
Parse raw yaml instances and init_config with dedicated base class method

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -45,7 +45,7 @@ ONE_PER_CONTEXT_METRIC_TYPES = [
 ]
 
 
-class __AgentCheck7(object):
+class __AgentCheckPy3(object):
     """
     The base class for any Agent based integrations
     """
@@ -70,12 +70,8 @@ class __AgentCheck7(object):
         self.metrics = defaultdict(list)
         self.check_id = ''
         self.instances = kwargs.get('instances', [])
-        if isinstance(self.instances, str):
-            self.instances = yaml.safe_load(self.instances)
         self.name = kwargs.get('name', '')
         self.init_config = kwargs.get('init_config', {})
-        if isinstance(self.init_config, str):
-            self.init_config = yaml.safe_load(self.init_config)
         self.agentConfig = kwargs.get('agentConfig', {})
         self.warnings = []
         self.metric_limiter = None
@@ -151,6 +147,13 @@ class __AgentCheck7(object):
             metric_limit = self.DEFAULT_METRIC_LIMIT
         if metric_limit > 0:
             self.metric_limiter = Limiter(self.name, 'metrics', metric_limit, self.warning)
+
+    @classmethod
+    def load_config(cls, yaml_str):
+        """
+        Convenience wrapper to ease programmatic use of this class from the C API.
+        """
+        return yaml.safe_load(yaml_str)
 
     @property
     def in_developer_mode(self):
@@ -409,7 +412,7 @@ class __AgentCheck7(object):
         return proxies if proxies else no_proxy_settings
 
 
-class __AgentCheck6(object):
+class __AgentCheckPy2(object):
     """
     The base class for any Agent based integrations
     """
@@ -504,6 +507,13 @@ class __AgentCheck6(object):
             metric_limit = self.DEFAULT_METRIC_LIMIT
         if metric_limit > 0:
             self.metric_limiter = Limiter(self.name, "metrics", metric_limit, self.warning)
+
+    @classmethod
+    def load_config(cls, yaml_str):
+        """
+        Convenience wrapper to ease programmatic use of this class from the C API.
+        """
+        return yaml.safe_load(yaml_str)
 
     @property
     def in_developer_mode(self):
@@ -786,8 +796,8 @@ class __AgentCheck6(object):
 
 
 if PY3:
-    AgentCheck = __AgentCheck7
-    del __AgentCheck6
+    AgentCheck = __AgentCheckPy3
+    del __AgentCheckPy2
 else:
-    AgentCheck = __AgentCheck6
-    del __AgentCheck7
+    AgentCheck = __AgentCheckPy2
+    del __AgentCheckPy3

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -148,8 +148,8 @@ class __AgentCheckPy3(object):
         if metric_limit > 0:
             self.metric_limiter = Limiter(self.name, 'metrics', metric_limit, self.warning)
 
-    @classmethod
-    def load_config(cls, yaml_str):
+    @staticmethod
+    def load_config(yaml_str):
         """
         Convenience wrapper to ease programmatic use of this class from the C API.
         """

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -11,6 +11,7 @@ import traceback
 import unicodedata
 import inspect
 
+import yaml
 from six import PY3, iteritems, text_type
 
 try:
@@ -69,8 +70,12 @@ class __AgentCheck7(object):
         self.metrics = defaultdict(list)
         self.check_id = ''
         self.instances = kwargs.get('instances', [])
+        if isinstance(self.instances, str):
+            self.instances = yaml.safe_load(self.instances)
         self.name = kwargs.get('name', '')
         self.init_config = kwargs.get('init_config', {})
+        if isinstance(self.init_config, str):
+            self.init_config = yaml.safe_load(self.init_config)
         self.agentConfig = kwargs.get('agentConfig', {})
         self.warnings = []
         self.metric_limiter = None

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -43,6 +43,7 @@ python-binary-memcached==0.26.1; sys_platform != 'win32'
 python3-gearman==0.1.0; sys_platform != 'win32' and python_version > '3.0'
 pyvmomi==v6.5.0.2017.5-1
 pywin32==224; sys_platform == 'win32'
+pyyaml==3.13
 redis==2.10.5
 requests==2.20.1
 requests-kerberos==0.12.0

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -7,3 +7,4 @@ simplejson==3.6.5
 six==1.11.0
 uptime==3.0.1
 uuid==1.30
+PyYAML==3.13

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -26,12 +26,9 @@ def test_instance():
     assert check.init_config == {'foo': 'bar'}
     assert check.instances == [{'bar': 'baz'}]
 
-    # use raw yaml
-    init_config = "raw_foo: bar"
-    instances = "[raw_bar: baz]"
-    check = AgentCheck(init_config=init_config, instances=instances)
-    assert check.init_config == {'raw_foo': 'bar'}
-    assert check.instances == [{'raw_bar': 'baz'}]
+
+def test_load_config():
+    assert AgentCheck.load_config("raw_foo: bar") == {'raw_foo': 'bar'}
 
 
 def test_log_critical_error():

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -14,7 +14,24 @@ def test_instance():
     """
     Simply assert the class can be instantiated
     """
-    AgentCheck()
+    # rely on default
+    check = AgentCheck()
+    assert check.init_config == {}
+    assert check.instances == []
+
+    # pass dict for 'init_config', a list for 'instances'
+    init_config = {'foo': 'bar'}
+    instances = [{'bar': 'baz'}]
+    check = AgentCheck(init_config=init_config, instances=instances)
+    assert check.init_config == {'foo': 'bar'}
+    assert check.instances == [{'bar': 'baz'}]
+
+    # use raw yaml
+    init_config = "raw_foo: bar"
+    instances = "[raw_bar: baz]"
+    check = AgentCheck(init_config=init_config, instances=instances)
+    assert check.init_config == {'raw_foo': 'bar'}
+    assert check.instances == [{'raw_bar': 'baz'}]
 
 
 def test_log_critical_error():


### PR DESCRIPTION
### What does this PR do?

This is a proposal to ~make `AgentCheck` constructor more flexible, accepting raw YAML contents for `init_config` and `instances` instead of a dict and a list respectively. If accepted, same changes would be applied to `__AgentCheck6`.~ add a static method to `AgentCheck` to be used from the C API to translate YAML to a Python object.

### Motivation

This would drastically simplify the Agent code we use to load and configure a check, right now we perform the following steps:

1. load yaml bits for init_config and instances
2. unmarshal to Go structs
3. instrospect Go structs from step 2 and convert contents to appropriate CPython objects
4. invoke `AgentCheck` constructor programmatically passing CPython objects from step 3

If we can use YAML as an exchange format instead, we would have:

1. load yaml bits for init_config and instances
2. translate the yaml text to `PyObject*` using the static method from `AgentCheck`
2. invoke `AgentCheck` constructor programmatically passing objects from step 2.
