### PR TITLE
Fix and clean tox config

### DIFF
--- a/process/tox.ini
+++ b/process/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-    {py27,py36}-process
+    py{27,36}-process
     flake8
 
 [testenv]
@@ -21,5 +21,5 @@ deps = flake8
 commands = flake8 .
 
 [flake8]
-exclude = .eggs,.tox
+exclude = .eggs,.tox,build
 max-line-length = 120

--- a/rabbitmq/tox.ini
+++ b/rabbitmq/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
   py{27,36}-{3.5,3.6,unit}
   flake8
@@ -28,5 +28,5 @@ deps = flake8
 commands = flake8 .
 
 [flake8]
-exclude = .eggs,.tox
+exclude = .eggs,.tox,build
 max-line-length = 120

--- a/riak/tox.ini
+++ b/riak/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-    {py27,py36}-riak
+    py{27,36}-riak
     flake8
 
 [testenv]

--- a/riakcs/tox.ini
+++ b/riakcs/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
   py{27,36}-unit
   py{27,36}-integration

--- a/snmp/tox.ini
+++ b/snmp/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-  {py27,py36}-snmp
-  {py27,py36}-unit
+  py{27,36}-{snmp,unit}
   bench
   flake8
 
@@ -15,13 +14,13 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install -r requirements.in
-    unit: pytest -v -munit
     snmp: pytest -v -m"not unit"
+    unit: pytest -v -m"unit"
 
 [testenv:bench]
 commands =
     pip install -r requirements.in
-    pytest
+    pytest -v
 
 [testenv:flake8]
 skip_install = true

--- a/spark/tox.ini
+++ b/spark/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
     py{27,36}-{spark}-{2.4}
     py{27,36}-unit

--- a/sqlserver/tox.ini
+++ b/sqlserver/tox.ini
@@ -8,7 +8,8 @@ envlist =
 [testenv]
 usedevelop = true
 platform =
-    {docker,unit}: linux|darwin
+    unit: linux|darwin|win32
+    docker: linux|darwin
     local: win32
 deps =
     -e../datadog_checks_base[deps]

--- a/sqlserver/tox.ini
+++ b/sqlserver/tox.ini
@@ -1,15 +1,14 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-    py{27,36}-{docker,local}
-    py{27,36}-unit
+    py{27,36}-{docker,local,unit}
     flake8
 
 [testenv]
 usedevelop = true
 platform =
-    docker: linux|darwin
+    {docker,unit}: linux|darwin
     local: win32
 deps =
     -e../datadog_checks_base[deps]
@@ -32,5 +31,5 @@ deps = flake8
 commands = flake8 .
 
 [flake8]
-exclude = .eggs,.tox
+exclude = .eggs,.tox,build
 max-line-length = 120

--- a/squid/tox.ini
+++ b/squid/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-  {py27,py36}-unit
-  {py27,py36}-latest
+  py{27,36}-{latest,unit}
   flake8
 
 [testenv]
@@ -28,5 +27,5 @@ deps = flake8
 commands = flake8 .
 
 [flake8]
-exclude = .eggs,.tox
+exclude = .eggs,.tox,build
 max-line-length = 120

--- a/ssh_check/tox.ini
+++ b/ssh_check/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-    {py27,py36}-latest
+    py{27,36}-latest
     flake8
 
 [testenv]
@@ -13,7 +13,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install -r requirements.in
-    pytest
+    pytest -v
 
 [testenv:flake8]
 skip_install = true

--- a/statsd/tox.ini
+++ b/statsd/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-    {py27,py36}-statsd
+    py{27,36}-statsd
     flake8
 
 [testenv]
@@ -24,5 +24,5 @@ deps = flake8
 commands = flake8 .
 
 [flake8]
-exclude = .eggs,.tox
+exclude = .eggs,.tox,build
 max-line-length = 120

--- a/supervisord/tox.ini
+++ b/supervisord/tox.ini
@@ -31,5 +31,5 @@ deps = flake8
 commands = flake8 .
 
 [flake8]
-exclude = .eggs,.tox
+exclude = .eggs,.tox,build
 max-line-length = 120

--- a/system_core/tox.ini
+++ b/system_core/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-    {py27,py36}-system_core
+    py{27,36}-system_core
     flake8
 
 [testenv]
@@ -13,7 +13,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install -r requirements.in
-    pytest
+    pytest -v
 
 [testenv:flake8]
 skip_install = true

--- a/system_swap/tox.ini
+++ b/system_swap/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-  {py27,py36}-unit
+  py{27,36}-unit
   flake8
 
 [testenv]
@@ -24,5 +24,5 @@ deps = flake8
 commands = flake8 .
 
 [flake8]
-exclude = .eggs,.tox
+exclude = .eggs,.tox,build
 max-line-length = 120

--- a/tcp_check/tox.ini
+++ b/tcp_check/tox.ini
@@ -1,13 +1,13 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-    {py27,py36}-unit
+    py{27,36}-unit
     flake8
 
 [testenv]
 usedevelop = true
-platform = linux2|darwin|windows
+platform = linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
@@ -21,5 +21,5 @@ deps = flake8
 commands = flake8 .
 
 [flake8]
-exlude = .eggs,.tox
+exclude = .eggs,.tox,build
 max-line-length = 120

--- a/teamcity/tox.ini
+++ b/teamcity/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-    {py27,py36}-unit
-    {py27,py36}-teamcity
+    py{27,36}-{unit,teamcity}
     flake8
 
 [testenv]

