### PR TITLE
[iis] adds `iis_host` tag to metrics

### DIFF
--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -48,6 +48,15 @@ class IIS(PDHBaseCheck):
     def __init__(self, name, init_config, agentConfig, instances):
         PDHBaseCheck.__init__(self, name, init_config, agentConfig, instances=instances, counter_list=DEFAULT_COUNTERS)
 
+    def get_iishost(self, instance):
+        inst_host = instance.get("host")
+        if inst_host in [".", "localhost"]:
+            # Use agen'ts hostname if local
+            iis_host = self.hostname
+        else:
+            iis_host = inst_host
+        return "iis_host:{}".format(self.normalize(iis_host))
+
     def check(self, instance):
         sites = instance.get('sites')
         if sites is None:
@@ -73,6 +82,7 @@ class IIS(PDHBaseCheck):
                     tags = []
                     if key in self._tags:
                         tags = list(self._tags[key])
+                    tags.append(self.get_iishost(instance))
 
                     try:
                         if not counter.is_single_instance():
@@ -114,5 +124,6 @@ class IIS(PDHBaseCheck):
             tags = []
             if key in self._tags:
                 tags = list(self._tags[key])
+            tags.append(self.get_iishost(instance))
             tags.append("site:{}".format(self.normalize(site)))
             self.service_check(self.SERVICE_CHECK, AgentCheck.CRITICAL, tags)

--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -50,7 +50,7 @@ class IIS(PDHBaseCheck):
 
     def get_iishost(self, instance):
         inst_host = instance.get("host")
-        if inst_host in [".", "localhost"]:
+        if inst_host in [".", "localhost", "127.0.0.1", None]:
             # Use agent's hostname if connecting to local machine.
             iis_host = self.hostname
         else:

--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -51,7 +51,7 @@ class IIS(PDHBaseCheck):
     def get_iishost(self, instance):
         inst_host = instance.get("host")
         if inst_host in [".", "localhost"]:
-            # Use agen'ts hostname if local
+            # Use agent's hostname if connecting to local machine.
             iis_host = self.hostname
         else:
             iis_host = inst_host

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -46,19 +46,20 @@ def test_check_on_specific_websites(aggregator):
     instance = INSTANCE
     c = IIS(CHECK_NAME, {}, {}, [instance])
     c.check(instance)
+    iis_host = c.get_iishost(instance)
 
     site_tags = ['Default_Web_Site', 'Exchange_Back_End', 'Total']
     for metric_def in DEFAULT_COUNTERS:
         metric = metric_def[3]
         for site_tag in site_tags:
-            aggregator.assert_metric(metric, tags=["site:{0}".format(site_tag)], count=1)
+            aggregator.assert_metric(metric, tags=["site:{0}".format(site_tag), iis_host], count=1)
 
     for site_tag in site_tags:
         aggregator.assert_service_check('iis.site_up', IIS.OK,
-                                        tags=["site:{0}".format(site_tag)], count=1)
+                                        tags=["site:{0}".format(site_tag), iis_host], count=1)
 
     aggregator.assert_service_check('iis.site_up', IIS.CRITICAL,
-                                    tags=["site:{0}".format('Non_Existing_Website')], count=1)
+                                    tags=["site:{0}".format('Non_Existing_Website'), iis_host], count=1)
 
     aggregator.assert_all_metrics_covered()
 

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -116,15 +116,16 @@ def test_check_without_sites_specified(aggregator):
     instance = WIN_SERVICES_MINIMAL_CONFIG
     c = IIS(CHECK_NAME, {}, {}, [instance])
     c.check(instance)
+    iis_host = c.get_iishost(instance)
 
     site_tags = ['Default_Web_Site', 'Exchange_Back_End', 'Total']
     for metric_def in DEFAULT_COUNTERS:
         mname = metric_def[3]
 
         for site_tag in site_tags:
-            aggregator.assert_metric(mname, tags=["mytag1", "mytag2", "site:{0}".format(site_tag)], count=1)
+            aggregator.assert_metric(mname, tags=["mytag1", "mytag2", "site:{0}".format(site_tag), iis_host], count=1)
 
     for site_tag in site_tags:
         aggregator.assert_service_check('iis.site_up', status=IIS.OK,
-                                        tags=["mytag1", "mytag2", "site:{0}".format(site_tag)], count=1)
+                                        tags=["mytag1", "mytag2", "site:{0}".format(site_tag), iis_host], count=1)
     aggregator.assert_all_metrics_covered()

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -25,16 +25,17 @@ def test_basic_check(aggregator):
     instance = MINIMAL_INSTANCE
     c = IIS(CHECK_NAME, {}, {}, [instance])
     c.check(instance)
