### PR TITLE
Fargate process agent

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -110,6 +110,9 @@ Metrics are collected with [DogStatsD][11] through UDP port 8125.
 
 To send custom metrics by listening to DogStatsD packets from other containers, set the environment variable `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` to `true` within the Datadog Agent container.
 
+#### Live process monitoring
+Enable Datadog's [Process Agent][22] with the environment variable `DD_PROCESS_AGENT_ENABLED` set to `true` in the Datadog Agent container. Because Amazon controls the underlying hosts for Fargate, live processes can only be collected from the Datadog Agent container.
+
 ### Log Collection
 
 1. Define the Fargate AwsLogDriver in your task. [Consult the AWS Fargate developer guide][12] for instructions.
@@ -191,3 +194,4 @@ Need help? Contact [Datadog support][16].
 [19]: https://docs.docker.com/engine/api/v1.30/#operation/ContainerStats
 [20]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-metrics.html
 [21]: https://docs.datadoghq.com/integrations/amazon_ecs/#data-collected
+[22]: https://docs.datadoghq.com/graphing/infrastructure/process/?tab=docker#installation

--- a/ecs_fargate/manifest.json
+++ b/ecs_fargate/manifest.json
@@ -13,7 +13,7 @@
   "metric_prefix": "ecs.",
   "metric_to_check": "ecs.fargate.cpu.user",
   "name": "ecs_fargate",
-  "public_title": "Datadog-ECS-Fargate Integration",
+  "public_title": "Datadog-ECS Fargate Integration",
   "short_description": "Track metrics for containers running with ECS Fargate",
   "support": "core",
   "supported_os": [


### PR DESCRIPTION
### What does this PR do?
- Specify the process agent can only gather live processes from the Datadog Agent container.
- Update docs page title for better search results.

### Motivation
- Trello request from support

### Additional Notes
- I verified this using the AWS demo account.
- I verified with burrito there is no way to collect processes from other containers.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
