### PR TITLE
Revert "fix queue_manager variable naming of IBM MQ"

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/connection.py
+++ b/ibm_mq/datadog_checks/ibm_mq/connection.py
@@ -61,6 +61,6 @@ def get_ssl_connection(config):
     sco.KeyRepository = config.ssl_key_repository_location
 
     queue_manager = pymqi.QueueManager(None)
-    queue_manager.connect_with_options(config.queue_manager_name, cd, sco)
+    queue_manager.connect_with_options(config.queue_manager, cd, sco)
 
     return queue_manager


### PR DESCRIPTION
Reverting due to Code Freeze

Reverts DataDog/integrations-core#3592