### PR TITLE
Allow Agent to configure which Python used to inspect wheels

### DIFF
--- a/datadog_checks_downloader/datadog_checks/downloader/cli.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/cli.py
@@ -8,7 +8,10 @@ import argparse
 import re
 
 # 2nd party.
-from .download import TUFDownloader
+from .download import (
+    PYTHON,
+    TUFDownloader
+)
 from .exceptions import (
     InconsistentSimpleIndex,
     MissingVersions,
@@ -78,6 +81,9 @@ def download():
     parser.add_argument('standard_distribution_name', type=str,
                         help='Standard distribution name of the desired Datadog check.')
 
+    parser.add_argument('--python', type=str, default=PYTHON,
+                        help='The path to the Python interpreter used to inspect wheels.')
+
     parser.add_argument('--version', type=str, default=None,
                         help='The version number of the desired Datadog check.')
 
@@ -85,6 +91,7 @@ def download():
                         help='Show verbose information about TUF and in-toto.')
 
     args = parser.parse_args()
+    python = args.python
     standard_distribution_name = args.standard_distribution_name
     version = args.version
     verbose = args.verbose
@@ -106,7 +113,7 @@ def download():
                                  wheel_distribution_name, version)
 
         try:
-            target_abspath = tuf_downloader.download(target_relpath)
+            target_abspath = tuf_downloader.download(target_relpath, python=python)
         except UnknownTargetError:
             raise NoSuchDatadogPackageOrVersion(standard_distribution_name, version)
 

--- a/datadog_checks_downloader/datadog_checks/downloader/parameters.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/parameters.py
@@ -18,7 +18,7 @@ EXCEPTIONS = {
 }
 
 
-def substitute(target_relpath):
+def substitute(target_relpath, python):
     filename = os.path.basename(target_relpath)
     name, ext = os.path.splitext(filename)
     wheel_distribution_name, package_version, _, _, _ = name.split('-')
@@ -40,8 +40,10 @@ def substitute(target_relpath):
         package_github_dir = wheel_distribution_name[8:]
 
     return {
-        'wheel_distribution_name': wheel_distribution_name,
         'package_version': package_version,
         'package_github_dir': package_github_dir,
-        'standard_distribution_name': standard_distribution_name
+        # The Python interpreter used to inspect wheels.
+        'python': python,
+        'standard_distribution_name': standard_distribution_name,
+        'wheel_distribution_name': wheel_distribution_name,
     }


### PR DESCRIPTION
### What does this PR do?

Allows the Agent to configure which Python used to inspect wheels.

### Motivation

Right now, the downloader is accidentally calling the correct, embedded Python on Windows, and calling the system Python on *nix.

This PR allows the downloader to always call the embedded Python no matter what.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
