### PR TITLE
Fix type override values in example config

### DIFF
--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -54,9 +54,9 @@ instances:
     #   flavor: origin
 
     ## @param type_overrides - list of key:value elements - optional
-    ## Type override allows you to override a type in the prometheus the payload
+    ## Type override allows you to override a type in the prometheus payload
     ## or type an untyped metrics (they're ignored by default)
-    ## Supported <METRIC_TYPE> are `gauge`, `count`, `rate`
+    ## Supported <METRIC_TYPE> are `gauge`, `counter`, `histogram`, `summary`
     #
     # type_overrides:
     #   <METRIC_NAME>: <METRIC_TYPE>

--- a/prometheus/datadog_checks/prometheus/data/conf.yaml.example
+++ b/prometheus/datadog_checks/prometheus/data/conf.yaml.example
@@ -53,9 +53,9 @@ instances:
     #   flavor: origin
 
     ## @param type_overrides - list of key:value element - optional
-    ## Type override allows you to override a type in the prometheus the payload
+    ## Type override allows you to override a type in the prometheus payload
     ## or type an untyped metrics (they're ignored by default)
-    ## Supported <METRIC_TYPE> are `gauge`, `count`, `rate`
+    ## Supported <METRIC_TYPE> are `gauge`, `counter`, `histogram`, `summary`
     #
     # type_overrides:
     #   <METRIC_NAME>: <METRIC_TYPE>


### PR DESCRIPTION
### What does this PR do?

This PR changes the override types supported in the `conf.yaml`, as the correct ones are here: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L33
If the override type is not in this list, the metric won't be sent: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L238-L239

### Motivation

A customer reported that the override wasn't working with the type `count` as specified in the config.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
