### PR TITLE
Change event type

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,6 +1,6 @@
 workflow "Create Trello Card" {
-  on = "pull_request"
   resolves = ["Datadog Github-Trello"]
+  on = "push"
 }
 
 action "Datadog Github-Trello" {


### PR DESCRIPTION
### What does this PR do?

There is a bug in github actions where the pull_request event isn't properly triggered when the pull request is merged. Changes are coming to the action to read from the push event but this needs to be changed first. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
