### PR TITLE
Try to manually set version to improve CI reliabilty

### DIFF
--- a/ceph/tests/compose/docker-compose.yaml
+++ b/ceph/tests/compose/docker-compose.yaml
@@ -12,3 +12,4 @@ services:
       - CEPH_DEMO_SECRET_KEY=demo
       - CEPH_DEMO_BUCKET=demo
       - DEBUG=verbose
+      - SREE_VERSION=leseb-Sree-v0.1-0-g4ab9969


### PR DESCRIPTION
### What does this PR do?

It fixes the version of the sree lib used in the ceph docker image.

### Motivation

This removes a discovery call to the github API which seems to fail very often in CI.

### Additional Notes

When moving to ceph 4 we won't need this anymore.