### PR TITLE
[Twemproxy] Migrating configuration file to the new norm

### DIFF
--- a/twemproxy/datadog_checks/twemproxy/data/conf.yaml.example
+++ b/twemproxy/datadog_checks/twemproxy/data/conf.yaml.example
@@ -1,5 +1,22 @@
 init_config:
 
 instances:
-    - host: localhost
-      port: 22222
+
+  ## @param host - string - required
+  ## Twemproxy host to connect to.
+  #
+  - host: localhost
+
+  ## @param port - integer - required
+  ## Twemproxy port to connect to.
+  #
+    port: 22222
+
+  ## @param tags  - list of key:value elements - optional
+  ## List of tags to attach to every metric, event, and service check emitted by this Integration.
+  ##
+  ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+  #
+  #  tags:
+  #    - <KEY_1>:<VALUE_1>
+  #    - <KEY_2>:<VALUE_2>


### PR DESCRIPTION
### What does this PR do?

Migrates Twemproxy configuration file to the new norm.