### PR TITLE
ensure_unicode with normalize for py3 compatibility

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -317,9 +317,9 @@ class __AgentCheckPy3(object):
         name = re.sub(br"_\.", b".", name)
 
         if prefix is not None:
-            return ensure_bytes(prefix) + b"." + name
-        else:
-            return name
+            name = ensure_bytes(prefix) + b"." + name
+
+        return ensure_unicode(name)
 
     FIRST_CAP_RE = re.compile(br'(.)([A-Z][a-z]+)')
     ALL_CAP_RE = re.compile(br'([a-z0-9])([A-Z])')

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -42,14 +42,14 @@ class TestMetricNormalization:
     def test_default(self):
         check = AgentCheck()
         metric_name = u'Klüft inför på fédéral'
-        normalized_metric_name = b'Kluft_infor_pa_federal'
+        normalized_metric_name = 'Kluft_infor_pa_federal'
 
         assert check.normalize(metric_name) == normalized_metric_name
 
     def test_fix_case(self):
         check = AgentCheck()
         metric_name = u'Klüft inför på fédéral'
-        normalized_metric_name = b'kluft_infor_pa_federal'
+        normalized_metric_name = 'kluft_infor_pa_federal'
 
         assert check.normalize(metric_name, fix_case=True) == normalized_metric_name
 
@@ -57,7 +57,7 @@ class TestMetricNormalization:
         check = AgentCheck()
         metric_name = u'metric'
         prefix = u'some'
-        normalized_metric_name = b'some.metric'
+        normalized_metric_name = 'some.metric'
 
         assert check.normalize(metric_name, prefix=prefix) == normalized_metric_name
 
@@ -65,7 +65,7 @@ class TestMetricNormalization:
         check = AgentCheck()
         metric_name = u'metric'
         prefix = b'some'
-        normalized_metric_name = b'some.metric'
+        normalized_metric_name = 'some.metric'
 
         assert check.normalize(metric_name, prefix=prefix) == normalized_metric_name
 
@@ -73,28 +73,28 @@ class TestMetricNormalization:
         check = AgentCheck()
         metric_name = b'metric'
         prefix = u'some'
-        normalized_metric_name = b'some.metric'
+        normalized_metric_name = 'some.metric'
 
         assert check.normalize(metric_name, prefix=prefix) == normalized_metric_name
 
     def test_underscores_redundant(self):
         check = AgentCheck()
         metric_name = u'a_few__redundant___underscores'
-        normalized_metric_name = b'a_few_redundant_underscores'
+        normalized_metric_name = 'a_few_redundant_underscores'
 
         assert check.normalize(metric_name) == normalized_metric_name
 
     def test_underscores_at_ends(self):
         check = AgentCheck()
         metric_name = u'_some_underscores_'
-        normalized_metric_name = b'some_underscores'
+        normalized_metric_name = 'some_underscores'
 
         assert check.normalize(metric_name) == normalized_metric_name
 
     def test_underscores_and_dots(self):
         check = AgentCheck()
         metric_name = u'some_.dots._and_._underscores'
-        normalized_metric_name = b'some.dots.and.underscores'
+        normalized_metric_name = 'some.dots.and.underscores'
 
         assert check.normalize(metric_name) == normalized_metric_name
 

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -75,7 +75,7 @@ class HTTPCheck(NetworkCheck):
         # Store tags in a temporary list so that we don't modify the global tags data structure
         tags_list = list(tags)
         tags_list.append('url:{}'.format(addr))
-        instance_name = ensure_unicode(self.normalize(instance['name']))
+        instance_name = self.normalize(instance['name'])
         tags_list.append("instance:{}".format(instance_name))
         service_checks = []
         r = None
@@ -237,7 +237,7 @@ class HTTPCheck(NetworkCheck):
         return service_checks
 
     def report_as_service_check(self, sc_name, status, instance, msg=None):
