### PR TITLE
Include version in the Varnish cache configuration file

### DIFF
--- a/varnish/datadog_checks/varnish/data/conf.yaml.example
+++ b/varnish/datadog_checks/varnish/data/conf.yaml.example
@@ -45,7 +45,8 @@ instances:
     # secretfile: /etc/varnish/secret
 
     # The (optional) parameters for specifying the host and port to connect to varnishadm
-    # Defaults to "localhost" and "6082" 
+    # Used in version 4.1.0 and above.
+    # Defaults to "localhost" and "6082".
     # daemon_host: localhost
     # daemon_port: 6082
     


### PR DESCRIPTION
### What does this PR do?

`daemon_host` and `daemon_port` are used with versions 4.1.0 of Varnish cache and above according to https://github.com/DataDog/integrations-core/blob/6.10.x/varnish/datadog_checks/varnish/varnish.py#L149-L157.

### Motivation

Customer use case.

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.