### PR TITLE
Make PDHCheck use PDHBaseCHeck

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/win/winpdh_base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/winpdh_base.py
@@ -27,8 +27,6 @@ class PDHBaseCheck(AgentCheck):
 
     def __init__(self, name, init_config, agentConfig, instances, counter_list):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
-        self._countersettypes = {}
-        self._counters = {}
         self._missing_counters = {}
         self._metrics = {}
         self._tags = {}
@@ -61,7 +59,7 @@ class PDHBaseCheck(AgentCheck):
                         win32wnet.WNetAddConnection2(nr, password, username, 0)
 
                     except Exception as e:
-                        self.log.error("Failed to make remote connection %s" % str(e))
+                        self.log.error("Failed to make remote connection %s", str(e))
                         return
 
                 # counter_data_types allows the precision with which counters are queried
@@ -77,19 +75,19 @@ class PDHBaseCheck(AgentCheck):
                 precisions = instance.get('counter_data_types')
                 if precisions is not None:
                     if not isinstance(precisions, list):
-                        self.log.warning("incorrect type for counter_data_type %s" % str(precisions))
+                        self.log.warning("incorrect type for counter_data_type %s", str(precisions))
                     else:
                         for p in precisions:
                             k, v = p.split(",")
                             v = v.lower().strip()
                             if v in int_types:
-                                self.log.info("Setting datatype for %s to integer" % k)
+                                self.log.info("Setting datatype for %s to integer", k)
                                 datatypes[k] = DATA_TYPE_INT
                             elif v in double_types:
-                                self.log.info("Setting datatype for %s to double" % k)
+                                self.log.info("Setting datatype for %s to double", k)
                                 datatypes[k] = DATA_TYPE_DOUBLE
                             else:
-                                self.log.warning("Unknown data type %s" % str(v))
+                                self.log.warning("Unknown data type %s", str(v))
 
                 self._make_counters(key, (counter_list, (datatypes, remote_machine, False, 'entry')))
 
@@ -132,7 +130,7 @@ class PDHBaseCheck(AgentCheck):
                     metric_func(dd_name, val, tags)
             except Exception as e:
                 # don't give up on all of the metrics because one failed
-                self.log.error("Failed to get data for %s %s: %s" % (inst_name, dd_name, str(e)))
+                self.log.error("Failed to get data for %s %s: %s", inst_name, dd_name, str(e))
 
     def _make_counters(self, key, counter_data):
         counter_list, (datatypes, remote_machine, check_instance, message) = counter_data
@@ -153,9 +151,11 @@ class PDHBaseCheck(AgentCheck):
                 )
             except Exception as e:
                 self.log.debug(
-                    'Could not create counter {}\\{} due to {}, will not report {}.'.format(
-                        counterset, counter_name, e, dd_name
-                    )
+                    'Could not create counter %s\\%s due to %s, will not report %s.',
+                    counterset,
+                    counter_name,
+                    e,
+                    dd_name,
                 )
                 self._missing_counters[(counterset, inst_name, counter_name, dd_name, mtype)] = (
                     datatypes,
@@ -168,7 +168,7 @@ class PDHBaseCheck(AgentCheck):
                 self._missing_counters.pop((counterset, inst_name, counter_name, dd_name, mtype), None)
 
             entry = [inst_name, dd_name, m, obj]
-            self.log.debug('{}: {}'.format(message, entry))
+            self.log.debug('%s: %s', message, entry)
             self._metrics[key].append(entry)
 
     @classmethod

--- a/pdh_check/datadog_checks/pdh_check/pdh_check.py
+++ b/pdh_check/datadog_checks/pdh_check/pdh_check.py
@@ -1,14 +1,11 @@
 # (C) Datadog, Inc. 2013-2017
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-from six import iteritems
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.checks.win import WinPDHCounter
-from datadog_checks.utils.containers import hash_mutable
+from datadog_checks.checks.win import PDHBaseCheck
 
 
-class PDHCheck(AgentCheck):
+class PDHCheck(PDHBaseCheck):
     """
     PDH check.
 
@@ -16,50 +13,12 @@ class PDHCheck(AgentCheck):
     """
 
     def __init__(self, name, init_config, agentConfig, instances=None):
-        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
-        self._countersettypes = {}
-        self._counters = {}
-        self._metrics = {}
-        self._tags = {}
+        counter_list = []
+        for instance in instances:
+            counterset = instance['countersetname']
 
-        try:
-            for instance in instances:
-                key = hash_mutable(instance)
-                counterset = instance.get('countersetname')
+            counter_list.extend(
+                (counterset, None, inst_name, dd_name, mtype) for inst_name, dd_name, mtype in instance['metrics']
+            )
 
-                cfg_tags = instance.get('tags')
-                if cfg_tags is not None:
-                    tags = cfg_tags.join(",")
-                    self._tags[key] = list(tags) if tags else []
-
-                metrics = instance.get('metrics')
-                # list of the metrics.  Each entry is itself an entry,
-                # which is the pdh name, datadog metric name, type, and the
-                # pdh counter object
-                self._metrics[key] = []
-                for inst_name, dd_name, mtype in metrics:
-                    m = getattr(self, mtype.lower())
-                    obj = WinPDHCounter(counterset, inst_name, self.log)
-                    if not obj:
-                        continue
-                    entry = [inst_name, dd_name, m, obj]
-                    self.log.debug("entry: %s" % str(entry))
-                    self._metrics[key].append(entry)
-
-        except Exception as e:
-            self.log.debug("Exception in PDH init: %s", str(e))
-            raise
-
-    def check(self, instance):
-        key = hash_mutable(instance)
-        for _, dd_name, metric_func, counter in self._metrics[key]:
-            vals = counter.get_all_values()
-            for key, val in iteritems(vals):
-                tags = []
-                if key in self._tags:
-                    tags = self._tags[key]
-
-                if not counter.is_single_instance():
-                    tag = "instance:%s" % key
-                    tags.append(tag)
-                metric_func(dd_name, val, tags)
+        PDHBaseCheck.__init__(self, name, init_config, agentConfig, instances, counter_list)


### PR DESCRIPTION
By reusing the base check class, we reduce duplication and get the
benefit of the `refresh_counters` config flag.