### PR TITLE
Add extra type for manifest validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -314,36 +314,16 @@ def manifest(fix, include_extras):
                     display_queue.append((echo_failure, '  required non-null sequence: categories'))
 
                 # type
-                correct_integration_type = 'check'
+                correct_integration_types = ['check', 'crawler']
                 integration_type = decoded.get('type')
                 if not integration_type or not isinstance(integration_type, string_types):
                     file_failures += 1
                     output = '  required non-null string: type'
-
-                    if fix:
-                        decoded['type'] = correct_integration_type
-
-                        display_queue.append((echo_warning, output))
-                        display_queue.append((echo_success, '  new `type`: {}'.format(correct_integration_type)))
-
-                        file_failures -= 1
-                        file_fixed = True
-                    else:
-                        display_queue.append((echo_failure, output))
-                elif integration_type != correct_integration_type:
+                    display_queue.append((echo_failure, output))
+                elif integration_type not in correct_integration_types:
                     file_failures += 1
                     output = '  invalid `type`: {}'.format(integration_type)
-
-                    if fix:
-                        decoded['type'] = correct_integration_type
-
-                        display_queue.append((echo_warning, output))
-                        display_queue.append((echo_success, '  new `type`: {}'.format(correct_integration_type)))
-
-                        file_failures -= 1
-                        file_fixed = True
-                    else:
-                        display_queue.append((echo_failure, output))
+                    display_queue.append((echo_failure, output))
 
                 # is_public
                 correct_is_public = True


### PR DESCRIPTION
### What does this PR do?

Add `crawler` to the list of types that a manifest can have. 

### Motivation

Some partner based integrations don't utilize the Agent structure and are instead more crawler based. This allows us to properly categorize those. 

### Additional Notes

The fix parameter will no longer fix the type here. Since there are multiple allowed types you can't determine which it should be. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
