### PR TITLE
Fix hdfs namenode environment

### DIFF
--- a/hdfs_namenode/tests/conftest.py
+++ b/hdfs_namenode/tests/conftest.py
@@ -19,7 +19,7 @@ def dd_environment():
         compose_file=os.path.join(HERE, "compose", "docker-compose.yaml"),
         log_patterns='Got finalize command for block pool',
     ):
-        yield
+        yield INSTANCE_INTEGRATION
 
 
 @pytest.fixture


### PR DESCRIPTION
### What does this PR do?

Fix hdfs_namenode test environment.
The environment does not start with ddev env start if nothing is yield, but the tests will be ok.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
