### PR TITLE
Revert "Fix integration name in service check"

### DIFF
--- a/jboss_wildfly/service_checks.json
+++ b/jboss_wildfly/service_checks.json
@@ -1,7 +1,7 @@
 [
     {
         "agent_version": "6.11.0",
-        "integration":"jboss_wildfly",
+        "integration":"JBoss/WildFly",
         "groups": ["host", "instance"],
         "check": "jboss_wildfly.can_connect",
         "statuses": ["ok", "critical"],


### PR DESCRIPTION
Reverts DataDog/integrations-core#3677

The name was correct, this is what is in the consul config, not the manifest.json.