### PR TITLE
Ensure the use of relative imports to avoid circular dependencies

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -13,8 +13,7 @@ from prometheus_client.parser import text_fd_to_metric_families
 from six import PY3, iteritems, string_types
 
 from .. import AgentCheck
-
-from datadog_checks.config import is_affirmative
+from ...config import is_affirmative
 
 if PY3:
     long = int

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 
 from six import iteritems
 
-from datadog_checks.checks import AgentCheck
+from ... import AgentCheck
 from .sampler import WMISampler
 
 WMIMetric = namedtuple('WMIMetric', ['name', 'value', 'tags'])


### PR DESCRIPTION
### Motivation

It is possible that our legacy redirects could trigger a circular import. Currently, only 2 checks are affected (`vsphere` and `teamcity`) due to the order of their imports.

```
ofek.lev@ozone ~\Desktop $ docker run -d -e DD_API_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa datadog/agent:6.10.0
1cd6ed9c8f1074938b264e33ec03afc507861c798368492e8bf04550f1883b59
ofek.lev@ozone ~\Desktop $ docker exec -it 1cd python
Python 2.7.15 (default, Feb 28 2019, 13:50:39)
[GCC 4.7.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from datadog_checks.teamcity import TeamCityCheck
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/teamcity/__init__.py", line 5, in <module>
    from .teamcity import TeamCityCheck
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/teamcity/teamcity.py", line 13, in <module>
    from datadog_checks.config import _is_affirmative
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/config.py", line 4, in <module>
    from .base.config import *
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/__init__.py", line 6, in <module>
    from .checks.openmetrics import OpenMetricsBaseCheck
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/openmetrics/__init__.py", line 6, in <module>
    from .base_check import OpenMetricsBaseCheck
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/openmetrics/base_check.py", line 4, in <module>
    from .mixins import OpenMetricsScraperMixin
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/openmetrics/mixins.py", line 17, in <module>
    from datadog_checks.config import is_affirmative
ImportError: cannot import name is_affirmative
>>>
>>> from datadog_checks.vsphere import VSphereCheck
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/vsphere/__init__.py", line 1, in <module>
    from .vsphere import VSphereCheck
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/vsphere/vsphere.py", line 17, in <module>
    from datadog_checks.config import is_affirmative
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/config.py", line 4, in <module>
    from .base.config import *
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/__init__.py", line 6, in <module>
    from .checks.openmetrics import OpenMetricsBaseCheck
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/openmetrics/__init__.py", line 6, in <module>
    from .base_check import OpenMetricsBaseCheck
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/openmetrics/base_check.py", line 4, in <module>
    from .mixins import OpenMetricsScraperMixin
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/openmetrics/mixins.py", line 17, in <module>
    from datadog_checks.config import is_affirmative
ImportError: cannot import name is_affirmative
>>>
```

### Discovery

Our `pytest` plugin used to import the aggegator stub immediately. See: https://github.com/DataDog/integrations-core/blob/87278a286edf11279e55b6a9646f0cd4174a983e/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py#L14-L28

I noticed that since the plugin is loaded before pytest-cov runs, we needed to import lazily so coverage can properly see imports, class/function definitions, etc. of the base package. As such, we switched to importing at the time of test execution. See: https://github.com/DataDog/integrations-core/pull/3308

This exposed the bug because [the root](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/__init__.py) was no longer being pre-loaded. Therefore, any shared import of your legacy selection and the traversal of the root namespace would conflict.

### Additional Notes

- CI on master will pass now
- Since we're deprecating the legacy imports soon, we need to be sure we're importing from `base` everywhere
- This hurt my head