### PR TITLE
Collect network usage metrics

### DIFF
--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -53,6 +53,8 @@ class CadvisorPrometheusScraperMixin(object):
             'container_memory_working_set_bytes': self.container_memory_working_set_bytes,
             'container_memory_rss': self.container_memory_rss,
             'container_spec_memory_limit_bytes': self.container_spec_memory_limit_bytes,
+            'container_network_tcp_usage_total': self.container_network_tcp_usage_total,
+            'container_network_udp_usage_total': self.container_network_udp_usage_total,
         }
 
     def _create_cadvisor_prometheus_instance(self, instance):
@@ -480,6 +482,16 @@ class CadvisorPrometheusScraperMixin(object):
         metric_name = scraper_config['namespace'] + '.network.rx_dropped'
         labels = ['interface']
         self._process_pod_rate(metric_name, metric, scraper_config, labels=labels)
+
+    def container_network_tcp_usage_total(self, metric, scraper_config):
+        metric_name = scraper_config['namespace'] + '.network.tcp.usage'
+        labels = ['tcp_state']
+        self._process_usage_metric(metric_name, metric, {}, scraper_config, labels=labels)
+
+    def container_network_udp_usage_total(self, metric, scraper_config):
+        metric_name = scraper_config['namespace'] + '.network.udp.usage'
+        labels = ['udp_state']
+        self._process_usage_metric(metric_name, metric, {}, scraper_config, labels=labels)
 
     def container_fs_usage_bytes(self, metric, scraper_config):
         """

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -47,14 +47,14 @@ class CadvisorPrometheusScraperMixin(object):
             'container_network_transmit_errors_total': self.container_network_transmit_errors_total,
             'container_network_transmit_packets_dropped_total': self.container_network_transmit_packets_dropped_total,
             'container_network_receive_packets_dropped_total': self.container_network_receive_packets_dropped_total,
+            'container_network_tcp_usage_total': self.container_network_tcp_usage_total,
+            'container_network_udp_usage_total': self.container_network_udp_usage_total,
             'container_fs_usage_bytes': self.container_fs_usage_bytes,
             'container_fs_limit_bytes': self.container_fs_limit_bytes,
             'container_memory_usage_bytes': self.container_memory_usage_bytes,
             'container_memory_working_set_bytes': self.container_memory_working_set_bytes,
             'container_memory_rss': self.container_memory_rss,
             'container_spec_memory_limit_bytes': self.container_spec_memory_limit_bytes,
-            'container_network_tcp_usage_total': self.container_network_tcp_usage_total,
-            'container_network_udp_usage_total': self.container_network_udp_usage_total,
         }
 
     def _create_cadvisor_prometheus_instance(self, instance):

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -65,6 +65,8 @@ EXPECTED_METRICS_PROMETHEUS = [
     'kubernetes.network.rx_errors',
     'kubernetes.network.tx_dropped',
     'kubernetes.network.tx_errors',
+    'kubernetes.network.tcp.usage',
+    'kubernetes.network.udp.usage',
     'kubernetes.io.write_bytes',
     'kubernetes.io.read_bytes',
     'kubernetes.apiserver.certificate.expiration.count',
@@ -129,6 +131,10 @@ METRICS_WITH_INTERFACE_TAG = {
     'kubernetes.network.rx_dropped': 'eth0',
     'kubernetes.network.tx_dropped': 'eth0',
 }
+
+METRICS_WITH_TCP_STATE_TAG = {'kubernetes.network.tcp.usage': 'close'}
+
+METRICS_WITH_UDP_STATE_TAG = {'kubernetes.network.udp.usage': 'dropped'}
 
 
 class MockStreamResponse:
@@ -660,4 +666,12 @@ def test_add_labels_to_tags(monkeypatch, aggregator):
 
     for metric in METRICS_WITH_INTERFACE_TAG:
         tag = 'interface:%s' % METRICS_WITH_INTERFACE_TAG[metric]
+        aggregator.assert_metric_has_tag(metric, tag)
+
+    for metric in METRICS_WITH_TCP_STATE_TAG:
+        tag = 'tcp_state:%s' % METRICS_WITH_TCP_STATE_TAG[metric]
+        aggregator.assert_metric_has_tag(metric, tag)
+
+    for metric in METRICS_WITH_UDP_STATE_TAG:
+        tag = 'udp_state:%s' % METRICS_WITH_UDP_STATE_TAG[metric]
         aggregator.assert_metric_has_tag(metric, tag)


### PR DESCRIPTION
### What does this PR do?

- collect `network.tcp.usage` and `network.udp.usage` metrics in the kubelet check
- add `tcp_state` and `udp_state` labels to the metric tags

### Motivation

Feature request


### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
