### PR TITLE
Add queue exclude example to rabbitmq config

### DIFF
--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -58,6 +58,7 @@ instances:
     #   - thisqueue-.*
     #   - another_\d+queue
     #   - (lepidorae)-\d+   # to tag queues in the lepidorae queue_family
+    #   - ^((?!errors|aliveness).)*$   # exclude queues with 'errors' or 'aliveness'
     
     # Use the `exchanges` or `exchanges_regexes` parameters to specify the exchanges you'd like to
     # collect metrics on (up to 50 exchanges).


### PR DESCRIPTION
### What does this PR do?

Adds example or queue exclusion to rabbit config.

### Motivation

No example on how to exclude queues via regex,

### Additional Notes

n/a

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
