### PR TITLE
Allow to filter out old pods when parsing the podlist to reduce memory usage

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -38,14 +38,12 @@ pymongo==3.5.1
 pymqi==1.8.0; sys_platform != 'win32' and sys_platform != 'darwin'
 pymysql==0.8.0
 pyodbc==4.0.22
-pyRFC3339==1.1
 pyro4==4.73; sys_platform == 'win32'
 pysmi==0.2.2
 pysnmp==4.4.3
 pysnmp-mibs==0.1.6
 python-binary-memcached==0.26.1; sys_platform != 'win32'
 python3-gearman==0.1.0; sys_platform != 'win32' and python_version > '3.0'
-pytz==2018.9
 pyvmomi==v6.5.0.2017.5-1
 pywin32==224; sys_platform == 'win32'
 pyyaml==3.13

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -12,7 +12,6 @@ enum34==1.1.6
 flup==1.0.3.dev-20110405; python_version < '3.0'
 gearman==2.0.2; sys_platform != 'win32' and python_version < '3.0'
 httplib2==0.10.3
-ijson==2.3
 in-toto==0.2.3
 ipaddress==1.0.22
 jaydebeapi==1.1.1

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -38,12 +38,14 @@ pymongo==3.5.1
 pymqi==1.8.0; sys_platform != 'win32' and sys_platform != 'darwin'
 pymysql==0.8.0
 pyodbc==4.0.22
+pyRFC3339==1.1
 pyro4==4.73; sys_platform == 'win32'
 pysmi==0.2.2
 pysnmp==4.4.3
 pysnmp-mibs==0.1.6
 python-binary-memcached==0.26.1; sys_platform != 'win32'
 python3-gearman==0.1.0; sys_platform != 'win32' and python_version > '3.0'
+pytz==2018.9
 pyvmomi==v6.5.0.2017.5-1
 pywin32==224; sys_platform == 'win32'
 pyyaml==3.13

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -12,6 +12,7 @@ enum34==1.1.6
 flup==1.0.3.dev-20110405; python_version < '3.0'
 gearman==2.0.2; sys_platform != 'win32' and python_version < '3.0'
 httplib2==0.10.3
+ijson==2.3
 in-toto==0.2.3
 ipaddress==1.0.22
 jaydebeapi==1.1.1

--- a/datadog_checks_base/datadog_checks/base/utils/date.py
+++ b/datadog_checks_base/datadog_checks/base/utils/date.py
@@ -1,0 +1,86 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copied from the kubernetes-client/python-base repository as a workaround for
+# https://github.com/kubernetes-client/python/issues/771
+#
+# Original URL:
+# https://github.com/kubernetes-client/python-base/blob/824c03c7eee71dd5ac52fada8d7d36aecf81a781/config/dateutil.py
+
+import datetime
+import math
+import re
+
+
+class TimezoneInfo(datetime.tzinfo):
+    def __init__(self, h, m):
+        self._name = "UTC"
+        if h != 0 and m != 0:
+            self._name += "%+03d:%2d" % (h, m)
+        self._delta = datetime.timedelta(hours=h, minutes=math.copysign(m, h))
+
+    def utcoffset(self, dt):
+        return self._delta
+
+    def tzname(self, dt):
+        return self._name
+
+    def dst(self, dt):
+        return datetime.timedelta(0)
+
+
+UTC = TimezoneInfo(0, 0)
+
+# ref https://www.ietf.org/rfc/rfc3339.txt
+_re_rfc3339 = re.compile(r"(\d\d\d\d)-(\d\d)-(\d\d)"        # full-date
+                         r"[ Tt]"                           # Separator
+                         r"(\d\d):(\d\d):(\d\d)([.,]\d+)?"  # partial-time
+                         r"([zZ ]|[-+]\d\d?:\d\d)?",        # time-offset
+                         re.VERBOSE + re.IGNORECASE)
+_re_timezone = re.compile(r"([-+])(\d\d?):?(\d\d)?")
+
+
+def parse_rfc3339(s):
+    if isinstance(s, datetime.datetime):
+        # no need to parse it, just make sure it has a timezone.
+        if not s.tzinfo:
+            return s.replace(tzinfo=UTC)
+        return s
+    groups = _re_rfc3339.search(s).groups()
+    dt = [0] * 7
+    for x in range(6):
+        dt[x] = int(groups[x])
+    if groups[6] is not None:
+        dt[6] = int(groups[6])
+    tz = UTC
+    if groups[7] is not None and groups[7] != 'Z' and groups[7] != 'z':
+        tz_groups = _re_timezone.search(groups[7]).groups()
+        hour = int(tz_groups[1])
+        minute = 0
+        if tz_groups[0] == "-":
+            hour *= -1
+        if tz_groups[2]:
+            minute = int(tz_groups[2])
+        tz = TimezoneInfo(hour, minute)
+    return datetime.datetime(
+        year=dt[0], month=dt[1], day=dt[2],
+        hour=dt[3], minute=dt[4], second=dt[5],
+        microsecond=dt[6], tzinfo=tz)
+
+
+def format_rfc3339(date_time):
+    if date_time.tzinfo is None:
+        date_time = date_time.replace(tzinfo=UTC)
+    date_time = date_time.astimezone(UTC)
+    return date_time.strftime('%Y-%m-%dT%H:%M:%SZ')

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -11,7 +11,8 @@ from datetime import datetime, timedelta
 import json
 
 import requests
