### PR TITLE
allow blacklisting of strings

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -218,7 +218,7 @@ class OpenMetricsScraperMixin(object):
         # List of strings to filter the input text payload on. If any line contains
         # one of these strings, it will be filtered out before being parsed.
         # INTERNAL FEATURE, might be removed in future versions
-        config['_text_filter_blacklist'] = []
+        config['_text_filter_blacklist'] = instance.get('_text_filter_blacklist', [])
 
         return config
 


### PR DESCRIPTION
### What does this PR do?

Allows `_text_filter_blacklist` to be configured via an integration's config file.

### Motivation

Initially derived from a support case. From the output of nginx-ingress-controller's `/metrics` endpoint, a majority of the metrics were histogram types. At the current moment, we neither pull in the exposed histograms as Datadog metrics nor do we filter them out. This means that the agent is doing unnecessary heavy lifting. Allowing the user to blacklist a string such as `"_bucket"` will allow the check to run quicker, and overall reduce the impact on the core agent. 

Testing this with an nginx-ingress metrics.txt output of approximately >18MB, where we simply added the config of `_text_filter_blacklist: ["_bucket"]`. Note the avg execution times:

Before:
```sh
    nginx_ingress_controller (1.0.0)
    --------------------------------
      Instance ID: nginx_ingress_controller:c1a1fca2d5895b4c [OK]
      Total Runs: 15
      Metric Samples: Last Run: 90, Total: 1,350
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 15
      Average Execution Time : 1.623s
```
After:
```sh
    nginx_ingress_controller (1.0.0)
    --------------------------------
      Instance ID: nginx_ingress_controller:9a73d0807f99b501 [OK]
      Total Runs: 4
      Metric Samples: Last Run: 90, Total: 360
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 4
      Average Execution Time : 333ms
```
### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
