### PR TITLE
Backport Agent V6 utils to the AgentCheck class

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/agent/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/utils/agent/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/datadog_checks_base/datadog_checks/base/utils/agent/packages.py
+++ b/datadog_checks_base/datadog_checks/base/utils/agent/packages.py
@@ -1,0 +1,18 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pkg_resources
+
+DATADOG_CHECK_PREFIX = "datadog-"
+
+
+def get_datadog_wheels():
+    packages = []
+    dist = list(pkg_resources.working_set)
+    for package in dist:
+        if package.project_name.startswith(DATADOG_CHECK_PREFIX):
+            name = package.project_name[len(DATADOG_CHECK_PREFIX):].replace('-', '_')
+            packages.append(name)
+
+    return packages

--- a/datadog_checks_base/tests/test_utils_agent_packages.py
+++ b/datadog_checks_base/tests/test_utils_agent_packages.py
@@ -1,0 +1,9 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from datadog_checks.base.utils.agent.packages import get_datadog_wheels
+
+
+def test_get_datadog_wheels():
+    assert ['checks_tests_helper', 'checks_dev', 'checks_base'] == get_datadog_wheels()


### PR DESCRIPTION
### What does this PR do?

Move the last python helpers from the agent to the AgentCheck class. This allows the agent to have all it's python helper in the same place (agent base class) and harmonize the way we use them.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
