### PR TITLE
Upgrade protobuf to 3.7.0

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -28,7 +28,7 @@ paramiko==2.1.5
 pg8000==1.10.1
 ply==3.10
 prometheus-client==0.3.0
-protobuf==3.5.1
+protobuf==3.7.0
 psutil==5.5.0
 psycopg2-binary==2.7.5
 pyasn1==0.4.2

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -1,7 +1,7 @@
 ddtrace==0.13.0
 kubernetes==8.0.1
 prometheus-client==0.3.0
-protobuf==3.5.1
+protobuf==3.7.0
 pywin32==224; sys_platform == 'win32'
 pyyaml==3.13
 requests==2.21.0

--- a/gitlab/requirements.in
+++ b/gitlab/requirements.in
@@ -1,1 +1,1 @@
-protobuf==3.5.1
+protobuf==3.7.0

--- a/gitlab_runner/requirements.in
+++ b/gitlab_runner/requirements.in
@@ -1,1 +1,1 @@
-protobuf==3.5.1
+protobuf==3.7.0

--- a/kube_dns/requirements.in
+++ b/kube_dns/requirements.in
@@ -1,1 +1,1 @@
-protobuf==3.5.1
+protobuf==3.7.0

--- a/kubernetes_state/requirements.in
+++ b/kubernetes_state/requirements.in
@@ -1,1 +1,1 @@
-protobuf==3.5.1
+protobuf==3.7.0


### PR DESCRIPTION
### Motivation

Python 3.7 compat https://github.com/protocolbuffers/protobuf/releases/tag/v3.7.0