### PR TITLE
Fix presto metric name

### DIFF
--- a/presto/datadog_checks/presto/data/conf.yaml.example
+++ b/presto/datadog_checks/presto/data/conf.yaml.example
@@ -299,7 +299,7 @@ instances:
           domain: presto.memory
           attribute:
             AssignedQueries:
-              alias: presto.memory.assigned_queries,gauge
+              alias: presto.memory.assigned_queries
             BlockedNodes:
               alias: presto.memory.blocked_nodes
             ClusterMemoryBytes:

--- a/presto/datadog_checks/presto/data/conf.yaml.example
+++ b/presto/datadog_checks/presto/data/conf.yaml.example
@@ -286,7 +286,7 @@ instances:
             TaskNotificationExecutor.CompletedTaskCount:
               alias: presto.execution.task_notification_executor.completed_task_count
             TaskNotificationExecutor.PoolSize:
-              alias: presto.execution.task_notification_executor.pool_size,gauge
+              alias: presto.execution.task_notification_executor.pool_size
             TaskNotificationExecutor.QueuedTaskCount:
               alias: presto.execution.task_notification_executor.queued_task_count
       - include:

--- a/presto/datadog_checks/presto/data/metrics.yaml
+++ b/presto/datadog_checks/presto/data/metrics.yaml
@@ -184,7 +184,7 @@ jmx_metrics:
         TaskNotificationExecutor.CompletedTaskCount:
           alias: presto.execution.task_notification_executor.completed_task_count
         TaskNotificationExecutor.PoolSize:
-          alias: presto.execution.task_notification_executor.pool_size,gauge
+          alias: presto.execution.task_notification_executor.pool_size
         TaskNotificationExecutor.QueuedTaskCount:
           alias: presto.execution.task_notification_executor.queued_task_count
   - include:
@@ -197,7 +197,7 @@ jmx_metrics:
       domain: presto.memory
       attribute:
         AssignedQueries:
-          alias: presto.memory.assigned_queries,gauge
+          alias: presto.memory.assigned_queries
         BlockedNodes:
           alias: presto.memory.blocked_nodes
         ClusterMemoryBytes:


### PR DESCRIPTION
### What does this PR do?

Fix a presto metric name in the configuration files.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
