### PR TITLE
[network] strip trailing whitespace from conntrack_max

### DIFF
--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -457,8 +457,9 @@ class Network(AgentCheck):
         try:
             with open(proc_conntrack_max_path, 'r') as conntrack_max_file:
                 # Starting at 0 as the last line has a line return
-                conntrack_max = conntrack_max_file.read()
-                self.gauge('system.net.conntrack.max', conntrack_max, tags=custom_tags)
+                conntrack_max = conntrack_max_file.read().rstrip()
+                if conntrack_max.isdigit():
+                    self.gauge('system.net.conntrack.max', conntrack_max, tags=custom_tags)
         except IOError:
             self.log.debug("Unable to read %s. Skipping nf_conntrack_max metrics pull.", proc_conntrack_max_path)
 

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -458,8 +458,7 @@ class Network(AgentCheck):
             with open(proc_conntrack_max_path, 'r') as conntrack_max_file:
                 # Starting at 0 as the last line has a line return
                 conntrack_max = conntrack_max_file.read().rstrip()
-                if conntrack_max.isdigit():
-                    self.gauge('system.net.conntrack.max', conntrack_max, tags=custom_tags)
+                self.gauge('system.net.conntrack.max', conntrack_max, tags=custom_tags)
         except IOError:
             self.log.debug("Unable to read %s. Skipping nf_conntrack_max metrics pull.", proc_conntrack_max_path)
 


### PR DESCRIPTION
### What does this PR do?

strips trailing whitespace and ensures the value is a digit before submitting as gauge

```
{"source_type_name": "System", "metric": "system.net.conntrack.max", 
"points": [[1552263474, "262100\n"]], "type": "gauge", "host": 
"i-0123xxxxxxxxx"}
```

### Motivation

customer issue

### Additional Notes

ticket 207993.
Could not replicate this internally
card: 854-network-conntrackmax-included-n-causing-float-conversion-to-fail

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
