### PR TITLE
Add ability to add additional tags to queues matching a regex

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -4,6 +4,8 @@
 
 import logging
 
+from six import iteritems
+
 from datadog_checks.config import is_affirmative
 
 # compatability layer for agents under 6.6.0

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import logging
+import re
 
 from six import iteritems
 

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -88,7 +88,7 @@ class IBMMQConfig:
                     [t.strip() for t in tags.split(',')]
                 ])
             except TypeError:
-                self.log.warning('{} is not a valid regular expression and will be ignored'.format(regex_str))
+                log.warning('{} is not a valid regular expression and will be ignored'.format(regex_str))
         return queue_tag_list
 
     @property

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import logging
+
 from datadog_checks.config import is_affirmative
 
 # compatability layer for agents under 6.6.0
@@ -9,6 +11,8 @@ try:
     from datadog_checks.errors import ConfigurationError
 except ImportError:
     ConfigurationError = Exception
+
+log = logging.getLogger(__file__)
 
 
 class IBMMQConfig:
@@ -57,6 +61,9 @@ class IBMMQConfig:
 
         self.mq_installation_dir = instance.get('mq_installation_dir', '/opt/mqm/')
 
+        self._queue_tag_re = instance.get('queue_tag_re', {})
+        self.queue_tag_re = self._compile_tag_re()
+
     def check_properly_configured(self):
         if not self.channel or not self.queue_manager_name or not self.host or not self.port:
             msg = "channel, queue_manager, host and port are all required configurations"
@@ -65,6 +72,21 @@ class IBMMQConfig:
     def add_queues(self, new_queues):
         # add queues without duplication
         self.queues = list(set(self.queues + new_queues))
+
+    def _compile_tag_re(self):
+        """
+        Compile regex strings from queue_tag_re option and return list of compiled regex/tag pairs
+        """
+        queue_tag_list = []
+        for regex_str, tags in iteritems(self._queue_tag_re):
+            try:
+                queue_tag_list.append([
+                    re.compile(regex_str),
+                    [t.strip() for t in tags.split(',')]
+                ])
+            except TypeError:
+                self.log.warning('{} is not a valid regular expression and will be ignored'.format(regex_str))
+        return queue_tag_list
 
     @property
     def tags(self):

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -80,6 +80,17 @@ instances:
   #    - <KEY_1>:<VALUE_1>
   #    - <KEY_2>:<VALUE_2>
 
+  ## @param queue_tag_re - list of regex:tags string - optional
+  ## Instruct the check to apply additional tags to matching
+  ## queues
+  ##
+  ## Multiple comma-separated tags are supported. You must properly quote the string if the
+  ## pattern contains special characters e.g. colons.
+  #
+  #  queue_tag_re:
+  #    'SYSTEM.*': queue_type:system
+  #    'DEV.*': role:dev,queue_type:default
+
 ## Log Section (Available for Agent >=6.0)
 ##
 ## type - mandatory - Type of log input source (tcp / udp / file / windows_event)

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -57,6 +57,11 @@ class IbmMqCheck(AgentCheck):
 
             for queue_name in config.queues:
                 queue_tags = config.tags + ["queue:{}".format(queue_name)]
+
+                for regex, q_tags in config.queue_tag_re:
+                    if regex.match(queue_name):
+                        queue_tags.extend(q_tags)
+
                 try:
                     queue = pymqi.Queue(queue_manager, queue_name)
                     self.queue_stats(queue, queue_tags)

--- a/ibm_mq/tests/common.py
+++ b/ibm_mq/tests/common.py
@@ -74,3 +74,18 @@ INSTANCE_COLLECT_ALL = {
         BAD_CHANNEL,
     ]
 }
+
+INSTANCE_QUEUE_REGEX_TAG = {
+    'channel': CHANNEL,
+    'queue_manager': QUEUE_MANAGER,
+    'host': HOST,
+    'port': PORT,
+    'username': USERNAME,
+    'password': PASSWORD,
+    'queues': [
+        QUEUE
+    ],
+    'queue_tag_re': {
+        'DEV.QUEUE.*': "foo:bar"
+    }
+}

