### PR TITLE
Improve resiliency of logging initialization phase

### DIFF
--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -2,7 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
-from six import text_type, PY2
+
+from six import PY2, text_type
 
 from .utils.common import to_string
 
@@ -56,10 +57,7 @@ def _get_py_loglevel(lvl):
     """
     # In Python2, transform the unicode object into plain string with utf-8 encoding
     if PY2 and isinstance(lvl, text_type):
-        try:
-            lvl = lvl.encode('utf-8')
-        except UnicodeError:
-            lvl = ''
+        lvl = lvl.encode('ascii', 'ignore')
 
     # Be resilient to bad input since `lvl` comes from a configuration file
     try:

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
-from six import text_type, string_types, PY2
+from six import text_type, PY2
 
 from .utils.common import to_string
 

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -55,7 +55,7 @@ def _get_py_loglevel(lvl):
     """
     Map log levels to strings
     """
-    # In Python2, transform the unicode object into plain string with utf-8 encoding
+    # In Python2, transform the unicode object into plain string
     if PY2 and isinstance(lvl, text_type):
         lvl = lvl.encode('ascii', 'ignore')
 

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
+from six import text_type, string_types, PY2
 
 from .utils.common import to_string
 
@@ -53,10 +54,21 @@ def _get_py_loglevel(lvl):
     """
     Map log levels to strings
     """
-    if not lvl:
-        lvl = 'INFO'
+    # In Python2, transform the unicode object into plain string with utf-8 encoding
+    if PY2 and isinstance(lvl, text_type):
+        try:
+            lvl = lvl.encode('utf-8')
+        except UnicodeError:
+            lvl = ''
 
-    return LOG_LEVEL_MAP.get(lvl.upper(), logging.DEBUG)
+    # Be resilient to bad input since `lvl` comes from a configuration file
+    try:
+        lvl = lvl.upper()
+    except AttributeError:
+        lvl = ''
+
+    # if `lvl` is not a valid level string, let it fall back to default logging value
+    return LOG_LEVEL_MAP.get(lvl, logging.INFO)
 
 
 def init_logging():

--- a/datadog_checks_base/tests/test_log.py
+++ b/datadog_checks_base/tests/test_log.py
@@ -11,7 +11,7 @@ from datadog_checks import log
 def test_get_py_loglevel():
     # default value for invalid input
     assert log._get_py_loglevel(None) == logging.INFO
-    # default value for invalid unicode input
+    # default value for valid unicode input encoding into an invalid key
     assert log._get_py_loglevel(u'dèbùg') == logging.INFO
     # check unicode works
     assert log._get_py_loglevel(u'crit') == logging.CRITICAL

--- a/datadog_checks_base/tests/test_log.py
+++ b/datadog_checks_base/tests/test_log.py
@@ -1,11 +1,19 @@
+# -*- coding: utf-8 -*-
+
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import logging
+
 from datadog_checks import log
 
 
 def test_get_py_loglevel():
-    """
-    Ensure function _get_py_loglevel is exposed
-    """
-    assert getattr(log, "_get_py_loglevel", None) is not None
+    # default value for invalid input
+    assert log._get_py_loglevel(None) == logging.INFO
+    # default value for invalid unicode input
+    assert log._get_py_loglevel(u'dèbùg') == logging.INFO
+    # check unicode works
+    assert log._get_py_loglevel(u'crit') == logging.CRITICAL
+    # check string works
+    assert log._get_py_loglevel('crit') == logging.CRITICAL


### PR DESCRIPTION
### What does this PR do?

1. encode the string when in Python2 and the input is unicode (this will be the normal case in Agent 6.12)
2. assume the input can be bogus since parameter is read from a config file
3. make the fallback case consistent (we now have 2 different defaults)

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
