### PR TITLE
Add integration_ids

### DIFF
--- a/active_directory/manifest.json
+++ b/active_directory/manifest.json
@@ -19,5 +19,6 @@
   "supported_os": [
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "active-directory"
 }

--- a/activemq/manifest.json
+++ b/activemq/manifest.json
@@ -23,5 +23,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "activemq"
 }

--- a/activemq_xml/manifest.json
+++ b/activemq_xml/manifest.json
@@ -21,5 +21,5 @@
     "windows"
   ],
   "type": "check",
-  "integration_id": "activemq"
+  "integration_id": "activemq-xml"
 }

--- a/activemq_xml/manifest.json
+++ b/activemq_xml/manifest.json
@@ -20,5 +20,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "activemq"
 }

--- a/agent_metrics/manifest.json
+++ b/agent_metrics/manifest.json
@@ -20,5 +20,5 @@
     "windows"
   ],
   "type": "check",
-  "integration_id": "agent"
+  "integration_id": "datadog-agent"
 }

--- a/agent_metrics/manifest.json
+++ b/agent_metrics/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "agent"
 }

--- a/amazon_eks/manifest.json
+++ b/amazon_eks/manifest.json
@@ -20,5 +20,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "amazon-eks"
 }

--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -26,5 +26,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "apache"
 }

--- a/aspdotnet/manifest.json
+++ b/aspdotnet/manifest.json
@@ -19,5 +19,5 @@
     "windows"
   ],
   "type": "check",
-  "integration_id": "asp-net"
+  "integration_id": "aspdotnet"
 }

--- a/aspdotnet/manifest.json
+++ b/aspdotnet/manifest.json
@@ -18,5 +18,6 @@
   "supported_os": [
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "asp-net"
 }

--- a/btrfs/manifest.json
+++ b/btrfs/manifest.json
@@ -18,5 +18,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "btrfs"
 }

--- a/cacti/manifest.json
+++ b/cacti/manifest.json
@@ -17,5 +17,6 @@
   "supported_os": [
     "linux"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "cacti"
 }

--- a/cassandra/manifest.json
+++ b/cassandra/manifest.json
@@ -23,5 +23,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "cassandra"
 }

--- a/cassandra_nodetool/manifest.json
+++ b/cassandra_nodetool/manifest.json
@@ -20,5 +20,5 @@
     "windows"
   ],
   "type": "check",
-  "integration_id": "cassandra"
+  "integration_id": "cassandra-nodetool"
 }

--- a/cassandra_nodetool/manifest.json
+++ b/cassandra_nodetool/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "cassandra"
 }

--- a/ceph/manifest.json
+++ b/ceph/manifest.json
@@ -1,5 +1,8 @@
 {
-  "categories": ["data store", "os & system"],
+  "categories": [
+    "data store",
+    "os & system"
+  ],
   "creates_events": false,
   "display_name": "Ceph",
   "guid": "8a60c34f-ecde-4269-bcae-636e6cbce98f",
@@ -9,10 +12,18 @@
   "metric_prefix": "ceph.",
   "metric_to_check": "ceph.write_bytes_sec",
   "name": "ceph",
-  "process_signatures": ["ceph-mon", "ceph-mgr", "ceph-osd"],
+  "process_signatures": [
+    "ceph-mon",
+    "ceph-mgr",
+    "ceph-osd"
+  ],
   "public_title": "Datadog-Ceph Integration",
   "short_description": "Collect per-pool performance metrics and monitor overall cluster status.",
   "support": "core",
-  "supported_os": ["linux", "mac_os"],
-  "type": "check"
+  "supported_os": [
+    "linux",
+    "mac_os"
+  ],
+  "type": "check",
+  "integration_id": "ceph"
 }

--- a/cisco_aci/manifest.json
+++ b/cisco_aci/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "cisco-aci"
 }

--- a/cockroachdb/manifest.json
+++ b/cockroachdb/manifest.json
@@ -20,5 +20,6 @@
     "data store"
   ],
   "type": "check",
-  "is_public": true
+  "is_public": true,
+  "integration_id": "cockroachdb"
 }

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -28,5 +28,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "consul"
 }

--- a/containerd/manifest.json
+++ b/containerd/manifest.json
@@ -13,9 +13,12 @@
     "windows"
   ],
   "public_title": "Datadog-Containerd Integration",
