### PR TITLE
Make load_config a staticmethod everywhere

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -518,8 +518,8 @@ class __AgentCheckPy2(object):
         if metric_limit > 0:
             self.metric_limiter = Limiter(self.name, "metrics", metric_limit, self.warning)
 
-    @classmethod
-    def load_config(cls, yaml_str):
+    @staticmethod
+    def load_config(yaml_str):
         """
         Convenience wrapper to ease programmatic use of this class from the C API.
         """


### PR DESCRIPTION
### What does this PR do?

Make `load_config` a `staticmethod` on both base classes

### Motivation

That was an oversight

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
