### PR TITLE
Add service check file for jboss

### DIFF
--- a/jboss_wildfly/service_checks.json
+++ b/jboss_wildfly/service_checks.json
@@ -1,0 +1,11 @@
+[
+    {
+        "agent_version": "6.11.0",
+        "integration":"JBoss/WildFly",
+        "groups": ["host", "instance"],
+        "check": "jboss_wildfly.can_connect",
+        "statuses": ["ok", "critical"],
+        "name": "Can Connect",
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored JBoss/WildFly instance. Returns `OK` otherwise."
+    }
+]


### PR DESCRIPTION
### What does this PR do?

Adds a service_checks.json file for JBOSS Wildfly integration

### Motivation

It was missing and required for integrations. JMX based integrations get a default service check of `<check_name>.can_connect`

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
