### PR TITLE
Fix tests for rabbitmq > 3.6.7

### DIFF
--- a/rabbitmq/tests/conftest.py
+++ b/rabbitmq/tests/conftest.py
@@ -4,6 +4,7 @@
 
 import os
 import subprocess
+import time
 
 import pytest
 import requests
@@ -32,6 +33,7 @@ def dd_environment():
 
     with docker_run(compose_file, log_patterns='Server startup complete', env_vars=env):
         setup_rabbitmq()
+        time.sleep(5)
         yield CONFIG
 
 

--- a/rabbitmq/tests/conftest.py
+++ b/rabbitmq/tests/conftest.py
@@ -4,7 +4,6 @@
 
 import os
 import subprocess
-import time
 
 import pytest
 import requests
@@ -31,9 +30,9 @@ def dd_environment():
 
     compose_file = os.path.join(HERE, 'compose', 'docker-compose.yaml')
 
-    with docker_run(compose_file, log_patterns='Server startup complete', env_vars=env):
-        setup_rabbitmq()
-        time.sleep(5)
+    with docker_run(
+        compose_file, log_patterns='Server startup complete', env_vars=env, conditions=[setup_rabbitmq], sleep=5
+    ):
         yield CONFIG
 
 

--- a/rabbitmq/tests/metrics.py
+++ b/rabbitmq/tests/metrics.py
@@ -15,14 +15,10 @@ COMMON_METRICS = [
 ]
 
 E_METRICS = [
-    'rabbitmq.exchange.messages.confirm.count',
-    'rabbitmq.exchange.messages.confirm.rate',
     'rabbitmq.exchange.messages.publish_in.count',
     'rabbitmq.exchange.messages.publish_in.rate',
     'rabbitmq.exchange.messages.publish_out.count',
     'rabbitmq.exchange.messages.publish_out.rate',
-    'rabbitmq.exchange.messages.return_unroutable.count',
-    'rabbitmq.exchange.messages.return_unroutable.rate',
 ]
 
 Q_METRICS = [

--- a/rabbitmq/tests/test_rabbitmq.py
+++ b/rabbitmq/tests/test_rabbitmq.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import logging
+import time
 from contextlib import closing
 
 import pika
@@ -185,6 +186,8 @@ def test_connections(aggregator, check):
 
     params = pika.ConnectionParameters(common.HOST)
     with closing(pika.BlockingConnection(params)), closing(pika.BlockingConnection(params)):
+        time.sleep(5)
+
         aggregator.reset()
         check.check(common.CONFIG)
         aggregator.assert_metric('rabbitmq.connections', tags=['rabbitmq_vhost:/', "tag1:1", "tag2"], value=2, count=1)

--- a/rabbitmq/tox.ini
+++ b/rabbitmq/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py37
 envlist =
-  py{27,37}-{3.5,3.6,unit}
+  py{27,37}-{3.5,3.6,3.7,unit}
 
 [testenv]
 dd_check_style = true
@@ -16,8 +16,9 @@ passenv =
     DOCKER*
 setenv =
     3.5: RABBITMQ_VERSION=3.5
-    3.6: RABBITMQ_VERSION=3.6.0
+    3.6: RABBITMQ_VERSION=3.6
+    3.7: RABBITMQ_VERSION=3.7
 commands =
     pip install -r requirements.in
     unit: pytest -v -m"unit" {posargs}
-    {3.5,3.6}: pytest -v -m"not unit" {posargs}
+    {3.5,3.6,3.7}: pytest -v -m"not unit" {posargs}


### PR DESCRIPTION
### What does this PR do?

Add rabbitmq 3.7 to the environment.
Remove 4 metrics from the tests that seems unavailable since 3.6.7.
Add some sleep in the tests to avoid race condition issues

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
