### PR TITLE
Add tags option to hyperv

### DIFF
--- a/hyperv/datadog_checks/hyperv/data/conf.yaml.example
+++ b/hyperv/datadog_checks/hyperv/data/conf.yaml.example
@@ -1,4 +1,12 @@
 init_config:
 
 instances:
-  - {}
+  -
+  ## @param tags  - list of key:value element - optional
+  ## List of tags to attach to every metric, event and service check emitted by this integration.
+  ##
+  ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+  #
+  #  tags:
+  #    - <KEY_1>:<VALUE_1>
+  #    - <KEY_2>:<VALUE_2>


### PR DESCRIPTION
### What does this PR do?

HyperV is a sub class of PDHBaseCheck so its supposed to support things like `tags` OOTB! - https://github.com/DataDog/integrations-core/blob/98935844e213008827af6390a846ae4b50853275/datadog_checks_base/datadog_checks/base/checks/win/winpdh_base.py#L46

### Motivation

Keep the yaml file up to date. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
