### PR TITLE
Update "public_title" to a better format

### DIFF
--- a/ibm_mq/manifest.json
+++ b/ibm_mq/manifest.json
@@ -12,7 +12,7 @@
   "supported_os": [
     "linux"
   ],
-  "public_title": "Datadog-Ibm_mq Integration",
+  "public_title": "Datadog-IBM MQ Integration",
   "categories": [
     "Message Queue",
     "log collection"


### PR DESCRIPTION
### What does this PR do?

Updates the  "public_title" to a better format, so that the docs page title displays `IBM MQ` vs. `Ibm_mq`
