### PR TITLE
Remove flake8 from tox.ini template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/tox.ini
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/tox.ini
@@ -4,7 +4,6 @@ skip_missing_interpreters = true
 basepython = py37
 envlist =
     py{{27,37}}-{check_name}
-    flake8
 
 [testenv]
 dd_check_style = true
@@ -19,12 +18,3 @@ passenv =
 commands =
     pip install -r requirements.in
     pytest -v
-
-[testenv:flake8]
-skip_install = true
-deps = flake8
-commands = flake8 .
-
-[flake8]
-exclude = .eggs,.tox,build
-max-line-length = 120


### PR DESCRIPTION
### What does this PR do?

This removes flake8 from the tox.ini template.

### Motivation

Now that datadog_checks_dev generates a style enviroment, we don't need to
manually add a flake8 environment in tox.ini and its configuration.