### PR TITLE
Upgrade to Python 3.7 for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: required
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,223 +60,223 @@ jobs:
         - ddev validate service-checks
         - ddev test --cov
         - ddev test --bench || true
-    # - stage: test
-    #   env: CHECK=datadog_checks_base PYTHON3=true
-    #   script:
-    #     - ddev validate agent-reqs
-    #     - ddev validate config
-    #     - ddev validate dep
-    #     - ddev validate manifest --include-extras
-    #     - ddev validate metadata
-    #     - ddev validate service-checks
-    #     - travis_retry ddev test --cov ${CHECK}
-    #     - ddev test ${CHECK} --bench || true
-    # - stage: test
-    #   env: CHECK=datadog_checks_dev PYTHON3=true
-    # - stage: test
-    #   env: CHECK=datadog_checks_downloader PYTHON3=true
-    # - stage: test
-    #   env: CHECK=active_directory PYTHON3=true
-    # - stage: test
-    #   env: CHECK=activemq_xml PYTHON3=true
-    # - stage: test
-    #   env: CHECK=aerospike PYTHON3=true
-    # - stage: test
-    # # Agent <=5.x.x integration - only supporting py2 is needed
-    #   env: CHECK=agent_metrics
-    # - stage: test
-    #   env: CHECK=apache PYTHON3=true
-    # - stage: test
-    #   env: CHECK=aspdotnet PYTHON3=true
-    # - stage: test
-    #   env: CHECK=btrfs PYTHON3=true
-    # - stage: test
-    #   env: CHECK=cacti PYTHON3=true
-    # - stage: test
-    #   env: CHECK=cassandra_nodetool PYTHON3=true
-    # - stage: test
-    #   env: CHECK=ceph PYTHON3=true
-    # - stage: test
-    #   env: CHECK=cisco_aci PYTHON3=true
-    # - stage: test
-    #   env: CHECK=cockroachdb PYTHON3=true
-    # - stage: test
-    #   env: CHECK=consul PYTHON3=true
-    # - stage: test
-    #   env: CHECK=coredns PYTHON3=true
-    # - stage: test
-    #   env: CHECK=couch PYTHON3=true
-    # - stage: test
-    #   env: CHECK=couchbase PYTHON3=true
-    # - stage: test
-    #   env: CHECK=crio PYTHON3=true
-    # - stage: test
-    #   env: CHECK=directory PYTHON3=true
-    # - stage: test
-    #   env: CHECK=disk PYTHON3=true
-    # - stage: test
-    # # python 2 support only
-    #   env: CHECK=dns_check
-    # - stage: test
-    #   env: CHECK=dotnetclr PYTHON3=true
-    # - stage: test
-    #   env: CHECK=ecs_fargate PYTHON3=true
-    # - stage: test
-    #   env: CHECK=elastic PYTHON3=true
-    # - stage: test
-    #   env: CHECK=envoy PYTHON3=true
-    # - stage: test
-    #   env: CHECK=etcd PYTHON3=true
-    # - stage: test
-    #   env: CHECK=exchange_server PYTHON3=true
-    # - stage: test
-    #   env: CHECK=fluentd PYTHON3=true
-    # - stage: test
-    #   env: CHECK=gearmand PYTHON3=true
-    # - stage: test
-    #   env: CHECK=gitlab PYTHON3=true
-    # - stage: test
-    #   env: CHECK=gitlab_runner PYTHON3=true
-    # - stage: test
-    #   env: CHECK=go_expvar PYTHON3=true
-    # - stage: test
-    #   env: CHECK=gunicorn PYTHON3=true
-    # - stage: test
-    #   env: CHECK=haproxy PYTHON3=true
-    # - stage: test
-    #   env: CHECK=hdfs_datanode PYTHON3=true
-    # - stage: test
-    #   env: CHECK=hdfs_namenode PYTHON3=true
+    - stage: test
+      env: CHECK=datadog_checks_base PYTHON3=true
+      script:
+        - ddev validate agent-reqs
+        - ddev validate config
+        - ddev validate dep
+        - ddev validate manifest --include-extras
+        - ddev validate metadata
+        - ddev validate service-checks
+        - travis_retry ddev test --cov ${CHECK}
+        - ddev test ${CHECK} --bench || true
+    - stage: test
+      env: CHECK=datadog_checks_dev PYTHON3=true
+    - stage: test
+      env: CHECK=datadog_checks_downloader PYTHON3=true
+    - stage: test
+      env: CHECK=active_directory PYTHON3=true
+    - stage: test
+      env: CHECK=activemq_xml PYTHON3=true
+    - stage: test
+      env: CHECK=aerospike PYTHON3=true
+    - stage: test
+    # Agent <=5.x.x integration - only supporting py2 is needed
+      env: CHECK=agent_metrics
+    - stage: test
+      env: CHECK=apache PYTHON3=true
+    - stage: test
+      env: CHECK=aspdotnet PYTHON3=true
+    - stage: test
+      env: CHECK=btrfs PYTHON3=true
+    - stage: test
+      env: CHECK=cacti PYTHON3=true
+    - stage: test
+      env: CHECK=cassandra_nodetool PYTHON3=true
+    - stage: test
+      env: CHECK=ceph PYTHON3=true
+    - stage: test
+      env: CHECK=cisco_aci PYTHON3=true
+    - stage: test
+      env: CHECK=cockroachdb PYTHON3=true
+    - stage: test
+      env: CHECK=consul PYTHON3=true
+    - stage: test
+      env: CHECK=coredns PYTHON3=true
+    - stage: test
+      env: CHECK=couch PYTHON3=true
+    - stage: test
+      env: CHECK=couchbase PYTHON3=true
+    - stage: test
+      env: CHECK=crio PYTHON3=true
+    - stage: test
+      env: CHECK=directory PYTHON3=true
+    - stage: test
+      env: CHECK=disk PYTHON3=true
+    - stage: test
+    # python 2 support only
+      env: CHECK=dns_check
+    - stage: test
+      env: CHECK=dotnetclr PYTHON3=true
+    - stage: test
+      env: CHECK=ecs_fargate PYTHON3=true
+    - stage: test
+      env: CHECK=elastic PYTHON3=true
+    - stage: test
+      env: CHECK=envoy PYTHON3=true
+    - stage: test
+      env: CHECK=etcd PYTHON3=true
+    - stage: test
+      env: CHECK=exchange_server PYTHON3=true
+    - stage: test
+      env: CHECK=fluentd PYTHON3=true
+    - stage: test
+      env: CHECK=gearmand PYTHON3=true
+    - stage: test
+      env: CHECK=gitlab PYTHON3=true
+    - stage: test
+      env: CHECK=gitlab_runner PYTHON3=true
+    - stage: test
+      env: CHECK=go_expvar PYTHON3=true
+    - stage: test
+      env: CHECK=gunicorn PYTHON3=true
+    - stage: test
+      env: CHECK=haproxy PYTHON3=true
+    - stage: test
+      env: CHECK=hdfs_datanode PYTHON3=true
+    - stage: test
+      env: CHECK=hdfs_namenode PYTHON3=true
     - stage: test
       env: CHECK=http_check PYTHON3=true
