### PR TITLE
Refactor openstack_controller check cache

### DIFF
--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -130,10 +130,8 @@ class OpenStackControllerCheck(AgentCheck):
         self._backoff = BackOffRetry()
 
         # Ex: servers_cache = {
-        #   <instance_name>: {
-        #       'servers': {<server_id>: <server_metadata>},
-        #       'changes_since': <ISO8601 date time>
-        #   }
+        #   'servers': {<server_id>: <server_metadata>},
+        #   'changes_since': <ISO8601 date time>
         # }
         self.servers_cache = {}
 
@@ -346,13 +344,13 @@ class OpenStackControllerCheck(AgentCheck):
     # Get all of the server IDs and their metadata and cache them
     # After the first run, we will only get servers that have changed state since the last collection run
     def get_all_servers(self, tenant_to_name, instance_name, exclude_server_id_rules):
-        cached_servers = self.servers_cache.get(instance_name, {}).get('servers')
+        cached_servers = self.servers_cache.get('servers')
         # NOTE: updated_time need to be set at the beginning of this method in order to no miss servers changes.
         changes_since = datetime.utcnow().isoformat()
         if cached_servers is None:
             updated_servers = self.get_active_servers(tenant_to_name)
         else:
-            previous_changes_since = self.servers_cache.get(instance_name, {}).get('changes_since')
+            previous_changes_since = self.servers_cache.get('changes_since')
             updated_servers = self.update_servers_cache(cached_servers, tenant_to_name, previous_changes_since)
 
         # Filter out excluded servers
@@ -362,7 +360,7 @@ class OpenStackControllerCheck(AgentCheck):
                 servers[updated_server_id] = updated_server
 
         # Initialize or update cache for this instance
-        self.servers_cache[instance_name] = {
+        self.servers_cache = {
             'servers': servers,
             'changes_since': changes_since
         }
@@ -709,7 +707,7 @@ class OpenStackControllerCheck(AgentCheck):
                     tenant_id_to_name[p.get('id')] = name
                 self.get_all_servers(tenant_id_to_name, self.instance_name, exclude_server_id_rules)
 
-                servers = self.servers_cache[self.instance_name]['servers']
+                servers = self.servers_cache['servers']
                 if collect_server_diagnostic_metrics:
                     self.log.debug("Fetch stats from %s server(s)" % len(servers))
                     for _, server in iteritems(servers):

--- a/openstack_controller/tests/common.py
+++ b/openstack_controller/tests/common.py
@@ -177,19 +177,17 @@ EXAMPLE_PROJECTS_RESPONSE = {
 
 # .. server/network
 SERVERS_CACHE_MOCK = {
-    "test_name": {
-        'servers': {
-            "server-1": {"id": "server-1", "name": "server-name-1",
-                         "status": "ACTIVE", "project_name": "testproj"},
-            "server-2": {"id": "server-2", "name": "server-name-2",
-                         "status": "ACTIVE", "project_name": "testproj"},
-            "other-1": {"id": "other-1", "name": "server-name-other-1",
-                        "status": "ACTIVE", "project_name": "blacklist_1"},
-            "other-2": {"id": "other-2", "name": "server-name-other-2",
-                        "status": "ACTIVE", "project_name": "blacklist_2"}
-        },
-        'change_since': datetime.datetime.utcnow().isoformat()
-    }
+    'servers': {
+        "server-1": {"id": "server-1", "name": "server-name-1",
+                     "status": "ACTIVE", "project_name": "testproj"},
+        "server-2": {"id": "server-2", "name": "server-name-2",
+                     "status": "ACTIVE", "project_name": "testproj"},
+        "other-1": {"id": "other-1", "name": "server-name-other-1",
+                    "status": "ACTIVE", "project_name": "blacklist_1"},
+        "other-2": {"id": "other-2", "name": "server-name-other-2",
+                    "status": "ACTIVE", "project_name": "blacklist_2"}
+    },
+    'change_since': datetime.datetime.utcnow().isoformat()
 }
 
 EMPTY_NOVA_SERVERS = []

--- a/openstack_controller/tests/test_openstack.py
+++ b/openstack_controller/tests/test_openstack.py
@@ -38,7 +38,7 @@ def test_get_all_servers_between_runs(servers_detail, aggregator):
     check.get_all_servers({'6f70656e737461636b20342065766572': 'testproj',
                            'blacklist_1': 'blacklist_1',
                            'blacklist_2': 'blacklist_2'}, "test_name", [])
-    servers = check.servers_cache['test_name']['servers']
+    servers = check.servers_cache['servers']
     assert 'server-1' not in servers
     assert 'server_newly_added' in servers
     assert 'other-1' in servers
@@ -63,7 +63,7 @@ def test_get_all_servers_with_project_name_none(servers_detail, aggregator):
     check.get_all_servers({'6f70656e737461636b20342065766572': None,
                            'blacklist_1': 'blacklist_1',
                            'blacklist_2': 'blacklist_2'}, "test_name", [])
-    servers = check.servers_cache['test_name']['servers']
+    servers = check.servers_cache['servers']
     assert 'server_newly_added' not in servers
     assert 'server-1' not in servers
     assert 'other-1' in servers
@@ -90,8 +90,7 @@ def test_get_paginated_server(servers_detail, aggregator):
         'paginated_server_limit': 1
     }, {}, instances=instances)
     check.get_all_servers({"6f70656e737461636b20342065766572": "testproj"}, "test_name", [])
-    assert len(check.servers_cache) == 1
-    servers = check.servers_cache['test_name']['servers']
+    servers = check.servers_cache['servers']
     assert 'server-1' in servers
     assert 'other-1' not in servers
     assert 'other-2' not in servers


### PR DESCRIPTION
### What does this PR do?

Refactoring `openstack_controller` cache to remove the dict with only one key. 
Moving from `self.servers_cache[instance_name]['thing']` to `self.servers_cache['thing']`. 

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
