### PR TITLE
Add e2e tcp_check

### DIFF
--- a/tcp_check/tests/common.py
+++ b/tcp_check/tests/common.py
@@ -1,0 +1,20 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+CHECK_NAME = "tcp_check"
+
+INSTANCE = {
+    'host': 'datadoghq.com',
+    'port': 80,
+    'timeout': 1.5,
+    'name': 'UpService',
+    'tags': ["foo:bar"]
+}
+
+INSTANCE_KO = {
+    'host': '127.0.0.1',
+    'port': 65530,
+    'timeout': 1.5,
+    'name': 'DownService',
+    'tags': ["foo:bar"],
+}

--- a/tcp_check/tests/conftest.py
+++ b/tcp_check/tests/conftest.py
@@ -1,0 +1,18 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+import pytest
+
+from datadog_checks.tcp_check import TCPCheck
+
+from . import common
+
+
+@pytest.fixture(scope='session')
+def dd_environment():
+    yield common.INSTANCE
+
+
+@pytest.fixture
+def check():
+    return TCPCheck(common.CHECK_NAME, {}, {})

--- a/tcp_check/tests/test_integration.py
+++ b/tcp_check/tests/test_integration.py
@@ -1,0 +1,19 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from copy import deepcopy
+
+from . import common
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.usefixture("dd_environment")
+def test_check(aggregator, check):
+    check.check(deepcopy(common.INSTANCE))
+
+    expected_tags = ['foo:bar', 'target_host:datadoghq.com', 'port:80', 'instance:UpService']
+    aggregator.assert_metric('network.tcp.can_connect', value=1, tags=expected_tags)
+    aggregator.assert_service_check('tcp.can_connect', status=check.OK, tags=expected_tags)


### PR DESCRIPTION
### What does this PR do?

Add e2e testing for tcp_check

### Motivation

### Additional Notes

The environment is considering that datadoghq.com:80 is always available

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
