### PR TITLE
Properly detect integration folder for py3 validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/py3.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/py3.py
@@ -8,7 +8,6 @@ from operator import itemgetter
 from a7 import validate_py3
 
 from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
-from ...constants import get_root
 from ...utils import get_valid_checks, get_version_file
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/py3.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/py3.py
@@ -8,8 +8,8 @@ from operator import itemgetter
 from a7 import validate_py3
 
 from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
-from ...constants import get_root, NOT_CHECKS
-from ...utils import get_valid_checks
+from ...constants import get_root
+from ...utils import get_valid_checks, get_version_file
 
 
 @click.command(
@@ -22,11 +22,8 @@ def py3(check):
     can be an integration name or a valid path to a Python module or package folder.
     """
 
-    root = get_root()
-    if check == 'datadog_checks_base':
-        path_to_module = os.path.join(root, check, 'datadog_checks', 'base')
-    elif check in get_valid_checks() and check not in NOT_CHECKS:
-        path_to_module = os.path.join(root, check, 'datadog_checks', check)
+    if check in get_valid_checks():
+        path_to_module = os.path.dirname(get_version_file(check))
     else:
         path_to_module = check
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/requirements.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/requirements.py
@@ -60,24 +60,6 @@ class Package:
         except (AttributeError, TypeError):
             return NotImplemented
 
-    def __cmp__(self, other):
-        """
-        This is here only to provide Python2 backward compat
-        """
-        eq = self.__eq__(other)
-        if eq != NotImplemented and eq:
-            return 0
-
-        lt = self.__lt__(other)
-        if lt != NotImplemented and lt:
-            return -1
-
-        gt = self.__gt__(other)
-        if gt != NotImplemented and gt:
-            return 1
-
-        return NotImplemented
-
     def __hash__(self):
         return hash((self.name, self.version, self.marker))
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/requirements.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/requirements.py
@@ -60,6 +60,24 @@ class Package:
         except (AttributeError, TypeError):
             return NotImplemented
 
+    def __ne__(self, other):
+        eq = self.__eq__(other)
+        if eq != NotImplemented:
+            return not eq
+        return NotImplemented
+
+    def __le__(self, other):
+        gt = self.__gt__(other)
+        if gt != NotImplemented:
+            return not gt
+        return NotImplemented
+
+    def __ge__(self, other):
+        lt = self.__lt__(other)
+        if lt != NotImplemented:
+            return not lt
+        return NotImplemented
+
     def __hash__(self):
         return hash((self.name, self.version, self.marker))
 


### PR DESCRIPTION
### What does this PR do?

The proper folder is the directory where the version file is. Let's reuse that and not duplicate the logic.

### Motivation

tests failed for datadog_check_downloader with ```/Users/hippolytehenry/Datadog/integrations-core/datadog_checks_downloader/datadog_checks/datadog_checks_downloader does not exist.```

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.