### PR TITLE
Strip white space when reading from proc_conntrack_max_path

### DIFF
--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -457,7 +457,7 @@ class Network(AgentCheck):
         try:
             with open(proc_conntrack_max_path, 'r') as conntrack_max_file:
                 # Starting at 0 as the last line has a line return
-                conntrack_max = conntrack_max_file.read()
+                conntrack_max = conntrack_max_file.read().rstrip()
                 self.gauge('system.net.conntrack.max', conntrack_max, tags=custom_tags)
         except IOError:
             self.log.debug("Unable to read %s. Skipping nf_conntrack_max metrics pull.", proc_conntrack_max_path)


### PR DESCRIPTION
### What does this PR do?

strips potential whitespaces when reading from `proc_conntrack_max_path`

### Motivation

Running the check manually on agent 5 includes trailing whitespaces for the value.

```
Metrics:
[('system.net.conntrack.max',
  1553479163,
  '16384\n',
  {'hostname': 'ubuntu-a5-1', 'type': 'gauge'})]
Events:
[]
Service Checks:
[]
Service Metadata:
[{}]
    network (5.32.1)
    ----------------
      - instance #0 [OK]
      - Collected 1 metric, 0 events & 0 service checks
```

### Additional Notes

Note: Actual value is actually successfully converted to float so there should be no impact to the values seen in UI.

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
