### PR TITLE
New metrics + always fetch aggregated data

### DIFF
--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -34,7 +34,12 @@ instances:
 
     ## @param collect_aggregates_only - boolean - optional - default: true
     ## This parameter instructs the check to collect metrics only from the aggregate frontend/backend
-    ## status lines from the stats output instead of for each backend.
+    ## status lines from the stats output instead of for each backend. With this parameter set to false the agent
+    ## collects data for each backend but ignores the aggregated data for backends. Because some metrics are only
+    ## available for aggregates, you can also set this parameter to the string 'both' to collect everything.
+    ## Please note that this mean that if if you have queries like computing the sum of all requests being made, the
+    ## result will be twice as expected. To get the correct result, you have to explicitly add some filters to the
+    ## query.
     #
     # collect_aggregates_only: true
 

--- a/haproxy/datadog_checks/haproxy/haproxy.py
+++ b/haproxy/datadog_checks/haproxy/haproxy.py
@@ -79,7 +79,9 @@ class HAProxy(AgentCheck):
         "eresp": ("rate", "errors.resp_rate"),
         "wretr": ("rate", "warnings.retr_rate"),
         "wredis": ("rate", "warnings.redis_rate"),
+        "lastchg": ("gauge", "uptime"),
         "req_rate": ("gauge", "requests.rate"),  # HA Proxy 1.4 and higher
+        "req_tot": ("rate", "requests.tot_rate"),  # HA Proxy 1.4 and higher
         "hrsp_1xx": ("rate", "response.1xx"),  # HA Proxy 1.4 and higher
         "hrsp_2xx": ("rate", "response.2xx"),  # HA Proxy 1.4 and higher
         "hrsp_3xx": ("rate", "response.3xx"),  # HA Proxy 1.4 and higher
@@ -90,7 +92,9 @@ class HAProxy(AgentCheck):
         "ctime": ("gauge", "connect.time"),  # HA Proxy 1.5 and higher
         "rtime": ("gauge", "response.time"),  # HA Proxy 1.5 and higher
         "ttime": ("gauge", "session.time"),  # HA Proxy 1.5 and higher
-        "lastchg": ("gauge", "uptime"),
+        "conn_rate": ("gauge", "connections.rate"),  # HA Proxy 1.7 and higher
+        "conn_tot": ("rate", "connections.tot_rate"),  # HA Proxy 1.7 and higher
+        "intercepted": ("rate", "requests.intercepted"),  # HA Proxy 1.7 and higher
     }
 
     SERVICE_CHECK_NAME = 'haproxy.backend_up'
@@ -426,16 +430,10 @@ class HAProxy(AgentCheck):
             hosts_statuses[key] += 1
 
     def _should_process(self, data_dict, collect_aggregates_only):
