### PR TITLE
Fix the twistlock readme again

### DIFF
--- a/twistlock/README.md
+++ b/twistlock/README.md
@@ -30,10 +30,10 @@ spec:
   template:
     metadata:
       annotations:
-        ad.datadoghq.com/twistlock.check_name: '["twistlock"]'
-        ad.datadoghq.com/twistlock.init_configs: '[{}]'
-        ad.datadoghq.com/twistlock.instances: '[{"url":"http://%%host%%:8083", "username":"USERNAME", "password": "PASSWORD"}]'
-        ad.datadoghq.com/twistlock.logs: '[{"source": "twistlock", "service": "twistlock"}]'
+        ad.datadoghq.com/twistlock-console.check_name: '["twistlock"]'
+        ad.datadoghq.com/twistlock-console.init_configs: '[{}]'
+        ad.datadoghq.com/twistlock-console.instances: '[{"url":"http://%%host%%:8083", "username":"USERNAME", "password": "PASSWORD"}]'
+        ad.datadoghq.com/twistlock-console.logs: '[{"source": "twistlock", "service": "twistlock"}]'
       name: twistlock-console
       namespace: twistlock
       labels:


### PR DESCRIPTION
### What does this PR do?

"twistlock" needs to be "twistlock-console" in the ad definitions. The AD definitions need to include the name of the docker container. 

The name will be "twistlock-console", instead of just "twistlock" in the default configuration. The documentation should reflect the default configuration, as it is generated by a twistlock tool. 

People can of course make changes but the goal is for it to work out of the box with the default config.