### PR TITLE
[Istio] Migrating configuration file to new norm

### DIFF
--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -1,14 +1,31 @@
 init_config:
 
 instances:
-  # To enable Istio metrics you must specify the url exposing the API
+
+  ## @param istio_mesh_endpoint - string - required
+  ## To enable Istio metrics you must specify the url exposing the API
+  ##
+  ## Note for RHEL and SUSE users: due to compatibility issues, the check does not make use of
+  ## the CPP extension to process Protocol buffer messages coming from the api. Depending
+  ## on the metrics volume, the check may run very slowly.
   #
-  # Note for RHEL and SUSE users: due to compatibility issues, the check does not make use of
-  # the CPP extension to process Protocol buffer messages coming from the api. Depending
-  # on the metrics volume, the check may run very slowly.
   - istio_mesh_endpoint: http://istio-telemetry.istio-system:42422/metrics
+
+  ## @param mixer_endpoint - string - required
+  ## 
+  #
     mixer_endpoint: http://istio-telemetry.istio-system:9093/metrics
+
+  ## @param send_histograms_buckets - boolean - required
+  ##
+  #
     send_histograms_buckets: true
-    # tags:
-    #   - optional_tag1
-    #   - optional_tag2
+
+  ## @param tags  - list of key:value elements - optional
+  ## List of tags to attach to every metric, event and service check emitted by this integration.
+  ##
+  ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+  #
+  #  tags:
+  #    - <KEY_1>:<VALUE_1>
+  #    - <KEY_2>:<VALUE_2>

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -12,12 +12,13 @@ instances:
   - istio_mesh_endpoint: http://istio-telemetry.istio-system:42422/metrics
 
   ## @param mixer_endpoint - string - required
-  ## 
+  ## Define the mixer endpoint in order to collect all Prometheus metrics on the Mixer process as well
+  ## as gRPC metrics related to API calls and metrics on adapter dispatch.
   #
     mixer_endpoint: http://istio-telemetry.istio-system:9093/metrics
 
   ## @param send_histograms_buckets - boolean - required
-  ##
+  ## Set send_histograms_buckets to true to send the histograms bucket from Istio. 
   #
     send_histograms_buckets: true
 


### PR DESCRIPTION
### What does this PR do?

Migrates Istio configuration file to the new format.

mixer_endpoint
and
send_histograms_buckets 

are still missing a description