### PR TITLE
Add hdfs_datanode e2e

### DIFF
--- a/hdfs_datanode/tests/common.py
+++ b/hdfs_datanode/tests/common.py
@@ -13,7 +13,7 @@ CUSTOM_TAGS = ['optional:tag1']
 TEST_USERNAME = 'AzureDiamond'
 TEST_PASSWORD = 'hunter2'
 
-INSTANCE_INTEGRATION = { "hdfs_datanode_jmx_uri": "http://localhost:50075" }
+INSTANCE_INTEGRATION = {"hdfs_datanode_jmx_uri": "http://localhost:50075"}
 
 EXPECTED_METRICS = [
     'hdfs.datanode.dfs_remaining',

--- a/hdfs_datanode/tests/common.py
+++ b/hdfs_datanode/tests/common.py
@@ -2,18 +2,19 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from datadog_checks.dev import get_here
+from datadog_checks.dev import get_docker_hostname, get_here
 
 HERE = get_here()
+HOST = get_docker_hostname()
 
-DATANODE_URI = 'http://localhost:50070/'
+DATANODE_URI = 'http://{}:50070/'.format(HOST)
 
 CUSTOM_TAGS = ['optional:tag1']
 
 TEST_USERNAME = 'AzureDiamond'
 TEST_PASSWORD = 'hunter2'
 
-INSTANCE_INTEGRATION = {"hdfs_datanode_jmx_uri": "http://localhost:50075"}
+INSTANCE_INTEGRATION = {"hdfs_datanode_jmx_uri": "http://{}:50075".format(HOST)}
 
 EXPECTED_METRICS = [
     'hdfs.datanode.dfs_remaining',

--- a/hdfs_datanode/tests/common.py
+++ b/hdfs_datanode/tests/common.py
@@ -2,9 +2,9 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import os
+from datadog_checks.dev import get_here
 
-HERE = os.path.dirname(os.path.abspath(__file__))
+HERE = get_here()
 
 DATANODE_URI = 'http://localhost:50070/'
 
@@ -12,6 +12,21 @@ CUSTOM_TAGS = ['optional:tag1']
 
 TEST_USERNAME = 'AzureDiamond'
 TEST_PASSWORD = 'hunter2'
+
+INSTANCE_INTEGRATION = { "hdfs_datanode_jmx_uri": "http://localhost:50075" }
+
+EXPECTED_METRICS = [
+    'hdfs.datanode.dfs_remaining',
+    'hdfs.datanode.dfs_capacity',
+    'hdfs.datanode.dfs_used',
+    'hdfs.datanode.cache_capacity',
+    'hdfs.datanode.cache_used',
+    'hdfs.datanode.last_volume_failure_date',
+    'hdfs.datanode.estimated_capacity_lost_total',
+    'hdfs.datanode.num_blocks_cached',
+    'hdfs.datanode.num_failed_volumes',
+    'hdfs.datanode.num_blocks_failed_to_cache',
+]
 
 HDFS_DATANODE_CONFIG = {'instances': [{'hdfs_datanode_jmx_uri': DATANODE_URI, 'tags': list(CUSTOM_TAGS)}]}
 

--- a/hdfs_datanode/tests/compose/docker-compose.yaml
+++ b/hdfs_datanode/tests/compose/docker-compose.yaml
@@ -1,0 +1,36 @@
+version: '3'
+# Inspired from
+# https://github.com/big-data-europe/docker-hadoop
+services:
+  namenode:
+    image: bde2020/hadoop-namenode:1.1.0-hadoop2.7.1-java8
+    container_name: namenode
+    volumes:
+      - hadoop_namenode:/hadoop/dfs/name
+    environment:
+      - CLUSTER_NAME=test
+      - HDFS_CONF_dfs_webhdfs_enabled=true
+      - HDFS_CONF_dfs_permissions_enabled=false
+    ports:
+      - "50070:50070"
+
+  datanode:
+    image: bde2020/hadoop-datanode:1.1.0-hadoop2.7.1-java8
+    container_name: datanode
+    depends_on:
+      - namenode
+    volumes:
+      - hadoop_datanode:/hadoop/dfs/data
+    environment:
+      - CORE_CONF_fs_defaultFS=hdfs://namenode:8020
+      - CORE_CONF_hadoop_http_staticuser_user=root
+      - CORE_CONF_hadoop_proxyuser_hue_hosts=*
+      - CORE_CONF_hadoop_proxyuser_hue_groups=*
+      - HDFS_CONF_dfs_webhdfs_enabled=true
+      - HDFS_CONF_dfs_permissions_enabled=false
+    ports:
+      - "50075:50075"
+
+volumes:
+  hadoop_namenode:
+  hadoop_datanode:

--- a/hdfs_datanode/tests/conftest.py
+++ b/hdfs_datanode/tests/conftest.py
@@ -21,7 +21,7 @@ def dd_environment():
         compose_file=os.path.join(HERE, "compose", "docker-compose.yaml"),
         log_patterns='Got finalize command for block pool',
     ):
-        yield INSTANCE_INTEGRATION
+        yield
 
 
 @pytest.fixture

--- a/hdfs_datanode/tests/conftest.py
+++ b/hdfs_datanode/tests/conftest.py
@@ -6,9 +6,32 @@ import json
 import os
 
 import pytest
+from copy import deepcopy
 from mock import patch
 
-from .common import HERE, TEST_PASSWORD, TEST_USERNAME
+from datadog_checks.dev import docker_run
+from datadog_checks.hdfs_datanode import HDFSDataNode
+
+from .common import HERE, INSTANCE_INTEGRATION, TEST_PASSWORD, TEST_USERNAME
+
+
+@pytest.fixture(scope="session")
+def dd_environment():
+    with docker_run(
+        compose_file=os.path.join(HERE, "compose", "docker-compose.yaml"),
+        log_patterns='Got finalize command for block pool',
+    ):
+        yield INSTANCE_INTEGRATION
+
+
+@pytest.fixture
+def check():
+    return HDFSDataNode('hdfs_datanode')
+
+
+@pytest.fixture
+def instance():
+    return deepcopy(INSTANCE_INTEGRATION)
 
 
 @pytest.fixture

--- a/hdfs_datanode/tests/conftest.py
+++ b/hdfs_datanode/tests/conftest.py
@@ -4,9 +4,9 @@
 
 import json
 import os
+from copy import deepcopy
 
 import pytest
-from copy import deepcopy
 from mock import patch
 
 from datadog_checks.dev import docker_run

--- a/hdfs_datanode/tests/test_integration.py
+++ b/hdfs_datanode/tests/test_integration.py
@@ -13,7 +13,5 @@ pytestmark = pytest.mark.integration
 def test_check(aggregator, check, instance):
     check.check(instance)
 
-    print(aggregator._metrics)
-
     for metric in common.EXPECTED_METRICS:
         aggregator.assert_metric(metric)

--- a/hdfs_datanode/tests/test_integration.py
+++ b/hdfs_datanode/tests/test_integration.py
@@ -1,0 +1,19 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pytest
+
+from . import common
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.usefixtures("dd_environment")
+def test_check(aggregator, check, instance):
+    check.check(instance)
+
+    print(aggregator._metrics)
+
+    for metric in common.EXPECTED_METRICS:
+        aggregator.assert_metric(metric)

--- a/hdfs_datanode/tox.ini
+++ b/hdfs_datanode/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py37
 envlist =
-    py{27,37}-unit
+    py{27,37}-{integration,unit}
 
 [testenv]
 dd_check_style = true
@@ -12,6 +12,10 @@ platform = linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
+passenv =
+    DOCKER*
+    COMPOSE*
 commands =
     pip install -r requirements.in
-    pytest -v
+    integration: pytest -m"integration" -v
+    unit: pytest -m"not integration" -v


### PR DESCRIPTION
### What does this PR do?

Add e2e testing to `hdfs_datanode`

### Motivation

### Additional Notes

Uses the same docker-compose.yaml as `hdfs_namenode`

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
