### PR TITLE
WIP: Automated E2E testing framework

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/_env.py
+++ b/datadog_checks_dev/datadog_checks/dev/_env.py
@@ -9,6 +9,7 @@ E2E_PREFIX = 'DDEV_E2E'
 E2E_ENV_VAR_PREFIX = '{}_ENV_'.format(E2E_PREFIX)
 E2E_SET_UP = '{}_UP'.format(E2E_PREFIX)
 E2E_TEAR_DOWN = '{}_DOWN'.format(E2E_PREFIX)
+E2E_CHECK_FILE = '{}_CHECK_FILE'.format(E2E_PREFIX)
 
 E2E_FIXTURE_NAME = 'dd_environment'
 TESTING_PLUGIN = 'DDEV_TESTING_PLUGIN'
@@ -32,16 +33,16 @@ def remove_env_vars(env_vars):
 def get_env_vars(raw=False):
     if raw:
         return {key: value for key, value in iteritems(os.environ) if key.startswith(E2E_ENV_VAR_PREFIX)}
-    else:
-        env_vars = {}
 
-        for key, value in iteritems(os.environ):
-            _, found, ev = key.partition(E2E_ENV_VAR_PREFIX)
-            if found:
-                # Normalize casing for Windows
-                env_vars[ev.lower()] = value
+    env_vars = {}
 
-        return env_vars
+    for key, value in iteritems(os.environ):
+        _, found, ev = key.partition(E2E_ENV_VAR_PREFIX)
+        if found:
+            # Normalize casing for Windows
+            env_vars[ev.lower()] = value
+
+    return env_vars
 
 
 def set_up_env():

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/__init__.py
@@ -10,8 +10,9 @@ from .prune import prune
 from .reload import reload_env
 from .start import start
 from .stop import stop
+from .test import test
 
-ALL_COMMANDS = (check_run, ls, prune, reload_env, start, stop)
+ALL_COMMANDS = (check_run, ls, prune, reload_env, start, stop, test)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Manage environments')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -186,6 +186,10 @@ def start(ctx, check, env, agent, dev, base, env_vars):
             environment.update_check()
             echo_success('success!')
 
+    if ctx.parent.info_name == 'test':
+        # Invoke from the test command, remove config boilerplate
+        return environment
+
     click.echo()
 
     try:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