-from kubernetes.config.dateutil import parse_rfc3339, UTC
+from pyrfc3339 import parse as parse_rfc3339
+from pytz import utc as UTC
 
 from datadog_checks.checks import AgentCheck
 from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
@@ -273,7 +274,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
             return podlist
         except Exception as e:
             self.log.warning('failed to retrieve pod list from the kubelet at %s : %s'
-                           % (self.pod_list_url, str(e)))
+                             % (self.pod_list_url, str(e)))
             return None
 
     @staticmethod

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -274,7 +274,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
             return pod_list
         except Exception as e:
             self.log.warning('failed to retrieve pod list from the kubelet at %s : %s'
-                           % (self.pod_list_url, str(e)))
+                             % (self.pod_list_url, str(e)))
             return None
 
     @staticmethod

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -11,8 +11,8 @@ from datetime import datetime, timedelta
 import json
 
 import requests
-from kubernetes.config.dateutil import parse_rfc3339, UTC
 
+from datadog_checks.base.utils.date import parse_rfc3339, UTC
 from datadog_checks.checks import AgentCheck
 from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.errors import CheckException

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -11,8 +11,7 @@ from datetime import datetime, timedelta
 import json
 
 import requests
-from pyrfc3339 import parse as parse_rfc3339
-from pytz import utc as UTC
+from kubernetes.config.dateutil import parse_rfc3339, UTC
 
 from datadog_checks.checks import AgentCheck
 from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
@@ -275,7 +274,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
             return pod_list
         except Exception as e:
             self.log.warning('failed to retrieve pod list from the kubelet at %s : %s'
-                             % (self.pod_list_url, str(e)))
+                           % (self.pod_list_url, str(e)))
             return None
 
     @staticmethod

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -261,18 +261,18 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
             with self.perform_kubelet_query(self.pod_list_url, stream=True) as r:
                 if cutoff_date:
                     f = ExpiredPodFilter(cutoff_date)
-                    podlist = json.load(r.raw, object_hook=f.json_hook)
-                    podlist['expired_count'] = f.expired_count
-                    if podlist.get("items") is not None:
+                    pod_list = json.load(r.raw, object_hook=f.json_hook)
+                    pod_list['expired_count'] = f.expired_count
+                    if pod_list.get("items") is not None:
                         # Wrap items in a generator to filter our None items
-                        podlist['items'] = (p for p in podlist['items'] if p is not None)
+                        pod_list['items'] = (p for p in pod_list['items'] if p is not None)
                 else:
-                    podlist = json.load(r.raw)
+                    pod_list = json.load(r.raw)
 
-            if podlist.get("items") is None:
+            if pod_list.get("items") is None:
                 # Sanitize input: if no pod are running, 'items' is a NoneObject
-                podlist['items'] = []
-            return podlist
+                pod_list['items'] = []
+            return pod_list
         except Exception as e:
             self.log.warning('failed to retrieve pod list from the kubelet at %s : %s'
                              % (self.pod_list_url, str(e)))

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -76,19 +76,19 @@ class ExpiredPodFilter(object):
         self.expired_count = 0
         self.cutoff_date = cutoff_date
 
-    def json_hook(self, pod):
+    def json_hook(self, obj):
         # Not a pod (hook is called for all objects)
