### PR TITLE
Fix mkdir exception when closing the env

### DIFF
--- a/activemq_xml/tests/conftest.py
+++ b/activemq_xml/tests/conftest.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import errno
 import os
 import stat
 import tarfile
@@ -19,7 +20,11 @@ def dd_environment():
     with TempDir() as tmp_dir:
         activemq_data_dir = os.path.join(tmp_dir, "data")
         fixture_archive = os.path.join(HERE, "fixtures", "apache-activemq-kahadb.tar.gz")
-        os.mkdir(activemq_data_dir)
+        try:
+            os.mkdir(activemq_data_dir)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+               raise 
         with tarfile.open(fixture_archive, "r:gz") as f:
             f.extractall(path=activemq_data_dir)
         os.chmod(os.path.join(activemq_data_dir, "kahadb"), stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)

--- a/activemq_xml/tests/conftest.py
+++ b/activemq_xml/tests/conftest.py
@@ -24,7 +24,7 @@ def dd_environment():
             os.mkdir(activemq_data_dir)
         except OSError as e:
             if e.errno != errno.EEXIST:
-               raise 
+                raise
         with tarfile.open(fixture_archive, "r:gz") as f:
             f.extractall(path=activemq_data_dir)
         os.chmod(os.path.join(activemq_data_dir, "kahadb"), stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)

--- a/activemq_xml/tests/conftest.py
+++ b/activemq_xml/tests/conftest.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import errno
 import os
 import stat
 import tarfile
@@ -20,11 +19,10 @@ def dd_environment():
     with TempDir() as tmp_dir:
         activemq_data_dir = os.path.join(tmp_dir, "data")
         fixture_archive = os.path.join(HERE, "fixtures", "apache-activemq-kahadb.tar.gz")
-        try:
+
+        if not os.path.exists(activemq_data_dir):
             os.mkdir(activemq_data_dir)
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                raise
+
         with tarfile.open(fixture_archive, "r:gz") as f:
             f.extractall(path=activemq_data_dir)
         os.chmod(os.path.join(activemq_data_dir, "kahadb"), stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)


### PR DESCRIPTION
### What does this PR do?

Fix mkdir exception during the environment closing when the directory already exists

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
