### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,8 +118,7 @@ jobs:
     - stage: test
       env: CHECK=disk PYTHON3=true
     - stage: test
-    # python 2 support only
-      env: CHECK=dns_check
+      env: CHECK=dns_check PYTHON3=true
     - stage: test
       env: CHECK=dotnetclr PYTHON3=true
     - stage: test

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -7,7 +7,7 @@ cffi==1.11.5
 cryptography==2.3.1
 cx_oracle==6.0.1
 ddtrace==0.13.0
-dnspython==1.12.0
+dnspython==1.16.0
 enum34==1.1.6
 flup==1.0.3.dev-20110405; python_version < '3.0'
 flup-py3==1.0.3; python_version > '3.0'

--- a/dns_check/datadog_checks/dns_check/dns_check.py
+++ b/dns_check/datadog_checks/dns_check/dns_check.py
@@ -79,7 +79,7 @@ class DNSCheck(NetworkCheck):
         t0 = time_func()
 
         try:
-            self.log.debug('Querying "{0}" record for hostname "{1}"...'.format(record_type, hostname))
+            self.log.debug('Querying "{}" record for hostname "{}"...'.format(record_type, hostname))
             if record_type == "NXDOMAIN":
                 try:
                     resolver.query(hostname)
@@ -96,18 +96,18 @@ class DNSCheck(NetworkCheck):
             response_time = time_func() - t0
 
         except dns.exception.Timeout:
-            self.log.error('DNS resolution of {0} timed out'.format(hostname))
-            return Status.CRITICAL, 'DNS resolution of {0} timed out'.format(hostname)
+            self.log.error('DNS resolution of {} timed out'.format(hostname))
+            return Status.CRITICAL, 'DNS resolution of {} timed out'.format(hostname)
 
         except Exception:
-            self.log.exception('DNS resolution of {0} has failed.'.format(hostname))
-            return Status.CRITICAL, 'DNS resolution of {0} has failed'.format(hostname)
+            self.log.exception('DNS resolution of {} has failed.'.format(hostname))
+            return Status.CRITICAL, 'DNS resolution of {} has failed'.format(hostname)
 
         else:
             tags = self._get_tags(instance)
             if response_time > 0:
                 self.gauge('dns.response_time', response_time, tags=tags)
-            self.log.debug('Resolved hostname: {0}'.format(hostname))
+            self.log.debug('Resolved hostname: {}'.format(hostname))
             return Status.UP, 'UP'
 
     def _check_answer(self, answer, resolves_as):
@@ -138,12 +138,12 @@ class DNSCheck(NetworkCheck):
         except IndexError:
             self.log.error('No DNS server was found on this host.')
 
-        tags = custom_tags + ['nameserver:{0}'.format(nameserver),
-                              'resolved_hostname:{0}'.format(hostname),
-                              'instance:{0}'.format(instance_name),
-                              'record_type:{0}'.format(record_type)]
+        tags = custom_tags + ['nameserver:{}'.format(nameserver),
+                              'resolved_hostname:{}'.format(hostname),
+                              'instance:{}'.format(instance_name),
+                              'record_type:{}'.format(record_type)]
         if resolved_as:
-            tags.append('resolved_as:{0}'.format(resolved_as))
+            tags.append('resolved_as:{}'.format(resolved_as))
 
         return tags
 

--- a/dns_check/requirements.in
+++ b/dns_check/requirements.in
@@ -1,1 +1,1 @@
-dnspython==1.12.0
+dnspython==1.16.0

--- a/dns_check/tests/mocks.py
+++ b/dns_check/tests/mocks.py
@@ -12,7 +12,7 @@ class MockDNSAnswer:
     class MockRrset:
         def __init__(self, address):
             addresses = [x.strip().lower() for x in address.split(',')]
-            if addresses > 1:
+            if len(addresses) > 1:
                 items = []
                 for address in addresses:
                     items.append(MockDNSAnswer.MockItem(address))

--- a/dns_check/tox.ini
+++ b/dns_check/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py37
 envlist =
-    py27-dns_check
+    py{27,37}-dns_check
     flake8
 
 [testenv]


### PR DESCRIPTION
### What does this PR do?

Supporting python3 for `dns_check`. The package [dnspython](http://www.dnspython.org/) v1.16 we use should support python 3.

### Motivation

### Additional Notes

It has already been try in https://github.com/DataDog/integrations-core/pull/2733

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
