### PR TITLE
Update Cassandra log instruction with multiline link

### DIFF
--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -52,6 +52,8 @@ See the [sample  cassandra.d/conf.yaml][5] for all available configuration optio
   Change the `path` and `service` parameter values and configure them for your environment.
   See the [sample  cassandra.d/conf.yaml][5] for all available configuration options.
 
+To make sure that stacktraces are properly aggregated as one single log, a [multiline processing rule][] can be added.
+
 * [Restart the Agent][6].
 
 ### Validation
@@ -92,3 +94,4 @@ Need help? Contact [Datadog support][9].
 [10]: https://www.datadoghq.com/blog/how-to-monitor-cassandra-performance-metrics
 [11]: https://www.datadoghq.com/blog/how-to-collect-cassandra-metrics
 [12]: https://www.datadoghq.com/blog/monitoring-cassandra-with-datadog
+[13]: https://docs.datadoghq.com/logs/log_collection/?tab=tailexistingfiles#multi-line-aggregation

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -52,7 +52,7 @@ See the [sample  cassandra.d/conf.yaml][5] for all available configuration optio
   Change the `path` and `service` parameter values and configure them for your environment.
   See the [sample  cassandra.d/conf.yaml][5] for all available configuration options.
 
-To make sure that stacktraces are properly aggregated as one single log, a [multiline processing rule][] can be added.
+To make sure that stacktraces are properly aggregated as one single log, a [multiline processing rule][13] can be added.
 
 * [Restart the Agent][6].
 


### PR DESCRIPTION
### What does this PR do?

Add a link to the multiline aggregation documentation in the Cassandra log instruction.

### Motivation

Cassandra logs can come as stack traces and depending on the format used, the beginning of the log can be a date or the severity or anything configured which is why having a default aggregation in the document could lead to issues and a link to the corresponding part of the documentation seems more accurate.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
