### PR TITLE
Use the conf.yaml.example file instead of the metrics.yaml file

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/utils.py
@@ -196,7 +196,7 @@ def load_jmx_config():
         root = new_root
 
     check = basepath(root)
-    jmx_config = path_join(root, 'datadog_checks', check, 'data', 'metrics.yaml')
+    jmx_config = path_join(root, 'datadog_checks', check, 'data', 'conf.yaml.example')
 
     return yaml.safe_load(read_file(jmx_config))
 


### PR DESCRIPTION
### What does this PR do?

Loads the conf.yaml.example file instead of the metrics.yaml file when loading the jmx config. 

### Motivation

The metrics.yml file has less information and is geared primarily to defining metrics. The conf.yaml.example file is what will include all the details about the host/port .

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
