### PR TITLE
Fix openldap environment

### DIFF
--- a/openldap/tests/conftest.py
+++ b/openldap/tests/conftest.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 import pytest
 
 from datadog_checks.dev import TempDir, docker_run
-from datadog_checks.dev.utils import create_file, file_exists
+from datadog_checks.dev.utils import create_file, path_exists
 from datadog_checks.openldap import OpenLDAP
 from .common import DEFAULT_INSTANCE, HERE, HOST
 
@@ -17,7 +17,7 @@ def dd_environment():
     with TempDir() as d:
         host_socket_path = os.path.join(d, 'ldapi')
 
-        if not file_exists(host_socket_path):
+        if not path_exists(host_socket_path):
             os.chmod(d, 0o770)
             create_file(host_socket_path)
             os.chmod(host_socket_path, 0o640)


### PR DESCRIPTION
### What does this PR do?

Changing `file_exists` to `path_exists`. The function `os.path.isfile` returns false for a socket, but `os.path.exists` does not.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
