### PR TITLE
[NTP] configuration file migration

### DIFF
--- a/nginx/datadog_checks/nginx/data/conf.yaml.example
+++ b/nginx/datadog_checks/nginx/data/conf.yaml.example
@@ -1,7 +1,7 @@
 init_config:
 
 instances:
-  
+
 ## @param nginx_status_url - string - required
 ## For every instance, you need an `nginx_status_url` and can optionally
 ## supply a list of tags.  This plugin requires nginx to be compiled with
@@ -12,7 +12,7 @@ instances:
 ##   http://docs.datadoghq.com/integrations/nginx/
 #
   - nginx_status_url: http://localhost:81/nginx_status/
-  
+
   ## @param use_plus_api - boolean - optional - default: false
   ## If you are using the commercial version of nginx, for releases R13 and above,
   ## there is a new API to replace the extended status API.

--- a/ntp/datadog_checks/ntp/data/conf.yaml.default
+++ b/ntp/datadog_checks/ntp/data/conf.yaml.default
@@ -1,17 +1,45 @@
-# This file is overwritten upon Agent upgrade.
-# To make modifications to the check configuration, please copy this file
-# to `ntp.yaml` and make your changes on that file.
+## This file is overwritten upon Agent upgrade.
+## To make modifications to the check configuration, please copy this file
+## to `ntp.yaml` and make your changes on that file.
 
 init_config:
 
 instances:
-  - offset_threshold: 60
 
-    # Optional params:
-    #
-    # host: pool.ntp.org
-    # port: ntp
-    # version: 3
-    # timeout: 5
-    # tags:
-    #   - optional:tag1
+  -
+  ## @param offset_threshold - integer - optional - default: 60
+  ## Offset threshold to apply.
+  #
+  #  offset_threshold: 60
+
+  ## @param host - string - optional - default: <X>.datadog.pool.ntp.org
+  ## NTP host to connect to, default is `<X>.datadog.pool.ntp.org` where
+  ## <X> is a number between 0 and 3.
+  #
+  #  host: <X>.datadog.pool.ntp.org
+
+  ## @param port - string - optional - default: ntp
+  ## Port to use when reaching the NTP server.
+  ## default port is the name of the service but lookup would fail if the /etc/services file
+  ## is missing. The ntp port then falls back to the numeric port 123.
+  #
+  #  port: ntp
+
+  ## @param version - integer - optional - default: 3
+  ## Version of NTP to use.
+  #
+  #  version: 3
+
+  ## @param timeout - integer - optional - default: 5
+  ## The timeout for connecting to the NTP server in second.
+  #
+  #  timeout: 5
+
+  ## @param tags  - list of key:value elements - optional
+  ## List of tags to attach to every metric, event, and service check emitted by this Integration.
+  ##
+  ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+  #
+  #  tags:
+  #    - <KEY_1>:<VALUE_1>
+  #    - <KEY_2>:<VALUE_2>

--- a/ntp/datadog_checks/ntp/data/conf.yaml.default
+++ b/ntp/datadog_checks/ntp/data/conf.yaml.default
@@ -8,7 +8,7 @@ instances:
 
   -
   ## @param offset_threshold - integer - optional - default: 60
-  ## Offset threshold to apply.
+  ## Offset threshold above which a CRITICAL service check is sent.
   #
   #  offset_threshold: 60
 


### PR DESCRIPTION
### What does this PR do?

Migrates NTP configuration file to the new norm.

All parameters seems to be optional. 