### PR TITLE
Fix cassandra_nodetools tox.ini envlist

### DIFF
--- a/cassandra_nodetool/tox.ini
+++ b/cassandra_nodetool/tox.ini
@@ -2,7 +2,6 @@
 minversion = 2.0
 basepython = py37
 envlist =
-    py{27,37}-{2.1,unit}
     py{27,37}-{2.1,3.0,unit}
 
 [testenv]


### PR DESCRIPTION
### What does this PR do?

Remove redundant environments in the `cassandra_nodetool` environment list. 

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
