### PR TITLE
Allow users to override TUF repository URL prefix

### DIFF
--- a/datadog_checks_downloader/datadog_checks/downloader/cli.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/cli.py
@@ -7,19 +7,12 @@
 import argparse
 import re
 
-# 2nd party.
-from .download import REPOSITORY_URL_PREFIX, TUFDownloader
-from .exceptions import (
-    NonCanonicalVersion,
-    NonDatadogPackage,
-    NoSuchDatadogPackageOrVersion,
-)
-
 # 3rd party.
 from tuf.exceptions import UnknownTargetError
 
 # 2nd party.
-from .download import TUFDownloader
+# 2nd party.
+from .download import REPOSITORY_URL_PREFIX, TUFDownloader
 from .exceptions import NonCanonicalVersion, NonDatadogPackage, NoSuchDatadogPackageOrVersion
 
 # Private module functions.
@@ -49,11 +42,11 @@ def download():
         'standard_distribution_name', type=str, help='Standard distribution name of the desired Datadog check.'
     )
 
-    parser.add_argument('--repository', type=str, default=REPOSITORY_URL_PREFIX,
-                        help='The complete URL prefix for the TUF repository.')
+    parser.add_argument(
+        '--repository', type=str, default=REPOSITORY_URL_PREFIX, help='The complete URL prefix for the TUF repository.'
+    )
 
-    parser.add_argument('--version', type=str, default=None,
-                        help='The version number of the desired Datadog check.')
+    parser.add_argument('--version', type=str, default=None, help='The version number of the desired Datadog check.')
 
     parser.add_argument(
         '-v', '--verbose', action='count', default=0, help='Show verbose information about TUF and in-toto.'

--- a/datadog_checks_downloader/datadog_checks/downloader/cli.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/cli.py
@@ -7,6 +7,14 @@
 import argparse
 import re
 
+# 2nd party.
+from .download import REPOSITORY_URL_PREFIX, TUFDownloader
+from .exceptions import (
+    NonCanonicalVersion,
+    NonDatadogPackage,
+    NoSuchDatadogPackageOrVersion,
+)
+
 # 3rd party.
 from tuf.exceptions import UnknownTargetError
 
@@ -41,13 +49,18 @@ def download():
         'standard_distribution_name', type=str, help='Standard distribution name of the desired Datadog check.'
     )
 
-    parser.add_argument('--version', type=str, default=None, help='The version number of the desired Datadog check.')
+    parser.add_argument('--repository', type=str, default=REPOSITORY_URL_PREFIX,
+                        help='The complete URL prefix for the TUF repository.')
+
+    parser.add_argument('--version', type=str, default=None,
+                        help='The version number of the desired Datadog check.')
 
     parser.add_argument(
         '-v', '--verbose', action='count', default=0, help='Show verbose information about TUF and in-toto.'
     )
 
     args = parser.parse_args()
+    repository_url_prefix = args.repository
     standard_distribution_name = args.standard_distribution_name
     version = args.version
     verbose = args.verbose
@@ -56,7 +69,7 @@ def download():
         raise NonDatadogPackage(standard_distribution_name)
     else:
         wheel_distribution_name = __get_wheel_distribution_name(standard_distribution_name)
-        tuf_downloader = TUFDownloader(verbose=verbose)
+        tuf_downloader = TUFDownloader(repository_url_prefix=repository_url_prefix, verbose=verbose)
 
         if not version:
             version = tuf_downloader.get_latest_version(standard_distribution_name, wheel_distribution_name)

--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -46,6 +46,7 @@ REPOSITORY_MIRRORS = {
         'confined_target_dirs': [''],
     }
 }
+REPOSITORY_URL_PREFIX = 'https://dd-integrations-core-wheels-build-stable.datadoghq.com'
 
 
 # Global variables.
@@ -53,7 +54,9 @@ logger = logging.getLogger(__name__)
 
 
 class TUFDownloader:
