### PR TITLE
Refactor openstack_controller check api and back caches

### DIFF
--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -645,7 +645,7 @@ class OpenStackControllerCheck(AgentCheck):
             raise IncompleteConfig()
 
         # have we been backed off
-        if not self._backoff.should_run(self.instance_name):
+        if not self._backoff.should_run():
             self.log.info('Skipping run due to exponential backoff in effect')
             return
 
@@ -748,13 +748,13 @@ class OpenStackControllerCheck(AgentCheck):
                 self.warning("Error reaching nova API: %s" % e)
             else:
                 # exponential backoff
-                self.do_backoff(self.instance_name, custom_tags)
+                self.do_backoff(custom_tags)
                 return
 
-        self._backoff.reset_backoff(self.instance_name)
+        self._backoff.reset_backoff()
 
-    def do_backoff(self, instance_name, tags):
-        backoff_interval, retries = self._backoff.do_backoff(instance_name)
+    def do_backoff(self, tags):
+        backoff_interval, retries = self._backoff.do_backoff()
 
         self.gauge("openstack.backoff.interval", backoff_interval, tags=tags)
         self.gauge("openstack.backoff.retries", retries, tags=tags)

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -565,7 +565,7 @@ class OpenStackControllerCheck(AgentCheck):
         Communicates with the identity server and initializes a new scope when one is absent, or has been forcibly
         removed due to token expiry
         """
-        api = None
+        api = self._api
         custom_tags = custom_tags or []
         keystone_server_url = instance_config.get("keystone_server_url")
         proxy_config = self.get_instance_proxy(instance_config, keystone_server_url)

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -121,10 +121,9 @@ class OpenStackControllerCheck(AgentCheck):
         super(OpenStackControllerCheck, self).__init__(name, init_config, agentConfig, instances)
         # We cache all api instances.
         # This allows to cache connection if the underlying implementation support it
-        # Ex: _apis = {
+        # Ex: _api =
         #   <instance_name>: <api object>
-        # }
-        self._apis = {}
+        self._api = None
 
         # BackOffRetry supports multiple instances
         self._backoff = BackOffRetry()
@@ -140,15 +139,12 @@ class OpenStackControllerCheck(AgentCheck):
         # Mapping of Nova-managed servers to tags for current instance name
         self.external_host_tags = {}
 
-    def delete_apis_cache(self, instance_name):
-        for name, scope in list(iteritems(self._apis)):
-            if name == instance_name:
-                self.log.debug("Deleting instance api for instance: %s", name)
-                del self._apis[name]
+    def delete_api_cache(self):
+        del self._api
 
-    def set_apis_cache(self, instance_name, api):
-        self.log.debug("Setting api for instance %s", instance_name)
-        self._apis[instance_name] = api
+    def set_api_cache(self, api):
+        self.log.debug("Setting api")
+        self._api = api
 
     def collect_networks_metrics(self, tags, network_ids, exclude_network_id_rules):
         """
@@ -573,9 +569,8 @@ class OpenStackControllerCheck(AgentCheck):
         custom_tags = custom_tags or []
         keystone_server_url = instance_config.get("keystone_server_url")
         proxy_config = self.get_instance_proxy(instance_config, keystone_server_url)
-        try:
-            api = self._apis[self.instance_name]
-        except KeyError:
+
+        if self._api is None:
             # We are missing the entire instance scope either because it is the first time we initialize it or because
             # authentication previously failed and got removed from the cache
             # Let's populate it now
@@ -632,7 +627,7 @@ class OpenStackControllerCheck(AgentCheck):
             # Fast fail in the absence of an api
             raise IncompleteConfig()
         # Set api to apis cache
-        self.set_apis_cache(self.instance_name, api)
+        self.set_api_cache(api)
         return api
 
     @traced
@@ -742,7 +737,7 @@ class OpenStackControllerCheck(AgentCheck):
                 self.warning("Configuration Incomplete! Check your openstack.yaml file")
         except AuthenticationNeeded:
             # Delete the scope, we'll populate a new one on the next run for this instance
