### PR TITLE
Fix openstack check instantiation in tests

### DIFF
--- a/openstack/tests/test_openstack.py
+++ b/openstack/tests/test_openstack.py
@@ -22,8 +22,8 @@ from datadog_checks.openstack.openstack import (
     IncompleteIdentity
 )
 
-
-instance = common.MOCK_CONFIG["instances"][0]
+instances = common.MOCK_CONFIG['instances']
+instance = common.MOCK_CONFIG['instances'][0]
 instance['tags'] = ['optional:tag1']
 init_config = common.MOCK_CONFIG['init_config']
 openstack_check = OpenStackCheck('openstack', init_config, {}, instances=[instance])
@@ -169,7 +169,7 @@ def test_from_auth_response():
 
 
 def test_ensure_auth_scope(aggregator):
-    instance = common.MOCK_CONFIG["instances"][0]
+    instance = common.MOCK_CONFIG['instances'][0]
     instance['tags'] = ['optional:tag1']
 
     with pytest.raises(KeyError):
@@ -227,7 +227,7 @@ def test_server_exclusion(*args):
         'keystone_server_url': 'http://10.0.2.15:5000',
         'ssl_verify': False,
         'exclude_server_ids': common.EXCLUDED_SERVER_IDS
-    }, {}, instances=common.MOCK_CONFIG)
+    }, {}, instances=instances)
 
     # Retrieve servers
     openstackCheck.server_details_by_id = copy.deepcopy(common.ALL_SERVER_DETAILS)
@@ -281,7 +281,7 @@ def test_cache_between_runs(self, *args):
         'keystone_server_url': 'http://10.0.2.15:5000',
         'ssl_verify': False,
         'exclude_server_ids': common.EXCLUDED_SERVER_IDS
-    }, {}, instances=common.MOCK_CONFIG)
+    }, {}, instances=instances)
 
     # Start off with a list of servers
     openstackCheck.server_details_by_id = copy.deepcopy(common.ALL_SERVER_DETAILS)

--- a/openstack_controller/tests/test_openstack.py
+++ b/openstack_controller/tests/test_openstack.py
@@ -7,11 +7,13 @@ from . import common
 from datadog_checks.openstack_controller import OpenStackControllerCheck
 
 
+instances = common.MOCK_CONFIG['instances']
+
+
 def test_parse_uptime_string(aggregator):
-    instance = common.MOCK_CONFIG["instances"][0]
-    instance['tags'] = ['optional:tag1']
+    instances[0]['tags'] = ['optional:tag1']
     init_config = common.MOCK_CONFIG['init_config']
-    check = OpenStackControllerCheck('openstack_controller', init_config, {}, instances=[instance])
+    check = OpenStackControllerCheck('openstack_controller', init_config, {}, instances=instances)
     response = u' 16:53:48 up 1 day, 21:34,  3 users,  load average: 0.04, 0.14, 0.19\n'
     uptime_parsed = check._parse_uptime_string(response)
     assert uptime_parsed == [0.04, 0.14, 0.19]
@@ -28,7 +30,7 @@ def test_get_all_servers_between_runs(servers_detail, aggregator):
         'keystone_server_url': 'http://10.0.2.15:5000',
         'ssl_verify': False,
         'exclude_server_ids': common.EXCLUDED_SERVER_IDS
-    }, {}, instances=common.MOCK_CONFIG)
+    }, {}, instances=instances)
 
     # Start off with a list of servers
     check.servers_cache = copy.deepcopy(common.SERVERS_CACHE_MOCK)
@@ -53,7 +55,7 @@ def test_get_all_servers_with_project_name_none(servers_detail, aggregator):
         'keystone_server_url': 'http://10.0.2.15:5000',
         'ssl_verify': False,
         'exclude_server_ids': common.EXCLUDED_SERVER_IDS
-    }, {}, instances=common.MOCK_CONFIG)
+    }, {}, instances=instances)
 
     # Start off with a list of servers
     check.servers_cache = copy.deepcopy(common.SERVERS_CACHE_MOCK)
@@ -86,7 +88,7 @@ def test_get_paginated_server(servers_detail, aggregator):
         'ssl_verify': False,
         'exclude_server_ids': common.EXCLUDED_SERVER_IDS,
         'paginated_server_limit': 1
-    }, {}, instances=common.MOCK_CONFIG)
+    }, {}, instances=instances)
     check.get_all_servers({"6f70656e737461636b20342065766572": "testproj"}, "test_name", [])
     assert len(check.servers_cache) == 1
     servers = check.servers_cache['test_name']['servers']
@@ -153,7 +155,7 @@ def test_collect_server_metrics_pre_2_48(server_diagnostics, os_aggregates, aggr
         'ssl_verify': False,
         'exclude_server_ids': common.EXCLUDED_SERVER_IDS,
         'paginated_server_limit': 1
-    }, {}, instances=common.MOCK_CONFIG)
+    }, {}, instances=instances)
 
     check.collect_server_diagnostic_metrics({})
 


### PR DESCRIPTION
### What does this PR do?

Tests have been broken since - https://github.com/DataDog/integrations-core/commit/5ba0031992255f7e9ef133cbb47975ace2cf3d24

This fixes that by properly passing the full instances list into the class instantiation

### Motivation

Fixes CI

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If PR adds a configuration option, it has been added to the configuration file.

### Additional Notes

Anything else we should know when reviewing?
