### PR TITLE
Reorganize tests and fix them on non-localhost docker

### DIFF
--- a/hdfs_namenode/tests/common.py
+++ b/hdfs_namenode/tests/common.py
@@ -3,11 +3,14 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from datadog_checks.dev import get_here
+from datadog_checks.dev.docker import get_docker_hostname
 
 HERE = get_here()
 
+HOST = get_docker_hostname()
+
 # Namenode URI
-NAMENODE_URI = 'http://localhost:50070/'
+NAMENODE_URI = 'http://{}:50070/'.format(HOST)
 NAMENODE_JMX_URI = NAMENODE_URI + 'jmx'
 
 # Namesystem state URL

--- a/hdfs_namenode/tests/conftest.py
+++ b/hdfs_namenode/tests/conftest.py
@@ -19,7 +19,7 @@ def dd_environment():
         compose_file=os.path.join(HERE, "compose", "docker-compose.yaml"),
         log_patterns='Got finalize command for block pool',
     ):
-        yield INSTANCE_INTEGRATION
+        yield
 
 
 @pytest.fixture

--- a/hdfs_namenode/tests/test_integration.py
+++ b/hdfs_namenode/tests/test_integration.py
@@ -9,6 +9,7 @@ from . import common
 pytestmark = pytest.mark.integration
 
 
+@pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
 def test_check(aggregator, check, instance):
     check.check(instance)

--- a/hdfs_namenode/tox.ini
+++ b/hdfs_namenode/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py37
 envlist =
-    py{27,37}-unit
+    py{27,37}-{integration,unit}
 
 [testenv]
 dd_check_style = true
@@ -11,6 +11,10 @@ platform = linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
+passenv =
+    DOCKER*
+    COMPOSE*
 commands =
     pip install -r requirements.in
-    pytest -v
+    unit: pytest -m"not integration" -v
+    integration: pytest -m"integration" -v


### PR DESCRIPTION
This fixes the tests when docker is not running locally, and add an integration
tox env for tests.