### PR TITLE
update kafka_consumer tests to assert all metrics are covered

### DIFF
--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -44,3 +44,4 @@ def test_check_kafka(aggregator, kafka_instance):
 
     # let's reassert for the __consumer_offsets - multiple partitions
     aggregator.assert_metric('kafka.broker_offset', at_least=1)
+    aggregator.assert_all_metrics_covered()

--- a/kafka_consumer/tests/test_kafka_consumer_zk.py
+++ b/kafka_consumer/tests/test_kafka_consumer_zk.py
@@ -77,6 +77,7 @@ def test_multiple_servers_zk(aggregator, zk_instance):
 
     aggregator.assert_all_metrics_covered()
 
+
 @pytest.mark.usefixtures('dd_environment', 'kafka_producer', 'zk_consumer')
 def test_check_nogroups_zk(aggregator, zk_instance):
     """
@@ -103,6 +104,7 @@ def test_check_nogroups_zk(aggregator, zk_instance):
                 aggregator.assert_metric(mname, at_least=1)
 
     aggregator.assert_all_metrics_covered()
+
 
 def test_should_zk():
     check = KafkaCheck('kafka_consumer', {}, {})

--- a/kafka_consumer/tests/test_kafka_consumer_zk.py
+++ b/kafka_consumer/tests/test_kafka_consumer_zk.py
@@ -48,6 +48,7 @@ def test_check_zk(aggregator, zk_instance):
 
     # let's reassert for the __consumer_offsets - multiple partitions
     aggregator.assert_metric('kafka.broker_offset', at_least=1)
+    aggregator.assert_all_metrics_covered()
 
 
 @pytest.mark.usefixtures('dd_environment', 'kafka_producer', 'zk_consumer')
@@ -74,6 +75,7 @@ def test_multiple_servers_zk(aggregator, zk_instance):
                     aggregator.assert_metric(mname, tags=tags +
                                              ["source:zk", "consumer_group:{}".format(name)], at_least=1)
 
+    aggregator.assert_all_metrics_covered()
 
 @pytest.mark.usefixtures('dd_environment', 'kafka_producer', 'zk_consumer')
 def test_check_nogroups_zk(aggregator, zk_instance):
@@ -100,6 +102,7 @@ def test_check_nogroups_zk(aggregator, zk_instance):
             for mname in BROKER_METRICS + CONSUMER_METRICS:
                 aggregator.assert_metric(mname, at_least=1)
 
+    aggregator.assert_all_metrics_covered()
 
 def test_should_zk():
     check = KafkaCheck('kafka_consumer', {}, {})


### PR DESCRIPTION
### What does this PR do?

Updates the `kafka_consumer` tests to assert all metrics have been covered. 

### Motivation

To ensure tests are being asserted on all collected metrics. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