@@ -1,0 +1,221 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+import os
+from tempfile import NamedTemporaryFile
+
+import click
+from six import string_types
+
+from ....utils import dir_exists, file_exists, path_join
+from ...e2e import E2E_SUPPORTED_TYPES, check_environment, derive_interface, start_environment, stop_environment
+from ...testing import get_available_tox_envs
+from ...utils import get_tox_file
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_waiting, echo_warning
+
+
+@click.command(context_settings=CONTEXT_SETTINGS, short_help='Test an environment')
+@click.argument('check')
+@click.argument('env')
+@click.option(
+    '--agent',
+    '-a',
+    default='6',
+    help=(
+        'The agent build to use e.g. a Docker image like `datadog/agent:6.5.2`. For '
+        'Docker environments you can use an integer corresponding to fields in the '
+        'config (agent5, agent6, etc.)'
+    ),
+)
+@click.option('--dev/--prod', help='Whether to use the latest version of a check or what is shipped')
+@click.option('--base', is_flag=True, help='Whether to use the latest version of the base check or what is shipped')
+@click.option(
+    '--env-vars',
+    '-e',
+    multiple=True,
+    help=(
+        'ENV Variable that should be passed to the Agent container. '
+        'Ex: -e DD_URL=app.datadoghq.com -e DD_API_KEY=123456'
+    ),
+)
+@click.pass_context
+def test(ctx, check, env, agent, dev, base, env_vars):
+    """Run a check test against an environment."""
+    # XXX reduce duplication with start
+    if not file_exists(get_tox_file(check)):
+        abort('`{}` is not a testable check.'.format(check))
+
+    base_package = None
+    if base:
+        core_dir = os.path.expanduser(ctx.obj.get('core', ''))
+        if not dir_exists(core_dir):
+            if core_dir:
+                abort('`{}` directory does not exist.'.format(core_dir))
+            else:
+                abort('`core` config setting does not exist.')
+
+        base_package = path_join(core_dir, 'datadog_checks_base')
+        if not dir_exists(base_package):
+            abort('`datadog_checks_base` directory does not exist.')
+
+    envs = get_available_tox_envs(check, e2e_only=True)
+
+    if env not in envs:
+        echo_failure('`{}` is not an available environment.'.format(env))
+        echo_info('See what is available via `ddev env ls {}`.'.format(check))
+        abort()
+
+    api_key = ctx.obj['dd_api_key']
+    if api_key is None:
+        echo_warning(
+            'Environment variable DD_API_KEY does not exist; a well-formatted '
+            'fake API key will be used instead. You can also set the API key '
+            'by doing `ddev config set dd_api_key`.'
+        )
+
+    echo_waiting('Setting up environment `{}`... '.format(env), nl=False)
+    config, metadata, error = start_environment(check, env)
+
+    if error:
+        echo_failure('failed!')
+        echo_waiting('Stopping the environment...')
+        stop_environment(check, env, metadata=metadata)
+        abort(error)
+    echo_success('success!')
+
+    env_type = metadata['env_type']
+    use_jmx = metadata.get('use_jmx', False)
+
+    # Support legacy config where agent5 and agent6 were strings
+    agent_ver = ctx.obj.get('agent{}'.format(agent), agent)
+    if isinstance(agent_ver, string_types):
+        agent_build = agent_ver
+        if agent_ver != agent:
+            echo_warning(
+                'Agent fields missing from ddev config, please update to the latest config via '
+                '`ddev config update`, falling back to latest docker image...'
+            )
+    else:
+        agent_build = agent_ver.get(env_type, env_type)
+
+    if not isinstance(agent_ver, string_types) and use_jmx:
+        agent_build = '{}-jmx'.format(agent_build)
+
+    interface = derive_interface(env_type)
+    if interface is None:
+        echo_failure('`{}` is an unsupported environment type.'.format(env_type))
+        echo_waiting('Stopping the environment...')
+        stop_environment(check, env, metadata=metadata)
+        abort()
+
+    if env_type not in E2E_SUPPORTED_TYPES and agent.isdigit():
+        echo_failure('Configuration for default Agents are only for Docker. You must specify the full build.')
+        echo_waiting('Stopping the environment...')
+        stop_environment(check, env, metadata=metadata)
+        abort()
+
+    environment = interface(check, env, base_package, config, env_vars, metadata, agent_build, api_key)
+
+    echo_waiting('Updating `{}`... '.format(agent_build), nl=False)
+    environment.update_agent()
+    echo_success('success!')
+
+    echo_waiting('Detecting the major version... ', nl=False)
+    environment.detect_agent_version()
+    echo_info('Agent {} detected'.format(environment.agent_version))
+
+    echo_waiting('Writing configuration for `{}`... '.format(env), nl=False)
+    environment.write_config()
+    echo_success('success!')
+
+    echo_waiting('Starting the Agent... ', nl=False)
+    result = environment.start_agent()
+    if result.code:
+        click.echo()
+        echo_info(result.stdout + result.stderr)
+        echo_failure('An error occurred.')
+        echo_waiting('Stopping the environment...')
+        stop_environment(check, env, metadata=metadata)
+        environment.remove_config()
+        abort()
+    echo_success('success!')
+
+    start_commands = metadata.get('start_commands', [])
+    if start_commands:
+        echo_waiting('Running extra start-up commands... ', nl=False)
+
+        for command in start_commands:
+            result = environment.exec_command(command, capture=True)
+            if result.code:
+                click.echo()
+                echo_info(result.stdout + result.stderr)
+                echo_failure('An error occurred.')
+                echo_waiting('Stopping the environment...')
+                stop_environment(check, env, metadata=metadata)
+                echo_waiting('Stopping the Agent...')
+                environment.stop_agent()
+                environment.remove_config()
+                abort()
+
+        echo_success('success!')
+
+    if base and not dev:
+        dev = True
+        echo_info(
+            'Will install the development version of the check too so the base package can import it (in editable mode)'
+        )
+
+    editable_warning = (
+        '\nEnv will started with an editable check install for the {} package. '
+        'This check will remain in an editable install after '
+        'the environment is torn down. Would you like to proceed?'
+    )
+
+    if base:
+        echo_waiting('Upgrading the base package to the development version... ', nl=False)
+        if environment.ENV_TYPE == 'local' and not click.confirm(editable_warning.format('base')):
+            echo_success('skipping')
+        else:
+            environment.update_base_package()
+            echo_success('success!')
+
+    if dev:
+        echo_waiting('Upgrading `{}` check to the development version... '.format(check), nl=False)
+        if environment.ENV_TYPE == 'local' and not click.confirm(editable_warning.format(environment.check)):
+            echo_success('skipping')
+        else:
+            environment.update_check()
+            echo_success('success!')
+
+    environment.wait_agent_ready()
+
+    check_file = NamedTemporaryFile()
+    try:
+        echo_waiting('Running check command... ', nl=False)
+        check_result = environment.run_check(as_json=True, capture=True)
+        if check_result.code:
+            click.echo(check_result.stderr)
+            echo_failure('failed!')
+        else:
+            echo_success('success!')
+            check_output = json.loads(check_result.stdout.split('=== JSON ===', 1)[1])
+            json.dump(check_output, check_file)
+            check_file.flush()
+            check_environment(check, env, check_file.name)
+    finally:
+        check_file.close()
+        echo_waiting('Stopping the Agent... ', nl=False)
+        environment.stop_agent()
+        echo_success('success!')
+
+        echo_waiting('Removing configuration files... ', nl=False)
+        environment.remove_config()
+        echo_success('success!')
+
+        echo_waiting('Stopping the environment... ', nl=False)
+        _, _, error = stop_environment(check, env, metadata=environment.metadata)
+        if error:
+            echo_failure('failed!')
+            abort(error)
+        echo_success('success!')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
@@ -2,17 +2,13 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
-import os
 from tempfile import NamedTemporaryFile
 
 import click
