### PR TITLE
Bump minor version of pdns_recursor 4 for tests

### DIFF
--- a/powerdns_recursor/tox.ini
+++ b/powerdns_recursor/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py37
 envlist =
-    py{27,37}-{3.7.3,4.0.3,unit}
+    py{27,37}-{3.7.3,4.0.9,unit}
 
 [testenv]
 dd_check_style = true
@@ -18,10 +18,10 @@ setenv =
   3.7.3: POWERDNS_IMAGE=datadog/docker-library:powerdns_recursor_3_7_3
   3.7.3: POWERDNS_HOST_PORT_0=18082
   3.7.3: POWERDNS_HOST_PORT_1=15353
-  4.0.3: POWERDNS_IMAGE=datadog/docker-library:powerdns_recursor_4_0_3
-  4.0.3: POWERDNS_HOST_PORT_0=28082
-  4.0.3: POWERDNS_HOST_PORT_1=25353
+  4.0.9: POWERDNS_IMAGE=datadog/docker-library:powerdns_recursor_4_0_9
+  4.0.9: POWERDNS_HOST_PORT_0=28082
+  4.0.9: POWERDNS_HOST_PORT_1=25353
 commands =
     pip install -r requirements.in
-    {3.7.3,4.0.3}: pytest -v -mintegration
+    {3.7.3,4.0.9}: pytest -v -mintegration
     unit: pytest -v -m"not integration"


### PR DESCRIPTION
### Motivation

The 4.0.3 docker image doesn't build anymore.
