### PR TITLE
Revert "Performance improvement in tracking signed files in git (#2872)"

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -115,17 +115,11 @@ def git_tag_list(pattern=None):
     return list(filter(regex.search, result))
 
 
-def git_ls_files(filenames):
+def git_ls_files(filename):
     """
-    Returns a stderr output, if any, indicating which files are not tracked by
-    git.
+    Return a boolean value for whether the given file is tracked by git.
     """
     with chdir(get_root()):
-        # We assume that we are given a list of strings.
-        # We then transform this into a giant space-delimited string.
-        # Also, ARGMAX on a modern system is large enough (2,097,152) that the
-        # number of filenames should not matter for practical purposes.
-        filenames = ' '.join(filenames)
         # https://stackoverflow.com/a/2406813
-        result = run_command('git ls-files --error-unmatch {}'.format(filenames), capture=True)
-        return result.stderr
+        result = run_command('git ls-files --error-unmatch {}'.format(filename), capture=True)
+        return result.code == 0

--- a/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
@@ -32,13 +32,12 @@ class YubikeyException(Exception):
 
 
 class UntrackedFileException(Exception):
-    def __init__(self, stderr):
-        self.stderr = stderr
+    def __init__(self, filename):
+        self.filename = filename
 
 
     def __str__(self):
-        # https://stackoverflow.com/a/18389510
-        return '\n\t{}'.format('\t'.join(self.stderr.splitlines(True)))
+        return '{} has not been tracked by git!'.format(self.filename)
 
 
 def read_gitignore_patterns():
@@ -118,10 +117,10 @@ def update_link_metadata(checks):
             tag = json.load(tag_json)
             products = tag['signed']['products']
 
-        stderr = git_ls_files(products)
-        if stderr:
-            os.remove(tag_link)
-            raise UntrackedFileException(stderr)
+        for product in products:
+            if not git_ls_files(product):
+                os.remove(tag_link)
+                raise UntrackedFileException(product)
 
         # Tell pipeline which tag link metadata to use.
         write_file(metadata_file_tracker, tag_link)

--- a/datadog_checks_dev/tests/tooling/test_git.py
+++ b/datadog_checks_dev/tests/tooling/test_git.py
@@ -6,7 +6,7 @@ import mock
 from datadog_checks.dev.tooling.constants import set_root
 from datadog_checks.dev.tooling.git import (
     get_current_branch, files_changed, get_commits_since, git_show_file,
-    git_commit, git_tag, git_tag_list, git_ls_files
+    git_commit, git_tag, git_tag_list
 )
 
 
@@ -50,15 +50,6 @@ def test_git_show_file():
             git_show_file('path-string', 'git-ref-string')
             chdir.assert_called_once_with('/foo/')
             run.assert_called_once_with('git show git-ref-string:path-string', capture=True)
-
-
-def test_git_ls_files():
-    with mock.patch('datadog_checks.dev.tooling.git.chdir') as chdir:
-        with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
-            set_root('/foo/')
-            git_ls_files(['bar1', 'bar2'])
-            chdir.assert_called_once_with('/foo/')
-            run.assert_called_once_with('git ls-files --error-unmatch bar1 bar2', capture=True)
 
 
 def test_git_commit():


### PR DESCRIPTION
### Motivation

Max call string length on Windows is 32k, meaning releasing all checks fails https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessa

No changelog since no release yet