-  "categories": ["containers"],
+  "categories": [
+    "containers"
+  ],
   "type": "check",
   "is_public": true,
   "display_name": "Containerd",
-  "creates_events": true
+  "creates_events": true,
+  "integration_id": "containerd"
 }

--- a/coredns/manifest.json
+++ b/coredns/manifest.json
@@ -11,12 +11,13 @@
   ],
   "guid": "9b316155-fc8e-4cb0-8bd5-8af270759cfb",
   "public_title": "Datadog-CoreDNS Integration",
-  "categories":[
+  "categories": [
     "containers",
     "network"
   ],
-  "type":"check",
-  "aliases":[],
+  "type": "check",
+  "aliases": [],
   "is_public": true,
-  "creates_events": false
+  "creates_events": false,
+  "integration_id": "coredns"
 }

--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -27,5 +27,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "couchdb"
 }

--- a/couchbase/manifest.json
+++ b/couchbase/manifest.json
@@ -11,7 +11,9 @@
   "metric_prefix": "couchbase.",
   "metric_to_check": "couchbase.ram.used",
   "name": "couchbase",
-  "process_signatures": ["beam.smp couchbase"],
+  "process_signatures": [
+    "beam.smp couchbase"
+  ],
   "public_title": "Datadog-CouchBase Integration",
   "short_description": "Track and graph your Couchbase activity and performance metrics.",
   "support": "core",
@@ -20,5 +22,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "couchbase"
 }

--- a/cri/manifest.json
+++ b/cri/manifest.json
@@ -17,5 +17,6 @@
   "supported_os": [
     "linux"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "cri"
 }

--- a/crio/manifest.json
+++ b/crio/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "cri-o"
 }

--- a/directory/manifest.json
+++ b/directory/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "directory"
 }

--- a/directory/manifest.json
+++ b/directory/manifest.json
@@ -20,5 +20,5 @@
     "windows"
   ],
   "type": "check",
-  "integration_id": "directory"
+  "integration_id": "system"
 }

--- a/disk/manifest.json
+++ b/disk/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "system"
 }

--- a/dns_check/manifest.json
+++ b/dns_check/manifest.json
@@ -23,5 +23,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "dns"
 }

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -29,5 +29,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "docker"
 }

--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -396,6 +396,7 @@ Find below the complete list of mandatory and optional attributes for your `mani
 
 | Attribute            | Type            | Mandatory/Optional | Description                                                                                                                                                                                                              |
 | -------------------- | --------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `integration_id` | String | Mandatory           | The unique identifying name of this integration. Usually kebab case of the Display Name |
 | `categories`         | Array of String | Mandatory          | Integration categories used on the [public documentation Integrations page][10].                                                                                                                                         |
 | `creates_events`     | Boolean         | Mandatory          | If the integration should be able to create events. If this is set to `false`, attempting to create an event from the integration results in an error.                                                                   |
 | `display_name`       | String          | Mandatory          | Title displayed on the corresponding integration tile in the Datadog application and on the [public documentation Integrations page][10]                                                                                 |
@@ -415,6 +416,7 @@ Find below the complete list of mandatory and optional attributes for your `mani
 | `metric_to_check`    | String          | Optional           | The presence of this metric determines if this integration is working properly. If this metric is not being reported when this integration is installed, the integration is marked as broken in the Datadog application. |
 | `metric_prefix`      | String          | Optional           | The namespace for this integration's metrics. Every metric reported by this integration will be prepended with this value.                                                                                               |
 | `process_signatures` | Array of String | Optional           | A list of signatures that matches the command line of this integration.                                                                                                                                                  |
+
 
 #### metadata.csv
 

--- a/dotnetclr/manifest.json
+++ b/dotnetclr/manifest.json
@@ -17,5 +17,6 @@
   "supported_os": [
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "dotnetclr"
 }

--- a/ecs_fargate/manifest.json
+++ b/ecs_fargate/manifest.json
@@ -21,5 +21,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "aws-fargate"
 }

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -26,5 +26,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "elasticsearch"
 }

--- a/envoy/manifest.json
+++ b/envoy/manifest.json
@@ -20,5 +20,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "envoy"
 }

--- a/etcd/manifest.json
+++ b/etcd/manifest.json
@@ -25,5 +25,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "etcd"
 }

--- a/exchange_server/manifest.json
+++ b/exchange_server/manifest.json
@@ -17,5 +17,6 @@
   "supported_os": [
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "exchange-server"
 }

