### PR TITLE
Fix aerospike E2E

### DIFF
--- a/aerospike/tests/common.py
+++ b/aerospike/tests/common.py
@@ -25,6 +25,6 @@ INSTANCE = {
         'truncate_lut',
         'memory_data_bytes',
     ],
-    'namespaces': {'test'},
+    'namespaces': ['test'],
     'tags': ['tag:value'],
 }


### PR DESCRIPTION
### What does this PR do?

There was a json serialization error in the plugin.py file when you spin up aerospike E2E. The reason was because it was choking trying to serialize a set. This changes the `instance` to just use a list instead. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