-from six import string_types
 
-from ....utils import dir_exists, file_exists, path_join
-from ...e2e import E2E_SUPPORTED_TYPES, check_environment, derive_interface, start_environment, stop_environment
-from ...testing import get_available_tox_envs
-from ...utils import get_tox_file
-from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_waiting, echo_warning
+from ...e2e import check_environment, stop_environment
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_success, echo_waiting
+from .start import start
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Test an environment')
@@ -42,151 +38,7 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_suc
 @click.pass_context
 def test(ctx, check, env, agent, dev, base, env_vars):
     """Run a check test against an environment."""
-    # XXX reduce duplication with start
-    if not file_exists(get_tox_file(check)):
-        abort('`{}` is not a testable check.'.format(check))
-
-    base_package = None
-    if base:
-        core_dir = os.path.expanduser(ctx.obj.get('core', ''))
-        if not dir_exists(core_dir):
-            if core_dir:
-                abort('`{}` directory does not exist.'.format(core_dir))
-            else:
-                abort('`core` config setting does not exist.')
-
-        base_package = path_join(core_dir, 'datadog_checks_base')
-        if not dir_exists(base_package):
-            abort('`datadog_checks_base` directory does not exist.')
-
-    envs = get_available_tox_envs(check, e2e_only=True)
-
-    if env not in envs:
-        echo_failure('`{}` is not an available environment.'.format(env))
-        echo_info('See what is available via `ddev env ls {}`.'.format(check))
-        abort()
-
-    api_key = ctx.obj['dd_api_key']
-    if api_key is None:
-        echo_warning(
-            'Environment variable DD_API_KEY does not exist; a well-formatted '
-            'fake API key will be used instead. You can also set the API key '
-            'by doing `ddev config set dd_api_key`.'
-        )
-
-    echo_waiting('Setting up environment `{}`... '.format(env), nl=False)
-    config, metadata, error = start_environment(check, env)
-
-    if error:
-        echo_failure('failed!')
-        echo_waiting('Stopping the environment...')
-        stop_environment(check, env, metadata=metadata)
-        abort(error)
-    echo_success('success!')
-
-    env_type = metadata['env_type']
-    use_jmx = metadata.get('use_jmx', False)
-
-    # Support legacy config where agent5 and agent6 were strings
-    agent_ver = ctx.obj.get('agent{}'.format(agent), agent)
-    if isinstance(agent_ver, string_types):
-        agent_build = agent_ver
-        if agent_ver != agent:
-            echo_warning(
-                'Agent fields missing from ddev config, please update to the latest config via '
-                '`ddev config update`, falling back to latest docker image...'
-            )
-    else:
-        agent_build = agent_ver.get(env_type, env_type)
-
-    if not isinstance(agent_ver, string_types) and use_jmx:
-        agent_build = '{}-jmx'.format(agent_build)
-
-    interface = derive_interface(env_type)
-    if interface is None:
-        echo_failure('`{}` is an unsupported environment type.'.format(env_type))
-        echo_waiting('Stopping the environment...')
-        stop_environment(check, env, metadata=metadata)
-        abort()
-
-    if env_type not in E2E_SUPPORTED_TYPES and agent.isdigit():
-        echo_failure('Configuration for default Agents are only for Docker. You must specify the full build.')
-        echo_waiting('Stopping the environment...')
-        stop_environment(check, env, metadata=metadata)
-        abort()
-
-    environment = interface(check, env, base_package, config, env_vars, metadata, agent_build, api_key)
-
-    echo_waiting('Updating `{}`... '.format(agent_build), nl=False)
-    environment.update_agent()
-    echo_success('success!')
-
-    echo_waiting('Detecting the major version... ', nl=False)
-    environment.detect_agent_version()
-    echo_info('Agent {} detected'.format(environment.agent_version))
-
-    echo_waiting('Writing configuration for `{}`... '.format(env), nl=False)
-    environment.write_config()
-    echo_success('success!')
-
-    echo_waiting('Starting the Agent... ', nl=False)
-    result = environment.start_agent()
-    if result.code:
-        click.echo()
-        echo_info(result.stdout + result.stderr)
-        echo_failure('An error occurred.')
-        echo_waiting('Stopping the environment...')
-        stop_environment(check, env, metadata=metadata)
-        environment.remove_config()
-        abort()
-    echo_success('success!')
-
-    start_commands = metadata.get('start_commands', [])
-    if start_commands:
-        echo_waiting('Running extra start-up commands... ', nl=False)
-
-        for command in start_commands:
-            result = environment.exec_command(command, capture=True)
-            if result.code:
-                click.echo()
-                echo_info(result.stdout + result.stderr)
-                echo_failure('An error occurred.')
-                echo_waiting('Stopping the environment...')
-                stop_environment(check, env, metadata=metadata)
-                echo_waiting('Stopping the Agent...')
-                environment.stop_agent()
-                environment.remove_config()
-                abort()
-
-        echo_success('success!')
-
-    if base and not dev:
-        dev = True
-        echo_info(
-            'Will install the development version of the check too so the base package can import it (in editable mode)'
-        )
-
-    editable_warning = (
-        '\nEnv will started with an editable check install for the {} package. '
-        'This check will remain in an editable install after '
-        'the environment is torn down. Would you like to proceed?'
-    )
-
-    if base:
-        echo_waiting('Upgrading the base package to the development version... ', nl=False)
-        if environment.ENV_TYPE == 'local' and not click.confirm(editable_warning.format('base')):
-            echo_success('skipping')
-        else:
-            environment.update_base_package()
-            echo_success('success!')
-
-    if dev:
-        echo_waiting('Upgrading `{}` check to the development version... '.format(check), nl=False)
-        if environment.ENV_TYPE == 'local' and not click.confirm(editable_warning.format(environment.check)):
-            echo_success('skipping')
-        else:
-            environment.update_check()
-            echo_success('success!')
+    environment = ctx.forward(start)
 
     environment.wait_agent_ready()
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -34,11 +34,7 @@ REQUIRED_ATTRIBUTES = {
     'type',
 }
 
