### PR TITLE
Fix template for new integration to use argument as display name

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -29,16 +29,15 @@ def get_valid_templates():
 
 def construct_template_fields(integration_name, repo_choice, **kwargs):
     normalized_integration_name = normalize_package_name(integration_name)
-    check_name_cap = integration_name.capitalize() if re.match(SIMPLE_NAME, integration_name) else integration_name
-    check_name_kebab = re.sub('_| ', '-', integration_name)
+    check_name_kebab = re.sub('_| ', '-', integration_name.lower())
 
     if repo_choice == 'core':
         author = 'Datadog'
         email = 'help@datadoghq.com'
         email_packages = 'packages@datadoghq.com'
         install_info = (
-            'The {check_name_cap} check is included in the [Datadog Agent][2] package.\n'
-            'No additional installation is needed on your server.'.format(check_name_cap=check_name_cap)
+            'The {integration_name} check is included in the [Datadog Agent][2] package.\n'
+            'No additional installation is needed on your server.'.format(integration_name=integration_name)
         )
         license_header = (
             '# (C) Datadog, Inc. {year}\n'
@@ -53,7 +52,7 @@ def construct_template_fields(integration_name, repo_choice, **kwargs):
         email = email_packages = 'friend@datadog.community'
         install_info = (
             'The {} check is not included in the [Datadog Agent][2] package, so it must\n'
-            'be installed manually.'.format(check_name_cap)
+            'be installed manually.'.format(integration_name)
         )
         license_header = ''
         support_type = 'contrib'
@@ -64,7 +63,7 @@ def construct_template_fields(integration_name, repo_choice, **kwargs):
         'author': author,
         'check_class': '{}Check'.format(''.join(part.capitalize() for part in normalized_integration_name.split('_'))),
         'check_name': normalized_integration_name,
-        'check_name_cap': check_name_cap,
+        'integration_name': integration_name,
         'check_name_kebab': check_name_kebab,
         'email': email,
         'email_packages': email_packages,

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/CHANGELOG.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/CHANGELOG.md
@@ -1,2 +1,1 @@
-# CHANGELOG - {check_name_cap}
-
+# CHANGELOG - {integration_name}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/README.md
@@ -1,8 +1,8 @@
-# Agent Check: {check_name_cap}
+# Agent Check: {integration_name}
 
 ## Overview
 
-This check monitors [{check_name_cap}][1] through the Datadog Agent.
+This check monitors [{integration_name}][1] through the Datadog Agent.
 
 ## Setup
 
@@ -24,15 +24,15 @@ This check monitors [{check_name_cap}][1] through the Datadog Agent.
 
 ### Metrics
 
-{check_name_cap} does not include any metrics.
+{integration_name} does not include any metrics.
 
 ### Service Checks
 
-{check_name_cap} does not include any service checks.
+{integration_name} does not include any service checks.
 
 ### Events
 
-{check_name_cap} does not include any events.
+{integration_name} does not include any events.
 
 ## Troubleshooting
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/manifest.json
@@ -1,5 +1,5 @@
 {{
-  "display_name": "{check_name_cap}",
+  "display_name": "{integration_name}",
   "maintainer": "{email}",
   "manifest_version": "1.0.0",
   "name": "{check_name}",
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-{check_name_cap} Integration",
+  "public_title": "Datadog-{integration_name} Integration",
   "categories": [
     ""
   ],

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/setup.py
@@ -21,7 +21,7 @@ CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 setup(
     name='datadog-{check_name}',
     version=ABOUT['__version__'],
-    description='The {check_name_cap} check',
+    description='The {integration_name} check',
     long_description=long_description,
     long_description_content_type='text/markdown',
     keywords='datadog agent {check_name} check',

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/CHANGELOG.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/CHANGELOG.md
@@ -1,2 +1,1 @@
-# CHANGELOG - {check_name_cap}
-
+# CHANGELOG - {integration_name}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/README.md
@@ -1,8 +1,8 @@
-# Agent Check: {check_name_cap}
+# Agent Check: {integration_name}
 
 ## Overview
 
-This check monitors [{check_name_cap}][1].
+This check monitors [{integration_name}][1].
 
 ## Setup
 
@@ -31,15 +31,15 @@ This check monitors [{check_name_cap}][1].
 
 ### Metrics
 
-{check_name_cap} does not include any metrics.
+{integration_name} does not include any metrics.
 
 ### Service Checks
 
-{check_name_cap} does not include any service checks.
+{integration_name} does not include any service checks.
 
 ### Events
 
-{check_name_cap} does not include any events.
+{integration_name} does not include any events.
 
 ## Troubleshooting
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/manifest.json
@@ -1,5 +1,5 @@
 {{
-  "display_name": "{check_name_cap}",
+  "display_name": "{integration_name}",
   "maintainer": "{email}",
   "manifest_version": "1.0.0",
   "name": "{check_name}",
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-{check_name_cap} Integration",
+  "public_title": "Datadog-{integration_name} Integration",
   "categories": [
     ""
   ],

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/setup.py
@@ -21,7 +21,7 @@ CHECKS_BASE_REQ = 'datadog-checks-base'
 setup(
     name='datadog-{check_name}',
     version=ABOUT['__version__'],
-    description='The {check_name_cap} check',
+    description='The {integration_name} check',
     long_description=long_description,
     long_description_content_type='text/markdown',
     keywords='datadog agent {check_name} check',

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/tile/{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/tile/{check_name}/README.md
@@ -1,8 +1,8 @@
-# Agent Check: {check_name_cap}
+# Agent Check: {integration_name}
 
 ## Overview
 
-This check monitors [{check_name_cap}][1].
+This check monitors [{integration_name}][1].
 
 ## Setup
 
@@ -22,15 +22,15 @@ This check monitors [{check_name_cap}][1].
 
 ### Metrics
 
-{check_name_cap} does not include any metrics.
+{integration_name} does not include any metrics.
 
 ### Service Checks
 
-{check_name_cap} does not include any service checks.
+{integration_name} does not include any service checks.
 
 ### Events
 
-{check_name_cap} does not include any events.
+{integration_name} does not include any events.
 
 ## Troubleshooting
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/tile/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/tile/{check_name}/manifest.json
@@ -1,5 +1,5 @@
 {{
-  "display_name": "{check_name_cap}",
+  "display_name": "{integration_name}",
   "maintainer": "{email}",
   "manifest_version": "1.0.0",
   "name": "{check_name}",
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-{check_name_cap} Integration",
+  "public_title": "Datadog-{integration_name} Integration",
   "categories": [
     ""
   ],


### PR DESCRIPTION
### What does this PR do?

The argument to the command should be the display name of the integration, which is then use to generate the proper folder name and integration_id.
The `integration_id` could include capital letters, so this fixes it.
Also removes the capitalization, because I might want to name my check `vSphere` for example, starting with a lower case letter.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
