### PR TITLE
Updating resource link

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -178,7 +178,7 @@ Need help? Contact [Datadog support][16].
 
 [1]: https://aws.amazon.com/cli
 [2]: https://aws.amazon.com/console
-[3]: https://docs.datadoghq.com/json/datadog-agent-ecs-fargate.json
+[3]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs-fargate.json
 [4]: https://app.datadoghq.com/account/settings#api
 [5]: http://docs.datadoghq.com/integrations/faq/integration-setup-ecs-fargate
 [6]: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html#ecs-config-s3


### PR DESCRIPTION
### What does this PR do?

Updates documentation resources link in order to not be localised:

https://github.com/DataDog/documentation/pull/4313