### PR TITLE
Fix valid check detection for single check

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/logos.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/logos.py
@@ -28,10 +28,15 @@ def logos(check):
 
     """Validate logo files. Specifying no check will validate all logos"""
 
+    valid_checks = get_valid_integrations()
     if check:
-        checks = [check]
+        if check in valid_checks:
+            checks = [check]
+        else:
+            echo_success('{} does not have a tile, skipping.'.format(check))
+            return
     else:
-        checks = sorted(get_valid_integrations())
+        checks = sorted(valid_checks)
 
     blacklisted_integrations_msg = ''
     count_successful = 0

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/logos.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/logos.py
@@ -8,7 +8,7 @@ from PIL import Image
 
 
 from ...constants import NOT_TILES, get_root
-from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_success, echo_waiting
+from ..console import CONTEXT_SETTINGS, abort, echo_info, echo_failure, echo_success, echo_waiting
 from ...utils import get_valid_integrations, load_manifest
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/logos.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/logos.py
@@ -33,7 +33,7 @@ def logos(check):
         if check in valid_checks:
             checks = [check]
         else:
-            echo_success('{} does not have a tile, skipping.'.format(check))
+            echo_info('{} is not an integration.'.format(check))
             return
     else:
         checks = sorted(valid_checks)


### PR DESCRIPTION
### What does this PR do?

When logo validation was merged, it ran the validation for each check in the CI (Travis).
However, in the validation code, when a single check is provided, there was no verification that the directory being tested was an actual integration. So the CI was failing because directories like datadog_checks_dev and datadog_checks_downloader. This fixes that.  

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
