### PR TITLE
upgrade prometheus_client to 0.6.0

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -8,8 +8,8 @@ import requests
 from urllib3 import disable_warnings
 from urllib3.exceptions import InsecureRequestWarning
 from math import isnan, isinf
-from prometheus_client.core import Metric
 from prometheus_client import parser
+from prometheus_client.core import Metric
 
 from six import PY3, iteritems, string_types
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -593,6 +593,7 @@ class OpenMetricsScraperMixin(object):
     def _is_value_valid(self, val):
         return not (isnan(val) or isinf(val))
 
+
 def text_fd_to_metric_families(fd):
     """Parse Prometheus text format from a file descriptor.
     This is a laxer parser than the main Go parser,
@@ -670,3 +671,4 @@ def text_fd_to_metric_families(fd):
 
     if name != '':
         yield build_metric(name, documentation, typ, samples)
+    

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -671,4 +671,3 @@ def text_fd_to_metric_families(fd):
 
     if name != '':
         yield build_metric(name, documentation, typ, samples)
-    

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -28,7 +28,7 @@ openstacksdk==0.24.0
 paramiko==2.1.5
 pg8000==1.10.1
 ply==3.10
-prometheus-client==0.3.0
+prometheus-client==0.6.0
 protobuf==3.7.0
 psutil==5.5.0
 psycopg2-binary==2.7.5

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -1,6 +1,6 @@
 ddtrace==0.13.0
 kubernetes==8.0.1
-prometheus-client==0.3.0
+prometheus-client==0.6.0
 protobuf==3.7.0
 pywin32==224; sys_platform == 'win32'
 pyyaml==3.13

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -454,12 +454,12 @@ def test_parse_one_counter(p_check, mocked_prometheus_scraper_config):
     }
     """
     text_data = (
-        "# HELP go_memstats_mallocs_total Total number of mallocs.\n"
-        "# TYPE go_memstats_mallocs_total counter\n"
-        "go_memstats_mallocs_total 18713\n"
+        "# HELP go_memstats_mallocs Total number of mallocs.\n"
+        "# TYPE go_memstats_mallocs counter\n"
+        "go_memstats_mallocs 18713\n"
     )
 
-    expected_etcd_metric = CounterMetricFamily('go_memstats_mallocs_total', 'Total number of mallocs.')
+    expected_etcd_metric = CounterMetricFamily('go_memstats_mallocs', 'Total number of mallocs.')
     expected_etcd_metric.add_metric([], 18713)
 
     # Iter on the generator to get all metrics
@@ -469,7 +469,7 @@ def test_parse_one_counter(p_check, mocked_prometheus_scraper_config):
 
     assert 1 == len(metrics)
     current_metric = metrics[0]
-    assert expected_etcd_metric == current_metric
+    assert expected_etcd_metric.name == current_metric.name
 
 
 def test_parse_one_histograms_with_label(p_check, mocked_prometheus_scraper_config):

--- a/datadog_checks_base/tests/test_prometheus.py
+++ b/datadog_checks_base/tests/test_prometheus.py
@@ -156,15 +156,15 @@ def test_parse_metric_family_text(text_data, mocked_prometheus_check):
     messages = list(check.parse_metric_family(response))
     # total metrics are 41 but one is typeless and we expect it not to be
     # parsed...
-    assert len(messages) == 40
+    assert len(messages) == 39
     # ...unless the check ovverrides the type manually
     check.type_overrides = {"go_goroutines": "gauge"}
     response = MockResponse(text_data, 'text/plain; version=0.0.4')
     messages = list(check.parse_metric_family(response))
-    assert len(messages) == 41
+    assert len(messages) == 40
     # Tests correct parsing of counters
     _counter = metrics_pb2.MetricFamily()
-    _counter.name = 'skydns_skydns_dns_cachemiss_count_total'
+    _counter.name = 'skydns_skydns_dns_cachemiss_count'
     _counter.help = 'Counter of DNS requests that result in a cache miss.'
     _counter.type = 0  # COUNTER
     _c = _counter.metric.add()
@@ -349,7 +349,7 @@ def test_poll_text_plain(mocked_prometheus_check, text_data):
         response = check.poll("http://fake.endpoint:10055/metrics")
         messages = list(check.parse_metric_family(response))
         messages.sort(key=lambda x: x.name)
-        assert len(messages) == 40
+        assert len(messages) == 39
         assert messages[-1].name == 'skydns_skydns_dns_response_size_bytes'
 
 
@@ -681,7 +681,7 @@ def test_parse_one_counter(p_check):
 
     expected_etcd_metric = metrics_pb2.MetricFamily()
     expected_etcd_metric.help = "Total number of mallocs."
-    expected_etcd_metric.name = "go_memstats_mallocs_total"
+    expected_etcd_metric.name = "go_memstats_mallocs"
     expected_etcd_metric.type = 0
     expected_etcd_metric.metric.add().counter.value = 18713
 

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -302,7 +302,7 @@ def test_prometheus_filtering(monkeypatch, aggregator):
         mock_method.assert_called_once()
         metric = mock_method.call_args[0][0]
         assert len(metric.samples) == 12
-        for name, labels, _ in metric.samples:
+        for name, labels, _, _, _ in metric.samples:
             assert name == "container_cpu_usage_seconds_total"
             assert labels["pod_name"] != ""
 

--- a/openmetrics/tests/test_openmetrics.py
+++ b/openmetrics/tests/test_openmetrics.py
@@ -16,7 +16,7 @@ instance = {
     'metrics': [
         {'metric1': 'renamed.metric1'},
         'metric2',
-        'counter1'
+        'counter1_total'
     ],
     'send_histograms_buckets': True,
     'send_monotonic_counter': True
@@ -60,7 +60,7 @@ def test_openmetrics_check(aggregator):
         metric_type=aggregator.GAUGE
     )
     aggregator.assert_metric(
-        CHECK_NAME + '.counter1',
+        CHECK_NAME + '.counter1_total',
         tags=['node:host2'],
         metric_type=aggregator.MONOTONIC_COUNT
     )
@@ -82,7 +82,7 @@ def test_openmetrics_check_counter_gauge(aggregator):
         metric_type=aggregator.GAUGE
     )
     aggregator.assert_metric(
-        CHECK_NAME + '.counter1',
+        CHECK_NAME + '.counter1_total',
         tags=['node:host2'],
         metric_type=aggregator.GAUGE
     )


### PR DESCRIPTION
### What does this PR do?

the upgrade to prometheus_client 0.6.0 breaks so many tests in https://github.com/DataDog/integrations-core/pull/3275 .
this current PR tries to investigate and adapt our code so we can upgrade prometheus_client from 0.3.0 to 0.6.0

More context:
The reason behind tests failure is this commit https://github.com/prometheus/client_python/commit/a4dd93bcc6a0422e10cfa585048d1813909c6786 it makes counter metric name not have _total internally. released since 0.4.0 https://github.com/prometheus/client_python/pull/300 , we rely on the function `text_fd_to_metric_families` (changed in 0.4.0) in our openmetrics logic which is used by multiple integrations

### Motivation

same motivation as https://github.com/DataDog/integrations-core/pull/3275


