### PR TITLE
Change `ibm_db2.connection.max` to gauge

### DIFF
--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -87,7 +87,7 @@ class IbmDb2Check(AgentCheck):
             self.gauge(self.m('application.executing'), db['appls_in_db2'], tags=self._tags)
 
             # https://www.ibm.com/support/knowledgecenter/SSEPGG_11.1.0/com.ibm.db2.luw.admin.mon.doc/doc/r0002225.html
-            self.monotonic_count(self.m('connection.max'), db['connections_top'], tags=self._tags)
+            self.gauge(self.m('connection.max'), db['connections_top'], tags=self._tags)
 
             # https://www.ibm.com/support/knowledgecenter/SSEPGG_11.1.0/com.ibm.db2.luw.admin.mon.doc/doc/r0001200.html
             self.monotonic_count(self.m('connection.total'), db['total_cons'], tags=self._tags)

--- a/ibm_db2/metadata.csv
+++ b/ibm_db2/metadata.csv
@@ -2,7 +2,7 @@ metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation
 ibm_db2.application.active,gauge,,connection,,The number of applications that are currently connected to the database.,0,ibm_db2,
 ibm_db2.application.executing,gauge,,connection,,The number of applications for which the database manager is currently processing a request.,0,ibm_db2,
 ibm_db2.connection.active,gauge,,connection,,The current number of connections.,0,ibm_db2,
-ibm_db2.connection.max,count,,connection,,The highest number of simultaneous connections to the database since the database was activated.,0,ibm_db2,
+ibm_db2.connection.max,gauge,,connection,,The highest number of simultaneous connections to the database since the database was activated.,0,ibm_db2,
 ibm_db2.connection.total,count,,connection,,"The total number of connections to the database since the first connect, activate, or last reset (coordinator agents).",0,ibm_db2,
 ibm_db2.lock.dead,count,,lock,,The total number of deadlocks that have occurred.,-1,ibm_db2,
 ibm_db2.lock.waiting,gauge,,lock,,The number of agents waiting on a lock.,-1,ibm_db2,


### PR DESCRIPTION
### What does this PR do?

The monotonic_count method was not appropriate

### Motivation

What inspired you to submit this pull request?

### Additional Notes

bug fix release is ok since this was not yet available in a agent.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.