### PR TITLE
Remove Encrypted column from results

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -852,7 +852,8 @@ class MySql(AgentCheck):
         try:
             with closing(db.cursor()) as cursor:
                 cursor.execute("SHOW BINARY LOGS;")
-                master_logs = dict(cursor.fetchall())
+                cursor_results = cursor.fetchall()
+                master_logs = {result[0]: result[1] for result in cursor_results}
 
                 binary_log_space = 0
                 for key, value in iteritems(master_logs):


### PR DESCRIPTION
### What does this PR do?

From version 8.0.14 and above of MySQL CE, an `Encrypted` column has been added: https://dev.mysql.com/doc/refman/8.0/en/show-binary-logs.html, we do not need it to compute the binary log stats. Without this update, the check would raise an Exception: `ValueError: dictionary update sequence element #0 has length 3; 2 is required` (the third element being that `Encrypted` column.

### Motivation

Customer report

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.