### PR TITLE
Remove `pre` from versioning scheme

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -21,7 +21,6 @@ VERSION_BUMP = OrderedDict([
     ('patch', semver.bump_patch),
     ('fix', semver.bump_patch),
     ('rc', lambda v: semver.bump_prerelease(v, 'rc')),
-    ('pre', lambda v: semver.bump_prerelease(v, 'pre')),
     ('alpha', lambda v: semver.bump_prerelease(v, 'alpha')),
     ('beta', lambda v: semver.bump_prerelease(v, 'beta')),
 ])


### PR DESCRIPTION

### Motivation

Wheels versioning scheme only accepts alpha, beta and rc, so `pre` is useless
https://www.python.org/dev/peps/pep-0440/#public-version-identifiers

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.