### PR TITLE
Fix datadog_check_base test

### DIFF
--- a/datadog_checks_base/tests/test_kube_leader.py
+++ b/datadog_checks_base/tests/test_kube_leader.py
@@ -161,7 +161,7 @@ class TestElectionRecord:
 
     def test_seconds_until_renew(self):
         raw = make_record(
-            holder="me", duration=30, acquire="2018-12-18T12:32:22Z", renew=datetime.now() + timedelta(seconds=20)
+            holder="me", duration=30, acquire="2018-12-18T12:32:22Z", renew=datetime.utcnow() + timedelta(seconds=20)
         )
 
         record = ElectionRecord(raw)
@@ -169,7 +169,7 @@ class TestElectionRecord:
         assert record.seconds_until_renew < 21
 
         raw = make_record(
-            holder="me", duration=30, acquire="2018-12-18T12:32:22Z", renew=datetime.now() - timedelta(seconds=5)
+            holder="me", duration=30, acquire="2018-12-18T12:32:22Z", renew=datetime.utcnow() - timedelta(seconds=5)
         )
 
         record = ElectionRecord(raw)


### PR DESCRIPTION
### What does this PR do?

Fix the `datadog_check_base` test that didn't specify the timezone used. 

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
