### PR TITLE
Improve API logs

### DIFF
--- a/cisco_aci/datadog_checks/cisco_aci/api.py
+++ b/cisco_aci/datadog_checks/cisco_aci/api.py
@@ -84,8 +84,7 @@ class SessionWrapper:
         try:
             response.raise_for_status()
         except Exception as e:
-            self.log.warning("Error making request: %s", e)
-            self.log.debug("Error response content: %s", response.content)
+            self.log.warning("Error making request: exception='%s' reponse.content='%s'", e, response.content)
             raise APIConnectionException("Error making request: {}".format(e))
         try:
             return response.json()

--- a/cisco_aci/datadog_checks/cisco_aci/api.py
+++ b/cisco_aci/datadog_checks/cisco_aci/api.py
@@ -84,7 +84,8 @@ class SessionWrapper:
         try:
             response.raise_for_status()
         except Exception as e:
-            self.log.warning("Error making request: {}".format(e))
+            self.log.warning("Error making request: %s", e)
+            self.log.debug("Error response content: %s", response.content)
             raise APIConnectionException("Error making request: {}".format(e))
         try:
             return response.json()


### PR DESCRIPTION
### What does this PR do?

[cisco_aci] improve logs on failed call to Cisco ACI api.

### Motivation

The response content include useful information from Cisco ACI.

Currently we only get: `400 Client Error: Bad Request for url`.

The response content contains info like: `the messaging layer was unable to deliver the stimulus (destination (node) is marked unavailable)`

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
