### PR TITLE
Run tests with Cassandra 3.0

### DIFF
--- a/cassandra_nodetool/tests/conftest.py
+++ b/cassandra_nodetool/tests/conftest.py
@@ -28,7 +28,9 @@ def dd_environment():
         cassandra_seed = get_container_ip("{}".format(common.CASSANDRA_CONTAINER_NAME))
         env['CASSANDRA_SEEDS'] = cassandra_seed
         with docker_run(
-            compose_file, service_name=common.CASSANDRA_CONTAINER_NAME_2, log_patterns=['All sessions completed']
+            compose_file,
+            service_name=common.CASSANDRA_CONTAINER_NAME_2,
+            log_patterns=['All sessions completed', 'Starting listening for CQL clients'],
         ):
             subprocess.check_call(
                 [

--- a/cassandra_nodetool/tests/test_integration.py
+++ b/cassandra_nodetool/tests/test_integration.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import time
+
 import pytest
 
 from datadog_checks.cassandra_nodetool import CassandraNodetoolCheck
@@ -15,7 +17,20 @@ def test_integration(aggregator, dd_environment):
     Testing Cassandra Nodetool Integration
     """
     integration = CassandraNodetoolCheck(common.CHECK_NAME, {}, {})
-    integration.check(common.CONFIG_INSTANCE)
+    # Starting with recent Cassandra versions, replication takes some time to
+    # warm up, let's retry a few times.
+    for _ in range(20):
+        integration.check(common.CONFIG_INSTANCE)
+        try:
+            aggregator.assert_metric(
+                'cassandra.nodetool.status.replication_availability',
+                value=200,
+                tags=['keyspace:test', 'datacenter:datacenter1', 'foo', 'bar'],
+            )
+        except AssertionError:
+            time.sleep(5)
+        else:
+            break
 
     aggregator.assert_metric(
         'cassandra.nodetool.status.replication_availability',

--- a/cassandra_nodetool/tox.ini
+++ b/cassandra_nodetool/tox.ini
@@ -3,6 +3,7 @@ minversion = 2.0
 basepython = py37
 envlist =
     py{27,37}-{2.1,unit}
+    py{27,37}-{2.1,3.0,unit}
 
 [testenv]
 dd_check_style = true
@@ -13,6 +14,7 @@ deps =
     -rrequirements-dev.txt
 setenv =
     2.1: CASSANDRA_VERSION=2.1.14
+    3.0: CASSANDRA_VERSION=3.0
     CONTAINER_PORT=7199
 passenv =
     DOCKER*
@@ -20,5 +22,5 @@ passenv =
     JMX_*
 commands =
     pip install -r requirements.in
-    2.1: pytest -m"integration" -v
-    unit: pytest -m"not integration" -v
+    {2.1,3.0}: pytest -m"integration" -v {posargs}
+    unit: pytest -m"not integration" -v {posargs}


### PR DESCRIPTION
This adds a new environment to run the tests with Cassandra 3.0, and adapt the
tests a bit to make them pass on that environment.