### PR TITLE
Add row length validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -250,6 +250,13 @@ def metadata(check):
                 reader._fieldnames = reader.fieldnames
 
             for row in reader:
+
+                # Number of rows is correct. Since metric is first in the list, should be safe to access
+                if len(row) != len(ALL_HEADERS):
+                    errors = True
+                    echo_failure('{}: {} Has the wrong amount of columns'.format(current_check, row['metric_name']))
+                    continue
+
                 if PY2:
                     for key, value in iteritems(row):
                         if value is not None:


### PR DESCRIPTION
### What does this PR do?

Add validation of row length to the `ddev validate metadata` length. 

### Motivation

When there is an extra comma or extra field in the metadata.csv file, the validation doesn't currently provide helpful output. This addresses that. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
