### PR TITLE
[vsphere] fix avoid payload['tags'] side effect

### DIFF
--- a/vsphere/datadog_checks/vsphere/event.py
+++ b/vsphere/datadog_checks/vsphere/event.py
@@ -114,14 +114,12 @@ class VSphereEvent(object):
         self.payload["msg_text"] += "\n".join(changes)
 
         self.payload['host'] = self.raw_event.vm.name
-        self.payload['tags'].extend(
-            [
-                'vsphere_host:{}'.format(ensure_unicode(pre_host)),
-                'vsphere_host:{}'.format(ensure_unicode(new_host)),
-                'vsphere_datacenter:{}'.format(ensure_unicode(pre_dc)),
-                'vsphere_datacenter:{}'.format(ensure_unicode(new_dc)),
-            ]
-        )
+        self.payload['tags'] = self.payload['tags'] + [
+            'vsphere_host:{}'.format(ensure_unicode(pre_host)),
+            'vsphere_host:{}'.format(ensure_unicode(new_host)),
+            'vsphere_datacenter:{}'.format(ensure_unicode(pre_dc)),
+            'vsphere_datacenter:{}'.format(ensure_unicode(new_dc)),
+        ]
         return self.payload
 
     def transform_alarmstatuschangedevent(self):


### PR DESCRIPTION
### What does this PR do?

Extending `payload['tags']` will modify the initial list of tags passed to the constructor `VSphereEvent(event, self.event_config[i_key], tags)`. It's better to avoid this kind of side effect.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
