### PR TITLE
Gitlab - Prevent the release manual job to run on branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,8 @@ release-manual:
   only:
     # Integration release tags e.g. any_check-X.Y.Z-rc.N
     - /.*-\d+\.\d+\.\d+(-(rc|pre|alpha|beta)\.\d+)?$/
+  except:
+    - branches
   script:
     # Get tagger info
     - tagger=$(git show "$CI_COMMIT_TAG" | head -2 | tail -1)


### PR DESCRIPTION
### What does this PR do?

The `release manual` gitlab job is triggered whenever a git reference matches the provided regex. This job is made for tags not for branches so let's ignore it with branches.
