### PR TITLE
added test for none tags warning logs

### DIFF
--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -256,6 +256,13 @@ class TestTags:
         normalized_tags = check._normalize_tags_type(tags, None)
         assert normalized_tags == ['tag:foo']
 
+    def test_none_value_warning_log(self, caplog):
+        check = AgentCheck()
+        tags = [None, 'tag:foo']
+
+        normalized_tags = check._normalize_tags_type(tags, None)
+        assert 'Error encoding tag' not in caplog.text
+
     def test_external_host_tag_normalization(self):
         """
         Tests that the external_host_tag modifies in place the list of tags in the provided object

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -249,18 +249,12 @@ class TestTags:
         in_str.encode.side_effect = Exception
         assert check._to_bytes(in_str) is None
 
-    def test_none_value(self):
+    def test_none_value(self, caplog):
         check = AgentCheck()
         tags = [None, 'tag:foo']
 
         normalized_tags = check._normalize_tags_type(tags, None)
         assert normalized_tags == ['tag:foo']
-
-    def test_none_value_warning_log(self, caplog):
-        check = AgentCheck()
-        tags = [None, 'tag:foo']
-
-        normalized_tags = check._normalize_tags_type(tags, None)
         assert 'Error encoding tag' not in caplog.text
 
     def test_external_host_tag_normalization(self):


### PR DESCRIPTION
### What does this PR do?

Added proper test for https://github.com/DataDog/integrations-core/pull/3665 with caplog.
Testing output as this won't throw an exception if tags are None.

### Motivation

Same as https://github.com/DataDog/integrations-core/pull/3665 and https://github.com/DataDog/integrations-core/pull/3249, the log was spamming some customer in some cases with a valid ksm payload.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
