### PR TITLE
Fixed default mesh endpoint in istio example

### DIFF
--- a/istio/README.md
+++ b/istio/README.md
@@ -28,7 +28,7 @@ Edit the `istio.d/conf.yaml` file, in the `conf.d/` folder at the root of your [
 init_config:
 
 instances:
-  - istio_mesh_endpoint: http://istio-telemetry.istio-system:42422/metrics
+  - istio_mesh_endpoint: http://istio-mesh.istio-system:42422/metrics
     mixer_endpoint: http://istio-telemetry.istio-system:15014/metrics
     send_histograms_buckets: true
 ```

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -9,7 +9,7 @@ instances:
     ## the CPP extension to process Protocol buffer messages coming from the api. Depending
     ## on the metrics volume, the check may run very slowly.
     #
-  - istio_mesh_endpoint: http://istio-telemetry.istio-system:42422/metrics
+  - istio_mesh_endpoint: http://istio-mesh.istio-system:42422/metrics
 
     ## @param mixer_endpoint - string - required
     ## Define the mixer endpoint in order to collect all Prometheus metrics on the Mixer process as well


### PR DESCRIPTION
### What does this PR do?

This PR resolves issue #3774. The documentation and example config regarding istio configuration has the wrong url shown as the default.

### Motivation

What inspired you to submit this pull request? 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.