### PR TITLE
[datadog_checks_dev] update doc about style checker only works for Python 3.6+

### DIFF
--- a/datadog_checks_dev/README.md
+++ b/datadog_checks_dev/README.md
@@ -10,10 +10,17 @@
 This is the developer toolkit designed for use by any [Agent-based][5] check or
 integration repository.
 
+## Prerequisites
+
+* Python 2.7 and Python 3.7+ need to be available on your system
+* Docker to run the full test suite.
+
+Using virtualenv is recommended.
+
 ## Installation
 
 `datadog-checks-dev` is distributed on [PyPI][6] as a universal wheel
-and is available on Linux, macOS, and Windows, and supports Python 2.7/3.5+ and PyPy.
+and is available on Linux, macOS, and Windows, and supports Python 2.7/3.7+ and PyPy.
 
 ```console
 $ pip install "datadog-checks-dev[cli]"

--- a/datadog_checks_dev/README.md
+++ b/datadog_checks_dev/README.md
@@ -12,7 +12,7 @@ integration repository.
 
 ## Prerequisites
 
-* Python 2.7 and Python 3.7+ need to be available on your system.
+* Python 3.7+ needs to be available on your system. Python 2.7 is optional.
 * Docker to run the full test suite.
 
 Using a virtual environment is recommended.

--- a/datadog_checks_dev/README.md
+++ b/datadog_checks_dev/README.md
@@ -12,7 +12,7 @@ integration repository.
 
 ## Prerequisites
 
-* Python 2.7 and Python 3.7+ need to be available on your system
+* Python 2.7 and Python 3.7+ need to be available on your system.
 * Docker to run the full test suite.
 
 Using virtualenv is recommended.

--- a/datadog_checks_dev/README.md
+++ b/datadog_checks_dev/README.md
@@ -15,7 +15,7 @@ integration repository.
 * Python 2.7 and Python 3.7+ need to be available on your system.
 * Docker to run the full test suite.
 
-Using virtualenv is recommended.
+Using a virtual environment is recommended.
 
 ## Installation
 

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -42,7 +42,7 @@ def add_style_checker(config, sections, make_envconfig, reader):
     section = '{}{}'.format(tox.config.testenvprefix, STYLE_CHECK_ENV_NAME)
     sections[section] = {
         'platform': 'linux|darwin|win32',
-        # These tools only support Python 3+
+        # These tools only support Python 3.6+, more info: https://github.com/ambv/black/issues/439#issuecomment-411429907
         'basepython': 'python3',
         'skip_install': 'true',
         'deps': 'flake8\nflake8-bugbear\nblack\nisort[pyproject]>=4.3.15',
@@ -64,7 +64,7 @@ def add_style_formatter(config, sections, make_envconfig, reader):
     section = '{}{}'.format(tox.config.testenvprefix, STYLE_FORMATTER_ENV_NAME)
     sections[section] = {
         'platform': 'linux|darwin|win32',
-        # These tools only support Python 3+
+        # These tools only support Python 3.6+, more info: https://github.com/ambv/black/issues/439#issuecomment-411429907
         'basepython': 'python3',
         'skip_install': 'true',
         'deps': 'black\nisort[pyproject]>=4.3.15',

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -42,7 +42,8 @@ def add_style_checker(config, sections, make_envconfig, reader):
     section = '{}{}'.format(tox.config.testenvprefix, STYLE_CHECK_ENV_NAME)
     sections[section] = {
         'platform': 'linux|darwin|win32',
-        # These tools only support Python 3.6+, more info: https://github.com/ambv/black/issues/439#issuecomment-411429907
+        # These tools only support Python 3.6+
+        # more info: https://github.com/ambv/black/issues/439#issuecomment-411429907
         'basepython': 'python3',
         'skip_install': 'true',
         'deps': 'flake8\nflake8-bugbear\nblack\nisort[pyproject]>=4.3.15',
@@ -64,7 +65,8 @@ def add_style_formatter(config, sections, make_envconfig, reader):
     section = '{}{}'.format(tox.config.testenvprefix, STYLE_FORMATTER_ENV_NAME)
     sections[section] = {
         'platform': 'linux|darwin|win32',
-        # These tools only support Python 3.6+, more info: https://github.com/ambv/black/issues/439#issuecomment-411429907
+        # These tools only support Python 3.6+
+        # more info: https://github.com/ambv/black/issues/439#issuecomment-411429907
         'basepython': 'python3',
         'skip_install': 'true',
         'deps': 'black\nisort[pyproject]>=4.3.15',

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -65,7 +65,7 @@ def add_style_formatter(config, sections, make_envconfig, reader):
     section = '{}{}'.format(tox.config.testenvprefix, STYLE_FORMATTER_ENV_NAME)
     sections[section] = {
         'platform': 'linux|darwin|win32',
-        # These tools only support Python 3.6+
+        # These tools require Python 3.6+
         # more info: https://github.com/ambv/black/issues/439#issuecomment-411429907
         'basepython': 'python3',
         'skip_install': 'true',

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -42,7 +42,7 @@ def add_style_checker(config, sections, make_envconfig, reader):
     section = '{}{}'.format(tox.config.testenvprefix, STYLE_CHECK_ENV_NAME)
     sections[section] = {
         'platform': 'linux|darwin|win32',
-        # These tools only support Python 3.6+
+        # These tools require Python 3.6+
         # more info: https://github.com/ambv/black/issues/439#issuecomment-411429907
         'basepython': 'python3',
         'skip_install': 'true',

--- a/docs/datadog_checks_dev.cli.rst
+++ b/docs/datadog_checks_dev.cli.rst
@@ -3,6 +3,14 @@
 The Developer Toolkit
 ---------------------
 
+Prerequisites
+^^^^^^^^^^^^^
+
+* Python 3.7+ needs to be available on your system. Python 2.7 is optional.
+* Docker to run the full test suite.
+
+Using a virtual environment is recommended.
+
 Installation
 ^^^^^^^^^^^^
 .. code-block:: bash


### PR DESCRIPTION
### What does this PR do?

Add precision about style checker requirement: Python 3.6+ is required.

### Motivation

The style checker fail due to `black`. It requires Python 3.6+. 

The following error happen when using Python 3.5.

```
ERROR: Could not find a version that satisfies the requirement black (from versions: none)
ERROR: No matching distribution found for black
```

More info: https://github.com/ambv/black/issues/439#issuecomment-411429907

### Additional Notes

Should we update the requirements listed here to avoid style checker not working due to Python3.x version below 3.6 ?
 
https://github.com/DataDog/integrations-core/blame/master/datadog_checks_dev/README.md#L16

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
