### PR TITLE
Adding alias for former ddev doc

### DIFF
--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -4,6 +4,7 @@ kind: documentation
 aliases:
     - /developers/integrations/integration_sdk/
     - /developers/integrations/testing/
+    - /integrations/datadog_checks_dev/
 ---
 
 To consider an Agent-based integration complete, and thus ready to be included in the core repository and bundled with the Agent package, a number of prerequisites must be met:


### PR DESCRIPTION
### What does this PR do?

Adds an alias to avoid blank page on the former ddev page in `/integrations/`
