### PR TITLE
Fix location of merged

### DIFF
--- a/.github/actions/trello_release/action.py
+++ b/.github/actions/trello_release/action.py
@@ -88,7 +88,7 @@ def should_create_card(pull_request_event):
         if label.startswith('changelog/') and label != 'changelog/no-changelog':
             pr_includes_changes = True
 
-    if pull_request_event.get('merged') and pull_request_event.get('action') == 'closed':
+    if pull_request_event.get('pull_request').get('merged') and pull_request_event.get('action') == 'closed':
         pr_is_merged = True
 
     return pr_includes_changes and pr_is_merged

--- a/.github/actions/trello_release/action.py
+++ b/.github/actions/trello_release/action.py
@@ -88,7 +88,7 @@ def should_create_card(pull_request_event):
         if label.startswith('changelog/') and label != 'changelog/no-changelog':
             pr_includes_changes = True
 
-    if pull_request_event.get('pull_request').get('merged') and pull_request_event.get('action') == 'closed':
+    if pull_request_event.get('pull_request', {}).get('merged') and pull_request_event.get('action') == 'closed':
         pr_is_merged = True
 
     return pr_includes_changes and pr_is_merged


### PR DESCRIPTION
### What does this PR do?

The location of `merged` is actually inside the pull request object, not the event itself - https://developer.github.com/v3/activity/events/types/#pullrequestevent

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
