### PR TITLE
Get details for both private and public flavors

### DIFF
--- a/openstack_controller/datadog_checks/openstack_controller/api.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api.py
@@ -361,6 +361,9 @@ class SimpleApi(AbstractApi):
 
     def get_flavors_detail(self, query_params):
         url = '{}/flavors/detail'.format(self.nova_endpoint)
+        if query_params is None:
+            query_params = {}
+        query_params["is_public"] = "none"
         return self._get_paginated_list(url, 'flavors', query_params)
 
     def _get_paginated_list(self, url, obj, query_params):


### PR DESCRIPTION
### What does this PR do?

This allows the check to get details for the public and private flavors. It uses the `is_public` parameter of the API endpoint and needs the user the check authenticates as to be admin, as per https://developer.openstack.org/api-ref/compute/?expanded=list-servers-detail,list-flavors-with-details-detail#list-flavors-with-details

### Motivation

Only public flavors can be obtained.

### Additional Notes

This only needs to be added to the SimpleAPI method, because it's already the default when using openstackSDK: https://github.com/openstack/openstacksdk/blob/e9a5d45e5099e3bfc04aad7a6ae54d54f9990de5/openstack/cloud/_compute.py#L167

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.