### PR TITLE
[cockroachdb] Add missing link to config directory location

### DIFF
--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -48,3 +48,4 @@ Need help? Contact [Datadog support][7].
 [5]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
 [6]: https://github.com/DataDog/integrations-core/blob/master/cockroachdb/metadata.csv
 [7]: https://docs.datadoghq.com/help
+[8]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/


### PR DESCRIPTION
### What does this PR do?

Adds a link to docs that explain where the Agent configuration files can be found.

### Motivation

I noticed that the cockroachdb docs currently have a reference to a markdown link (`[8]`) that doesn't exist.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