-    # - stage: test
-    #   env: CHECK=ibm_mq PYTHON3=true
-    # - stage: test
-    #   env: CHECK=ibm_was PYTHON3=true
-    # - stage: test
-    #   env: CHECK=iis PYTHON3=true
-    # - stage: test
-    #   env: CHECK=istio PYTHON3=true
-    # - stage: test
-    #   env: CHECK=kafka_consumer PYTHON3=true
-    # - stage: test
-    #   env: CHECK=kong PYTHON3=true
-    # - stage: test
-    #   env: CHECK=kube_controller_manager PYTHON3=true
-    # - stage: test
-    #   env: CHECK=kube_dns PYTHON3=true
-    # - stage: test
-    #   env: CHECK=kube_proxy PYTHON3=true
-    # - stage: test
-    #   env: CHECK=kubelet PYTHON3=true
-    # - stage: test
-    #   env: CHECK=kubernetes_state PYTHON3=true
-    # - stage: test
-    #   env: CHECK=kyototycoon PYTHON3=true
-    # - stage: test
-    #   env: CHECK=lighttpd PYTHON3=true
-    # - stage: test
-    #   env: CHECK=linkerd
-    # - stage: test
-    #   env: CHECK=linux_proc_extras PYTHON3=true
-    # - stage: test
-    #   env: CHECK=mapreduce PYTHON3=true
-    # - stage: test
-    #   env: CHECK=marathon PYTHON3=true
-    # - stage: test
-    #   env: CHECK=mcache PYTHON3=true
-    # - stage: test
-    #   env: CHECK=mesos_slave PYTHON3=true
-    # - stage: test
-    #   env: CHECK=mesos_master PYTHON3=true
-    # - stage: test
-    #   env: CHECK=mongo PYTHON3=true
-    # - stage: test
-    #   env: CHECK=mysql PYTHON3=true
-    # - stage: test
-    #   env: CHECK=nagios PYTHON3=true
-    # - stage: test
-    #   env: CHECK=network PYTHON3=true
-    # - stage: test
-    #   env: CHECK=nfsstat PYTHON3=true
-    # - stage: test
-    #   env: CHECK=nginx PYTHON3=true
-    # - stage: test
-    #   env: CHECK=nginx_ingress_controller PYTHON3=true
-    # - stage: test
-    #   env: CHECK=ntp
-    # - stage: test
-    #   env: CHECK=openldap PYTHON3=true
-    # - stage: test
-    #   env: CHECK=openmetrics PYTHON3=true
-    # - stage: test
-    #   env: CHECK=openstack PYTHON3=true
-    # - stage: test
-    #   env: CHECK=openstack_controller PYTHON3=true
-    # - stage: test
-    #   env: CHECK=oracle PYTHON3=true
-    # - stage: test
-    #   env: CHECK=pdh_check PYTHON3=true
-    # - stage: test
-    #   env: CHECK=pgbouncer PYTHON3=true
-    # - stage: test
-    #   env: CHECK=php_fpm PYTHON3=true
-    # - stage: test
-    #   env: CHECK=postgres PYTHON3=true
-    # - stage: test
-    #   env: CHECK=postfix PYTHON3=true
-    # - stage: test
-    #   env: CHECK=powerdns_recursor PYTHON3=true
-    # - stage: test
-    #   env: CHECK=process PYTHON3=true
-    # - stage: test
-    #   env: CHECK=prometheus PYTHON3=true
-    # - stage: test
-    #   env: CHECK=rabbitmq PYTHON3=true
-    # - stage: test
-    #   env: CHECK=redisdb PYTHON3=true
-    # - stage: test
-    #   env: CHECK=riak PYTHON3=true
-    # - stage: test
-    #   env: CHECK=riakcs PYTHON3=true
-    # - stage: test
-    #   env: CHECK=snmp PYTHON3=true
-    # - stage: test
-    #   env: CHECK=spark PYTHON3=true
-    # - stage: test
-    #   env: CHECK=sqlserver PYTHON3=true
-    # - stage: test
-    #   env: CHECK=ssh_check PYTHON3=true
-    # - stage: test
-    #   env: CHECK=statsd PYTHON3=true
-    # - stage: test
-    # # python 2 support only
-    #   env: CHECK=supervisord
-    # - stage: test
-    #   env: CHECK=squid PYTHON3=true
-    # - stage: test
-    #   env: CHECK=system_core PYTHON3=true
-    # - stage: test
-    #   env: CHECK=system_swap PYTHON3=true
-    # - stage: test
-    #   env: CHECK=tcp_check PYTHON3=true
-    # - stage: test
-    #   env: CHECK=teamcity PYTHON3=true
-    # - stage: test
-    # # python 2 support only
-    #   env: CHECK=tokumx
-    # - stage: test
-    #   env: CHECK=twemproxy PYTHON3=true
-    # - stage: test
-    #   env: CHECK=varnish PYTHON3=true
-    # - stage: test
-    #   env: CHECK=vault PYTHON3=true
-    # - stage: test
-    #   env: CHECK=vsphere
-    # - stage: test
-    #   env: CHECK=yarn PYTHON3=true
-    # - stage: test
-    #   env: CHECK=zk PYTHON3=true
+    - stage: test
+      env: CHECK=ibm_mq PYTHON3=true
+    - stage: test
+      env: CHECK=ibm_was PYTHON3=true
+    - stage: test
+      env: CHECK=iis PYTHON3=true
+    - stage: test
+      env: CHECK=istio PYTHON3=true
+    - stage: test
+      env: CHECK=kafka_consumer PYTHON3=true
+    - stage: test
+      env: CHECK=kong PYTHON3=true
+    - stage: test
+      env: CHECK=kube_controller_manager PYTHON3=true
+    - stage: test
+      env: CHECK=kube_dns PYTHON3=true
+    - stage: test
+      env: CHECK=kube_proxy PYTHON3=true
+    - stage: test
+      env: CHECK=kubelet PYTHON3=true
+    - stage: test
+      env: CHECK=kubernetes_state PYTHON3=true
+    - stage: test
+      env: CHECK=kyototycoon PYTHON3=true
+    - stage: test
+      env: CHECK=lighttpd PYTHON3=true
+    - stage: test
+      env: CHECK=linkerd
+    - stage: test
+      env: CHECK=linux_proc_extras PYTHON3=true
+    - stage: test
+      env: CHECK=mapreduce PYTHON3=true
+    - stage: test
+      env: CHECK=marathon PYTHON3=true
+    - stage: test
+      env: CHECK=mcache PYTHON3=true
+    - stage: test
+      env: CHECK=mesos_slave PYTHON3=true
+    - stage: test
+      env: CHECK=mesos_master PYTHON3=true
+    - stage: test
+      env: CHECK=mongo PYTHON3=true
+    - stage: test
+      env: CHECK=mysql PYTHON3=true
+    - stage: test
+      env: CHECK=nagios PYTHON3=true
+    - stage: test
+      env: CHECK=network PYTHON3=true
+    - stage: test
+      env: CHECK=nfsstat PYTHON3=true
+    - stage: test
+      env: CHECK=nginx PYTHON3=true
+    - stage: test
+      env: CHECK=nginx_ingress_controller PYTHON3=true
+    - stage: test
+      env: CHECK=ntp
+    - stage: test
+      env: CHECK=openldap PYTHON3=true
+    - stage: test
+      env: CHECK=openmetrics PYTHON3=true
+    - stage: test
+      env: CHECK=openstack PYTHON3=true
+    - stage: test
+      env: CHECK=openstack_controller PYTHON3=true
+    - stage: test
+      env: CHECK=oracle PYTHON3=true
+    - stage: test
+      env: CHECK=pdh_check PYTHON3=true
+    - stage: test
+      env: CHECK=pgbouncer PYTHON3=true
+    - stage: test
+      env: CHECK=php_fpm PYTHON3=true
+    - stage: test
+      env: CHECK=postgres PYTHON3=true
+    - stage: test
+      env: CHECK=postfix PYTHON3=true
+    - stage: test
+      env: CHECK=powerdns_recursor PYTHON3=true
+    - stage: test
+      env: CHECK=process PYTHON3=true
+    - stage: test
+      env: CHECK=prometheus PYTHON3=true
+    - stage: test
+      env: CHECK=rabbitmq PYTHON3=true
+    - stage: test
+      env: CHECK=redisdb PYTHON3=true
+    - stage: test
+      env: CHECK=riak PYTHON3=true
+    - stage: test
+      env: CHECK=riakcs PYTHON3=true
+    - stage: test
+      env: CHECK=snmp PYTHON3=true
+    - stage: test
+      env: CHECK=spark PYTHON3=true
+    - stage: test
+      env: CHECK=sqlserver PYTHON3=true
+    - stage: test
+      env: CHECK=ssh_check PYTHON3=true
+    - stage: test
+      env: CHECK=statsd PYTHON3=true
+    - stage: test
+    # python 2 support only
+      env: CHECK=supervisord
+    - stage: test
+      env: CHECK=squid PYTHON3=true
+    - stage: test
+      env: CHECK=system_core PYTHON3=true
+    - stage: test
+      env: CHECK=system_swap PYTHON3=true
+    - stage: test
+      env: CHECK=tcp_check PYTHON3=true
+    - stage: test
+      env: CHECK=teamcity PYTHON3=true
+    - stage: test
+    # python 2 support only
+      env: CHECK=tokumx
+    - stage: test
+      env: CHECK=twemproxy PYTHON3=true
+    - stage: test
+      env: CHECK=varnish PYTHON3=true
+    - stage: test
+      env: CHECK=vault PYTHON3=true
+    - stage: test
+      env: CHECK=vsphere
+    - stage: test
+      env: CHECK=yarn PYTHON3=true
+    - stage: test
+      env: CHECK=zk PYTHON3=true
 before_install:
   - bash .travis/prepare.sh
   - PATH="$PATH:$(pyenv root)/versions/3.6.7/bin:$(pyenv root)/versions/3.7.1/bin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -279,7 +279,7 @@ jobs:
       env: CHECK=zk PYTHON3=true
 before_install:
   - bash .travis/prepare.sh
-  - PATH="$PATH:$(pyenv root)/versions/3.6.7/bin:$(pyenv root)/versions/3.7.1/bin"
+  - PATH="$(pyenv root)/versions/3.7.1/bin:$PATH:$(pyenv root)/versions/3.6.7/bin"
 install:
   - pip install -U pip setuptools codecov
   - pip install ./datadog_checks_dev[cli]

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 addons:
   apt:
     packages:
-      - tdsodbc
+      - unixodbc-dev
 cache:
   directories:
     - "$HOME/.cache/pip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 addons:
   apt:
     packages:
