### PR TITLE
Add e2e hdfs_namenode

### DIFF
--- a/hdfs_namenode/tests/common.py
+++ b/hdfs_namenode/tests/common.py
@@ -2,9 +2,9 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import os
+from datadog_checks.dev import get_here
 
-HERE = os.path.dirname(os.path.abspath(__file__))
+HERE = get_here()
 
 # Namenode URI
 NAMENODE_URI = 'http://localhost:50070/'
@@ -21,6 +21,33 @@ CUSTOM_TAGS = ["cluster_name:hdfs_dev", "instance:level_tags"]
 # Authentication Parameters
 TEST_USERNAME = 'Picard'
 TEST_PASSWORD = 'NCC-1701'
+
+INSTANCE_INTEGRATION = {
+    "hdfs_namenode_jmx_uri": NAMENODE_URI,
+}
+
+EXPECTED_METRICS = [
+    'hdfs.namenode.capacity_total',
+    'hdfs.namenode.capacity_used',
+    'hdfs.namenode.capacity_remaining',
+    'hdfs.namenode.total_load',
+    'hdfs.namenode.blocks_total',
+    'hdfs.namenode.max_objects',
+    'hdfs.namenode.files_total',
+    'hdfs.namenode.pending_replication_blocks',
+    'hdfs.namenode.under_replicated_blocks',
+    'hdfs.namenode.scheduled_replication_blocks',
+    'hdfs.namenode.pending_deletion_blocks',
+    'hdfs.namenode.num_live_data_nodes',
+    'hdfs.namenode.num_dead_data_nodes',
+    'hdfs.namenode.num_decom_live_data_nodes',
+    'hdfs.namenode.num_decom_dead_data_nodes',
+    'hdfs.namenode.volume_failures_total',
+    'hdfs.namenode.estimated_capacity_lost_total',
+    'hdfs.namenode.num_decommissioning_data_nodes',
+    'hdfs.namenode.num_stale_data_nodes',
+    'hdfs.namenode.num_stale_storages',
+]
 
 HDFS_NAMENODE_CONFIG = {
     'instances': [

--- a/hdfs_namenode/tests/compose/docker-compose.yaml
+++ b/hdfs_namenode/tests/compose/docker-compose.yaml
@@ -1,0 +1,36 @@
+version: '3'
+# Inspired from
+# https://github.com/big-data-europe/docker-hadoop
+services:
+  namenode:
+    image: bde2020/hadoop-namenode:1.1.0-hadoop2.7.1-java8
+    container_name: namenode
+    volumes:
+      - hadoop_namenode:/hadoop/dfs/name
+    environment:
+      - CLUSTER_NAME=test
+      - HDFS_CONF_dfs_webhdfs_enabled=true
+      - HDFS_CONF_dfs_permissions_enabled=false
+    ports:
+      - "50070:50070"
+
+  datanode:
+    image: bde2020/hadoop-datanode:1.1.0-hadoop2.7.1-java8
+    container_name: datanode
+    depends_on:
+      - namenode
+    volumes:
+      - hadoop_datanode:/hadoop/dfs/data
+    environment:
+      - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
+      - CORE_CONF_hadoop_http_staticuser_user=root
+      - CORE_CONF_hadoop_proxyuser_hue_hosts=*
+      - CORE_CONF_hadoop_proxyuser_hue_groups=*
+      - HDFS_CONF_dfs_webhdfs_enabled=true
+      - HDFS_CONF_dfs_permissions_enabled=false
+    ports:
+      - "50075:50075"
+
+volumes:
+  hadoop_namenode:
+  hadoop_datanode:

--- a/hdfs_namenode/tests/conftest.py
+++ b/hdfs_namenode/tests/conftest.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2018
+# (C) Datadog, Inc. 2018-2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -9,15 +9,28 @@ from mock import patch
 # 3rd party
 import json
 
-from .common import HERE, NAME_SYSTEM_STATE_URL, NAME_SYSTEM_URL, TEST_USERNAME, TEST_PASSWORD
+from datadog_checks.hdfs_namenode import HDFSNameNode
+from datadog_checks.dev import docker_run
+from .common import HERE, INSTANCE_INTEGRATION, NAME_SYSTEM_STATE_URL, NAME_SYSTEM_URL, TEST_USERNAME, TEST_PASSWORD
+
+
+@pytest.fixture(scope="session")
+def dd_environment():
+    with docker_run(
+        compose_file=os.path.join(HERE, "compose", "docker-compose.yaml"),
+        log_patterns='Got finalize command for block pool'
+    ):
+        yield INSTANCE_INTEGRATION
 
 
 @pytest.fixture
-def aggregator():
-    from datadog_checks.stubs import aggregator
+def instance():
+    return INSTANCE_INTEGRATION
 
-    aggregator.reset()
-    return aggregator
+
+@pytest.fixture
+def check():
+    return HDFSNameNode("hdfs_namenode", {}, {})
 
 
 @pytest.fixture

--- a/hdfs_namenode/tests/test_integration.py
+++ b/hdfs_namenode/tests/test_integration.py
@@ -1,0 +1,17 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pytest
+
+from . import common
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.usefixtures("dd_environment")
+def test_check(aggregator, check, instance):
+    check.check(instance)
+
+    for metric in common.EXPECTED_METRICS:
+        aggregator.assert_metric(metric)


### PR DESCRIPTION
### What does this PR do?

Add e2e testing for `hdfs_namenode`

### Motivation

More testing

### Additional Notes

The same docker-compose file will certainly be used for `hdfs_datanode`.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