--- a/fluentd/manifest.json
+++ b/fluentd/manifest.json
@@ -27,5 +27,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "fluentd"
 }

--- a/gearmand/manifest.json
+++ b/gearmand/manifest.json
@@ -25,5 +25,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "gearman"
 }

--- a/gitlab/manifest.json
+++ b/gitlab/manifest.json
@@ -21,5 +21,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "gitlab"
 }

--- a/gitlab_runner/manifest.json
+++ b/gitlab_runner/manifest.json
@@ -21,5 +21,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "gitlab-runner"
 }

--- a/go-metro/manifest.json
+++ b/go-metro/manifest.json
@@ -18,5 +18,6 @@
   "supported_os": [
     "linux"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "go-metro"
 }

--- a/go_expvar/manifest.json
+++ b/go_expvar/manifest.json
@@ -23,5 +23,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "go-expvar"
 }

--- a/gunicorn/manifest.json
+++ b/gunicorn/manifest.json
@@ -22,5 +22,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "gunicorn"
 }

--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -26,5 +26,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "haproxy"
 }

--- a/hdfs_datanode/manifest.json
+++ b/hdfs_datanode/manifest.json
@@ -19,5 +19,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "hdfs"
 }

--- a/hdfs_datanode/manifest.json
+++ b/hdfs_datanode/manifest.json
@@ -20,5 +20,5 @@
     "mac_os"
   ],
   "type": "check",
-  "integration_id": "hdfs"
+  "integration_id": "hdfs-datanode"
 }

--- a/hdfs_namenode/manifest.json
+++ b/hdfs_namenode/manifest.json
@@ -19,5 +19,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "hdfs"
 }

--- a/hdfs_namenode/manifest.json
+++ b/hdfs_namenode/manifest.json
@@ -20,5 +20,5 @@
     "mac_os"
   ],
   "type": "check",
-  "integration_id": "hdfs"
+  "integration_id": "hdfs-namenode"
 }

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -24,5 +24,5 @@
     "windows"
   ],
   "type": "check",
-  "integration_id": "http-check"
+  "integration_id": "network"
 }

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -23,5 +23,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "http-check"
 }

--- a/hyperv/manifest.json
+++ b/hyperv/manifest.json
@@ -20,5 +20,6 @@
     "os & system"
   ],
   "type": "check",
-  "is_public": true
+  "is_public": true,
+  "integration_id": "hyper-v"
 }

--- a/ibm_mq/manifest.json
+++ b/ibm_mq/manifest.json
@@ -17,5 +17,6 @@
     "Message Queue"
   ],
   "type": "check",
-  "is_public": true
+  "is_public": true,
+  "integration_id": "ibm-mq"
 }

--- a/ibm_was/manifest.json
+++ b/ibm_was/manifest.json
@@ -21,5 +21,6 @@
     "log collection"
   ],
   "type": "check",
-  "is_public": false
+  "is_public": false,
+  "integration_id": "ibm-was"
 }

--- a/iis/manifest.json
+++ b/iis/manifest.json
@@ -18,5 +18,6 @@
   "supported_os": [
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "iis"
 }

--- a/istio/manifest.json
+++ b/istio/manifest.json
@@ -20,5 +20,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "istio"
 }

--- a/kafka/manifest.json
+++ b/kafka/manifest.json
@@ -24,5 +24,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "kafka"
 }

--- a/kafka_consumer/manifest.json
+++ b/kafka_consumer/manifest.json
@@ -20,5 +20,5 @@
     "mac_os"
   ],
   "type": "check",
-  "integration_id": "kafka"
+  "integration_id": "kafka-consumer"
 }

--- a/kafka_consumer/manifest.json
+++ b/kafka_consumer/manifest.json
@@ -19,5 +19,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "kafka"
 }

--- a/kong/manifest.json
+++ b/kong/manifest.json
@@ -23,5 +23,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "kong"
 }

--- a/kube_controller_manager/manifest.json
+++ b/kube_controller_manager/manifest.json
@@ -20,5 +20,6 @@
     "containers"
   ],
   "type": "check",
-  "is_public": true
+  "is_public": true,
+  "integration_id": "kubernetes"
 }

--- a/kube_controller_manager/manifest.json
+++ b/kube_controller_manager/manifest.json
@@ -21,5 +21,5 @@
   ],
   "type": "check",
   "is_public": true,
