### PR TITLE
Fixed decoding warning for None tags for python2 check base class

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -813,7 +813,7 @@ class __AgentCheckPy2(object):
         if not isinstance(data, bytes):
             try:
                 return data.encode('utf-8')
-            except UnicodeError:
+            except Exception:
                 return None
 
         return data

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -789,6 +789,8 @@ class __AgentCheckPy2(object):
 
         if tags is not None:
             for tag in tags:
+                if tag is None:
+                    continue
                 encoded_tag = self._to_bytes(tag)
                 if encoded_tag is None:
                     self.log.warning(
@@ -811,7 +813,7 @@ class __AgentCheckPy2(object):
         if not isinstance(data, bytes):
             try:
                 return data.encode('utf-8')
-            except Exception:
+            except UnicodeError:
                 return None
 
         return data

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -217,8 +217,8 @@ class TestTags:
         check = AgentCheck()
         assert isinstance(check._to_bytes(b"tag:foo"), bytes)
         assert isinstance(check._to_bytes(u"tag:☣"), bytes)
-        in_str = mock.MagicMock(side_effect=UnicodeError)
-        in_str.encode.side_effect = UnicodeError
+        in_str = mock.MagicMock(side_effect=Exception)
+        in_str.encode.side_effect = Exception
         assert check._to_bytes(in_str) is None
 
     def test_none_value(self):

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -217,8 +217,8 @@ class TestTags:
         check = AgentCheck()
         assert isinstance(check._to_bytes(b"tag:foo"), bytes)
         assert isinstance(check._to_bytes(u"tag:☣"), bytes)
-        in_str = mock.MagicMock(side_effect=Exception)
-        in_str.encode.side_effect = Exception
+        in_str = mock.MagicMock(side_effect=UnicodeError)
+        in_str.encode.side_effect = UnicodeError
         assert check._to_bytes(in_str) is None
 
     def test_none_value(self):


### PR DESCRIPTION
### What does this PR do?

Complete this PR: https://github.com/DataDog/integrations-core/pull/3249 by adding the same fix but for the python2 check base class.
Updated tests and code for the `_to_bytes` method to make it more restrictive in term of exception, as in the python 3 check base class.

### Motivation

The issue was still not fixed as the version 6 of the agent will use the python 2 check base class.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