+    iis_host = c.get_iishost(instance)
 
     site_tags = ['Default_Web_Site', 'Exchange_Back_End', 'Total']
     for metric_def in DEFAULT_COUNTERS:
         metric = metric_def[3]
         for site_tag in site_tags:
-            aggregator.assert_metric(metric, tags=["site:{0}".format(site_tag)], count=1)
+            aggregator.assert_metric(metric, tags=["site:{0}".format(site_tag), iis_host], count=1)
 
     for site_tag in site_tags:
         aggregator.assert_service_check('iis.site_up', IIS.OK,
-                                        tags=["site:{0}".format(site_tag)], count=1)
+                                        tags=["site:{0}".format(site_tag), iis_host], count=1)
 
     aggregator.assert_all_metrics_covered()
 

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -26,6 +26,7 @@ def test_basic_check(aggregator):
     c = IIS(CHECK_NAME, {}, {}, [instance])
     c.check(instance)
     iis_host = c.get_iishost(instance)
+    print(iis_host)
 
     site_tags = ['Default_Web_Site', 'Exchange_Back_End', 'Total']
     for metric_def in DEFAULT_COUNTERS:

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -82,6 +82,7 @@ def test_check(aggregator):
     instance = WIN_SERVICES_CONFIG
     c = IIS(CHECK_NAME, {}, {}, [instance])
     c.check(instance)
+    iis_host = c.get_iishost(instance)
 
     # Test metrics
     # ... normalize site-names
@@ -92,13 +93,13 @@ def test_check(aggregator):
     for site_name in [default_site_name, ok_site_name, 'Total']:
         for metric_def in DEFAULT_COUNTERS:
             mname = metric_def[3]
-            aggregator.assert_metric(mname, tags=["mytag1", "mytag2", "site:{0}".format(site_name)], count=1)
+            aggregator.assert_metric(mname, tags=["mytag1", "mytag2", "site:{0}".format(site_name), iis_host], count=1)
 
         aggregator.assert_service_check('iis.site_up', status=IIS.OK,
-                                        tags=["mytag1", "mytag2", "site:{0}".format(site_name)], count=1)
+                                        tags=["mytag1", "mytag2", "site:{0}".format(site_name), iis_host], count=1)
 
     aggregator.assert_service_check('iis.site_up', status=IIS.CRITICAL,
-                                    tags=["mytag1", "mytag2", "site:{0}".format(fail_site_name)], count=1)
+                                    tags=["mytag1", "mytag2", "site:{0}".format(fail_site_name), iis_host], count=1)
 
     # Check completed with no warnings
     # self.assertFalse(logger.warning.called)

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -69,8 +69,9 @@ def test_service_check_with_invalid_host(aggregator):
     instance = INVALID_HOST_INSTANCE
     c = IIS(CHECK_NAME, {}, {}, [instance])
     c.check(instance)
+    iis_host = c.get_iishost(instance)
 
-    aggregator.assert_service_check('iis.site_up', IIS.CRITICAL, tags=["site:{0}".format('Total')])
+    aggregator.assert_service_check('iis.site_up', IIS.CRITICAL, tags=["site:{0}".format('Total'), iis_host])
 
 
 @pytest.mark.usefixtures('pdh_mocks_fixture')

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -26,7 +26,6 @@ def test_basic_check(aggregator):
     c = IIS(CHECK_NAME, {}, {}, [instance])
     c.check(instance)
     iis_host = c.get_iishost(instance)
-    print(iis_host)
 
     site_tags = ['Default_Web_Site', 'Exchange_Back_End', 'Total']
     for metric_def in DEFAULT_COUNTERS:


### PR DESCRIPTION
### What does this PR do?

PR adds `iis_host` tags to the metrics.

### Motivation

If there are multiple instance configured, there's no distinction whether a metric came from which instance.

```
instances:
 - host: "."
 - host: "RemoteIISServer"
   username: "RemoteIISServer\user"
   password: "secret"
```

### Additional Notes

- If the host is either "." or "localhost", the agent's hostname will be used as the `iis_host` instead

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
