### PR TITLE
Remove uuid dependency

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -61,4 +61,3 @@ six==1.12.0
 supervisor==3.3.3; python_version < '3.0'
 tuf==0.11.2.dev3
 uptime==3.0.1
-uuid==1.30

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -8,4 +8,3 @@ requests==2.21.0
 simplejson==3.6.5
 six==1.12.0
 uptime==3.0.1
-uuid==1.30


### PR DESCRIPTION
### Motivation

Fails on Python 3.7 and is not used in any check (just ddev and one test file)

### Additional Notes

Last release was in 2006 b/c it became part of the standard library