-  "integration_id": "kubernetes"
+  "integration_id": "kube-controller-manager"
 }

--- a/kube_dns/manifest.json
+++ b/kube_dns/manifest.json
@@ -20,5 +20,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "kubernetes"
 }

--- a/kube_dns/manifest.json
+++ b/kube_dns/manifest.json
@@ -21,5 +21,5 @@
     "windows"
   ],
   "type": "check",
-  "integration_id": "kubernetes"
+  "integration_id": "kube-dns"
 }

--- a/kube_proxy/manifest.json
+++ b/kube_proxy/manifest.json
@@ -20,5 +20,5 @@
     "windows"
   ],
   "type": "check",
-  "integration_id": "kubernetes"
+  "integration_id": "kube-proxy"
 }

--- a/kube_proxy/manifest.json
+++ b/kube_proxy/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "kubernetes"
 }

--- a/kubelet/manifest.json
+++ b/kubelet/manifest.json
@@ -18,5 +18,5 @@
     "linux"
   ],
   "type": "check",
-  "integration_id": "kubernetes"
+  "integration_id": "kubelet"
 }

--- a/kubelet/manifest.json
+++ b/kubelet/manifest.json
@@ -17,5 +17,6 @@
   "supported_os": [
     "linux"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "kubernetes"
 }

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -20,5 +20,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "kubernetes"
 }

--- a/kubernetes_state/manifest.json
+++ b/kubernetes_state/manifest.json
@@ -19,5 +19,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "kubernetes"
 }

--- a/kubernetes_state/manifest.json
+++ b/kubernetes_state/manifest.json
@@ -20,5 +20,5 @@
     "mac_os"
   ],
   "type": "check",
-  "integration_id": "kubernetes"
+  "integration_id": "kubernetes-state"
 }

--- a/kyototycoon/manifest.json
+++ b/kyototycoon/manifest.json
@@ -22,5 +22,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "kyoto-tycoon"
 }

--- a/lighttpd/manifest.json
+++ b/lighttpd/manifest.json
@@ -22,5 +22,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "lighttpd"
 }

--- a/linkerd/manifest.json
+++ b/linkerd/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "linkerd"
 }

--- a/linux_proc_extras/manifest.json
+++ b/linux_proc_extras/manifest.json
@@ -17,5 +17,6 @@
   "supported_os": [
     "linux"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "system"
 }

--- a/mapreduce/manifest.json
+++ b/mapreduce/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "mapreduce"
 }

--- a/marathon/manifest.json
+++ b/marathon/manifest.json
@@ -22,5 +22,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "marathon"
 }

--- a/mcache/manifest.json
+++ b/mcache/manifest.json
@@ -25,5 +25,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "memcached"
 }

--- a/mesos_master/manifest.json
+++ b/mesos_master/manifest.json
@@ -29,5 +29,5 @@
     "mac_os"
   ],
   "type": "check",
-  "integration_id": "mesos"
+  "integration_id": "mesos-master"
 }

--- a/mesos_master/manifest.json
+++ b/mesos_master/manifest.json
@@ -28,5 +28,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "mesos"
 }

--- a/mesos_slave/manifest.json
+++ b/mesos_slave/manifest.json
@@ -21,5 +21,5 @@
     "mac_os"
   ],
   "type": "check",
-  "integration_id": "mesos"
+  "integration_id": "mesos-slave"
 }

--- a/mesos_slave/manifest.json
+++ b/mesos_slave/manifest.json
@@ -20,5 +20,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "mesos"
 }

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -26,5 +26,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "mongodb"
 }

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -24,5 +24,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "mysql"
 }

--- a/nagios/manifest.json
+++ b/nagios/manifest.json
@@ -1,5 +1,8 @@
 {
-  "categories": ["monitoring", "notification"],
+  "categories": [
+    "monitoring",
+    "notification"
+  ],
   "creates_events": true,
   "display_name": "Nagios",
   "guid": "f7629918-751c-4a05-87e7-0e3de34e51e7",
@@ -8,10 +11,17 @@
   "manifest_version": "1.0.0",
   "metric_prefix": "nagios.",
   "name": "nagios",
-  "process_signatures": ["nagios"],
+  "process_signatures": [
+    "nagios"
+  ],
   "public_title": "Datadog-Nagios Integration",
   "short_description": "Send Nagios service flaps, host alerts, and more to your Datadog event stream.",
   "support": "core",
-  "supported_os": ["linux", "mac_os", "windows"],
-  "type": "check"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "type": "check",
+  "integration_id": "nagios"
 }

