### PR TITLE
Add log setup and configuration

### DIFF
--- a/jboss_wildfly/README.md
+++ b/jboss_wildfly/README.md
@@ -26,7 +26,7 @@ No additional installation is needed on your server.
 
 #### Log Collection
 
-Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
+To enable collecting logs in the Datadog Agent, update `logs_enabled` in `datadog.yaml`:
 ```
     logs_enabled: true
 ```

--- a/jboss_wildfly/README.md
+++ b/jboss_wildfly/README.md
@@ -24,6 +24,23 @@ No additional installation is needed on your server.
 
 2. [Restart the Agent][5].
 
+#### Log Collection
+
+Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
+```
+    logs_enabled: true
+```
+
+Next, edit `jboss_wildfly.d/conf.yaml` by uncommenting the `logs` lines at the bottom. Update the logs `path` with the correct path to your JBoss log files.
+
+```yaml
+logs:
+ - type: file
+   path: /opt/jboss/wildfly/standalone/log/*.log
+   source: jboss_wildfly
+   service: myapplication
+```
+
 ### Validation
 
 [Run the Agent's status subcommand][6] and look for `jboss_wildfly` under the Checks section.

--- a/jboss_wildfly/README.md
+++ b/jboss_wildfly/README.md
@@ -38,7 +38,7 @@ logs:
  - type: file
    path: /opt/jboss/wildfly/standalone/log/*.log
    source: jboss_wildfly
-   service: myapplication
+   service: <APPLICATION_NAME>
 ```
 
 ### Validation

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -232,3 +232,26 @@ init_config:
         sessionMaxAliveTime:
           alias: jboss.undertow_session.alivetime_max
           metric_type: gauge
+
+## Log Section (Available for Agent >=6.0)
+##
+## type - mandatory - Type of log input source (tcp / udp / file / windows_event)
+## port / path / channel_path - mandatory - Set port if type is tcp or udp. Set path if type is file. Set channel_path if type is windows_event
+## service - mandatory - Name of the service that generated the log
+## source  - mandatory - Attribute that defines which Integration sent the logs
+## sourcecategory - optional - Multiple value attribute. Used to refine the source attribute
+## tags: - optional - Add tags to the collected logs
+##
+## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
+##
+## JBoss/Wildfly logs are located in the log subfolder of the jboss home folder.
+#
+# logs:
+#   - type: file
+#     path: /opt/jboss/wildfly/standalone/log/*.log
+#     source: jboss_wildfly
+#     service: myapplication
+#     log_processing_rules:
+#       - type: multi_line
+#         name: log_start_with_date
+#         pattern: \d{4}-\d{2}-\d{2}

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -250,7 +250,7 @@ init_config:
 #   - type: file
 #     path: /opt/jboss/wildfly/standalone/log/*.log
 #     source: jboss_wildfly
-#     service: myapplication
+#     service: <APPLICATION_NAME>
 #     log_processing_rules:
 #       - type: multi_line
 #         name: log_start_with_date

--- a/jboss_wildfly/manifest.json
+++ b/jboss_wildfly/manifest.json
@@ -16,7 +16,8 @@
   ],
   "public_title": "Datadog-JBoss/WildFly Integration",
   "categories": [
-    "web"
+    "web",
+    "log collection"
   ],
   "type": "check",
   "integration_id": "jboss-wildfly",


### PR DESCRIPTION
This adds the default configuration, and the setup instructions, to be able to
collect JBoss/Wildfly logs.