### PR TITLE
Add env var support to E2E containers

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -30,10 +30,17 @@ from ....utils import dir_exists, file_exists, path_join
         'config (agent5, agent6, etc.)'
     )
 )
+@click.option(
+    '--env-vars', '-v', default='',
+    help=(
+        'A quoted, space separated list of ENV Variables that should be passed to the Agent container. '
+        'Ex: \'DD_URL=app.datadoghq.com DD_API_KEY=123456\''
+    )
+)
 @click.option('--dev/--prod', help='Whether to use the latest version of a check or what is shipped')
 @click.option('--base', is_flag=True, help='Whether to use the latest version of the base check or what is shipped')
 @click.pass_context
-def start(ctx, check, env, agent, dev, base):
+def start(ctx, check, env, agent, dev, base, env_vars):
     """Start an environment."""
     if not file_exists(get_tox_file(check)):
         abort('`{}` is not a testable check.'.format(check))
@@ -102,7 +109,7 @@ def start(ctx, check, env, agent, dev, base):
         stop_environment(check, env, metadata=metadata)
         abort()
 
-    environment = interface(check, env, base_package, config, metadata, agent_build, api_key)
+    environment = interface(check, env, base_package, config, env_vars, metadata, agent_build, api_key)
 
     echo_waiting('Updating `{}`... '.format(agent_build), nl=False)
     environment.update_agent()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -30,6 +30,8 @@ from ....utils import dir_exists, file_exists, path_join
         'config (agent5, agent6, etc.)'
     )
 )
+@click.option('--dev/--prod', help='Whether to use the latest version of a check or what is shipped')
+@click.option('--base', is_flag=True, help='Whether to use the latest version of the base check or what is shipped')
 @click.option(
     '--env-vars', '-e', multiple=True,
     help=(
@@ -37,12 +39,9 @@ from ....utils import dir_exists, file_exists, path_join
         'Ex: -e DD_URL=app.datadoghq.com -e DD_API_KEY=123456'
     )
 )
-@click.option('--dev/--prod', help='Whether to use the latest version of a check or what is shipped')
-@click.option('--base', is_flag=True, help='Whether to use the latest version of the base check or what is shipped')
 @click.pass_context
 def start(ctx, check, env, agent, dev, base, env_vars):
     """Start an environment."""
-
     if not file_exists(get_tox_file(check)):
         abort('`{}` is not a testable check.'.format(check))
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -31,10 +31,10 @@ from ....utils import dir_exists, file_exists, path_join
     )
 )
 @click.option(
-    '--env-vars', '-v', default='',
+    '--env-vars', '-e', multiple=True,
     help=(
-        'A quoted, space separated list of ENV Variables that should be passed to the Agent container. '
-        'Ex: \'DD_URL=app.datadoghq.com DD_API_KEY=123456\''
+        'ENV Variable that should be passed to the Agent container. '
+        'Ex: -e DD_URL=app.datadoghq.com -e DD_API_KEY=123456'
     )
 )
 @click.option('--dev/--prod', help='Whether to use the latest version of a check or what is shipped')
@@ -42,6 +42,7 @@ from ....utils import dir_exists, file_exists, path_join
 @click.pass_context
 def start(ctx, check, env, agent, dev, base, env_vars):
     """Start an environment."""
+
     if not file_exists(get_tox_file(check)):
         abort('`{}` is not a testable check.'.format(check))
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -24,7 +24,7 @@ class DockerInterface(object):
     ):
         self.check = check
         self.env = env
-        self.env_vars = env_vars.split()
+        self.env_vars = env_vars
         self.base_package = base_package
         self.config = config or {}
         self.metadata = metadata or {}
@@ -122,7 +122,7 @@ class DockerInterface(object):
             ]
 
             # Any environment variables passed to the start command
-            command.extend(['-e {}'.format(var) for var in self.env_vars])
+            command.extend('-e {}'.format(var) for var in self.env_vars)
 
             if self.base_package:
                 # Mount the check directory

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -19,7 +19,9 @@ from ...utils import path_join
 class DockerInterface(object):
     ENV_TYPE = 'docker'
 
-    def __init__(self, check, env, base_package=None, config=None, env_vars=None, metadata=None, agent_build=None, api_key=None):
+    def __init__(
+        self, check, env, base_package=None, config=None, env_vars=None, metadata=None, agent_build=None, api_key=None
+    ):
         self.check = check
         self.env = env
         self.env_vars = env_vars.split()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -19,9 +19,10 @@ from ...utils import path_join
 class DockerInterface(object):
     ENV_TYPE = 'docker'
 
-    def __init__(self, check, env, base_package=None, config=None, metadata=None, agent_build=None, api_key=None):
+    def __init__(self, check, env, base_package=None, config=None, env_vars=None, metadata=None, agent_build=None, api_key=None):
         self.check = check
         self.env = env
+        self.env_vars = env_vars.split()
         self.base_package = base_package
         self.config = config or {}
         self.metadata = metadata or {}
@@ -117,6 +118,9 @@ class DockerInterface(object):
                 # Mount the check directory
                 '-v', '{}:{}'.format(path_join(get_root(), self.check), self.check_mount_dir),
             ]
+
+            # Any environment variables passed to the start command
+            command.extend(['-e {}'.format(var) for var in self.env_vars])
 
             if self.base_package:
                 # Mount the check directory

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -24,11 +24,13 @@ from ...subprocess import run_command
 class LocalAgentInterface(object):
     ENV_TYPE = 'local'
 
-    def __init__(self, check, env, base_package=None, config=None, metadata=None, agent_build=None, api_key=None):
+    def __init__(self, check, env, base_package=None, config=None, env_vars=None, metadata=None, agent_build=None, api_key=None):
         self.check = check
         self.env = env
         self.base_package = base_package
         self.config = config or {}
+        # Env vars are not currently used in local E2E
+        self.env_vars = env_vars
         self.metadata = metadata or {}
         self.agent_build = agent_build
         self.api_key = api_key or FAKE_API_KEY

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -24,7 +24,9 @@ from ...subprocess import run_command
 class LocalAgentInterface(object):
     ENV_TYPE = 'local'
 
-    def __init__(self, check, env, base_package=None, config=None, env_vars=None, metadata=None, agent_build=None, api_key=None):
+    def __init__(
+        self, check, env, base_package=None, config=None, env_vars=None, metadata=None, agent_build=None, api_key=None
+    ):
         self.check = check
         self.env = env
         self.base_package = base_package


### PR DESCRIPTION
### What does this PR do?

Adds the ability to pass in a `vars` option to ddev env start. This will allow you pass in arbitrary environ variables to the run command for starting the docker container agent. 

### Motivation

Internal request. Now you can easily change supported attributes of the container agent when spinning up E2E for testing such as the DD_URL. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
