### PR TITLE
Add e2e tests for openmetrics integration

### DIFF
--- a/openmetrics/tests/common.py
+++ b/openmetrics/tests/common.py
@@ -1,0 +1,1 @@
+CHECK_NAME = 'openmetrics'

--- a/openmetrics/tests/compose/config/prometheus.yml
+++ b/openmetrics/tests/compose/config/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 1s
+  evaluation_interval: 1s
+
+alerting:
+  alertmanagers:
+  - static_configs:
+    - targets:
+
+rule_files:
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']

--- a/openmetrics/tests/compose/docker-compose.yaml
+++ b/openmetrics/tests/compose/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  openmetrics:
+    image: prom/prometheus
+    volumes:
+     - ./config:/etc/prometheus
+    ports:
+     - 9090:9090

--- a/openmetrics/tests/conftest.py
+++ b/openmetrics/tests/conftest.py
@@ -1,0 +1,55 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import os
+
+import mock
+import pytest
+from prometheus_client import CollectorRegistry, Counter, Gauge, generate_latest
+
+from datadog_checks.base import ensure_unicode
+from datadog_checks.dev import docker_run, get_docker_hostname
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+HOST = get_docker_hostname()
+
+INSTANCE = {
+    'prometheus_url': 'http://{}:9090/metrics'.format(HOST),
+    'namespace': 'openmetrics',
+    'metrics': [{'prometheus_target_interval_length_seconds': 'target_interval_seconds'}, 'go_memstats_mallocs_total'],
+}
+
+
+@pytest.fixture(scope="session")
+def dd_environment():
+    compose_file = os.path.join(HERE, 'compose', 'docker-compose.yaml')
+    log_patterns = ['Server is ready to receive web requests']
+
+    with docker_run(compose_file, log_patterns=log_patterns, sleep=10):
+        yield INSTANCE
+
+
+@pytest.fixture
+def poll_mock():
+    registry = CollectorRegistry()
+    g1 = Gauge('metric1', 'processor usage', ['matched_label', 'node', 'flavor'], registry=registry)
+    g1.labels(matched_label="foobar", node="host1", flavor="test").set(99.9)
+    g2 = Gauge('metric2', 'memory usage', ['matched_label', 'node', 'timestamp'], registry=registry)
+    g2.labels(matched_label="foobar", node="host2", timestamp="123").set(12.2)
+    c1 = Counter('counter1', 'hits', ['node'], registry=registry)
+    c1.labels(node="host2").inc(42)
+    g3 = Gauge('metric3', 'memory usage', ['matched_label', 'node', 'timestamp'], registry=registry)
+    g3.labels(matched_label="foobar", node="host2", timestamp="456").set(float('inf'))
+
+    poll_mock_patch = mock.patch(
+        'requests.get',
+        return_value=mock.MagicMock(
+            status_code=200,
+            iter_lines=lambda **kwargs: ensure_unicode(generate_latest(registry)).split("\n"),
+            headers={'Content-Type': "text/plain"},
+        ),
+    )
+    with poll_mock_patch:
+        yield

--- a/openmetrics/tests/conftest.py
+++ b/openmetrics/tests/conftest.py
@@ -9,16 +9,21 @@ import pytest
 from prometheus_client import CollectorRegistry, Counter, Gauge, generate_latest
 
 from datadog_checks.base import ensure_unicode
-from datadog_checks.dev import docker_run, get_docker_hostname
+from datadog_checks.dev import docker_run, get_docker_hostname, get_here
 
-HERE = os.path.dirname(os.path.abspath(__file__))
+HERE = get_here()
 
 HOST = get_docker_hostname()
 
 INSTANCE = {
     'prometheus_url': 'http://{}:9090/metrics'.format(HOST),
     'namespace': 'openmetrics',
-    'metrics': [{'prometheus_target_interval_length_seconds': 'target_interval_seconds'}, 'go_memstats_mallocs_total'],
+    'metrics': [
+        {'prometheus_target_interval_length_seconds': 'target_interval_seconds'},  # summary
+        {'prometheus_http_request_duration_seconds': 'http_req_duration_seconds'},  # histogram
+        'go_memstats_mallocs_total',  # counter
+        'go_memstats_alloc_bytes',  # gauge
+    ],
 }
 
 

