### PR TITLE
Fix name in service_checks.json

### DIFF
--- a/ibm_db2/service_checks.json
+++ b/ibm_db2/service_checks.json
@@ -1,7 +1,7 @@
 [
     {
         "agent_version": "6.11.0",
-        "integration": "ibm_db2",
+        "integration": "IBM Db2",
         "groups": ["host", "db"],
         "check": "ibm_db2.can_connect",
         "statuses": ["ok", "critical"],
@@ -10,7 +10,7 @@
     },
     {
         "agent_version": "6.11.0",
-        "integration": "ibm_db2",
+        "integration": "IBM Db2",
         "groups": ["host", "db"],
         "check": "ibm_db2.status",
         "statuses": ["ok", "warning", "critical", "unknown"],


### PR DESCRIPTION
The `integration` field from the service_checks.json file has to match the display name from the manifest.json file. 