### PR TITLE
Upgrade prometheus_client to 0.6.0

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -27,7 +27,7 @@ openstacksdk==0.24.0
 paramiko==2.1.5
 pg8000==1.10.1
 ply==3.10
-prometheus-client==0.3.0
+prometheus_client==0.6.0
 protobuf==3.7.0
 psutil==5.5.0
 psycopg2-binary==2.7.5

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -1,6 +1,6 @@
 ddtrace==0.13.0
 kubernetes==8.0.1
-prometheus-client==0.3.0
+prometheus_client==0.6.0
 protobuf==3.7.0
 pywin32==224; sys_platform == 'win32'
 pyyaml==3.13


### PR DESCRIPTION
### Motivation

- better OpenMetrics support https://github.com/prometheus/client_python/releases/tag/v0.5.0
- fix for Python 3.7 memory leak https://github.com/prometheus/client_python/releases/tag/v0.6.0