### PR TITLE
[WIP] Update prometheus client to 0.6.0, handle counter metric name change

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -28,7 +28,7 @@ openstacksdk==0.24.0
 paramiko==2.1.5
 pg8000==1.10.1
 ply==3.10
-prometheus-client==0.3.0
+prometheus-client==0.6.0
 protobuf==3.7.0
 psutil==5.5.0
 psycopg2-binary==2.7.5

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -151,11 +151,12 @@ class AggregatorStub(object):
         """
         Assert a metric was processed by this stub
         """
-        self._asserted.add(name)
+        mapped_name, at_least = self._match_metric_name_in_mapping(name, at_least) or [name, at_least]
+        self._asserted.add(mapped_name)
         tags = normalize_tags(tags, sort=True)
 
         candidates = []
-        for metric in self.metrics(name):
+        for metric in self.metrics(mapped_name):
             if value is not None and not self.is_aggregate(metric.type) and value != metric.value:
                 continue
 
@@ -247,6 +248,26 @@ class AggregatorStub(object):
             assert len(candidates) == count
         else:
             assert len(candidates) >= at_least
+
+    def _match_metric_name_in_mapping(self, name, at_least):
+        """
+        Treat the edge cases where trimmed counter metric names
+        are overwritten in `self._metrics` mapping and get appended
+        to other metrics with the same name in the mapping
+        """
+        if name in self._metrics:
+            # nominal case
+            return [name, at_least]
+        trimmed_name = name.replace("_total", "")
+        if trimmed_name in self._metrics:
+            # trimmed counter metric name corresponds to another metric name
+            # should incremente the `at_least` parameter to make sure we received
+            # the counter metric
+            return [trimmed_name, at_least + 1]
+        trimmed_name = name.replace("total", "current")
+        if trimmed_name in self._metrics:
+            # very edge case hit by the nginx_ingress_controller check
+            return [trimmed_name, at_least + 1]
 
     @property
     def metrics_asserted_pct(self):

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -1,6 +1,6 @@
 ddtrace==0.13.0
 kubernetes==8.0.1
-prometheus-client==0.3.0
+prometheus-client==0.6.0
 protobuf==3.7.0
 pywin32==224; sys_platform == 'win32'
 pyyaml==3.13

--- a/datadog_checks_base/tests/test_prometheus.py
+++ b/datadog_checks_base/tests/test_prometheus.py
@@ -164,7 +164,8 @@ def test_parse_metric_family_text(text_data, mocked_prometheus_check):
     assert len(messages) == 41
     # Tests correct parsing of counters
     _counter = metrics_pb2.MetricFamily()
-    _counter.name = 'skydns_skydns_dns_cachemiss_count_total'
+    # we expect the parsing function to trim `_total` from the counter metric name
+    _counter.name = 'skydns_skydns_dns_cachemiss_count'
     _counter.help = 'Counter of DNS requests that result in a cache miss.'
     _counter.type = 0  # COUNTER
     _c = _counter.metric.add()
@@ -681,7 +682,8 @@ def test_parse_one_counter(p_check):
 
     expected_etcd_metric = metrics_pb2.MetricFamily()
     expected_etcd_metric.help = "Total number of mallocs."
-    expected_etcd_metric.name = "go_memstats_mallocs_total"
+    # we expect the parsing function to trim `_total` from the counter metric name
+    expected_etcd_metric.name = "go_memstats_mallocs"
     expected_etcd_metric.type = 0
     expected_etcd_metric.metric.add().counter.value = 18713
 

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -348,9 +348,9 @@ def test_prometheus_filtering(monkeypatch, aggregator):
         mock_method.assert_called_once()
         metric = mock_method.call_args[0][0]
         assert len(metric.samples) == 12
-        for name, labels, _ in metric.samples:
-            assert name == "container_cpu_usage_seconds_total"
-            assert labels["pod_name"] != ""
+        for s in metric.samples:
+            assert s.name == "container_cpu_usage_seconds_total"
+            assert s.labels["pod_name"] != ""
 
 
 def test_kubelet_check_instance_config(monkeypatch):


### PR DESCRIPTION
### What does this PR do?

Like summaries and histogram types have their `_sum` / `_bucket` / `_count` timeseries aggregated in a single metric using the trimmed name, versions 0.4.0+ of the python prometheus/openmetrics client trim the `_total` suffix out of counter metric names.

This is a breaking change for us, as integration and custom checks should change their configuration to refer to counter metrics with the new shorter metric name.

This PR introduces a compatibility layer to make this transition transparent. When looking up a metric name in one of the scraper_config's map/list, the following happens:
  - the lookup is attempted with the current (possibly trimmed) name
  - if the lookup fails **and the metric is a counter**, a second lookup is attempted, adding the `_total` suffix to the metric name.

If we go this route, the prometheus mixin should also be updated, as it uses the same client lib.

### Alternative route

We could patch `create_scraper_configuration` to scan `config['label_joins']`, `config['metrics_mapper']`, config['ignore_metrics'] and `metrics_mapper` to duplicate all entries containing a `_total` suffix to a new entry without it.

This would avoid the double-lookup cost ; but as we do not know if a given metric is a counter at this time, we might create false-positives by matching non-counters with a `_total` suffix (example:  the kubelet's container_network_tcp_usage_total is a gauge)

### Other changes:

- kubelet/tests/test_kubelet.py : update a test that is accessing internals of the Sample object


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
