### PR TITLE
Upgrade pyyaml to 5.1

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -47,7 +47,7 @@ python-binary-memcached==0.26.1; sys_platform != 'win32'
 python3-gearman==0.1.0; sys_platform != 'win32' and python_version > '3.0'
 pyvmomi==v6.5.0.2017.5-1
 pywin32==224; sys_platform == 'win32'
-pyyaml==3.13
+pyyaml==5.1
 redis==2.10.5
 requests==2.21.0
 requests-kerberos==0.12.0

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -3,7 +3,7 @@ kubernetes==8.0.1
 prometheus-client==0.3.0
 protobuf==3.7.0
 pywin32==224; sys_platform == 'win32'
-pyyaml==3.13
+pyyaml==5.1
 requests==2.21.0
 simplejson==3.6.5
 six==1.12.0

--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -24,7 +24,7 @@ with open(path.join(HERE, 'README.md'), 'r', encoding='utf-8') as f:
 REQUIRES = [
     'coverage>=4.5.1',
     'mock',
-    'PyYAML>=3.13',
+    'PyYAML>=5.1',
     'pytest',
     'pytest-benchmark>=3.2.1',
     'pytest-cov>=2.6.1',


### PR DESCRIPTION
### What does this PR do?

Bumps PyYaml to the latest 5.1.

### Motivation

Enable new `full_load()` option for customers perhaps wanting to use that after `load_all()` was patched for security reasons.

### Notes:

Not sure how you guys are dealing with versioning at the moment! Please enlighten me! :)

Related PRs: https://github.com/DataDog/omnibus-software/pull/311, https://github.com/DataDog/dd-agent/pull/3839