### PR TITLE
Upgrade psycopg2-binary to 2.8.2

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -31,7 +31,7 @@ ply==3.10
 prometheus-client==0.3.0
 protobuf==3.7.0
 psutil==5.5.0
-psycopg2-binary==2.7.5
+psycopg2-binary==2.8.2
 pyasn1==0.4.2
 pycparser==2.18
 pycryptodomex==3.4.7

--- a/pgbouncer/requirements.in
+++ b/pgbouncer/requirements.in
@@ -1,1 +1,1 @@
-psycopg2-binary==2.7.5
+psycopg2-binary==2.8.2

--- a/postgres/requirements.in
+++ b/postgres/requirements.in
@@ -1,2 +1,2 @@
 pg8000==1.10.1
-psycopg2-binary==2.7.5
+psycopg2-binary==2.8.2


### PR DESCRIPTION
### Motivation

The wheels are now properly packaged which grants thread-safety https://github.com/psycopg/psycopg2/issues/543#issuecomment-484355883