### PR TITLE
No need to switch back to previous cwd

### DIFF
--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -166,7 +166,6 @@ class TUFDownloader:
     def __verify_in_toto_metadata(self, target_relpath, in_toto_metadata_relpaths, pubkey_relpaths):
         # Make a temporary directory.
         tempdir = tempfile.mkdtemp()
-        prev_cwd = os.getcwd()
 
         try:
             # Copy files over into temp dir.
@@ -192,8 +191,8 @@ class TUFDownloader:
             logger.exception('in-toto failed to verify {}'.format(target_relpath))
             raise
         finally:
-            os.chdir(prev_cwd)
-            # Delete temp dir.
+            # NOTE: No need to switch back to previous cwd, because we do not
+            # need it for anything else, but do delete the temp dir.
             shutil.rmtree(tempdir)
 
 


### PR DESCRIPTION
### What does this PR do?

Removes an unnecessary call to switch back to previous working directory.

### Motivation

To make it unnecessary to [set the CWD](https://github.com/DataDog/datadog-agent/pull/3067) for calling the downloader from the Agent.

### Additional Notes

Let's keep [the other PR](https://github.com/DataDog/datadog-agent/pull/3067) merged for now until we test that this will work when integrated with the Agent itself. Thanks for your kind understanding!

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