-        if 'metadata' not in pod or 'status' not in pod:
-            return pod
+        if 'metadata' not in obj or 'status' not in obj:
+            return obj
 
         # Quick exit for running/pending containers
-        pod_phase = pod.get('status', {}).get('phase')
+        pod_phase = obj.get('status', {}).get('phase')
         if pod_phase in ["Running", "Pending"]:
-            return pod
+            return obj
 
         # Filter out expired terminated pods, based on container finishedAt time
         expired = True
-        for ctr in pod['status'].get('containerStatuses', []):
+        for ctr in obj['status'].get('containerStatuses', []):
             if "terminated" not in ctr.get("state", {}):
                 expired = False
                 break
@@ -100,7 +100,7 @@ class ExpiredPodFilter(object):
                 expired = False
                 break
         if not expired:
-            return pod
+            return obj
 
         # We are ignoring this pod
         self.expired_count += 1

--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -1,6 +1,7 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 kubernetes.containers.last_state.terminated,gauge,,,,The number of containers that were previously terminated,0,kubelet,k8s.containers.last_state.terminated
 kubernetes.pods.running,gauge,,,,The number of running pods,1,kubelet,k8s.pods.running
+kubernetes.pods.expired,gauge,,,,The number of expired pods the check ignored,-1,kubelet,k8s.pods.expired
 kubernetes.containers.running,gauge,,,,The number of running containers,1,kubelet,k8s.containers.running
 kubernetes.containers.restarts,gauge,,,,The number of times the container has been restarted,1,kubelet,k8s.containers.restarts
 kubernetes.containers.state.terminated,gauge,,,,The number of currently terminated containers,0,kubelet,k8s.containers.state.terminated

--- a/kubelet/requirements.in
+++ b/kubelet/requirements.in
@@ -1,1 +1,3 @@
-# integration pip requirements
+ijson==2.3
+cffi==1.11.5
+kubernetes==8.0.1

--- a/kubelet/requirements.in
+++ b/kubelet/requirements.in
@@ -1,1 +1,0 @@
-kubernetes==8.0.1

--- a/kubelet/requirements.in
+++ b/kubelet/requirements.in
@@ -1,2 +1,1 @@
-pyRFC3339==1.1
-pytz==2018.9
+kubernetes==8.0.1

--- a/kubelet/requirements.in
+++ b/kubelet/requirements.in
@@ -1,3 +1,1 @@
-ijson==2.3
-cffi==1.11.5
 kubernetes==8.0.1

--- a/kubelet/requirements.in
+++ b/kubelet/requirements.in
@@ -1,1 +1,2 @@
-kubernetes==8.0.1
+pyRFC3339==1.1
+pytz==2018.9

