### PR TITLE
Do not tag container restarts/state metrics by container_id anymore

### DIFF
--- a/kubelet/conftest.py
+++ b/kubelet/conftest.py
@@ -5,15 +5,6 @@ def get_conn_info():
     return {'url': 'http://127.0.0.1:10255'}
 
 
-def get_tags(entity, high_card):
-    tag_store = {}
-    return tag_store.get(entity, [])
-
-
 kubeutil = type(sys)('kubeutil')
 kubeutil.get_connection_info = get_conn_info
 sys.modules['kubeutil'] = kubeutil
-
-tagger = type(sys)('tagger')
-tagger.get_tags = get_tags
-sys.modules['tagger'] = tagger

--- a/kubelet/datadog_checks/kubelet/cadvisor.py
+++ b/kubelet/datadog_checks/kubelet/cadvisor.py
@@ -15,7 +15,7 @@ import logging
 import requests
 
 from .common import tags_for_docker, tags_for_pod, is_static_pending_pod, get_pod_by_uid
-from tagger import get_tags
+from datadog_checks.base.utils.tagging import tagger
 
 NAMESPACE = "kubernetes"
 DEFAULT_MAX_DEPTH = 10
@@ -162,12 +162,12 @@ class CadvisorScraper(object):
 
         # Let's see who we have here
         if is_pod:
-            tags = tags_for_pod(pod_uid, True)
+            tags = tags_for_pod(pod_uid, tagger.HIGH)
         elif in_static_pod and k_container_name:
             # FIXME static pods don't have container statuses so we can't
             # get the container id with the scheme, assuming docker here
