### PR TITLE
add UNKNOWN status to service check

### DIFF
--- a/kubernetes_state/assets/service_checks.json
+++ b/kubernetes_state/assets/service_checks.json
@@ -3,45 +3,45 @@
         "agent_version": "5.6.0",
         "integration":"kubernetes",
         "check": "kubernetes_state.node.ready",
-        "statuses": ["ok", "critical"],
+        "statuses": ["ok", "unknown", "critical"],
         "groups": ["host", "node"],
         "name": "Node Ready",
-        "description": "Returns `CRITICAL` if a cluster node is not ready. Returns `OK` otherwise."
+        "description": "Returns `CRITICAL` if a cluster node is not ready. Returns `UNKNOWN` if status is unknown. Returns `OK` otherwise."
     },
     {
         "agent_version": "5.6.0",
         "integration":"kubernetes",
         "check": "kubernetes_state.node.out_of_disk",
-        "statuses": ["ok", "critical"],
+        "statuses": ["ok", "unknown", "critical"],
         "groups": ["host", "node"],
         "name": "Node Out Of Disk",
-        "description": "Returns `CRITICAL` if a cluster node is out of disk space. Returns `OK` otherwise."
+        "description": "Returns `CRITICAL` if a cluster node is out of disk space. Returns `UNKNOWN` if status is unknown. Returns `OK` otherwise."
     },
     {
         "agent_version": "5.6.0",
         "integration":"kubernetes",
         "check": "kubernetes_state.node.disk_pressure",
-        "statuses": ["ok", "critical"],
+        "statuses": ["ok", "unknown", "critical"],
         "groups": ["host", "node"],
         "name": "Node Disk Pressure",
-        "description": "Returns `CRITICAL` if a cluster node is in a disk pressure state. Returns `OK` otherwise."
+        "description": "Returns `CRITICAL` if a cluster node is in a disk pressure state. Returns `UNKNOWN` if status is unknown. Returns `OK` otherwise."
     },
     {
         "agent_version": "5.6.0",
         "integration":"kubernetes",
         "check": "kubernetes_state.node.memory_pressure",
-        "statuses": ["ok", "critical"],
+        "statuses": ["ok", "unknown", "critical"],
         "groups": ["host", "node"],
         "name": "Node Memory Pressure",
-        "description": "Returns `CRITICAL` if a cluster node is in a memory pressure state. Returns `OK` otherwise."
+        "description": "Returns `CRITICAL` if a cluster node is in a memory pressure state. Returns `UNKNOWN` if status is unknown. Returns `OK` otherwise."
     },
     {
         "agent_version": "5.6.0",
         "integration":"kubernetes",
         "check": "kubernetes_state.node.network_unavailable",
-        "statuses": ["ok", "critical"],
+        "statuses": ["ok", "unknown", "critical"],
         "groups": ["host", "node"],
         "name": "Node Network Unavailable",
-        "description": "Returns `CRITICAL` if a cluster node is in a network unavailable state. Returns `OK` otherwise."
+        "description": "Returns `CRITICAL` if a cluster node is in a network unavailable state. Returns `UNKNOWN` if status is unknown. Returns `OK` otherwise."
     }
 ]


### PR DESCRIPTION
### What does this PR do?

Add unknown condition statuses to KSM service checks.

### Motivation

Via support ticket. `unknown` statuses are meant to be included in the kubernetes_state service checks: https://github.com/DataDog/integrations-core/blob/master/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py#L48-L50. 

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
