### PR TITLE
unit change for istio metric

### DIFF
--- a/istio/metadata.csv
+++ b/istio/metadata.csv
@@ -1,6 +1,6 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 istio.mesh.request.count,gauge,,request,,The number of requests,0,istio,request count
-istio.mesh.request.duration.count,gauge,,millisecond,,count of request durations,0,istio,request durations count
+istio.mesh.request.duration.count,gauge,,request,,count of request durations,0,istio,request durations count
 istio.mesh.request.duration.sum,gauge,,millisecond,,sum of request durations,0,istio,request durations sum
 istio.mesh.request.size.count,gauge,,request,,count of request sizes,0,istio,request sizes count
 istio.mesh.request.size.sum,gauge,,request,,sum of request sizes,0,istio,request sizes sum


### PR DESCRIPTION
### What does this PR do?

Changing unit for istio.mesh.request.duration.count following up on https://trello.com/c/Wg8frCim/1214-compute-the-average-requests-latency-for-istio-integration

### Motivation

https://trello.com/c/Wg8frCim/1214-compute-the-average-requests-latency-for-istio-integration

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
