### PR TITLE
adds channel metrics

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -74,3 +74,11 @@ class IBMMQConfig:
             "port:{}".format(self.port),
             "channel:{}".format(self.channel)
         ] + self.custom_tags
+
+    @property
+    def tags_no_channel(self):
+        return [
+            "queue_manager:{}".format(self.queue_manager_name),
+            "host:{}".format(self.host),
+            "port:{}".format(self.port),
+        ] + self.custom_tags

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -41,6 +41,8 @@ class IBMMQConfig:
         self.queues = instance.get('queues', [])
         self.queue_patterns = instance.get('queue_patterns', [])
 
+        self.channels = instance.get('channels', [])
+
         self.custom_tags = instance.get('tags', [])
 
         self.auto_discover_queues = is_affirmative(instance.get('auto_discover_queues', False))

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -44,6 +44,12 @@ instances:
   #    - 'DEV.*'
   #    - 'SYSTEM.*'
 
+  ## @param channels - list of string - optional
+  ## Check the status of the following channels
+  #
+  #  channels:
+  #    - '<CHANNEL_NAME>'
+
   ## @param auto_discover_queues - string - optional - default: false
   ## Autodiscover the queues to monitor
   ## Warning: this will lead to some warnings in your logs

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -52,6 +52,8 @@ class IbmMqCheck(AgentCheck):
             self.service_check(self.SERVICE_CHECK, AgentCheck.CRITICAL, config.tags)
             return
 
+        self.get_pcf_channel_metrics(queue_manager, tags, config)
+
         self.discover_queues(queue_manager, config)
 
         try:
@@ -170,7 +172,7 @@ class IbmMqCheck(AgentCheck):
     def get_pcf_channel_metrics(self, queue_manager, tags, config):
         try:
             pcf = pymqi.PCFExecute(queue_manager)
-            response = pcf.MQCMD_INQUIRE_CHANNEL(CHANNEL_ARGS)
+            response = pcf.MQCMD_INQUIRE_CHANNEL(self.CHANNEL_ARGS)
         except pymqi.MQMIError as e:
             self.warning("Error getting CHANNEL stats {}".format(e))
         else:
@@ -180,7 +182,7 @@ class IbmMqCheck(AgentCheck):
 
         try:
             pcf = pymqi.PCFExecute(queue_manager)
-            response = pcf.MQCMD_INQUIRE_CHANNEL_STATUS(CHANNEL_ARGS)
+            response = pcf.MQCMD_INQUIRE_CHANNEL_STATUS(self.CHANNEL_ARGS)
         except pymqi.MQMIError as e:
             self.warning("Error getting CHANNEL stats {}".format(e))
         else:

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -174,7 +174,7 @@ class IbmMqCheck(AgentCheck):
             pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_INQUIRE_CHANNEL(self.CHANNEL_ARGS)
         except pymqi.MQMIError as e:
-            self.warning("Error getting CHANNEL stats {}".format(e))
+            self.log.warning("Error getting CHANNEL stats {}".format(e))
         else:
             channels = len(response)
             mname = '{}.channel.channels'.format(self.METRIC_PREFIX)
@@ -184,7 +184,7 @@ class IbmMqCheck(AgentCheck):
             pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_INQUIRE_CHANNEL_STATUS(self.CHANNEL_ARGS)
         except pymqi.MQMIError as e:
-            self.warning("Error getting CHANNEL stats {}".format(e))
+            self.log.warning("Error getting CHANNEL stats {}".format(e))
         else:
             for channel_info in response:
                 name = channel_info[pymqi.CMQCFC.MQCACH_CHANNEL_NAME]
@@ -209,7 +209,7 @@ class IbmMqCheck(AgentCheck):
                 pcf = pymqi.PCFExecute(queue_manager)
                 response = pcf.MQCMD_INQUIRE_CHANNEL_STATUS(args)
             except pymqi.MQMIError as e:
-                self.warning("Error getting CHANNEL stats {}".format(e))
+                self.log.warning("Error getting CHANNEL stats {}".format(e))
                 self.service_check(self.SERVICE_CHECK, AgentCheck.CRITICAL, channel_tags)
             else:
                 for channel_info in response:

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -175,7 +175,7 @@ class IbmMqCheck(AgentCheck):
             self.warning("Error getting CHANNEL stats {}".format(e))
         else:
             channels = len(response)