+      - tdsodbc
       - unixodbc-dev
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -278,7 +278,7 @@ jobs:
       env: CHECK=zk PYTHON3=true
 before_install:
   - bash .travis/prepare.sh
-  - PATH="$PATH:$(pyenv root)/versions/3.6/bin"
+  - PATH="$PATH:$(pyenv root)/versions/3.6.7/bin:$(pyenv root)/versions/3.7.1/bin"
 install:
   - pip install -U pip setuptools codecov
   - pip install ./datadog_checks_dev[cli]

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,223 +60,223 @@ jobs:
         - ddev validate service-checks
         - ddev test --cov
         - ddev test --bench || true
-    - stage: test
-      env: CHECK=datadog_checks_base PYTHON3=true
-      script:
-        - ddev validate agent-reqs
-        - ddev validate config
-        - ddev validate dep
-        - ddev validate manifest --include-extras
-        - ddev validate metadata
-        - ddev validate service-checks
-        - travis_retry ddev test --cov ${CHECK}
-        - ddev test ${CHECK} --bench || true
-    - stage: test
-      env: CHECK=datadog_checks_dev PYTHON3=true
-    - stage: test
-      env: CHECK=datadog_checks_downloader PYTHON3=true
-    - stage: test
-      env: CHECK=active_directory PYTHON3=true
-    - stage: test
-      env: CHECK=activemq_xml PYTHON3=true
-    - stage: test
-      env: CHECK=aerospike PYTHON3=true
-    - stage: test
-    # Agent <=5.x.x integration - only supporting py2 is needed
-      env: CHECK=agent_metrics
-    - stage: test
-      env: CHECK=apache PYTHON3=true
-    - stage: test
-      env: CHECK=aspdotnet PYTHON3=true
-    - stage: test
-      env: CHECK=btrfs PYTHON3=true
-    - stage: test
-      env: CHECK=cacti PYTHON3=true
-    - stage: test
-      env: CHECK=cassandra_nodetool PYTHON3=true
-    - stage: test
-      env: CHECK=ceph PYTHON3=true
-    - stage: test
-      env: CHECK=cisco_aci PYTHON3=true
-    - stage: test
-      env: CHECK=cockroachdb PYTHON3=true
-    - stage: test
-      env: CHECK=consul PYTHON3=true
-    - stage: test
-      env: CHECK=coredns PYTHON3=true
-    - stage: test
-      env: CHECK=couch PYTHON3=true
-    - stage: test
-      env: CHECK=couchbase PYTHON3=true
-    - stage: test
-      env: CHECK=crio PYTHON3=true
-    - stage: test
-      env: CHECK=directory PYTHON3=true
-    - stage: test
-      env: CHECK=disk PYTHON3=true
-    - stage: test
-    # python 2 support only
-      env: CHECK=dns_check
-    - stage: test
-      env: CHECK=dotnetclr PYTHON3=true
-    - stage: test
-      env: CHECK=ecs_fargate PYTHON3=true
-    - stage: test
-      env: CHECK=elastic PYTHON3=true
-    - stage: test
-      env: CHECK=envoy PYTHON3=true
-    - stage: test
-      env: CHECK=etcd PYTHON3=true
-    - stage: test
-      env: CHECK=exchange_server PYTHON3=true
-    - stage: test
-      env: CHECK=fluentd PYTHON3=true
-    - stage: test
-      env: CHECK=gearmand PYTHON3=true
-    - stage: test
-      env: CHECK=gitlab PYTHON3=true
-    - stage: test
-      env: CHECK=gitlab_runner PYTHON3=true
-    - stage: test
-      env: CHECK=go_expvar PYTHON3=true
-    - stage: test
-      env: CHECK=gunicorn PYTHON3=true
-    - stage: test
-      env: CHECK=haproxy PYTHON3=true
-    - stage: test
-      env: CHECK=hdfs_datanode PYTHON3=true
-    - stage: test
-      env: CHECK=hdfs_namenode PYTHON3=true
+    # - stage: test
+    #   env: CHECK=datadog_checks_base PYTHON3=true
+    #   script:
+    #     - ddev validate agent-reqs
+    #     - ddev validate config
+    #     - ddev validate dep
+    #     - ddev validate manifest --include-extras
+    #     - ddev validate metadata
+    #     - ddev validate service-checks
+    #     - travis_retry ddev test --cov ${CHECK}
+    #     - ddev test ${CHECK} --bench || true
+    # - stage: test
+    #   env: CHECK=datadog_checks_dev PYTHON3=true
+    # - stage: test
+    #   env: CHECK=datadog_checks_downloader PYTHON3=true
+    # - stage: test
+    #   env: CHECK=active_directory PYTHON3=true
+    # - stage: test
+    #   env: CHECK=activemq_xml PYTHON3=true
+    # - stage: test
+    #   env: CHECK=aerospike PYTHON3=true
+    # - stage: test
+    # # Agent <=5.x.x integration - only supporting py2 is needed
+    #   env: CHECK=agent_metrics
+    # - stage: test
+    #   env: CHECK=apache PYTHON3=true
+    # - stage: test
+    #   env: CHECK=aspdotnet PYTHON3=true
+    # - stage: test
+    #   env: CHECK=btrfs PYTHON3=true
+    # - stage: test
+    #   env: CHECK=cacti PYTHON3=true
+    # - stage: test
+    #   env: CHECK=cassandra_nodetool PYTHON3=true
+    # - stage: test
+    #   env: CHECK=ceph PYTHON3=true
+    # - stage: test
+    #   env: CHECK=cisco_aci PYTHON3=true
+    # - stage: test
+    #   env: CHECK=cockroachdb PYTHON3=true
+    # - stage: test
+    #   env: CHECK=consul PYTHON3=true
+    # - stage: test
+    #   env: CHECK=coredns PYTHON3=true
+    # - stage: test
+    #   env: CHECK=couch PYTHON3=true
+    # - stage: test
+    #   env: CHECK=couchbase PYTHON3=true
+    # - stage: test
+    #   env: CHECK=crio PYTHON3=true
+    # - stage: test
+    #   env: CHECK=directory PYTHON3=true
+    # - stage: test
+    #   env: CHECK=disk PYTHON3=true
+    # - stage: test
+    # # python 2 support only
+    #   env: CHECK=dns_check
+    # - stage: test
+    #   env: CHECK=dotnetclr PYTHON3=true
+    # - stage: test
+    #   env: CHECK=ecs_fargate PYTHON3=true
+    # - stage: test
+    #   env: CHECK=elastic PYTHON3=true
+    # - stage: test
+    #   env: CHECK=envoy PYTHON3=true
+    # - stage: test
+    #   env: CHECK=etcd PYTHON3=true
+    # - stage: test
+    #   env: CHECK=exchange_server PYTHON3=true
+    # - stage: test
+    #   env: CHECK=fluentd PYTHON3=true
+    # - stage: test
+    #   env: CHECK=gearmand PYTHON3=true
+    # - stage: test
+    #   env: CHECK=gitlab PYTHON3=true
+    # - stage: test
+    #   env: CHECK=gitlab_runner PYTHON3=true
+    # - stage: test
+    #   env: CHECK=go_expvar PYTHON3=true
+    # - stage: test
+    #   env: CHECK=gunicorn PYTHON3=true
+    # - stage: test
+    #   env: CHECK=haproxy PYTHON3=true
+    # - stage: test
+    #   env: CHECK=hdfs_datanode PYTHON3=true
+    # - stage: test
+    #   env: CHECK=hdfs_namenode PYTHON3=true
     - stage: test
       env: CHECK=http_check PYTHON3=true
