### PR TITLE
Properly utilize the provided `metrics_mapper`

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
@@ -146,6 +146,8 @@ class GenericPrometheusCheck(AgentCheck):
                 metrics_mapper[metric] = metric
             else:
                 metrics_mapper.update(metric)
+        # update metrics mapper with values provided by user
+        metrics_mapper.update(instance.get("metrics_mapper", {}))
 
         scraper.metrics_mapper = metrics_mapper
         scraper.labels_mapper = default_instance.get("labels_mapper", {})


### PR DESCRIPTION
### What does this PR do?

The current implementation of the Prometheus check ignores completely the values of `metrics_mapper`, because the code is pretty much building it using the original metric names.

Instead, we should use the mappings provided by the user in the `metrics_mapper` dictionary.

### Motivation

Given an example config like this:

```yml
    metrics:
      - cp_kafka_server_replicamanager_underreplicatedpartitions
    type_overrides:
      cp_kafka_server_replicamanager_underreplicatedpartitions: gauge
    metrics_mapper:
      cp_kafka_server_replicamanager_underreplicatedpartitions: server.replica_manager.under_replicated_partitions
```

We should emit metrics named `server.replica_manager.under_replicated_partitions` instead of `cp_kafka_server_replicamanager_underreplicatedpartitions` which is what the agent does currently.

### Additional Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
