### PR TITLE
Change .container.restarts to be actionnable in a monitor

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -457,7 +457,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
                 tags = tagger.tag('%s' % cid, tagger.ORCHESTRATOR) + instance_tags
 
                 restart_count = ctr_status.get('restartCount', 0)
-                self.gauge(self.NAMESPACE + '.containers.restarts', restart_count, tags)
+                self.monotonic_count(self.NAMESPACE + '.containers.restarts', restart_count, tags)
 
                 for (metric_name, field_name) in [('state', 'state'), ('last_state', 'lastState')]:
                     c_state = ctr_status.get(field_name, {})

--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -3,7 +3,7 @@ kubernetes.containers.last_state.terminated,gauge,,,,The number of containers th
 kubernetes.pods.running,gauge,,,,The number of running pods,1,kubelet,k8s.pods.running
 kubernetes.pods.expired,gauge,,,,The number of expired pods the check ignored,-1,kubelet,k8s.pods.expired
 kubernetes.containers.running,gauge,,,,The number of running containers,1,kubelet,k8s.containers.running
-kubernetes.containers.restarts,gauge,,,,The number of times the container has been restarted,1,kubelet,k8s.containers.restarts
+kubernetes.containers.restarts,counter,,,,The number of times the container has been restarted,-1,kubelet,k8s.containers.restarts
 kubernetes.containers.state.terminated,gauge,,,,The number of currently terminated containers,0,kubelet,k8s.containers.state.terminated
 kubernetes.containers.state.waiting,gauge,,,,The number of currently waiting containers,0,kubelet,k8s.containers.state.waiting
 kubernetes.cpu.load.10s.avg,gauge,,,,Container cpu load average over the last 10 seconds,0,kubelet,k8s.cpu.load.10s


### PR DESCRIPTION
### What does this PR do?

The `kubernetes.containers.restarts` metric is currently collected as a ever-increasing gauge, and tagged by `container_id`. This makes the value stay at 1 and change tags every time a container restarts inside a given pod:

![](https://cl.ly/5db053c97873/series_churn.png)

This makes the metric very hard to use for alerting, while we would expect it to give an actual count of restarts per pod_name/kube_container_name. This PR does the following:

- **change the collection type** to a monotonic counter: the agent will compute the value delta and only send non-zero when a restart occurred 
- move this gauge (and the other container state gauges) to orchestrator cardinality, meaning the timeseries will not churn when the container restart

Depends on https://github.com/DataDog/integrations-core/pull/3413 , the target branch will be changed back to `master` after the first PR is merged.

### Monitor example

Testing with 2 then 6 restarts of redis containers on a given host:

##### Before (gauge)

![](https://cl.ly/6ea1fadc6d24/Image%202019-03-28%20at%204.41.54%20PM.png)

##### After

![](https://cl.ly/51746bed4c9d/Image%202019-03-28%20at%204.40.00%20PM.png)

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