--- a/kubelet/tests/fixtures/pods_expired.json
+++ b/kubelet/tests/fixtures/pods_expired.json
@@ -1,0 +1,250 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [{
+      "metadata": {
+        "name": "dd-agent-ntepl",
+        "generateName": "dd-agent-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/dd-agent-ntepl",
+        "uid": "12ceeaa9-33ca-11e6-ac8f-42010af00003"
+      },
+      "spec": {},
+      "status": {
+        "phase": "Running",
+        "conditions": [{
+          "type": "Ready",
+          "status": "True",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2016-06-16T13:56:09Z"
+        }],
+        "hostIP": "10.240.0.9",
+        "podIP": "10.244.2.5",
+        "startTime": "2016-06-16T13:56:07Z",
+        "containerStatuses": [{
+          "name": "dd-agent",
+          "state": {
+            "running": {
+              "startedAt": "2016-06-16T13:56:08Z"
+            }
+          },
+          "lastState": {},
+          "ready": true,
+          "restartCount": 0,
+          "image": "datadog/docker-dd-agent:massi_ingest_k8s_events",
+          "imageID": "docker://22c8298aadea7bae69765758a88fc373118c9a0c332d23aa99869d4f84d75a8e",
+          "containerID": "docker://32fc50ecfe24df055f6d56037acb966337eef7282ad5c203a1be58f2dd2fe743"
+        }]
+      }
+    },
+    {
+      "metadata": {
+        "name": "hello1-1550504220-ljnzx",
+        "generateName": "hello1-1550504220-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/hello1-1550504220-ljnzx",
+        "uid": "0a5e233a-3393-11e9-a13f-42010a9c0082"
+      },
+      "spec": {},
+      "status": {
+        "phase": "Succeeded",
+        "conditions": [{
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-18T15:37:03Z",
+            "reason": "PodCompleted"
+          },
+          {
+            "type": "Ready",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-18T15:37:03Z",
+            "reason": "PodCompleted"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": null,
+            "reason": "PodCompleted"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-18T15:37:03Z"
+          }
+        ],
+        "hostIP": "10.156.0.36",
+        "podIP": "10.72.0.130",
+        "startTime": "2019-02-18T15:37:03Z",
+        "containerStatuses": [{
+          "name": "hello",
+          "state": {
+            "terminated": {
+              "exitCode": 0,
+              "reason": "Completed",
+              "startedAt": "2019-02-18T15:37:06Z",
+              "finishedAt": "2019-02-18T15:37:06Z",
+              "containerID": "docker://0c11e7adb7d2814de191c6de4a1678700f7434db8780a73f5775b8404bd3ee04"
+            }
+          },
+          "lastState": {},
+          "ready": false,
+          "restartCount": 0,
+          "image": "busybox:latest",
+          "imageID": "docker-pullable://busybox@sha256:4415a904b1aca178c2450fd54928ab362825e863c0ad5452fd020e92f7a6a47e",
+          "containerID": "docker://0c11e7adb7d2814de191c6de4a1678700f7434db8780a73f5775b8404bd3ee04"
+        }],
+        "qosClass": "Burstable"
+      }
+    },
+    {
+      "metadata": {
+        "name": "hello5-1550509440-rlgvf",
+        "generateName": "hello5-1550509440-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/hello5-1550509440-rlgvf",
+        "uid": "35024d26-339f-11e9-a13f-42010a9c0082"
+      },
+      "spec": {},
+      "status": {
+        "phase": "Succeeded",
+        "conditions": [{
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-18T17:04:09Z",
+            "reason": "PodCompleted"
+          },
+          {
+            "type": "Ready",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-18T17:04:09Z",
+            "reason": "PodCompleted"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": null,
+            "reason": "PodCompleted"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-18T17:04:09Z"
+          }
+        ],
+        "hostIP": "10.156.0.36",
+        "podIP": "10.72.0.235",
+        "startTime": "2019-02-18T17:04:09Z",
+        "containerStatuses": [{
+          "name": "hello",
+          "state": {
+            "terminated": {
+              "exitCode": 0,
+              "reason": "Completed",
+              "startedAt": "2019-02-18T17:04:12Z",
+              "finishedAt": "2019-02-18T17:04:13Z",
+              "containerID": "docker://a7721b1906fe3c130a50803ff1cbdb286c8cf0a4ce041a55d87e695e72a9ce4e"
+            }
+          },
+          "lastState": {},
+          "ready": false,
+          "restartCount": 0,
+          "image": "busybox:latest",
+          "imageID": "docker-pullable://busybox@sha256:4415a904b1aca178c2450fd54928ab362825e863c0ad5452fd020e92f7a6a47e",
+          "containerID": "docker://a7721b1906fe3c130a50803ff1cbdb286c8cf0a4ce041a55d87e695e72a9ce4e"
+        }],
+        "qosClass": "Burstable"
+      }
+    },
+    {
+      "metadata": {
+        "name": "hello8-1550505780-kdnjx",
+        "generateName": "hello8-1550505780-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/hello8-1550505780-kdnjx",
+        "uid": "ab06c814-3396-11e9-a13f-42010a9c0082"
+      },
+      "spec": {},
+      "status": {
+        "phase": "Succeeded",
+        "conditions": [{
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-18T16:03:02Z",
+            "reason": "PodCompleted"
+          },
+          {
+            "type": "Ready",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-18T16:03:02Z",
+            "reason": "PodCompleted"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": null,
+            "reason": "PodCompleted"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-18T16:03:01Z"
+          }
+        ],
+        "hostIP": "10.156.0.36",
+        "podIP": "10.72.0.98",
+        "startTime": "2019-02-18T16:03:02Z",
+        "containerStatuses": [{
+            "name": "expired",
+            "state": {
+              "terminated": {
+                "exitCode": 0,
+                "reason": "Completed",
+                "startedAt": "2019-02-18T16:03:05Z",
+                "finishedAt": "2019-02-18T16:03:05Z",
+                "containerID": "docker://b11c99327eaedd721d74a22d87cac957c887dfa551bf43512ee30586ef004321"
+              }
+            },
+            "lastState": {},
+            "ready": false,
+            "restartCount": 0,
+            "image": "busybox:latest",
+            "imageID": "docker-pullable://busybox@sha256:4415a904b1aca178c2450fd54928ab362825e863c0ad5452fd020e92f7a6a47e",
+            "containerID": "docker://b11c99327eaedd721d74a22d87cac957c887dfa551bf43512ee30586ef004321"
+          },
+          {
+            "name": "not-expired",
+            "state": {
+              "terminated": {
+                "exitCode": 0,
+                "reason": "Completed",
+                "startedAt": "2019-02-18T15:37:06Z",
+                "finishedAt": "2019-02-18T15:37:06Z",
+                "containerID": "docker://0c11e7adb7d2814de191c6de4a1678700f7434db8780a73f5775b8404bd3ee04"
+              }
+            },
+            "lastState": {},
+            "ready": false,
+            "restartCount": 0,
+            "image": "busybox:latest",
+            "imageID": "docker-pullable://busybox@sha256:4415a904b1aca178c2450fd54928ab362825e863c0ad5452fd020e92f7a6a47e",
+            "containerID": "docker://0c11e7adb7d2814de191c6de4a1678700f7434db8780a73f5775b8404bd3ee04"
+          }
+        ],
+        "qosClass": "Burstable"
+      }
+    }
+  ]
+}

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -9,7 +9,8 @@ from datetime import datetime
 import mock
 import pytest
 from six import iteritems
