### PR TITLE
Use execute instead of callproc if using (py)odbc

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -544,7 +544,7 @@ class SQLServer(AgentCheck):
                     cursor.callproc(proc)
                 else:
                     # pyodbc does not support callproc; use execute instead.
-                    # Reference: https://github.com/mkleehammer/pyodbc/wiki/Cursor#callprocprocname-parameters
+                    # Reference: https://github.com/mkleehammer/pyodbc/wiki/Calling-Stored-Procedures
                     cursor.execute(proc)
 
                 rows = cursor.fetchall()

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -540,7 +540,13 @@ class SQLServer(AgentCheck):
 
             try:
                 self.log.debug("Calling Stored Procedure : {}".format(proc))
-                cursor.callproc(proc)
+                if self._get_connector(instance) == 'adodbapi':
+                    cursor.callproc(proc)
+                else:
+                    # pyodbc does not support callproc; use execute instead.
+                    # Reference: https://github.com/mkleehammer/pyodbc/wiki/Cursor#callprocprocname-parameters
+                    cursor.execute(proc)
+
                 rows = cursor.fetchall()
                 self.log.debug("Row count ({}) : {}".format(proc, cursor.rowcount))
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -545,7 +545,8 @@ class SQLServer(AgentCheck):
                 else:
                     # pyodbc does not support callproc; use execute instead.
                     # Reference: https://github.com/mkleehammer/pyodbc/wiki/Calling-Stored-Procedures
-                    cursor.execute(proc)
+                    call_proc = '{{CALL {}}}'.format(proc)
+                    cursor.execute(call_proc)
 
                 rows = cursor.fetchall()
                 self.log.debug("Row count ({}) : {}".format(proc, cursor.rowcount))


### PR DESCRIPTION
### What does this PR do?

Uses `execute` instead of `callproc` if connector is not `adodbapi`
> pyodbc does not currently implement the optional .callproc method. (It has been investigated.)
> However, ODBC defines a {CALL ...} escape sequence that should be supported by well-behaved ODBC drivers.

### Motivation

seems that it would also address the issue - 159-sqlserver-only-one-driver-supports-stored-procs

### Additional Notes

Needed for tests to work in https://github.com/DataDog/integrations-core/pull/3100

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
