### PR TITLE
Add styles checkers to tox envlist more broadly

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -54,7 +54,7 @@ def add_style_checker(config, sections, make_envconfig, reader):
     )
 
     # Intentionally add to envlist when seeing what is available
-    if any('--listenvs' in arg for arg in config.args):
+    if config.option.env is None or config.option.env == STYLE_CHECK_ENV_NAME:
         config.envlist.append(STYLE_CHECK_ENV_NAME)
 
 
@@ -76,7 +76,7 @@ def add_style_formatter(config, sections, make_envconfig, reader):
     )
 
     # Intentionally add to envlist when seeing what is available
-    if any('--listenvs' in arg for arg in config.args):
+    if config.option.env is None or config.option.env == STYLE_FORMATTER_ENV_NAME:
         config.envlist.append(STYLE_FORMATTER_ENV_NAME)
 
 


### PR DESCRIPTION
### What does this PR do?

This adds the style and the format_style tox environments to the envlist config
option more often.

### Motivation

This fixes tox invocation like `tox` without any environment and `tox -estyle`.