### PR TITLE
Add __main__ module to package

### DIFF
--- a/datadog_checks_downloader/datadog_checks/downloader/__main__.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/__main__.py
@@ -1,0 +1,9 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import sys
+
+from .cli import download
+
+sys.exit(download())


### PR DESCRIPTION
### What does this PR do?

Add `__main__` module to package, so that it can be executed with `python -m datadog_checks.downloader datadog-vsphere`

### Motivation

Needed for windows so that the integration command can use the downloader

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
