### PR TITLE
Simplify JSON flattening for timestamps and bool

### DIFF
--- a/nginx/tests/test_unit.py
+++ b/nginx/tests/test_unit.py
@@ -22,6 +22,17 @@ def test_flatten_json(check):
     assert parsed == expected
 
 
+def test_flatten_json_timestamp(check):
+    assert (
+        check.parse_json(
+            """
+    {"timestamp": "2018-10-23T12:12:23.123212Z"}
+    """
+        )
+        == [('nginx.timestamp', 1540296743, [], 'gauge')]
+    )
+
+
 def test_plus_api(check, instance, aggregator):
     instance = deepcopy(instance)
     instance['use_plus_api'] = True


### PR DESCRIPTION
This simplifies Boolean conversion and leverages
`datetime.datetime.fromisoformat` on Python >= 3.7.

The string is only parsed if it's likely to match a timestamp by checking the
last char, in order to speed up the conversion a bit.

This makes the conversion code 25-35% on Python 2 and 3.