-    def __init__(self, verbose=0):
+
+
+    def __init__(self, repository_url_prefix=REPOSITORY_URL_PREFIX, verbose=0):
         # 0 => 60 (effectively /dev/null)
         # 1 => 50 (CRITICAL)
         # 2 => 40 (ERROR)
@@ -79,7 +82,14 @@ class TUFDownloader:
         # https://github.com/theupdateframework/tuf/blob/aa2ab218f22d8682e03c992ea98f88efd155cffd/tuf/client/updater.py#L628-L683
         # NOTE: This updater will store files under:
         # os.path.join(REPOSITORIES_DIR, REPOSITORY_DIR)
-        self.__updater = Updater(REPOSITORY_DIR, REPOSITORY_MIRRORS)
+        self.__updater = Updater(REPOSITORY_DIR, {
+            'repo': {
+                'url_prefix': repository_url_prefix,
+                'metadata_path': 'metadata.staged',
+                'targets_path': 'targets',
+                'confined_target_dirs': [''],
+            }
+        })
 
         # NOTE: Update to the latest top-level role metadata only ONCE, so that
         # we use the same consistent snapshot to download targets.

--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -54,7 +54,6 @@ logger = logging.getLogger(__name__)
 
 
 class TUFDownloader:
-
     def __init__(self, repository_url_prefix=REPOSITORY_URL_PREFIX, verbose=0):
         # 0 => 60 (effectively /dev/null)
         # 1 => 50 (CRITICAL)
@@ -81,14 +80,17 @@ class TUFDownloader:
         # https://github.com/theupdateframework/tuf/blob/aa2ab218f22d8682e03c992ea98f88efd155cffd/tuf/client/updater.py#L628-L683
         # NOTE: This updater will store files under:
         # os.path.join(REPOSITORIES_DIR, REPOSITORY_DIR)
-        self.__updater = Updater(REPOSITORY_DIR, {
-            'repo': {
-                'url_prefix': repository_url_prefix,
-                'metadata_path': 'metadata.staged',
-                'targets_path': 'targets',
-                'confined_target_dirs': [''],
-            }
-        })
+        self.__updater = Updater(
+            REPOSITORY_DIR,
+            {
+                'repo': {
+                    'url_prefix': repository_url_prefix,
+                    'metadata_path': 'metadata.staged',
+                    'targets_path': 'targets',
+                    'confined_target_dirs': [''],
+                }
+            },
+        )
 
         # NOTE: Update to the latest top-level role metadata only ONCE, so that
         # we use the same consistent snapshot to download targets.

--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -55,7 +55,6 @@ logger = logging.getLogger(__name__)
 
 class TUFDownloader:
 
-
     def __init__(self, repository_url_prefix=REPOSITORY_URL_PREFIX, verbose=0):
         # 0 => 60 (effectively /dev/null)
         # 1 => 50 (CRITICAL)

--- a/datadog_checks_downloader/tests/test_downloader.py
+++ b/datadog_checks_downloader/tests/test_downloader.py
@@ -8,12 +8,16 @@ import re
 import subprocess
 
 import requests
+import six
+
+from datadog_checks.downloader.download import REPOSITORY_URL_PREFIX
 
 log = logging.getLogger('test_downloader')
 
 
 def test_downloader():
-    r = requests.get('https://dd-integrations-core-wheels-build-stable.datadoghq.com/targets/simple/index.html')
+    index = six.moves.urllib_parse.urljoin(REPOSITORY_URL_PREFIX, 'targets/simple/index.html')
+    r = requests.get(index)
     r.raise_for_status()
 
     for line in r.text.split('\n'):


### PR DESCRIPTION
### What does this PR do?

Allow users to override TUF repository URL prefix.

### Motivation

So that you can override where the repository resides, if needed (e.g., for localhost testing).

### Additional Notes

N/A.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
