### PR TITLE
Add a wrapper for requests

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -1,0 +1,248 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import threading
+import warnings
+from collections import OrderedDict
+from contextlib import contextmanager
+
+import requests
+from six import iteritems, string_types
+from six.moves.urllib.parse import urlparse
+from urllib3.exceptions import InsecureRequestWarning
+
+from ..config import is_affirmative
+try:
+    import datadog_agent
+except ImportError:
+    from ..stubs import datadog_agent
+
+STANDARD_FIELDS = {
+    'headers': None,
+    'password': None,
+    'persist_connections': False,
+    'proxy': None,
+    'skip_proxy': False,
+    'ssl_ca_cert': None,
+    'ssl_cert': None,
+    'ssl_ignore_warning': False,
+    'ssl_private_key': None,
+    'ssl_verify': True,
+    'timeout': 10,
+    'username': None,
+}
+DEFAULT_REMAPPED_FIELDS = {
+    # TODO: Remove in 6.13
+    'no_proxy': {'name': 'skip_proxy'},
+}
+PROXY_SETTINGS_DISABLED = {
+    # This will instruct `requests` to ignore the `HTTP_PROXY`/`HTTPS_PROXY`
+    # environment variables. If the proxy options `http`/`https` are missing
+    # or are `None` then `requests` will use the aforementioned environment
+    # variables, hence the need to set each to an empty string.
+    'http': '', 'https': ''
+}
+
+
+class RequestsWrapper(object):
+    __slots__ = ('ignore_ssl_warning', 'persist_connections', 'no_proxy_uris', 'options', '_session')
+
+    # For modifying the warnings filter since the context
+    # manager that is provided changes module constants
+    warning_lock = threading.Lock()
+
+    def __init__(self, instance, init_config, remapper=None):
+        default_fields = dict(STANDARD_FIELDS)
+
+        # Update the default behavior for skipping proxies
+        default_fields['skip_proxy'] = init_config.get('skip_proxy', default_fields['skip_proxy'])
+
+        # Populate with the default values
+        config = {field: instance.get(field, value) for field, value in iteritems(default_fields)}
+
+        # Support non-standard (usually legacy) configurations, for example:
+        # {
+        #     'disable_ssl_validation': {
+        #         'name': 'ssl_verify',
+        #         'default': False,
+        #         'invert': True,
+        #     },
+        #     ...
+        # }
+        if remapper is None:
+            remapper = {}
+
+        remapper.update(DEFAULT_REMAPPED_FIELDS)
+
+        for remapped_field, data in iteritems(remapper):
+            field = data.get('name')
+
+            # Ignore fields we don't recognize
+            if field not in STANDARD_FIELDS:
+                continue
+
+            # Ignore remapped fields if the standard one is already used
+            if field in instance:
+                continue
+
+            # Get value, with a possible default
+            value = instance.get(remapped_field, data.get('default', default_fields[field]))
+
+            # Invert booleans if need be
+            if data.get('invert'):
+                value = not is_affirmative(value)
+
+            config[field] = value
+
+        # http://docs.python-requests.org/en/master/user/advanced/#timeouts
+        timeout = int(config['timeout'])
+
+        # http://docs.python-requests.org/en/master/user/quickstart/#custom-headers
+        # http://docs.python-requests.org/en/master/user/advanced/#header-ordering
+        headers = None
+        if config['headers']:
+            headers = OrderedDict((key, str(value)) for key, value in iteritems(config['headers']))
+
+        # http://docs.python-requests.org/en/master/user/authentication/
+        auth = None
+        if config['username'] and config['password']:
+            auth = (config['username'], config['password'])
+
+        # http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
+        verify = True
+        if isinstance(config['ssl_ca_cert'], string_types):
+            verify = config['ssl_ca_cert']
+        elif not is_affirmative(config['ssl_verify']):
+            verify = False
+
+        # http://docs.python-requests.org/en/master/user/advanced/#client-side-certificates
+        cert = None
+        if isinstance(config['ssl_cert'], string_types):
+            if isinstance(config['ssl_private_key'], string_types):
+                cert = (config['ssl_cert'], config['ssl_private_key'])
+            else:
+                cert = config['ssl_cert']
+
+        # http://docs.python-requests.org/en/master/user/advanced/#proxies
+        no_proxy_uris = None
+        if is_affirmative(config['skip_proxy']):
+            proxies = PROXY_SETTINGS_DISABLED.copy()
+        else:
+            proxies = config['proxy'] or init_config.get('proxy')
+
+            # TODO: Deprecate this flag now that we support skip_proxy in init_config
+            if not proxies and is_affirmative(init_config.get('use_agent_proxy', True)):
+                proxies = datadog_agent.get_config('proxy')
+
+            if proxies:
+                proxies = proxies.copy()
+
+                # TODO: Pass `no_proxy` directly to `requests` once this issue is fixed:
+                # https://github.com/kennethreitz/requests/issues/5000
+                if 'no_proxy' in proxies:
+                    no_proxy_uris = proxies.pop('no_proxy')
+
+                    if isinstance(no_proxy_uris, string_types):
+                        no_proxy_uris = no_proxy_uris.replace(';', ',').split(',')
+            else:
+                proxies = None
+
+        # Default options
+        self.options = {
+            'auth': auth,
+            'cert': cert,
+            'headers': headers,
+            'proxies': proxies,
+            'timeout': timeout,
+            'verify': verify,
+        }
+
+        # For manual parsing until `requests` properly handles `no_proxy`
+        self.no_proxy_uris = no_proxy_uris
+
+        # Ignore warnings for lack of SSL validation
+        self.ignore_ssl_warning = is_affirmative(config['ssl_ignore_warning'])
+
+        # For connection and cookie persistence, if desired. See:
+        # https://en.wikipedia.org/wiki/HTTP_persistent_connection#Advantages
+        # http://docs.python-requests.org/en/master/user/advanced/#session-objects
+        # http://docs.python-requests.org/en/master/user/advanced/#keep-alive
+        self.persist_connections = is_affirmative(config['persist_connections'])
+        self._session = None
+
+    def get(self, url, **options):
+        return self._request('get', url, options)
+
+    def post(self, url, **options):
+        return self._request('post', url, options)
+
+    def head(self, url, **options):
+        return self._request('head', url, options)
+
+    def put(self, url, **options):
+        return self._request('put', url, options)
+
+    def patch(self, url, **options):
+        return self._request('patch', url, options)
+
+    def delete(self, url, **options):
+        return self._request('delete', url, options)
+
+    def _request(self, method, url, options):
+        if self.no_proxy_uris:
+            parsed_uri = urlparse(url)
+
+            for no_proxy_uri in self.no_proxy_uris:
+                if no_proxy_uri in parsed_uri.netloc:
+                    options.setdefault('proxies', PROXY_SETTINGS_DISABLED)
+                    break
+
+        persist = options.pop('persist', None)
+        if persist is None:
+            persist = self.persist_connections
+
+        with self.handle_ssl_warning():
+            if persist:
+                return getattr(self.session, method)(url, **options)
+            else:
+                return getattr(requests, method)(url, **self.populate_options(options))
+
+    def populate_options(self, options):
+        # Avoid needless dictionary update if there are no options
+        if not options:
+            return self.options
+
+        for option, value in iteritems(self.options):
+            # Make explicitly set options take precedence
+            options.setdefault(option, value)
+
+        return options
+
+    @contextmanager
+    def handle_ssl_warning(self):
+        with self.warning_lock:
+
+            with warnings.catch_warnings():
+                if self.ignore_ssl_warning:
+                    warnings.simplefilter('ignore', InsecureRequestWarning)
+
+                yield
+
+    @property
+    def session(self):
+        if self._session is None:
+            self._session = requests.Session()
+
+            # Attributes can't be passed to the constructor
+            for option, value in iteritems(self.options):
+                setattr(self._session, option, value)
+
+        return self._session
+
+    def __del__(self):  # no cov
+        try:
+            self._session.close()
+        except AttributeError:
+            # A persistent connection was never used or an error occurred during instantiation
+            # before _session was ever defined (since __del__ executes even if __init__ fails).
+            pass

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -31,6 +31,7 @@ STANDARD_FIELDS = {
     'timeout': 10,
     'username': None,
 }
