### PR TITLE
Fix the initialization of ignored metrics for OpenMetrics

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -131,7 +131,7 @@ class OpenMetricsScraperMixin(object):
         # Some metrics are ignored because they are duplicates or introduce a
         # very high cardinality. Metrics included in this list will be silently
         # skipped without a 'Unable to handle metric' debug line in the logs
-        config['ignore_metrics'] = []
+        config['ignore_metrics'] = instance.get('ignore_metrics', default_instance.get('ignore_metrics', []))
 
         # If you want to send the buckets as tagged values when dealing with histograms,
         # set send_histograms_buckets to True, set to False otherwise.

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2016
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import copy
 import logging
 import math
 import os
@@ -971,6 +972,22 @@ def test_parse_one_summary_with_none_values(p_check, mocked_prometheus_scraper_c
     assert math.isnan(current_metric.samples[0][2])
     assert math.isnan(current_metric.samples[1][2])
     assert math.isnan(current_metric.samples[2][2])
+
+
+def test_ignore_metric(aggregator, mocked_prometheus_check, ref_gauge):
+    """
+    Test that an ignored metric is properly discarded.
+    """
+    check = mocked_prometheus_check
+    instance = copy.deepcopy(PROMETHEUS_CHECK_INSTANCE)
+    instance['ignore_metrics'] = ['process_virtual_memory_bytes']
+
+    config = check.get_scraper_config(instance)
+    config['_dry_run'] = False
+
+    check.process_metric(ref_gauge, config)
+
+    aggregator.assert_metric('prometheus.process.vm.bytes', count=0)
 
 
 def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get):


### PR DESCRIPTION
### What does this PR do?

Correct the way ignored metrics are loaded from the check's configuration.

### Motivation

The list of ignored metrics is not loaded properly, consequently recurrent debug log entries like `Unable to handle metric: <metric_name>` are seen since we still try to process them.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
