### PR TITLE
Update prometheus client to 0.6.0, handle counter metric name change

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -380,8 +380,10 @@ class OpenMetricsScraperMixin(object):
                 except Exception as err:
                     self.log.warning("Error handling metric: {} - error: {}".format(metric.name, err))
             else:
-                self.log.debug("Unable to handle metric: {0} - error: "
-                               "No handler function named '{0}' defined".format(metric.name))
+                self.log.debug(
+                    "Unable to handle metric: {0} - error: "
+                    "No handler function named '{0}' defined".format(metric.name)
+                )
         else:
             # build the wildcard list if first pass
             if scraper_config['_metrics_wildcards'] is None:

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -234,7 +234,7 @@ class OpenMetricsScraperMixin(object):
             input_gen = self._text_filter_input(input_gen, scraper_config)
 
         for metric in text_fd_to_metric_families(input_gen):
-            metric.type = scraper_config['type_overrides'].get(metric.name, metric.type)
+            metric.type = self._match_metric_in_mapping(metric, scraper_config['type_overrides']) or metric.type
             if metric.type not in self.METRIC_TYPES:
                 continue
             metric.name = self._remove_metric_prefix(metric.name, scraper_config)
@@ -301,8 +301,9 @@ class OpenMetricsScraperMixin(object):
 
     def _store_labels(self, metric, scraper_config):
         # If targeted metric, store labels
-        if metric.name in scraper_config['label_joins']:
-            matching_label = scraper_config['label_joins'][metric.name]['label_to_match']
+        join_config = self._match_metric_in_mapping(metric, scraper_config['label_joins'])
+        if join_config:
+            matching_label = join_config['label_to_match']
             for sample in metric.samples:
                 # metadata-only metrics that are used for label joins are always equal to 1
                 # this is required for metrics where all combinations of a state are sent
@@ -315,7 +316,7 @@ class OpenMetricsScraperMixin(object):
                 for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
                     if label_name == matching_label:
                         matching_value = label_value
-                    elif label_name in scraper_config['label_joins'][metric.name]['labels_to_get']:
+                    elif label_name in join_config['labels_to_get']:
                         label_dict[label_name] = label_value
                 try:
                     if scraper_config['_label_mapping'][matching_label].get(matching_value):
@@ -357,7 +358,7 @@ class OpenMetricsScraperMixin(object):
         # If targeted metric, store labels
         self._store_labels(metric, scraper_config)
 
-        if metric.name in scraper_config['ignore_metrics']:
+        if self._is_metric_in_list(metric, scraper_config['ignore_metrics']):
             return  # Ignore the metric
 
         # Filter metric to see if we can enrich with joined labels
@@ -366,31 +367,30 @@ class OpenMetricsScraperMixin(object):
         if scraper_config['_dry_run']:
             return
 
-        try:
-            self.submit_openmetric(scraper_config['metrics_mapper'][metric.name], metric, scraper_config)
-        except KeyError:
-            if metric_transformers is not None:
-                if metric.name in metric_transformers:
-                    try:
-                        # Get the transformer function for this specific metric
-                        transformer = metric_transformers[metric.name]
-                        transformer(metric, scraper_config)
-                    except Exception as err:
-                        self.log.warning("Error handling metric: {} - error: {}".format(metric.name, err))
-                else:
-                    self.log.debug(
-                        "Unable to handle metric: {0} - error: "
-                        "No handler function named '{0}' defined".format(metric.name)
-                    )
-            else:
-                # build the wildcard list if first pass
-                if scraper_config['_metrics_wildcards'] is None:
-                    scraper_config['_metrics_wildcards'] = [x for x in scraper_config['metrics_mapper'] if '*' in x]
+        mapped_name = self._match_metric_in_mapping(metric, scraper_config['metrics_mapper'])
+        if mapped_name:
+            self.submit_openmetric(mapped_name, metric, scraper_config)
+            return
 