-from kubernetes.config.dateutil import parse_rfc3339, UTC
+from pyrfc3339 import parse as parse_rfc3339
+from pytz import utc as UTC
 
 from datadog_checks.kubelet import KubeletCheck, KubeletCredentials
 
@@ -111,6 +112,7 @@ class MockStreamResponse:
 
     def __exit__(self, *args):
         pass
+
 
 @pytest.fixture
 def aggregator():

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -102,6 +102,15 @@ class MockStreamResponse:
     def raw(self):
         return open(os.path.join(HERE, 'fixtures', self.filename))
 
+    def json(self):
+        with open(os.path.join(HERE, 'fixtures', self.filename)) as f:
+            return json.load(f)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
 
 @pytest.fixture
 def aggregator():

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -9,8 +9,7 @@ from datetime import datetime
 import mock
 import pytest
 from six import iteritems
-from pyrfc3339 import parse as parse_rfc3339
-from pytz import utc as UTC
+from kubernetes.config.dateutil import parse_rfc3339, UTC
 
 from datadog_checks.kubelet import KubeletCheck, KubeletCredentials
 
@@ -112,7 +111,6 @@ class MockStreamResponse:
 
     def __exit__(self, *args):
         pass
-
 
 @pytest.fixture
 def aggregator():

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -4,11 +4,15 @@
 import json
 import os
 import sys
+from datetime import datetime
 
 import mock
 import pytest
 from six import iteritems
+from kubernetes.config.dateutil import parse_rfc3339, UTC
+
 from datadog_checks.kubelet import KubeletCheck, KubeletCredentials
+
 
 # Skip the whole tests module on Windows
 pytestmark = pytest.mark.skipif(sys.platform == 'win32', reason='tests for linux only')
@@ -87,6 +91,18 @@ EXPECTED_METRICS_PROMETHEUS = [
 ]
 
 
+class MockStreamResponse:
+    """
+    Mocks raw contents of a stream request for the podlist get
+    """
+    def __init__(self, filename):
+        self.filename = filename
+
+    @property
+    def raw(self):
+        return open(os.path.join(HERE, 'fixtures', self.filename))
+
+
 @pytest.fixture
 def aggregator():
     from datadog_checks.stubs import aggregator
@@ -103,6 +119,7 @@ def mock_kubelet_check(monkeypatch, instances):
     monkeypatch.setattr(check, 'retrieve_pod_list', mock.Mock(return_value=json.loads(mock_from_file('pods.json'))))
     monkeypatch.setattr(check, '_retrieve_node_spec', mock.Mock(return_value=NODE_SPEC))
     monkeypatch.setattr(check, '_perform_kubelet_check', mock.Mock(return_value=None))
