### PR TITLE
Add e2e tests for mysql 8.0

### DIFF
--- a/cacti/requirements.in
+++ b/cacti/requirements.in
@@ -1,1 +1,1 @@
-PyMySQL==0.8.0
+pymysql==0.9.3

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -37,7 +37,7 @@ pycparser==2.18
 pycryptodomex==3.4.7
 pymongo==3.5.1
 pymqi==1.8.0; sys_platform != 'win32' and sys_platform != 'darwin'
-pymysql==0.8.0
+pymysql==0.9.3
 pyodbc==4.0.22; sys_platform != 'darwin'
 pyro4==4.73; sys_platform == 'win32'
 pysmi==0.2.2

--- a/mysql/requirements.in
+++ b/mysql/requirements.in
@@ -1,1 +1,2 @@
-pymysql==0.8.0
+cryptography==2.3.1
+pymysql==0.9.3

--- a/mysql/tests/common.py
+++ b/mysql/tests/common.py
@@ -17,4 +17,3 @@ SLAVE_PORT = 13307
 
 USER = 'dog'
 PASS = 'dog'
-MARIA_ROOT_PASS = 'master_root_password'

--- a/mysql/tests/compose/mariadb.yaml
+++ b/mysql/tests/compose/mariadb.yaml
@@ -4,8 +4,7 @@ services:
   mysql-master:
     image: "${MYSQL_DOCKER_REPO}:${MYSQL_VERSION}"
     environment:
-      - MYSQL_ALLOW_EMPTY_PASSWORD=1
-      - MARIADB_ROOT_PASSWORD=master_root_password
+      - ALLOW_EMPTY_PASSWORD=yes
       - MARIADB_REPLICATION_MODE=master
       - MARIADB_REPLICATION_USER=my_repl_user
       - MARIADB_REPLICATION_PASSWORD=my_repl_password
@@ -18,15 +17,14 @@ services:
   mysql-slave:
     image: "${MYSQL_DOCKER_REPO}:${MYSQL_VERSION}"
     environment:
-      - MYSQL_ALLOW_EMPTY_PASSWORD=1
+      - ALLOW_EMPTY_PASSWORD=yes
       - MASTER_HOST=mysql-master
       - MASTER_PORT=3306
       - MARIADB_REPLICATION_MODE=slave
       - MARIADB_REPLICATION_USER=my_repl_user
       - MARIADB_REPLICATION_PASSWORD=my_repl_password
       - MARIADB_MASTER_HOST=mysql-master
-      - MARIADB_MASTER_PORT=3306
-      - MARIADB_MASTER_ROOT_PASSWORD=master_root_password
+      - MARIADB_MASTER_PORT_NUMBER=3306
     ports:
       - "${MYSQL_SLAVE_PORT}:3306"
     depends_on:

--- a/mysql/tests/compose/mysql8.yaml
+++ b/mysql/tests/compose/mysql8.yaml
@@ -1,0 +1,31 @@
+version: '3.5'
+
+services:
+  mysql-master:
+    image: "${MYSQL_DOCKER_REPO}:${MYSQL_VERSION}"
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - MYSQL_REPLICATION_MODE=master
+      - MYSQL_REPLICATION_USER=my_repl_user
+      - MYSQL_REPLICATION_PASSWORD=my_repl_password
+      - MYSQL_USER=my_user
+      - MYSQL_PASSWORD=my_password
+      - MYSQL_DATABASE=my_database
+    ports:
+      - "${MYSQL_PORT}:3306"
+
+  mysql-slave:
+    image: "${MYSQL_DOCKER_REPO}:${MYSQL_VERSION}"
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - MASTER_HOST=mysql-master
+      - MASTER_PORT=3306
+      - MYSQL_REPLICATION_MODE=slave
+      - MYSQL_REPLICATION_USER=my_repl_user
+      - MYSQL_REPLICATION_PASSWORD=my_repl_password
+      - MYSQL_MASTER_HOST=mysql-master
+      - MYSQL_MASTER_PORT_NUMBER=3306
+    ports:
+      - "${MYSQL_SLAVE_PORT}:3306"
+    depends_on:
+      - "mysql-master"

--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -21,14 +21,11 @@ commands =
 setenv =
     COMPOSE_FILE=mysql.yaml
     MYSQL_FLAVOR=mysql
-
     5.5: MYSQL_VERSION=5.5
     5.6: MYSQL_VERSION=5.6
     5.7: MYSQL_VERSION=5.7
-
     8.0: COMPOSE_FILE=mysql8.yaml
     8.0: MYSQL_VERSION=8.0
-
     maria: COMPOSE_FILE=mariadb.yaml
     maria: MYSQL_FLAVOR=mariadb
     maria: MYSQL_VERSION=10.1.30-r1

--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py37
 envlist =
-    py{27,37}-{5.5,5.6,5.7,maria,unit}
+    py{27,37}-{5.5,5.6,5.7,8.0,maria,unit}
 
 [testenv]
 dd_check_style = true
@@ -16,12 +16,19 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install -r requirements.in
-    {5.5,5.6,5.7,maria}: pytest -v -m"not unit"
+    {5.5,5.6,5.7,8.0,maria}: pytest -v -m"not unit"
     unit: pytest -v -m"unit"
 setenv =
+    COMPOSE_FILE=mysql.yaml
     MYSQL_FLAVOR=mysql
+
     5.5: MYSQL_VERSION=5.5
     5.6: MYSQL_VERSION=5.6
     5.7: MYSQL_VERSION=5.7
+
+    8.0: COMPOSE_FILE=mysql8.yaml
+    8.0: MYSQL_VERSION=8.0
+
+    maria: COMPOSE_FILE=mariadb.yaml
     maria: MYSQL_FLAVOR=mariadb
     maria: MYSQL_VERSION=10.1.30-r1


### PR DESCRIPTION
### What does this PR do?

This PR adds an end-to-end test for mysql version 8.0.
To do so:

- pymysql had to be updated
- cryptography version 2.3.1 is added to mysql (already used for other integrations)
- The docker image for mysql8 is https://hub.docker.com/r/bitnami/mysql
- database is now populated after both master and slave are fully setup

### Motivation

https://github.com/DataDog/integrations-core/pull/3174

### Additional Notes

The "USE %DATABASE%" commands were necessary to populate the 'performance_schema' database.

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
