### PR TITLE
Feature OpenMetricsScraperMixin _filter_metric method

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -70,3 +70,9 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
         This is generally a noop, but it can be used to change the tags before sending metrics
         """
         return _tags
+
+    def _filter_metric(self, metric):
+        """
+        Used to filter metrics at the begining of the processing, by default no metric is filtered
+        """
+        return False

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -360,6 +360,9 @@ class OpenMetricsScraperMixin(object):
         if metric.name in scraper_config['ignore_metrics']:
             return  # Ignore the metric
 
+        if self._filter_metric(metric):
+            return  # Ignore the metric
+
         # Filter metric to see if we can enrich with joined labels
         self._join_labels(metric, scraper_config)
 

--- a/datadog_checks_base/tests/fixtures/prometheus/deprecated.txt
+++ b/datadog_checks_base/tests/fixtures/prometheus/deprecated.txt
@@ -1,0 +1,6 @@
+# HELP kube_pod_container_status_restarts The number of container restarts per container.
+# TYPE kube_pod_container_status_restarts counter
+kube_pod_container_status_restarts{namespace="kube-system",pod="kube-dns-autoscaler-97162954-mf6d3"} 42
+# HELP kube_pod_container_status_restarts_old (Deprecated) The number of container restarts per container.
+# TYPE kube_pod_container_status_restarts_old counter
+kube_pod_container_status_restarts_old{namespace="kube-system",pod="kube-dns-autoscaler-97162954-mf6d3"} 24

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -1524,3 +1524,63 @@ def test_text_filter_input(mocked_prometheus_check, mocked_prometheus_scraper_co
 
     filtered = [x for x in check._text_filter_input(lines_in, mocked_prometheus_scraper_config)]
     assert filtered == expected_out
+
+
+@pytest.fixture()
+def mock_filter_get():
+    text_data = None
+    f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'prometheus', 'deprecated.txt')
+    with open(f_name, 'r') as f:
+        text_data = f.read()
+    with mock.patch(
+        'requests.get',
+        return_value=mock.MagicMock(
+            status_code=200,
+            iter_lines=lambda **kwargs: text_data.split("\n"),
+            headers={'Content-Type': text_content_type},
+        ),
+    ):
+        yield text_data
+
+
+class FilterOpentMetricsCheck(OpenMetricsBaseCheck):
+    def _filter_metric(self, metric):
+        if metric.documentation.startswith("(Deprecated)"):
+            return True
+        return False
+
+
+@pytest.fixture
+def mocked_filter_openmetrics_check():
+    check = FilterOpentMetricsCheck('prometheus_check', {}, {})
+    check.log = logging.getLogger('datadog-prometheus.test')
+    check.log.debug = mock.MagicMock()
+    return check
+
+
+@pytest.fixture
+def mocked_filter_openmetrics_check_scraper_config(mocked_filter_openmetrics_check):
+    yield mocked_filter_openmetrics_check.get_scraper_config(PROMETHEUS_CHECK_INSTANCE)
+
+
+def test_filter_metrics(aggregator, mocked_filter_openmetrics_check,
+                        mocked_filter_openmetrics_check_scraper_config, mock_filter_get):
+    """ Tests label join GC on text format """
+    check = mocked_filter_openmetrics_check
+    mocked_filter_openmetrics_check_scraper_config['namespace'] = 'filter'
+    mocked_filter_openmetrics_check_scraper_config['metrics_mapper'] = {
+        'kube_pod_container_status_restarts': 'pod.restart',
+        'kube_pod_container_status_restarts_old': 'pod.restart'}
+    # dry run to build mapping
+    check.process(mocked_filter_openmetrics_check_scraper_config)
+    # run with submit
+    check.process(mocked_filter_openmetrics_check_scraper_config)
+    # check a bunch of metrics
+    aggregator.assert_metric(
+        'filter.pod.restart',
+        tags=[
+            'pod:kube-dns-autoscaler-97162954-mf6d3',
+            'namespace:kube-system',
+        ],
+        value=42,
+    )

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -1545,9 +1545,7 @@ def mock_filter_get():
 
 class FilterOpentMetricsCheck(OpenMetricsBaseCheck):
     def _filter_metric(self, metric):
-        if metric.documentation.startswith("(Deprecated)"):
-            return True
-        return False
+        return metric.documentation.startswith("(Deprecated)")
 
 
 @pytest.fixture
@@ -1584,3 +1582,4 @@ def test_filter_metrics(aggregator, mocked_filter_openmetrics_check,
         ],
         value=42,
     )
+    aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

Aim of `_filter_metric()` is to allow check based on `OpenMetricsScraperMixin`
to discard metrics from ingestion base on data present in the metric's fields: name,
documentation or value...

### Motivation

Kube_scheduler check and other kube_* check will benefit from it, when they will need to handle "deprecated" metrics.

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
