### PR TITLE
Add project tags to hypervisor metrics

### DIFF
--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -205,7 +205,8 @@ class OpenStackControllerCheck(AgentCheck):
         uptime = self.get_os_hypervisor_uptime(hyp_id)
         return self._parse_uptime_string(uptime)
 
-    def collect_hypervisors_metrics(self, custom_tags=None,
+    def collect_hypervisors_metrics(self, servers,
+                                    custom_tags=None,
                                     use_shortname=False,
                                     collect_hypervisor_metrics=True,
                                     collect_hypervisor_load=False):
@@ -213,16 +214,28 @@ class OpenStackControllerCheck(AgentCheck):
         Submits stats for all hypervisors registered to this control plane
         Raises specific exceptions based on response code
         """
+        # Create a dictionary with hypervisor hostname as key and the list of project names as value
+        hyp_project_names = {}
+        for _, server in iteritems(servers):
+            if not server['hypervisor_hostname']:
+                self.log.debug("hypervisor_hostname is None for server %s. "
+                               "Check that your user is an administrative users.", server['server_id'])
+            else:
+                if not hyp_project_names.get(server['hypervisor_hostname']):
+                    hyp_project_names[server['hypervisor_hostname']] = set()
+                hyp_project_names[server['hypervisor_hostname']].add(server['project_name'])
+
         hypervisors = self.get_os_hypervisors_detail()
         for hyp in hypervisors:
-            self.get_stats_for_single_hypervisor(hyp, custom_tags=custom_tags,
+            self.get_stats_for_single_hypervisor(hyp, hyp_project_names,
+                                                 custom_tags=custom_tags,
                                                  use_shortname=use_shortname,
                                                  collect_hypervisor_metrics=collect_hypervisor_metrics,
                                                  collect_hypervisor_load=collect_hypervisor_load)
         if not hypervisors:
             self.warning("Unable to collect any hypervisors from Nova response.")
 
-    def get_stats_for_single_hypervisor(self, hyp, custom_tags=None,
+    def get_stats_for_single_hypervisor(self, hyp, hyp_project_names, custom_tags=None,
                                         use_shortname=False,
                                         collect_hypervisor_metrics=True,
                                         collect_hypervisor_load=True):
@@ -234,6 +247,12 @@ class OpenStackControllerCheck(AgentCheck):
             'virt_type:{}'.format(hyp['hypervisor_type']),
             'status:{}'.format(hyp['status']),
         ]
+
+        # add hypervisor project names as tags
+        project_names = hyp_project_names.get(hyp_hostname, {})
+        for project_name in project_names:
+            tags.append('project_name:{}'.format(project_name))
+
         host_tags = self._get_host_aggregate_tag(hyp_hostname, use_shortname=use_shortname)
         tags.extend(host_tags)
         tags.extend(custom_tags)
@@ -334,7 +353,19 @@ class OpenStackControllerCheck(AgentCheck):
 
     # Get all of the server IDs and their metadata and cache them
     # After the first run, we will only get servers that have changed state since the last collection run
-    def get_all_servers(self, tenant_to_name, instance_name, exclude_server_id_rules):
+    def populate_servers_cache(self, projects, exclude_server_id_rules):
+        # projects is being fetched from
+        # https://developer.openstack.org/api-ref/identity/v3/?expanded=list-projects-detail#list-projects
+        # It has an id (project id) and a name (project name)
+        # The id is referenced as the tenant_id in other endpoints like
+        # https://developer.openstack.org/api-ref/compute/?expanded=list-servers-detail#list-servers
+        # as mentioned in a note:
+        # "tenant_id can also be requested which is alias of project_id but that is not
+        # recommended to use as that will be removed in future."
+        tenant_to_name = {}
+        for name, p in iteritems(projects):
+            tenant_to_name[p.get('id')] = name
+
         cached_servers = self.servers_cache.get('servers')
         # NOTE: updated_time need to be set at the beginning of this method in order to no miss servers changes.
         changes_since = datetime.utcnow().isoformat()
@@ -355,6 +386,7 @@ class OpenStackControllerCheck(AgentCheck):
             'servers': servers,
             'changes_since': changes_since
         }
+        return servers
 
     def collect_server_diagnostic_metrics(self, server_details, tags=None, use_shortname=False):
         def _is_valid_metric(label):
@@ -681,19 +713,15 @@ class OpenStackControllerCheck(AgentCheck):
                 for name, project in iteritems(projects):
                     self.collect_project_limit(project, custom_tags)
 
-            self.collect_hypervisors_metrics(custom_tags=custom_tags,
+            servers = self.populate_servers_cache(projects, exclude_server_id_rules)
+
+            self.collect_hypervisors_metrics(servers,
+                                             custom_tags=custom_tags,
                                              use_shortname=use_shortname,
                                              collect_hypervisor_metrics=collect_hypervisor_metrics,
                                              collect_hypervisor_load=collect_hypervisor_load)
 
             if collect_server_diagnostic_metrics or collect_server_flavor_metrics:
-                # This updates the server cache directly
-                tenant_id_to_name = {}
-                for name, p in iteritems(projects):
-                    tenant_id_to_name[p.get('id')] = name
-                self.get_all_servers(tenant_id_to_name, self.instance_name, exclude_server_id_rules)
-
-                servers = self.servers_cache['servers']
                 if collect_server_diagnostic_metrics:
                     self.log.debug("Fetch stats from %s server(s)" % len(servers))
                     for _, server in iteritems(servers):

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -223,8 +223,6 @@ class OpenStackControllerCheck(AgentCheck):
                 self.log.debug("hypervisor_hostname is None for server %s. "
                                "Check that your user is an administrative users.", server['server_id'])
             else:
-                if not hyp_project_names.get(hypervisor_hostname):
-                    hyp_project_names[hypervisor_hostname] = set()
                 hyp_project_names[hypervisor_hostname].add(server['project_name'])
 
         hypervisors = self.get_os_hypervisors_detail()
@@ -251,7 +249,7 @@ class OpenStackControllerCheck(AgentCheck):
         ]
 
         # add hypervisor project names as tags
-        project_names = hyp_project_names.get(hyp_hostname, {})
+        project_names = hyp_project_names.get(hyp_hostname, set())
         for project_name in project_names:
             tags.append('project_name:{}'.format(project_name))
 

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -216,14 +216,15 @@ class OpenStackControllerCheck(AgentCheck):
         """
         # Create a dictionary with hypervisor hostname as key and the list of project names as value
         hyp_project_names = {}
-        for _, server in iteritems(servers):
-            if not server['hypervisor_hostname']:
+        for server in itervalues(servers):
+            hypervisor_hostname = server.get('hypervisor_hostname')
+            if not hypervisor_hostname:
                 self.log.debug("hypervisor_hostname is None for server %s. "
                                "Check that your user is an administrative users.", server['server_id'])
             else:
-                if not hyp_project_names.get(server['hypervisor_hostname']):
-                    hyp_project_names[server['hypervisor_hostname']] = set()
-                hyp_project_names[server['hypervisor_hostname']].add(server['project_name'])
+                if not hyp_project_names.get(hypervisor_hostname):
+                    hyp_project_names[hypervisor_hostname] = set()
+                hyp_project_names[hypervisor_hostname].add(server['project_name'])
 
         hypervisors = self.get_os_hypervisors_detail()
         for hyp in hypervisors:
@@ -724,7 +725,7 @@ class OpenStackControllerCheck(AgentCheck):
             if collect_server_diagnostic_metrics or collect_server_flavor_metrics:
                 if collect_server_diagnostic_metrics:
                     self.log.debug("Fetch stats from %s server(s)" % len(servers))
-                    for _, server in iteritems(servers):
+                    for server in itervalues(servers):
                         self.collect_server_diagnostic_metrics(server, tags=custom_tags,
                                                                use_shortname=use_shortname)
                 if collect_server_flavor_metrics:
@@ -734,7 +735,7 @@ class OpenStackControllerCheck(AgentCheck):
                         flavors = self.get_flavors()
                     else:
                         flavors = None
-                    for _, server in iteritems(servers):
+                    for server in itervalues(servers):
                         self.collect_server_flavor_metrics(server, flavors, tags=custom_tags,
                                                            use_shortname=use_shortname)
 

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -5,6 +5,7 @@ import re
 import copy
 import requests
 
+from collections import defaultdict
 from six import iteritems, itervalues, next
 from datetime import datetime
 
@@ -215,7 +216,7 @@ class OpenStackControllerCheck(AgentCheck):
         Raises specific exceptions based on response code
         """
         # Create a dictionary with hypervisor hostname as key and the list of project names as value
-        hyp_project_names = {}
+        hyp_project_names = defaultdict(set)
         for server in itervalues(servers):
             hypervisor_hostname = server.get('hypervisor_hostname')
             if not hypervisor_hostname:

--- a/openstack_controller/tests/test_end_to_end.py
+++ b/openstack_controller/tests/test_end_to_end.py
@@ -204,34 +204,35 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb', value=7982.0,
                                      tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb', value=7982.0,
                                      tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb', value=7982.0,
                                      tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb', value=7982.0,
                                      tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled',
+                                           'project_name:testProj1', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb', value=7982.0,
                                      tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb', value=7982.0,
                                      tags=['hypervisor:compute6.openstack.local', 'hypervisor_id:11',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb', value=7982.0,
                                      tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb', value=7982.0,
                                      tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb', value=7982.0,
                                      tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb', value=7982.0,
                                      tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.server.rx_errors', value=0.0,
                                      tags=['nova_managed_server', 'project_name:admin',
                                            'hypervisor:compute4.openstack.local', 'server_name:server_take_zero-2',
@@ -387,34 +388,35 @@ def test_scenario(make_request, aggregator):
                                      hostname=u'f2dd3f90-e738-4135-84d4-1a2d30d04929')
             aggregator.assert_metric('openstack.nova.current_workload', value=0.0,
                                      tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.current_workload', value=0.0,
                                      tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.current_workload', value=0.0,
                                      tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.current_workload', value=0.0,
                                      tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled',
+                                           'project_name:testProj1', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.current_workload', value=0.0,
                                      tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.current_workload', value=0.0,
                                      tags=['hypervisor:compute6.openstack.local', 'hypervisor_id:11',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.current_workload', value=0.0,
                                      tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.current_workload', value=0.0,
                                      tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.current_workload', value=0.0,
                                      tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.current_workload', value=0.0,
                                      tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.limits.max_total_floating_ips', value=10.0,
                                      tags=['tenant_id:***************************4bfc1', 'project_name:service'],
                                      hostname='')
@@ -513,34 +515,35 @@ def test_scenario(make_request, aggregator):
                                      hostname=u'836f724f-0028-4dc0-b9bd-e0843d767ca2')
             aggregator.assert_metric('openstack.nova.free_ram_mb', value=3886.0,
                                      tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.free_ram_mb', value=2862.0,
                                      tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.free_ram_mb', value=5934.0,
                                      tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.free_ram_mb', value=2862.0,
                                      tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled',
+                                           'project_name:testProj1', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.free_ram_mb', value=3886.0,
                                      tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.free_ram_mb', value=5934.0,
                                      tags=['hypervisor:compute6.openstack.local', 'hypervisor_id:11',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.free_ram_mb', value=2862.0,
                                      tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.free_ram_mb', value=3886.0,
                                      tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.free_ram_mb', value=5934.0,
                                      tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.free_ram_mb', value=2862.0,
                                      tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.server.rx_packets', value=207.0,
                                      tags=['nova_managed_server', 'project_name:admin',
                                            'hypervisor:compute1.openstack.local', 'server_name:jenga',
@@ -759,34 +762,35 @@ def test_scenario(make_request, aggregator):
                                      hostname=u'2e1ce152-b19d-4c4a-9cc7-0d150fa97a18')
             aggregator.assert_metric('openstack.nova.vcpus_used', value=4.0,
                                      tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus_used', value=6.0,
                                      tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus_used', value=0.0,
                                      tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus_used', value=6.0,
                                      tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled',
+                                           'project_name:testProj1', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus_used', value=4.0,
                                      tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus_used', value=0.0,
                                      tags=['hypervisor:compute6.openstack.local', 'hypervisor_id:11',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus_used', value=6.0,
                                      tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus_used', value=4.0,
                                      tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus_used', value=0.0,
                                      tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus_used', value=6.0,
                                      tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.server.tx_errors', value=0.0,
                                      tags=['nova_managed_server', 'project_name:admin',
                                            'hypervisor:compute2.openstack.local', 'server_name:jnrgjoner',
@@ -835,34 +839,35 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.running_vms', value=2.0,
                                      tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.running_vms', value=3.0,
                                      tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.running_vms', value=0.0,
                                      tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.running_vms', value=3.0,
                                      tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled',
+                                           'project_name:testProj1', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.running_vms', value=2.0,
                                      tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.running_vms', value=0.0,
                                      tags=['hypervisor:compute6.openstack.local', 'hypervisor_id:11',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.running_vms', value=3.0,
                                      tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.running_vms', value=2.0,
                                      tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.running_vms', value=0.0,
                                      tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.running_vms', value=3.0,
                                      tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.server.tx_errors', value=0.0,
                                      tags=['nova_managed_server', 'project_name:admin',
                                            'hypervisor:compute1.openstack.local', 'server_name:Rocky',
@@ -870,34 +875,35 @@ def test_scenario(make_request, aggregator):
                                      hostname=u'2e1ce152-b19d-4c4a-9cc7-0d150fa97a18')
             aggregator.assert_metric('openstack.nova.vcpus', value=8.0,
                                      tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus', value=8.0,
                                      tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus', value=8.0,
                                      tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus', value=8.0,
                                      tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled',
+                                           'project_name:testProj1', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus', value=8.0,
                                      tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus', value=8.0,
                                      tags=['hypervisor:compute6.openstack.local', 'hypervisor_id:11',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus', value=8.0,
                                      tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus', value=8.0,
                                      tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus', value=8.0,
                                      tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.vcpus', value=8.0,
                                      tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.server.tx_packets', value=9.0,
                                      tags=['nova_managed_server', 'project_name:admin',
                                            'hypervisor:compute5.openstack.local', 'server_name:moarserver-13',
@@ -963,64 +969,66 @@ def test_scenario(make_request, aggregator):
                                      hostname=u'acb4197c-f54e-488e-a40a-1b7f59cc9117')
             aggregator.assert_metric('openstack.nova.free_disk_gb', value=26.0,
                                      tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.free_disk_gb', value=16.0,
                                      tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.free_disk_gb', value=46.0,
                                      tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.free_disk_gb', value=16.0,
                                      tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled',
+                                           'project_name:testProj1', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.free_disk_gb', value=26.0,
                                      tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.free_disk_gb', value=46.0,
                                      tags=['hypervisor:compute6.openstack.local', 'hypervisor_id:11',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.free_disk_gb', value=16.0,
                                      tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.free_disk_gb', value=26.0,
                                      tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.free_disk_gb', value=46.0,
                                      tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.free_disk_gb', value=16.0,
                                      tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.local_gb_used', value=22.0,
                                      tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.local_gb_used', value=32.0,
                                      tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.local_gb_used', value=2.0,
                                      tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.local_gb_used', value=32.0,
                                      tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled',
+                                           'project_name:testProj1', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.local_gb_used', value=22.0,
                                      tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.local_gb_used', value=2.0,
                                      tags=['hypervisor:compute6.openstack.local', 'hypervisor_id:11',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.local_gb_used', value=32.0,
                                      tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.local_gb_used', value=22.0,
                                      tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.local_gb_used', value=2.0,
                                      tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14',
                                            'virt_type:QEMU', 'status:enabled'], hostname='')
             aggregator.assert_metric('openstack.nova.local_gb_used', value=32.0,
                                      tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.server.memory', value=1048576.0,
                                      tags=['nova_managed_server', 'project_name:admin',
                                            'hypervisor:compute10.openstack.local', 'server_name:finalDestination-6',
@@ -1749,11 +1757,11 @@ def test_scenario(make_request, aggregator):
                                      hostname=u'7324440d-915b-4e12-8b85-ec8c9a524d6c')
             aggregator.assert_metric('openstack.nova.local_gb', value=48.0,
                                      tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.local_gb', value=48.0,
                                      tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.local_gb', value=48.0,
                                      tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8',
@@ -1761,11 +1769,12 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.local_gb', value=48.0,
                                      tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled',
+                                           'project_name:testProj1', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.local_gb', value=48.0,
                                      tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.local_gb', value=48.0,
                                      tags=['hypervisor:compute6.openstack.local', 'hypervisor_id:11',
@@ -1773,11 +1782,11 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.local_gb', value=48.0,
                                      tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.local_gb', value=48.0,
                                      tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.local_gb', value=48.0,
                                      tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14',
@@ -1785,7 +1794,7 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.local_gb', value=48.0,
                                      tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.server.tx_errors', value=0.0,
                                      tags=['nova_managed_server', 'project_name:admin',
@@ -1862,11 +1871,11 @@ def test_scenario(make_request, aggregator):
                                      hostname=u'57030997-f1b5-4f79-9429-8cb285318633')
             aggregator.assert_metric('openstack.nova.disk_available_least', value=14.0,
                                      tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.disk_available_least', value=-2.0,
                                      tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.disk_available_least', value=38.0,
                                      tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8',
@@ -1874,11 +1883,12 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.disk_available_least', value=2.0,
                                      tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled',
+                                           'project_name:testProj1', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.disk_available_least', value=14.0,
                                      tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.disk_available_least', value=37.0,
                                      tags=['hypervisor:compute6.openstack.local', 'hypervisor_id:11',
@@ -1886,11 +1896,11 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.disk_available_least', value=3.0,
                                      tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.disk_available_least', value=13.0,
                                      tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.disk_available_least', value=3.0,
                                      tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14',
@@ -1898,7 +1908,7 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.disk_available_least', value=3.0,
                                      tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.server.tx', value=0.0,
                                      tags=['nova_managed_server', 'project_name:admin',
@@ -2140,11 +2150,11 @@ def test_scenario(make_request, aggregator):
                                      hostname=u'1cc21586-8d43-40ea-bdc9-6f54a79957b4')
             aggregator.assert_metric('openstack.nova.memory_mb_used', value=4096.0,
                                      tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb_used', value=5120.0,
                                      tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb_used', value=2048.0,
                                      tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8',
@@ -2152,11 +2162,12 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb_used', value=5120.0,
                                      tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled',
+                                           'project_name:testProj1', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb_used', value=4096.0,
                                      tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb_used', value=2048.0,
                                      tags=['hypervisor:compute6.openstack.local', 'hypervisor_id:11',
@@ -2164,11 +2175,11 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb_used', value=5120.0,
                                      tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb_used', value=4096.0,
                                      tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb_used', value=2048.0,
                                      tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14',
@@ -2176,7 +2187,7 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.memory_mb_used', value=5120.0,
                                      tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.server.tx_packets', value=9.0,
                                      tags=['nova_managed_server', 'project_name:admin',
@@ -2784,11 +2795,11 @@ def test_scenario(make_request, aggregator):
 
             aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
                                      tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1', 'virt_type:QEMU',
-                                           'status:enabled'],
+                                           'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
                                      tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
                                      tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8', 'virt_type:QEMU',
@@ -2796,11 +2807,12 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
                                      tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled',
+                                           'project_name:testProj1', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
                                      tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10', 'virt_type:QEMU',
-                                           'status:enabled'],
+                                           'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
                                      tags=['hypervisor:compute6.openstack.local', 'hypervisor_id:11', 'virt_type:QEMU',
@@ -2808,11 +2820,11 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
                                      tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12', 'virt_type:QEMU',
-                                           'status:enabled'],
+                                           'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
                                      tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13', 'virt_type:QEMU',
-                                           'status:enabled'],
+                                           'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
                                      tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14', 'virt_type:QEMU',
@@ -2820,15 +2832,15 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.15', value=0.14,
                                      tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15', 'virt_type:QEMU',
-                                           'status:enabled'],
+                                           'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
                                      tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1', 'virt_type:QEMU',
-                                           'status:enabled'],
+                                           'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
                                      tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
                                      tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8', 'virt_type:QEMU',
@@ -2836,11 +2848,12 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
                                      tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled',
+                                           'project_name:testProj1', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
                                      tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10', 'virt_type:QEMU',
-                                           'status:enabled'],
+                                           'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
                                      tags=['hypervisor:compute6.openstack.local', 'hypervisor_id:11', 'virt_type:QEMU',
@@ -2848,11 +2861,11 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
                                      tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12', 'virt_type:QEMU',
-                                           'status:enabled'],
+                                           'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
                                      tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13', 'virt_type:QEMU',
-                                           'status:enabled'],
+                                           'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
                                      tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14', 'virt_type:QEMU',
@@ -2860,26 +2873,27 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.5', value=0.12,
                                      tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15', 'virt_type:QEMU',
-                                           'status:enabled'],
+                                           'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
                                      tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1', 'virt_type:QEMU',
-                                           'status:enabled'],
+                                           'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
                                      tags=['hypervisor:compute2.openstack.local', 'hypervisor_id:2',
-                                           'virt_type:QEMU', 'status:enabled'], hostname='')
+                                           'virt_type:QEMU', 'status:enabled', 'project_name:admin'], hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
                                      tags=['hypervisor:compute3.openstack.local', 'hypervisor_id:8', 'virt_type:QEMU',
                                            'status:enabled'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
                                      tags=['hypervisor:compute4.openstack.local', 'hypervisor_id:9',
-                                           'virt_type:QEMU', 'status:enabled'],
+                                           'virt_type:QEMU', 'status:enabled',
+                                           'project_name:testProj1', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
                                      tags=['hypervisor:compute5.openstack.local', 'hypervisor_id:10', 'virt_type:QEMU',
-                                           'status:enabled'],
+                                           'status:enabled', 'project_name:admin'],
                                      hostname='')
 
             aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
@@ -2888,11 +2902,11 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
                                      tags=['hypervisor:compute7.openstack.local', 'hypervisor_id:12', 'virt_type:QEMU',
-                                           'status:enabled'],
+                                           'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
                                      tags=['hypervisor:compute8.openstack.local', 'hypervisor_id:13', 'virt_type:QEMU',
-                                           'status:enabled'],
+                                           'status:enabled', 'project_name:admin'],
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
                                      tags=['hypervisor:compute9.openstack.local', 'hypervisor_id:14', 'virt_type:QEMU',
@@ -2900,7 +2914,7 @@ def test_scenario(make_request, aggregator):
                                      hostname='')
             aggregator.assert_metric('openstack.nova.hypervisor_load.1', value=0.2,
                                      tags=['hypervisor:compute10.openstack.local', 'hypervisor_id:15', 'virt_type:QEMU',
-                                           'status:enabled'],
+                                           'status:enabled', 'project_name:admin'],
                                      hostname='')
 
         # Assert coverage for this check on this instance

--- a/openstack_controller/tests/test_openstack.py
+++ b/openstack_controller/tests/test_openstack.py
@@ -21,7 +21,7 @@ def test_parse_uptime_string(aggregator):
 
 @mock.patch('datadog_checks.openstack_controller.OpenStackControllerCheck.get_servers_detail',
             return_value=common.MOCK_NOVA_SERVERS)
-def test_get_all_servers_between_runs(servers_detail, aggregator):
+def test_populate_servers_cache_between_runs(servers_detail, aggregator):
     """
     Ensure the cache contains the expected VMs between check runs.
     """
@@ -35,9 +35,9 @@ def test_get_all_servers_between_runs(servers_detail, aggregator):
     # Start off with a list of servers
     check.servers_cache = copy.deepcopy(common.SERVERS_CACHE_MOCK)
     # Update the cached list of servers based on what the endpoint returns
-    check.get_all_servers({'6f70656e737461636b20342065766572': 'testproj',
-                           'blacklist_1': 'blacklist_1',
-                           'blacklist_2': 'blacklist_2'}, "test_name", [])
+    check.populate_servers_cache({'testproj': {"id": '6f70656e737461636b20342065766572', "name": "testproj"},
+                                  'blacklist_1': {"id": 'blacklist_1', "name": 'blacklist_1'},
+                                  'blacklist_2': {"id": 'blacklist_2', "name": 'blacklist_2'}}, [])
     servers = check.servers_cache['servers']
     assert 'server-1' not in servers
     assert 'server_newly_added' in servers
@@ -47,7 +47,7 @@ def test_get_all_servers_between_runs(servers_detail, aggregator):
 
 @mock.patch('datadog_checks.openstack_controller.OpenStackControllerCheck.get_servers_detail',
             return_value=common.MOCK_NOVA_SERVERS)
-def test_get_all_servers_with_project_name_none(servers_detail, aggregator):
+def test_populate_servers_cache_with_project_name_none(servers_detail, aggregator):
     """
     Ensure the cache contains the expected VMs between check runs.
     """
@@ -60,9 +60,9 @@ def test_get_all_servers_with_project_name_none(servers_detail, aggregator):
     # Start off with a list of servers
     check.servers_cache = copy.deepcopy(common.SERVERS_CACHE_MOCK)
     # Update the cached list of servers based on what the endpoint returns
-    check.get_all_servers({'6f70656e737461636b20342065766572': None,
-                           'blacklist_1': 'blacklist_1',
-                           'blacklist_2': 'blacklist_2'}, "test_name", [])
+    check.populate_servers_cache({'': {"id": '6f70656e737461636b20342065766572', "name": None},
+                                  'blacklist_1': {"id": 'blacklist_1', "name": 'blacklist_1'},
+                                  'blacklist_2': {"id": 'blacklist_2', "name": 'blacklist_2'}}, [])
     servers = check.servers_cache['servers']
     assert 'server_newly_added' not in servers
     assert 'server-1' not in servers
@@ -89,7 +89,7 @@ def test_get_paginated_server(servers_detail, aggregator):
         'exclude_server_ids': common.EXCLUDED_SERVER_IDS,
         'paginated_server_limit': 1
     }, {}, instances=instances)
-    check.get_all_servers({"6f70656e737461636b20342065766572": "testproj"}, "test_name", [])
+    check.populate_servers_cache({'testproj': {"id": "6f70656e737461636b20342065766572", "name": "testproj"}}, [])
     servers = check.servers_cache['servers']
     assert 'server-1' in servers
     assert 'other-1' not in servers


### PR DESCRIPTION
### What does this PR do?

Add project name to hypervisor metrics.

It does so by looking at project name associated to each servers.
We also map servers with their hypervisor hostname.
We end up with a map of hypervisor hostname to a set of project names
From there when fetching hypervisor infos, we use the hypervisor hostname to get related project names.

### Motivation

Customer request

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
