### PR TITLE
add useful prometheus labels to metric tags

### DIFF
--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -264,11 +264,14 @@ class CadvisorPrometheusScraperMixin(object):
                 # metric.Clear()  # Ignore this metric message
         return seen
 
-    def _process_container_metric(self, type, metric_name, metric, scraper_config):
+    def _process_container_metric(self, type, metric_name, metric, scraper_config, labels=None):
         """
         Takes a simple metric about a container, reports it as a rate or gauge.
         If several series are found for a given container, values are summed before submission.
         """
+        if labels is None:
+            labels = []
+
         if metric.type not in METRIC_TYPES:
             self.log.error("Metric type %s unsupported for metric %s" % (metric.type, metric.name))
             return
@@ -290,6 +293,11 @@ class CadvisorPrometheusScraperMixin(object):
                 tags += self._get_kube_container_name(sample[self.SAMPLE_LABELS])
                 tags = list(set(tags))
 
+            for label in labels:
+                value = sample[self.SAMPLE_LABELS][label]
+                if value != '':
+                    tags.append('%s:%s' % (label, value))
+
             val = sample[self.SAMPLE_VALUE]
 
             if "rate" == type:
@@ -297,11 +305,14 @@ class CadvisorPrometheusScraperMixin(object):
             elif "gauge" == type:
                 self.gauge(metric_name, val, tags)
 
-    def _process_pod_rate(self, metric_name, metric, scraper_config):
+    def _process_pod_rate(self, metric_name, metric, scraper_config, labels=None):
         """
         Takes a simple metric about a pod, reports it as a rate.
         If several series are found for a given pod, values are summed before submission.
         """
+        if labels is None:
+            labels = []
+
         if metric.type not in METRIC_TYPES:
             self.log.error("Metric type %s unsupported for metric %s" % (metric.type, metric.name))
             return
@@ -312,15 +323,22 @@ class CadvisorPrometheusScraperMixin(object):
                 continue
             tags = tagger.tag('kubernetes_pod://%s' % pod_uid, tagger.HIGH)
             tags += scraper_config['custom_tags']
+            for label in labels:
+                value = sample[self.SAMPLE_LABELS][label]
+                if value != '':
+                    tags.append('%s:%s' % (label, value))
             val = sample[self.SAMPLE_VALUE]
             self.rate(metric_name, val, tags)
 
-    def _process_usage_metric(self, m_name, metric, cache, scraper_config):
+    def _process_usage_metric(self, m_name, metric, cache, scraper_config, labels=None):
         """
         Takes a metric object, a metric name, and a cache dict where it will store
         container_name --> (value, tags) so that _process_limit_metric can compute usage_pct
         it also submit said value and tags as a gauge.
         """
+        if labels is None:
+            labels = []
+
         # track containers that still exist in the cache
         seen_keys = {k: False for k in cache}
 
@@ -343,6 +361,11 @@ class CadvisorPrometheusScraperMixin(object):
                 tags += tagger.tag('kubernetes_pod://%s' % pod["metadata"]["uid"], tagger.HIGH)
                 tags += self._get_kube_container_name(sample[self.SAMPLE_LABELS])
                 tags = list(set(tags))
+
+            for label in labels:
+                value = sample[self.SAMPLE_LABELS][label]
+                if value != '':
+                    tags.append('%s:%s' % (label, value))
 
             val = sample[self.SAMPLE_VALUE]
             cache[c_name] = (val, tags)
@@ -420,35 +443,43 @@ class CadvisorPrometheusScraperMixin(object):
 
     def container_fs_reads_bytes_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.io.read_bytes'
-        self._process_container_metric('rate', metric_name, metric, scraper_config)
+        labels = ['device']
+        self._process_container_metric('rate', metric_name, metric, scraper_config, labels=labels)
 
     def container_fs_writes_bytes_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.io.write_bytes'
