### PR TITLE
Add a note about users running the integration install

### DIFF
--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -458,6 +458,8 @@ To install your integration, build your Python wheel first (see the [Building](#
 datadog-agent integration install -w /path/to/wheel.whl
 ```
 
+Note that it may require to use a specific user to run that command, such as `dd-agent`.
+
 
 [1]: https://virtualenv.pypa.io/en/stable
 [2]: https://github.com/DataDog/integrations-core/blob/master/docs/dev/python.md


### PR DESCRIPTION
The command to install an extra wheel needs to be run as dd-agent on linux,
let's add a note about it.