### PR TITLE
Standardize TLS/SSL protocol naming

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -23,11 +23,11 @@ STANDARD_FIELDS = {
     'persist_connections': False,
     'proxy': None,
     'skip_proxy': False,
-    'ssl_ca_cert': None,
-    'ssl_cert': None,
-    'ssl_ignore_warning': False,
-    'ssl_private_key': None,
-    'ssl_verify': True,
+    'tls_ca_cert': None,
+    'tls_cert': None,
+    'tls_ignore_warning': False,
+    'tls_private_key': None,
+    'tls_verify': True,
     'timeout': 10,
     'username': None,
 }
@@ -46,7 +46,7 @@ PROXY_SETTINGS_DISABLED = {
 
 
 class RequestsWrapper(object):
-    __slots__ = ('ignore_ssl_warning', 'persist_connections', 'no_proxy_uris', 'options', '_session')
+    __slots__ = ('ignore_tls_warning', 'persist_connections', 'no_proxy_uris', 'options', '_session')
 
     # For modifying the warnings filter since the context
     # manager that is provided changes module constants
@@ -64,7 +64,7 @@ class RequestsWrapper(object):
         # Support non-standard (usually legacy) configurations, for example:
         # {
         #     'disable_ssl_validation': {
-        #         'name': 'ssl_verify',
+        #         'name': 'tls_verify',
         #         'default': False,
         #         'invert': True,
         #     },
@@ -111,18 +111,18 @@ class RequestsWrapper(object):
 
         # http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
         verify = True
-        if isinstance(config['ssl_ca_cert'], string_types):
-            verify = config['ssl_ca_cert']
-        elif not is_affirmative(config['ssl_verify']):
+        if isinstance(config['tls_ca_cert'], string_types):
+            verify = config['tls_ca_cert']
+        elif not is_affirmative(config['tls_verify']):
             verify = False
 
         # http://docs.python-requests.org/en/master/user/advanced/#client-side-certificates
         cert = None
-        if isinstance(config['ssl_cert'], string_types):
-            if isinstance(config['ssl_private_key'], string_types):
-                cert = (config['ssl_cert'], config['ssl_private_key'])
+        if isinstance(config['tls_cert'], string_types):
+            if isinstance(config['tls_private_key'], string_types):
+                cert = (config['tls_cert'], config['tls_private_key'])
             else:
-                cert = config['ssl_cert']
+                cert = config['tls_cert']
 
         # http://docs.python-requests.org/en/master/user/advanced/#proxies
         no_proxy_uris = None
@@ -166,7 +166,7 @@ class RequestsWrapper(object):
         self.no_proxy_uris = no_proxy_uris
 
         # Ignore warnings for lack of SSL validation
-        self.ignore_ssl_warning = is_affirmative(config['ssl_ignore_warning'])
+        self.ignore_tls_warning = is_affirmative(config['tls_ignore_warning'])
 
         # For connection and cookie persistence, if desired. See:
         # https://en.wikipedia.org/wiki/HTTP_persistent_connection#Advantages
@@ -206,7 +206,7 @@ class RequestsWrapper(object):
         if persist is None:
             persist = self.persist_connections
 
-        with self.handle_ssl_warning():
+        with self.handle_tls_warning():
             if persist:
                 return getattr(self.session, method)(url, **options)
             else:
@@ -224,11 +224,11 @@ class RequestsWrapper(object):
         return options
 
     @contextmanager
-    def handle_ssl_warning(self):
+    def handle_tls_warning(self):
         with self.warning_lock:
 
             with warnings.catch_warnings():
-                if self.ignore_ssl_warning:
+                if self.ignore_tls_warning:
                     warnings.simplefilter('ignore', InsecureRequestWarning)
 
                 yield

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -82,21 +82,21 @@ class TestVerify:
         assert http.options['verify'] is True
 
     def test_config_verify(self):
-        instance = {'ssl_verify': False}
+        instance = {'tls_verify': False}
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
         assert http.options['verify'] is False
 
     def test_config_ca_cert(self):
-        instance = {'ssl_ca_cert': 'ca_cert'}
+        instance = {'tls_ca_cert': 'ca_cert'}
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
         assert http.options['verify'] == 'ca_cert'
 
     def test_config_verify_and_ca_cert(self):
-        instance = {'ssl_verify': True, 'ssl_ca_cert': 'ca_cert'}
+        instance = {'tls_verify': True, 'tls_ca_cert': 'ca_cert'}
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
@@ -112,14 +112,14 @@ class TestCert:
         assert http.options['cert'] is None
 
     def test_config_cert(self):
-        instance = {'ssl_cert': 'cert'}
+        instance = {'tls_cert': 'cert'}
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
         assert http.options['cert'] == 'cert'
 
     def test_config_cert_and_private_key(self):
-        instance = {'ssl_cert': 'cert', 'ssl_private_key': 'key'}
+        instance = {'tls_cert': 'cert', 'tls_private_key': 'key'}
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
@@ -294,20 +294,20 @@ class TestProxies:
         http.get('https://www.google.com')
 
 
-class TestIgnoreSSLWarning:
+class TestIgnoreTLSWarning:
     def test_config_default(self):
         instance = {}
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
-        assert http.ignore_ssl_warning is False
+        assert http.ignore_tls_warning is False
 
     def test_config_flag(self):
-        instance = {'ssl_ignore_warning': True}
+        instance = {'tls_ignore_warning': True}
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
-        assert http.ignore_ssl_warning is True
+        assert http.ignore_tls_warning is True
 
     def test_default_no_ignore(self):
         instance = {}
@@ -318,7 +318,7 @@ class TestIgnoreSSLWarning:
             http.get('https://www.google.com', verify=False)
 
     def test_ignore(self):
-        instance = {'ssl_ignore_warning': True}
+        instance = {'tls_ignore_warning': True}
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
@@ -336,7 +336,7 @@ class TestIgnoreSSLWarning:
             http.get('https://www.google.com', verify=False)
 
     def test_ignore_session(self):
-        instance = {'ssl_ignore_warning': True, 'persist_connections': True}
+        instance = {'tls_ignore_warning': True, 'persist_connections': True}
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
@@ -392,15 +392,15 @@ class TestRemapper:
     def test_invert(self):
         instance = {'disable_ssl_validation': False}
         init_config = {}
-        remapper = {'disable_ssl_validation': {'name': 'ssl_verify', 'default': False, 'invert': True}}
+        remapper = {'disable_ssl_validation': {'name': 'tls_verify', 'default': False, 'invert': True}}
         http = RequestsWrapper(instance, init_config, remapper)
 
         assert http.options['verify'] is True
 
     def test_standard_override(self):
-        instance = {'disable_ssl_validation': True, 'ssl_verify': False}
+        instance = {'disable_ssl_validation': True, 'tls_verify': False}
         init_config = {}
-        remapper = {'disable_ssl_validation': {'name': 'ssl_verify', 'default': False, 'invert': True}}
+        remapper = {'disable_ssl_validation': {'name': 'tls_verify', 'default': False, 'invert': True}}
         http = RequestsWrapper(instance, init_config, remapper)
 
         assert http.options['verify'] is False
@@ -408,7 +408,7 @@ class TestRemapper:
     def test_unknown_name_default(self):
         instance = {}
         init_config = {}
-        remapper = {'verify_ssl': {'name': 'verify', 'default': False}}
+        remapper = {'verify_tls': {'name': 'verify', 'default': False}}
         http = RequestsWrapper(instance, init_config, remapper)
 
         assert http.options['verify'] is True


### PR DESCRIPTION
### Motivation

https://github.com/DataDog/integrations-core/pull/3256

SSL is deprecated

### Additional Notes

Not used yet