### PR TITLE
Add integration_id to manifest validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -35,7 +35,8 @@ OPTIONAL_ATTRIBUTES = {
     'aliases',
     'description',
     'is_beta',
-    # Move these two below (metric_to_check and metric_prefix) to mandatory when all integration are fixed
+    # Move these three below (integration_id, metric_to_check, metric_prefix) to mandatory when all integration are fixed
+    'integration_id',
     'metric_to_check',
     'metric_prefix',
     'process_signatures',

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -35,7 +35,8 @@ OPTIONAL_ATTRIBUTES = {
     'aliases',
     'description',
     'is_beta',
-    # Move these three below (integration_id, metric_to_check, metric_prefix) to mandatory when all integration are fixed
+    # Move these three below (integration_id, metric_to_check, metric_prefix)
+    # to mandatory when all integration are fixed
     'integration_id',
     'metric_to_check',
     'metric_prefix',


### PR DESCRIPTION
### What does this PR do?

Adds the new `integration_id` field to the manifest validation command. 

### Motivation

Currently the CI/ddev validate manifest fails because it isn't expecting this new field. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
