### PR TITLE
Fixed decoding warning for None tags

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -351,16 +351,17 @@ class __AgentCheckPy3(object):
 
         if tags is not None:
             for tag in tags:
-                if not isinstance(tag, str):
-                    try:
-                        tag = tag.decode('utf-8')
-                    except UnicodeError:
-                        self.log.warning(
-                            'Error decoding tag `{}` as utf-8 for metric `{}`, ignoring tag'.format(tag, metric_name)
-                        )
-                        continue
+                if not tag:
+                    if not isinstance(tag, str):
+                        try:
+                            tag = tag.decode('utf-8')
+                        except UnicodeError:
+                            self.log.warning(
+                                'Error decoding tag `{}` as utf-8 for metric `{}`, ignoring tag'.format(tag, metric_name)
+                            )
+                            continue
 
-                normalized_tags.append(tag)
+                    normalized_tags.append(tag)
 
         return normalized_tags
 

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -351,17 +351,17 @@ class __AgentCheckPy3(object):
 
         if tags is not None:
             for tag in tags:
-                if not tag:
-                    if not isinstance(tag, str):
-                        try:
-                            tag = tag.decode('utf-8')
-                        except UnicodeError:
-                            self.log.warning(
-                                'Error decoding tag `{}` as utf-8 for metric `{}`, ignoring tag'.format(tag, metric_name)
-                            )
-                            continue
+                if tag is None: continue
+                if not isinstance(tag, str):
+                    try:
+                        tag = tag.decode('utf-8')
+                    except UnicodeError:
+                        self.log.warning(
+                            'TESTEST Error decoding tag `{}` as utf-8 for metric `{}`, ignoring tag'.format(tag, metric_name)
+                        )
+                        continue
 
-                    normalized_tags.append(tag)
+                normalized_tags.append(tag)
 
         return normalized_tags
 

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -351,7 +351,8 @@ class __AgentCheckPy3(object):
 
         if tags is not None:
             for tag in tags:
-                if tag is None: continue
+                if tag is None:
+                    continue
                 if not isinstance(tag, str):
                     try:
                         tag = tag.decode('utf-8')

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -357,7 +357,7 @@ class __AgentCheckPy3(object):
                         tag = tag.decode('utf-8')
                     except UnicodeError:
                         self.log.warning(
-                            'TESTEST Error decoding tag `{}` as utf-8 for metric `{}`, ignoring tag'.format(tag, metric_name)
+                            'Error decoding tag `{}` as utf-8 for metric `{}`, ignoring tag'.format(tag, metric_name)
                         )
                         continue
 

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -218,6 +218,7 @@ class TestTags:
         normalized_tags = check._normalize_tags_type(tags, None)
         assert normalized_tags == ['tag:foo']
 
+
 class LimitedCheck(AgentCheck):
     DEFAULT_METRIC_LIMIT = 10
 

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -211,6 +211,12 @@ class TestTags:
         in_str.encode.side_effect = Exception
         assert check._to_bytes(in_str) is None
 
+    def test_none_value(self):
+        check = AgentCheck()
+        tags = [None, 'tag:foo']
+
+        normalized_tags = check._normalize_tags_type(tags, None)
+        assert len(normalized_tags) == 1
 
 class LimitedCheck(AgentCheck):
     DEFAULT_METRIC_LIMIT = 10

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -216,7 +216,7 @@ class TestTags:
         tags = [None, 'tag:foo']
 
         normalized_tags = check._normalize_tags_type(tags, None)
-        assert len(normalized_tags) == 1
+        assert normalized_tags == ['tag:foo']
 
 class LimitedCheck(AgentCheck):
     DEFAULT_METRIC_LIMIT = 10


### PR DESCRIPTION
### What does this PR do?

If an integration tries to send a metric with tag set to `None`, there will be a warning thrown by this code: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/base.py#L352-L363
As we cannot decode it.

Now, we simply ignore if a tag is set to None.

### Motivation

Customer which had his logs spammed by this warning, because of a label missing in a prometheus payload.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
