### PR TITLE
Fix health check during first check run

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -175,6 +175,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
         self.node_spec_url = urljoin(endpoint, NODE_SPEC_PATH)
         self.pod_list_url = urljoin(endpoint, POD_LIST_PATH)
         self.instance_tags = instance.get('tags', [])
+        self.kubelet_credentials = KubeletCredentials(kubelet_conn_info)
 
         # Test the kubelet health ASAP
         self._perform_kubelet_check(self.instance_tags)
@@ -193,7 +194,6 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
                                                                      urljoin(endpoint, KUBELET_METRICS_PATH))
 
         # Kubelet credentials handling
-        self.kubelet_credentials = KubeletCredentials(kubelet_conn_info)
         self.kubelet_credentials.configure_scraper(
             self.cadvisor_scraper_config
         )


### PR DESCRIPTION
### What does this PR do?

`self.kubelet_credentials` was set after `self._perform_kubelet_check` making it fail on the first run. While other check runs were OK, that can trigger false-positives on the service check.

Fix moves the credential retrieval logic to the very start of the check, in the configuration stage.

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
