### PR TITLE
Use configuration user for pgsql activity metric (#3439)

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -292,7 +292,7 @@ SELECT s.schemaname,
     ACTIVITY_METRICS_9_6 = [
         "SUM(CASE WHEN xact_start IS NOT NULL THEN 1 ELSE 0 END)",
         "SUM(CASE WHEN state = 'idle in transaction' THEN 1 ELSE 0 END)",
-        "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{datadog_user}'))"
+        "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{dd__user}'))"
         "THEN 1 ELSE null END )",
         "COUNT(CASE WHEN wait_event is NOT NULL AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
     ]
@@ -301,7 +301,7 @@ SELECT s.schemaname,
     ACTIVITY_METRICS_9_2 = [
         "SUM(CASE WHEN xact_start IS NOT NULL THEN 1 ELSE 0 END)",
         "SUM(CASE WHEN state = 'idle in transaction' THEN 1 ELSE 0 END)",
-        "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{datadog_user}'))"
+        "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{dd__user}'))"
         "THEN 1 ELSE null END )",
         "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
     ]
@@ -310,7 +310,7 @@ SELECT s.schemaname,
     ACTIVITY_METRICS_8_3 = [
         "SUM(CASE WHEN xact_start IS NOT NULL THEN 1 ELSE 0 END)",
         "SUM(CASE WHEN current_query LIKE '<IDLE> in transaction' THEN 1 ELSE 0 END)",
-        "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{datadog_user}'))"
+        "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{dd__user}'))"
         "THEN 1 ELSE null END )",
         "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
     ]
@@ -319,7 +319,7 @@ SELECT s.schemaname,
     ACTIVITY_METRICS_LT_8_3 = [
         "SUM(CASE WHEN query_start IS NOT NULL THEN 1 ELSE 0 END)",
         "SUM(CASE WHEN current_query LIKE '<IDLE> in transaction' THEN 1 ELSE 0 END)",
-        "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{datadog_user}'))"
+        "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{dd__user}'))"
         "THEN 1 ELSE null END )",
         "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
     ]
@@ -629,7 +629,10 @@ GROUP BY datid, datname
             else:
                 metrics_query = self.ACTIVITY_METRICS_LT_8_3
 
-            metrics_query = [q.format(datadog_user=user) if 'datadog_user' in q else q for q in metrics_query]
+            for i, q in enumerate(metrics_query):
+                if '{dd__user}' in q:
+                    metrics_query[i] = q.format(dd__user=user)
+
             metrics = {k: v for k, v in zip(metrics_query, self.ACTIVITY_DD_METRICS)}
             self.activity_metrics[key] = (metrics, query)
         else:

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -292,7 +292,7 @@ SELECT s.schemaname,
     ACTIVITY_METRICS_9_6 = [
         "SUM(CASE WHEN xact_start IS NOT NULL THEN 1 ELSE 0 END)",
         "SUM(CASE WHEN state = 'idle in transaction' THEN 1 ELSE 0 END)",
-        "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', 'datadog'))"
+        "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{datadog_user}'))"
         "THEN 1 ELSE null END )",
         "COUNT(CASE WHEN wait_event is NOT NULL AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
     ]
@@ -301,7 +301,7 @@ SELECT s.schemaname,
     ACTIVITY_METRICS_9_2 = [
         "SUM(CASE WHEN xact_start IS NOT NULL THEN 1 ELSE 0 END)",
         "SUM(CASE WHEN state = 'idle in transaction' THEN 1 ELSE 0 END)",
-        "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', 'datadog'))"
+        "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{datadog_user}'))"
         "THEN 1 ELSE null END )",
         "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
     ]
@@ -310,7 +310,7 @@ SELECT s.schemaname,
     ACTIVITY_METRICS_8_3 = [
         "SUM(CASE WHEN xact_start IS NOT NULL THEN 1 ELSE 0 END)",
         "SUM(CASE WHEN current_query LIKE '<IDLE> in transaction' THEN 1 ELSE 0 END)",
-        "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', 'datadog'))"
+        "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{datadog_user}'))"
         "THEN 1 ELSE null END )",
         "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
     ]
@@ -319,7 +319,7 @@ SELECT s.schemaname,
     ACTIVITY_METRICS_LT_8_3 = [
         "SUM(CASE WHEN query_start IS NOT NULL THEN 1 ELSE 0 END)",
         "SUM(CASE WHEN current_query LIKE '<IDLE> in transaction' THEN 1 ELSE 0 END)",
-        "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', 'datadog'))"
+        "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{datadog_user}'))"
         "THEN 1 ELSE null END )",
         "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
     ]
@@ -610,7 +610,7 @@ GROUP BY datid, datname
             metrics = self.replication_metrics.get(key)
         return metrics
 
-    def _get_activity_metrics(self, key, db):
+    def _get_activity_metrics(self, key, db, user):
         """ Use ACTIVITY_METRICS_LT_8_3 or ACTIVITY_METRICS_8_3 or ACTIVITY_METRICS_9_2
         depending on the postgres version in conjunction with ACTIVITY_QUERY_10 or ACTIVITY_QUERY_LT_10.
         Uses a dictionnary to save the result for each instance
@@ -629,6 +629,7 @@ GROUP BY datid, datname
             else:
                 metrics_query = self.ACTIVITY_METRICS_LT_8_3
 
+            metrics_query = [q.format(datadog_user=user) if 'datadog_user' in q else q for q in metrics_query]
             metrics = {k: v for k, v in zip(metrics_query, self.ACTIVITY_DD_METRICS)}
             self.activity_metrics[key] = (metrics, query)
         else:
@@ -760,6 +761,7 @@ GROUP BY datid, datname
         self,
         key,
         db,
+        user,
         instance_tags,
         relations,
         custom_metrics,
@@ -818,7 +820,7 @@ GROUP BY datid, datname
             )
 
             if collect_activity_metrics:
-                activity_metrics = self._get_activity_metrics(key, db)
+                activity_metrics = self._get_activity_metrics(key, db, user)
                 self._query_scope(
                     cursor, activity_metrics, key, db, instance_tags, False, programming_error, relations_config
                 )
@@ -1063,6 +1065,7 @@ GROUP BY datid, datname
             self._collect_stats(
                 key,
                 db,
+                user,
                 tags,
                 relations,
                 custom_metrics,
@@ -1081,6 +1084,7 @@ GROUP BY datid, datname
             self._collect_stats(
                 key,
                 db,
+                user,
                 tags,
                 relations,
                 custom_metrics,


### PR DESCRIPTION
Instead of hardcoding the excluded user to 'datadog',
use the actual configuration value to be excluded.

### What does this PR do?

Update the ACTIVITY Metric query to exclude the actual 'datadog' user configured in the configuration file instead of the hardcoded 'datadog' string.

### Motivation

This allows the user of the datadog monitoring tool for postgres to use an existing 'monitoring' user (like db_monitor, or something) instead of 'datadog' and continue to get the same accurate values.

### Additional Notes

Not really

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