-        """
-            if collect_aggregates_only, we process only the aggregates
-            else we process all except Services.BACKEND
+        """if collect_aggregates_only, we process only the aggregates
         """
         if collect_aggregates_only:
-            if self._is_aggregate(data_dict):
-                return True
-            return False
-        elif data_dict['svname'] == Services.BACKEND:
-            return False
+            return self._is_aggregate(data_dict)
         return True
 
     def _is_service_excl_filtered(self, service_name, services_incl_filter, services_excl_filter):

--- a/haproxy/datadog_checks/haproxy/haproxy.py
+++ b/haproxy/datadog_checks/haproxy/haproxy.py
@@ -120,7 +120,7 @@ class HAProxy(AgentCheck):
 
             data = self._fetch_url_data(url, username, password, verify, custom_headers)
 
-        collect_aggregates_only = _is_affirmative(instance.get('collect_aggregates_only', True))
+        collect_aggregates_only = instance.get('collect_aggregates_only', True)
         collect_status_metrics = _is_affirmative(instance.get('collect_status_metrics', False))
 
         collect_status_metrics_by_host = _is_affirmative(instance.get('collect_status_metrics_by_host', False))
@@ -432,9 +432,12 @@ class HAProxy(AgentCheck):
     def _should_process(self, data_dict, collect_aggregates_only):
         """if collect_aggregates_only, we process only the aggregates
         """
-        if collect_aggregates_only:
+        if _is_affirmative(collect_aggregates_only):
             return self._is_aggregate(data_dict)
-        return True
+        elif str(collect_aggregates_only).lower() == 'both':
+            return True
+
+        return data_dict['svname'] != Services.BACKEND
 
     def _is_service_excl_filtered(self, service_name, services_incl_filter, services_excl_filter):
         if self._tag_match_patterns(service_name, services_excl_filter):

--- a/haproxy/metadata.csv
+++ b/haproxy/metadata.csv
@@ -16,6 +16,7 @@ haproxy.backend.response.4xx,gauge,,response,,Backend HTTP responses with 4xx co
 haproxy.backend.response.5xx,gauge,,response,,Backend HTTP responses with 5xx code.,-1,haproxy,backend resp 5xx
 haproxy.backend.response.other,gauge,,response,,Backend HTTP responses with other code (protocol error).,0,haproxy,backend resp other
 haproxy.backend.response.time,gauge,,millisecond,,Average response time over the last 1024 requests (0 for TCP).,-1,haproxy,backend resp time
+haproxy.backend.requests.tot_rate,gauge,,request,second,Rate of total number of HTTP requests.,0,haproxy,backend total req rate
 haproxy.backend.session.current,gauge,,connection,,Number of active backend sessions.,0,haproxy,backend sess
 haproxy.backend.session.limit,gauge,,connection,,Configured backend session limit.,0,haproxy,backend sess lim
 haproxy.backend.session.pct,gauge,,percent,,Percentage of sessions in use (backend.session.current/backend.session.limit * 100).,-1,haproxy,backend sess pct
@@ -27,10 +28,14 @@ haproxy.backend.warnings.retr_rate,gauge,,error,second,Number of times a connect
 haproxy.count_per_status,gauge,,host,,Number of hosts by status (UP/DOWN/NOLB/MAINT).,0,haproxy,hosts status
 haproxy.frontend.bytes.in_rate,gauge,,byte,second,Rate of bytes in on frontend hosts.,0,haproxy,frontend bytes in rate
 haproxy.frontend.bytes.out_rate,gauge,,byte,second,Rate of bytes out on frontend hosts.,0,haproxy,frontend bytes out rate
+haproxy.frontend.connections.rate,gauge,,connection,second,Number of connections per second.,0,haproxy,frontend connections rate
+haproxy.frontend.connections.tot_rate,gauge,,connection,second,Rate of total number of connections.,0,haproxy,frontend tot connections rate
 haproxy.frontend.denied.req_rate,gauge,,request,second,Number of requests denied due to security concerns.,-1,haproxy,frontend den req rate
 haproxy.frontend.denied.resp_rate,gauge,,response,second,Number of responses denied due to security concerns.,-1,haproxy,frontend den resp rate
 haproxy.frontend.errors.req_rate,gauge,,error,second,Rate of request errors.,-1,haproxy,frontend err req rate
+haproxy.frontend.requests.intercepted,gauge,,request,second,Number of intercepted requests per second.,0,haproxy,frontend intercepted req rate
 haproxy.frontend.requests.rate,gauge,,request,second,Number of HTTP requests per second.,0,haproxy,frontend req rate
+haproxy.frontend.requests.tot_rate,gauge,,request,second,Rate of total number of HTTP requests.,0,haproxy,frontend total req rate
 haproxy.frontend.response.1xx,gauge,,response,,Frontend HTTP responses with 1xx code.,0,haproxy,frontend resp 1xx
 haproxy.frontend.response.2xx,gauge,,response,,Frontend HTTP responses with 2xx code.,0,haproxy,frontend resp 2xx
 haproxy.frontend.response.3xx,gauge,,response,,Frontend HTTP responses with 3xx code.,0,haproxy,frontend resp 3xx

--- a/haproxy/tests/common.py
+++ b/haproxy/tests/common.py
@@ -51,7 +51,7 @@ CHECK_CONFIG = {
     'active_tag': True,
 }
 
-CHECK_CONFIG_OPEN = {'url': STATS_URL_OPEN, 'collect_aggregates_only': False, 'collect_status_metrics': True}
+CHECK_CONFIG_OPEN = {'url': STATS_URL_OPEN, 'collect_aggregates_only': 'both', 'collect_status_metrics': True}
 
 BACKEND_SERVICES = ['anotherbackend', 'datadog']
 

--- a/haproxy/tests/common.py
+++ b/haproxy/tests/common.py
@@ -46,12 +46,12 @@ CHECK_CONFIG = {
     'username': USERNAME,
     'password': PASSWORD,
     'status_check': True,
-    'collect_aggregates_only': False,
+    'collect_aggregates_only': 'both',
     'tag_service_check_by_host': True,
     'active_tag': True,
 }
 
-CHECK_CONFIG_OPEN = {'url': STATS_URL_OPEN, 'collect_aggregates_only': 'both', 'collect_status_metrics': True}
+CHECK_CONFIG_OPEN = {'url': STATS_URL_OPEN, 'collect_aggregates_only': False, 'collect_status_metrics': True}
 
 BACKEND_SERVICES = ['anotherbackend', 'datadog']
 
@@ -67,16 +67,14 @@ BACKEND_TO_ADDR = {
 BACKEND_HOSTS_METRIC = 'haproxy.backend_hosts'
 BACKEND_STATUS_METRIC = 'haproxy.count_per_status'
 
-FRONTEND_CHECK_GAUGES = [
+FRONTEND_CHECK = [
+    # gauges
     ('haproxy.frontend.session.current', ['1', '0']),
     ('haproxy.frontend.session.limit', ['1', '0']),
     ('haproxy.frontend.session.pct', ['1', '0']),
     ('haproxy.frontend.requests.rate', ['1', '4']),
     ('haproxy.frontend.connections.rate', ['1', '7']),
-]
-
-
-FRONTEND_CHECK_RATES = [
+    # rates
     ('haproxy.frontend.bytes.in_rate', ['1', '0']),
     ('haproxy.frontend.bytes.out_rate', ['1', '0']),
     ('haproxy.frontend.denied.req_rate', ['1', '0']),
@@ -94,7 +92,8 @@ FRONTEND_CHECK_RATES = [
     ('haproxy.frontend.requests.intercepted', ['1', '7']),
 ]
 
-BACKEND_CHECK_GAUGES = [
+BACKEND_CHECK = [
+    # gauges
     ('haproxy.backend.queue.current', ['1', '0']),
     ('haproxy.backend.session.current', ['1', '0']),
     ('haproxy.backend.queue.time', ['1', '5']),
@@ -102,9 +101,7 @@ BACKEND_CHECK_GAUGES = [
     ('haproxy.backend.response.time', ['1', '5']),
     ('haproxy.backend.session.time', ['1', '5']),
     ('haproxy.backend.uptime', ['1', '7']),
-]
-
-BACKEND_CHECK_RATES = [
+    # rates
     ('haproxy.backend.bytes.in_rate', ['1', '0']),
     ('haproxy.backend.bytes.out_rate', ['1', '0']),
     ('haproxy.backend.denied.resp_rate', ['1', '0']),
@@ -121,13 +118,12 @@ BACKEND_CHECK_RATES = [
     ('haproxy.backend.response.other', ['1', '4']),
 ]
 
-BACKEND_AGGREGATE_ONLY_CHECK_GAUGES = [
+BACKEND_AGGREGATE_ONLY_CHECK = [
+    # gauges
     ('haproxy.backend.uptime', ['1', '0']),
     ('haproxy.backend.session.limit', ['1', '0']),
     ('haproxy.backend.session.pct', ['1', '5']),
-]
-
-BACKEND_AGGREGATE_ONLY_CHECK_RATES = [
+    # rates
     ('haproxy.backend.denied.req_rate', ['1', '0']),
     ('haproxy.backend.requests.tot_rate', ['1', '7']),
 ]

--- a/haproxy/tests/common.py
+++ b/haproxy/tests/common.py
@@ -63,65 +63,73 @@ BACKEND_TO_ADDR = {
     'otherserver': '127.0.0.1:1234',
 }
 
-FRONTEND_CHECK_GAUGES = [
-    'haproxy.frontend.session.current',
-    'haproxy.frontend.session.limit',
-    'haproxy.frontend.session.pct',
-]
-
-FRONTEND_CHECK_GAUGES_POST_1_4 = ['haproxy.frontend.requests.rate']
-
-BACKEND_CHECK_GAUGES = ['haproxy.backend.queue.current', 'haproxy.backend.session.current']
 
 BACKEND_HOSTS_METRIC = 'haproxy.backend_hosts'
 BACKEND_STATUS_METRIC = 'haproxy.count_per_status'
 
-
-BACKEND_CHECK_GAUGES_POST_1_5 = [
-    'haproxy.backend.queue.time',
-    'haproxy.backend.connect.time',
-    'haproxy.backend.response.time',
-    'haproxy.backend.session.time',
+FRONTEND_CHECK_GAUGES = [
+    ('haproxy.frontend.session.current', ['1', '0']),
+    ('haproxy.frontend.session.limit', ['1', '0']),
+    ('haproxy.frontend.session.pct', ['1', '0']),
+    ('haproxy.frontend.requests.rate', ['1', '4']),
+    ('haproxy.frontend.connections.rate', ['1', '7']),
 ]
+
 
 FRONTEND_CHECK_RATES = [
-    'haproxy.frontend.bytes.in_rate',
-    'haproxy.frontend.bytes.out_rate',
-    'haproxy.frontend.denied.req_rate',
-    'haproxy.frontend.denied.resp_rate',
-    'haproxy.frontend.errors.req_rate',
-    'haproxy.frontend.session.rate',
+    ('haproxy.frontend.bytes.in_rate', ['1', '0']),
+    ('haproxy.frontend.bytes.out_rate', ['1', '0']),
+    ('haproxy.frontend.denied.req_rate', ['1', '0']),
+    ('haproxy.frontend.denied.resp_rate', ['1', '0']),
+    ('haproxy.frontend.errors.req_rate', ['1', '0']),
+    ('haproxy.frontend.session.rate', ['1', '0']),
+    ('haproxy.frontend.response.1xx', ['1', '4']),
+    ('haproxy.frontend.response.2xx', ['1', '4']),
+    ('haproxy.frontend.response.3xx', ['1', '4']),
+    ('haproxy.frontend.response.4xx', ['1', '4']),
+    ('haproxy.frontend.response.5xx', ['1', '4']),
+    ('haproxy.frontend.response.other', ['1', '4']),
+    ('haproxy.frontend.requests.tot_rate', ['1', '4']),
+    ('haproxy.frontend.connections.tot_rate', ['1', '7']),
+    ('haproxy.frontend.requests.intercepted', ['1', '7']),
 ]
 
-FRONTEND_CHECK_RATES_POST_1_4 = [
-    'haproxy.frontend.response.1xx',
-    'haproxy.frontend.response.2xx',
-    'haproxy.frontend.response.3xx',
-    'haproxy.frontend.response.4xx',
-    'haproxy.frontend.response.5xx',
-    'haproxy.frontend.response.other',
+BACKEND_CHECK_GAUGES = [
+    ('haproxy.backend.queue.current', ['1', '0']),
+    ('haproxy.backend.session.current', ['1', '0']),
+    ('haproxy.backend.queue.time', ['1', '5']),
+    ('haproxy.backend.connect.time', ['1', '5']),
+    ('haproxy.backend.response.time', ['1', '5']),
+    ('haproxy.backend.session.time', ['1', '5']),
+    ('haproxy.backend.uptime', ['1', '7']),
 ]
 
 BACKEND_CHECK_RATES = [
-    'haproxy.backend.bytes.in_rate',
-    'haproxy.backend.bytes.out_rate',
-    'haproxy.backend.denied.resp_rate',
-    'haproxy.backend.errors.con_rate',
-    'haproxy.backend.errors.resp_rate',
-    'haproxy.backend.session.rate',
-    'haproxy.backend.warnings.redis_rate',
-    'haproxy.backend.warnings.retr_rate',
+    ('haproxy.backend.bytes.in_rate', ['1', '0']),
+    ('haproxy.backend.bytes.out_rate', ['1', '0']),
+    ('haproxy.backend.denied.resp_rate', ['1', '0']),
+    ('haproxy.backend.errors.con_rate', ['1', '0']),
+    ('haproxy.backend.errors.resp_rate', ['1', '0']),
+    ('haproxy.backend.session.rate', ['1', '0']),
+    ('haproxy.backend.warnings.redis_rate', ['1', '0']),
+    ('haproxy.backend.warnings.retr_rate', ['1', '0']),
+    ('haproxy.backend.response.1xx', ['1', '4']),
+    ('haproxy.backend.response.2xx', ['1', '4']),
+    ('haproxy.backend.response.3xx', ['1', '4']),
+    ('haproxy.backend.response.4xx', ['1', '4']),
+    ('haproxy.backend.response.5xx', ['1', '4']),
+    ('haproxy.backend.response.other', ['1', '4']),
 ]
 
-BACKEND_CHECK_RATES_POST_1_4 = [
-    'haproxy.backend.response.1xx',
-    'haproxy.backend.response.2xx',
-    'haproxy.backend.response.3xx',
-    'haproxy.backend.response.4xx',
-    'haproxy.backend.response.5xx',
-    'haproxy.backend.response.other',
+BACKEND_AGGREGATE_ONLY_CHECK_GAUGES = [
+    ('haproxy.backend.uptime', ['1', '0']),
+    ('haproxy.backend.session.limit', ['1', '0']),
+    ('haproxy.backend.session.pct', ['1', '5']),
 ]
 
-BACKEND_CHECK_GAUGES_POST_1_7 = ['haproxy.backend.uptime']
+BACKEND_AGGREGATE_ONLY_CHECK_RATES = [
+    ('haproxy.backend.denied.req_rate', ['1', '0']),
+    ('haproxy.backend.requests.tot_rate', ['1', '7']),
+]
 
 SERVICE_CHECK_NAME = 'haproxy.backend_up'


### PR DESCRIPTION
### What does this PR do?

Adds, `requests.tot_rate`, `connections.rate`, `connections.tot_rate` and `requests.intercepted` to haproxy integration.
Also changes the behavior of the `collect_aggregates_only` config parameter.

Beforehand the behavior was:
collect_aggregates_only: true -> Only aggregated values
collect_aggregates_only: false -> Only non-aggregated values

Now the behavior is:
collect_aggregates_only: true -> Only aggregated values
collect_aggregates_only: false -> All values

For backends, some metrics are only available when you look at the aggregated data, with previous behavior we were missing them. The list of those metrics is:

```
haproxy.backend.uptime
haproxy.backend.session.limit
haproxy.backend.session.pct
haproxy.backend.denied.req_rate
haproxy.backend.requests.tot_rate
```

### Motivation

Internal request to add `haproxy.backend.requests.tot_rate` to help with a kubernetes deployment. 

### Additional Notes

I also refactored the testing code but nothing major in there except that now aggregated only metrics are also tested.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
