### PR TITLE
Add easier namespacing for data submission

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -290,7 +290,9 @@ class __AgentCheckPy3(object):
         else:
             message = ensure_unicode(message)
 
-        aggregator.submit_service_check(self, self.check_id, self._format_namespace(name), status, tags, hostname, message)
+        aggregator.submit_service_check(
+            self, self.check_id, self._format_namespace(name), status, tags, hostname, message
+        )
 
     def event(self, event):
         # Enforce types of some fields, considerably facilitates handling in go bindings downstream
@@ -698,7 +700,9 @@ class __AgentCheckPy2(object):
         else:
             message = ensure_bytes(message)
 
-        aggregator.submit_service_check(self, self.check_id, self._format_namespace(name), status, tags, hostname, message)
+        aggregator.submit_service_check(
+            self, self.check_id, self._format_namespace(name), status, tags, hostname, message
+        )
 
     def event(self, event):
         # Enforce types of some fields, considerably facilitates handling in go bindings downstream

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -100,6 +100,14 @@ class TestMetricNormalization:
 
 
 class TestMetrics:
+    def test_namespace(self, aggregator):
+        check = AgentCheck()
+        check.__NAMESPACE__ = 'test'
+
+        check.gauge('metric', 0)
+
+        aggregator.assert_metric('test.metric')
+
     def test_non_float_metric(self, aggregator):
         check = AgentCheck()
         metric_name = 'test_metric'
@@ -120,6 +128,19 @@ class TestEvents:
         }
         check.event(event)
         aggregator.assert_event('test event test event')
+
+    def test_namespace(self, aggregator):
+        check = AgentCheck()
+        check.__NAMESPACE__ = 'test'
+        event = {
+            'event_type': 'new.event',
+            'msg_title': 'new test event',
+            'aggregation_key': 'test.event',
+            'msg_text': 'test event test event',
+            'tags': None,
+        }
+        check.event(event)
+        aggregator.assert_event('test event test event', source_type_name='test')
 
 
 class TestServiceChecks:
@@ -146,6 +167,13 @@ class TestServiceChecks:
 
         check.service_check("testservicecheckwithnonemessage", AgentCheck.OK, message=None)
         aggregator.assert_service_check("testservicecheckwithnonemessage", status=AgentCheck.OK)
+
+    def test_namespace(self, aggregator):
+        check = AgentCheck()
+        check.__NAMESPACE__ = 'test'
+
+        check.service_check('service_check', AgentCheck.OK)
+        aggregator.assert_service_check('test.service_check', status=AgentCheck.OK)
 
 
 class TestTags:


### PR DESCRIPTION
### Motivation

Remove the need to perform string formatting throughout every check, see for example https://github.com/DataDog/integrations-core/blob/d3931adfe50ba0f4429bbca5ea3a288a75b2424e/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py#L85

I'll be using this for the integration I'm currently working on