-    - stage: test
-      env: CHECK=ibm_mq PYTHON3=true
-    - stage: test
-      env: CHECK=ibm_was PYTHON3=true
-    - stage: test
-      env: CHECK=iis PYTHON3=true
-    - stage: test
-      env: CHECK=istio PYTHON3=true
-    - stage: test
-      env: CHECK=kafka_consumer PYTHON3=true
-    - stage: test
-      env: CHECK=kong PYTHON3=true
-    - stage: test
-      env: CHECK=kube_controller_manager PYTHON3=true
-    - stage: test
-      env: CHECK=kube_dns PYTHON3=true
-    - stage: test
-      env: CHECK=kube_proxy PYTHON3=true
-    - stage: test
-      env: CHECK=kubelet PYTHON3=true
-    - stage: test
-      env: CHECK=kubernetes_state PYTHON3=true
-    - stage: test
-      env: CHECK=kyototycoon PYTHON3=true
-    - stage: test
-      env: CHECK=lighttpd PYTHON3=true
-    - stage: test
-      env: CHECK=linkerd
-    - stage: test
-      env: CHECK=linux_proc_extras PYTHON3=true
-    - stage: test
-      env: CHECK=mapreduce PYTHON3=true
-    - stage: test
-      env: CHECK=marathon PYTHON3=true
-    - stage: test
-      env: CHECK=mcache PYTHON3=true
-    - stage: test
-      env: CHECK=mesos_slave PYTHON3=true
-    - stage: test
-      env: CHECK=mesos_master PYTHON3=true
-    - stage: test
-      env: CHECK=mongo PYTHON3=true
-    - stage: test
-      env: CHECK=mysql PYTHON3=true
-    - stage: test
-      env: CHECK=nagios PYTHON3=true
-    - stage: test
-      env: CHECK=network PYTHON3=true
-    - stage: test
-      env: CHECK=nfsstat PYTHON3=true
-    - stage: test
-      env: CHECK=nginx PYTHON3=true
-    - stage: test
-      env: CHECK=nginx_ingress_controller PYTHON3=true
-    - stage: test
-      env: CHECK=ntp
-    - stage: test
-      env: CHECK=openldap PYTHON3=true
-    - stage: test
-      env: CHECK=openmetrics PYTHON3=true
-    - stage: test
-      env: CHECK=openstack PYTHON3=true
-    - stage: test
-      env: CHECK=openstack_controller PYTHON3=true
-    - stage: test
-      env: CHECK=oracle PYTHON3=true
-    - stage: test
-      env: CHECK=pdh_check PYTHON3=true
-    - stage: test
-      env: CHECK=pgbouncer PYTHON3=true
-    - stage: test
-      env: CHECK=php_fpm PYTHON3=true
-    - stage: test
-      env: CHECK=postgres PYTHON3=true
-    - stage: test
-      env: CHECK=postfix PYTHON3=true
-    - stage: test
-      env: CHECK=powerdns_recursor PYTHON3=true
-    - stage: test
-      env: CHECK=process PYTHON3=true
-    - stage: test
-      env: CHECK=prometheus PYTHON3=true
-    - stage: test
-      env: CHECK=rabbitmq PYTHON3=true
-    - stage: test
-      env: CHECK=redisdb PYTHON3=true
-    - stage: test
-      env: CHECK=riak PYTHON3=true
-    - stage: test
-      env: CHECK=riakcs PYTHON3=true
-    - stage: test
-      env: CHECK=snmp PYTHON3=true
-    - stage: test
-      env: CHECK=spark PYTHON3=true
-    - stage: test
-      env: CHECK=sqlserver PYTHON3=true
-    - stage: test
-      env: CHECK=ssh_check PYTHON3=true
-    - stage: test
-      env: CHECK=statsd PYTHON3=true
-    - stage: test
-    # python 2 support only
-      env: CHECK=supervisord
-    - stage: test
-      env: CHECK=squid PYTHON3=true
-    - stage: test
-      env: CHECK=system_core PYTHON3=true
-    - stage: test
-      env: CHECK=system_swap PYTHON3=true
-    - stage: test
-      env: CHECK=tcp_check PYTHON3=true
-    - stage: test
-      env: CHECK=teamcity PYTHON3=true
-    - stage: test
-    # python 2 support only
-      env: CHECK=tokumx
-    - stage: test
-      env: CHECK=twemproxy PYTHON3=true
-    - stage: test
-      env: CHECK=varnish PYTHON3=true
-    - stage: test
-      env: CHECK=vault PYTHON3=true
-    - stage: test
-      env: CHECK=vsphere
-    - stage: test
-      env: CHECK=yarn PYTHON3=true
-    - stage: test
-      env: CHECK=zk PYTHON3=true
+    # - stage: test
+    #   env: CHECK=ibm_mq PYTHON3=true
+    # - stage: test
+    #   env: CHECK=ibm_was PYTHON3=true
+    # - stage: test
+    #   env: CHECK=iis PYTHON3=true
+    # - stage: test
+    #   env: CHECK=istio PYTHON3=true
+    # - stage: test
+    #   env: CHECK=kafka_consumer PYTHON3=true
+    # - stage: test
+    #   env: CHECK=kong PYTHON3=true
+    # - stage: test
+    #   env: CHECK=kube_controller_manager PYTHON3=true
+    # - stage: test
+    #   env: CHECK=kube_dns PYTHON3=true
+    # - stage: test
+    #   env: CHECK=kube_proxy PYTHON3=true
+    # - stage: test
+    #   env: CHECK=kubelet PYTHON3=true
+    # - stage: test
+    #   env: CHECK=kubernetes_state PYTHON3=true
+    # - stage: test
+    #   env: CHECK=kyototycoon PYTHON3=true
+    # - stage: test
+    #   env: CHECK=lighttpd PYTHON3=true
+    # - stage: test
+    #   env: CHECK=linkerd
+    # - stage: test
+    #   env: CHECK=linux_proc_extras PYTHON3=true
+    # - stage: test
+    #   env: CHECK=mapreduce PYTHON3=true
+    # - stage: test
+    #   env: CHECK=marathon PYTHON3=true
+    # - stage: test
+    #   env: CHECK=mcache PYTHON3=true
+    # - stage: test
+    #   env: CHECK=mesos_slave PYTHON3=true
+    # - stage: test
+    #   env: CHECK=mesos_master PYTHON3=true
+    # - stage: test
+    #   env: CHECK=mongo PYTHON3=true
+    # - stage: test
+    #   env: CHECK=mysql PYTHON3=true
+    # - stage: test
+    #   env: CHECK=nagios PYTHON3=true
+    # - stage: test
+    #   env: CHECK=network PYTHON3=true
+    # - stage: test
+    #   env: CHECK=nfsstat PYTHON3=true
+    # - stage: test
+    #   env: CHECK=nginx PYTHON3=true
+    # - stage: test
+    #   env: CHECK=nginx_ingress_controller PYTHON3=true
+    # - stage: test
+    #   env: CHECK=ntp
+    # - stage: test
+    #   env: CHECK=openldap PYTHON3=true
+    # - stage: test
+    #   env: CHECK=openmetrics PYTHON3=true
+    # - stage: test
+    #   env: CHECK=openstack PYTHON3=true
+    # - stage: test
+    #   env: CHECK=openstack_controller PYTHON3=true
+    # - stage: test
+    #   env: CHECK=oracle PYTHON3=true
+    # - stage: test
+    #   env: CHECK=pdh_check PYTHON3=true
+    # - stage: test
+    #   env: CHECK=pgbouncer PYTHON3=true
+    # - stage: test
+    #   env: CHECK=php_fpm PYTHON3=true
+    # - stage: test
+    #   env: CHECK=postgres PYTHON3=true
+    # - stage: test
+    #   env: CHECK=postfix PYTHON3=true
+    # - stage: test
+    #   env: CHECK=powerdns_recursor PYTHON3=true
+    # - stage: test
+    #   env: CHECK=process PYTHON3=true
+    # - stage: test
+    #   env: CHECK=prometheus PYTHON3=true
+    # - stage: test
+    #   env: CHECK=rabbitmq PYTHON3=true
+    # - stage: test
+    #   env: CHECK=redisdb PYTHON3=true
+    # - stage: test
+    #   env: CHECK=riak PYTHON3=true
+    # - stage: test
+    #   env: CHECK=riakcs PYTHON3=true
+    # - stage: test
+    #   env: CHECK=snmp PYTHON3=true
+    # - stage: test
+    #   env: CHECK=spark PYTHON3=true
+    # - stage: test
+    #   env: CHECK=sqlserver PYTHON3=true
+    # - stage: test
+    #   env: CHECK=ssh_check PYTHON3=true
+    # - stage: test
+    #   env: CHECK=statsd PYTHON3=true
+    # - stage: test
+    # # python 2 support only
+    #   env: CHECK=supervisord
+    # - stage: test
+    #   env: CHECK=squid PYTHON3=true
+    # - stage: test
+    #   env: CHECK=system_core PYTHON3=true
+    # - stage: test
+    #   env: CHECK=system_swap PYTHON3=true
+    # - stage: test
+    #   env: CHECK=tcp_check PYTHON3=true
+    # - stage: test
+    #   env: CHECK=teamcity PYTHON3=true
+    # - stage: test
+    # # python 2 support only
+    #   env: CHECK=tokumx
+    # - stage: test
+    #   env: CHECK=twemproxy PYTHON3=true
+    # - stage: test
+    #   env: CHECK=varnish PYTHON3=true
+    # - stage: test
+    #   env: CHECK=vault PYTHON3=true
+    # - stage: test
+    #   env: CHECK=vsphere
+    # - stage: test
+    #   env: CHECK=yarn PYTHON3=true
+    # - stage: test
+    #   env: CHECK=zk PYTHON3=true
 before_install:
   - bash .travis/prepare.sh
   - PATH="$PATH:$(pyenv root)/versions/3.6.7/bin:$(pyenv root)/versions/3.7.1/bin"

--- a/active_directory/tox.ini
+++ b/active_directory/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-active_directory
+    py{27,37}-active_directory
     flake8
 
 [testenv]

--- a/activemq_xml/tox.ini
+++ b/activemq_xml/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-activemq_xml
+    py{27,37}-activemq_xml
     flake8
 
 [testenv]

