### PR TITLE
Refactor Kong dd environment

### DIFF
--- a/kong/tests/common.py
+++ b/kong/tests/common.py
@@ -1,6 +1,4 @@
 import logging
-import requests
-import time
 
 from datadog_checks.utils.common import get_docker_hostname
 from datadog_checks.dev import get_here
@@ -26,17 +24,3 @@ instance_2 = {
 }
 
 CONFIG_STUBS = [instance_1, instance_2]
-
-
-def wait_for_cluster():
-    for _ in range(0, 100):
-        res = None
-        try:
-            res = requests.get(STATUS_URL)
-            res.raise_for_status()
-            return True
-        except Exception as e:
-            log.debug("exception: {0} res: {1}".format(e, res))
-            time.sleep(2)
-
-    return False

--- a/kong/tests/common.py
+++ b/kong/tests/common.py
@@ -1,0 +1,42 @@
+import logging
+import requests
+import time
+
+from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.dev import get_here
+
+log = logging.getLogger('test_kong')
+
+HERE = get_here()
+
+CHECK_NAME = 'kong'
+HOST = get_docker_hostname()
+PORT = 8001
+
+STATUS_URL = 'http://{0}:{1}/status/'.format(HOST, PORT)
+
+instance_1 = {
+    'kong_status_url': STATUS_URL,
+    'tags': ['first_instance']
+}
+
+instance_2 = {
+    'kong_status_url': STATUS_URL,
+    'tags': ['second_instance']
+}
+
+CONFIG_STUBS = [instance_1, instance_2]
+
+
+def wait_for_cluster():
+    for _ in range(0, 100):
+        res = None
+        try:
+            res = requests.get(STATUS_URL)
+            res.raise_for_status()
+            return True
+        except Exception as e:
+            log.debug("exception: {0} res: {1}".format(e, res))
+            time.sleep(2)
+
+    return False

--- a/kong/tests/common.py
+++ b/kong/tests/common.py
@@ -1,7 +1,6 @@
 import logging
 
-from datadog_checks.utils.common import get_docker_hostname
-from datadog_checks.dev import get_here
+from datadog_checks.dev import get_here, get_docker_hostname
 
 log = logging.getLogger('test_kong')
 
@@ -11,7 +10,7 @@ CHECK_NAME = 'kong'
 HOST = get_docker_hostname()
 PORT = 8001
 
-STATUS_URL = 'http://{0}:{1}/status/'.format(HOST, PORT)
+STATUS_URL = 'http://{}:{}/status/'.format(HOST, PORT)
 
 instance_1 = {
     'kong_status_url': STATUS_URL,

--- a/kong/tests/compose/docker-compose.yml
+++ b/kong/tests/compose/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - 127.0.0.1
 
   nginx-lb:
-    build: ${COMPOSE_DIRECTORY_PATH}/nginx/
+    build: ./nginx/
     depends_on:
       consul:
         condition: service_healthy
@@ -55,7 +55,7 @@ services:
       retries: 5
 
   kong:
-    build: ${COMPOSE_DIRECTORY_PATH}/kong_$KONG_VERSION/
+    build: ./kong_$KONG_VERSION/
     depends_on:
       kong-database:
         condition: service_healthy

--- a/kong/tests/conftest.py
+++ b/kong/tests/conftest.py
@@ -15,8 +15,7 @@ def dd_environment():
 
     with docker_run(
         compose_file=os.path.join(compose_directory, 'docker-compose.yml'),
-        env_vars={'COMPOSE_DIRECTORY_PATH': compose_directory}
+        env_vars={'COMPOSE_DIRECTORY_PATH': compose_directory},
+        endpoints=common.STATUS_URL
     ):
-        if not common.wait_for_cluster():
-            raise Exception("Kong cluster boot timed out!")
         yield common.instance_1

--- a/kong/tests/conftest.py
+++ b/kong/tests/conftest.py
@@ -11,11 +11,8 @@ def dd_environment():
     """
     Start a kong cluster
     """
-    compose_directory = os.path.join(common.HERE, 'compose')
-
     with docker_run(
-        compose_file=os.path.join(compose_directory, 'docker-compose.yml'),
-        env_vars={'COMPOSE_DIRECTORY_PATH': compose_directory},
+        compose_file=os.path.join(common.HERE, 'compose', 'docker-compose.yml'),
         endpoints=common.STATUS_URL
     ):
         yield common.instance_1

--- a/kong/tests/conftest.py
+++ b/kong/tests/conftest.py
@@ -1,0 +1,22 @@
+import pytest
+import os
+
+from datadog_checks.dev import docker_run
+
+from . import common
+
+
+@pytest.fixture(scope="session")
+def dd_environment():
+    """
+    Start a kong cluster
+    """
+    compose_directory = os.path.join(common.HERE, 'compose')
+
+    with docker_run(
+        compose_file=os.path.join(compose_directory, 'docker-compose.yml'),
+        env_vars={'COMPOSE_DIRECTORY_PATH': compose_directory}
+    ):
+        if not common.wait_for_cluster():
+            raise Exception("Kong cluster boot timed out!")
+        yield common.instance_1


### PR DESCRIPTION
### What does this PR do?

Refactor the `dd_environment` fixture.

### Motivation

The previous `dd_environment` stopped the containers. So the environment could be started with `ddev env start` without any issue, but the `ddev env check` could not contact the stopped containers.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