--- a/tokumx/tox.ini
+++ b/tokumx/tox.ini
@@ -2,11 +2,12 @@
 minversion = 2.0
 basepython = py27
 envlist =
-  {py27,py36}-latest
+  py27-latest
   flake8
 
 [testenv]
 usedevelop = true
+platform = linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
@@ -23,5 +24,5 @@ deps = flake8
 commands = flake8 .
 
 [flake8]
-exclude = .eggs,.tox,*/vendor/*
+exclude = .eggs,.tox,build,*/vendor/*
 max-line-length = 120

--- a/twemproxy/tox.ini
+++ b/twemproxy/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-    {py27,py36}-latest
+    py{27,36}-latest
     flake8
 
 [testenv]
@@ -20,10 +20,11 @@ commands =
     pytest -v
 
 [testenv:flake8]
+platform = linux|darwin|win32
 skip_install = true
 deps = flake8
 commands = flake8 .
 
 [flake8]
-exclude = .eggs,.tox
+exclude = .eggs,.tox,build
 max-line-length = 120

--- a/varnish/tox.ini
+++ b/varnish/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-    {py27,py36}-{417,521,unit}
+    py{27,36}-{unit,417,521}
     flake8
 
 [testenv]
@@ -20,12 +20,8 @@ setenv =
     unit: VARNISH_VERSION=5_2_1
 commands =
     pip install -r requirements.in
-    pytest -m"integration" -v
-
-[testenv:unit]
-commands =
-    pip install -r requirements.in
-    pytest -m"not integration" -v
+    417,521: pytest -m"integration" -v
+    unit: pytest -m"not integration" -v
 
 [testenv:flake8]
 skip_install = true

--- a/vault/tox.ini
+++ b/vault/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py27
+basepython = py36
 envlist =
-    {py27,py36}-latest
+    py{27,36}-latest
     flake8
     bench
 
@@ -20,15 +20,15 @@ commands =
     pip install -r requirements.in
     pytest -v --benchmark-skip
 
-[testenv:flake8]
-skip_install = true
-deps = flake8
-commands = flake8 .
-
 [testenv:bench]
 commands =
     pip install -r requirements.in
     pytest --benchmark-only --benchmark-cprofile=tottime
+
+[testenv:flake8]
+skip_install = true
+deps = flake8
+commands = flake8 .
 
 [flake8]
 exclude = .eggs,.tox,build

--- a/vsphere/tox.ini
+++ b/vsphere/tox.ini
@@ -7,7 +7,7 @@ envlist =
 
 [testenv]
 usedevelop = true
-platform = linux2|darwin
+platform = linux|darwin
 
 [testenv:vsphere]
 deps =
@@ -18,6 +18,7 @@ commands =
     pytest -v
 
 [testenv:flake8]
+platform = linux|darwin|win32
 skip_install = true
 deps = flake8
 commands = flake8 .

--- a/win32_event_log/tox.ini
+++ b/win32_event_log/tox.ini
@@ -1,21 +1,22 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-    {py27,py36}-win32_event_log
+    py{27,36}-win32_event_log
     flake8
 
 [testenv]
 usedevelop = true
+platform = win32
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
-platform = win32
 commands =
     pip install -r requirements.in
     pytest -v
 
 [testenv:flake8]
+platform = linux|darwin|win32
 skip_install = true
 deps = flake8
 commands = flake8 .

--- a/windows_service/tox.ini
+++ b/windows_service/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py27
+basepython = py36
 envlist =
-    {py27,py36}-windows_service
+    py{27,36}-windows_service
     flake8
     bench
 
@@ -18,6 +18,7 @@ commands =
     pytest -v
 
 [testenv:flake8]
+platform = linux|darwin|win32
 skip_install = true
 deps = flake8
 commands = flake8 .

--- a/wmi_check/tox.ini
+++ b/wmi_check/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-    {py27,py36}-wmi_check
+    py{27,36}-wmi_check
     flake8
 
 [testenv]
@@ -16,6 +16,7 @@ commands =
     pytest -v
 
 [testenv:flake8]
+platform = linux|darwin|win32
 skip_install = true
 deps = flake8
 commands = flake8 .

--- a/yarn/tox.ini
+++ b/yarn/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-    {py27,py36}-yarn
+    py{27,36}-yarn
     flake8
 
 [testenv]
@@ -21,5 +21,5 @@ deps = flake8
 commands = flake8 .
 
 [flake8]
-exclude = .eggs,.tox
+exclude = .eggs,.tox,build
 max-line-length = 120

--- a/zk/tox.ini
+++ b/zk/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py36
 envlist =
-    {py27,py36}-{3.4,3.5}
+    py{27,36}-{3.4,3.5}
     flake8
 
 [testenv]
@@ -14,7 +14,7 @@ deps =
 commands =
     pip install -r requirements.in
     pytest -v
-setenv = 
+setenv =
     3.4: ZK_VERSION=3.4.11
     3.5: ZK_VERSION=3.5
 passenv =
@@ -27,5 +27,5 @@ deps = flake8
 commands = flake8 .
 
 [flake8]
-exclude = .eggs,.tox
+exclude = .eggs,.tox,build
 max-line-length = 120


### PR DESCRIPTION
### What does this PR do?

Clean .tox files:
- Similar `flake8` config
- Remove `linux2` platform in favor of `linux`
- Run flake8 on all main platforms
- Added `-v` param to `pytest`
- Run `py2` and `py3` for everything (where currently supported)

### Motivation

Run all test with both python 2 and 3.
Clean `.tox` files so they look the same

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
