### PR TITLE
Add style checker and formatter

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+# TODO: port this to pyproject.toml when supported: https://gitlab.com/pycqa/flake8/merge_requests/245
+
+[flake8]
+select = B,C,E,F,W,B001,B003,B006,B007,B301,B305,B306,B902
+ignore = E203,E722,W503
+exclude = .eggs,.tox,build,compat.py,__init__.py,datadog_checks/dev/tooling/templates/*,datadog_checks/*/vendor/*
+max-line-length = 120

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import absolute_import
+
 import json
 import os
 from base64 import urlsafe_b64encode

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -1,0 +1,104 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import absolute_import
+
+import tox
+import tox.config
+
+STYLE_CHECK_ENV_NAME = 'style'
+STYLE_FORMATTER_ENV_NAME = 'format_style'
+STYLE_FLAG = 'dd_check_style'
+
+
+@tox.hookimpl
+def tox_configure(config):
+    """
+    For more info, see: https://tox.readthedocs.io/en/latest/plugins.html
+    For an example, see: https://github.com/tox-dev/tox-travis
+    """
+    sections = config._cfg.sections
+
+    # Cache these
+    make_envconfig = None
+    reader = None
+
+    # Default to false so:
+    # 1. we don't affect other projects using tox
+    # 2. check migrations can happen gradually
+    if str(sections.get('testenv', {}).get(STYLE_FLAG, 'false')).lower() == 'true':
+        # Disable flake8 since we already include that
+        config.envlist[:] = [env for env in config.envlist if not env.endswith('flake8')]
+
+        make_envconfig = get_make_envconfig(make_envconfig)
+        reader = get_reader(reader, config)
+
+        add_style_checker(config, sections, make_envconfig, reader)
+        add_style_formatter(config, sections, make_envconfig, reader)
+
+
+def add_style_checker(config, sections, make_envconfig, reader):
+    # testenv:style
+    section = '{}{}'.format(tox.config.testenvprefix, STYLE_CHECK_ENV_NAME)
+    sections[section] = {
+        # These tools only support Python 3+
+        'basepython': 'python3',
+        'skip_install': 'true',
+        'deps': 'flake8\nflake8-bugbear\nblack\nisort[pyproject]>=4.3.15',
+        'commands': 'flake8 --config=../.flake8 .\nblack --check --diff .\nisort --check-only --diff --recursive .',
+    }
+
+    # Always add the environment configurations
+    config.envconfigs[STYLE_CHECK_ENV_NAME] = make_envconfig(
+        config, STYLE_CHECK_ENV_NAME, section, reader._subs, config
+    )
+
+    # Intentionally add to envlist when seeing what is available
+    if any('--listenvs' in arg for arg in config.args):
+        config.envlist.append(STYLE_CHECK_ENV_NAME)
+
+
+def add_style_formatter(config, sections, make_envconfig, reader):
+    # testenv:format_style
+    section = '{}{}'.format(tox.config.testenvprefix, STYLE_FORMATTER_ENV_NAME)
+    sections[section] = {
+        # These tools only support Python 3+
+        'basepython': 'python3',
+        'skip_install': 'true',
+        'deps': 'black\nisort[pyproject]>=4.3.15',
+        # Run formatter AFTER sorting imports
+        'commands': 'isort --recursive .\nblack .',
+    }
+
+    # Always add the environment configurations
+    config.envconfigs[STYLE_FORMATTER_ENV_NAME] = make_envconfig(
+        config, STYLE_FORMATTER_ENV_NAME, section, reader._subs, config
+    )
+
+    # Intentionally add to envlist when seeing what is available
+    if any('--listenvs' in arg for arg in config.args):
+        config.envlist.append(STYLE_FORMATTER_ENV_NAME)
+
+
+def get_make_envconfig(make_envconfig):
+    if make_envconfig is None:
+        make_envconfig = tox.config.ParseIni.make_envconfig
+
+        # Make this a non-bound method for Python 2 compatibility
+        make_envconfig = getattr(make_envconfig, '__func__', make_envconfig)
+
+    return make_envconfig
+
+
+def get_reader(reader, config):
+    if reader is None:
+        # This is just boilerplate necessary to create a valid reader
+        reader = tox.config.SectionReader('tox', config._cfg)
+        reader.addsubstitutions(toxinidir=config.toxinidir, homedir=config.homedir)
+        reader.addsubstitutions(toxworkdir=config.toxworkdir)
+        config.distdir = reader.getpath('distdir', '{toxworkdir}/dist')
+        reader.addsubstitutions(distdir=config.distdir)
+        config.distshare = reader.getpath('distshare', '{homedir}/.tox/distshare')
+        reader.addsubstitutions(distshare=config.distshare)
+
+    return reader

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/datadog_checks/{check_name}/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/datadog_checks/{check_name}/__init__.py
@@ -1,7 +1,4 @@
 {license_header}from .__about__ import __version__
 from .{check_name} import {check_class}
 
-__all__ = [
-    '__version__',
-    '{check_class}'
-]
+__all__ = ['__version__', '{check_class}']

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/setup.py
@@ -25,17 +25,13 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     keywords='datadog agent {check_name} check',
-
     # The project's main homepage.
     url='https://github.com/DataDog/integrations-{repo_choice}',
-
     # Author details
     author='{author}',
     author_email='{email_packages}',
-
     # License
     license='BSD-3-Clause',
-
     # See https://pypi.org/classifiers
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -47,13 +43,10 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
-
     # The package we're going to ship
     packages=['datadog_checks.{check_name}'],
-
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
-
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/tox.ini
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/tox.ini
@@ -7,6 +7,7 @@ envlist =
     flake8
 
 [testenv]
+dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =

--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -7,12 +7,11 @@ from .utils import get_testable_checks
 from ..subprocess import run_command
 from ..utils import chdir, path_join, read_file_binary, write_file_binary
 
-STYLE_ENVS = {
-    'flake8',
-}
+STYLE_CHECK_ENVS = {'flake8', 'style'}
+STYLE_ENVS = {'flake8', 'style', 'format_style'}
 
 
-def get_tox_envs(checks, style=False, benchmark=False, every=False, changed_only=False, sort=False):
+def get_tox_envs(checks, style=False, format_style=False, benchmark=False, every=False, changed_only=False, sort=False):
     testable_checks = get_testable_checks()
     # Run `get_changed_checks` at most once because git calls are costly
     changed_checks = get_changed_checks() if not checks or changed_only else None
@@ -36,10 +35,15 @@ def get_tox_envs(checks, style=False, benchmark=False, every=False, changed_only
         envs_selected = envs_selected.split(',') if envs_selected else []
         envs_available = get_available_tox_envs(check, sort=sort)
 
-        if style:
+        if format_style:
             envs_selected[:] = [
                 e for e in envs_available
-                if e in STYLE_ENVS
+                if 'format_style' in e
+            ]
+        elif style:
+            envs_selected[:] = [
+                e for e in envs_available
+                if e in STYLE_CHECK_ENVS
             ]
         elif benchmark:
             envs_selected[:] = [
@@ -64,7 +68,7 @@ def get_tox_envs(checks, style=False, benchmark=False, every=False, changed_only
             else:
                 envs_selected[:] = [
                     e for e in envs_available
-                    if 'bench' not in e
+                    if 'bench' not in e and 'format_style' not in e
                 ]
 
         yield check, envs_selected

--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -83,14 +83,15 @@ setup(
             'semver',
             'setuptools>=38.6.0',
             'toml>=0.9.4, <1.0.0',
-            'tox',
+            'tox>=3.7.0',
             'twine>=1.11.0',
             'wheel>=0.31.0',
         ],
     },
 
     entry_points={
-        'pytest11': ['datadog_checks = datadog_checks.dev.plugin.plugin'],
+        'pytest11': ['datadog_checks = datadog_checks.dev.plugin.pytest'],
+        'tox': ['datadog_checks = datadog_checks.dev.plugin.tox'],
         'console_scripts': [
             'ddev = datadog_checks.dev.tooling.cli:ddev',
         ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,46 @@
+# NOTE: You have to use single-quoted strings in TOML for regular expressions.
+# It's the equivalent of r-strings in Python. Multiline strings are treated as
+# verbose regular expressions by Black. Use [ ] to denote a significant space
+# character.
+
 [tool.black]
+exclude = '''
+# Directories
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+
+  # New integration templates
+  | datadog_checks/dev/tooling/templates
+  # Vendored third party libraries
+  | datadog_checks/[^/]+/vendor
+)/
+  |
+# Files
+(
+    # TODO: remove when upstream addresses https://github.com/DataDog/integrations-core/blob/c71e6d7204192a8002109da92452003598df2d28/datadog_checks_dev/datadog_checks/dev/tooling/signing.py#L9-L14
+    datadog_checks/dev/tooling/signing\.py$
+)
+'''
+include = '\.pyi?$'
 line-length = 120
+py36 = false
 skip-string-normalization = true
+
+[tool.isort]
+default_section = 'THIRDPARTY'
+force_grid_wrap = 0
+include_trailing_comma = true
+known_first_party = 'datadog_checks'
+line_length = 120
+multi_line_output = 3
+skip_glob = 'datadog_checks/dev/tooling/signing.py,datadog_checks/dev/tooling/templates/*,datadog_checks/*/vendor/*'
+use_parentheses = true


### PR DESCRIPTION
### What does this PR do?

This adds the ability to easily test for style in our CI and format code locally at will.

### Motivation

Consistent code formatting across https://github.com/DataDog/integrations-core and https://github.com/DataDog/integrations-extras.

### Implementation

We use a [tox plugin](https://tox.readthedocs.io/en/latest/plugins.html) that, when `dd_check_style` is set to true in `tox.ini`, will dynamically expose 2 new environments:

1. `style` - This will check the formatting using a variety of tools. Using the `-s/--style` flag of `ddev test` will execute this environment rather than standalone `flake8`.
2. `format_style` - This will format the code for you, often without the need for any additional manual edits. You can run the formatter by using the new `-fs/--format-style` flag of `ddev test`.

New checks will have this enabled upon creation.

### Style

We now use all of the main style checkers the Python community has coalesced on.

- [black](https://github.com/ambv/black) - An opinionated formatter, like JavaScript's [prettier](https://github.com/prettier/prettier) and Golang's [gofmt](https://golang.org/cmd/gofmt).
- [isort](https://github.com/timothycrosley/isort) - A tool to sort imports lexicographically, by section, and by type. We use the 5 standard sections: `__future__`, stdlib, third party, first party, and local. `datadog_checks` is configured as a first party namespace.
- [flake8](https://github.com/PyCQA/flake8) - An easy-to-use wrapper around [pycodestyle](https://github.com/PyCQA/pycodestyle) and [pyflakes](https://github.com/PyCQA/pyflakes). We select everything it provides and only ignore a few things to give precedence to other tools.
- [bugbear](https://github.com/PyCQA/flake8-bugbear) - A `flake8` plugin for finding likely bugs and design problems in programs. We use:
    - **B001**: "Do not use bare `except:`, it also catches unexpected events like memory errors, interrupts, system exit, and so on. Prefer `except Exception:`."
    - **B003**: "Assigning to `os.environ` doesn't clear the environment. Subprocesses are going to see outdated variables, in disagreement with the current process. Use `os.environ.clear()` or the `env=` argument to Popen."
    - **B006**: "Do not use mutable data structures for argument defaults. All calls reuse one instance of that data structure, persisting changes between them."
    - **B007**: "Loop control variable not used within the loop body. If this is intended, start the name with an underscore."
    - **B301**: "Python 3 does not include `.iter*` methods on dictionaries. The default behavior is to return iterables. Simply remove the `iter` prefix from the method. For Python 2 compatibility, also prefer the Python 3 equivalent if you expect that the size of the dict to be small and bounded. The performance regression on Python 2 will be negligible and the code is going to be the clearest. Alternatively, use `six.iter*`."
    - **B306**: `BaseException.message` has been deprecated as of Python 2.6 and is removed in Python 3. Use `str(e)` to access the user-readable message. Use `e.args` to access arguments passed to the exception."
    - **B902**: Invalid first argument used for method. Use `self` for instance methods, and `cls` for class methods."

### Config files

`black` and `isort` configuration resides in the [now-standardized](https://www.python.org/dev/peps/pep-0518) `pyproject.toml` at the root. `flake8` will follow suit when [support lands](https://gitlab.com/pycqa/flake8/merge_requests/245), but for now resides in its usual `.flake8`.

Once this is merged we'll start syncing these with https://github.com/DataDog/integrations-extras.

### Future

Add the `black` readme badge for each repo when finished

Also, we may want to eventually:

- Get rid of the standalone `flake8` environment
- Set a threshold for [cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity)
- Use [bandit](https://github.com/PyCQA/bandit) to find common security issues

### Notes

There are only 2 things to look out for when formatting:

- https://github.com/ambv/black/issues/26
- https://github.com/ambv/black/issues/251