### PR TITLE
Fix package order of `get_datadog_wheels`

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/agent/packages.py
+++ b/datadog_checks_base/datadog_checks/base/utils/agent/packages.py
@@ -9,7 +9,7 @@ DATADOG_CHECK_PREFIX = "datadog-"
 
 def get_datadog_wheels():
     packages = []
-    dist = list(pkg_resources.working_set)
+    dist = sorted(pkg_resources.working_set)
     for package in dist:
         if package.project_name.startswith(DATADOG_CHECK_PREFIX):
             name = package.project_name[len(DATADOG_CHECK_PREFIX) :].replace('-', '_')

--- a/datadog_checks_base/datadog_checks/base/utils/agent/packages.py
+++ b/datadog_checks_base/datadog_checks/base/utils/agent/packages.py
@@ -9,7 +9,7 @@ DATADOG_CHECK_PREFIX = "datadog-"
 
 def get_datadog_wheels():
     packages = []
-    dist = sorted(pkg_resources.working_set)
+    dist = sorted(pkg_resources.working_set)[::-1]
     for package in dist:
         if package.project_name.startswith(DATADOG_CHECK_PREFIX):
             name = package.project_name[len(DATADOG_CHECK_PREFIX) :].replace('-', '_')

--- a/datadog_checks_base/datadog_checks/base/utils/agent/packages.py
+++ b/datadog_checks_base/datadog_checks/base/utils/agent/packages.py
@@ -9,7 +9,7 @@ DATADOG_CHECK_PREFIX = "datadog-"
 
 def get_datadog_wheels():
     packages = []
-    dist = pkg_resources.working_set
+    dist = list(pkg_resources.working_set)
     for package in dist:
         if package.project_name.startswith(DATADOG_CHECK_PREFIX):
             name = package.project_name[len(DATADOG_CHECK_PREFIX) :].replace('-', '_')

--- a/datadog_checks_base/datadog_checks/base/utils/agent/packages.py
+++ b/datadog_checks_base/datadog_checks/base/utils/agent/packages.py
@@ -9,10 +9,10 @@ DATADOG_CHECK_PREFIX = "datadog-"
 
 def get_datadog_wheels():
     packages = []
-    dist = sorted(pkg_resources.working_set)[::-1]
+    dist = pkg_resources.working_set
     for package in dist:
         if package.project_name.startswith(DATADOG_CHECK_PREFIX):
             name = package.project_name[len(DATADOG_CHECK_PREFIX) :].replace('-', '_')
             packages.append(name)
 
-    return packages
+    return sorted(packages)[::-1]


### PR DESCRIPTION
### Motivation

One of our dependencies now pulls in `packaging` which seems to alter the order of the results