### PR TITLE
Fix variable name

### DIFF
--- a/oracle/datadog_checks/oracle/data/conf.yaml.example
+++ b/oracle/datadog_checks/oracle/data/conf.yaml.example
@@ -25,7 +25,7 @@ init_config:
 ##
 ## is what the following example configuration would become.
 #
-#  custom_queries:
+#  global_custom_queries:
 #   - metric_prefix: oracle.custom_query
 #     query: |  # Use the pipe if you require a multi-line script.
 #       SELECT columns


### PR DESCRIPTION
### What does this PR do?

Change name from `custom_queries` to `global_custom_queries` in the conf.yaml.example, to match the name used by the [check](https://github.com/DataDog/integrations-core/blob/master/oracle/datadog_checks/oracle/oracle.py#L94).

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
