### PR TITLE
Increase requests timeout

### DIFF
--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -10,9 +10,11 @@ import os
 import shutil
 import tempfile
 
-# Turn off TUF file logging.
 import tuf.settings
+# Turn off TUF file logging.
 tuf.settings.ENABLE_FILE_LOGGING = False
+# Increase requests timeout.
+tuf.settings.SOCKET_TIMEOUT = 60
 
 # Import what we need from TUF.
 from tuf.client.updater import Updater


### PR DESCRIPTION
### What does this PR do?

Increase network timeout for `requests` (via TUF).

### Motivation

To reduce odds of users seeing spurious network issues from too onerous a timeout value [(example)](https://travis-ci.com/DataDog/integrations-core/builds/101834585#L1791).

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
