### PR TITLE
Fix e2e for couch v2

### DIFF
--- a/couch/tests/common.py
+++ b/couch/tests/common.py
@@ -44,6 +44,12 @@ BASIC_CONFIG = {
     "server": URL
 }
 
+BASIC_CONFIG_V2 = {
+    "server": URL,
+    "user": "dduser",
+    "password": "pawprint",
+}
+
 BASIC_CONFIG_TAGS = [
     "instance:{}".format(URL)
 ]

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -56,7 +56,10 @@ def dd_environment():
         env_vars=env,
         conditions=[CheckEndpoints([common.URL]), lambda: generate_data(couch_version), lambda: time.sleep(20)],
     ):
-        yield common.BASIC_CONFIG
+        if couch_version == '1':
+            yield common.BASIC_CONFIG
+        elif couch_version == '2':
+            yield common.BASIC_CONFIG_V2
 
 
 def generate_data(couch_version):


### PR DESCRIPTION
### What does this PR do?

Adding a configuration for couch V2. The container for couch V2 needs `user` and `password`, or the check in the `ddev env` returns a 401.

### Motivation

### Additional Notes

I don't know if this is the best way to solve this issue.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
