### PR TITLE
Make the aggregator fixture lazily import the stub

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2018
+# (C) Datadog, Inc. 2018-2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import absolute_import
@@ -11,21 +11,24 @@ import pytest
 
 from .._env import E2E_FIXTURE_NAME, TESTING_PLUGIN, e2e_active, get_env_vars
 
-try:
-    from datadog_checks.base.stubs import aggregator as __aggregator
+__aggregator = None
 
-    @pytest.fixture
-    def aggregator():
-        """This fixture returns a mocked Agent aggregator with state cleared."""
-        __aggregator.reset()
-        return __aggregator
 
-except ImportError:
-    __aggregator = None
+@pytest.fixture
+def aggregator():
+    """This fixture returns a mocked Agent aggregator with state cleared."""
+    global __aggregator
 
-    @pytest.fixture
-    def aggregator():
-        raise ImportError('datadog-checks-base is not installed!')
+    # Since this plugin is loaded before pytest-cov, we need to import lazily so coverage
+    # can see imports, class/function definitions, etc. of the base package.
+    if __aggregator is None:
+        try:
+            from datadog_checks.base.stubs import aggregator as __aggregator
+        except ImportError:
+            raise ImportError('datadog-checks-base is not installed!')
+
+    __aggregator.reset()
+    return __aggregator
 
 
 @pytest.fixture(scope='session', autouse=True)


### PR DESCRIPTION
### Motivation

Since the plugin is loaded before pytest-cov runs, we need to import lazily so coverage can see imports, class/function definitions, etc. of the base package. See:

https://github.com/nedbat/coveragepy/blob/master/doc/faq.rst
https://travis-ci.com/DataDog/integrations-core/jobs/185296386#L979