### PR TITLE
gunicorn note and small improvements

### DIFF
--- a/gunicorn/README.md
+++ b/gunicorn/README.md
@@ -10,7 +10,7 @@ Gunicorn itself can provide further metrics via DogStatsD, including those for:
 
 * Total request rate
 * Request rate by status code (2xx, 3xx, 4xx, 5xx)
-* Request duration (average, median, max, 95th percentile, etc)
+* Request duration (average, median, max, 95th percentile, etc.)
 * Log message rate by log level (critical, error, warning, exception)
 
 ## Setup
@@ -23,12 +23,12 @@ The Gunicorn check requires your Gunicorn app's Python environment to have the [
 
 ### Configuration
 
-Edit the `gunicorn.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4] to start collecting your GUNICORN [metrics](#metric-collection) and [logs](#log-collection).
+Edit the `gunicorn.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4] to start collecting your Gunicorn [metrics](#metric-collection) and [logs](#log-collection).
 See the [sample gunicorn.yaml][5] for all available configuration options.
 
 #### Metric Collection
 
-* Add this configuration block to your `gunicorn.d/conf.yaml` file to start gathering your [GUNICORN metrics](#metrics):
+* Add this configuration block to your `gunicorn.d/conf.yaml` file to start gathering your [Gunicorn metrics](#metrics):
 
     ```yaml
     init_config:
@@ -46,11 +46,13 @@ See the [sample gunicorn.yaml][5] for all available configuration options.
 
 Since version 19.1, Gunicorn [provides an option][6] to send its metrics to a daemon that implements the StatsD protocol, such as [DogStatsD][7]. As with many Gunicorn options, you can either pass it to `gunicorn` on the CLI (`--statsd-host`) or set it in your app's configuration file (`statsd_host`). Configure your app to send metrics to DogStatsD at `"localhost:8125"`, and restart the app.
 
+**Note**: If you are using this option, do **not** add the metric collection configuration block to `gunicorn.d/conf.yaml`. That is, if you are connecting Gunicorn to DogStatsD, ignore the directions in the [Metric Collection](#metric-collection) section of this document.
+
 #### Log Collection
 
 **Available for Agent >6.0**
 
-* Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
+* Collecting logs is disabled by default in the Datadog Agent. Enable it in `datadog.yaml`:
 
   ```
   logs_enabled: true
@@ -59,7 +61,7 @@ Since version 19.1, Gunicorn [provides an option][6] to send its metrics to a da
 * Use the following command to configure the path of the access log file as explained in the [Gunicorn Documentation][8]: `--access-logfile <MY_FILE_PATH>`
 * Use the following command to configure the path of the error log file as explained in the [Gunicorn Documentation][9]: `--error-logfile FILE, --log-file <MY_FILE_PATH>`
 
-*  Add this configuration block to your `gunicorn.d/conf.yaml` file to start collecting your Gunicorn Logs:
+*  Add this configuration block to your `gunicorn.d/conf.yaml` file to start collecting your Gunicorn logs:
 
   ```
   logs:
@@ -89,7 +91,7 @@ Since version 19.1, Gunicorn [provides an option][6] to send its metrics to a da
 
 [Run the Agent's `status` subcommand][10] and look for `gunicorn` under the Checks section.
 
-If the status is not OK, see the Troubleshooting section.
+If the status is not `OK`, see the Troubleshooting section.
 
 Use `netstat` to verify that Gunicorn is sending _its_ metrics, too:
 
@@ -111,7 +113,7 @@ The Gunicorn check does not include any events.
 
 `gunicorn.is_running`:
 
-Returns CRITICAL if the Agent cannot find a Gunicorn master process, or if cannot find any working or idle worker processes.
+Returns `CRITICAL` if the Agent cannot find a Gunicorn master process, or if cannot find any working or idle worker processes.
 
 
 ## Troubleshooting
@@ -150,7 +152,7 @@ ubuntu   18463 18457  0 20:26 pts/0    00:00:00 gunicorn: worker [my_app]
 ```
 
 ## Further Reading
-To get a better idea of how (or why) to integrate your Gunicorn apps with Datadog, check out our [blog post][12].
+To get a better idea of how (or why) to integrate your Gunicorn apps with Datadog, refer to the [blog post][12].
 
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/gunicorn/images/gunicorn-dash.png


### PR DESCRIPTION
### What does this PR do?

Adds a note to the Gunicorn readme that users who connect to DogStatsD shouldn't configure their thing to send metrics.

### Motivation

Request from @mikezvi 

### Additional Notes

Also some style things

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
