### PR TITLE
Use safe default when validating manifests

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -95,7 +95,7 @@ def manifest(fix, include_extras):
             for attr in sorted(REQUIRED_ATTRIBUTES - attrs):
                 file_failures += 1
                 display_queue.append((echo_failure, '  Attribute `{}` is required'.format(attr)))
-            for attr in sorted(REQUIRED_ASSET_ATTRIBUTES - set(decoded.get('assets'))):
+            for attr in sorted(REQUIRED_ASSET_ATTRIBUTES - set(decoded.get('assets', {}))):
                 file_failures += 1
                 display_queue.append((echo_failure, ' Attribute `{}` under `assets` is required'.format(attr)))
 


### PR DESCRIPTION
### What does this PR do?

Uses a safe dict default when accessing the `assets` key of the manifest file. 

### Motivation

The manifest validation code, when looking for the `assets` key was being converted to a `set`. However if the key didn't exist, `None` couldn't be converted to a set and a messy error traceback was produced. This fixes that

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