--- a/network/manifest.json
+++ b/network/manifest.json
@@ -20,5 +20,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "system"
 }

--- a/nfsstat/manifest.json
+++ b/nfsstat/manifest.json
@@ -18,5 +18,5 @@
     "linux"
   ],
   "type": "check",
-  "integration_id": "nfsstat"
+  "integration_id": "system"
 }

--- a/nfsstat/manifest.json
+++ b/nfsstat/manifest.json
@@ -17,5 +17,6 @@
   "supported_os": [
     "linux"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "nfsstat"
 }

--- a/nginx/manifest.json
+++ b/nginx/manifest.json
@@ -23,5 +23,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "nginx"
 }

--- a/nginx_ingress_controller/manifest.json
+++ b/nginx_ingress_controller/manifest.json
@@ -24,5 +24,5 @@
   ],
   "type": "check",
   "is_public": true,
-  "integration_id": "nginx"
+  "integration_id": "nginx-ingress-controller"
 }

--- a/nginx_ingress_controller/manifest.json
+++ b/nginx_ingress_controller/manifest.json
@@ -23,5 +23,6 @@
     "network"
   ],
   "type": "check",
-  "is_public": true
+  "is_public": true,
+  "integration_id": "nginx"
 }

--- a/ntp/manifest.json
+++ b/ntp/manifest.json
@@ -20,5 +20,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "ntp"
 }

--- a/openldap/manifest.json
+++ b/openldap/manifest.json
@@ -20,5 +20,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "openldap"
 }

--- a/openmetrics/manifest.json
+++ b/openmetrics/manifest.json
@@ -17,5 +17,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "openmetrics"
 }

--- a/openshift/manifest.json
+++ b/openshift/manifest.json
@@ -18,5 +18,6 @@
   "supported_os": [
     "linux"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "openshift"
 }

--- a/openstack/manifest.json
+++ b/openstack/manifest.json
@@ -22,5 +22,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "openstack"
 }

--- a/openstack_controller/manifest.json
+++ b/openstack_controller/manifest.json
@@ -19,5 +19,6 @@
     "cloud"
   ],
   "type": "check",
-  "is_public": false
+  "is_public": false,
+  "integration_id": "openstack"
 }

--- a/openstack_controller/manifest.json
+++ b/openstack_controller/manifest.json
@@ -20,5 +20,5 @@
   ],
   "type": "check",
   "is_public": false,
-  "integration_id": "openstack"
+  "integration_id": "openstack-controller"
 }

--- a/oracle/manifest.json
+++ b/oracle/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "oracle"
 }

--- a/pdh_check/manifest.json
+++ b/pdh_check/manifest.json
@@ -16,5 +16,6 @@
   "supported_os": [
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "pdh"
 }

--- a/pgbouncer/manifest.json
+++ b/pgbouncer/manifest.json
@@ -21,5 +21,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "pgbouncer"
 }

--- a/php_fpm/manifest.json
+++ b/php_fpm/manifest.json
@@ -32,5 +32,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "php-fpm"
 }

--- a/pivotal_pks/manifest.json
+++ b/pivotal_pks/manifest.json
@@ -18,5 +18,5 @@
   ],
   "type": "check",
   "is_public": true,
-  "integration_id": "pivotal"
+  "integration_id": "pivotal-pks"
 }

--- a/pivotal_pks/manifest.json
+++ b/pivotal_pks/manifest.json
@@ -17,5 +17,6 @@
     "orchestration"
   ],
   "type": "check",
-  "is_public": true
+  "is_public": true,
+  "integration_id": "pivotal"
 }

--- a/postfix/manifest.json
+++ b/postfix/manifest.json
@@ -22,5 +22,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "postfix"
 }

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -28,5 +28,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "postgres"
 }

--- a/powerdns_recursor/manifest.json
+++ b/powerdns_recursor/manifest.json
@@ -27,5 +27,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "powerdns"
 }

--- a/process/manifest.json
+++ b/process/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "system"
 }

--- a/prometheus/manifest.json
+++ b/prometheus/manifest.json
@@ -17,5 +17,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "prometheus"
 }

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -23,5 +23,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "rabbitmq"
 }