-            self.delete_api_cache(self.instance_name)
+            self.delete_api_cache()
         except (requests.exceptions.HTTPError, requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
             if isinstance(e, requests.exceptions.HTTPError) and e.response.status_code < 500:
                 self.warning("Error reaching nova API: %s" % e)
@@ -776,32 +771,32 @@ class OpenStackControllerCheck(AgentCheck):
 
     # Nova Proxy methods
     def get_nova_endpoint(self):
-        return self._apis.get(self.instance_name).get_nova_endpoint()
+        return self._api.get_nova_endpoint()
 
     def get_os_hypervisor_uptime(self, hyp_id):
-        return self._apis.get(self.instance_name).get_os_hypervisor_uptime(hyp_id)
+        return self._api.get_os_hypervisor_uptime(hyp_id)
 
     def get_os_aggregates(self):
-        return self._apis.get(self.instance_name).get_os_aggregates()
+        return self._api.get_os_aggregates()
 
     def get_os_hypervisors_detail(self):
-        return self._apis.get(self.instance_name).get_os_hypervisors_detail()
+        return self._api.get_os_hypervisors_detail()
 
     def get_servers_detail(self, query_params):
-        return self._apis.get(self.instance_name).get_servers_detail(query_params)
+        return self._api.get_servers_detail(query_params)
 
     def get_server_diagnostics(self, server_id):
-        return self._apis.get(self.instance_name).get_server_diagnostics(server_id)
+        return self._api.get_server_diagnostics(server_id)
 
     def get_project_limits(self, tenant_id):
-        return self._apis.get(self.instance_name).get_project_limits(tenant_id)
+        return self._api.get_project_limits(tenant_id)
 
     def get_flavors_detail(self, query_params):
-        return self._apis.get(self.instance_name).get_flavors_detail(query_params)
+        return self._api.get_flavors_detail(query_params)
 
     # Keystone Proxy Methods
     def get_projects(self, include_project_name_rules, exclude_project_name_rules):
-        projects = self._apis.get(self.instance_name).get_projects()
+        projects = self._api.get_projects()
         project_by_name = {}
         for project in projects:
             name = project.get('name')
@@ -814,7 +809,7 @@ class OpenStackControllerCheck(AgentCheck):
 
     # Neutron Proxy Methods
     def get_neutron_endpoint(self):
-        return self._apis.get(self.instance_name).get_neutron_endpoint()
+        return self._api.get_neutron_endpoint()
 
     def get_networks(self):
-        return self._apis.get(self.instance_name).get_networks()
+        return self._api.get_networks()

--- a/openstack_controller/datadog_checks/openstack_controller/retry.py
+++ b/openstack_controller/datadog_checks/openstack_controller/retry.py
@@ -13,31 +13,31 @@ MAX_BACKOFF_SECS = 300
 class BackOffRetry(object):
 
     def __init__(self):
-        self.backoff = {}
+        self.backoff = None
         self.random = SystemRandom()
 
-    def should_run(self, instance_name):
-        if instance_name not in self.backoff:
-            self.backoff[instance_name] = {'retries': 0, 'scheduled': time.time()}
+    def should_run(self):
+        if self.backoff is None:
+            self.backoff = {'retries': 0, 'scheduled': time.time()}
 
-        if self.backoff[instance_name]['scheduled'] <= time.time():
+        if self.backoff['scheduled'] <= time.time():
             return True
 
         return False
 
-    def do_backoff(self, instance_name):
-        tracker = self.backoff[instance_name]
+    def do_backoff(self):
+        tracker = self.backoff
 
-        self.backoff[instance_name]['retries'] += 1
-        jitter = min(MAX_BACKOFF_SECS, BASE_BACKOFF_SECS * 2 ** self.backoff[instance_name]['retries'])
+        self.backoff['retries'] += 1
+        jitter = min(MAX_BACKOFF_SECS, BASE_BACKOFF_SECS * 2 ** self.backoff['retries'])
 
         # let's add some jitter (half jitter)
         backoff_interval = jitter // 2
         backoff_interval += self.random.randint(0, backoff_interval)
 
         tracker['scheduled'] = time.time() + backoff_interval
-        return backoff_interval, self.backoff[instance_name]['retries']
+        return backoff_interval, self.backoff['retries']
 
-    def reset_backoff(self, instance_name):
-        self.backoff[instance_name]['retries'] = 0
-        self.backoff[instance_name]['scheduled'] = time.time()
+    def reset_backoff(self):
+        self.backoff['retries'] = 0
+        self.backoff['scheduled'] = time.time()

--- a/openstack_controller/tests/test_retry.py
+++ b/openstack_controller/tests/test_retry.py
@@ -12,21 +12,21 @@ def test_retry():
     instance = copy.deepcopy(common.MOCK_CONFIG["instances"][0])
     instance['tags'] = ['optional:tag1']
     retry = BackOffRetry()
-    assert retry.should_run('test_name') is True
-    assert retry.backoff["test_name"]['retries'] == 0
+    assert retry.should_run() is True
+    assert retry.backoff['retries'] == 0
     # Make sure it is idempotent
-    assert retry.should_run('test_name') is True
-    assert retry.backoff["test_name"]['retries'] == 0
+    assert retry.should_run() is True
+    assert retry.backoff['retries'] == 0
 
-    retry.do_backoff('test_name')
-    assert retry.should_run('test_name') is False
-    assert retry.backoff["test_name"]['retries'] == 1
-    scheduled_1 = retry.backoff["test_name"]['scheduled']
-    retry.do_backoff('test_name')
-    scheduled_2 = retry.backoff["test_name"]['scheduled']
-    retry.do_backoff('test_name')
-    scheduled_3 = retry.backoff["test_name"]['scheduled']
-    retry.do_backoff('test_name')
-    scheduled_4 = retry.backoff["test_name"]['scheduled']
-    assert retry.backoff["test_name"]['retries'] == 4
+    retry.do_backoff()
+    assert retry.should_run() is False
+    assert retry.backoff['retries'] == 1
+    scheduled_1 = retry.backoff['scheduled']
+    retry.do_backoff()
+    scheduled_2 = retry.backoff['scheduled']
+    retry.do_backoff()
+    scheduled_3 = retry.backoff['scheduled']
+    retry.do_backoff()
+    scheduled_4 = retry.backoff['scheduled']
+    assert retry.backoff['retries'] == 4
     assert time.time() < scheduled_1 < scheduled_2 < scheduled_3 < scheduled_4


### PR DESCRIPTION
### What does this PR do?

Changing `self._apis[instance_name]` to `self._api` in OpenStackControllerCheck.
Changing `self.backoff[instance_name]` to `self.backoff` in BackOffRetry.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