--- a/aerospike/tox.ini
+++ b/aerospike/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-latest
+    py{27,37}-latest
     flake8
 
 [testenv]

--- a/agent_metrics/tox.ini
+++ b/agent_metrics/tox.ini
@@ -1,15 +1,13 @@
 [tox]
 minversion = 2.0
-basepython = py37
+basepython = py27
 envlist =
-    agent_metrics
+    py27-agent_metrics
     flake8
 
 [testenv]
 usedevelop = true
 platform = linux|darwin|win32
-
-[testenv:agent_metrics]
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt

--- a/agent_metrics/tox.ini
+++ b/agent_metrics/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
     agent_metrics
     flake8

--- a/apache/tox.ini
+++ b/apache/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-apache
+    py{27,37}-apache
     flake8
 
 [testenv]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: '{branch}.{build}'
+image: Visual Studio 2017
 clone_depth: 3
 build: off
 test: off
@@ -9,7 +10,7 @@ services:
   # We can't start more than one MSSQL instance to avoid conflicts on TCP port 1433. The only workaround to test a check
   # against multiple versions is letting the test code to start/stop the corresponding services so that they run one at
   # a time. See https://www.appveyor.com/docs/services-databases/ for details.
-  - mssql2008r2sp2
+  - mssql2017
 
 skip_branch_with_pr: true
 skip_tags: true
@@ -19,15 +20,15 @@ branches:
 
 environment:
   PYTHON2: C:\Python27-x64
-  PYTHON3: C:\Python36-x64
+  PYTHON3: C:\Python37-x64
 
 init:
-  # Add Python 3 to PATH
-  - set PATH=%PYTHON3%;%PYTHON3%\Scripts;%PATH%
+  # Add Python 2 to PATH
+  - set PATH=%PYTHON2%;%PYTHON2%\Scripts;%PATH%
   - python -c "import sys; print(sys.version)"
 
-  # Add Python 2 to PATH before Python 3
-  - set PATH=%PYTHON2%;%PYTHON2%\Scripts;%PATH%
+  # Add Python 3 to PATH before Python 2
+  - set PATH=%PYTHON3%;%PYTHON3%\Scripts;%PATH%
   - python -c "import sys; print(sys.version)"
 
   # Decide how we'll run tests

--- a/aspdotnet/tox.ini
+++ b/aspdotnet/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-aspdotnet
+    py{27,37}-aspdotnet
     flake8
 
 [testenv]

--- a/btrfs/tox.ini
+++ b/btrfs/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-btrfs
+    py{27,37}-btrfs
     flake8
 
 [testenv]

--- a/cacti/tox.ini
+++ b/cacti/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-cacti
+    py{27,37}-cacti
     flake8
 
 [testenv]

--- a/cassandra_nodetool/tox.ini
+++ b/cassandra_nodetool/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{2.1,unit}
+    py{27,37}-{2.1,unit}
     flake8
 
 [testenv]

--- a/ceph/tox.ini
+++ b/ceph/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-latest
+    py{27,37}-latest
     flake8
 
 [testenv]

--- a/cisco_aci/tox.ini
+++ b/cisco_aci/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-  py{27,36}-unit
+  py{27,37}-unit
   flake8
 
 [testenv]

--- a/cockroachdb/tox.ini
+++ b/cockroachdb/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-(latest,2.0.5}
+    py{27,37}-(latest,2.0.5}
     flake8
     bench
 

--- a/consul/tox.ini
+++ b/consul/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{0.6.4,0.7.2,1.0.0,1.0.6,unit}
+    py{27,37}-{0.6.4,0.7.2,1.0.0,1.0.6,unit}
     flake8
 
 [testenv]

--- a/coredns/tox.ini
+++ b/coredns/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{1.2.0}
+    py{27,37}-{1.2.0}
     flake8
 
 [testenv]

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -88,7 +88,7 @@ def generate_data(couch_version):
     ]
 
     ready = defaultdict(bool)
