### PR TITLE
Include exception in connection error messages

### DIFF
--- a/couch/datadog_checks/couch/couch.py
+++ b/couch/datadog_checks/couch/couch.py
@@ -69,8 +69,8 @@ class CouchDb(AgentCheck):
 
             try:
                 version = self.get(self.get_server(instance), instance, tags, True)['version']
-            except Exception:
-                raise errors.ConnectionError("Unable to talk to the server")
+            except Exception as e:
+                raise errors.ConnectionError("Unable to talk to the server: {}".format(e))
 
             if version.startswith('1.'):
                 self.checker = CouchDB1(self)

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -54,7 +54,7 @@ def dd_environment():
     with docker_run(
         compose_file=os.path.join(common.HERE, 'compose', 'compose_v{}.yaml'.format(couch_version)),
         env_vars=env,
-        conditions=[CheckEndpoints([common.URL]), lambda: generate_data(couch_version), lambda: time.sleep(10)],
+        conditions=[CheckEndpoints([common.URL]), lambda: generate_data(couch_version), lambda: time.sleep(20)],
     ):
         yield common.BASIC_CONFIG
 


### PR DESCRIPTION
### What does this PR do?

Attempt to fix couch tests in CI. Updating the attempt timeout seems to fix this for now. Its possible the update to xenial caused some issues, but there's no hard evidence there?

I also updated the error messaging to print the  exception thrown when we try the get request. 

### Motivation

CI has been failing - https://travis-ci.com/DataDog/integrations-core/jobs/183113018 Errors are rather generic. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