-        instance_name = ensure_unicode(self.normalize(instance['name']))
+        instance_name = self.normalize(instance['name'])
         url = instance.get('url', None)
         if url is not None:
             url = ensure_unicode(url)

--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -78,14 +78,14 @@ class IIS(PDHBaseCheck):
                         if not counter.is_single_instance():
                             # Skip any sites we don't specifically want.
                             if not sites:
-                                tags.append("site:{0}".format(ensure_unicode(self.normalize(sitename))))
+                                tags.append("site:{0}".format(self.normalize(sitename)))
                             # always report total
                             elif sitename == "_Total":
-                                tags.append("site:{0}".format(ensure_unicode(self.normalize(sitename))))
+                                tags.append("site:{0}".format(self.normalize(sitename)))
                             elif sitename not in sites:
                                 continue
                             else:
-                                tags.append("site:{0}".format(ensure_unicode(self.normalize(sitename))))
+                                tags.append("site:{0}".format(self.normalize(sitename)))
                     except Exception as e:
                         self.log.error("Caught exception {} setting tags".format(str(e)))
 
@@ -114,5 +114,5 @@ class IIS(PDHBaseCheck):
             tags = []
             if key in self._tags:
                 tags = list(self._tags[key])
-            tags.append("site:{}".format(ensure_unicode(self.normalize(site))))
+            tags.append("site:{}".format(self.normalize(site)))
             self.service_check(self.SERVICE_CHECK, AgentCheck.CRITICAL, tags)

--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from six import iteritems
 
-from datadog_checks.base import AgentCheck, PDHBaseCheck, ensure_unicode
+from datadog_checks.base import AgentCheck, PDHBaseCheck
 from datadog_checks.utils.containers import hash_mutable
 
 

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -4,7 +4,6 @@
 import socket
 import time
 
-from datadog_checks.base import ensure_unicode
 from datadog_checks.base.checks import NetworkCheck, Status
 
 
@@ -104,7 +103,7 @@ class TCPCheck(NetworkCheck):
         return Status.UP, "UP"
 
     def report_as_service_check(self, sc_name, status, instance, msg=None):
-        instance_name = ensure_unicode(self.normalize(instance['name']))
+        instance_name = self.normalize(instance['name'])
         host = instance.get('host', None)
         port = instance.get('port', None)
         custom_tags = instance.get('tags', [])

--- a/varnish/datadog_checks/varnish/varnish.py
+++ b/varnish/datadog_checks/varnish/varnish.py
@@ -13,7 +13,6 @@ import xml.parsers.expat  # python 2.4 compatible
 
 from datadog_checks.checks import AgentCheck
 from datadog_checks.utils.subprocess_output import get_subprocess_output
-from datadog_checks.base import ensure_unicode
 
 if PY3:
     long = int
@@ -58,7 +57,7 @@ class Varnish(AgentCheck):
 
     def _end_element(self, name, tags):
         if name == "stat":
-            m_name = ensure_unicode(self.normalize(self._current_metric))
+            m_name = self.normalize(self._current_metric)
             if self._current_type in ("a", "c"):
                 self.rate(m_name, long(self._current_value), tags=tags)
             elif self._current_type in ("i", "g"):
@@ -232,7 +231,7 @@ class Varnish(AgentCheck):
                     self.rate(self.normalize(name, prefix="varnish"), long(value), tags=tags)
                 elif metric["flag"] in ("g", "i"):
                     self.gauge(self.normalize(name, prefix="varnish"), long(value), tags=tags)
-                    if 'n_purges' in ensure_unicode(self.normalize(name, prefix="varnish")):
+                    if 'n_purges' in self.normalize(name, prefix="varnish"):
                         self.rate('varnish.n_purgesps', long(value), tags=tags)
         elif varnishstat_format == "text":
             for line in output.split("\n"):


### PR DESCRIPTION
### What does this PR do?

`normalize` is being `ensure_unicode` almost everywhere but not everywhere.
Hence, I am moving the logic as part of the `normalize` method since it needs to be done all the time.

### Motivation

Python 3 compatibility

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
