### PR TITLE
Refactor - use range instead of xrange

### DIFF
--- a/btrfs/datadog_checks/btrfs/btrfs.py
+++ b/btrfs/datadog_checks/btrfs/btrfs.py
@@ -12,7 +12,7 @@ import struct
 
 import psutil
 from six import iteritems
-from six.moves import xrange
+from six.moves import range
 
 from datadog_checks.checks import AgentCheck
 
@@ -126,7 +126,7 @@ class BTRFS(AgentCheck):
             fcntl.ioctl(fd, BTRFS_IOC_SPACE_INFO, data)
 
         _, total_spaces = TWO_LONGS_STRUCT.unpack_from(ret, 0)
-        for offset in xrange(TWO_LONGS_STRUCT.size, buffer_size, THREE_LONGS_STRUCT.size):
+        for offset in range(TWO_LONGS_STRUCT.size, buffer_size, THREE_LONGS_STRUCT.size):
             # https://github.com/spotify/linux/blob/master/fs/btrfs/ioctl.h#L40-L44
             flags, total_bytes, used_bytes = THREE_LONGS_STRUCT.unpack_from(data, offset)
             results.append((flags, total_bytes, used_bytes))
@@ -145,7 +145,7 @@ class BTRFS(AgentCheck):
             max_id, num_devices = fs_info[0], fs_info[1]
 
             # Loop through all devices, and sum the number of unallocated bytes on each one
-            for dev_id in xrange(max_id + 1):
+            for dev_id in range(max_id + 1):
                 if num_devices == 0:
                     break
                 try:


### PR DESCRIPTION
### Motivation

Both use py3 version https://github.com/DataDog/integrations-core/pull/2900/files#r246194134