### PR TITLE
Enforcing service check placeholder for docs

### DIFF
--- a/activemq/README.md
+++ b/activemq/README.md
@@ -97,8 +97,8 @@ See [metadata.csv][9] for a list of metrics provided by this integration.
 The ActiveMQ check does not include any events.
 
 ### Service Checks
-**activemq.can_connect**:
-Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored ActiveMQ instance. Returns `OK` otherwise.
+
+See [service_checks.json][13] for a list of Service Checks provided by this integration.
 
 ## Troubleshooting
 Need help? Contact [Datadog support][10].
@@ -122,3 +122,4 @@ Additional helpful documentation, links, and articles:
 [10]: https://docs.datadoghq.com/help
 [11]: https://www.datadoghq.com/blog/activemq-architecture-and-metrics
 [12]: https://www.datadoghq.com/blog/monitor-activemq-metrics-performance
+[13]: https://github.com/DataDog/integrations-core/blob/master/activemq/assets/service_checks.json

--- a/activemq_xml/README.md
+++ b/activemq_xml/README.md
@@ -32,7 +32,7 @@ See [metadata.csv][116] for a list of metrics provided by this integration.
 The ActiveMQ XML check does not include any events.
 
 ### Service Checks
-The ActiveMQ XML check does not include any service checks.
+The ActiveMQ XML check does not include any Service Checks.
 
 ## Troubleshooting
 Need help? Contact [Datadog support][117].

--- a/aerospike/README.md
+++ b/aerospike/README.md
@@ -32,12 +32,11 @@ See [metadata.csv][4] for a list of metrics provided by this integration.
 
 ### Service Checks
 
-- `aerospike.can_connect`
-- `aerospike.cluster_up`
+The Aerospike check does not include any Service Checks.
 
 ### Events
 
-Aerospike does not include any events.
+The Aerospike check does not include any events.
 
 ## Troubleshooting
 

--- a/agent_metrics/README.md
+++ b/agent_metrics/README.md
@@ -36,7 +36,8 @@ See [metadata.csv][8] for a list of metrics provided by this integration.
 The Agent_metrics check does not include any events.
 
 ### Service Checks
-The Agent_metrics check does not include any service checks.
+
+The Agent_metrics check does not include any Service Checks.
 
 ## Troubleshooting
 Need help? Contact [Datadog support][9].

--- a/ambari/README.md
+++ b/ambari/README.md
@@ -56,15 +56,13 @@ whitelisted service component the metrics with headers in the white list.
 
 See [metadata.csv][7] for a list of all metrics provided by this integration.
 
-### Service Checks
-
-- `ambari.can_connect` - Returns `OK` if the cluster is reachable, `CRITICAL` otherwise.
-- `ambari.state` - Returns `OK` if the service is installed or running, `WARNING` if the service is stopping or uninstalling,
-  or `CRITICAL` if the service is uninstalled or stopped. For a complete enumeration, see [this file][8].
-
 ### Events
 
 Ambari does not include any events.
+
+### Service Checks
+
+See [service_checks.json][9] for a list of Service Checks provided by this integration.
 
 ## Troubleshooting
 
@@ -78,3 +76,4 @@ Need help? Contact [Datadog support][5].
 [6]: https://docs.datadoghq.com/agent/
 [7]: https://github.com/DataDog/integrations-core/blob/master/ambari/datadog_checks/ambari/data/conf.yaml.example
 [8]: https://github.com/DataDog/integrations-core/blob/master/ambari/datadog_checks/ambari/common.py
+[15]: https://github.com/DataDog/integrations-core/blob/master/ambari/assets/service_checks.json

--- a/ambari/README.md
+++ b/ambari/README.md
@@ -76,4 +76,4 @@ Need help? Contact [Datadog support][5].
 [6]: https://docs.datadoghq.com/agent/
 [7]: https://github.com/DataDog/integrations-core/blob/master/ambari/datadog_checks/ambari/data/conf.yaml.example
 [8]: https://github.com/DataDog/integrations-core/blob/master/ambari/datadog_checks/ambari/common.py
-[15]: https://github.com/DataDog/integrations-core/blob/master/ambari/assets/service_checks.json
+[9]: https://github.com/DataDog/integrations-core/blob/master/ambari/assets/service_checks.json

--- a/apache/README.md
+++ b/apache/README.md
@@ -87,8 +87,7 @@ The Apache check does not include any events.
 
 ### Service Checks
 
-**apache.can_connect**:
-Returns CRITICAL if the Agent cannot connect to the configured `apache_status_url`, otherwise OK.
+See [service_checks.json][15] for a list of Service Checks provided by this integration.
 
 ## Troubleshooting
 
@@ -118,3 +117,4 @@ Additional helpful documentation, links, and articles:
 [12]: https://www.datadoghq.com/blog/monitoring-apache-web-server-performance
 [13]: https://www.datadoghq.com/blog/collect-apache-performance-metrics
 [14]: https://www.datadoghq.com/blog/monitor-apache-web-server-datadog
+[15]: https://github.com/DataDog/integrations-core/blob/master/apache/assets/service_checks.json

--- a/aspdotnet/README.md
+++ b/aspdotnet/README.md
@@ -33,7 +33,7 @@ See [metadata.csv][6] for a list of metrics provided by this check.
 The ASP.NET check does not include any events.
 
 ### Service Checks
-The ASP.NET check does not include any service checks.
+The ASP.NET check does not include any Service Checks.
 
 ## Troubleshooting
 Need help? Contact [Datadog support][7].

--- a/btrfs/README.md
+++ b/btrfs/README.md
@@ -30,10 +30,12 @@ The Btrfs check is included in the [Datadog Agent][2] package, so you don't need
 See [metadata.csv][7] for a list of metrics provided by this integration.
 
 ### Events
+
 The Btrfs check does not include any events.
 
 ### Service Checks
-The Btrfs check does not include any service checks.
+
+The Btrfs check does not include any Service Checks.
 
 ## Troubleshooting
 Need help? Contact [Datadog support][8].


### PR DESCRIPTION
### What does this PR do?

Enforces wording to make the documentation use the new `service_checks.json` file to display service checks.

### Motivation

* It allows to dynamically display the service check list when they are available (like for the metrics)
* It allows to benefit from the localisation process of the documentation for Service Checks.

### Additional Notes

Corresponding Doc PR: https://github.com/DataDog/documentation/pull/4646