### PR TITLE
Support docker.kmem.usage

### DIFF
--- a/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py
+++ b/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py
@@ -76,6 +76,13 @@ CGROUP_METRICS = [
         },
     },
     {
+        "cgroup": "memory",
+        "file": "memory.kmem.usage_in_bytes",
+        "metrics": {
+            "kmemusage": ("docker.kmem.usage", GAUGE),
+        },
+    },
+    {
         "cgroup": "cpuacct",
         "file": "cpuacct.stat",
         "metrics": {
@@ -1033,6 +1040,10 @@ class DockerDaemon(AgentCheck):
                     # 2 ** 60 is kept for consistency of other cgroups metrics
                     if value < 2 ** 60:
                         return dict({'softlimit': value})
+                elif 'memory.kmem.usage_in_bytes' in stat_file:
+                    value = int(fp.read())
+                    if value < 2 ** 60:
+                        return dict({'kmemusage': value})
                 elif 'cpu.shares' in stat_file:
                     value = int(fp.read())
                     return {'shares': value}

--- a/docker_daemon/metadata.csv
+++ b/docker_daemon/metadata.csv
@@ -14,6 +14,7 @@ docker.cpu.user.median,gauge,,percent,,Median value of docker.cpu.user,0,docker,
 docker.cpu.usage,gauge,,percent,,The percent of CPU time obtained by this container,0,docker,docker.cpu.usage
 docker.cpu.throttled,gauge,,,,Number of times the cgroup has been throttled,-1,docker,cpu throttled
 docker.cpu.shares,gauge,,,,Shares of CPU usage allocated to the container,0,docker,cpu shares
+docker.kmem.usage,gauge,,byte,,"The amount of kernel memory that belongs to the container's processes.",0,docker,kmem usage
 docker.mem.cache,gauge,,byte,,The amount of memory that is being used to cache data from disk (e.g. memory contents that can be associated precisely with a block on a block device),0,docker,mem cache
 docker.mem.cache.95percentile,gauge,,byte,,95th percentile value of docker.mem.cache,0,docker,mem cache 95%
 docker.mem.cache.avg,gauge,,byte,,Average value of docker.mem.cache,0,docker,mem cache avg


### PR DESCRIPTION
Some recent versions of Docker perform Kernel Memory accounting. Because
of this, it's necessary to monitor a container's Kernel Memory usage.
This gives us a GAUGE counter to determine kernel memory. This has been
in use in production on our site for 6 months.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>

### What does this PR do?

Adds metrics collection for Docker container Kernel memory usage.

### Motivation

Running Docker versions > 1.13 on RHEL-based kernels enabled kernel memory process accounting. However, this used the old cgroup v1 interface, which was essentially broken. To properly size container limits, accounting of the container's kernel memory usage was required.

### Additional Notes

This is fairly simple and doesn't touch existing functionality.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