-            mname = '{}.channels'.format(self.METRIC_PREFIX)
+            mname = '{}.channel.channels'.format(self.METRIC_PREFIX)
             self.gauge(mname, channels, tags=tags)
 
         try:

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -168,11 +168,11 @@ class IbmMqCheck(AgentCheck):
     def get_pcf_channel_metrics(self, queue_manager, tags, config):
         if PY3:
             args = {
-                pymqi.CMQCFC.MQCACH_CHANNEL_NAME: '*'
+                pymqi.CMQCFC.MQCACH_CHANNEL_NAME: ensure_bytes('*')
             }
         else:
             args = {
-                pymqi.CMQCFC.MQCACH_CHANNEL_NAME: ensure_bytes('*')
+                pymqi.CMQCFC.MQCACH_CHANNEL_NAME: '*'
             }
 
         try:

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -169,6 +169,7 @@ class IbmMqCheck(AgentCheck):
 
     def get_pcf_channel_metrics(self, queue_manager, tags, config):
         try:
+            pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_INQUIRE_CHANNEL(CHANNEL_ARGS)
         except pymqi.MQMIError as e:
             self.warning("Error getting CHANNEL stats {}".format(e))
@@ -178,6 +179,7 @@ class IbmMqCheck(AgentCheck):
             self.gauge(mname, channels, tags=tags)
 
         try:
+            pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_INQUIRE_CHANNEL_STATUS(CHANNEL_ARGS)
         except pymqi.MQMIError as e:
             self.warning("Error getting CHANNEL stats {}".format(e))
@@ -202,6 +204,7 @@ class IbmMqCheck(AgentCheck):
                 args = {
                     pymqi.CMQCFC.MQCACH_CHANNEL_NAME: channel
                 }
+                pcf = pymqi.PCFExecute(queue_manager)
                 response = pcf.MQCMD_INQUIRE_CHANNEL_STATUS(args)
             except pymqi.MQMIError as e:
                 self.warning("Error getting CHANNEL stats {}".format(e))

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -6,7 +6,7 @@ from datadog_checks.checks import AgentCheck
 
 from datadog_checks.base import ensure_bytes
 
-from six import iteritems, PY3
+from six import iteritems
 import logging
 
 from . import errors, metrics, connection

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -33,7 +33,7 @@ class IbmMqCheck(AgentCheck):
     CHANNEL_SERVICE_CHECK = 'ibm_mq.channel'
 
     CHANNEL_ARGS = {
-        pymqi.CMQCFC.MQCACH_CHANNEL_NAME: '*'
+        pymqi.CMQCFC.MQCACH_CHANNEL_NAME: pymqi.ByteString('*')
     }
 
     def check(self, instance):

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -48,7 +48,7 @@ class IbmMqCheck(AgentCheck):
             self.service_check(self.SERVICE_CHECK, AgentCheck.CRITICAL, config.tags)
             return
 
-        self.get_pcf_channel_metrics(queue_manager, config.tags, config)
+        self.get_pcf_channel_metrics(queue_manager, config.tags_no_channel, config)
 
         self.discover_queues(queue_manager, config)
 

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -177,7 +177,7 @@ class IbmMqCheck(AgentCheck):
 
         try:
             pcf = pymqi.PCFExecute(queue_manager)
-            response = pcf.MQCMD_INQUIRE_CHANNEL(self.CHANNEL_ARGS)
+            response = pcf.MQCMD_INQUIRE_CHANNEL(args)
         except pymqi.MQMIError as e:
             self.log.warning("Error getting CHANNEL stats {}".format(e))
         else:
@@ -187,7 +187,7 @@ class IbmMqCheck(AgentCheck):
 
         try:
             pcf = pymqi.PCFExecute(queue_manager)
-            response = pcf.MQCMD_INQUIRE_CHANNEL_STATUS(self.CHANNEL_ARGS)
+            response = pcf.MQCMD_INQUIRE_CHANNEL_STATUS(args)
         except pymqi.MQMIError as e:
             self.log.warning("Error getting CHANNEL stats {}".format(e))
         else:

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -52,7 +52,7 @@ class IbmMqCheck(AgentCheck):
             self.service_check(self.SERVICE_CHECK, AgentCheck.CRITICAL, config.tags)
             return
 
-        self.get_pcf_channel_metrics(queue_manager, tags, config)
+        self.get_pcf_channel_metrics(queue_manager, config.tags, config)
 
         self.discover_queues(queue_manager, config)
 

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -168,11 +168,11 @@ class IbmMqCheck(AgentCheck):
     def get_pcf_channel_metrics(self, queue_manager, tags, config):
         if PY3:
             args = {
-                pymqi.CMQCFC.MQCACH_CHANNEL_NAME: pymqi.ByteString('*')
+                pymqi.CMQCFC.MQCACH_CHANNEL_NAME: '*'
             }
         else:
             args = {
-                pymqi.CMQCFC.MQCACH_CHANNEL_NAME: '*'
+                pymqi.CMQCFC.MQCACH_CHANNEL_NAME: ensure_bytes('*')
             }
 
         try:

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -6,7 +6,7 @@ from datadog_checks.checks import AgentCheck
 
 from datadog_checks.base import ensure_bytes
 