-REQUIRED_ASSET_ATTRIBUTES = {
-    'monitors',
-    'dashboards',
-    'service_checks',
-}
+REQUIRED_ASSET_ATTRIBUTES = {'monitors', 'dashboards', 'service_checks'}
 
 OPTIONAL_ATTRIBUTES = {
     'aliases',

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/__init__.py
@@ -3,6 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from .config import get_configured_checks, get_configured_envs
 from .core import create_interface, derive_interface
-from .run import start_environment, stop_environment
+from .run import check_environment, start_environment, stop_environment
 
 E2E_SUPPORTED_TYPES = {'docker', 'local'}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import re
+import time
 
 from ...subprocess import run_command
 from ...utils import path_join
@@ -102,6 +103,13 @@ class DockerInterface(object):
             command += ' --breakpoint {}'.format(break_point)
 
         return self.exec_command(command, capture=capture, interactive=break_point is not None)
+
+    def wait_agent_ready(self):
+        for _ in range(10):
+            result = self.exec_command('ls /etc/datadog-agent/datadog.yaml', capture=True)
+            if not result.code:
+                break
+            time.sleep(1)
 
     def exists(self):
         return env_exists(self.check, self.env)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -131,6 +131,9 @@ class LocalAgentInterface(object):
 
         return run_command(command, capture=capture)
 
+    def wait_agent_ready(self):
+        pass
+
     def update_check(self):
         install_cmd = get_agent_pip_install(self.agent_version, self.platform) + [
             '-e',

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/run.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/run.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from ..._env import E2E_ENV_VAR_PREFIX, E2E_SET_UP, E2E_TEAR_DOWN
+from ..._env import E2E_CHECK_FILE, E2E_ENV_VAR_PREFIX, E2E_SET_UP, E2E_TEAR_DOWN
 from ...subprocess import run_command
 from ...utils import chdir, path_join
 from ..constants import get_root
@@ -35,3 +35,19 @@ def stop_environment(check, env, metadata=None):
         result = run_command(command, capture=True)
 
     return parse_config_from_result(env, result)
+
+
+def check_environment(check, env, check_file):
+    command = 'tox --develop -e {}'.format(env)
+    env_vars = {
+        E2E_TEAR_DOWN: 'false',
+        E2E_SET_UP: 'false',
+        E2E_CHECK_FILE: check_file,
+        'PYTEST_ADDOPTS': '-m e2e',
+        'TOX_TESTENV_PASSENV': '{}* {} {} {} PYTEST_ADDOPTS'.format(
+            E2E_ENV_VAR_PREFIX, E2E_SET_UP, E2E_TEAR_DOWN, E2E_CHECK_FILE
+        ),
+    }
+
+    with chdir(path_join(get_root(), check), env_vars=env_vars):
+        run_command(command)


### PR DESCRIPTION
This adds a new test subcommand to run a full E2E testing with an agent.
It adds new pytest marker which will use the check output to populate
the aggregator.

This is tested against lighttpd. To check how it works, you can call
`ddev env test lighttpd py27-latest`.