--- a/redisdb/manifest.json
+++ b/redisdb/manifest.json
@@ -27,5 +27,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "redis"
 }

--- a/riak/manifest.json
+++ b/riak/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "riak"
 }

--- a/riakcs/manifest.json
+++ b/riakcs/manifest.json
@@ -22,5 +22,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "riak-cs"
 }

--- a/snmp/manifest.json
+++ b/snmp/manifest.json
@@ -20,5 +20,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "snmp"
 }

--- a/solr/manifest.json
+++ b/solr/manifest.json
@@ -23,5 +23,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "solr"
 }

--- a/spark/manifest.json
+++ b/spark/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "spark"
 }

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -18,5 +18,6 @@
     "linux",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "sql-server"
 }

--- a/squid/manifest.json
+++ b/squid/manifest.json
@@ -20,5 +20,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "squid"
 }

--- a/ssh_check/manifest.json
+++ b/ssh_check/manifest.json
@@ -27,5 +27,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "ssh"
 }

--- a/statsd/manifest.json
+++ b/statsd/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "statsd"
 }

--- a/supervisord/manifest.json
+++ b/supervisord/manifest.json
@@ -26,5 +26,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "supervisord"
 }

--- a/system_core/manifest.json
+++ b/system_core/manifest.json
@@ -22,5 +22,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "system"
 }

--- a/system_swap/manifest.json
+++ b/system_swap/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "system"
 }

--- a/tcp_check/manifest.json
+++ b/tcp_check/manifest.json
@@ -23,5 +23,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "system"
 }

--- a/teamcity/manifest.json
+++ b/teamcity/manifest.json
@@ -1,5 +1,7 @@
 {
-  "categories": ["configuration & deployment"],
+  "categories": [
+    "configuration & deployment"
+  ],
   "creates_events": true,
   "display_name": "Teamcity",
   "guid": "b390dd3f-47d5-4555-976a-36722833f000",
@@ -8,10 +10,18 @@
   "manifest_version": "1.0.0",
   "metric_prefix": "teamcity.",
   "name": "teamcity",
-  "process_signatures": ["teamcity-server.sh", "teamcity-server"],
+  "process_signatures": [
+    "teamcity-server.sh",
+    "teamcity-server"
+  ],
   "public_title": "Datadog-Teamcity Integration",
   "short_description": "Track builds and understand the performance impact of every deploy.",
   "support": "core",
-  "supported_os": ["linux", "mac_os", "windows"],
-  "type": "check"
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "type": "check",
+  "integration_id": "teamcity"
 }

--- a/tokumx/manifest.json
+++ b/tokumx/manifest.json
@@ -22,5 +22,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "tokumx"
 }

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -23,5 +23,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "tomcat"
 }

--- a/twemproxy/manifest.json
+++ b/twemproxy/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "twemproxy"
 }

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -24,5 +24,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "varnish"
 }

--- a/vault/manifest.json
+++ b/vault/manifest.json
@@ -22,5 +22,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "vault"
 }

--- a/vsphere/manifest.json
+++ b/vsphere/manifest.json
@@ -22,5 +22,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "vsphere"
 }

--- a/win32_event_log/manifest.json
+++ b/win32_event_log/manifest.json
@@ -21,5 +21,6 @@
   "supported_os": [
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "win32-event-log"
 }

--- a/windows_service/manifest.json
+++ b/windows_service/manifest.json
@@ -19,5 +19,6 @@
   "supported_os": [
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "windows-service"
 }

--- a/wmi_check/manifest.json
+++ b/wmi_check/manifest.json
@@ -19,5 +19,6 @@
   "supported_os": [
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "wmi"
 }

--- a/yarn/manifest.json
+++ b/yarn/manifest.json
@@ -19,5 +19,6 @@
     "mac_os",
     "windows"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "yarn"
 }

--- a/zk/manifest.json
+++ b/zk/manifest.json
@@ -27,5 +27,6 @@
     "linux",
     "mac_os"
   ],
-  "type": "check"
+  "type": "check",
+  "integration_id": "zookeeper"
 }


### PR DESCRIPTION
### What does this PR do?

Adds a new field to the manifest.json file `integration_id`

This is part of a larger work to standardize how an integration is identified in various locations. This will always be the kebab casing of the integration name. 

`openstack_controller`'s integration id would become `openstack-controller`

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
