### PR TITLE
Added .daemonset.updated gauge to track daemonset updates

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -123,6 +123,7 @@ class KubernetesState(OpenMetricsBaseCheck):
                 'kube_daemonset_status_desired_number_scheduled': 'daemonset.desired',
                 'kube_daemonset_status_number_misscheduled': 'daemonset.misscheduled',
                 'kube_daemonset_status_number_ready': 'daemonset.ready',
+                'kube_daemonset_updated_number_scheduled': 'daemonset.updated',
                 'kube_deployment_spec_paused': 'deployment.paused',
                 'kube_deployment_spec_replicas': 'deployment.replicas_desired',
                 'kube_deployment_spec_strategy_rollingupdate_max_unavailable': 'deployment.rollingupdate.max_unavailable',  # noqa: E501

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -201,11 +201,18 @@ class KubernetesState(OpenMetricsBaseCheck):
                 'kube_replicaset_created',
                 'kube_replicationcontroller_created',
                 'kube_resourcequota_created',
+                'kube_replicaset_owner',
                 'kube_service_created',
                 'kube_service_info',
                 'kube_service_labels',
+                'kube_service_spec_external_ip',
+                'kube_service_status_load_balancer_ingress',
                 'kube_statefulset_labels',
                 'kube_statefulset_created',
+                'kube_statefulset_status_current_revision',
+                'kube_statefulset_status_update_revision',
+                # Already provided by the kubelet integration
+                'kube_pod_container_status_last_terminated_reason',
                 # _generation metrics are more metadata than metrics, no real use case for now
                 'kube_daemonset_metadata_generation',
                 'kube_deployment_metadata_generation',

--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -16,6 +16,7 @@ kubernetes_state.daemonset.scheduled,gauge,,,,The number of nodes running at lea
 kubernetes_state.daemonset.misscheduled,gauge,,,,The number of nodes running a daemon pod but are not supposed to,-1,kubernetes,k8s_state.ds.misscheduled
 kubernetes_state.daemonset.desired,gauge,,,,The number of nodes that should be running the daemon pod,0,kubernetes,k8s_state.ds.desired
 kubernetes_state.daemonset.ready,gauge,,,,The number of nodes that should be running the daemon pod and have one or more running and ready,0,kubernetes,k8s_state.ds.ready
+kubernetes_state.daemonset.updated,gauge,,,,The number of nodes that run the updated daemon pod spec,0,kubernetes,k8s_state.ds.updated
 kubernetes_state.deployment.replicas,gauge,,,,The number of replicas per deployment,0,kubernetes,k8s_state.deployment.replicas
 kubernetes_state.deployment.replicas_available,gauge,,,,The number of available replicas per deployment,0,kubernetes,k8s_state.deployment.replicas_available
 kubernetes_state.deployment.replicas_unavailable,gauge,,,,The number of unavailable replicas per deployment,0,kubernetes,k8s_state.deployment.replicas_unavailable

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -846,3 +846,8 @@ kube_resourcequota{namespace="default",resource="pods",resourcequota="custom-res
 # HELP kube_limitrange Information about limit range.
 # TYPE kube_limitrange gauge
 kube_limitrange{constraint="defaultRequest",limitrange="limits",namespace="default",resource="cpu",type="Container"} 0.1
+# HELP kube_daemonset_updated_number_scheduled The total number of nodes that are running updated daemon pod
+# TYPE kube_daemonset_updated_number_scheduled gauge
+kube_daemonset_updated_number_scheduled{namespace="kube-system",daemonset="kube-proxy"} 3
+kube_daemonset_updated_number_scheduled{namespace="kube-system",daemonset="kube-svc-redirect"} 3
+kube_daemonset_updated_number_scheduled{namespace="default",daemonset="dd-datadog"} 3

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -42,6 +42,7 @@ METRICS = [
     NAMESPACE + '.daemonset.scheduled',
     NAMESPACE + '.daemonset.misscheduled',
     NAMESPACE + '.daemonset.desired',
+    NAMESPACE + '.daemonset.updated',
     # hpa
     NAMESPACE + '.hpa.min_replicas',
     NAMESPACE + '.hpa.max_replicas',


### PR DESCRIPTION
### What does this PR do?

Add the kubernetes_state.daemonset.updated gauge, reporting how many pods in a daemonset are running the updated spec.

This mirrors the gauges we already have:
  - kubernetes_state.deployment.replicas_updated
  - kubernetes_state.statefulset.replicas_updated

Also, update the `ignored_metrics` with new metadata metrics.

### Motivation

Allow to track daemonset rolling updates

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [x] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