--- a/openmetrics/tests/test_integration.py
+++ b/openmetrics/tests/test_integration.py
@@ -1,0 +1,19 @@
+import pytest
+
+from datadog_checks.openmetrics import OpenMetricsCheck
+
+from .common import CHECK_NAME
+
+
+@pytest.mark.integration
+def test_integration(aggregator, dd_environment):
+    c = OpenMetricsCheck('openmetrics', None, {}, [dd_environment])
+    c.check(dd_environment)
+    aggregator.assert_metric(CHECK_NAME + '.target_interval_seconds.sum', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric(CHECK_NAME + '.target_interval_seconds.count', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric(CHECK_NAME + '.target_interval_seconds.quantile', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric(CHECK_NAME + '.go_memstats_mallocs_total', metric_type=aggregator.MONOTONIC_COUNT)
+    aggregator.assert_metric(CHECK_NAME + '.go_memstats_alloc_bytes', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric(CHECK_NAME + '.http_req_duration_seconds.count', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric(CHECK_NAME + '.http_req_duration_seconds.sum', metric_type=aggregator.GAUGE)
+    aggregator.assert_all_metrics_covered()

--- a/openmetrics/tests/test_openmetrics.py
+++ b/openmetrics/tests/test_openmetrics.py
@@ -6,8 +6,9 @@ import pytest
 
 from datadog_checks.openmetrics import OpenMetricsCheck
 
-CHECK_NAME = 'openmetrics'
-NAMESPACE = 'openmetrics'
+from .common import CHECK_NAME
+
+pytestmark = pytest.mark.usefixtures("poll_mock")
 
 instance = {
     'prometheus_url': 'http://localhost:10249/metrics',
@@ -18,7 +19,6 @@ instance = {
 }
 
 
-@pytest.mark.usefixtures("poll_mock")
 def test_openmetrics_check(aggregator):
     c = OpenMetricsCheck('openmetrics', None, {}, [instance])
     c.check(instance)
@@ -36,7 +36,6 @@ def test_openmetrics_check(aggregator):
     aggregator.assert_all_metrics_covered()
 
 
-@pytest.mark.usefixtures("poll_mock")
 def test_openmetrics_check_counter_gauge(aggregator):
     instance['send_monotonic_counter'] = False
     c = OpenMetricsCheck('openmetrics', None, {}, [instance])
@@ -55,7 +54,6 @@ def test_openmetrics_check_counter_gauge(aggregator):
     aggregator.assert_all_metrics_covered()
 
 
-@pytest.mark.usefixtures("poll_mock")
 def test_invalid_metric(aggregator):
     """
     Testing that invalid values of metrics are discarded
@@ -71,7 +69,6 @@ def test_invalid_metric(aggregator):
     assert aggregator.metrics('metric3') == []
 
 
-@pytest.mark.usefixtures("poll_mock")
 def test_openmetrics_wildcard(aggregator):
     instance_wildcard = {
         'prometheus_url': 'http://localhost:10249/metrics',
@@ -94,7 +91,6 @@ def test_openmetrics_wildcard(aggregator):
     aggregator.assert_all_metrics_covered()
 
 
-@pytest.mark.usefixtures("poll_mock")
 def test_openmetrics_default_instance(aggregator):
     """
     Testing openmetrics with default instance
@@ -128,7 +124,6 @@ def test_openmetrics_default_instance(aggregator):
     aggregator.assert_all_metrics_covered()
 
 
-@pytest.mark.usefixtures("poll_mock")
 def test_openmetrics_mixed_instance(aggregator):
     c = OpenMetricsCheck(
         CHECK_NAME,
@@ -176,18 +171,4 @@ def test_openmetrics_mixed_instance(aggregator):
         tags=['extra:foo', 'matched_label:foobar', 'timestamp:123', 'node:host2'],
         metric_type=aggregator.GAUGE,
     )
-    aggregator.assert_all_metrics_covered()
-
-
-@pytest.mark.integration
-def test_integration(aggregator, dd_environment):
-    c = OpenMetricsCheck('openmetrics', None, {}, [dd_environment])
-    c.check(dd_environment)
-    aggregator.assert_metric(CHECK_NAME + '.target_interval_seconds.sum', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric(CHECK_NAME + '.target_interval_seconds.count', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric(CHECK_NAME + '.target_interval_seconds.quantile', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric(CHECK_NAME + '.go_memstats_mallocs_total', metric_type=aggregator.MONOTONIC_COUNT)
-    aggregator.assert_metric(CHECK_NAME + '.go_memstats_alloc_bytes', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric(CHECK_NAME + '.http_req_duration_seconds.count', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric(CHECK_NAME + '.http_req_duration_seconds.sum', metric_type=aggregator.GAUGE)
     aggregator.assert_all_metrics_covered()

--- a/openmetrics/tests/test_openmetrics.py
+++ b/openmetrics/tests/test_openmetrics.py
@@ -187,4 +187,7 @@ def test_integration(aggregator, dd_environment):
     aggregator.assert_metric(CHECK_NAME + '.target_interval_seconds.count', metric_type=aggregator.GAUGE)
     aggregator.assert_metric(CHECK_NAME + '.target_interval_seconds.quantile', metric_type=aggregator.GAUGE)
     aggregator.assert_metric(CHECK_NAME + '.go_memstats_mallocs_total', metric_type=aggregator.MONOTONIC_COUNT)
+    aggregator.assert_metric(CHECK_NAME + '.go_memstats_alloc_bytes', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric(CHECK_NAME + '.http_req_duration_seconds.count', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric(CHECK_NAME + '.http_req_duration_seconds.sum', metric_type=aggregator.GAUGE)
     aggregator.assert_all_metrics_covered()

--- a/openmetrics/tox.ini
+++ b/openmetrics/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py37
 envlist =
-    py{27,37}-openmetrics
+    py{27,37}-{unit,integration}
 
 [testenv]
 dd_check_style = true
@@ -17,4 +17,5 @@ passenv =
     COMPOSE*
 commands =
     pip install -r requirements.in
-    pytest -v
+    unit: pytest -m"not integration" -v
+    integration: pytest -m"integration" -v


### PR DESCRIPTION
### What does this PR do?

This PR adds e2e tests to the openmetrics integration.

### Motivation

e2e are being added to all integrations.

### Additional Notes

The testing here is very similar to what we already do with the prometheus integration.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
