### PR TITLE
Fix changelog generation for new checks

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/changelog.py
@@ -23,7 +23,7 @@ from ....utils import write_file, read_file
 )
 @click.option('--since', help="Initial Agent version", default='6.3.0')
 @click.option('--to', help="Final Agent version")
-@click.option('--write', '-w', help="Write to the changelog file, if omitted contents will be printed to stdout")
+@click.option('--write', '-w', is_flag=True, help="Write to the changelog file, if omitted contents will be printed to stdout")
 @click.option('--force', '-f', is_flag=True, default=False, help="Replace an existing file")
 def changelog(since, to, write, force):
     """
@@ -70,6 +70,9 @@ def changelog(since, to, write, force):
                 # determine whether major version changed
                 breaking = old_ver.split('.')[0] < ver.split('.')[0]
                 changes_per_agent[current_tag][name] = (ver, breaking)
+            elif not old_ver:
+                # New integration
+                changes_per_agent[current_tag][name] = (ver, False)
 
     # store the changelog in memory
     changelog_contents = StringIO()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/changelog.py
@@ -23,7 +23,12 @@ from ....utils import write_file, read_file
 )
 @click.option('--since', help="Initial Agent version", default='6.3.0')
 @click.option('--to', help="Final Agent version")
-@click.option('--write', '-w', is_flag=True, help="Write to the changelog file, if omitted contents will be printed to stdout")
+@click.option(
+    '--write',
+    '-w',
+    is_flag=True,
+    help="Write to the changelog file, if omitted contents will be printed to stdout"
+)
 @click.option('--force', '-f', is_flag=True, default=False, help="Replace an existing file")
 def changelog(since, to, write, force):
     """

--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -29,6 +29,7 @@ VERSION_BUMP = OrderedDict([
 AGENT_V5_ONLY = {
     'agent_metrics',
     'docker_daemon',
+    'go-metro',
     'kubernetes',
     'ntp',
 }


### PR DESCRIPTION
### What does this PR do?

Allow adding new checks to the changelog

### Motivation

They were missing

### Additional Notes

Also add go-metro to the list of agent5 only checks

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.