### PR TITLE
Add upper_bound tag for the total count when collecting histograms buckets

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -591,6 +591,8 @@ class OpenMetricsScraperMixin(object):
                 )
             elif sample[self.SAMPLE_NAME].endswith("_count"):
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname)
+                if scraper_config['send_histograms_buckets']:
+                    tags = tags + ["upper_bound:none"]
                 self.gauge(
                     "{}.{}.count".format(scraper_config['namespace'], metric_name),
                     val,

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -592,7 +592,7 @@ class OpenMetricsScraperMixin(object):
             elif sample[self.SAMPLE_NAME].endswith("_count"):
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname)
                 if scraper_config['send_histograms_buckets']:
-                    tags = tags + ["upper_bound:none"]
+                    tags.append("upper_bound:none")
                 self.gauge(
                     "{}.{}.count".format(scraper_config['namespace'], metric_name),
                     val,

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -672,7 +672,10 @@ class PrometheusScraperMixin(object):
         # histograms do not have a value attribute
         val = getattr(metric, self.METRIC_TYPES[4]).sample_count
         if self._is_value_valid(val):
-            self._submit_gauge("{}.count".format(name), val, metric, custom_tags)
+            if send_histograms_buckets:
+                self._submit_gauge("{}.count".format(name), val, metric, custom_tags=custom_tags + ["upper_bound:none"])
+            else:
+                self._submit_gauge("{}.count".format(name), val, metric, custom_tags)
         else:
             self.log.debug("Metric value is not supported for metric {}.count.".format(name))
         val = getattr(metric, self.METRIC_TYPES[4]).sample_sum

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -365,7 +365,7 @@ def test_submit_histogram(aggregator, mocked_prometheus_check, mocked_prometheus
     check = mocked_prometheus_check
     check.submit_openmetric('custom.histogram', _histo, mocked_prometheus_scraper_config)
     aggregator.assert_metric('prometheus.custom.histogram.sum', 1337, tags=[], count=1)
-    aggregator.assert_metric('prometheus.custom.histogram.count', 4, tags=[], count=1)
+    aggregator.assert_metric('prometheus.custom.histogram.count', 4, tags=['upper_bound:none'], count=1)
     aggregator.assert_metric('prometheus.custom.histogram.count', 1, tags=['upper_bound:1.0'], count=1)
     aggregator.assert_metric('prometheus.custom.histogram.count', 2, tags=['upper_bound:31104000.0'], count=1)
     aggregator.assert_metric('prometheus.custom.histogram.count', 3, tags=['upper_bound:432400000.0'], count=1)

--- a/datadog_checks_base/tests/test_prometheus.py
+++ b/datadog_checks_base/tests/test_prometheus.py
@@ -556,7 +556,7 @@ def test_submit_histogram(mocked_prometheus_check):
     check._submit('custom.histogram', _histo)
     check.gauge.assert_has_calls(
         [
-            mock.call('prometheus.custom.histogram.count', 42, [], hostname=None),
+            mock.call('prometheus.custom.histogram.count', 42, ['upper_bound:none'], hostname=None),
             mock.call('prometheus.custom.histogram.sum', 3.14, [], hostname=None),
             mock.call('prometheus.custom.histogram.count', 33, ['upper_bound:12.7'], hostname=None),
             mock.call('prometheus.custom.histogram.count', 666, ['upper_bound:18.2'], hostname=None),


### PR DESCRIPTION
### What does this PR do?

When `send_histograms_buckets` is activated buckets are send adding `upper_bound` tag to the `*.count` metrics. The issue is the total count which does not include any tag is not queryable.

This PR add the tag `upper_bound:none` to properly query it along with buckets.

### Motivation

Fix querying the total count on Datadog when collecting buckets

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
