### PR TITLE
clarifying documentation text on `redis.expires` and `redis.expires.percent`

### DIFF
--- a/redisdb/metadata.csv
+++ b/redisdb/metadata.csv
@@ -10,8 +10,8 @@ redis.cpu.sys,gauge,,second,,System CPU consumed by the Redis server.,-1,redis,c
 redis.cpu.sys_children,gauge,,second,,System CPU consumed by the background processes.,-1,redis,cpu sys children
 redis.cpu.user,gauge,,second,,User CPU consumed by the Redis server.,-1,redis,cpu user
 redis.cpu.user_children,gauge,,second,,User CPU consumed by the background processes.,-1,redis,cpu user children
-redis.expires,gauge,,key,,The number of keys that have expired.,0,redis,expires
-redis.expires.percent,gauge,,percent,,Percentage of total keys that have been expired.,0,redis,expires pct
+redis.expires,gauge,,key,,The number of keys with an expiration.,0,redis,expires
+redis.expires.percent,gauge,,percent,,Percentage of total keys with an expiration.,0,redis,expires pct
 redis.info.latency_ms,gauge,,millisecond,,The latency of the redis INFO command.,0,redis,info latency
 redis.key.length,gauge,,,,"The number of elements in a given key, tagged by key, e.g. 'key:mykeyname'. Enable in Agent's redisdb.yaml with the keys option.",0,redis,key length
 redis.keys,gauge,,key,,The total number of keys.,0,redis,keys


### PR DESCRIPTION
### What does this PR do?

In the Redis documentation at https://redis.io/commands/INFO, the INFO's command's "expires" command says 
> The statistics are the number of keys, and the number of keys with an expiration.

This isn't the keys that have already expired, these are keys which have an expiration value set. 

Updated documentation to reflect this.

### Motivation

In my Datadog dashboard, I noticed that `redis.expires` was always at 100%, and that seemed weird to me, so I set about looking at what this field is, and decided to update the documentation to be more clear about the field defination.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
