### PR TITLE
Don't ship `pyodbc` on macOS as SQLServer integration is not shipped on macOS

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -38,7 +38,7 @@ pycryptodomex==3.4.7
 pymongo==3.5.1
 pymqi==1.8.0; sys_platform != 'win32' and sys_platform != 'darwin'
 pymysql==0.8.0
-pyodbc==4.0.22
+pyodbc==4.0.22; sys_platform != 'darwin'
 pyro4==4.73; sys_platform == 'win32'
 pysmi==0.2.2
 pysnmp==4.4.3

--- a/sqlserver/requirements.in
+++ b/sqlserver/requirements.in
@@ -1,5 +1,5 @@
 adodbapi==2.6.0.7; sys_platform == 'win32'
-pyodbc==4.0.22
+pyodbc==4.0.22; sys_platform != 'darwin'
 pyro4==4.73; sys_platform == 'win32'
 pywin32==224; sys_platform == 'win32'
 selectors34==1.2.0; sys_platform == 'win32' and python_version < '3.4'


### PR DESCRIPTION
### What does this PR do?

Avoid trying to install pyodbc on darwin.

### Motivation

It fails on darwin since no pre-built wheels are available for our builder os version.

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
