### PR TITLE
Support Python 3

### DIFF
--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -40,14 +40,14 @@ class NfsStatCheck(AgentCheck):
         custom_tags = instance.get("tags", [])
         stats = stat_out.splitlines()
 
-        if b'No NFS mount point' in stats[0]:
+        if 'No NFS mount point' in stats[0]:
             self.warning("No NFS mount points were found")
             return
 
         for l in stats:
             if not l:
                 continue
-            elif l.find(b'mounted on') >= 0 and len(this_device) > 0:
+            elif l.find('mounted on') >= 0 and len(this_device) > 0:
                 # if it's a new device, create the device and add it to the array
                 device = Device(this_device, self.log)
                 all_devices.append(device)
@@ -84,8 +84,8 @@ class Device(object):
         self.log.info(self._device_header)
         self.device_name = self._device_header[0]
         self.mount = self._device_header[-1][:-1]
-        self.nfs_server = self.device_name.split(b':')[0]
-        self.nfs_export = self.device_name.split(b':')[1]
+        self.nfs_server = self.device_name.split(':')[0]
+        self.nfs_export = self.device_name.split(':')[1]
 
     def _parse_ops(self):
         ops = self._device_data[2]
@@ -98,7 +98,7 @@ class Device(object):
         self.read_kb_per_s = float(read_data[1])
         self.read_kb_per_op = float(read_data[2])
         self.read_retrans = float(read_data[3])
-        self.read_retrans_pct = read_data[4].strip(b'(').strip(b')').strip(b'%')
+        self.read_retrans_pct = read_data[4].strip('(').strip(')').strip('%')
         self.read_retrans_pct = float(self.read_retrans_pct)
         self.read_avg_rtt = float(read_data[5])
         self.read_avg_exe = float(read_data[6])
@@ -109,7 +109,7 @@ class Device(object):
         self.write_kb_per_s = float(write_data[1])
         self.write_kb_per_op = float(write_data[2])
         self.write_retrans = float(write_data[3])
-        self.write_retrans_pct = write_data[4].strip(b'(').strip(b')').strip(b'%')
+        self.write_retrans_pct = write_data[4].strip('(').strip(')').strip('%')
         self.write_retrans_pct = float(self.write_retrans_pct)
         self.write_avg_rtt = float(write_data[5])
         self.write_avg_exe = float(write_data[6])

--- a/nfsstat/tests/test_nfsstat.py
+++ b/nfsstat/tests/test_nfsstat.py
@@ -6,6 +6,7 @@ import logging
 
 import mock
 
+from datadog_checks.base import ensure_unicode
 from datadog_checks.nfsstat import NfsStatCheck
 
 metrics = [
@@ -48,7 +49,7 @@ class TestNfsstat:
         instance = self.INSTANCES['main']
         c = NfsStatCheck(self.CHECK_NAME, self.INIT_CONFIG, {}, [instance])
         with mock.patch('datadog_checks.nfsstat.nfsstat.get_subprocess_output',
-                        return_value=(b'No NFS mount points were found', '', 0)):
+                        return_value=('No NFS mount points were found', '', 0)):
             c.check(instance)
 
     def test_check(self, aggregator):
@@ -56,7 +57,7 @@ class TestNfsstat:
         c = NfsStatCheck(self.CHECK_NAME, self.INIT_CONFIG, {}, [instance])
 
         with open(os.path.join(FIXTURE_DIR, 'nfsiostat'), 'rb') as f:
-            mock_output = f.read()
+            mock_output = ensure_unicode(f.read())
 
         with mock.patch('datadog_checks.nfsstat.nfsstat.get_subprocess_output',
                         return_value=(mock_output, '', 0)):


### PR DESCRIPTION
### What does this PR do?

Add python3 support to the nfsstat check.

get_subprocess_output in checks_base actually returns unicode, and the check was comparing this against bytes. The tests were passing because get_subprocess_output was mocked and returning bytes as well. This fixes that by ensuring_unicode on the mocked values, and removing byte comparisons from the check. 

### Motivation

🐍 3️⃣ :allthethings:

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
