### PR TITLE
Add debug to compare short names, service names and patterns

### DIFF
--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -58,6 +58,8 @@ class WindowsService(AgentCheck):
         for short_name, desc, service_status in service_statuses:
             if 'ALL' not in services:
                 for service, service_pattern in iteritems(service_patterns):
+                    self.log.debug('Service: {} with Short Name: {} and Pattern: {}'
+                                   .format(service, short_name, service_pattern.pattern))
                     if service_pattern.match(short_name):
                         services_unseen.discard(service)
                         break


### PR DESCRIPTION
### What does this PR do?

Adds a debug line to compare `service` name, `short_name` and `pattern` values. cc @jcstorms1 

### Motivation

Helps with troubleshooting in case of short name / service name mismatch. 

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.