### PR TITLE
Add ability to detect if using JMX based on metadata

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -75,6 +75,7 @@ def start(ctx, check, env, agent, dev, base, env_vars):
 
     echo_waiting('Setting up environment `{}`... '.format(env), nl=False)
     config, metadata, error = start_environment(check, env)
+
     if error:
         echo_failure('failed!')
         echo_waiting('Stopping the environment...')
@@ -83,6 +84,7 @@ def start(ctx, check, env, agent, dev, base, env_vars):
     echo_success('success!')
 
     env_type = metadata['env_type']
+    use_jmx = metadata.get('use_jmx', False)
 
     # Support legacy config where agent5 and agent6 were strings
     agent_ver = ctx.obj.get('agent{}'.format(agent), agent)
@@ -95,6 +97,8 @@ def start(ctx, check, env, agent, dev, base, env_vars):
             )
     else:
         agent_build = agent_ver.get(env_type, env_type)
+
+    agent_build = '{}-jmx'.format(agent_build) if use_jmx else agent_build
 
     interface = derive_interface(env_type)
     if interface is None:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -98,7 +98,8 @@ def start(ctx, check, env, agent, dev, base, env_vars):
     else:
         agent_build = agent_ver.get(env_type, env_type)
 
-    agent_build = '{}-jmx'.format(agent_build) if use_jmx else agent_build
+    if not agent and use_jmx:
+        agent_build = '{}-jmx'.format(agent_build)
 
     interface = derive_interface(env_type)
     if interface is None:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -98,7 +98,7 @@ def start(ctx, check, env, agent, dev, base, env_vars):
     else:
         agent_build = agent_ver.get(env_type, env_type)
 
-    if not agent and use_jmx:
+    if not isinstance(agent_ver, string_types) and use_jmx:
         agent_build = '{}-jmx'.format(agent_build)
 
     interface = derive_interface(env_type)


### PR DESCRIPTION
### What does this PR do?

Adds `use_jmx` to the metadata for E2E to allow the command to automatically use the jmx agent container if its needed. 

To use this on an existing check, its as simple as modifying the `yield` statement in a `dd_environment` fixture. For example:

```
yield common.BASIC_CONFIG
```

would become:

```
yield common.BASIC_CONFIG, {'use_jmx': True}
```

This doesn't impact `local` E2E because the host level Agent already includes JMXFetch

### Motivation

When testing JMX based integrations with E2E it's required to always pass in the `-a` flag and use the JMX based agent container. This will auto detect that and allow us to specify in the fixture whether the check should default to using the JMX container. 

### Additional Notes

If the `-a` flag is passed, the change made in this PR are ignored. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
