### PR TITLE
Adjust latency tracking in redisdb integration

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -172,7 +172,9 @@ class Redis(AgentCheck):
         start = time.time()
         try:
             info = conn.info()
+            latency_ms = round_value((time.time() - start) * 1000, 2)
             tags = sorted(tags + ["redis_role:%s" % info["role"]])
+            self.gauge('redis.info.latency_ms', latency_ms, tags=tags)
             status = AgentCheck.OK
             self.service_check('redis.can_connect', status, tags=tags)
             self._collect_metadata(info)
@@ -184,9 +186,6 @@ class Redis(AgentCheck):
             status = AgentCheck.CRITICAL
             self.service_check('redis.can_connect', status, tags=tags)
             raise
-
-        latency_ms = round_value((time.time() - start) * 1000, 2)
-        self.gauge('redis.info.latency_ms', latency_ms, tags=tags)
 
         # Save the database statistics.
         for key in info.keys():


### PR DESCRIPTION
### What does this PR do?

Tightens the scope of the redisdb latency timer

### Motivation

In my Redis monitoring, I see extremely frequent latency spikes to ~100ms (leading me to believe there's a timeout of _something_ being hit). After fairly significant investigation, I can't find any indication from Redis itself that these are genuine. That led me to believe that the latency reported was in the actual monitoring agent.

As such, this proposal reduces the amount of activity that happens inside the latency timer to just the `conn.info()` call. It at least gives me more confidence that the measured Redis latency is accurate, and not including the submission time of other metrics.

### Additional Notes

I pretty rarely write Python code, so this may not be the most "pythonic" change. Very open to style feedback! Due to the `raise`s in the error code, I do not believe other behavior will change at all.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
