### PR TITLE
Fix podlist multiple iterations when using pod expiration

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -263,8 +263,8 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
                     pod_list = json.load(r.raw, object_hook=f.json_hook)
                     pod_list['expired_count'] = f.expired_count
                     if pod_list.get("items") is not None:
-                        # Wrap items in a generator to filter our None items
-                        pod_list['items'] = (p for p in pod_list['items'] if p is not None)
+                        # Filter out None items from the list
+                        pod_list['items'] = [p for p in pod_list['items'] if p is not None]
                 else:
                     pod_list = json.load(r.raw)
 

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -129,6 +129,12 @@ COMMON_TAGS = {
     ],
     "docker://f69aa93ce78ee11e78e7c75dc71f535567961740a308422dafebdb4030b04903": [
         'pod_name:pi-kff76'
+    ],
+    "kubernetes_pod://12ceeaa9-33ca-11e6-ac8f-42010af00003": [
+        'pod_name:dd-agent-ntepl'
+    ],
+    "docker://32fc50ecfe24df055f6d56037acb966337eef7282ad5c203a1be58f2dd2fe743": [
+        'pod_name:dd-agent-ntepl'
     ]
 }
 
@@ -539,6 +545,11 @@ def test_pod_expiration(monkeypatch, aggregator, tagger):
     # Test .pods.expired gauge is submitted
     check._report_container_state_metrics(pod_list, ["custom:tag"])
     aggregator.assert_metric("kubernetes.pods.expired", value=1, tags=["custom:tag"])
+
+    # Ensure we can iterate twice over the podlist
+    check._report_pods_running(pod_list, [])
+    aggregator.assert_metric("kubernetes.pods.running", value=1, tags=["pod_name:dd-agent-ntepl"])
+    aggregator.assert_metric("kubernetes.containers.running", value=1, tags=["pod_name:dd-agent-ntepl"])
 
 
 class MockResponse(mock.Mock):


### PR DESCRIPTION
### What does this PR do?

The pod expiration logic needs to filter out `None` items from the podlist. Code in RC1 does it through a generator to save wall time. The issue is that we iterate four times over the podlist during one check run.

This PR moves to a pre-filtered list instead of a generator to allow multiple iterations.

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