+# For any known legacy fields that may be widespread
 DEFAULT_REMAPPED_FIELDS = {
     # TODO: Remove in 6.13
     'no_proxy': {'name': 'skip_proxy'},
@@ -128,6 +129,10 @@ class RequestsWrapper(object):
         if is_affirmative(config['skip_proxy']):
             proxies = PROXY_SETTINGS_DISABLED.copy()
         else:
+            # Order of precedence is:
+            # 1. instance
+            # 2. init_config
+            # 3. agent config
             proxies = config['proxy'] or init_config.get('proxy')
 
             # TODO: Deprecate this flag now that we support skip_proxy in init_config

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -1,0 +1,614 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from collections import OrderedDict
+
+import mock
+import pytest
+import requests
+from requests.exceptions import ConnectTimeout, ProxyError
+from six import iteritems
+from urllib3.exceptions import InsecureRequestWarning
+
+from datadog_checks.base import AgentCheck
+from datadog_checks.base.utils.http import STANDARD_FIELDS, RequestsWrapper
+from datadog_checks.dev import EnvVars
+
+pytestmark = pytest.mark.http
+
+
+def test_default_timeout():
+    # Assert the timeout is slightly larger than a multiple of 3,
+    # which is the default TCP packet retransmission window. See:
+    # https://tools.ietf.org/html/rfc2988
+    assert 0 < STANDARD_FIELDS['timeout'] % 3 <= 1
+
+
+class TestAttribute:
+    def test_default(self):
+        check = AgentCheck('test', {}, [{}])
+
+        assert check._http is None
+
+    def test_flag(self):
+        check = AgentCheck('test', {}, [{}])
+
+        assert check.http == check._http
+        assert isinstance(check.http, RequestsWrapper)
+
+    def test_remapper_no_trigger(self):
+        class TestCheck(AgentCheck):
+            HTTP_CONFIG_REMAPPER = {'foo': {}}
+
+        check = TestCheck('test', {}, [{}])
+
+        assert check._http is None
+
+
+class TestTimeout:
+    def test_config_default(self):
+        instance = {}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['timeout'] == STANDARD_FIELDS['timeout']
+
+    def test_config_timeout(self):
+        instance = {'timeout': 25}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['timeout'] == 25
+
+
+class TestHeaders:
+    def test_config_default(self):
+        instance = {}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['headers'] is None
+
+    def test_config_headers(self):
+        headers = OrderedDict((('key1', 'value1'), ('key2', 'value2')))
+        instance = {'headers': headers}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert list(iteritems(http.options['headers'])) == list(iteritems(headers))
+
+    def test_config_headers_string_values(self):
+        instance = {'headers': {'answer': 42}}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['headers'] == {'answer': '42'}
+
+
+class TestVerify:
+    def test_config_default(self):
+        instance = {}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['verify'] is True
+
+    def test_config_verify(self):
+        instance = {'ssl_verify': False}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['verify'] is False
+
+    def test_config_ca_cert(self):
+        instance = {'ssl_ca_cert': 'ca_cert'}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['verify'] == 'ca_cert'
+
+    def test_config_verify_and_ca_cert(self):
+        instance = {'ssl_verify': True, 'ssl_ca_cert': 'ca_cert'}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['verify'] == 'ca_cert'
+
+
+class TestCert:
+    def test_config_default(self):
+        instance = {}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['cert'] is None
+
+    def test_config_cert(self):
+        instance = {'ssl_cert': 'cert'}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['cert'] == 'cert'
+
+    def test_config_cert_and_private_key(self):
+        instance = {'ssl_cert': 'cert', 'ssl_private_key': 'key'}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['cert'] == ('cert', 'key')
+
+
+class TestAuth:
+    def test_config_default(self):
+        instance = {}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['auth'] is None
+
+    def test_config_basic(self):
+        instance = {'username': 'user', 'password': 'pass'}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['auth'] == ('user', 'pass')
+
+    def test_config_basic_only_username(self):
+        instance = {'username': 'user'}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['auth'] is None
+
+    def test_config_basic_only_password(self):
+        instance = {'password': 'pass'}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['auth'] is None
+
+
+class TestProxies:
+    def test_config_default(self):
+        instance = {}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['proxies'] is None
+        assert http.no_proxy_uris is None
+
+    def test_config_proxy_agent(self):
+        with mock.patch(
+            'datadog_checks.base.stubs.datadog_agent.get_config',
+            return_value={'http': 'http_host', 'https': 'https_host', 'no_proxy': 'uri1,uri2;uri3,uri4'},
+        ):
+            instance = {}
+            init_config = {}
+            http = RequestsWrapper(instance, init_config)
+
+            assert http.options['proxies'] == {'http': 'http_host', 'https': 'https_host'}
+            assert http.no_proxy_uris == ['uri1', 'uri2', 'uri3', 'uri4']
+
+    def test_config_proxy_init_config_override(self):
+        with mock.patch(
+            'datadog_checks.base.stubs.datadog_agent.get_config',
+            return_value={'http': 'unused', 'https': 'unused', 'no_proxy': 'unused'},
+        ):
+            instance = {}
+            init_config = {'proxy': {'http': 'http_host', 'https': 'https_host', 'no_proxy': 'uri1,uri2;uri3,uri4'}}
+            http = RequestsWrapper(instance, init_config)
+
+            assert http.options['proxies'] == {'http': 'http_host', 'https': 'https_host'}
+            assert http.no_proxy_uris == ['uri1', 'uri2', 'uri3', 'uri4']
+
+    def test_config_proxy_instance_override(self):
+        with mock.patch(
+            'datadog_checks.base.stubs.datadog_agent.get_config',
+            return_value={'http': 'unused', 'https': 'unused', 'no_proxy': 'unused'},
+        ):
+            instance = {'proxy': {'http': 'http_host', 'https': 'https_host', 'no_proxy': 'uri1,uri2;uri3,uri4'}}
+            init_config = {'proxy': {'http': 'unused', 'https': 'unused', 'no_proxy': 'unused'}}
+            http = RequestsWrapper(instance, init_config)
+
+            assert http.options['proxies'] == {'http': 'http_host', 'https': 'https_host'}
+            assert http.no_proxy_uris == ['uri1', 'uri2', 'uri3', 'uri4']
+
+    def test_config_no_proxy_as_list(self):
+        with mock.patch(
+            'datadog_checks.base.stubs.datadog_agent.get_config',
+            return_value={'http': 'http_host', 'https': 'https_host', 'no_proxy': ['uri1', 'uri2', 'uri3', 'uri4']},
+        ):
+            instance = {}
+            init_config = {}
+            http = RequestsWrapper(instance, init_config)
+
+            assert http.options['proxies'] == {'http': 'http_host', 'https': 'https_host'}
+            assert http.no_proxy_uris == ['uri1', 'uri2', 'uri3', 'uri4']
+
+    def test_config_proxy_skip(self):
+        instance = {'proxy': {'http': 'unused', 'https': 'unused', 'no_proxy': 'unused'}, 'skip_proxy': True}
+        init_config = {'proxy': {'http': 'unused', 'https': 'unused', 'no_proxy': 'unused'}}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['proxies'] == {'http': '', 'https': ''}
+        assert http.no_proxy_uris is None
+
+    def test_config_proxy_skip_init_config(self):
+        instance = {'proxy': {'http': 'unused', 'https': 'unused', 'no_proxy': 'unused'}}
+        init_config = {'proxy': {'http': 'unused', 'https': 'unused', 'no_proxy': 'unused'}, 'skip_proxy': True}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['proxies'] == {'http': '', 'https': ''}
+        assert http.no_proxy_uris is None
+
+    def test_proxy_env_vars_skip(self):
+        instance = {'skip_proxy': True}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        with EnvVars({'HTTP_PROXY': 'http://1.2.3.4:567'}):
+            response = http.get('http://www.google.com')
+            response.raise_for_status()
+
+        with EnvVars({'HTTPS_PROXY': 'https://1.2.3.4:567'}):
+            response = http.get('https://www.google.com')
+            response.raise_for_status()
+
+    def test_proxy_env_vars_override_skip_fail(self):
+        instance = {'skip_proxy': True}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        with EnvVars({'HTTP_PROXY': 'http://1.2.3.4:567'}):
+            with pytest.raises((ConnectTimeout, ProxyError)):
+                http.get('http://www.google.com', timeout=1, proxies=None)
+
+        with EnvVars({'HTTPS_PROXY': 'https://1.2.3.4:567'}):
+            with pytest.raises((ConnectTimeout, ProxyError)):
+                http.get('https://www.google.com', timeout=1, proxies=None)
+
+    def test_proxy_bad(self):
+        instance = {'proxy': {'http': 'http://1.2.3.4:567', 'https': 'https://1.2.3.4:567'}}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        with pytest.raises((ConnectTimeout, ProxyError)):
+            http.get('http://www.google.com', timeout=1)
+
+        with pytest.raises((ConnectTimeout, ProxyError)):
+            http.get('https://www.google.com', timeout=1)
+
+    def test_proxy_bad_no_proxy_override_success(self):
+        instance = {
+            'proxy': {'http': 'http://1.2.3.4:567', 'https': 'https://1.2.3.4:567', 'no_proxy': 'unused,google.com'}
+        }
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        response = http.get('http://www.google.com')
+        response.raise_for_status()
+
+        response = http.get('https://www.google.com')
+        response.raise_for_status()
+
+    def test_no_proxy_uris_coverage(self):
+        http = RequestsWrapper({}, {})
+
+        # Coverage is not smart enough to detect that looping an empty
+        # iterable will never occur when gated by `if iterable:`.
+        http.no_proxy_uris = mock.MagicMock()
+
+        setattr(http.no_proxy_uris, '__iter__', lambda self, *args, **kwargs: iter([]))
+        setattr(http.no_proxy_uris, '__bool__', lambda self, *args, **kwargs: True)
+        # TODO: Remove with Python 2
+        setattr(http.no_proxy_uris, '__nonzero__', lambda self, *args, **kwargs: True)
+
+        http.get('https://www.google.com')
+
+
+class TestIgnoreSSLWarning:
+    def test_config_default(self):
+        instance = {}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.ignore_ssl_warning is False
+
+    def test_config_flag(self):
+        instance = {'ssl_ignore_warning': True}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.ignore_ssl_warning is True
+
+    def test_default_no_ignore(self):
+        instance = {}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        with pytest.warns(InsecureRequestWarning):
+            http.get('https://www.google.com', verify=False)
+
+    def test_ignore(self):
+        instance = {'ssl_ignore_warning': True}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        with pytest.warns(None) as record:
+            http.get('https://www.google.com', verify=False)
+
+        assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
+
+    def test_default_no_ignore_session(self):
+        instance = {'persist_connections': True}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        with pytest.warns(InsecureRequestWarning):
+            http.get('https://www.google.com', verify=False)
+
+    def test_ignore_session(self):
+        instance = {'ssl_ignore_warning': True, 'persist_connections': True}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        with pytest.warns(None) as record:
+            http.get('https://www.google.com', verify=False)
+
+        assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
+
+
+class TestSession:
+    def test_default_none(self):
+        instance = {}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http._session is None
+
+    def test_lazy_create(self):
+        instance = {}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.session is http._session
+        assert isinstance(http.session, requests.Session)
+
+    def test_attributes(self):
+        instance = {}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        for key, value in iteritems(http.options):
+            assert hasattr(http.session, key)
+            assert getattr(http.session, key) == value
+
+
+class TestRemapper:
+    def test_legacy_no_proxy(self):
+        instance = {'no_proxy': True}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['proxies'] == {'http': '', 'https': ''}
+        assert http.no_proxy_uris is None
+
+    def test_no_default(self):
+        instance = {}
+        init_config = {}
+        remapper = {'prometheus_timeout': {'name': 'timeout'}}
+        http = RequestsWrapper(instance, init_config, remapper)
+
+        assert http.options['timeout'] == STANDARD_FIELDS['timeout']
+
+    def test_invert(self):
+        instance = {'disable_ssl_validation': False}
+        init_config = {}
+        remapper = {'disable_ssl_validation': {'name': 'ssl_verify', 'default': False, 'invert': True}}
+        http = RequestsWrapper(instance, init_config, remapper)
+
+        assert http.options['verify'] is True
+
+    def test_standard_override(self):
+        instance = {'disable_ssl_validation': True, 'ssl_verify': False}
+        init_config = {}
+        remapper = {'disable_ssl_validation': {'name': 'ssl_verify', 'default': False, 'invert': True}}
+        http = RequestsWrapper(instance, init_config, remapper)
+
+        assert http.options['verify'] is False
+
+    def test_unknown_name_default(self):
+        instance = {}
+        init_config = {}
+        remapper = {'verify_ssl': {'name': 'verify', 'default': False}}
+        http = RequestsWrapper(instance, init_config, remapper)
+
+        assert http.options['verify'] is True
+
+
+class TestAPI:
+    def test_get(self):
+        http = RequestsWrapper({}, {})
+
+        with mock.patch('requests.get'):
+            http.get('https://www.google.com')
+            requests.get.assert_called_once_with('https://www.google.com', **http.options)
+
+    def test_get_session(self):
+        http = RequestsWrapper({'persist_connections': True}, {})
+
+        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+            http.get('https://www.google.com')
+            http.session.get.assert_called_once_with('https://www.google.com')
+
+    def test_get_option_override(self):
+        http = RequestsWrapper({}, {})
+        options = http.options.copy()
+        options['auth'] = ('user', 'pass')
+
+        with mock.patch('requests.get'):
+            http.get('https://www.google.com', auth=options['auth'])
+            requests.get.assert_called_once_with('https://www.google.com', **options)
+
+    def test_get_session_option_override(self):
+        http = RequestsWrapper({}, {})
+        options = {'auth': ('user', 'pass')}
+
+        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+            http.get('https://www.google.com', persist=True, auth=options['auth'])
+            http.session.get.assert_called_once_with('https://www.google.com', **options)
+
+    def test_post(self):
+        http = RequestsWrapper({}, {})
+
+        with mock.patch('requests.post'):
+            http.post('https://www.google.com')
+            requests.post.assert_called_once_with('https://www.google.com', **http.options)
+
+    def test_post_session(self):
+        http = RequestsWrapper({'persist_connections': True}, {})
+
+        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+            http.post('https://www.google.com')
+            http.session.post.assert_called_once_with('https://www.google.com')
+
+    def test_post_option_override(self):
+        http = RequestsWrapper({}, {})
+        options = http.options.copy()
+        options['auth'] = ('user', 'pass')
+
+        with mock.patch('requests.post'):
+            http.post('https://www.google.com', auth=options['auth'])
+            requests.post.assert_called_once_with('https://www.google.com', **options)
+
+    def test_post_session_option_override(self):
+        http = RequestsWrapper({}, {})
+        options = {'auth': ('user', 'pass')}
+
+        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+            http.post('https://www.google.com', persist=True, auth=options['auth'])
+            http.session.post.assert_called_once_with('https://www.google.com', **options)
+
+    def test_head(self):
+        http = RequestsWrapper({}, {})
+
+        with mock.patch('requests.head'):
+            http.head('https://www.google.com')
+            requests.head.assert_called_once_with('https://www.google.com', **http.options)
+
+    def test_head_session(self):
+        http = RequestsWrapper({'persist_connections': True}, {})
+
+        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+            http.head('https://www.google.com')
+            http.session.head.assert_called_once_with('https://www.google.com')
+
+    def test_head_option_override(self):
+        http = RequestsWrapper({}, {})
+        options = http.options.copy()
+        options['auth'] = ('user', 'pass')
+
+        with mock.patch('requests.head'):
+            http.head('https://www.google.com', auth=options['auth'])
+            requests.head.assert_called_once_with('https://www.google.com', **options)
+
+    def test_head_session_option_override(self):
+        http = RequestsWrapper({}, {})
+        options = {'auth': ('user', 'pass')}
+
+        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+            http.head('https://www.google.com', persist=True, auth=options['auth'])
+            http.session.head.assert_called_once_with('https://www.google.com', **options)
+
+    def test_put(self):
+        http = RequestsWrapper({}, {})
+
+        with mock.patch('requests.put'):
+            http.put('https://www.google.com')
+            requests.put.assert_called_once_with('https://www.google.com', **http.options)
+
+    def test_put_session(self):
+        http = RequestsWrapper({'persist_connections': True}, {})
+
+        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+            http.put('https://www.google.com')
+            http.session.put.assert_called_once_with('https://www.google.com')
+
+    def test_put_option_override(self):
+        http = RequestsWrapper({}, {})
+        options = http.options.copy()
+        options['auth'] = ('user', 'pass')
+
+        with mock.patch('requests.put'):
+            http.put('https://www.google.com', auth=options['auth'])
+            requests.put.assert_called_once_with('https://www.google.com', **options)
+
+    def test_put_session_option_override(self):
+        http = RequestsWrapper({}, {})
+        options = {'auth': ('user', 'pass')}
+
+        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+            http.put('https://www.google.com', persist=True, auth=options['auth'])
+            http.session.put.assert_called_once_with('https://www.google.com', **options)
+
+    def test_patch(self):
+        http = RequestsWrapper({}, {})
+
+        with mock.patch('requests.patch'):
+            http.patch('https://www.google.com')
+            requests.patch.assert_called_once_with('https://www.google.com', **http.options)
+
+    def test_patch_session(self):
+        http = RequestsWrapper({'persist_connections': True}, {})
+
+        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+            http.patch('https://www.google.com')
+            http.session.patch.assert_called_once_with('https://www.google.com')
+
+    def test_patch_option_override(self):
+        http = RequestsWrapper({}, {})
+        options = http.options.copy()
+        options['auth'] = ('user', 'pass')
+
+        with mock.patch('requests.patch'):
+            http.patch('https://www.google.com', auth=options['auth'])
+            requests.patch.assert_called_once_with('https://www.google.com', **options)
+
+    def test_patch_session_option_override(self):
+        http = RequestsWrapper({}, {})
+        options = {'auth': ('user', 'pass')}
+
+        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+            http.patch('https://www.google.com', persist=True, auth=options['auth'])
+            http.session.patch.assert_called_once_with('https://www.google.com', **options)
+
+    def test_delete(self):
+        http = RequestsWrapper({}, {})
+
+        with mock.patch('requests.delete'):
+            http.delete('https://www.google.com')
+            requests.delete.assert_called_once_with('https://www.google.com', **http.options)
+
+    def test_delete_session(self):
+        http = RequestsWrapper({'persist_connections': True}, {})
+
+        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+            http.delete('https://www.google.com')
+            http.session.delete.assert_called_once_with('https://www.google.com')
+
+    def test_delete_option_override(self):
+        http = RequestsWrapper({}, {})
+        options = http.options.copy()
+        options['auth'] = ('user', 'pass')
+
+        with mock.patch('requests.delete'):
+            http.delete('https://www.google.com', auth=options['auth'])
+            requests.delete.assert_called_once_with('https://www.google.com', **options)
+
+    def test_delete_session_option_override(self):
+        http = RequestsWrapper({}, {})
+        options = {'auth': ('user', 'pass')}
+
+        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+            http.delete('https://www.google.com', persist=True, auth=options['auth'])
+            http.session.delete.assert_called_once_with('https://www.google.com', **options)


### PR DESCRIPTION
### Motivation

Consistent HTTP(S) behavior based on configuration, especially important for proxies

### Implementation (Agent 6.13+)

Every check has a member named `http` that, upon first access, is set to an instance of `RequestsWrapper`.

The wrapper automatically parses configuration from the `instance`, `init_config`, and agent config. Also, this is only done once during initialization and cached to reduce the overhead of every call (for legacy reasons we usually had to re-parse configs at every check run or network call).

The standard settings are:

- `username` - For basic authentication
- `password` - For basic authentication
- `timeout` - The number of seconds to wait on a connect or read (default 10)
- `headers` - Map of headers to send on every request
- `proxy` - Map of proxy settings e.g. `HTTP: example.com`. May be defined in the agent config, `init_config`, or `instance` (with increasing priority)
- `skip_proxy` - Whether or not to ignore proxy settings entirely. May be defined in the `init_config` or `instance` (with increasing priority)
- `ssl_verify` - Whether or not to verify SSL certificates (default true)
- `ssl_ca_cert` - The path to a CA_BUNDLE file or directory with certificates of trusted CAs. Implicitly sets `ssl_verify` to true
- `ssl_cert` - The client side certificate to use
- `ssl_private_key` - The private key to use if it's not included in the `ssl_cert` file
- `ssl_ignore_warning` - Whether or not to ignore `urllib3`'s `InsecureRequestWarning` when `ssl_verify` is false
- `persist_connections` - Whether or not to persist cookies and use connection pooling

The wrapper exposes the exact same interface as `requests`, so all you have to do is e.g.:

```python
response = self.http.[get|post|head|put|patch|delete](url)
```

and the wrapper will pass the right things to `requests` based on configuration. All methods accept optional keyword arguments like `stream`, etc.

Any method-level option will override configuration. So for example if `ssl_verify` was set to false and you do `self.http.get(url, verify=True)`, then SSL certificates will be verified on that particular request. You can use the keyword argument `persist` to override `persist_connections`.

There is also support for non-standard or legacy configurations with the `HTTP_CONFIG_REMAPPER` class attribute. For example:

```python
class MyCheck(AgentCheck):
    HTTP_CONFIG_REMAPPER = {
        'disable_ssl_validation': {
            'name': 'ssl_verify',
            'default': False,
            'invert': True,
        },
        ...
    }
    ...
```

### Future

- We'll switch all checks that use `requests` to this, including OpenMetrics base class.
- I chose to add our other forms of authentication (Kerberos, NTLM, etc.) in a separate PR to ease the review.
- Cookies. They can be set globally, per-domain, and even per-path! Therefore, the configuration may be complex if not thought out adequately. We'll discuss options for what that might look like. Only our `cisco_aci` check currently sets cookies, and that is based on code logic, not configuration.
- I disagree with our supposed [default headers](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/utils/headers.py) (except `User-Agent`) and the function has a legacy signature. We'll reassess whether or not these are still desired, and add any that are as defaults.

### Additional Notes

This has 100% coverage 😄 