### PR TITLE
Fix pagination logic when making request to get servers/flavors details

### DIFF
--- a/openstack_controller/datadog_checks/openstack_controller/api.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api.py
@@ -369,9 +369,9 @@ class SimpleApi(AbstractApi):
 
             objects = resp.get(obj, [])
             result.extend(objects)
-            # Avoid the extra request since we know we're done when the response has anywhere between
-            # 0 and paginated_limit servers
-            if len(objects) < query_params['limit']:
+            # If there is no link to the next object, it means we're done.
+            # For servers, see https://developer.openstack.org/api-ref/compute/?expanded=list-servers-detailed-detail
+            if resp.get("{}_links".format(obj)) is None:
                 break
 
             query_params['marker'] = objects[-1]['id']

--- a/openstack_controller/datadog_checks/openstack_controller/api.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api.py
@@ -23,8 +23,8 @@ class ApiFactory(object):
     def create(logger, proxies, instance_config):
         keystone_server_url = instance_config.get("keystone_server_url")
         ssl_verify = is_affirmative(instance_config.get("ssl_verify", True))
-        paginated_limit = instance_config.get('paginated_limit')
-        request_timeout = instance_config.get('request_timeout')
+        paginated_limit = instance_config.get('paginated_limit', DEFAULT_PAGINATED_LIMIT)
+        request_timeout = instance_config.get('request_timeout', DEFAULT_API_REQUEST_TIMEOUT)
         user = instance_config.get("user")
         openstack_config_file_path = instance_config.get("openstack_config_file_path")
         openstack_cloud_name = instance_config.get("openstack_cloud_name")

--- a/openstack_controller/datadog_checks/openstack_controller/api.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api.py
@@ -365,7 +365,7 @@ class SimpleApi(AbstractApi):
                     query_params['limit'] //= 2
                     retry += 1
             else:
-                raise e
+                raise Exception("Error making request to {}".format(url))
 
             objects = resp.get(obj, [])
             result.extend(objects)

--- a/openstack_controller/tests/test_simple_api.py
+++ b/openstack_controller/tests/test_simple_api.py
@@ -497,12 +497,6 @@ def get_servers_detail_post_v2_63_response(url, headers, params=None, timeout=No
                 "updated": "2017-10-10T15:49:09Z",
                 "user_id": "fake"
             }
-        ],
-        "servers_links": [
-            {
-                "href": "http://openstack.example.com/v2.1/6f70656e737461636b20342065766572/servers/detail?limit=1&marker=569f39f9-7c76-42a1-9c2d-8394e2638a6d",
-                "rel": "next"
-            }
         ]
     }""")  # noqa: E501
 
@@ -634,7 +628,8 @@ def test__get_paginated_list():
         side_effect=[
             # Second call: all good, 1 page with 4 results, one with 1
             {
-                "obj": [{"id": 0}, {"id": 1}, {"id": 2}, {"id": 3}]
+                "obj": [{"id": 0}, {"id": 1}, {"id": 2}, {"id": 3}],
+                "obj_links": "test"
             },
             {
                 "obj": [{"id": 4}]
@@ -653,10 +648,12 @@ def test__get_paginated_list():
             # Third call: 1 exception, limit is divided once by 2
             Exception,
             {
-                "obj": [{"id": 0}, {"id": 1}]
+                "obj": [{"id": 0}, {"id": 1}],
+                "obj_links": "test"
             },
             {
-                "obj": [{"id": 2}, {"id": 3}]
+                "obj": [{"id": 2}, {"id": 3}],
+                "obj_links": "test"
             },
             {
                 "obj": [{"id": 4}]

--- a/openstack_controller/tests/test_simple_api.py
+++ b/openstack_controller/tests/test_simple_api.py
@@ -7,7 +7,7 @@ import copy
 import pytest
 import simplejson as json
 
-from datadog_checks.openstack_controller.api import SimpleApi, Authenticator, Credential
+from datadog_checks.openstack_controller.api import ApiFactory, SimpleApi, Authenticator, Credential
 from datadog_checks.openstack_controller.exceptions import (IncompleteIdentity, MissingNovaEndpoint,
                                                             MissingNeutronEndpoint)
 from . import common
@@ -603,6 +603,71 @@ def test_get_servers_detail(aggregator):
                 "user_id": "fake"
             }
         ]
+
+
+def test__get_paginated_list():
+
+    log = mock.MagicMock()
+
+    instance = copy.deepcopy(common.MOCK_CONFIG["instances"][0])
+    instance["paginated_limit"] = 4
+
+    with mock.patch("datadog_checks.openstack_controller.api.SimpleApi.connect"):
+        api = ApiFactory.create(log, None, instance)
+    with mock.patch(
+        "datadog_checks.openstack_controller.api.SimpleApi._make_request",
+        side_effect=[
+            # First call: 3 exceptions -> failure
+            Exception,
+            Exception,
+            Exception,
+        ]
+    ):
+        # First call
+        with pytest.raises(Exception):
+            api._get_paginated_list("url", "obj", {})
+        assert log.debug.call_count == 3
+        log.reset_mock()
+
+    with mock.patch(
+        "datadog_checks.openstack_controller.api.SimpleApi._make_request",
+        side_effect=[
+            # Second call: all good, 1 page with 4 results, one with 1
+            {
+                "obj": [{"id": 0}, {"id": 1}, {"id": 2}, {"id": 3}]
+            },
+            {
+                "obj": [{"id": 4}]
+            },
+        ]
+    ):
+        # Second call
+        assert api.paginated_limit == 4
+        result = api._get_paginated_list("url", "obj", {})
+        assert log.debug.call_count == 0
+        assert result == [{"id": 0}, {"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]
+
+    with mock.patch(
+        "datadog_checks.openstack_controller.api.SimpleApi._make_request",
+        side_effect=[
+            # Third call: 1 exception, limit is divided once by 2
+            Exception,
+            {
+                "obj": [{"id": 0}, {"id": 1}]
+            },
+            {
+                "obj": [{"id": 2}, {"id": 3}]
+            },
+            {
+                "obj": [{"id": 4},]
+            }
+        ]
+    ):
+        # Third call
+        result = api._get_paginated_list("url", "obj", {})
+        assert log.debug.call_count == 1
+        assert result == [{"id": 0}, {"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]
+
 
 
 def get_server_diagnostics_post_v2_48_response(url, headers, params=None, timeout=None):

--- a/openstack_controller/tests/test_simple_api.py
+++ b/openstack_controller/tests/test_simple_api.py
@@ -659,7 +659,7 @@ def test__get_paginated_list():
                 "obj": [{"id": 2}, {"id": 3}]
             },
             {
-                "obj": [{"id": 4},]
+                "obj": [{"id": 4}]
             }
         ]
     ):
@@ -667,7 +667,6 @@ def test__get_paginated_list():
         result = api._get_paginated_list("url", "obj", {})
         assert log.debug.call_count == 1
         assert result == [{"id": 0}, {"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]
-
 
 
 def get_server_diagnostics_post_v2_48_response(url, headers, params=None, timeout=None):


### PR DESCRIPTION
### What does this PR do?

Logic was flawed, and we would always only get 1 page

### Motivation

Customer had more than page limit of servers, so some servers were missing in the app.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
