### PR TITLE
Add custom query capabilities

### DIFF
--- a/mongo/README.md
+++ b/mongo/README.md
@@ -9,6 +9,8 @@ Connect MongoDB to Datadog in order to:
 * Visualize key MongoDB metrics.
 * Correlate MongoDB performance with the rest of your applications.
 
+You can also create your own metrics using custom `find`, `count` and `aggregate` queries.
+
 ## Setup
 ### Installation
 
@@ -44,7 +46,7 @@ db.createUser({
 
 #### Metric Collection
 
-* Add this configuration block to your `mongo.d/conf.yaml` file to start gathering your [MongoDB Metrics](#metrics). See the [sample mongo.d/conf.yaml][4] for all available configuration options:
+* Add this configuration block to your `mongo.d/conf.yaml` file to start gathering your [MongoDB Metrics](#metrics):
 
   ```
   init_config:
@@ -56,7 +58,7 @@ db.createUser({
         - tcmalloc
         - top
   ```
-  See the [sample mongo.yaml][4] for all available configuration options
+  See the [sample mongo.yaml][4] for all available configuration options, including those for custom metrics.
 
 * [Restart the Agent][5] to start sending MongoDB metrics to Datadog.
 

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -93,6 +93,51 @@ instances:
     #
     # collections_indexes_stats: false
 
+    ## @param custom_queries - list - optional
+    ## Each query must have 3 fields:
+    ##
+    ## 1. metric_prefix - This is what each metric will start with.
+    ## 2. query  - This is the Mongo query to execute. The query needs to be written in a format compatible with
+    ##             the Mongo runCommand https://docs.mongodb.com/manual/reference/command/. Note that the agent
+    ##             only supports count, find and aggregates queries.
+    ## 3. fields - Ignored for `count` queries. This is a list representing each field with no specific order.
+    ##             Unspecified and missing fields will be ignored.
+    ##             There are 3 required pieces of data:
+    ##               a. field_name - This is the name of the field from which to fetch the data.
+    ##               b. name       - This is the suffix to append to the metric_prefix
+    ##                               in order to form the full metric name. If `type` is
+    ##                               `tag`, this column will instead be considered a tag
+    ##                               and will be applied to every metric collected by
+    ##                               this particular query.
+    ##               c. type       - This is the submission method (gauge, count, rate, etc.).
+    ##                               This can also be set to `tag` to tag each metric in the row
+    ##                               with the name and value of the item in this column. You can
+    ##                               use the `count` type to perform aggregation for queries that
+    ##                               return multiple rows with the same or no tags.
+    ## 4. tags (optional) - A list of tags to apply to each metric.
+    ## 5. count_type (optional) - For count queries only, this is the submission method (gauge, count, rate, etc.) of
+    ##                            the count result. Ignored for non count queries.
+    #
+    # custom_queries:
+    #   - metric_prefix: mongo
+    #     query:
+    #       aggregate: <COLLECTION_NAME>
+    #       pipeline:
+    #         - $match:
+    #             <FIELD_NAME>: <FIELD_VALUE>
+    #         - $group:
+    #             _id: <FIELD_NAME>
+    #       cursor: {}
+    #     fields:
+    #       - field_name: <FIELD_NAME>
+    #         name: <METRIC_SUFFIX>
+    #         type: <gauge|count|rate|monotonic_count>
+    #       - field_name: _id
+    #         name: cluster_id
+    #         type: tag
+    #     tags:
+    #       - test:mongodb
+
 ## Log Section (Available for Agent >=6.0)
 ##
 ## type - mandatory - Type of log input source (tcp / udp / file / windows_event)

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -663,7 +663,7 @@ class MongoDb(AgentCheck):
         """Extract the command (find, count or aggregate) from the query. Even though mongo and pymongo are supposed
         to work with the query as a single document, pymongo expects the command to be the `first` element of the
         query dict.
-        Because python dicts are not ordered, the command is extracted to be later run as the first argument
+        Because python 2 dicts are not ordered, the command is extracted to be later run as the first argument
         of pymongo `runcommand`
         """
         for command in ALLOWED_CUSTOM_QUERIES_COMMANDS:

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -1,10 +1,11 @@
-# (C) Datadog, Inc. 2018
+# (C) Datadog, Inc. 2018-2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
 import re
 import time
+from copy import deepcopy
 from distutils.version import LooseVersion
 
 import pymongo
@@ -20,6 +21,8 @@ if PY3:
 DEFAULT_TIMEOUT = 30
 GAUGE = AgentCheck.gauge
 RATE = AgentCheck.rate
+ALLOWED_CUSTOM_METRICS_TYPES = ['gauge', 'rate', 'count', 'monotonic_count']
+ALLOWED_CUSTOM_QUERIES_COMMANDS = ['aggregate', 'count', 'find']
 
 
 class MongoDb(AgentCheck):
@@ -650,6 +653,115 @@ class MongoDb(AgentCheck):
             except Exception as e:
                 self.log.error("Could not fetch indexes stats for collection %s: %s", coll_name, e)
 
+    def _get_submission_method(self, method_name):
+        if method_name not in ALLOWED_CUSTOM_METRICS_TYPES:
+            raise Exception('Metric type {} is not one of {}.'.format(method_name, ALLOWED_CUSTOM_METRICS_TYPES))
+        return getattr(self, method_name)
+
+    @staticmethod
+    def _extract_command_from_mongo_query(mongo_query):
+        """Extract the command (find, count or aggregate) from the query. Even though mongo and pymongo are supposed
+        to work with the query as a single document, pymongo expects the command to be the `first` element of the
+        query dict.
+        Because python dicts are not ordered, the command is extracted to be later run as the first argument
+        of pymongo `runcommand`
+        """
+        for command in ALLOWED_CUSTOM_QUERIES_COMMANDS:
+            if command in mongo_query:
+                return command
+        raise Exception("Custom query command must be of type {}".format(ALLOWED_CUSTOM_QUERIES_COMMANDS))
+
+    def _collect_custom_metrics_for_query(self, db, raw_query, tags):
+        """Validates the raw_query object, executes the mongo query then submits the metrics to datadog"""
+        metric_prefix = raw_query.get('metric_prefix')
+        if not metric_prefix:  # no cov
+            raise ValueError("Custom query field `metric_prefix` is required")
+        metric_prefix = metric_prefix.rstrip('.')
+
+        mongo_query = deepcopy(raw_query.get('query'))
+        if not mongo_query:  # no cov
+            raise ValueError("Custom query field `query` is required")
+        mongo_command = self._extract_command_from_mongo_query(mongo_query)
+        collection_name = mongo_query[mongo_command]
+        del mongo_query[mongo_command]
+        if mongo_command not in ALLOWED_CUSTOM_QUERIES_COMMANDS:
+            raise ValueError("Custom query command must be of type {}".format(ALLOWED_CUSTOM_QUERIES_COMMANDS))
+
+        submit_method = self.gauge
+        fields = []
+
+        if mongo_command == 'count':
+            count_type = raw_query.get('count_type')
+            if not count_type:  # no cov
+                raise ValueError('Custom query field `count_type` is required with a `count` query')
+            submit_method = self._get_submission_method(count_type)
+        else:
+            fields = raw_query.get('fields')
+            if not fields:  # no cov
+                raise ValueError('Custom query field `fields` is required')
+
+        for field in fields:
+            field_name = field.get('field_name')
+            if not field_name:  # no cov
+                raise ValueError('Field `field_name` is required for metric_prefix `{}`'.format(metric_prefix))
+
+            name = field.get('name')
+            if not name:  # no cov
+                raise ValueError('Field `name` is required for metric_prefix `{}`'.format(metric_prefix))
+
+            field_type = field.get('type')
+            if not field_type:  # no cov
+                raise ValueError('Field `type` is required for metric_prefix `{}`'.format(metric_prefix))
+            if field_type not in ALLOWED_CUSTOM_METRICS_TYPES + ['tag']:
+                raise ValueError('Field `type` must be one of {}'.format(ALLOWED_CUSTOM_METRICS_TYPES + ['tag']))
+
+        tags = tags + raw_query.get('tags', []) + ['collection:{}'.format(collection_name)]
+
+        try:
+            # This is where it is necessary to extract the command and its argument from the query to pass it as the
+            # first two params.
+            result = db.command(mongo_command, collection_name, **mongo_query)
+            if result['ok'] == 0:
+                raise pymongo.errors.PyMongoError(result['errmsg'])
+        except pymongo.errors.PyMongoError:
+            self.log.error("Failed to run custom query for metric {}".format(metric_prefix))
+            raise
+
+        if mongo_command == 'count':
+            # A count query simply returns a number, no need to iterate through it.
+            submit_method(metric_prefix, result['n'], tags)
+            return
+
+        cursor = pymongo.command_cursor.CommandCursor(
+            pymongo.collection.Collection(db, collection_name), result['cursor'], None
+        )
+
+        for row in cursor:
+            metric_info = []
+            query_tags = list(tags)
+
+            for field in fields:
+                field_name = field['field_name']
+                if field_name not in row:
+                    # Each row can have different fields, do not fail here.
+                    continue
+
+                field_type = field['type']
+                if field_type == 'tag':
+                    tag_name = field['name']
+                    query_tags.append('{}:{}'.format(tag_name, row[field_name]))
+                else:
+                    metric_suffix = field['name']
+                    submit_method = self._get_submission_method(field_type)
+                    metric_name = '{}.{}'.format(metric_prefix, metric_suffix)
+                    try:
+                        metric_info.append((metric_name, float(row[field_name]), submit_method))
+                    except ValueError:
+                        continue
+
+            for metric_name, metric_value, submit_method in metric_info:
+                submit_method(metric_name, metric_value, tags=query_tags)
+
     def check(self, instance):
         """
         Returns a dictionary that looks a lot like what's sent back by
@@ -1043,3 +1155,11 @@ class MongoDb(AgentCheck):
         except Exception as e:
             self.log.warning(u"Failed to record `collection` metrics.")
             self.log.exception(e)
+
+        custom_queries = instance.get("queries", [])
+        custom_query_tags = tags + ["db:{}".format(db_name)]
+        for raw_query in custom_queries:
+            try:
+                self._collect_custom_metrics_for_query(db, raw_query, custom_query_tags)
+            except Exception as e:
+                self.log.warning(e)

--- a/mongo/tests/conftest.py
+++ b/mongo/tests/conftest.py
@@ -14,13 +14,13 @@ from . import common
 
 
 @pytest.fixture(scope='session')
-def dd_environment(instance):
+def dd_environment(instance_custom_queries):
     compose_file = os.path.join(common.HERE, 'compose', 'docker-compose.yml')
 
     with docker_run(
         compose_file, conditions=[WaitFor(setup_sharding, args=(compose_file,), attempts=5, wait=5), InitializeDB()]
     ):
-        yield instance
+        yield instance_custom_queries
 
 
 @pytest.fixture(scope='session')
@@ -28,14 +28,81 @@ def instance():
     return {'server': common.MONGODB_SERVER}
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def instance_user():
     return {'server': 'mongodb://testUser2:testPass2@{}:{}/test'.format(common.HOST, common.PORT1)}
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def instance_authdb():
     return {'server': 'mongodb://testUser:testPass@{}:{}/test?authSource=authDB'.format(common.HOST, common.PORT1)}
+
+
+@pytest.fixture(scope='session')
+def instance_custom_queries():
+    return {
+        'server': 'mongodb://testUser2:testPass2@{}:{}/test'.format(common.HOST, common.PORT1),
+        'queries': [
+            {
+                "metric_prefix": "dd.custom.mongo.query_a",
+                "query": {'find': "orders", 'filter': {'amount': {'$gt': 25}}, 'sort': {'amount': -1}},
+                "fields": [
+                    {
+                        "field_name": "cust_id",
+                        "name": "cluster_id",
+                        "type": "tag",
+                    },
+                    {
+                        "field_name": "status",
+                        "name": "status_tag",
+                        "type": "tag",
+                    },
+                    {
+                        "field_name": "amount",
+                        "name": "amount",
+                        "type": "count",
+                    },
+                    {
+                        "field_name": "elements",
+                        "name": "el",
+                        "type": "count",
+                    },
+                ],
+                "tags": ['tag1:val1', 'tag2:val2'],
+            },
+            {
+                "query": {'count': "foo", 'query': {'1': {'$type': 16}}},
+                "metric_prefix": "dd.custom.mongo.count",
+                "tags": ['tag1:val1', 'tag2:val2'],
+                "count_type": 'gauge',
+            },
+            {
+                "query": {
+                    'aggregate': "orders",
+                    'pipeline': [
+                        {"$match": {"status": "A"}},
+                        {"$group": {"_id": "$cust_id", "total": {"$sum": "$amount"}}},
+                        {"$sort": {"total": -1}},
+                    ],
+                    'cursor': {},
+                },
+                "fields": [
+                    {
+                        "field_name": "total",
+                        "name": "total",
+                        "type": "count",
+                    },
+                    {
+                        "field_name": "_id",
+                        "name": "cluster_id",
+                        "type": "tag",
+                    },
+                ],
+                "metric_prefix": "dd.custom.mongo.aggregate",
+                "tags": ['tag1:val1', 'tag2:val2'],
+            },
+        ],
+    }
 
 
 @pytest.fixture
@@ -67,9 +134,9 @@ class InitializeDB(LazyFunction):
         )
 
         foos = []
-        for _ in range(70):
+        for i in range(70):
             foos.append({'1': []})
-            foos.append({'1': []})
+            foos.append({'1': i})
             foos.append({})
 
         bars = []
@@ -77,9 +144,19 @@ class InitializeDB(LazyFunction):
             bars.append({'1': []})
             bars.append({})
 
+        orders = [
+            {"cust_id": "abc1", "status": "A", "amount": 50, "elements": 3},
+            {"cust_id": "xyz1", "status": "A", "amount": 100},
+            {"cust_id": "abc1", "status": "D", "amount": 50, "elements": 1},
+            {"cust_id": "abc1", "status": "A", "amount": 25},
+            {"cust_id": "xyz1", "status": "A", "amount": 25},
+            {"cust_id": "abc1", "status": "A", "amount": 300, "elements": 10},
+        ]
+
         db = cli['test']
         db.foo.insert_many(foos)
         db.bar.insert_many(bars)
+        db.orders.insert_many(orders)
 
         auth_db = cli['authDB']
         auth_db.command("createUser", 'testUser', pwd='testPass', roles=[{'role': 'read', 'db': 'test'}])

--- a/mongo/tests/conftest.py
+++ b/mongo/tests/conftest.py
@@ -14,13 +14,13 @@ from . import common
 
 
 @pytest.fixture(scope='session')
-def dd_environment(instance_custom_queries):
+def dd_environment(instance):
     compose_file = os.path.join(common.HERE, 'compose', 'docker-compose.yml')
 
     with docker_run(
         compose_file, conditions=[WaitFor(setup_sharding, args=(compose_file,), attempts=5, wait=5), InitializeDB()]
     ):
-        yield instance_custom_queries
+        yield instance
 
 
 @pytest.fixture(scope='session')
@@ -47,26 +47,10 @@ def instance_custom_queries():
                 "metric_prefix": "dd.custom.mongo.query_a",
                 "query": {'find': "orders", 'filter': {'amount': {'$gt': 25}}, 'sort': {'amount': -1}},
                 "fields": [
-                    {
-                        "field_name": "cust_id",
-                        "name": "cluster_id",
-                        "type": "tag",
-                    },
-                    {
-                        "field_name": "status",
-                        "name": "status_tag",
-                        "type": "tag",
-                    },
-                    {
-                        "field_name": "amount",
-                        "name": "amount",
-                        "type": "count",
-                    },
-                    {
-                        "field_name": "elements",
-                        "name": "el",
-                        "type": "count",
-                    },
+                    {"field_name": "cust_id", "name": "cluster_id", "type": "tag"},
+                    {"field_name": "status", "name": "status_tag", "type": "tag"},
+                    {"field_name": "amount", "name": "amount", "type": "count"},
+                    {"field_name": "elements", "name": "el", "type": "count"},
                 ],
                 "tags": ['tag1:val1', 'tag2:val2'],
             },
@@ -87,16 +71,8 @@ def instance_custom_queries():
                     'cursor': {},
                 },
                 "fields": [
-                    {
-                        "field_name": "total",
-                        "name": "total",
-                        "type": "count",
-                    },
-                    {
-                        "field_name": "_id",
-                        "name": "cluster_id",
-                        "type": "tag",
-                    },
+                    {"field_name": "total", "name": "total", "type": "count"},
+                    {"field_name": "_id", "name": "cluster_id", "type": "tag"},
                 ],
                 "metric_prefix": "dd.custom.mongo.aggregate",
                 "tags": ['tag1:val1', 'tag2:val2'],

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2018
+# (C) Datadog, Inc. 2018-2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging


### PR DESCRIPTION
### What does this PR do?

Give the mongo integration the ability to run custom queries and submit metric to Datadog. This is alike yet different from what we have for idb_db2 or postgres, because mongo work with json documents and queries as code e.g. `db.collection_name.find({})`) 

To prevent parsing a string and run code accordingly, we leverage [db.runCommand](https://docs.mongodb.com/manual/reference/method/db.runCommand/) to run arbitrarily commands with the same syntax. To configure the integration, the customer musts rewrite his commands as a mongo `runCommand` (effort: low), then translate that into YAML to put it in the config.

The syntax of the config file is almost the same as what we have for other integrations supporting custom queries, except that relational databases requires columns to be ordered as the resulting queries without requiring the name of the column. For mongo, (db) fields are not ordered thus, a new (config) field named "field_name" is added. 

### Motivation

Customer requests

### Additional Notes

Only `count`, `find` and `aggregate` commands are supported. This is explicit non-support for read-only operations `group` and `mapReduce`, because `group` is deprecated in favor of `aggregate`, and `mapReduce` requires adding javascript into the command while in most cases `aggregate` can be sufficient.

- `count` queries return a single number. The number is used as is as the metric value.
- `find` and `aggregate` queries are handled the same way. The query can return multiple documents with multiple fields. Each field can either be ignored/used as a tag with a custom prefix/used as a specific metric.

One thing to note though. Mongo queries use javascript by default and this is what customers will be the most used too.  It is not an option to have a field in the config with the javascript query that would need to be parsed manually. Instead, the queries (at least those we support here) simply are dictionaries and can be converted to JSON or YAML then added to the config in a similar fashion as what is done below:

```
queries:
 - metric_prefix: dd.mongo.aggregate
    tags:
      - mytag:value
      - role:$_id
    fields:
      - field_name: total
         name: total_value
         type: count
      - field_name: _id
         name: role
         type: tag
    query:
      aggregate: foo
      cursor: {}
      pipeline:
        - $match:
             status: UP
         - $group:
             _id: $role
             total:
               $sum: $amount
         - $sort:
              total: -1
    field: total
```

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
