### PR TITLE
Revert "[prometheus check] Actually use provided "metrics_mapper" (#3…

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
@@ -147,8 +147,6 @@ class GenericPrometheusCheck(AgentCheck):
                 metrics_mapper[metric] = metric
             else:
                 metrics_mapper.update(metric)
-        # update metrics mapper with values provided by user
-        metrics_mapper.update(instance.get("metrics_mapper", {}))
 
         scraper.metrics_mapper = metrics_mapper
         scraper.labels_mapper = default_instance.get("labels_mapper", {})


### PR DESCRIPTION
The proper way to change a metric name is by setting up the optional <NEW_METRIC_NAME> field in the metrics param.