### PR TITLE
Fix default for bearer_token and ssl_verify

### DIFF
--- a/kube_apiserver_metrics/README.md
+++ b/kube_apiserver_metrics/README.md
@@ -25,6 +25,9 @@ Annotations:       ad.datadoghq.com/endpoint.check_names: ["kube_apiserver_metri
                          "bearer_token_auth": "true"
                        }
                      ]
+                   ad.datadoghq.com/service.check_names: [""]
+                   ad.datadoghq.com/service.init_configs: [{}]
+                   ad.datadoghq.com/service.instances: [{}]
 ```
 Then the Datadog Cluster Agent schedules the check(s) for each endpoint onto Datadog Agent(s).
 

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
@@ -19,6 +19,8 @@ class KubeAPIServerMetricsCheck(OpenMetricsBaseCheck):
     # Set up metrics_transformers
     metric_transformers = {}
     DEFAULT_SCHEME = 'https'
+    DEFAULT_SSL_VERIFY = False
+    DEFAULT_BEARER_TOKEN_AUTH = True
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         # Set up metrics_transformers
@@ -72,8 +74,16 @@ class KubeAPIServerMetricsCheck(OpenMetricsBaseCheck):
         kube_apiserver_metrics_instance = deepcopy(instance)
         endpoint = instance.get('prometheus_url')
         scheme = instance.get('scheme', self.DEFAULT_SCHEME)
-
         kube_apiserver_metrics_instance['prometheus_url'] = "{0}://{1}".format(scheme, endpoint)
+
+        # Most set ups are using self signed certificates as the APIServer can be used as a CA.
+        ssl_verify = instance.get('ssl_verify', self.DEFAULT_SSL_VERIFY)
+        kube_apiserver_metrics_instance['ssl_verify'] = ssl_verify
+
+        # We should default to supporting environments using RBAC to access the APIServer.
+        bearer_token_auth = instance.get('bearer_token_auth', self.DEFAULT_BEARER_TOKEN_AUTH)
+        kube_apiserver_metrics_instance['bearer_token_auth'] = bearer_token_auth
+
         return kube_apiserver_metrics_instance
 
     def submit_as_gauge_and_monotonic_count(self, metric_suffix, metric, scraper_config):

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
@@ -15,7 +15,9 @@ from .common import APISERVER_INSTANCE_BEARER_TOKEN
 
 customtag = "custom:tag"
 
-instance = {'prometheus_url': 'localhost:443/metrics', 'scheme': 'https', 'tags': [customtag]}
+minimal_instance = {'prometheus_url': 'localhost:443/metrics'}
+
+instance = {'prometheus_url': 'localhost:443/metrics', 'bearer_token_auth': 'false', 'scheme': 'https', 'tags': [customtag]}
 
 instanceSecure = {
     'prometheus_url': 'localhost:443/metrics',
@@ -71,7 +73,7 @@ class TestKubeAPIServerMetrics:
 
     def test_check(self, aggregator, mock_get):
         """
-        Testing kube_apiserver_metrics check.
+        Testing kube_apiserver_metrics metrics collection.
         """
 
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, {}, [instance])
@@ -101,3 +103,14 @@ class TestKubeAPIServerMetrics:
 
         os.remove(temp_bearer_file)
         assert configured_instance["_bearer_token"] == APISERVER_INSTANCE_BEARER_TOKEN
+
+    def test_default_config(self, aggregator):
+        """
+        Testing the default configuration.
+        """
+        check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, {}, [minimal_instance])
+        apiserver_instance = check._create_kube_apiserver_metrics_instance(minimal_instance)
+
+        assert apiserver_instance["ssl_verify"] == False
+        assert apiserver_instance["bearer_token_auth"] == True
+        assert apiserver_instance["prometheus_url"] == "https://localhost:443/metrics"

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
@@ -17,7 +17,12 @@ customtag = "custom:tag"
 
 minimal_instance = {'prometheus_url': 'localhost:443/metrics'}
 
-instance = {'prometheus_url': 'localhost:443/metrics', 'bearer_token_auth': 'false', 'scheme': 'https', 'tags': [customtag]}
+instance = {
+    'prometheus_url': 'localhost:443/metrics',
+    'bearer_token_auth': 'false',
+    'scheme': 'https',
+    'tags': [customtag],
+}
 
 instanceSecure = {
     'prometheus_url': 'localhost:443/metrics',
@@ -111,6 +116,6 @@ class TestKubeAPIServerMetrics:
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, {}, [minimal_instance])
         apiserver_instance = check._create_kube_apiserver_metrics_instance(minimal_instance)
 
-        assert apiserver_instance["ssl_verify"] == False
-        assert apiserver_instance["bearer_token_auth"] == True
+        assert not apiserver_instance["ssl_verify"]
+        assert apiserver_instance["bearer_token_auth"]
         assert apiserver_instance["prometheus_url"] == "https://localhost:443/metrics"


### PR DESCRIPTION
### What does this PR do?

The `ssl_verify` and the `bearer_token_auth` options were not set correctly.
We want to default to supporting secure environments and the most common configs:
- Accessing the APIServer using a Service Account (RBAC) to be authenticated
- Using self signed certificates as  the APIServer is used as a CA.

Also makes the README more accurate.

### Motivation

QA.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
