### PR TITLE
adding note about `send_monotonic_counter`

### DIFF
--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -32,6 +32,8 @@ More advanced settings (ssl, labels joining, custom tags,...) are documented in 
 
 Due to the nature of this integration, it's possible to submit a high number of custom metrics to Datadog. To provide users control over the maximum number of metrics sent in the case of configuration errors or input changes, the check has a default limit of 2000 metrics. If needed, this limit can be increased by setting the option `max_returned_metrics` in the `prometheus.d/conf.yaml` file.
 
+If `send_monotonic_counter: True`, the Agent sends the deltas of the values in question, and the in-app type is set to count (this is the default behaviour). If `send_monotonic_counter: False`, the Agent sends the raw, monotonically increasing value, and the in-app type is set to gauge.
+
 ### Validation
 
 [Run the Agent's `status` subcommand][2] and look for `prometheus` under the Checks section.
@@ -40,8 +42,6 @@ Due to the nature of this integration, it's possible to submit a high number of 
 ### Metrics
 
 All metrics collected by the prometheus check are forwarded to Datadog as custom metrics.
-
-If `send_monotonic_counter: True`, the Agent sends the deltas of the values in question, and the in-app type is set to count (this is the default behaviour). If `send_monotonic_counter: False`, the Agent sends the raw, monotonically increasing value, and the in-app type is set to gauge.
 
 ### Events
 The Prometheus check does not include any events.

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -41,6 +41,8 @@ Due to the nature of this integration, it's possible to submit a high number of 
 
 All metrics collected by the prometheus check are forwarded to Datadog as custom metrics.
 
+The metric `send_monotonic_counter` defaults to `True` and uses `self.monotonic_count`, so the agent sends the deltas and the in-app type is count. With `send_monotonic_counter: False` Datadog sends the raw, monotonically increasing value, and the in-app type is gauge.
+
 ### Events
 The Prometheus check does not include any events.
 

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -41,7 +41,7 @@ Due to the nature of this integration, it's possible to submit a high number of 
 
 All metrics collected by the prometheus check are forwarded to Datadog as custom metrics.
 
-The metric `send_monotonic_counter` defaults to `True` and uses `self.monotonic_count`, so the agent sends the deltas and the in-app type is count. With `send_monotonic_counter: False` Datadog sends the raw, monotonically increasing value, and the in-app type is gauge.
+If `send_monotonic_counter: True`, the Agent sends the deltas of the values in question, and the in-app type is set to count (this is the default behaviour). If `send_monotonic_counter: False`, the Agent sends the raw, monotonically increasing value, and the in-app type is set to gauge.
 
 ### Events
 The Prometheus check does not include any events.


### PR DESCRIPTION
### What does this PR do?

Adds a note to clarify `send_monotonic_counter`.

### Motivation

Better docs for a better world.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