-from six import iteritems
+from six import iteritems, PY3
 import logging
 
 from . import errors, metrics, connection
@@ -31,10 +31,6 @@ class IbmMqCheck(AgentCheck):
     QUEUE_SERVICE_CHECK = 'ibm_mq.queue'
 
     CHANNEL_SERVICE_CHECK = 'ibm_mq.channel'
-
-    CHANNEL_ARGS = {
-        pymqi.CMQCFC.MQCACH_CHANNEL_NAME: pymqi.ByteString('*')
-    }
 
     def check(self, instance):
         config = IBMMQConfig(instance)
@@ -170,6 +166,15 @@ class IbmMqCheck(AgentCheck):
                         log.debug(msg)
 
     def get_pcf_channel_metrics(self, queue_manager, tags, config):
+        if PY3:
+            args = {
+                pymqi.CMQCFC.MQCACH_CHANNEL_NAME: pymqi.ByteString('*')
+            }
+        else:
+            args = {
+                pymqi.CMQCFC.MQCACH_CHANNEL_NAME: '*'
+            }
+
         try:
             pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_INQUIRE_CHANNEL(self.CHANNEL_ARGS)

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -166,14 +166,9 @@ class IbmMqCheck(AgentCheck):
                         log.debug(msg)
 
     def get_pcf_channel_metrics(self, queue_manager, tags, config):
-        if PY3:
-            args = {
-                pymqi.CMQCFC.MQCACH_CHANNEL_NAME: ensure_bytes('*')
-            }
-        else:
-            args = {
-                pymqi.CMQCFC.MQCACH_CHANNEL_NAME: '*'
-            }
+        args = {
+            pymqi.CMQCFC.MQCACH_CHANNEL_NAME: ensure_bytes('*')
+        }
 
         try:
             pcf = pymqi.PCFExecute(queue_manager)

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -189,7 +189,7 @@ class IbmMqCheck(AgentCheck):
         for channel in config.channels:
             self._get_channel_status(queue_manager, channel, tags, config)
 
-    def _get_channel_status(queue_manager, channel, tags, config):
+    def _get_channel_status(self, queue_manager, channel, tags, config):
         channel_tags = tags + ["channel:{}".format(channel)]
         try:
             args = {

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -199,7 +199,7 @@ class IbmMqCheck(AgentCheck):
             response = pcf.MQCMD_INQUIRE_CHANNEL_STATUS(args)
         except pymqi.MQMIError as e:
             self.log.warning("Error getting CHANNEL stats {}".format(e))
-            self.service_check(self.SERVICE_CHECK, AgentCheck.CRITICAL, channel_tags)
+            self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.CRITICAL, channel_tags)
         else:
             for channel_info in response:
                 name = channel_info[pymqi.CMQCFC.MQCACH_CHANNEL_NAME]
@@ -208,6 +208,6 @@ class IbmMqCheck(AgentCheck):
                 # running = 3, stopped = 4
                 status = channel_info[pymqi.CMQCFC.MQIACH_CHANNEL_STATUS]
                 if status == 3:
-                    self.service_check(self.SERVICE_CHECK, AgentCheck.OK, channel_tags)
+                    self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.OK, channel_tags)
                 elif status == 4:
-                    self.service_check(self.SERVICE_CHECK, AgentCheck.WARNING, channel_tags)
+                    self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.WARNING, channel_tags)

--- a/ibm_mq/tests/common.py
+++ b/ibm_mq/tests/common.py
@@ -20,6 +20,8 @@ CHANNEL = 'DEV.ADMIN.SVRCONN'
 
 QUEUE = 'DEV.QUEUE.1'
 
+BAD_CHANNEL = 'DEV.NOTHERE.SVRCONN'
+
 MQ_VERSION = os.environ.get('IBM_MQ_VERSION', '9')
 
 COMPOSE_FILE_NAME = 'docker-compose-v{}.yml'.format(MQ_VERSION)
@@ -35,6 +37,10 @@ INSTANCE = {
     'password': PASSWORD,
     'queues': [
         QUEUE
+    ],
+    'channels': [
+        CHANNEL,
+        BAD_CHANNEL,
     ]
 }
 
@@ -48,6 +54,10 @@ INSTANCE_PATTERN = {
     'queue_patterns': [
         'DEV.*',
         'SYSTEM.*'
+    ],
+    'channels': [
+        CHANNEL,
+        BAD_CHANNEL,
     ]
 }
 
