### PR TITLE
Add ability to pass -m & -k to pytest

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -27,14 +27,30 @@ def display_envs(check_envs):
 @click.option('--style', '-s', is_flag=True, help='Run only style checks')
 @click.option('--bench', '-b', is_flag=True, help='Run only benchmarks')
 @click.option('--cov', '-c', 'coverage', is_flag=True, help='Measure code coverage')
-@click.option('--cov-missing', '-m', is_flag=True, help='Show line numbers of statements that were not executed')
+@click.option('--cov-missing', '-cm', is_flag=True, help='Show line numbers of statements that were not executed')
+@click.option('--marker', '-m', help='Only run tests matching given marker expression')
+@click.option('--filter', '-k', 'test_filter', help='Only run tests matching given substring expression')
 @click.option('--pdb', 'enter_pdb', is_flag=True, help='Drop to PDB on first failure, then end test session')
 @click.option('--debug', '-d', is_flag=True, help='Set the log level to debug')
 @click.option('--verbose', '-v', count=True, help='Increase verbosity (can be used additively)')
 @click.option('--list', '-l', 'list_envs', is_flag=True, help='List available test environments')
 @click.option('--changed', is_flag=True, help='Only test changed checks')
 @click.option('--cov-keep', is_flag=True, help='Keep coverage reports')
-def test(checks, style, bench, coverage, cov_missing, enter_pdb, debug, verbose, list_envs, changed, cov_keep):
+def test(
+    checks,
+    style,
+    bench,
+    coverage,
+    cov_missing,
+    marker,
+    test_filter,
+    enter_pdb,
+    debug,
+    verbose,
+    list_envs,
+    changed,
+    cov_keep,
+):
     """Run tests for Agent-based checks.
 
     If no checks are specified, this will only test checks that
@@ -53,12 +69,18 @@ def test(checks, style, bench, coverage, cov_missing, enter_pdb, debug, verbose,
     root = get_root()
     testing_on_ci = running_on_ci()
 
+    # Implicitly track coverage
+    if cov_missing:
+        coverage = True
+
     pytest_options = construct_pytest_options(
         verbose=verbose,
         enter_pdb=enter_pdb,
         debug=debug,
         bench=bench,
-        coverage=coverage
+        coverage=coverage,
+        marker=marker,
+        test_filter=test_filter,
     )
     coverage_show_missing_lines = str(cov_missing or testing_on_ci)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -139,7 +139,9 @@ def fix_coverage_report(check, report_file):
     write_file_binary(report_file, report)
 
 
-def construct_pytest_options(verbose=0, enter_pdb=False, debug=False, bench=False, coverage=False):
+def construct_pytest_options(
+    verbose=0, enter_pdb=False, debug=False, bench=False, coverage=False, marker='', test_filter=''
+):
     # Prevent no verbosity
     pytest_options = '--verbosity={}'.format(verbose or 1)
 
@@ -166,6 +168,12 @@ def construct_pytest_options(verbose=0, enter_pdb=False, debug=False, bench=Fals
             # This will be formatted to the appropriate coverage paths for each package
             ' {}'
         )
+
+    if marker:
+        pytest_options += ' -m {}'.format(marker)
+
+    if test_filter:
+        pytest_options += ' -k {}'.format(test_filter)
 
     return pytest_options
 


### PR DESCRIPTION
### Motivation

We'll remove every tox env that tests just a specific marker, which should reduce our ci time by 10-20%. To iterate rapidly locally you can use these flags instead.