### PR TITLE
[hive] fix hive init file

### DIFF
--- a/hive/datadog_checks/hive/__init__.py
+++ b/hive/datadog_checks/hive/__init__.py
@@ -2,9 +2,5 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from .__about__ import __version__
-from .hive import HiveCheck
 
-__all__ = [
-    '__version__',
-    'HiveCheck'
-]
+__all__ = ['__version__']


### PR DESCRIPTION
`hive.py` does not exist, so no need to import it.