### PR TITLE
Fix instance identifier

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -843,9 +843,8 @@ GROUP BY datid, datname
     def _get_service_check_tags(cls, host, port, tags):
         service_check_tags = [
             "host:%s" % host,
-            "port:%s" % port,
         ]
-        service_check_tags.extend([t for t in tags if not t.startswith('pg_instance')])
+        service_check_tags.extend(tags)
         service_check_tags = list(set(service_check_tags))
         return service_check_tags
 
@@ -1053,8 +1052,12 @@ GROUP BY datid, datname
         else:
             tags = list(set(tags))
 
-        # preset tags to host (if using socket) or host-port
-        tags.extend(["pg_instance:%s" % (host if host.startswith('/') else "{}-{}".format(host, port))])
+        # preset tags to host
+        tags.append('server:{}'.format(host))
+        if port:
+            tags.append('port:{}'.format(port))
+        else:
+            tags.append('port:socket')
 
         # preset tags to the database name
         tags.extend(["db:%s" % dbname])

--- a/postgres/service_checks.json
+++ b/postgres/service_checks.json
@@ -4,7 +4,7 @@
         "integration":"postgres",
         "check": "postgres.can_connect",
         "statuses": ["ok", "critical"],
-        "groups": ["host", "port", "db"],
+        "groups": ["host", "server", "port", "db"],
         "name": "Can Connect",
         "description": "Returns `CRITICAL` if the Agent is unable to connect to the monitored PostgreSQL instance. Returns `OK` otherwise."
     }

--- a/postgres/tests/test_common.py
+++ b/postgres/tests/test_common.py
@@ -79,7 +79,8 @@ def test_common_metrics(aggregator, check, pg_instance):
     check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + [
-        'pg_instance:{}-{}'.format(HOST, PORT),
+        'server:{}'.format(HOST),
+        'port:{}'.format(PORT),
     ]
     check_bgw_metrics(aggregator, expected_tags)
 
@@ -100,6 +101,7 @@ def test_common_metrics_without_size(aggregator, check, pg_instance):
 def test_can_connect_service_check(aggregator, check, pg_instance):
     expected_tags = pg_instance['tags'] + [
         'host:{}'.format(HOST),
+        'server:{}'.format(HOST),
         'port:{}'.format(PORT),
         'db:{}'.format(DB_NAME),
     ]
@@ -113,7 +115,8 @@ def test_schema_metrics(aggregator, check, pg_instance):
     check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + [
-        'pg_instance:{}-{}'.format(HOST, PORT),
+        'server:{}'.format(HOST),
+        'port:{}'.format(PORT),
         'schema:public',
     ]
     aggregator.assert_metric('postgresql.table.count', value=1, count=1,
@@ -126,7 +129,10 @@ def test_schema_metrics(aggregator, check, pg_instance):
 def test_connections_metrics(aggregator, check, pg_instance):
     check.check(pg_instance)
 
-    expected_tags = pg_instance['tags'] + ['pg_instance:{}-{}'.format(HOST, PORT)]
+    expected_tags = pg_instance['tags'] + [
+        'server:{}'.format(HOST),
+        'port:{}'.format(PORT),
+    ]
     for name in CONNECTION_METRICS:
         aggregator.assert_metric(name, count=1, tags=expected_tags)
     expected_tags += ['db:datadog_test']
@@ -142,7 +148,8 @@ def test_locks_metrics(aggregator, check, pg_instance):
             check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + [
-        'pg_instance:{}-{}'.format(HOST, PORT),
+        'server:{}'.format(HOST),
+        'port:{}'.format(PORT),
         'db:datadog_test',
         'lock_mode:AccessExclusiveLock', 'table:persons',
     ]
@@ -156,7 +163,8 @@ def test_activity_metrics(aggregator, check, pg_instance):
     check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + [
-        'pg_instance:{}-{}'.format(HOST, PORT),
+        'server:{}'.format(HOST),
+        'port:{}'.format(PORT),
         'db:datadog_test',
     ]
     for name in ACTIVITY_METRICS:

--- a/postgres/tests/test_custom_metrics.py
+++ b/postgres/tests/test_custom_metrics.py
@@ -23,8 +23,7 @@ def test_custom_metrics(aggregator, pg_instance):
     postgres_check = PostgreSql('postgres', {}, {})
     postgres_check.check(pg_instance)
 
-    tags = ['customdb:a']
-    tags.append('pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port']))
+    tags = ['customdb:a', 'server:{}'.format(pg_instance['host']), 'port:{}'.format(pg_instance['port'])]
     tags.extend(pg_instance['tags'])
 
     aggregator.assert_metric('custom.num', value=21, tags=tags)
@@ -67,8 +66,11 @@ def test_custom_queries(aggregator, pg_instance):
     })
     postgres_check = PostgreSql('postgres', {}, {})
     postgres_check.check(pg_instance)
-    tags = ['db:{}'.format(pg_instance['dbname'])]
-    tags.append('pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port']))
+    tags = [
+        'db:{}'.format(pg_instance['dbname']),
+        'server:{}'.format(pg_instance['host']),
+        'port:{}'.format(pg_instance['port']),
+    ]
     tags.extend(pg_instance['tags'])
 
     for tag in ('a', 'b', 'c'):

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -53,13 +53,15 @@ def test_relations_metrics(aggregator, pg_instance):
     posgres_check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + [
-        'pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port']),
+        'server:{}'.format(pg_instance['host']),
+        'port:{}'.format(pg_instance['port']),
         'db:%s' % pg_instance['dbname'],
         'table:persons', 'schema:public',
     ]
 
     expected_size_tags = pg_instance['tags'] + [
-        'pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port']),
+        'server:{}'.format(pg_instance['host']),
+        'port:{}'.format(pg_instance['port']),
         'db:%s' % pg_instance['dbname'],
         'table:persons',
     ]
@@ -85,7 +87,8 @@ def test_index_metrics(aggregator, pg_instance):
     posgres_check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + [
-        'pg_instance:{}-{}'.format(pg_instance['host'], pg_instance['port']),
+        'server:{}'.format(pg_instance['host']),
+        'port:{}'.format(pg_instance['port']),
         'db:dogs', 'table:breed', 'index:breed_names', 'schema:public',
     ]
 


### PR DESCRIPTION
### Motivation

It wasn't being sent with service checks

### Additional Notes

Normalized it too like https://github.com/DataDog/integrations-core/blob/d165455909a8e15bd944c764023eaeb6cb459a99/redisdb/datadog_checks/redisdb/redisdb.py#L155-L164