### PR TITLE
Better log message for unsafe yaml loading/dumping

### DIFF
--- a/datadog_checks_base/datadog_checks/base/ddyaml.py
+++ b/datadog_checks_base/datadog_checks/base/ddyaml.py
@@ -41,7 +41,7 @@ def safe_yaml_dump_all(
 ):
     if Dumper != yDumper:
         stream_name = get_stream_name(stream)
-        log.info("Unsafe dumping of YAML has been disabled - using safe dumper instead in {}".format(stream_name))
+        log.debug("Unsafe dumping of YAML has been disabled - using safe dumper instead in {}".format(stream_name))
 
     if pyyaml_dump_all:
         return pyyaml_dump_all(
@@ -84,7 +84,7 @@ def safe_yaml_dump_all(
 def safe_yaml_load(stream, Loader=yLoader):
     if Loader != yLoader:
         stream_name = get_stream_name(stream)
-        log.info("Unsafe loading of YAML has been disabled - using safe loader instead in {}".format(stream_name))
+        log.debug("Unsafe loading of YAML has been disabled - using safe loader instead in {}".format(stream_name))
 
     if pyyaml_load:
         return pyyaml_load(stream, Loader=yLoader)
@@ -95,7 +95,7 @@ def safe_yaml_load(stream, Loader=yLoader):
 def safe_yaml_load_all(stream, Loader=yLoader):
     if Loader != yLoader:
         stream_name = get_stream_name(stream)
-        log.info("Unsafe loading of YAML has been disabled - using safe loader instead in {}".format(stream_name))
+        log.debug("Unsafe loading of YAML has been disabled - using safe loader instead in {}".format(stream_name))
 
     if pyyaml_load_all:
         return pyyaml_load_all(stream, Loader=yLoader)
@@ -104,7 +104,8 @@ def safe_yaml_load_all(stream, Loader=yLoader):
 
 
 def get_stream_name(stream):
-    """Using the same logic as pyyaml to handle both string types and file types"""
+    """Using the same logic as pyyaml to handle both string types and file types. All file objects do not necessarily
+    have a `name` attribute, in that case we can only say the stream is a file."""
     if isinstance(stream, string_types):
         return "<string>"
     elif hasattr(stream, 'name'):

--- a/datadog_checks_base/datadog_checks/base/ddyaml.py
+++ b/datadog_checks_base/datadog_checks/base/ddyaml.py
@@ -2,8 +2,10 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import logging
+from os.path import realpath
 
 import yaml
+from six import string_types
 
 try:
     from yaml import CSafeLoader as yLoader
@@ -38,7 +40,8 @@ def safe_yaml_dump_all(
     tags=None,
 ):
     if Dumper != yDumper:
-        log.warning("Unsafe dumping of YAML has been disabled - using safe dumper instead")
+        stream_name = get_stream_name(stream)
+        log.info("Unsafe dumping of YAML has been disabled - using safe dumper instead in {}".format(stream_name))
 
     if pyyaml_dump_all:
         return pyyaml_dump_all(
@@ -80,7 +83,8 @@ def safe_yaml_dump_all(
 
 def safe_yaml_load(stream, Loader=yLoader):
     if Loader != yLoader:
-        log.warning("Unsafe loading of YAML has been disabled - using safe loader instead")
+        stream_name = get_stream_name(stream)
+        log.info("Unsafe loading of YAML has been disabled - using safe loader instead in {}".format(stream_name))
 
     if pyyaml_load:
         return pyyaml_load(stream, Loader=yLoader)
@@ -90,12 +94,23 @@ def safe_yaml_load(stream, Loader=yLoader):
 
 def safe_yaml_load_all(stream, Loader=yLoader):
     if Loader != yLoader:
-        log.warning("Unsafe loading of YAML has been disabled - using safe loader instead")
+        stream_name = get_stream_name(stream)
+        log.info("Unsafe loading of YAML has been disabled - using safe loader instead in {}".format(stream_name))
 
     if pyyaml_load_all:
         return pyyaml_load_all(stream, Loader=yLoader)
 
     return yaml.load_all(stream, Loader=yLoader)
+
+
+def get_stream_name(stream):
+    """Using the same logic as pyyaml to handle both string types and file types"""
+    if isinstance(stream, string_types):
+        return "<string>"
+    elif hasattr(stream, 'name'):
+        return realpath(stream.name)
+    else:
+        return "<file>"
 
 
 def monkey_patch_pyyaml():


### PR DESCRIPTION
### What does this PR do?

Unsafe yaml and dumping messages are now logged with a level of INFO instead of WARNING. The PR also adds the absolute file path to the yaml file being read. 

### Motivation

Agent logs being flooded.

### Additional Notes

There's possibly something better to do than displaying the file path in order to help understand what the log line refers to. Feel free if you have any good idea.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
