### PR TITLE
Fix handling of gray events

### DIFF
--- a/vsphere/datadog_checks/vsphere/event.py
+++ b/vsphere/datadog_checks/vsphere/event.py
@@ -14,7 +14,7 @@ from datadog_checks.base import ensure_unicode
 from .common import SOURCE_TYPE
 
 EXCLUDE_FILTERS = {
-    'AlarmStatusChangedEvent': [r'Gray'],
+    'AlarmStatusChangedEvent': [r'Gray to Green', r'Green to Gray'],
     'TaskEvent': [
         r'Initialize powering On',
         r'Power Off virtual machine',
@@ -50,7 +50,7 @@ class VSphereEvent(object):
             "timestamp": self.timestamp,
             "event_type": SOURCE_TYPE,
             "source_type_name": SOURCE_TYPE,
-            "tags": tags,
+            "tags": tags[:],
         }
         if event_config is None:
             self.event_config = {}
@@ -138,7 +138,7 @@ class VSphereEvent(object):
                 return 'Triggered'
             return 'Recovered'
 
-        TO_ALERT_TYPE = {'green': 'success', 'yellow': 'warning', 'red': 'error'}
+        TO_ALERT_TYPE = {'green': 'success', 'yellow': 'warning', 'red': 'error', 'gray': 'info'}
 
         def get_agg_key(alarm_event):
             return 'h:{0}|dc:{1}|a:{2}'.format(

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -17,7 +17,7 @@ from pyVmomi import vmodl  # pylint: disable=E0611
 from six import iteritems
 from six.moves import range
 
-from datadog_checks.base import ensure_unicode
+from datadog_checks.base import ensure_unicode, to_string
 from datadog_checks.base.checks import AgentCheck
 from datadog_checks.base.checks.libs.thread_pool import SENTINEL, Pool
 from datadog_checks.base.checks.libs.timer import Timer
@@ -818,6 +818,8 @@ class VSphereCheck(AgentCheck):
                     tags = ['instance:{}'.format(ensure_unicode(instance_name))]
                     if not hostname:  # no host tags available
                         tags.extend(mor['tags'])
+                    else:
+                        hostname = to_string(hostname)
 
                     tags.extend(custom_tags)
 


### PR DESCRIPTION
Ignoring completely events in gray states removes all notifications for
an alarm the first time it's triggered. To remove noise, let's ignore
transition from green to gray or gray to green, but keep the others.