@@ -59,4 +69,8 @@ INSTANCE_COLLECT_ALL = {
     'username': USERNAME,
     'password': PASSWORD,
     'auto_discover_queues': True,
+    'channels': [
+        CHANNEL,
+        BAD_CHANNEL,
+    ]
 }

--- a/ibm_mq/tests/test_ibm_mq.py
+++ b/ibm_mq/tests/test_ibm_mq.py
@@ -8,6 +8,8 @@ import pytest
 
 from datadog_checks.ibm_mq import IbmMqCheck
 
+from . import common
+
 log = logging.getLogger(__file__)
 
 METRICS = [
@@ -68,6 +70,11 @@ def test_check(aggregator, instance, seed_data):
         aggregator.assert_metric(metric, at_least=0)
 
     aggregator.assert_all_metrics_covered()
+
+    tags = ['channel:{}'.format(common.CHANNEL)]
+    aggregator.assert_service_check('ibm_mq.channel', check.OK, tags=tags)
+    tags = ['channel:{}'.format(common.BAD_CHANNEL)]
+    aggregator.assert_service_check('ibm_mq.channel', check.CRITICAL, tags=tags)
 
 
 @pytest.mark.usefixtures("dd_environment")

--- a/ibm_mq/tests/test_ibm_mq.py
+++ b/ibm_mq/tests/test_ibm_mq.py
@@ -71,9 +71,13 @@ def test_check(aggregator, instance, seed_data):
 
     aggregator.assert_all_metrics_covered()
 
-    tags = ['channel:{}'.format(common.CHANNEL)]
+    from six import iteritems
+    for sc, data in iteritems(aggregator._service_checks):
+        log.warning("{} {}".format(sc, data))
+
+    channel_tags = ['channel:{}'.format(common.CHANNEL)]
     aggregator.assert_service_check('ibm_mq.channel', check.OK, tags=tags)
-    tags = ['channel:{}'.format(common.BAD_CHANNEL)]
+    bad_channel_tags = ['channel:{}'.format(common.BAD_CHANNEL)]
     aggregator.assert_service_check('ibm_mq.channel', check.CRITICAL, tags=tags)
 
 

--- a/ibm_mq/tests/test_ibm_mq.py
+++ b/ibm_mq/tests/test_ibm_mq.py
@@ -71,10 +71,6 @@ def test_check(aggregator, instance, seed_data):
 
     aggregator.assert_all_metrics_covered()
 
-    from six import iteritems
-    for sc, data in iteritems(aggregator._service_checks):
-        log.warning("{} {}".format(sc, data))
-
     tags = ['queue_manager:datadog', 'host:localhost', 'port:11414']
 
     channel_tags = tags + ['channel:{}'.format(common.CHANNEL)]

--- a/ibm_mq/tests/test_ibm_mq.py
+++ b/ibm_mq/tests/test_ibm_mq.py
@@ -42,6 +42,7 @@ METRICS = [
     'ibm_mq.queue.depth_percent',
     'ibm_mq.queue_manager.dist_lists',
     'ibm_mq.queue_manager.max_msg_list',
+    'ibm_mq.channel.channels',
 ]
 
 OPTIONAL_METRICS = [

--- a/ibm_mq/tests/test_ibm_mq.py
+++ b/ibm_mq/tests/test_ibm_mq.py
@@ -75,10 +75,12 @@ def test_check(aggregator, instance, seed_data):
     for sc, data in iteritems(aggregator._service_checks):
         log.warning("{} {}".format(sc, data))
 
-    channel_tags = ['channel:{}'.format(common.CHANNEL)]
-    aggregator.assert_service_check('ibm_mq.channel', check.OK, tags=tags)
-    bad_channel_tags = ['channel:{}'.format(common.BAD_CHANNEL)]
-    aggregator.assert_service_check('ibm_mq.channel', check.CRITICAL, tags=tags)
+    tags = ['queue_manager:datadog', 'host:localhost', 'port:11414']
+
+    channel_tags = tags + ['channel:{}'.format(common.CHANNEL)]
+    aggregator.assert_service_check('ibm_mq.channel', check.OK, tags=channel_tags)
+    bad_channel_tags = tags + ['channel:{}'.format(common.BAD_CHANNEL)]
+    aggregator.assert_service_check('ibm_mq.channel', check.CRITICAL, tags=bad_channel_tags)
 
 
 @pytest.mark.usefixtures("dd_environment")


### PR DESCRIPTION
### What does this PR do?

This adds channel metrics for IBM MQ

### Motivation

customer request

### Additional Notes

The number of channels metric was requested. There aren't really many other metrics for channels that are exposed, so the only other thing we could do is status.

We let them set the channels so that we can send a warning if a channel is not there. A channel that exists has only two statuses, on and off. A channel that's not there won't trigger anything when we look for the status automatically.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