-        self._process_container_metric('rate', metric_name, metric, scraper_config)
+        labels = ['device']
+        self._process_container_metric('rate', metric_name, metric, scraper_config, labels=labels)
 
     def container_network_receive_bytes_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.network.rx_bytes'
-        self._process_pod_rate(metric_name, metric, scraper_config)
+        labels = ['interface']
+        self._process_pod_rate(metric_name, metric, scraper_config, labels=labels)
 
     def container_network_transmit_bytes_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.network.tx_bytes'
-        self._process_pod_rate(metric_name, metric, scraper_config)
+        labels = ['interface']
+        self._process_pod_rate(metric_name, metric, scraper_config, labels=labels)
 
     def container_network_receive_errors_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.network.rx_errors'
-        self._process_pod_rate(metric_name, metric, scraper_config)
+        labels = ['interface']
+        self._process_pod_rate(metric_name, metric, scraper_config, labels=labels)
 
     def container_network_transmit_errors_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.network.tx_errors'
-        self._process_pod_rate(metric_name, metric, scraper_config)
+        labels = ['interface']
+        self._process_pod_rate(metric_name, metric, scraper_config, labels=labels)
 
     def container_network_transmit_packets_dropped_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.network.tx_dropped'
-        self._process_pod_rate(metric_name, metric, scraper_config)
+        labels = ['interface']
+        self._process_pod_rate(metric_name, metric, scraper_config, labels=labels)
 
     def container_network_receive_packets_dropped_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.network.rx_dropped'
-        self._process_pod_rate(metric_name, metric, scraper_config)
+        labels = ['interface']
+        self._process_pod_rate(metric_name, metric, scraper_config, labels=labels)
 
     def container_fs_usage_bytes(self, metric, scraper_config):
         """
@@ -458,7 +489,8 @@ class CadvisorPrometheusScraperMixin(object):
         if metric.type not in METRIC_TYPES:
             self.log.error("Metric type %s unsupported for metric %s" % (metric.type, metric.name))
             return
-        self._process_usage_metric(metric_name, metric, self.fs_usage_bytes, scraper_config)
+        labels = ['device']
+        self._process_usage_metric(metric_name, metric, self.fs_usage_bytes, scraper_config, labels=labels)
 
     def container_fs_limit_bytes(self, metric, scraper_config):
         """

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -294,8 +294,8 @@ class CadvisorPrometheusScraperMixin(object):
                 tags = list(set(tags))
 
             for label in labels:
-                value = sample[self.SAMPLE_LABELS][label]
-                if value != '':
+                value = sample[self.SAMPLE_LABELS].get(label)
+                if value:
                     tags.append('%s:%s' % (label, value))
 
             val = sample[self.SAMPLE_VALUE]
@@ -324,8 +324,8 @@ class CadvisorPrometheusScraperMixin(object):
             tags = tagger.tag('kubernetes_pod://%s' % pod_uid, tagger.HIGH)
             tags += scraper_config['custom_tags']
             for label in labels:
-                value = sample[self.SAMPLE_LABELS][label]
-                if value != '':
+                value = sample[self.SAMPLE_LABELS].get(label)
+                if value:
                     tags.append('%s:%s' % (label, value))
             val = sample[self.SAMPLE_VALUE]
             self.rate(metric_name, val, tags)
@@ -363,8 +363,8 @@ class CadvisorPrometheusScraperMixin(object):
                 tags = list(set(tags))
 
             for label in labels:
-                value = sample[self.SAMPLE_LABELS][label]
-                if value != '':
+                value = sample[self.SAMPLE_LABELS].get(label)
+                if value:
                     tags.append('%s:%s' % (label, value))
 
             val = sample[self.SAMPLE_VALUE]


### PR DESCRIPTION
### What does this PR do?

Adds prometheus labels ( `device` and `interface` ) to metric tags in the kubelet check

### Motivation

these labels would be useful for users if added as tags

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
