### PR TITLE
Support old nodetool output format

### DIFF
--- a/cassandra_nodetool/datadog_checks/cassandra_nodetool/cassandra_nodetool.py
+++ b/cassandra_nodetool/datadog_checks/cassandra_nodetool/cassandra_nodetool.py
@@ -33,9 +33,22 @@ TO_BYTES = {
 class CassandraNodetoolCheck(AgentCheck):
 
     datacenter_name_re = re.compile('^Datacenter: (.*)')
-    node_status_re = re.compile(r'^(?P<status>[UD])[NLJM] +(?P<address>\d+\.\d+\.\d+\.\d+) +'
-                                r'(?P<load>\d+(\.\d*)?) (?P<load_unit>(K|M|G|T)?i?B) +\d+ +'
-                                r'(?P<owns>(\d+(\.\d+)?)|\?)%? +(?P<id>[a-fA-F0-9-]*) +(?P<rack>.*)')
+
+    # nodetool status output
+    node_status_re_pattans = [
+        # --  Address    Load       Tokens  Owns    Host ID                               Rack
+        # UN  127.0.0.1  47.66 KB   1       33.3%   aaa1b7c1-6049-4a08-ad3e-3697a0e30e10  rack1
+        re.compile(r'^(?P<status>[UD])[NLJM] +(?P<address>\d+\.\d+\.\d+\.\d+) +'
+                   r'(?P<load>\d+(\.\d*)?) (?P<load_unit>(K|M|G|T)?i?B) +\d+ +'
+                   r'(?P<owns>(\d+(\.\d+)?)|\?)%? +(?P<id>[a-fA-F0-9-]*) +(?P<rack>.*)'),
+        # old nodetool status output
+        # --  Address    Load       Owns    Host ID                               Token  Rack
+        # UN  127.0.0.1  47.66 KB   33.3%   aaa1b7c1-6049-4a08-ad3e-3697a0e30e10  4035225268091337308       rack1
+        re.compile(r'^(?P<status>[UD])[NLJM] +(?P<address>\d+\.\d+\.\d+\.\d+) +'
+                   r'(?P<load>\d+(\.\d*)?) (?P<load_unit>(K|M|G|T)?i?B) +'
+                   r'(?P<owns>(\d+(\.\d+)?)|\?)%? +(?P<id>[a-fA-F0-9-]*) +-?\d+ +'
+                   r'(?P<rack>.*)'),
+    ]
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
@@ -134,18 +147,20 @@ class CassandraNodetoolCheck(AgentCheck):
                 datacenter_name = match.group(1)
                 continue
 
-            match = self.node_status_re.search(line)
-            if match:
-                node = {
-                    'status': match.group('status'),
-                    'address': match.group('address'),
-                    'load': match.group('load'),
-                    'load_unit': match.group('load_unit'),
-                    'owns': match.group('owns'),
-                    'id': match.group('id'),
-                    'rack': match.group('rack'),
-                    'datacenter': datacenter_name
-                }
-                nodes.append(node)
+            for node_status_re in self.node_status_re_pattans:
+                match = node_status_re.search(line)
+                if match:
+                    node = {
+                        'status': match.group('status'),
+                        'address': match.group('address'),
+                        'load': match.group('load'),
+                        'load_unit': match.group('load_unit'),
+                        'owns': match.group('owns'),
+                        'id': match.group('id'),
+                        'rack': match.group('rack'),
+                        'datacenter': datacenter_name
+                    }
+                    nodes.append(node)
+                    break
 
         return nodes

--- a/cassandra_nodetool/tests/fixtures/nodetool_output_1.2
+++ b/cassandra_nodetool/tests/fixtures/nodetool_output_1.2
@@ -1,0 +1,15 @@
+Datacenter: dc1
+===============
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address        Load       Owns (effective)  Host ID                               Token                                    Rack
+DN  172.21.0.6  178.43 KB   35.4%             f86d2d7a-e5c7-4c46-b36e-df08c565171a  4035225268091337308                      rack1
+UN  172.21.0.3  184.8 KB    31.0%             7501ef03-eb63-4db0-95e6-20bfeb7cdd87  6052837901153319516                      RAC1
+UN  172.21.0.2  182.05 KB   33.5%             fa859fcc-5e76-44ce-9609-1f314bdf21c1  -432345564227567616                      RAC1
+Datacenter: dc2
+===============
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address        Load       Owns (effective)  Host ID                               Token                                    Rack
+UN  172.21.0.5  216.75 KB   100.0%              2250363b-7453-48f2-b6cb-ef79cad0612b  4035225268091337308                      RAC1
+UN  172.21.0.4  223.34 KB   100.0%              e521a2a4-39d3-4311-a195-667bf56450f4  6052837901153319516                      RAC1

--- a/cassandra_nodetool/tests/test_unit.py
+++ b/cassandra_nodetool/tests/test_unit.py
@@ -8,14 +8,31 @@ from . import common
 from datadog_checks.cassandra_nodetool import CassandraNodetoolCheck
 
 
-def mock_output(*args, **kwargs):
-    with open(path.join(common.HERE, 'fixtures', 'nodetool_output')) as f:
+def _read_fixture(filename):
+    with open(path.join(common.HERE, 'fixtures', filename)) as f:
         contents = f.read()
         return contents, "", 0
 
 
+def mock_output(*args, **kwargs):
+    return _read_fixture('nodetool_output')
+
+
+def mock_output_old_format(*args, **kwargs):
+    return _read_fixture('nodetool_output_1.2')
+
+
 @patch('datadog_checks.cassandra_nodetool.cassandra_nodetool.get_subprocess_output', side_effect=mock_output)
 def test_check(mock_output, aggregator):
+    _check(mock_output, aggregator)
+
+
+@patch('datadog_checks.cassandra_nodetool.cassandra_nodetool.get_subprocess_output', side_effect=mock_output_old_format)
+def test_check_old_format(mock_output, aggregator):
+    _check(mock_output, aggregator)
+
+
+def _check(mock_output, aggregator):
     integration = CassandraNodetoolCheck(common.CHECK_NAME, {}, {})
     integration.check(common.CONFIG_INSTANCE)
 


### PR DESCRIPTION
### What does this PR do?

Support output format of old version nodetool.

Current format
```txt
# Datacenter: dc1
# ===============
# Status=Up/Down
# |/ State=Normal/Leaving/Joining/Moving
# --  Address     Load       Tokens  Owns (effective)  Host ID                   Rack
# UN  172.21.0.3  184.8 KB   256     38.4%             7501ef03-eb63-4db0-95e6-20bfeb7cdd87  RAC1
```

Old format
```txt
Datacenter: dc1
===============
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address        Load       Owns (effective)  Host ID                               Token                                    Rack
DN  172.21.0.6  178.43 KB   35.4%             f86d2d7a-e5c7-4c46-b36e-df08c565171a  4035225268091337308                      rack1
```

### Motivation

I want to monitor old (and also newer) cassandra servers.

### Additional Notes

Please check that this PR doesn't break backward compatibilities.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