--- a/ibm_mq/tests/conftest.py
+++ b/ibm_mq/tests/conftest.py
@@ -41,6 +41,12 @@ def instance_collect_all():
 
 
 @pytest.fixture
+def instance_queue_regex_tag():
+    inst = copy.deepcopy(common.INSTANCE_QUEUE_REGEX_TAG)
+    return inst
+
+
+@pytest.fixture
 def seed_data():
     publish()
     consume()

--- a/ibm_mq/tests/test_ibm_mq.py
+++ b/ibm_mq/tests/test_ibm_mq.py
@@ -123,6 +123,7 @@ def test_check_regex(aggregator, instance_queue_regex_tag, seed_data):
         'host:{}'.format(common.HOST),
         'port:{}'.format(common.PORT),
         'channel:{}'.format(common.CHANNEL),
+        'queue:{}'.format(common.QUEUE),
         'foo:bar',
     ]
 

--- a/ibm_mq/tests/test_ibm_mq.py
+++ b/ibm_mq/tests/test_ibm_mq.py
@@ -12,7 +12,7 @@ from . import common
 
 log = logging.getLogger(__file__)
 
-METRICS = [
+QUEUE_METRICS = [
     'ibm_mq.queue.service_interval',
     'ibm_mq.queue.inhibit_put',
     'ibm_mq.queue.depth_low_limit',
@@ -42,10 +42,13 @@ METRICS = [
     'ibm_mq.queue.open_output_count',
     'ibm_mq.queue.trigger_type',
     'ibm_mq.queue.depth_percent',
+]
+
+METRICS = [
     'ibm_mq.queue_manager.dist_lists',
     'ibm_mq.queue_manager.max_msg_list',
     'ibm_mq.channel.channels',
-]
+] + QUEUE_METRICS
 
 OPTIONAL_METRICS = [
     'ibm_mq.queue.max_channels',
@@ -71,7 +74,11 @@ def test_check(aggregator, instance, seed_data):
 
     aggregator.assert_all_metrics_covered()
 
-    tags = ['queue_manager:datadog', 'host:localhost', 'port:11414']
+    tags = [
+        'queue_manager:{}'.format(common.QUEUE_MANAGER),
+        'host:{}'.format(common.HOST),
+        'port:{}'.format(common.PORT),
+    ]
 
     channel_tags = tags + ['channel:{}'.format(common.CHANNEL)]
     aggregator.assert_service_check('ibm_mq.channel', check.OK, tags=channel_tags)
@@ -105,3 +112,19 @@ def test_check_all(aggregator, instance_collect_all, seed_data):
         aggregator.assert_metric(metric, at_least=0)
 
     aggregator.assert_all_metrics_covered()
+
+
+def test_check_regex(aggregator, instance_queue_regex_tag, seed_data):
+    check = IbmMqCheck('ibm_mq', {}, {})
+    check.check(instance_queue_regex_tag)
+
+    tags = [
+        'queue_manager:{}'.format(common.QUEUE_MANAGER),
+        'host:{}'.format(common.HOST),
+        'port:{}'.format(common.PORT),
+        'channel:{}'.format(common.CHANNEL),
+        'foo:bar',
+    ]
+
+    for metric in QUEUE_METRICS:
+        aggregator.assert_metric(metric, tags=tags)


### PR DESCRIPTION
### What does this PR do?

The disk check lets you tag mounts with a regex. This will apply the same logic to the IBM MQ check

### Motivation

Customer request

### Additional Notes

I took a lot of inspiration from what we do in the disk check, the implementation is largely the same.

Here's the disk implementation for reference:

https://github.com/DataDog/integrations-core/blob/master/disk/datadog_checks/disk/disk.py#L461-L474

https://github.com/DataDog/integrations-core/blob/master/disk/datadog_checks/disk/disk.py#L131-L133

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
