### PR TITLE
[kafka] updating metrics unit

### DIFF
--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -9,7 +9,7 @@ kafka.request.fetch.failed,gauge,10,request,,Number of client fetch request fail
 kafka.request.fetch.failed_per_second,gauge,10,request,second,Rate of client fetch request failures per second.,-1,kafka,req fetch fail rate
 kafka.request.handler.avg.idle.pct,gauge,10,fraction,,Average fraction of time the request handler threads are idle.,1,kafka,req handle avg idle
 kafka.request.produce.time.avg,gauge,10,rate,millisecond,Average time for a produce request.,0,kafka,req prod time avg
-kafka.request.produce.time.99percentile,gauge,10,millisecond,Time for produce requests for 99th percentile.,0,kafka,req prod time 99
+kafka.request.produce.time.99percentile,gauge,10,rate,millisecond,Time for produce requests for 99th percentile.,0,kafka,req prod time 99
 kafka.request.produce.failed_per_second,gauge,10,request,second,Rate of failed produce requests per second.,-1,kafka,req prod fail rate
 kafka.request.produce.failed,gauge,10,request,,Number of failed produce requests.,-1,kafka,req prod fail
 kafka.request.fetch.time.avg,gauge,10,millisecond,,Average time per fetch request.,0,kafka,req fetch time avg

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -8,7 +8,7 @@ kafka.request.channel.queue.size,gauge,10,request,,Number of queued requests.,-1
 kafka.request.fetch.failed,gauge,10,request,,Number of client fetch request failures.,-1,kafka,req fetch fail
 kafka.request.fetch.failed_per_second,gauge,10,request,second,Rate of client fetch request failures per second.,-1,kafka,req fetch fail rate
 kafka.request.handler.avg.idle.pct,gauge,10,fraction,,Average fraction of time the request handler threads are idle.,1,kafka,req handle avg idle
-kafka.request.produce.time.avg,gauge,10,millisecond,Average time for a produce request.,0,kafka,req prod time avg
+kafka.request.produce.time.avg,gauge,10,rate,millisecond,Average time for a produce request.,0,kafka,req prod time avg
 kafka.request.produce.time.99percentile,gauge,10,millisecond,Time for produce requests for 99th percentile.,0,kafka,req prod time 99
 kafka.request.produce.failed_per_second,gauge,10,request,second,Rate of failed produce requests per second.,-1,kafka,req prod fail rate
 kafka.request.produce.failed,gauge,10,request,,Number of failed produce requests.,-1,kafka,req prod fail

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -8,8 +8,8 @@ kafka.request.channel.queue.size,gauge,10,request,,Number of queued requests.,-1
 kafka.request.fetch.failed,gauge,10,request,,Number of client fetch request failures.,-1,kafka,req fetch fail
 kafka.request.fetch.failed_per_second,gauge,10,request,second,Rate of client fetch request failures per second.,-1,kafka,req fetch fail rate
 kafka.request.handler.avg.idle.pct,gauge,10,fraction,,Average fraction of time the request handler threads are idle.,1,kafka,req handle avg idle
-kafka.request.produce.time.avg,gauge,10,request,second,Average time for a produce request.,0,kafka,req prod time avg
-kafka.request.produce.time.99percentile,gauge,10,request,second,Time for produce requests for 99th percentile.,0,kafka,req prod time 99
+kafka.request.produce.time.avg,gauge,10,millisecond,Average time for a produce request.,0,kafka,req prod time avg
+kafka.request.produce.time.99percentile,gauge,10,millisecond,Time for produce requests for 99th percentile.,0,kafka,req prod time 99
 kafka.request.produce.failed_per_second,gauge,10,request,second,Rate of failed produce requests per second.,-1,kafka,req prod fail rate
 kafka.request.produce.failed,gauge,10,request,,Number of failed produce requests.,-1,kafka,req prod fail
 kafka.request.fetch.time.avg,gauge,10,millisecond,,Average time per fetch request.,0,kafka,req fetch time avg

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -8,7 +8,7 @@ kafka.request.channel.queue.size,gauge,10,request,,Number of queued requests.,-1
 kafka.request.fetch.failed,gauge,10,request,,Number of client fetch request failures.,-1,kafka,req fetch fail
 kafka.request.fetch.failed_per_second,gauge,10,request,second,Rate of client fetch request failures per second.,-1,kafka,req fetch fail rate
 kafka.request.handler.avg.idle.pct,gauge,10,fraction,,Average fraction of time the request handler threads are idle.,1,kafka,req handle avg idle
-kafka.request.produce.time.avg,gauge,10,rate,millisecond,Average time for a produce request.,0,kafka,req prod time avg
+kafka.request.produce.time.avg,gauge,10,millisecond,,Average time for a produce request.,0,kafka,req prod time avg
 kafka.request.produce.time.99percentile,gauge,10,rate,millisecond,Time for produce requests for 99th percentile.,0,kafka,req prod time 99
 kafka.request.produce.failed_per_second,gauge,10,request,second,Rate of failed produce requests per second.,-1,kafka,req prod fail rate
 kafka.request.produce.failed,gauge,10,request,,Number of failed produce requests.,-1,kafka,req prod fail

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -9,7 +9,7 @@ kafka.request.fetch.failed,gauge,10,request,,Number of client fetch request fail
 kafka.request.fetch.failed_per_second,gauge,10,request,second,Rate of client fetch request failures per second.,-1,kafka,req fetch fail rate
 kafka.request.handler.avg.idle.pct,gauge,10,fraction,,Average fraction of time the request handler threads are idle.,1,kafka,req handle avg idle
 kafka.request.produce.time.avg,gauge,10,millisecond,,Average time for a produce request.,0,kafka,req prod time avg
-kafka.request.produce.time.99percentile,gauge,10,rate,millisecond,Time for produce requests for 99th percentile.,0,kafka,req prod time 99
+kafka.request.produce.time.99percentile,gauge,10,millisecond,,Time for produce requests for 99th percentile.,0,kafka,req prod time 99
 kafka.request.produce.failed_per_second,gauge,10,request,second,Rate of failed produce requests per second.,-1,kafka,req prod fail rate
 kafka.request.produce.failed,gauge,10,request,,Number of failed produce requests.,-1,kafka,req prod fail
 kafka.request.fetch.time.avg,gauge,10,millisecond,,Average time per fetch request.,0,kafka,req fetch time avg


### PR DESCRIPTION
### What does this PR do?
`kafka.request.produce.time.99percentile` and `kafka.request.produce.time.avg` should be showing in milliseconds vs request/second

### Motivation

A customer reached out for clarification on the values shown. 

### Additional Notes

This was changed previously with another set of metrics: https://github.com/DataDog/integrations-core/pull/663/files 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
