### PR TITLE
Ddev env bind /proc

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -119,6 +119,8 @@ class DockerInterface(object):
                 '-v', '{}:{}'.format(self.config_dir, get_agent_conf_dir(self.check, self.agent_version)),
                 # Mount the check directory
                 '-v', '{}:{}'.format(path_join(get_root(), self.check), self.check_mount_dir),
+                # Mount the /proc directory
+                '-v', '/proc:/host/proc',
             ]
 
             # Any environment variables passed to the start command


### PR DESCRIPTION
### What does this PR do?

Binding `/proc:/host/proc` when starting the agent for the `ddev env start`.

### Motivation

Used for the E2E process testing.
The agent is started in a container with `ddev env start`, and needs to check the process. However, because it's started in a container, the agent is looking for the process in `/host/proc` which is not found in the container.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
