### PR TITLE
Enforce new integration_id field

### DIFF
--- a/aerospike/manifest.json
+++ b/aerospike/manifest.json
@@ -18,5 +18,6 @@
     "data store"
   ],
   "type": "check",
-  "is_public": false
+  "is_public": false,
+  "integration_id": "aerospike"
 }

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -20,6 +20,7 @@ REQUIRED_ATTRIBUTES = {
     'creates_events',
     'display_name',
     'guid',
+    'integration_id',
     'is_public',
     'maintainer',
     'manifest_version',
@@ -37,7 +38,6 @@ OPTIONAL_ATTRIBUTES = {
     'is_beta',
     # Move these three below (integration_id, metric_to_check, metric_prefix)
     # to mandatory when all integration are fixed
-    'integration_id',
     'metric_to_check',
     'metric_prefix',
     'process_signatures',

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -34,6 +34,7 @@ def construct_template_fields(integration_name, repo_choice, **kwargs):
         if re.match(SIMPLE_NAME, integration_name)
         else integration_name
     )
+    check_name_kebab = re.sub('_| ', '-', integration_name)
 
     if repo_choice == 'core':
         author = 'Datadog'
@@ -71,6 +72,7 @@ def construct_template_fields(integration_name, repo_choice, **kwargs):
         ),
         'check_name': normalized_integration_name,
         'check_name_cap': check_name_cap,
+        'check_name_kebab': check_name_kebab,
         'email': email,
         'email_packages': email_packages,
         'guid': uuid4(),

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/manifest.json
@@ -19,5 +19,6 @@
     ""
   ],
   "type": "check",
-  "is_public": false
+  "is_public": false,
+  "integration_id": "{check_name_kebab}"
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/manifest.json
@@ -19,5 +19,6 @@
     ""
   ],
   "type": "check",
-  "is_public": false
+  "is_public": false,
+  "integration_id": "{check_case_kebab}"
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/tile/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/tile/{check_name}/manifest.json
@@ -19,5 +19,6 @@
     ""
   ],
   "type": "check",
-  "is_public": true
+  "is_public": true,
+  "integration_id": "{check_case_kebab}"
 }}

--- a/twistlock/manifest.json
+++ b/twistlock/manifest.json
@@ -20,5 +20,6 @@
     "log collection"
   ],
   "type": "check",
-  "is_public": true
+  "is_public": true,
+  "integration_id": "twistlock"
 }


### PR DESCRIPTION
### What does this PR do?

Enforces the new `integration_field` part of the manifest.json. 
It was missing from two of the newly merged integrations (🚀) so I added it to them (twistlock and aerospike)
Also adds the new field to the templates for new checks created by the ddev create command.

### Motivation

We now require the integration_id field in manifest.json, so lets enforce it and help make sure its present. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
