### PR TITLE
Fix link to containerd integration metadata

### DIFF
--- a/containerd/README.md
+++ b/containerd/README.md
@@ -51,4 +51,4 @@ Need help? Contact [Datadog support][2].
 [1]: https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/dist/conf.d/containerd.d/conf.yaml.example
 [2]: https://docs.datadoghq.com/help
 [3]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#start-stop-and-restart-the-agent
-[4]: https://github.com/DataDog/integrations-core/blob/master/cri/metadata.csv
+[4]: https://github.com/DataDog/integrations-core/blob/master/containerd/metadata.csv


### PR DESCRIPTION
### What does this PR do?

It fixes the link to the integration metadata file.

### Motivation

https://docs.datadoghq.com/integrations/containerd/#metrics metadata.csv link points to the metadata of the CRI integration instead.
