### PR TITLE
Mirror the kubernetes_pod_expiration_duration option name and unit changes

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -280,15 +280,15 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
     @staticmethod
     def _compute_pod_expiration_datetime():
         """
-        Looks up the agent's kubernetes_pod_expiration_minutes option and returns either:
+        Looks up the agent's kubernetes_pod_expiration_duration option and returns either:
           - None if expiration is disabled (set to 0)
           - A (timezone aware) datetime object to compare against
         """
         try:
-            minutes = int(get_config("kubernetes_pod_expiration_minutes"))
-            if minutes == 0:  # Expiration disabled
+            seconds = int(get_config("kubernetes_pod_expiration_duration"))
+            if seconds == 0:  # Expiration disabled
                 return None
-            return datetime.utcnow().replace(tzinfo=UTC) - timedelta(minutes=minutes)
+            return datetime.utcnow().replace(tzinfo=UTC) - timedelta(seconds=seconds)
         except (ValueError, TypeError):
             return None
 

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -608,8 +608,10 @@ def test_retrieved_pod_list_failure(monkeypatch):
 
 def test_compute_pod_expiration_datetime(monkeypatch):
     # Invalid input
-    with mock.patch("datadog_checks.kubelet.kubelet.get_config", return_value=""):
+    with mock.patch("datadog_checks.kubelet.kubelet.get_config", return_value="") as p:
         assert KubeletCheck._compute_pod_expiration_datetime() is None
+        p.assert_called_with("kubernetes_pod_expiration_duration")
+
     with mock.patch("datadog_checks.kubelet.kubelet.get_config", return_value="invalid"):
         assert KubeletCheck._compute_pod_expiration_datetime() is None
 
@@ -618,7 +620,7 @@ def test_compute_pod_expiration_datetime(monkeypatch):
         assert KubeletCheck._compute_pod_expiration_datetime() is None
 
     # Set to 15 minutes
-    with mock.patch("datadog_checks.kubelet.kubelet.get_config", return_value="15"):
+    with mock.patch("datadog_checks.kubelet.kubelet.get_config", return_value="900"):
         expire = KubeletCheck._compute_pod_expiration_datetime()
         assert expire is not None
         now = datetime.utcnow().replace(tzinfo=UTC)


### PR DESCRIPTION
### What does this PR do?

During review of https://github.com/DataDog/datadog-agent/pull/3227 we changed the name and unit of the option used for both the go and python sides. This updates the python code accordingly. `no-changelog` as the previous code was not released yet.

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
