### PR TITLE
update windows_service config file

### DIFF
--- a/windows_service/README.md
+++ b/windows_service/README.md
@@ -22,9 +22,9 @@ instances:
   ##
   ## If any service is set to `ALL`, all services registered with the SCM will be monitored.
   ##
-  ## The services are treated as regular expressions to allow for advanced matching. So if
-  ## you say `Event.*`, the check will monitor any service starting with the word `Event`.
-  #
+  ## This matches all services starting with service, as if service.* is configured.
+  ## For an exact match, use ^service$
+  
   - services:
       - <SERVICE_NAME_1>
       - <SERVICE_NAME_2>

--- a/windows_service/README.md
+++ b/windows_service/README.md
@@ -24,7 +24,7 @@ instances:
   ##
   ## This matches all services starting with service, as if service.* is configured.
   ## For an exact match, use ^service$
-  
+  #
   - services:
       - <SERVICE_NAME_1>
       - <SERVICE_NAME_2>

--- a/windows_service/datadog_checks/windows_service/data/conf.yaml.example
+++ b/windows_service/datadog_checks/windows_service/data/conf.yaml.example
@@ -5,9 +5,9 @@ instances:
   ## List of services to monitor e.g. Dnscache, wmiApSrv, etc.
   ##
   ## If any service is set to `ALL`, all services registered with the SCM will be monitored.
-  ##
-  ## The services are treated as regular expressions to allow for advanced matching. So if
-  ## you say `Event.*`, the check will monitor any service starting with the word `Event`.
+  ##  
+  ## This matches all services starting with service, as if service.* is configured.
+  ## For an exact match, use ^service$
   #
   - services:
       - <SERVICE_NAME_1>


### PR DESCRIPTION
### What does this PR do?
Changes the windows_service integration config file. Previously it had implied that exact matching is done, when actually keyword.* matching is done. Specifies that you should use ^keyword$ if you want exact matching.

### Motivation

Support request h/t @HadhemiDD 

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
