### PR TITLE
Adds weave-npc and weave-kube to the nginx ingress controller docs page

### DIFF
--- a/nginx_ingress_controller/README.md
+++ b/nginx_ingress_controller/README.md
@@ -20,6 +20,8 @@ The `nginx-ingress-controller` check is included in the [Datadog Agent][2] packa
 
 #### Log Collection
 
+Gather your logs from NGINX Ingress Controller, including Weave NPC and Weave Kube and send them to Datadog.
+
 **Available for Agent >6.0**
 
 * Collecting logs is disabled by default in the Datadog Agent. Enable it in your [daemonset configuration][4]:


### PR DESCRIPTION
### What does this PR do?

Adds weave-npc and weave-kube to the nginx ingress controller docs page.

### Motivation

Missing data

