### PR TITLE
Revert "[openmetrics] allow blacklisting of strings"

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -221,7 +221,7 @@ class OpenMetricsScraperMixin(object):
         # List of strings to filter the input text payload on. If any line contains
         # one of these strings, it will be filtered out before being parsed.
         # INTERNAL FEATURE, might be removed in future versions
-        config['_text_filter_blacklist'] = instance.get('_text_filter_blacklist', [])
+        config['_text_filter_blacklist'] = []
 
         # Whether or not to use the service account bearer token for authentication
         # if 'bearer_token_path' is not set, we use /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
### What does this PR do?

Reverts DataDog/integrations-core#3709

### Motivation

the parameter `_text_filter_blacklist` is a private `openmetricsmixins` parameter and should not be exposed directly in any integration.
We will work on a proper implementation in the `nginx_ingress_controller` to expose a new parameter for filtering metrics base on the name.