-                # try matching wildcard (generic check)
-                for wildcard in scraper_config['_metrics_wildcards']:
-                    if fnmatchcase(metric.name, wildcard):
-                        self.submit_openmetric(metric.name, metric, scraper_config)
+        if metric_transformers is not None:
+            transformer = self._match_metric_in_mapping(metric, metric_transformers)
+            if transformer:
+                try:
+                    transformer(metric, scraper_config)
+                except Exception as err:
+                    self.log.warning("Error handling metric: {} - error: {}".format(metric.name, err))
+            else:
+                self.log.debug("Unable to handle metric: {0} - error: "
+                               "No handler function named '{0}' defined".format(metric.name))
+        else:
+            # build the wildcard list if first pass
+            if scraper_config['_metrics_wildcards'] is None:
+                scraper_config['_metrics_wildcards'] = [x for x in scraper_config['metrics_mapper'] if '*' in x]
+
+            # try matching wildcard (generic check)
+            for wildcard in scraper_config['_metrics_wildcards']:
+                if fnmatchcase(metric.name, wildcard):
+                    self.submit_openmetric(metric.name, metric, scraper_config)
 
     def poll(self, scraper_config, headers=None):
         """
@@ -622,3 +622,26 @@ class OpenMetricsScraperMixin(object):
 
     def _is_value_valid(self, val):
         return not (isnan(val) or isinf(val))
+
+    @staticmethod
+    def _match_metric_in_mapping(metric, mapping):
+        """
+        Lookup a metric name in a mapping
+        If the lookup fails for a counter metric, add `_total`suffix
+        to the metric name and perform a second lookup
+        """
+        if metric.name in mapping:
+            return mapping.get(metric.name)
+        elif metric.type == "counter":
+            return mapping.get(metric.name + "_total")
+
+    @staticmethod
+    def _is_metric_in_list(metric, name_list):
+        """
+        Lookup a metric name in a list
+        If the lookup fails for a counter metric, add `_total`suffix
+        to the metric name and perform a second lookup
+        """
+        if metric.name in name_list:
+            return True
+        return metric.type == "counter" and metric.name + "_total" in name_list

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -214,9 +214,17 @@ class PrometheusScraperMixin(object):
             for metric in text_fd_to_metric_families(input_gen):
                 metric.name = self.remove_metric_prefix(metric.name)
                 metric_name = "%s_bucket" % metric.name if metric.type == "histogram" else metric.name
-                metric_type = self.type_overrides.get(metric_name, metric.type)
+                metric_type = self._match_metric_in_mapping(metric, self.type_overrides) or metric.type
                 if metric_type == "untyped" or metric_type not in self.METRIC_TYPES:
                     continue
+
+                if metric.name in obj_map and metric.type == "counter":
+                    # we already received a metric with this name
+                    # it means "_total" was trimmed when parsing
+                    # the counter metric, we readd the "_total" to avoid
+                    # overwriting the metric in `obj_map` and `obj_help` and `messages`
+                    metric.name += "_total"
+                    metric_name += "_total"
 
                 for sample in metric.samples:
                     if (sample[0].endswith("_sum") or sample[0].endswith("_count")) and metric_type in [
@@ -400,7 +408,8 @@ class PrometheusScraperMixin(object):
 
     def store_labels(self, message):
         # If targeted metric, store labels
-        if message.name in self.label_joins:
+        join_config = self._match_metric_in_mapping(message, self.label_joins)
+        if join_config:
             matching_label = self.label_joins[message.name]['label_to_match']
             for metric in message.metric:
                 labels_list = []
@@ -408,7 +417,7 @@ class PrometheusScraperMixin(object):
                 for label in metric.label:
                     if label.name == matching_label:
                         matching_value = label.value
-                    elif label.name in self.label_joins[message.name]['labels_to_get']:
+                    elif label.name in join_config['labels_to_get']:
                         labels_list.append((label.name, label.value))
                 try:
                     self._label_mapping[matching_label][matching_value] = labels_list
@@ -448,7 +457,7 @@ class PrometheusScraperMixin(object):
         # If targeted metric, store labels
         self.store_labels(message)
 
-        if message.name in self.ignore_metrics:
+        if self._is_metric_in_list(message, self.ignore_metrics):
             return  # Ignore the metric
 
         # Filter metric to see if we can enrich with joined labels
@@ -461,15 +470,11 @@ class PrometheusScraperMixin(object):
 
         try:
             if not self._dry_run:
-                try:
-                    self._submit(
-                        self.metrics_mapper[message.name],
-                        message,
-                        send_histograms_buckets,
-                        send_monotonic_counter,
-                        custom_tags,
-                    )
-                except KeyError:
+                mapped_name = self._match_metric_in_mapping(message, self.metrics_mapper)
+                if mapped_name:
+                    self._submit(mapped_name, message, send_histograms_buckets, send_monotonic_counter, custom_tags)
+                    return
+                else:
                     if not ignore_unmapped:
                         # call magic method (non-generic check)
                         handler = getattr(self, message.name)  # Lookup will throw AttributeError if not found
@@ -701,3 +706,26 @@ class PrometheusScraperMixin(object):
     def set_prometheus_timeout(self, instance, default_value=10):
         """ extract `prometheus_timeout` directly from the instance configuration """
         self.prometheus_timeout = instance.get('prometheus_timeout', default_value)
+
+    @staticmethod
+    def _match_metric_in_mapping(metric, mapping):
+        """
+        Lookup a metric name in a mapping
+        If the lookup fails for a counter metric, add `_total`suffix
+        to the metric name and perform a second lookup
+        """
+        if metric.name in mapping:
+            return mapping.get(metric.name)
+        elif metric.type == "counter":
+            return mapping.get(metric.name + "_total")
+
+    @staticmethod
+    def _is_metric_in_list(metric, name_list):
+        """
+        Lookup a metric name in a list
+        If the lookup fails for a counter metric, add `_total`suffix
+        to the metric name and perform a second lookup
+        """
+        if metric.name in name_list:
+            return True
+        return metric.type == "counter" and metric.name + "_total" in name_list

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -28,7 +28,7 @@ openstacksdk==0.24.0
 paramiko==2.1.5
 pg8000==1.10.1
 ply==3.10
-prometheus-client==0.3.0
+prometheus-client==0.6.0
 protobuf==3.7.0
 psutil==5.6.2
 psycopg2-binary==2.8.2

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -1,6 +1,6 @@
 ddtrace==0.13.0
 kubernetes==8.0.1
-prometheus-client==0.3.0
+prometheus-client==0.6.0
 protobuf==3.7.0
 pywin32==224; sys_platform == 'win32'
 pyyaml==3.13

--- a/datadog_checks_base/tests/test_prometheus.py
+++ b/datadog_checks_base/tests/test_prometheus.py
@@ -163,7 +163,8 @@ def test_parse_metric_family_text(text_data, mocked_prometheus_check):
     assert len(messages) == 41
     # Tests correct parsing of counters
     _counter = metrics_pb2.MetricFamily()
-    _counter.name = 'skydns_skydns_dns_cachemiss_count_total'
+    # we expect the parsing function to trim `_total` from the counter metric name
+    _counter.name = 'skydns_skydns_dns_cachemiss_count'
     _counter.help = 'Counter of DNS requests that result in a cache miss.'
     _counter.type = 0  # COUNTER
     _c = _counter.metric.add()
@@ -680,7 +681,8 @@ def test_parse_one_counter(p_check):
 
     expected_etcd_metric = metrics_pb2.MetricFamily()
     expected_etcd_metric.help = "Total number of mallocs."
-    expected_etcd_metric.name = "go_memstats_mallocs_total"
+    # we expect the parsing function to trim `_total` from the counter metric name
+    expected_etcd_metric.name = "go_memstats_mallocs"
     expected_etcd_metric.type = 0
     expected_etcd_metric.metric.add().counter.value = 18713
 

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -334,9 +334,9 @@ def test_prometheus_filtering(monkeypatch, aggregator):
         mock_method.assert_called_once()
         metric = mock_method.call_args[0][0]
         assert len(metric.samples) == 12
-        for name, labels, _ in metric.samples:
-            assert name == "container_cpu_usage_seconds_total"
-            assert labels["pod_name"] != ""
+        for s in metric.samples:
+            assert s.name == "container_cpu_usage_seconds_total"
+            assert s.labels["pod_name"] != ""
 
 
 def test_kubelet_check_instance_config(monkeypatch):


### PR DESCRIPTION
follow up on https://github.com/DataDog/integrations-core/pull/3443

### What does this PR do?
Like summaries and histogram types have their `_sum` / `_bucket` / `_count` timeseries aggregated in a single metric using the trimmed name, versions 0.4.0+ of the python prometheus/openmetrics client trim the `_total` suffix out of counter metric names.

This is a breaking change for us, as integration and custom checks should change their configuration to refer to counter metrics with the new shorter metric name.

This PR introduces a compatibility layer to make this transition transparent. When looking up a metric name in one of the scraper_config's map/list, the following happens:

the lookup is attempted with the current (possibly trimmed) name
if the lookup fails and the metric is a counter, a second lookup is attempted, adding the `_total` suffix to the metric name.
If we go this route, the prometheus mixin should also be updated, as it uses the same client lib.

#### Other changes:
kubelet/tests/test_kubelet.py : update a test that is accessing internals of the Sample object

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
