### PR TITLE
Fix non-ascii mounted folder name

### DIFF
--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -114,9 +114,9 @@ class Device(object):
 
     def _parse_tags(self):
         self.tags = []
-        self.tags.append('nfs_server:{0}'.format(ensure_unicode(self.nfs_server)))
-        self.tags.append('nfs_export:{0}'.format(ensure_unicode(self.nfs_export)))
-        self.tags.append('nfs_mount:{0}'.format(ensure_unicode(self.mount)))
+        self.tags.append(u'nfs_server:{0}'.format(ensure_unicode(self.nfs_server)))
+        self.tags.append(u'nfs_export:{0}'.format(ensure_unicode(self.nfs_export)))
+        self.tags.append(u'nfs_mount:{0}'.format(ensure_unicode(self.mount)))
 
     def send_metrics(self, gauge, tags):
         metric_prefix = 'system.nfs.'

--- a/nfsstat/tests/fixtures/nfsiostat
+++ b/nfsstat/tests/fixtures/nfsiostat
@@ -18,3 +18,13 @@ read:              ops/s            kB/s           kB/op         retrans    avg 
                    0.382           2.304           6.038        0 (0.0%)           0.302           0.493
 write:             ops/s            kB/s           kB/op         retrans    avg RTT (ms)    avg exe (ms)
                    5.976          33.733           5.645        0 (0.0%)           0.535           5.222
+
+192.168.34.1:/exports/nfs/datadog/thréé mounted on /mnt/datadog/thréé:
+
+           ops/s       rpc bklog
+         111.507           0.000
+
+read:              ops/s            kB/s           kB/op         retrans    avg RTT (ms)    avg exe (ms)
+                   0.382           2.304           6.038        0 (0.0%)           0.302           0.493
+write:             ops/s            kB/s           kB/op         retrans    avg RTT (ms)    avg exe (ms)
+                   5.976          33.733           5.645        0 (0.0%)           0.535           5.222

--- a/nfsstat/tests/test_nfsstat.py
+++ b/nfsstat/tests/test_nfsstat.py
@@ -60,8 +60,17 @@ class TestNfsstat:
 
         tags = list(instance['tags'])
         tags.extend(['nfs_server:192.168.34.1', 'nfs_export:/exports/nfs/datadog/two', 'nfs_mount:/mnt/datadog/two'])
+        tags_unicode = list(instance['tags'])
+        tags_unicode.extend(
+            [
+                u'nfs_server:192.168.34.1',
+                u'nfs_export:/exports/nfs/datadog/thr\u00E9\u00E9',
+                u'nfs_mount:/mnt/datadog/thr\u00E9\u00E9',
+            ]
+        )
 
         for metric in metrics:
             aggregator.assert_metric(metric, tags=tags)
+            aggregator.assert_metric(metric, tags=tags_unicode)
 
         assert aggregator.metrics_asserted_pct == 100.0


### PR DESCRIPTION
### What does this PR do?

Fix exception when checking a mounted folder with non-ascii character.

### Motivation

### Additional Notes

Added a test.
Used `\u00E9` instead of `é` to work on python2 and python3.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
