### PR TITLE
Fix Python 3.7 support

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 import _strptime  # noqa
 import re
 import socket
-from six import PY3
 import ssl
 import time
 import warnings

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -297,7 +297,7 @@ class HTTPCheck(NetworkCheck):
             cert = ssl_sock.getpeercert()
 
         except Exception as e:
-            msg = e.verify_message if PY3 and isinstance(e, ssl.CertificateError) else str(e)
+            msg = str(e)
             if 'expiration' in msg:
                 self.log.debug("error: {}. Cert might be expired.".format(e))
                 return Status.DOWN, 0, 0, msg

--- a/http_check/tests/test_http_check.py
+++ b/http_check/tests/test_http_check.py
@@ -57,9 +57,7 @@ def test_check_cert_expiration(http_check):
     assert status == 'CRITICAL'
     assert days_left == 0
     assert seconds_left == 0
-    # supporting both python <3.7, >= 3.7 message formats
-    assert msg in ["hostname 'wrong.host.badssl.com' doesn't match either of '*.badssl.com', 'badssl.com'",
-                   "Hostname mismatch, certificate is not valid for 'wrong.host.badssl.com'."]
+    assert 'Hostname mismatch' in msg or "doesn't match" in msg
 
     # site is down
     instance = {

--- a/http_check/tests/test_http_check.py
+++ b/http_check/tests/test_http_check.py
@@ -57,7 +57,9 @@ def test_check_cert_expiration(http_check):
     assert status == 'CRITICAL'
     assert days_left == 0
     assert seconds_left == 0
-    assert msg == "hostname 'wrong.host.badssl.com' doesn't match either of '*.badssl.com', 'badssl.com'"
+    # supporting both python <3.7, >= 3.7 message formats
+    assert msg in ["hostname 'wrong.host.badssl.com' doesn't match either of '*.badssl.com', 'badssl.com'",
+                   "Hostname mismatch, certificate is not valid for 'wrong.host.badssl.com'."]
 
     # site is down
     instance = {

--- a/http_check/tox.ini
+++ b/http_check/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py37
 envlist =
-    py{27,36}-{default,unit}
+    py{27,37}-{default,unit}
     flake8
 
 [testenv]


### PR DESCRIPTION
### What does this PR do?

Adds Python 3.7 support to http check. Mostly changes in exception handling. Python 3.7 changes returned exception types so it was cleaner to support python 2+3 by checking exception messages than type.

### Motivation

Adding Python3 support 
(╯°□°)╯︵ ┻━┻ 
🐍3🐍3🐍3🐍3🐍3🐍3🐍3🐍3🐍3

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
