### PR TITLE
Remove noprealloc option, supports latest 4.1 image

### DIFF
--- a/mongo/tests/compose/docker-compose.yml
+++ b/mongo/tests/compose/docker-compose.yml
@@ -6,51 +6,51 @@ services:
   ## Config Servers
   config01:
     image: mongo:$MONGO_VERSION
-    command: mongod --port 27017 --bind_ip=0.0.0.0 --configsvr --replSet configserver --noprealloc --oplogSize 16
+    command: mongod --port 27017 --bind_ip=0.0.0.0 --configsvr --replSet configserver --oplogSize 16
     volumes:
       - ./scripts:/scripts
   config02:
     image: mongo:$MONGO_VERSION
-    command: mongod --port 27017 --bind_ip=0.0.0.0 --configsvr --replSet configserver --noprealloc --oplogSize 16
+    command: mongod --port 27017 --bind_ip=0.0.0.0 --configsvr --replSet configserver --oplogSize 16
     volumes:
       - ./scripts:/scripts
   config03:
     image: mongo:$MONGO_VERSION
-    command: mongod --port 27017 --bind_ip=0.0.0.0 --configsvr --replSet configserver --noprealloc --oplogSize 16
+    command: mongod --port 27017 --bind_ip=0.0.0.0 --configsvr --replSet configserver --oplogSize 16
     volumes:
       - ./scripts:/scripts
 
   ## Shards
   shard01a:
     image: mongo:$MONGO_VERSION
-    command: mongod --port 27018 --bind_ip=0.0.0.0 --shardsvr --replSet shard01 --noprealloc --oplogSize 16
+    command: mongod --port 27018 --bind_ip=0.0.0.0 --shardsvr --replSet shard01 --oplogSize 16
     ports:
       - "27018:27018"
     volumes:
       - ./scripts:/scripts
   shard01b:
     image: mongo:$MONGO_VERSION
-    command: mongod --port 27018 --bind_ip=0.0.0.0 --shardsvr --replSet shard01 --noprealloc --oplogSize 16
+    command: mongod --port 27018 --bind_ip=0.0.0.0 --shardsvr --replSet shard01 --oplogSize 16
     volumes:
       - ./scripts:/scripts
   shard02a:
     image: mongo:$MONGO_VERSION
-    command: mongod --port 27019 --bind_ip=0.0.0.0 --shardsvr --replSet shard02 --noprealloc --oplogSize 16
+    command: mongod --port 27019 --bind_ip=0.0.0.0 --shardsvr --replSet shard02 --oplogSize 16
     volumes:
       - ./scripts:/scripts
   shard02b:
     image: mongo:$MONGO_VERSION
-    command: mongod --port 27019 --bind_ip=0.0.0.0 --shardsvr --replSet shard02 --noprealloc --oplogSize 16
+    command: mongod --port 27019 --bind_ip=0.0.0.0 --shardsvr --replSet shard02 --oplogSize 16
     volumes:
       - ./scripts:/scripts
   shard03a:
     image: mongo:$MONGO_VERSION
-    command: mongod --port 27020 --bind_ip=0.0.0.0 --shardsvr --replSet shard03 --noprealloc --oplogSize 16
+    command: mongod --port 27020 --bind_ip=0.0.0.0 --shardsvr --replSet shard03 --oplogSize 16
     volumes:
       - ./scripts:/scripts
   shard03b:
     image: mongo:$MONGO_VERSION
-    command: mongod --port 27020 --bind_ip=0.0.0.0 --shardsvr --replSet shard03 --noprealloc --oplogSize 16
+    command: mongod --port 27020 --bind_ip=0.0.0.0 --shardsvr --replSet shard03 --oplogSize 16
     volumes:
       - ./scripts:/scripts
 

--- a/mongo/tox.ini
+++ b/mongo/tox.ini
@@ -22,7 +22,7 @@ setenv =
     3.2.10: MONGO_VERSION=3.2.10
     3.4: MONGO_VERSION=3.4
     3.5: MONGO_VERSION=3.5
-    4.1: MONGO_VERSION=4.1.6
+    4.1: MONGO_VERSION=4.1
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
### What does this PR do?

This removes the --pre-alloc option from our docker test scripts, as it was
doing nothing previously and now doesn't work with the last mongo versions.

### Motivation

We want to support the latest mongo containers, and this achieves it.