### PR TITLE
Set coverage target for project and disable patch status

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,5 @@
 comment:
-  layout: "diff"
+  layout: "diff, flags"
   behavior: default
   branches: null
 
@@ -10,6 +10,8 @@ coverage:
   precision: 2
 
   status:
-    patch:
+    project:
       default:
-        target: '10'
+        target: 75
+        if_ci_failed: error
+    patch: off


### PR DESCRIPTION
### Motivation

Decrease PR failures due to incorrect Codecov reports

e.g. https://github.com/pyca/cryptography/pull/4715#pullrequestreview-194220527