### PR TITLE
document HTTP(S) requirement on HDFS NameNode JMX URI port

### DIFF
--- a/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
@@ -11,7 +11,7 @@ instances:
     ## the property dfs.namenode.http-address
     ## https://hadoop.apache.org/docs/r2.7.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
     #
-  - hdfs_namenode_jmx_uri: http://localhost:50075
+  - hdfs_namenode_jmx_uri: http://localhost:50070
 
     ## @param username - string - optional
     ## The username to use if the `hdfs_namenode_jmx_uri` is behind basic auth.

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
@@ -4,8 +4,8 @@ instances:
 
     ## @param hdfs_namenode_jmx_uri - string - required
     ## The HDFS DataNode check retrieves metrics from the HDFS DataNode's JMX
-    ## interface. This check must be installed on a HDFS DataNode. The HDFS
-    ## DataNode JMX URI is composed of the DataNode's hostname and port.
+    ## interface via HTTP(S) (not a JMX remote connection). This check must be installed on 
+    ## a HDFS DataNode. The HDFS DataNode JMX URI is composed of the DataNode's hostname and port.
     ##
     ## The hostname and port can be found in the hdfs-site.xml conf file under
     ## the property dfs.datanode.http.address

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
@@ -3,12 +3,13 @@ init_config:
 instances:
 
     ## @param hdfs_namenode_jmx_uri - string - required
-    ## The HDFS DataNode check retrieves metrics from the HDFS DataNode's JMX
+    ## The HDFS NameNode check retrieves metrics from the HDFS NameNode's JMX
     ## interface via HTTP(S) (not a JMX remote connection). This check must be installed on 
-    ## a HDFS DataNode. The HDFS DataNode JMX URI is composed of the DataNode's hostname and port.
+    ## a HDFS NameNode. The HDFS NameNode JMX URI is composed of the NameNode's hostname and port.
     ##
     ## The hostname and port can be found in the hdfs-site.xml conf file under
-    ## the property dfs.datanode.http.address
+    ## the property dfs.namenode.http-address
+    ## https://hadoop.apache.org/docs/r2.7.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
     #
   - hdfs_namenode_jmx_uri: http://localhost:50075
 


### PR DESCRIPTION
### What does this PR do?

Documents requirement of HTTP(s) on the HDFS NameNode JMX URI port. 

### Motivation

Support case

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
