### PR TITLE
Properly cache zookeeper connection strings

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -67,7 +67,7 @@ class KafkaCheck(AgentCheck):
         zk_hosts_ports = instance.get('zk_connect_str')
         zk_prefix = instance.get('zk_prefix', '')
         zk_interval = int(instance.get('zk_iteration_ival', 0))
-        get_kafka_consumer_offsets = is_affirmative(instance.get('kafka_consumer_offsets', zk_hosts_ports) is None)
+        get_kafka_consumer_offsets = is_affirmative(instance.get('kafka_consumer_offsets', zk_hosts_ports is None))
 
         custom_tags = instance.get('tags', [])
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -81,12 +81,14 @@ class KafkaCheck(AgentCheck):
 
         zk_consumer_offsets = None
 
-        if zk_hosts_ports:
+        if isinstance(zk_hosts_ports, list):
             zk_hosts_ports = [
                 zk_host_port for zk_host_port in zk_hosts_ports if self._should_zk(
                     zk_host_port, zk_interval, get_kafka_consumer_offsets
                 )
             ]
+
+        if zk_hosts_ports:
             zk_consumer_offsets, consumer_groups = self._get_zk_consumer_offsets(
                 zk_hosts_ports, consumer_groups, zk_prefix)
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -67,7 +67,7 @@ class KafkaCheck(AgentCheck):
         zk_hosts_ports = instance.get('zk_connect_str')
         zk_prefix = instance.get('zk_prefix', '')
         zk_interval = int(instance.get('zk_iteration_ival', 0))
-        get_kafka_consumer_offsets = is_affirmative(instance.get('kafka_consumer_offsets', zk_hosts_ports is None))
+        get_kafka_consumer_offsets = is_affirmative(instance.get('kafka_consumer_offsets', zk_hosts_ports) is None)
 
         custom_tags = instance.get('tags', [])
 
@@ -80,12 +80,13 @@ class KafkaCheck(AgentCheck):
             self._validate_explicit_consumer_groups(consumer_groups)
 
         zk_consumer_offsets = None
-        zk_hosts_ports = [
-            zk_host_port for zk_host_port in zk_hosts_ports if self._should_zk(
-                zk_host_port, zk_interval, get_kafka_consumer_offsets
-            )
-        ]
-        if zk_hosts_ports and self._should_zk(zk_hosts_ports, zk_interval, get_kafka_consumer_offsets):
+
+        if zk_hosts_ports:
+            zk_hosts_ports = [
+                zk_host_port for zk_host_port in zk_hosts_ports if self._should_zk(
+                    zk_host_port, zk_interval, get_kafka_consumer_offsets
+                )
+            ]
             zk_consumer_offsets, consumer_groups = self._get_zk_consumer_offsets(
                 zk_hosts_ports, consumer_groups, zk_prefix)
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -80,6 +80,11 @@ class KafkaCheck(AgentCheck):
             self._validate_explicit_consumer_groups(consumer_groups)
 
         zk_consumer_offsets = None
+        zk_hosts_ports = [
+            zk_host_port for zk_host_port in zk_hosts_ports if self._should_zk(
+                zk_host_port, zk_interval, get_kafka_consumer_offsets
+            )
+        ]
         if zk_hosts_ports and self._should_zk(zk_hosts_ports, zk_interval, get_kafka_consumer_offsets):
             zk_consumer_offsets, consumer_groups = self._get_zk_consumer_offsets(
                 zk_hosts_ports, consumer_groups, zk_prefix)
@@ -362,9 +367,9 @@ class KafkaCheck(AgentCheck):
         try:
             children = zk_conn.get_children(zk_path)
         except NoNodeError:
-            self.log.info('No zookeeper node at %s', zk_path)
-        except Exception:
-            self.log.exception('Could not read %s from %s', name_for_error, zk_path)
+            self.log.info('No zookeeper node at {}'.format(zk_path))
+        except Exception as e:
+            self.log.exception('Could not read {} from {}. Exception: {}'.format(name_for_error, zk_path, e))
         return children
 
     def _get_zk_consumer_offsets(self, zk_hosts_ports, consumer_groups=None, zk_prefix=''):
@@ -490,16 +495,16 @@ class KafkaCheck(AgentCheck):
 
         return consumer_offsets
 
-    def _should_zk(self, zk_hosts_ports, interval, kafka_collect=False):
+    def _should_zk(self, zk_host_port, interval, kafka_collect=False):
         if not kafka_collect or not interval:
             return True
 
         now = time()
-        last = self._zk_last_ts.get(zk_hosts_ports, 0)
+        last = self._zk_last_ts.get(zk_host_port, 0)
 
         should_zk = False
         if now - last >= interval:
-            self._zk_last_ts[zk_hosts_ports] = last
+            self._zk_last_ts[zk_host_port] = last
             should_zk = True
 
         return should_zk

--- a/kafka_consumer/tests/test_kafka_consumer_zk.py
+++ b/kafka_consumer/tests/test_kafka_consumer_zk.py
@@ -7,6 +7,7 @@ import time
 import pytest
 from six import iteritems
 
+from datadog_checks.base.utils.containers import hash_mutable
 from datadog_checks.kafka_consumer import KafkaCheck
 from .common import HOST, PARTITIONS, TOPICS, ZK_CONNECT_STR, is_supported
 
@@ -103,9 +104,10 @@ def test_check_nogroups_zk(aggregator, zk_instance):
 def test_should_zk():
     check = KafkaCheck('kafka_consumer', {}, {})
     # Kafka Consumer Offsets set to True and we have a zk_connect_str that hasn't been run yet
-    assert (check._should_zk(ZK_CONNECT_STR, 10, True) is True)
+    assert (check._should_zk([ZK_CONNECT_STR, ZK_CONNECT_STR], 10, True) is True)
     # Kafka Consumer Offsets is set to False, should immediately ZK
     assert (check._should_zk(ZK_CONNECT_STR, 10, False) is True)
     # Last time we checked ZK_CONNECT_STR was less than interval ago, shouldn't ZK
-    check._zk_last_ts[ZK_CONNECT_STR] = time.time()
+    zk_connect_hash = hash_mutable(ZK_CONNECT_STR)
+    check._zk_last_ts[zk_connect_hash] = time.time()
     assert (check._should_zk(ZK_CONNECT_STR, 100, True) is False)


### PR DESCRIPTION
### What does this PR do?

Properly uses the last_zk seen cache for the case when users provided a list of connection strings. Before we were assuming there was only one. 

Also adds the exception to an error message we provide. 

### Motivation

We accept both a string and a list of strings for `zk_connect_str` in the yaml file. However, the _should_zk function was attempting to use this to access a dictionary. In the case of it being a list, you'd end up with an exception about list being an unhashable type. This addresses that, with a test :) 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
