### PR TITLE
Add service check validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
@@ -64,6 +64,24 @@ def service_checks():
                     file_failed = True
                     display_queue.append((echo_failure, '  Attribute `{}` is required'.format(attr)))
 
+                # integration name matches display_name from manifest.json
+                manifest_file = os.path.join(root, check_name, 'manifest.json')
+                try:
+                    decoded = json.loads(read_file(manifest_file).strip(), object_pairs_hook=OrderedDict)
+                except JSONDecodeError as e:
+                    file_failed = True
+                    display_queue.append((echo_failure('{}/manifest.json doesn\'t exist'.format(check_name))))
+                    echo_info('{}/manifest.json... '.format(check_name), nl=False)
+
+                if decoded.get('display_name').lower() != service_check.get('integration').lower():
+                    file_failed = True
+                    display_queue.append(
+                        (
+                            echo_failure,
+                            'Integration field must match the display_name from {}/manifest.json'.format(check_name),
+                        )
+                    )
+
                 # agent_version
                 agent_version = service_check.get('agent_version')
                 version_parts = parse_version_parts(agent_version)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
@@ -10,7 +10,7 @@ from six import string_types
 
 from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
 from ...constants import get_root
-from ...utils import parse_version_parts
+from ...utils import load_manifest, parse_version_parts
 from ....compat import JSONDecodeError
 from ....utils import file_exists, read_file
 
@@ -65,15 +65,12 @@ def service_checks():
                     display_queue.append((echo_failure, '  Attribute `{}` is required'.format(attr)))
 
                 # integration name matches display_name from manifest.json
-                manifest_file = os.path.join(root, check_name, 'manifest.json')
-                try:
-                    decoded = json.loads(read_file(manifest_file).strip(), object_pairs_hook=OrderedDict)
-                except JSONDecodeError as e:
+                manifest_json = load_manifest(check_name)
+                if not manifest_json:
                     file_failed = True
                     display_queue.append((echo_failure('{}/manifest.json doesn\'t exist'.format(check_name))))
                     echo_info('{}/manifest.json... '.format(check_name), nl=False)
-
-                if decoded.get('display_name').lower() != service_check.get('integration').lower():
+                elif manifest_json.get('display_name').lower() != service_check.get('integration').lower():
                     file_failed = True
                     display_queue.append(
                         (


### PR DESCRIPTION
### What does this PR do?

Tooling requires that the integration name in service_checks.json match what the display name is in manifest.json. This adds a validation to that constraint in our CI. 

### Motivation

Know immediately if we're going to run into these kinds of issues. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
