### PR TITLE
Trigger gitlab only on tags

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,3 +36,5 @@ requirements.txt                                          @DataDog/prodsec
 datadog_checks_dev/datadog_checks/dev/tooling/signing.py  @DataDog/prodsec
 # As well as the secure downloader.
 /datadog_checks_downloader/                               @DataDog/prodsec
+# As well as the wheel building process
+.gitlab-ci.yml                                            @DataDog/prodsec

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,6 @@
 test:
   only:
-    - master
-    # e.g.: any_check-X.Y.Z-rc.N
-    - /.*-\d\.\d\.\d-(rc|pre|alpha|beta)\.\d+$/
+    # e.g.: any_check-X.Y.Z-rc.N, zk-1.15.0
+    - /.*-\d+\.\d+\.\d+(-(rc|pre|alpha|beta)\.\d+)?$/
   script: if [ -n "$DD_TEST_CMD" ] ; then eval "$DD_TEST_CMD" ; else echo "skipping, DD_TEST_CMD is not set" ; fi
   tags: [ "runner:main", "size:large" ]


### PR DESCRIPTION
### What does this PR do?

Trigger the gitlab pipeline on tags instead of every merge to master. 

### Motivation

We always tag each release anyway, so reduce the noise and only trigger on tags anyway. 
Comes with the bonus of being one step closer towards being able to build beta + pre-release builds. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