-    for i in range(60):
+    for i in range(120):
         print("Waiting for stats to be generated on the nodes...")
         try:
             for url in urls:

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -63,9 +63,10 @@ def generate_data(couch_version):
     """
     # pass in authentication info for version 2
     auth = (common.USER, common.PASSWORD) if couch_version == "2" else None
+    headers = {'Accept': 'text/json'}
 
     # Generate a test database
-    requests.put("{}/kennel".format(common.URL), auth=auth)
+    requests.put("{}/kennel".format(common.URL), auth=auth, headers=headers)
 
     # Populate the database
     data = {
@@ -79,7 +80,7 @@ def generate_data(couch_version):
             }
         }
     }
-    requests.put("{}/kennel/_design/dummy".format(common.URL), json=data, auth=auth)
+    requests.put("{}/kennel/_design/dummy".format(common.URL), json=data, auth=auth, headers=headers)
 
     urls = [
         "{}/_node/node1@127.0.0.1/_stats".format(common.URL),
@@ -93,7 +94,7 @@ def generate_data(couch_version):
         try:
             for url in urls:
                 if not ready[url]:
-                    res = requests.get(url, auth=auth)
+                    res = requests.get(url, auth=auth, headers=headers)
                     if res.json():
                         ready[url] = True
             if len(ready) and all(ready.values()):

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -3,6 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 import json
+import time
+
 import pytest
 import requests
 
@@ -52,7 +54,7 @@ def dd_environment():
     with docker_run(
         compose_file=os.path.join(common.HERE, 'compose', 'compose_v{}.yaml'.format(couch_version)),
         env_vars=env,
-        conditions=[CheckEndpoints([common.URL]), lambda: generate_data(couch_version)],
+        conditions=[CheckEndpoints([common.URL]), lambda: generate_data(couch_version), lambda: time.sleep(10)],
     ):
         yield common.BASIC_CONFIG
 

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -497,8 +497,13 @@ def test_view_compaction_metrics(aggregator, check, gauges, instance):
         metric_found = False
         while not metric_found and tries < 40:
             tries += 1
-            for config in [common.NODE1, common.NODE2, common.NODE3]:
-                check.check(config)
+
+            try:
+                for config in [common.NODE1, common.NODE2, common.NODE3]:
+                    check.check(config)
+            except Exception:
+                time.sleep(1)
+                continue
 
             for m_name in aggregator._metrics:
                 if re.search(r'view_compaction\.progress', str(m_name)) is not None:

--- a/couch/tox.ini
+++ b/couch/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-  py{27,36}-{1.6,2.0}
+  py{27,37}-{1.6,2.0}
   flake8
 
 [testenv]

--- a/couchbase/tests/conftest.py
+++ b/couchbase/tests/conftest.py
@@ -45,11 +45,11 @@ def dd_environment():
         compose_file=os.path.join(HERE, 'compose', 'standalone.compose'),
         env_vars={'CB_CONTAINER_NAME': CB_CONTAINER_NAME},
         conditions=[
-            WaitFor(couchbase_container, attempts=15),
-            WaitFor(couchbase_init, attempts=15),
-            WaitFor(couchbase_setup, attempts=15),
-            WaitFor(node_stats, attempts=15),
-            WaitFor(bucket_stats, attempts=15),
+            WaitFor(couchbase_container),
+            WaitFor(couchbase_init),
+            WaitFor(couchbase_setup),
+            WaitFor(node_stats),
+            WaitFor(bucket_stats),
         ]
     ):
         yield DEFAULT_INSTANCE

--- a/couchbase/tox.ini
+++ b/couchbase/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{5.5.3,unit}
+    py{27,37}-{5.5.3,unit}
     flake8
 
 [testenv]

--- a/crio/tox.ini
+++ b/crio/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-crio
+    py{27,37}-crio
     flake8
 
 [testenv]

--- a/datadog_checks_base/tox.ini
+++ b/datadog_checks_base/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 skip_missing_interpreters = true
 envlist =
-    py{27,36}
+    py{27,37}
     flake8
 
 [testenv]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/tox.ini
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py37
+basepython = py36
 envlist =
-    py{{27,37}}-{check_name}
+    py{{27,36}}-{check_name}
     flake8
 
 [testenv]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/tox.ini
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{{27,36}}-{check_name}
+    py{{27,37}}-{check_name}
     flake8
 
 [testenv]

--- a/datadog_checks_dev/tox.ini
+++ b/datadog_checks_dev/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{docker,default}
+    py{27,37}-{docker,default}
     flake8
 
 [testenv]

--- a/datadog_checks_downloader/tox.ini
+++ b/datadog_checks_downloader/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 skip_missing_interpreters = true
 envlist =
-    py{27,36,37}
+    py{27,37}
     flake8
 
 [testenv]

--- a/directory/tox.ini
+++ b/directory/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-directory
+    py{27,37}-directory
     flake8
     bench
 

--- a/disk/tox.ini
+++ b/disk/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-default
+    py{27,37}-default
     flake8
 
 [testenv]

--- a/dns_check/tox.ini
+++ b/dns_check/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py37
 envlist =
-    dns_check
+    py27-dns_check
     flake8
 
 [testenv]

--- a/dotnetclr/tox.ini
+++ b/dotnetclr/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-dotnetclr
+    py{27,37}-dotnetclr
     flake8
 
 [testenv]

--- a/ecs_fargate/tox.ini
+++ b/ecs_fargate/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-unit
+    py{27,37}-unit
     flake8
 
 [testenv]

--- a/elastic/tox.ini
+++ b/elastic/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 skip_missing_interpreters = true
 envlist =
-    py{27,36}-{dd}-{0.90}
-    py{27,36}-{hub}-{1,2}
-    py{27,36}-{5.4,5.5,5.6,6.0,6.1,6.2,6.3,6.4,unit}
+    py{27,37}-{dd}-{0.90}
+    py{27,37}-{hub}-{1,2}
+    py{27,37}-{5.4,5.5,5.6,6.0,6.1,6.2,6.3,6.4,unit}
     bench
     flake8
 

--- a/envoy/tox.ini
+++ b/envoy/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-envoy
+    py{27,37}-envoy
     flake8
     bench
 

--- a/etcd/tox.ini
+++ b/etcd/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{3.3.8,3.3.9,3.3.10}
+    py{27,37}-{3.3.8,3.3.9,3.3.10}
     flake8
 
 [testenv]

--- a/exchange_server/tox.ini
+++ b/exchange_server/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-exchange_server
+    py{27,37}-exchange_server
     flake8
 
 [testenv]

--- a/fluentd/tox.ini
+++ b/fluentd/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-  py{27,36}-0.12.23
+  py{27,37}-0.12.23
   flake8
 
 [testenv]

--- a/gearmand/tox.ini
+++ b/gearmand/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-  py{27,36}-gearmand
+  py{27,37}-gearmand
   flake8
 
 [testenv]

--- a/gitlab/tox.ini
+++ b/gitlab/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-gitlab
+    py{27,37}-gitlab
     flake8
     bench
 

--- a/gitlab_runner/tox.ini
+++ b/gitlab_runner/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-10.8.0
+    py{27,37}-10.8.0
     flake8
 
 [testenv]

--- a/go_expvar/tox.ini
+++ b/go_expvar/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{go_expvar,unit}
+    py{27,37}-{go_expvar,unit}
     flake8
 
 [testenv]

--- a/gunicorn/tox.ini
+++ b/gunicorn/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-gunicorn
+    py{27,37}-gunicorn
     flake8
 
 [testenv]

--- a/hdfs_datanode/tox.ini
+++ b/hdfs_datanode/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-unit
+    py{27,37}-unit
     flake8
 
 [testenv]

--- a/hdfs_namenode/tox.ini
+++ b/hdfs_namenode/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-unit
+    py{27,37}-unit
     flake8
 
 [testenv]

--- a/http_check/tests/test_http_check.py
+++ b/http_check/tests/test_http_check.py
@@ -57,10 +57,7 @@ def test_check_cert_expiration(http_check):
     assert status == 'CRITICAL'
     assert days_left == 0
     assert seconds_left == 0
-    assert (
-        msg == "hostname 'wrong.host.badssl.com' doesn't match either of '*.badssl.com', 'badssl.com'"
-        or "Hostname mismatch, certificate is not valid for 'wrong.host.badssl.com'" in msg
-    )
+    assert msg == "hostname 'wrong.host.badssl.com' doesn't match either of '*.badssl.com', 'badssl.com'"
 
     # site is down
     instance = {
@@ -76,7 +73,6 @@ def test_check_cert_expiration(http_check):
         'url': 'https://expired.badssl.com/'
     }
     status, days_left, seconds_left, msg = http_check.check_cert_expiration(instance, 10, cert_path, check_hostname)
-    assert msg == ''
     assert status == 'DOWN'
     assert days_left == 0
     assert seconds_left == 0

--- a/http_check/tests/test_http_check.py
+++ b/http_check/tests/test_http_check.py
@@ -57,7 +57,10 @@ def test_check_cert_expiration(http_check):
     assert status == 'CRITICAL'
     assert days_left == 0
     assert seconds_left == 0
-    assert msg == "hostname 'wrong.host.badssl.com' doesn't match either of '*.badssl.com', 'badssl.com'"
+    assert (
+        msg == "hostname 'wrong.host.badssl.com' doesn't match either of '*.badssl.com', 'badssl.com'"
+        or "Hostname mismatch, certificate is not valid for 'wrong.host.badssl.com'" in msg
+    )
 
     # site is down
     instance = {
@@ -73,6 +76,7 @@ def test_check_cert_expiration(http_check):
         'url': 'https://expired.badssl.com/'
     }
     status, days_left, seconds_left, msg = http_check.check_cert_expiration(instance, 10, cert_path, check_hostname)
+    assert msg == ''
     assert status == 'DOWN'
     assert days_left == 0
     assert seconds_left == 0

--- a/http_check/tox.ini
+++ b/http_check/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{default,unit}
+    py{27,37}-{default,unit}
     flake8
 
 [testenv]

--- a/http_check/tox.ini
+++ b/http_check/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py37
 envlist =
-    py{27,37}-{default,unit}
+    py{27,36}-{default,unit}
     flake8
 
 [testenv]

--- a/hyperv/tox.ini
+++ b/hyperv/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-hyperv
+    py{27,37}-hyperv
     flake8
     bench
 

--- a/ibm_mq/tox.ini
+++ b/ibm_mq/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{8,9}
+    py{27,37}-{8,9}
     flake8
 
 [testenv]

--- a/ibm_was/tox.ini
+++ b/ibm_was/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    ; py{27,36}-8.5
-    py{27,36}-latest
+    ; py{27,37}-8.5
+    py{27,37}-latest
     flake8
 
 [testenv]

--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -66,7 +66,7 @@ class IIS(PDHBaseCheck):
                 try:
                     vals = counter.get_all_values()
                 except Exception as e:
-                    self.log.error("Failed to get_all_values {} {}".format(inst_name, dd_name))
+                    self.log.error("Failed to get_all_values {} {}: {}".format(inst_name, dd_name, e))
                     continue
 
                 for sitename, val in iteritems(vals):

--- a/iis/tox.ini
+++ b/iis/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-iis
+    py{27,37}-iis
     flake8
 
 [testenv]

--- a/istio/tox.ini
+++ b/istio/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-unit
+    py{27,37}-unit
     flake8
 
 [testenv]

--- a/kafka_consumer/tox.ini
+++ b/kafka_consumer/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{0.9,0.10,0.11,1.0,1.1,2.0,2.1}-{kafka,zk}
+    py{27,37}-{0.9,0.10,0.11,1.0,1.1,2.0,2.1}-{kafka,zk}
     flake8
 
 [testenv]

--- a/kong/tox.ini
+++ b/kong/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-  py{27,36}-{0.13.0}
+  py{27,37}-{0.13.0}
   flake8
 
 [testenv]

--- a/kube_controller_manager/tox.ini
+++ b/kube_controller_manager/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-kube_controller_manager
+    py{27,37}-kube_controller_manager
     flake8
 
 [testenv]

--- a/kube_dns/tox.ini
+++ b/kube_dns/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-unit
+    py{27,37}-unit
     flake8
 
 [testenv]

--- a/kube_proxy/tox.ini
+++ b/kube_proxy/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-unit
+    py{27,37}-unit
     flake8
 
 [testenv]

--- a/kubelet/tox.ini
+++ b/kubelet/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-kubelet
+    py{27,37}-kubelet
     flake8
 
 [testenv]

--- a/kubernetes_state/tox.ini
+++ b/kubernetes_state/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    {py27,py36}-unit
+    py{27,37}-unit
     flake8
 
 [testenv]

--- a/kyototycoon/tox.ini
+++ b/kyototycoon/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-kyototycoon
+    py{27,37}-kyototycoon
     flake8
 
 [testenv]

--- a/lighttpd/tox.ini
+++ b/lighttpd/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-latest
+    py{27,37}-latest
     flake8
 
 [testenv]
@@ -16,7 +16,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install -r requirements.in
-    pytest -m"integration" -v
+    pytest -v
 
 [testenv:flake8]
 skip_install = true

--- a/linkerd/tox.ini
+++ b/linkerd/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-unit
+    py{27,37}-unit
     flake8
 
 [testenv]

--- a/linux_proc_extras/tox.ini
+++ b/linux_proc_extras/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-linux_proc_extras
+    py{27,37}-linux_proc_extras
     flake8
 
 [testenv]

--- a/mapreduce/tox.ini
+++ b/mapreduce/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-unit
+    py{27,37}-unit
     flake8
 
 [testenv]

--- a/marathon/tox.ini
+++ b/marathon/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{unit,marathon}
+    py{27,37}-{unit,marathon}
     flake8
 
 [testenv]

--- a/mcache/tox.ini
+++ b/mcache/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{integration,unit}
+    py{27,37}-{integration,unit}
     flake8
 
 [testenv]

--- a/mesos_master/tox.ini
+++ b/mesos_master/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-unit
+    py{27,37}-unit
     flake8
 
 [testenv]

--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -116,7 +116,7 @@ class MesosSlave(AgentCheck):
             else:
                 status = AgentCheck.OK
                 msg = "Mesos master instance detected at %s " % url
-        except requests.exceptions.Timeout as e:
+        except requests.exceptions.Timeout:
             # If there's a timeout
             msg = "%s seconds timeout when hitting %s" % (timeout, url)
             status = AgentCheck.CRITICAL

--- a/mesos_slave/tox.ini
+++ b/mesos_slave/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-unit
+    py{27,37}-unit
     flake8
 
 [testenv]

--- a/mongo/tox.ini
+++ b/mongo/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-  py{27,36}-{3.2.10,3.4,3.5,4.1,unit}
+  py{27,37}-{3.2.10,3.4,3.5,4.1,unit}
   flake8
 
 [testenv]

--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{5.5,5.6,5.7,maria,unit}
+    py{27,37}-{5.5,5.6,5.7,maria,unit}
     flake8
 
 [testenv]

--- a/nagios/tox.ini
+++ b/nagios/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{unit,nagios}
+    py{27,37}-{unit,nagios}
     flake8
 
 [testenv]

--- a/network/tox.ini
+++ b/network/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-unit
+    py{27,37}-unit
     flake8
 
 [testenv]

--- a/nfsstat/tox.ini
+++ b/nfsstat/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-nfsstat
+    py{27,37}-nfsstat
     flake8
 
 [testenv]

--- a/nginx/tox.ini
+++ b/nginx/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{1.12,1.13,vts}
+    py{27,37}-{1.12,1.13,vts}
     flake8
 
 [testenv]

--- a/nginx_ingress_controller/tox.ini
+++ b/nginx_ingress_controller/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-nginx_ingress_controller
+    py{27,37}-nginx_ingress_controller
     flake8
 
 [testenv]

--- a/ntp/tox.ini
+++ b/ntp/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py37
 envlist =
     py27-ntp
     flake8

--- a/openldap/tox.ini
+++ b/openldap/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{2.4,unit}
+    py{27,37}-{2.4,unit}
     flake8
 
 [testenv]

--- a/openmetrics/tox.ini
+++ b/openmetrics/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-openmetrics
+    py{27,37}-openmetrics
     flake8
 
 [testenv]

--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -945,7 +945,7 @@ class OpenStackCheck(AgentCheck):
                 self.log.debug("Removing server from cache: %s", new_server)
                 try:
                     del self.server_details_by_id[new_server['server_id']]
-                except KeyError as e:
+                except KeyError:
                     self.log.debug("Server: %s has already been removed from the cache", new_server['server_id'])
 
         return self.server_details_by_id
@@ -1302,7 +1302,7 @@ class OpenStackCheck(AgentCheck):
                 self.warning("Error reaching nova API")
 
             return
-        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
+        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
             # exponential backoff
             self.do_backoff(instance)
             self.warning("There were some problems reaching the nova API - applying exponential backoff")

--- a/openstack/tox.ini
+++ b/openstack/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-openstack
+    py{27,37}-openstack
     flake8
 
 [testenv]

--- a/openstack_controller/tox.ini
+++ b/openstack_controller/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-openstack_controller
+    py{27,37}-openstack_controller
     flake8
 
 [testenv]

--- a/oracle/tox.ini
+++ b/oracle/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-oracle
+    py{27,37}-oracle
     flake8
 
 [testenv]

--- a/pdh_check/tox.ini
+++ b/pdh_check/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-pdh_check
+    py{27,37}-pdh_check
     flake8
 
 [testenv]

--- a/pgbouncer/tox.ini
+++ b/pgbouncer/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{1_7,1_8}
+    py{27,37}-{1.7,1.8}
     flake8
 
 [testenv]
@@ -18,8 +18,8 @@ commands =
     pip install -r requirements.in
     pytest -v
 setenv =
-    1_7: PGBOUNCER_VERSION=1_7
-    1_8: PGBOUNCER_VERSION=1_8
+    1.7: PGBOUNCER_VERSION=1_7
+    1.8: PGBOUNCER_VERSION=1_8
 
 [testenv:flake8]
 skip_install = true

--- a/php_fpm/tox.ini
+++ b/php_fpm/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{integration,unit}
+    py{27,37}-{integration,unit}
     flake8
 
 [testenv]
@@ -17,7 +17,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install -r requirements.in
-    py36: pip install flup==1.0.3
+    py37: pip install flup==1.0.3
     unit: pytest -v -m "not integration"
     integration: pytest -v -m "integration"
 

--- a/postfix/tox.ini
+++ b/postfix/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-integration
+    py{27,37}-integration
     flake8
 
 [testenv]

--- a/postgres/tox.ini
+++ b/postgres/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{93,94,95,96,10,11}-pg8000
-    py{27,36}-unit
-    py36-11-psycopg2
+    py{27,37}-{93,94,95,96,10,11}-{psycopg2,pg8000}
+    py{27,37}-unit
     flake8
 
 [testenv]

--- a/powerdns_recursor/tox.ini
+++ b/powerdns_recursor/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{3.7.3,4.0.3,unit}
+    py{27,37}-{3.7.3,4.0.3,unit}
     flake8
 
 [testenv]

--- a/process/tox.ini
+++ b/process/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-process
+    py{27,37}-process
     flake8
 
 [testenv]

--- a/prometheus/tox.ini
+++ b/prometheus/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-prometheus
+    py{27,37}-prometheus
     flake8
 
 [testenv]

--- a/rabbitmq/requirements-dev.txt
+++ b/rabbitmq/requirements-dev.txt
@@ -1,2 +1,2 @@
 -e ../datadog_checks_dev
-pika==0.10.0
+pika==0.13.0

--- a/rabbitmq/tox.ini
+++ b/rabbitmq/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-  py{27,36}-{3.5,3.6,unit}
+  py{27,37}-{3.5,3.6,unit}
   flake8
 
 [testenv]

--- a/redisdb/tox.ini
+++ b/redisdb/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{3.2,4.0,latest,unit}
+    py{27,37}-{3.2,4.0,latest,unit}
     flake8
 
 [testenv]

--- a/riak/tox.ini
+++ b/riak/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-riak
+    py{27,37}-riak
     flake8
 
 [testenv]
@@ -14,7 +14,6 @@ passenv =
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
-setenv = REDIS_VERSION=3.2
 commands =
     pip install -r requirements.in
     pytest -v

--- a/riakcs/tests/conftest.py
+++ b/riakcs/tests/conftest.py
@@ -20,7 +20,7 @@ def dd_environment():
     compose_file = os.path.join(common.HERE, "compose", "docker-compose.yaml")
     with docker_run(
         compose_file=compose_file,
-        conditions=[CheckDockerLogs("dd-test-riakcs", "INFO success: riak-cs entered RUNNING state", attempts=120)],
+        conditions=[CheckDockerLogs("dd-test-riakcs", "INFO success: riak-cs entered RUNNING state", attempts=240)],
     ):
         yield common.generate_config_with_creds()
 

--- a/riakcs/tox.ini
+++ b/riakcs/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-  py{27,36}-unit
-  py{27,36}-integration
+  py{27,37}-unit
+  py{27,37}-integration
   flake8
 
 [testenv]

--- a/snmp/tox.ini
+++ b/snmp/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-  py{27,36}-{snmp,unit}
+  py{27,37}-{snmp,unit}
   bench
   flake8
 

--- a/spark/tox.ini
+++ b/spark/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{spark}-{2.4}
-    py{27,36}-unit
+    py{27,37}-{spark}-{2.4}
+    py{27,37}-unit
     flake8
 
 [testenv]

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -671,7 +671,7 @@ class SQLServer(AgentCheck):
                     self.log.info("Could not close adodbapi db connection\n{0}".format(e))
 
                 self.connections[conn_key]['conn'] = rawconn
-        except Exception as e:
+        except Exception:
             cx = "{} - {}".format(host, database)
             message = "Unable to connect to SQL Server for instance {}.".format(cx)
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -36,8 +36,8 @@ INSTANCE_DOCKER = {
     'tags': ['optional:tag1'],
 }
 
-INSTANCE_SQL2008 = {
-    'host': r'(local)\SQL2008R2SP2',
+INSTANCE_SQL2017 = {
+    'host': r'(local)\SQL2017',
     'username': 'sa',
     'password': 'Password12!',
 }

--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -14,7 +14,7 @@ except ImportError:
 from datadog_checks.dev import docker_run, WaitFor
 
 from .common import (
-    INIT_CONFIG, INIT_CONFIG_OBJECT_NAME, INSTANCE_SQL2008, INSTANCE_DOCKER, HOST, PORT, HERE, FULL_CONFIG, lib_tds_path
+    INIT_CONFIG, INIT_CONFIG_OBJECT_NAME, INSTANCE_SQL2017, INSTANCE_DOCKER, HOST, PORT, HERE, FULL_CONFIG, lib_tds_path
 )
 
 
@@ -29,8 +29,8 @@ def init_config_object_name():
 
 
 @pytest.fixture
-def instance_sql2008():
-    return deepcopy(INSTANCE_SQL2008)
+def instance_sql2017():
+    return deepcopy(INSTANCE_SQL2017)
 
 
 @pytest.fixture

--- a/sqlserver/tests/test_sqlserver.py
+++ b/sqlserver/tests/test_sqlserver.py
@@ -47,10 +47,10 @@ def test_object_name(aggregator, init_config_object_name, instance_docker):
 
 
 @pytest.mark.local
-def test_check_local(aggregator, init_config, instance_sql2008):
-    sqlserver_check = SQLServer(CHECK_NAME, init_config, {}, [instance_sql2008])
-    sqlserver_check.check(instance_sql2008)
-    expected_tags = instance_sql2008.get('tags', []) + [r'host:(local)\SQL2008R2SP2', 'db:master']
+def test_check_local(aggregator, init_config, instance_sql2017):
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, {}, [instance_sql2017])
+    sqlserver_check.check(instance_sql2017)
+    expected_tags = instance_sql2017.get('tags', []) + [r'host:(local)\SQL2017', 'db:master']
     _assert_metrics(aggregator, expected_tags)
 
 

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -12,11 +12,11 @@ pytestmark = pytest.mark.unit
 CHECK_NAME = 'sqlserver'
 
 
-def test_get_cursor(instance_sql2008):
+def test_get_cursor(instance_sql2017):
     """
     Ensure we don't leak connection info in case of a KeyError when the
     connection pool is empty or the params for `get_cursor` are invalid.
     """
     check = SQLServer(CHECK_NAME, {}, {}, [])
     with pytest.raises(SQLConnectionError):
-        check.get_cursor(instance_sql2008, 'foo')
+        check.get_cursor(instance_sql2017, 'foo')

--- a/sqlserver/tox.ini
+++ b/sqlserver/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{docker,local,unit}
+    py{27,37}-{docker,local,unit}
     flake8
 
 [testenv]

--- a/squid/tox.ini
+++ b/squid/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-  py{27,36}-{latest,unit}
+  py{27,37}-{latest,unit}
   flake8
 
 [testenv]

--- a/ssh_check/tox.ini
+++ b/ssh_check/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-latest
+    py{27,37}-latest
     flake8
 
 [testenv]

--- a/statsd/tox.ini
+++ b/statsd/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-statsd
+    py{27,37}-statsd
     flake8
 
 [testenv]

--- a/supervisord/datadog_checks/supervisord/supervisord.py
+++ b/supervisord/datadog_checks/supervisord/supervisord.py
@@ -64,7 +64,7 @@ class SupervisordCheck(AgentCheck):
                 'An error occurred while reading process information: %s %s'
                 % (error.faultCode, error.faultString)
             )
-        except socket.error, e:
+        except socket.error:
             host = instance.get('host', DEFAULT_HOST)
             port = instance.get('port', DEFAULT_PORT)
             sock = instance.get('socket')

--- a/supervisord/tox.ini
+++ b/supervisord/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 basepython = py37
 envlist =
     py27-3.3.3
-    unit
+    py27-unit
     flake8
 
 [testenv]

--- a/supervisord/tox.ini
+++ b/supervisord/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py37
 envlist =
-    integration_3.3.3
+    py27-3.3.3
     unit
     flake8
 
-[testenv:integration_3.3.3]
+[testenv]
 platform = linux|darwin|win32
 setenv = SUPERVISOR_IMAGE=datadog/docker-library:supervisord_3_3_3
 deps =
@@ -14,7 +14,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install -r requirements.in
-    integration_3.3.3: pytest -v -m integration
+    3.3.3: pytest -v -m integration
     unit: pytest -v -m unit
 
 [testenv:flake8]

--- a/system_core/tox.ini
+++ b/system_core/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-system_core
+    py{27,37}-system_core
     flake8
 
 [testenv]

--- a/system_swap/tox.ini
+++ b/system_swap/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-  py{27,36}-unit
+  py{27,37}-unit
   flake8
 
 [testenv]

--- a/tcp_check/tox.ini
+++ b/tcp_check/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-unit
+    py{27,37}-unit
     flake8
 
 [testenv]

--- a/teamcity/tox.ini
+++ b/teamcity/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{unit,teamcity}
+    py{27,37}-{unit,teamcity}
     flake8
 
 [testenv]

--- a/twemproxy/tox.ini
+++ b/twemproxy/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-latest
+    py{27,37}-latest
     flake8
 
 [testenv]

--- a/twistlock/tox.ini
+++ b/twistlock/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-twistlock
+    py{27,37}-twistlock
     flake8
 
 [testenv]

--- a/varnish/tox.ini
+++ b/varnish/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{unit,417,521}
+    py{27,37}-{unit,417,521}
     flake8
 
 [testenv]

--- a/vault/tox.ini
+++ b/vault/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-latest
+    py{27,37}-latest
     flake8
     bench
 

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -13,6 +13,7 @@ import threading
 from pyVim import connect
 from pyVmomi import vim  # pylint: disable=E0611
 from pyVmomi import vmodl  # pylint: disable=E0611
+from six.moves import range
 
 from datadog_checks.config import is_affirmative
 from datadog_checks.checks import AgentCheck
@@ -676,7 +677,7 @@ class VSphereCheck(AgentCheck):
             batch_size = self.batch_morlist_size or self.mor_objects_queue.size(i_key, resource_type)
             while self.mor_objects_queue.size(i_key, resource_type):
                 mors = []
-                for _ in xrange(batch_size):
+                for _ in range(batch_size):
                     mor = self.mor_objects_queue.pop(i_key, resource_type)
                     if mor is None:
                         self.log.debug("No more objects of type '{}' left in the queue".format(resource_type))

--- a/vsphere/tests/test_mor_cache.py
+++ b/vsphere/tests/test_mor_cache.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 import time
+from six.moves import range
 
 from datadog_checks.vsphere.mor_cache import MorCache, MorNotFoundError
 
@@ -73,7 +74,7 @@ def test_set_metrics(cache):
 
 def test_mors(cache):
     cache._mor['foo_instance'] = {}
-    for i in xrange(9):
+    for i in range(9):
         # For the sake of this test, Mor name is `i` and Mor object is `None`
         cache._mor['foo_instance'][i] = None
 
@@ -83,7 +84,7 @@ def test_mors(cache):
 
 def test_mors_batch(cache):
     cache._mor['foo_instance'] = {}
-    for i in xrange(9):
+    for i in range(9):
         # For the sake of this test, Mor name is `i` and Mor object is `None`
         cache._mor['foo_instance'][i] = None
 
@@ -113,7 +114,7 @@ def test_mors_batch(cache):
 
 def test_purge(cache):
     cache._mor['foo_instance'] = {}
-    for i in xrange(3):
+    for i in range(3):
         # set last access to 0, these will be purged
         cache._mor['foo_instance'][i] = {'creation_time': 0}
     # this entry should stay

--- a/vsphere/tox.ini
+++ b/vsphere/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py27
+basepython = py37
 envlist =
-    vsphere
+    py27-vsphere
     flake8
 
 [testenv]

--- a/win32_event_log/tox.ini
+++ b/win32_event_log/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-win32_event_log
+    py{27,37}-win32_event_log
     flake8
 
 [testenv]

--- a/windows_service/tox.ini
+++ b/windows_service/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-windows_service
+    py{27,37}-windows_service
     flake8
     bench
 

--- a/wmi_check/tox.ini
+++ b/wmi_check/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-wmi_check
+    py{27,37}-wmi_check
     flake8
 
 [testenv]

--- a/yarn/tox.ini
+++ b/yarn/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-yarn
+    py{27,37}-yarn
     flake8
 
 [testenv]

--- a/zk/tox.ini
+++ b/zk/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 2.0
-basepython = py36
+basepython = py37
 envlist =
-    py{27,36}-{3.4,3.5}
+    py{27,37}-{3.4,3.5}
     flake8
 
 [testenv]


### PR DESCRIPTION
### Motivation

🐍 3️⃣ 

### Notes

- Python 3.7 required an upgrade of our Travis & AppVeyor images
- Xenial on Travis exposed some test setups with insufficient retry mechanisms. I've simply increased some of the timeouts until we discover what the proper things to check for "up" status are
- Running `flake8` on 3.7 exposed some things that were not caught on 2.x, for some reason. I fixed those too

### Notes

Certificate handling in the `http_check` does not work on 3.7 so that still uses 3.6. We'll fix that in a subsequent pr