### PR TITLE
Use new JMX E2E metadata

### DIFF
--- a/presto/tests/conftest.py
+++ b/presto/tests/conftest.py
@@ -11,7 +11,7 @@ from datadog_checks.dev import docker_run, get_here
 @pytest.fixture(scope='session')
 def dd_environment(instance):
     with docker_run(os.path.join(get_here(), 'docker', 'docker-compose.yaml')):
-        yield instance
+        yield instance, {'use_jmx': True}
 
 
 @pytest.fixture(scope='session', autouse=True)


### PR DESCRIPTION
### What does this PR do?

Uses the new E2E metadata option available in https://github.com/DataDog/integrations-core/pull/3330

### Motivation

Now when spinning up presto end to end, you'll get the agent container with JMX by default.  

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
