### PR TITLE
Add a pytest-args option to ddev test

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -37,6 +37,7 @@ def display_envs(check_envs):
 @click.option('--list', '-l', 'list_envs', is_flag=True, help='List available test environments')
 @click.option('--changed', is_flag=True, help='Only test changed checks')
 @click.option('--cov-keep', is_flag=True, help='Keep coverage reports')
+@click.option('--pytest-args', '-pa', help='Additional arguments to pytest')
 def test(
     checks,
     format_style,
@@ -52,6 +53,7 @@ def test(
     list_envs,
     changed,
     cov_keep,
+    pytest_args,
 ):
     """Run tests for Agent-based checks.
 
@@ -83,6 +85,7 @@ def test(
         coverage=coverage,
         marker=marker,
         test_filter=test_filter,
+        pytest_args=pytest_args,
     )
     coverage_show_missing_lines = str(cov_missing or testing_on_ci)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -146,7 +146,7 @@ def fix_coverage_report(check, report_file):
 
 
 def construct_pytest_options(
-    verbose=0, enter_pdb=False, debug=False, bench=False, coverage=False, marker='', test_filter=''
+    verbose=0, enter_pdb=False, debug=False, bench=False, coverage=False, marker='', test_filter='', pytest_args=''
 ):
     # Prevent no verbosity
     pytest_options = '--verbosity={}'.format(verbose or 1)
@@ -180,6 +180,9 @@ def construct_pytest_options(
 
     if test_filter:
         pytest_options += ' -k {}'.format(test_filter)
+
+    if pytest_args:
+        pytest_options += ' {}'.format(pytest_args)
 
     return pytest_options
 


### PR DESCRIPTION
### What does this PR do?

This adds a new --pytest-args to ddev test.

### Motivation

This allows additional customization of the pytest call done by ddev test, in particular:
 * Pass a test name to run a single test
 * Pass --junit-xml to collect junit output.