### PR TITLE
Make a new exception for in-toto parameter substitutions, and add comments

### DIFF
--- a/datadog_checks_downloader/datadog_checks/downloader/parameters.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/parameters.py
@@ -14,6 +14,7 @@ from pkg_resources import safe_name
 EXCEPTIONS = {
     'datadog_checks_base',
     'datadog_checks_dev',
+    'datadog_checks_downloader',
 }
 
 
@@ -24,13 +25,17 @@ def substitute(target_relpath):
     assert wheel_distribution_name.startswith('datadog_'), wheel_distribution_name
     standard_distribution_name = safe_name(wheel_distribution_name)
 
-    # These names are the exceptions.
+    # These names are the exceptions. In this case, the wheel distribution name
+    # matches exactly the directory name of the check on GitHub.
     if wheel_distribution_name in EXCEPTIONS:
         package_github_dir = wheel_distribution_name
     # FIXME: This is the only other package at the time of writing (Sep 7 2018)
     # that does not replace `-` with `_`.
     elif wheel_distribution_name == 'datadog_go_metro':
         package_github_dir = 'go-metro'
+    # Otherwise, the prefix of the wheel distribution name is expected to be
+    # "datadog-", and the directory name of the check on GitHub is expected not
+    # have this prefix.
     else:
         package_github_dir = wheel_distribution_name[8:]
 


### PR DESCRIPTION
### What does this PR do?

Make a new exception for in-toto parameter substitutions, and add comments.

### Motivation

To enable `datadog-checks-downloader` itself to be securely updated independently of the Agent release.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