-            tags = tags_for_docker(subcontainer_id, True)
-            tags += tags_for_pod(pod_uid, True)
+            tags = tags_for_docker(subcontainer_id, tagger.HIGH)
+            tags += tags_for_pod(pod_uid, tagger.HIGH)
             tags.append("kube_container_name:%s" % k_container_name)
         else:  # Standard container
             cid = pod_list_utils.get_cid_by_name_tuple(
@@ -176,7 +176,7 @@ class CadvisorScraper(object):
             if pod_list_utils.is_excluded(cid):
                 self.log.debug("Filtering out " + cid)
                 return
-            tags = get_tags(cid, True)
+            tags = tagger.tag(cid, tagger.HIGH)
 
         if not tags:
             self.log.debug("Subcontainer {} doesn't have tags, skipping.".format(subcontainer_id))

--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-from tagger import get_tags
+from datadog_checks.base.utils.tagging import tagger
 
 try:
     from containers import is_excluded
@@ -25,7 +25,7 @@ def tags_for_pod(pod_id, cardinality):
     Queries the tagger for a given pod uid
     :return: string array, empty if pod not found
     """
-    return get_tags('kubernetes_pod://%s' % pod_id, cardinality)
+    return tagger.tag('kubernetes_pod://%s' % pod_id, cardinality)
 
 
 def tags_for_docker(cid, cardinality):
@@ -33,7 +33,7 @@ def tags_for_docker(cid, cardinality):
     Queries the tagger for a given container id
     :return: string array, empty if container not found
     """
-    return get_tags('docker://%s' % cid, cardinality)
+    return tagger.tag('docker://%s' % cid, cardinality)
 
 
 def get_pod_by_uid(uid, podlist):

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -13,13 +13,13 @@ import json
 import requests
 
 from datadog_checks.base.utils.date import parse_rfc3339, UTC
+from datadog_checks.base.utils.tagging import tagger
 from datadog_checks.checks import AgentCheck
 from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.errors import CheckException
 from kubeutil import get_connection_info
 from six import iteritems
 from six.moves.urllib.parse import urljoin
-from tagger import get_tags
 
 from .common import CADVISOR_DEFAULT_PORT, PodListUtils, KubeletCredentials
 from .cadvisor import CadvisorScraper
@@ -367,7 +367,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
                 if "running" not in container.get('state', {}):
                     continue
                 has_container_running = True
-                tags = get_tags(container_id, False) or None
+                tags = tagger.tag(container_id, tagger.LOW) or None
                 if not tags:
                     continue
                 tags += instance_tags
@@ -380,7 +380,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
             if not pod_id:
                 self.log.debug('skipping pod with no uid')
                 continue
-            tags = get_tags('kubernetes_pod://%s' % pod_id, False) or None
+            tags = tagger.tag('kubernetes_pod://%s' % pod_id, tagger.LOW) or None
             if not tags:
                 continue
             tags += instance_tags
@@ -417,7 +417,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
                 if self.pod_list_utils.is_excluded(cid, pod_uid):
                     continue
 
-                tags = get_tags('%s' % cid, True) + instance_tags
+                tags = tagger.tag('%s' % cid, tagger.HIGH) + instance_tags
 
                 try:
                     for resource, value_str in iteritems(ctr.get('resources', {}).get('requests', {})):
@@ -454,7 +454,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
                 if self.pod_list_utils.is_excluded(cid, pod_uid):
                     continue
 
-                tags = get_tags('%s' % cid, True) + instance_tags
+                tags = tagger.tag('%s' % cid, tagger.ORCHESTRATOR) + instance_tags
 
                 restart_count = ctr_status.get('restartCount', 0)
                 self.gauge(self.NAMESPACE + '.containers.restarts', restart_count, tags)

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from six import iteritems
 
 from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
-from tagger import get_tags
+from datadog_checks.base.utils.tagging import tagger
 
 from .common import is_static_pending_pod, get_pod_by_uid
 
@@ -278,14 +278,14 @@ class CadvisorPrometheusScraperMixin(object):
             if self.pod_list_utils.is_excluded(c_id, pod_uid):
                 continue
 
-            tags = get_tags(c_id, True)
+            tags = tagger.tag(c_id, tagger.HIGH)
             tags += scraper_config['custom_tags']
 
             # FIXME we are forced to do that because the Kubelet PodList isn't updated
             # for static pods, see https://github.com/kubernetes/kubernetes/pull/59948
             pod = self._get_pod_by_metric_label(sample[self.SAMPLE_LABELS])
             if pod is not None and is_static_pending_pod(pod):
-                tags += get_tags('kubernetes_pod://%s' % pod["metadata"]["uid"], True)
+                tags += tagger.tag('kubernetes_pod://%s' % pod["metadata"]["uid"], tagger.HIGH)
                 tags += self._get_kube_container_name(sample[self.SAMPLE_LABELS])
                 tags = list(set(tags))
 
@@ -309,7 +309,7 @@ class CadvisorPrometheusScraperMixin(object):
         for pod_uid, sample in iteritems(samples):
             if '.network.' in metric_name and self._is_pod_host_networked(pod_uid):
                 continue
-            tags = get_tags('kubernetes_pod://%s' % pod_uid, True)
+            tags = tagger.tag('kubernetes_pod://%s' % pod_uid, tagger.HIGH)
             tags += scraper_config['custom_tags']
             val = sample[self.SAMPLE_VALUE]
             self.rate(metric_name, val, tags)
@@ -332,14 +332,14 @@ class CadvisorPrometheusScraperMixin(object):
             if self.pod_list_utils.is_excluded(c_id, pod_uid):
                 continue
 
-            tags = get_tags(c_id, True)
+            tags = tagger.tag(c_id, tagger.HIGH)
             tags += scraper_config['custom_tags']
 
             # FIXME we are forced to do that because the Kubelet PodList isn't updated
             # for static pods, see https://github.com/kubernetes/kubernetes/pull/59948
             pod = self._get_pod_by_metric_label(sample[self.SAMPLE_LABELS])
             if pod is not None and is_static_pending_pod(pod):
-                tags += get_tags('kubernetes_pod://%s' % pod["metadata"]["uid"], True)
+                tags += tagger.tag('kubernetes_pod://%s' % pod["metadata"]["uid"], tagger.HIGH)
                 tags += self._get_kube_container_name(sample[self.SAMPLE_LABELS])
                 tags = list(set(tags))
 
@@ -366,7 +366,7 @@ class CadvisorPrometheusScraperMixin(object):
             if self.pod_list_utils.is_excluded(c_id, pod_uid):
                 continue
 
-            tags = get_tags(c_id, True)
+            tags = tagger.tag(c_id, tagger.HIGH)
             tags += scraper_config['custom_tags']
 
             if m_name:

--- a/kubelet/setup.py
+++ b/kubelet/setup.py
@@ -23,7 +23,7 @@ def get_requirements(fpath):
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog_checks_base >= 6.5.0'
 
 setup(
     name='datadog-kubelet',

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -42,6 +42,8 @@ NODE_SPEC = {
 }
 
 EXPECTED_METRICS_COMMON = [
+    'kubernetes.pods.running',
+    'kubernetes.containers.running',
     'kubernetes.containers.restarts',
     'kubernetes.cpu.capacity',
     'kubernetes.cpu.usage.total',
@@ -90,6 +92,46 @@ EXPECTED_METRICS_PROMETHEUS = [
     'kubernetes.kubelet.volume.stats.inodes_used',
 ]
 
+COMMON_TAGS = {
+    "kubernetes_pod://2edfd4d9-10ce-11e8-bd5a-42010af00137": [
+        "pod_name:fluentd-gcp-v2.0.10-9q9t4"
+    ],
+    "kubernetes_pod://2fdfd4d9-10ce-11e8-bd5a-42010af00137": [
+        "pod_name:fluentd-gcp-v2.0.10-p13r3"
+    ],
+    'docker://5741ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76561': [
+        'kube_container_name:fluentd-gcp',
+        'kube_deployment:fluentd-gcp-v2.0.10'
+    ],
+    "docker://580cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b05": [
+        'kube_container_name:prometheus-to-sd-exporter',
+        'kube_deployment:fluentd-gcp-v2.0.10'
+    ],
+    'docker://6941ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76561': [
+        'kube_container_name:fluentd-gcp',
+        'kube_deployment:fluentd-gcp-v2.0.10'
+    ],
+    "docker://690cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b05": [
+        'kube_container_name:prometheus-to-sd-exporter',
+        'kube_deployment:fluentd-gcp-v2.0.10'
+    ],
+    "docker://5f93d91c7aee0230f77fbe9ec642dd60958f5098e76de270a933285c24dfdc6f": [
+        "pod_name:demo-app-success-c485bc67b-klj45"
+    ],
+    "kubernetes_pod://d2e71e36-10d0-11e8-bd5a-42010af00137": [
+        'pod_name:dd-agent-q6hpw'
+    ],
+    "kubernetes_pod://260c2b1d43b094af6d6b4ccba082c2db": [
+        'pod_name:kube-proxy-gke-haissam-default-pool-be5066f1-wnvn'
+    ],
+    "kubernetes_pod://24d6daa3-10d8-11e8-bd5a-42010af00137": [
+        'pod_name:demo-app-success-c485bc67b-klj45'
+    ],
+    "docker://f69aa93ce78ee11e78e7c75dc71f535567961740a308422dafebdb4030b04903": [
+        'pod_name:pi-kff76'
+    ]
+}
+
 
 class MockStreamResponse:
     """
@@ -118,6 +160,14 @@ def aggregator():
     from datadog_checks.stubs import aggregator
     aggregator.reset()
     return aggregator
+
+
+@pytest.fixture
+def tagger():
+    from datadog_checks.base.stubs import tagger
+    tagger.reset()
+    tagger.set_tags(COMMON_TAGS)
+    return tagger
 
 
 def mock_kubelet_check(monkeypatch, instances):
@@ -182,15 +232,15 @@ def test_kubelet_default_options():
     assert isinstance(check.kubelet_scraper_config, dict)
 
 
-def test_kubelet_check_prometheus_instance_tags(monkeypatch, aggregator):
-    _test_kubelet_check_prometheus(monkeypatch, aggregator, ["instance:tag"])
+def test_kubelet_check_prometheus_instance_tags(monkeypatch, aggregator, tagger):
+    _test_kubelet_check_prometheus(monkeypatch, aggregator, tagger, ["instance:tag"])
 
 
-def test_kubelet_check_prometheus_no_instance_tags(monkeypatch, aggregator):
-    _test_kubelet_check_prometheus(monkeypatch, aggregator, None)
+def test_kubelet_check_prometheus_no_instance_tags(monkeypatch, aggregator, tagger):
+    _test_kubelet_check_prometheus(monkeypatch, aggregator, tagger, None)
 
 
-def _test_kubelet_check_prometheus(monkeypatch, aggregator, instance_tags):
+def _test_kubelet_check_prometheus(monkeypatch, aggregator, tagger, instance_tags):
     instance = {}
     if instance_tags:
         instance["tags"] = instance_tags
@@ -221,12 +271,10 @@ def _test_kubelet_check_prometheus(monkeypatch, aggregator, instance_tags):
     assert aggregator.metrics_asserted_pct == 100.0
 
 
-def test_prometheus_cpu_summed(monkeypatch, aggregator):
+def test_prometheus_cpu_summed(monkeypatch, aggregator, tagger):
     check = mock_kubelet_check(monkeypatch, [{}])
     monkeypatch.setattr(check, 'rate', mock.Mock())
-
-    with mock.patch("datadog_checks.kubelet.prometheus.get_tags", side_effect=mocked_get_tags):
-        check.check({"cadvisor_metrics_endpoint": "http://dummy/metrics/cadvisor", "kubelet_metrics_endpoint": ""})
+    check.check({"cadvisor_metrics_endpoint": "http://dummy/metrics/cadvisor", "kubelet_metrics_endpoint": ""})
 
     # Make sure we submit the summed rates correctly for containers:
     # - fluentd-gcp-v2.0.10-9q9t4 uses two cpus, we need to sum (1228.32 + 825.32) * 10**9 = 2053640000000
@@ -256,12 +304,10 @@ def test_prometheus_cpu_summed(monkeypatch, aggregator):
         assert c not in check.rate.mock_calls
 
 
-def test_prometheus_net_summed(monkeypatch, aggregator):
+def test_prometheus_net_summed(monkeypatch, aggregator, tagger):
     check = mock_kubelet_check(monkeypatch, [{}])
     monkeypatch.setattr(check, 'rate', mock.Mock())
-
-    with mock.patch("datadog_checks.kubelet.prometheus.get_tags", side_effect=mocked_get_tags):
-        check.check({"cadvisor_metrics_endpoint": "http://dummy/metrics/cadvisor", "kubelet_metrics_endpoint": ""})
+    check.check({"cadvisor_metrics_endpoint": "http://dummy/metrics/cadvisor", "kubelet_metrics_endpoint": ""})
 
     # Make sure we submit the summed rates correctly for pods:
     # - dd-agent-q6hpw has two interfaces, we need to sum (1.2638051777 + 2.2638051777) * 10**10 = 35276103554
@@ -329,60 +375,13 @@ def test_kubelet_check_instance_config(monkeypatch):
     check.check({"cadvisor_port": 0, "metrics_endpoint": "", "kubelet_metrics_endpoint": "http://dummy"})
 
 
-def mocked_get_tags(entity, _):
-    tag_store = {
-        "kubernetes_pod://2edfd4d9-10ce-11e8-bd5a-42010af00137": [
-            "pod_name:fluentd-gcp-v2.0.10-9q9t4"
-        ],
-        "kubernetes_pod://2fdfd4d9-10ce-11e8-bd5a-42010af00137": [
-            "pod_name:fluentd-gcp-v2.0.10-p13r3"
-        ],
-        'docker://5741ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76561': [
-            'kube_container_name:fluentd-gcp',
-            'kube_deployment:fluentd-gcp-v2.0.10'
-        ],
-        "docker://580cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b05": [
-            'kube_container_name:prometheus-to-sd-exporter',
-            'kube_deployment:fluentd-gcp-v2.0.10'
-        ],
-        'docker://6941ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76561': [
-            'kube_container_name:fluentd-gcp',
-            'kube_deployment:fluentd-gcp-v2.0.10'
-        ],
-        "docker://690cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b05": [
-            'kube_container_name:prometheus-to-sd-exporter',
-            'kube_deployment:fluentd-gcp-v2.0.10'
-        ],
-        "docker://5f93d91c7aee0230f77fbe9ec642dd60958f5098e76de270a933285c24dfdc6f": [
-            "pod_name:demo-app-success-c485bc67b-klj45"
-        ],
-        "kubernetes_pod://d2e71e36-10d0-11e8-bd5a-42010af00137": [
-            'pod_name:dd-agent-q6hpw'
-        ],
-        "kubernetes_pod://260c2b1d43b094af6d6b4ccba082c2db": [
-            'pod_name:kube-proxy-gke-haissam-default-pool-be5066f1-wnvn'
-        ],
-        "kubernetes_pod://24d6daa3-10d8-11e8-bd5a-42010af00137": [
-            'pod_name:demo-app-success-c485bc67b-klj45'
-        ],
-        "docker://f69aa93ce78ee11e78e7c75dc71f535567961740a308422dafebdb4030b04903": [
-            'pod_name:pi-kff76'
-        ]
-    }
-    # Match agent 6.5 behaviour of not accepting None
-    if entity is None:
-        raise ValueError("None is not a valid entity id")
-    return tag_store.get(entity, [])
-
-
-def test_report_pods_running(monkeypatch):
+def test_report_pods_running(monkeypatch, tagger):
     check = KubeletCheck('kubelet', None, {}, [{}])
     monkeypatch.setattr(check, 'retrieve_pod_list', mock.Mock(return_value=json.loads(mock_from_file('pods.json'))))
     monkeypatch.setattr(check, 'gauge', mock.Mock())
     pod_list = check.retrieve_pod_list()
 
-    with mock.patch("datadog_checks.kubelet.kubelet.get_tags", side_effect=mocked_get_tags):
-        check._report_pods_running(pod_list, [])
+    check._report_pods_running(pod_list, [])
 
     calls = [
         mock.call('kubernetes.pods.running', 1, ["pod_name:fluentd-gcp-v2.0.10-9q9t4"]),
@@ -408,7 +407,7 @@ def test_report_pods_running(monkeypatch):
         assert c not in check.gauge.mock_calls
 
 
-def test_report_pods_running_none_ids(monkeypatch):
+def test_report_pods_running_none_ids(monkeypatch, tagger):
     # Make sure the method is resilient to inconsistent podlists
     podlist = json.loads(mock_from_file('pods.json'))
     podlist["items"][0]['metadata']['uid'] = None
@@ -419,8 +418,7 @@ def test_report_pods_running_none_ids(monkeypatch):
     monkeypatch.setattr(check, 'gauge', mock.Mock())
     pod_list = check.retrieve_pod_list()
 
-    with mock.patch("datadog_checks.kubelet.kubelet.get_tags", side_effect=mocked_get_tags):
-        check._report_pods_running(pod_list, [])
+    check._report_pods_running(pod_list, [])
 
     calls = [
         mock.call('kubernetes.pods.running', 1, ["pod_name:fluentd-gcp-v2.0.10-9q9t4"]),
@@ -432,7 +430,7 @@ def test_report_pods_running_none_ids(monkeypatch):
     check.gauge.assert_has_calls(calls, any_order=True)
 
 
-def test_report_container_spec_metrics(monkeypatch):
+def test_report_container_spec_metrics(monkeypatch, tagger):
     check = KubeletCheck('kubelet', None, {}, [{}])
     monkeypatch.setattr(check, 'retrieve_pod_list', mock.Mock(return_value=json.loads(mock_from_file('pods.json'))))
     monkeypatch.setattr(check, 'gauge', mock.Mock())
@@ -442,8 +440,7 @@ def test_report_container_spec_metrics(monkeypatch):
 
     pod_list = check.retrieve_pod_list()
     instance_tags = ["one:1", "two:2"]
-    with mock.patch("datadog_checks.kubelet.kubelet.get_tags", side_effect=mocked_get_tags):
-        check._report_container_spec_metrics(pod_list, instance_tags)
+    check._report_container_spec_metrics(pod_list, instance_tags)
 
     calls = [
         mock.call('kubernetes.cpu.requests', 0.1, [
@@ -470,7 +467,7 @@ def test_report_container_spec_metrics(monkeypatch):
     check.gauge.assert_has_calls(calls, any_order=True)
 
 
-def test_report_container_state_metrics(monkeypatch):
+def test_report_container_state_metrics(monkeypatch, tagger):
     check = KubeletCheck('kubelet', None, {}, [{}])
     check.pod_list_url = "dummyurl"
     monkeypatch.setattr(check, 'perform_kubelet_query',
@@ -484,8 +481,7 @@ def test_report_container_state_metrics(monkeypatch):
     pod_list = check.retrieve_pod_list()
 
     instance_tags = ["one:1", "two:2"]
-    with mock.patch("datadog_checks.kubelet.kubelet.get_tags", side_effect=mocked_get_tags):
-        check._report_container_state_metrics(pod_list, instance_tags)
+    check._report_container_state_metrics(pod_list, instance_tags)
 
     calls = [
         mock.call('kubernetes.containers.last_state.terminated', 1, [
@@ -515,7 +511,7 @@ def test_report_container_state_metrics(monkeypatch):
         raise AssertionError('kubernetes.containers.state.* was submitted without a reason')
 
 
-def test_pod_expiration(monkeypatch, aggregator):
+def test_pod_expiration(monkeypatch, aggregator, tagger):
     check = KubeletCheck('kubelet', None, {}, [{}])
     check.pod_list_url = "dummyurl"
 
@@ -541,8 +537,7 @@ def test_pod_expiration(monkeypatch, aggregator):
     assert collected_names == expected_names
 
     # Test .pods.expired gauge is submitted
-    with mock.patch("datadog_checks.kubelet.kubelet.get_tags", return_value=[]):
-        check._report_container_state_metrics(pod_list, ["custom:tag"])
+    check._report_container_state_metrics(pod_list, ["custom:tag"])
     aggregator.assert_metric("kubernetes.pods.expired", value=1, tags=["custom:tag"])
 
 


### PR DESCRIPTION
### What does this PR do?

Use orchestrator cardinality for metrics from `_report_container_state_metrics`. This requires the new 6.11+ tagger API and has two reasons:

- these metrics are not directly tied to the container_id, but to the pod_name + kube_container_name (restarts is the number of restarts BEFORE the current container)
- tagging per container_id churned the timeseries at every restart

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