+    monkeypatch.setattr(check, '_compute_pod_expiration_datetime', mock.Mock(return_value=None))
 
     def mocked_poll(*args, **kwargs):
         scraper_config = args[0]
@@ -445,8 +462,12 @@ def test_report_container_spec_metrics(monkeypatch):
 
 def test_report_container_state_metrics(monkeypatch):
     check = KubeletCheck('kubelet', None, {}, [{}])
-    monkeypatch.setattr(check, 'retrieve_pod_list',
-                        mock.Mock(return_value=json.loads(mock_from_file('pods_crashed.json'))))
+    check.pod_list_url = "dummyurl"
+    monkeypatch.setattr(check, 'perform_kubelet_query',
+                        mock.Mock(return_value=MockStreamResponse('pods_crashed.json')))
+
+
+    monkeypatch.setattr(check, '_compute_pod_expiration_datetime', mock.Mock(return_value=None))
     monkeypatch.setattr(check, 'gauge', mock.Mock())
 
     attrs = {'is_excluded.return_value': False}
@@ -486,6 +507,37 @@ def test_report_container_state_metrics(monkeypatch):
         raise AssertionError('kubernetes.containers.state.* was submitted without a reason')
 
 
+def test_pod_expiration(monkeypatch, aggregator):
+    check = KubeletCheck('kubelet', None, {}, [{}])
+    check.pod_list_url = "dummyurl"
+
+    # Fixtures contains four pods:
+    #   - dd-agent-ntepl old but running
+    #   - hello1-1550504220-ljnzx succeeded and old enough to expire
+    #   - hello5-1550509440-rlgvf succeeded but not old enough
+    #   - hello8-1550505780-kdnjx has one old container and a recent container, don't expire
+    monkeypatch.setattr(check, 'perform_kubelet_query',
+                        mock.Mock(return_value=MockStreamResponse('pods_expired.json')))
+    monkeypatch.setattr(check, '_compute_pod_expiration_datetime', mock.Mock(
+        return_value=parse_rfc3339("2019-02-18T16:00:06Z")
+        ))
+
+    attrs = {'is_excluded.return_value': False}
+    check.pod_list_utils = mock.Mock(**attrs)
+
+    pod_list = check.retrieve_pod_list()
+    assert pod_list['expired_count'] == 1
+
+    expected_names = ['dd-agent-ntepl', 'hello5-1550509440-rlgvf', 'hello8-1550505780-kdnjx']
+    collected_names = [p['metadata']['name'] for p in pod_list['items']]
+    assert collected_names == expected_names
+
+    # Test .pods.expired gauge is submitted
+    with mock.patch("datadog_checks.kubelet.kubelet.get_tags", return_value=[]):
+        check._report_container_state_metrics(pod_list, ["custom:tag"])
+    aggregator.assert_metric("kubernetes.pods.expired", value=1, tags=["custom:tag"])
+
+
 class MockResponse(mock.Mock):
     @staticmethod
     def iter_lines():
@@ -504,8 +556,8 @@ def test_perform_kubelet_check(monkeypatch):
         check._perform_kubelet_check(instance_tags)
 
     get.assert_has_calls([
-        mock.call('http://127.0.0.1:10255/healthz', cert=None, headers=None, params={'verbose': True}, timeout=10,
-                  verify=None)])
+        mock.call('http://127.0.0.1:10255/healthz', cert=None, headers=None,
+                  params={'verbose': True}, stream=False, timeout=10, verify=None)])
     calls = [mock.call('kubernetes.kubelet.check', 0, tags=instance_tags)]
     check.service_check.assert_has_calls(calls)
 
@@ -523,20 +575,18 @@ def test_report_node_metrics(monkeypatch):
 
 
 def test_retrieve_pod_list_success(monkeypatch):
-    class MockResponse:
-        def __init__(self, json_data):
-            self.json_data = json_data
-
-        def json(self):
-            return (json.loads(self.json_data))
-
     check = KubeletCheck('kubelet', None, {}, [{}])
     check.pod_list_url = "dummyurl"
     monkeypatch.setattr(check, 'perform_kubelet_query',
-                        mock.Mock(return_value=MockResponse(mock_from_file('pod_list_raw.dat'))))
+                        mock.Mock(return_value=MockStreamResponse('pod_list_raw.dat')))
+    monkeypatch.setattr(check, '_compute_pod_expiration_datetime', mock.Mock(return_value=None))
 
     retrieved = check.retrieve_pod_list()
