### PR TITLE
fix queue_manager variable naming of IBM MQ

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/connection.py
+++ b/ibm_mq/datadog_checks/ibm_mq/connection.py
@@ -61,6 +61,6 @@ def get_ssl_connection(config):
     sco.KeyRepository = config.ssl_key_repository_location
 
     queue_manager = pymqi.QueueManager(None)
-    queue_manager.connect_with_options(config.queue_manager, cd, sco)
+    queue_manager.connect_with_options(config.queue_manager_name, cd, sco)
 
     return queue_manager


### PR DESCRIPTION
### What does this PR do?

There was a bug in the code because I the variable queue_manager should have been queue_manager_name. This should fix it.

### Motivation

Customer bug report.
This is the error that appears in the check: https://cl.ly/ec4ec4c83d6f

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
