### PR TITLE
Fix 'custom_queries' field name

### DIFF
--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -1158,7 +1158,7 @@ class MongoDb(AgentCheck):
             self.log.warning(u"Failed to record `collection` metrics.")
             self.log.exception(e)
 
-        custom_queries = instance.get("queries", [])
+        custom_queries = instance.get("custom_queries", [])
         custom_query_tags = tags + ["db:{}".format(db_name)]
         for raw_query in custom_queries:
             try:

--- a/mongo/tests/conftest.py
+++ b/mongo/tests/conftest.py
@@ -42,7 +42,7 @@ def instance_authdb():
 def instance_custom_queries():
     return {
         'server': 'mongodb://testUser2:testPass2@{}:{}/test'.format(common.HOST, common.PORT1),
-        'queries': [
+        'custom_queries': [
             {
                 "metric_prefix": "dd.custom.mongo.query_a",
                 "query": {'find': "orders", 'filter': {'amount': {'$gt': 25}}, 'sort': {'amount': -1}},


### PR DESCRIPTION
See https://github.com/DataDog/integrations-core/pull/3796

Config and code were out of sync, using `custom_queries` instead of `queries`.
