### PR TITLE
[snmp] Match OIDs with leading dots

### DIFF
--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -453,7 +453,7 @@ class SnmpCheck(NetworkCheck):
         for metric in metrics:
             forced_type = metric.get('forced_type')
             if 'OID' in metric:
-                queried_oid = metric['OID']
+                queried_oid = metric['OID'].lstrip('.')
                 if queried_oid in results:
                     value = results[queried_oid]
                 else:

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -65,6 +65,7 @@ INVALID_FORCED_METRICS = [
 SCALAR_OBJECTS = [
     {'OID': "1.3.6.1.2.1.7.1.0", 'name': "udpDatagrams"},
     {'OID': "1.3.6.1.2.1.6.10.0", 'name': "tcpInSegs"},
+    {'OID': ".1.3.6.1.6.3.10.2.1.3.0", 'name': "snmpEngineTime"},  # OID with leading dot
     {'MIB': "TCP-MIB", 'symbol': "tcpCurrEstab"},
 ]
 


### PR DESCRIPTION
### What does this PR do?

Strips leading dots `.` from the OID to query if an OID has been specified. So either of the following should match.

```
- OID: 1.3.6.1.2.1.7.1.0
  name: udpDatagrams
- OID: .1.3.6.1.2.1.7.1.0
  name: udpDatagrams
```

### Motivation

- It is pretty common for SNMP apps to return OIDs with leading dots `.`. 
  - `snmpwalk -On` (print OIDs numerically) returns OIDs with leading dots `.`
  - other tools (iReasoning MIB Browser) also returns OIDs with leading dots.
- Users tend to just copy from them which would then result in OIDs not matching just because of the leading dot `.`.

### Additional Notes

- none

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