-    expected = json.loads(mock_from_file("pod_list_raw.json"))
+    parsed = json.loads(mock_from_file("pod_list_raw.json"))
+    expected = {
+        "items": parsed["items"],
+        "expired_count": 0,
+    }
     assert (json.dumps(retrieved, sort_keys=True) == json.dumps(expected, sort_keys=True))
 
 
@@ -550,3 +600,21 @@ def test_retrieved_pod_list_failure(monkeypatch):
 
     retrieved = check.retrieve_pod_list()
     assert retrieved is None
+
+def test_compute_pod_expiration_datetime(monkeypatch):
+    # Invalid input
+    with mock.patch("datadog_checks.kubelet.kubelet.get_config", return_value=""):
+        assert KubeletCheck._compute_pod_expiration_datetime() == None
+    with mock.patch("datadog_checks.kubelet.kubelet.get_config", return_value="invalid"):
+        assert KubeletCheck._compute_pod_expiration_datetime() == None
+
+    # Disabled
+    with mock.patch("datadog_checks.kubelet.kubelet.get_config", return_value="0"):
+        assert KubeletCheck._compute_pod_expiration_datetime() == None
+
+    # Set to 15 minutes
+    with mock.patch("datadog_checks.kubelet.kubelet.get_config", return_value="15"):
+        expire = KubeletCheck._compute_pod_expiration_datetime()
+        assert expire is not None
+        now = datetime.utcnow().replace(tzinfo=UTC)
+        assert abs((now-expire).seconds - 60*15) < 2

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -9,7 +9,7 @@ from datetime import datetime
 import mock
 import pytest
 from six import iteritems
-from kubernetes.config.dateutil import parse_rfc3339, UTC
+from datadog_checks.base.utils.date import parse_rfc3339, UTC
 
 from datadog_checks.kubelet import KubeletCheck, KubeletCredentials
 

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -112,6 +112,7 @@ class MockStreamResponse:
     def __exit__(self, *args):
         pass
 
+
 @pytest.fixture
 def aggregator():
     from datadog_checks.stubs import aggregator


### PR DESCRIPTION
### What does this PR do?

In order to be resilient to growing podlists containing mostly succeeded / terminated pods, change the podlist retrieval logic for the following:

- open the kubelet connection in streaming mode to avoid keeping the whole payload in memory
- iterate on pods while unmarshalling them, to only keep:
  - pending/running pods
  - stopped pods for which at least one container was still running less than 15 minutes ago (configurable, default set in `datadog-agent`, 0 to disable)

Various considerations:
- While "dropped" pods are still unmarshalled, their memory is quickly reused, keeping the RSS stable.
- We are still bound to the number of running pods, but running the whole check on a streaming logic would require more intrusive changes, for little improvement on the nominal cases
- I investigated more low-level filtering and alternative unmarshalling libraries, but the stdlib gives the best performance (see below).

### Motivation

Some users do not automatically garbage-collect cronjobs and had 4000 pods in their podlist.

### Performance

Baseline measurement with `agent check cpu -r`:
> 1.04user 0.70system 0:04.22elapsed 41%CPU (0avgtext+0avgdata 152864maxresident)k
> (the golang code unserialises the whole podlist for now)

Performance tests on running `agent check kubelet -r` on a podlist holding 3000+ completed pods:

- `master` (stdlib json, keep whole podlist)
> 10.40user 3.66system 0:18.37elapsed 76%CPU (0avgtext+0avgdata 297260maxresident)k
- ijson (pure python), iterate on items and keep non-expired pods
> 21.62user 0.74system 0:25.42elapsed 87%CPU (0avgtext+0avgdata 176800maxresident)k
- ijson + yajl C bindings
> 10.66user 0.67system 0:14.10elapsed 80%CPU (0avgtext+0avgdata 168484maxresident)k
- stdlib json + decoding hook
> 4.27user 0.77system 0:06.85elapsed 73%CPU (0avgtext+0avgdata 201440maxresident)k

This means the PR reduces the maxresident of the python side by 3, and the check wall time by a lot more.

**Nominal case is also improved a bit**, mostly due to not keeping the whole raw payload in memory. Avg agent usage on 3 nodes, 30 pods/node (master -> branch):
  - CPU: 4.04% -> 3.77%
  - RSS: 111 MB -> 98 MB

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
