### PR TITLE
Fix prometheus/openmetrics type override values

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -813,7 +813,7 @@ class __AgentCheckPy2(object):
         if not isinstance(data, bytes):
             try:
                 return data.encode('utf-8')
-            except UnicodeError:
+            except Exception:
                 return None
 
         return data

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -789,6 +789,8 @@ class __AgentCheckPy2(object):
 
         if tags is not None:
             for tag in tags:
+                if tag is None:
+                    continue
                 encoded_tag = self._to_bytes(tag)
                 if encoded_tag is None:
                     self.log.warning(
@@ -811,7 +813,7 @@ class __AgentCheckPy2(object):
         if not isinstance(data, bytes):
             try:
                 return data.encode('utf-8')
-            except Exception:
+            except UnicodeError:
                 return None
 
         return data

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -217,8 +217,8 @@ class TestTags:
         check = AgentCheck()
         assert isinstance(check._to_bytes(b"tag:foo"), bytes)
         assert isinstance(check._to_bytes(u"tag:☣"), bytes)
-        in_str = mock.MagicMock(side_effect=UnicodeError)
-        in_str.encode.side_effect = UnicodeError
+        in_str = mock.MagicMock(side_effect=Exception)
+        in_str.encode.side_effect = Exception
         assert check._to_bytes(in_str) is None
 
     def test_none_value(self):

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -217,8 +217,8 @@ class TestTags:
         check = AgentCheck()
         assert isinstance(check._to_bytes(b"tag:foo"), bytes)
         assert isinstance(check._to_bytes(u"tag:☣"), bytes)
-        in_str = mock.MagicMock(side_effect=Exception)
-        in_str.encode.side_effect = Exception
+        in_str = mock.MagicMock(side_effect=UnicodeError)
+        in_str.encode.side_effect = UnicodeError
         assert check._to_bytes(in_str) is None
 
     def test_none_value(self):

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -54,9 +54,9 @@ instances:
     #   flavor: origin
 
     ## @param type_overrides - list of key:value elements - optional
-    ## Type override allows you to override a type in the prometheus the payload
+    ## Type override allows you to override a type in the prometheus payload
     ## or type an untyped metrics (they're ignored by default)
-    ## Supported <METRIC_TYPE> are `gauge`, `count`, `rate`
+    ## Supported <METRIC_TYPE> are `gauge`, `counter`, `summary`, `histogram`
     #
     # type_overrides:
     #   <METRIC_NAME>: <METRIC_TYPE>

--- a/prometheus/datadog_checks/prometheus/data/conf.yaml.example
+++ b/prometheus/datadog_checks/prometheus/data/conf.yaml.example
@@ -53,9 +53,9 @@ instances:
     #   flavor: origin
 
     ## @param type_overrides - list of key:value element - optional
-    ## Type override allows you to override a type in the prometheus the payload
+    ## Type override allows you to override a type in the prometheus payload
     ## or type an untyped metrics (they're ignored by default)
-    ## Supported <METRIC_TYPE> are `gauge`, `count`, `rate`
+    ## Supported <METRIC_TYPE> are `gauge`, `counter`, `summary`, `histogram`
     #
     # type_overrides:
     #   <METRIC_NAME>: <METRIC_TYPE>


### PR DESCRIPTION
### What does this PR do?

This PR changes the override types supported in the conf.yaml, as the correct ones are here: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L33
If the override type is not in this list, the metric won't be sent: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L238-L239

### Motivation

A customer reported that the override wasn't working with the type `count` as specified in the config.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
