### PR TITLE
Fix conf.yaml.example typos

### DIFF
--- a/ambari/datadog_checks/ambari/data/conf.yaml.example
+++ b/ambari/datadog_checks/ambari/data/conf.yaml.example
@@ -1,11 +1,11 @@
 init_config:
     ## @param collect_service_metrics - boolean - optional - default: true
-    ## Change to False to omit collecting service level metrics
+    ## Change to `false` to omit collecting service level metrics
     #
     # collect_service_metrics: true
 
     ## @param collect_service_status - boolean - optional - default: false
-    ## Change to False to omit collecting services status
+    ## Change to `false` to omit collecting services status
     #
     # collect_service_status: false
 

--- a/ceph/datadog_checks/ceph/data/conf.yaml.example
+++ b/ceph/datadog_checks/ceph/data/conf.yaml.example
@@ -20,7 +20,7 @@ instances:
     ##
     ## to your sudoers file, and uncomment the option below:
     #
-    # use_sudo: True
+    # use_sudo: true
 
     ## @param collect_service_check_for - list of string - optional
     ## If you wish to customize the health checks sent as a service check, uncomment and edit the list below.

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -45,7 +45,7 @@ instances:
 
     ## @param ca_bundle_file - string - optional - default: true
     ## Whether to verifiy SSL certificates for HTTPS requests.
-    ## Possible values: True, False or '<TRUSTED_CA_BUNDLE_FILE_PATH>'
+    ## Possible values: `true`, `true` or '<TRUSTED_CA_BUNDLE_FILE_PATH>'
     #
     # ca_bundle_file: true
 

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -17,16 +17,16 @@ instances:
     tags:
       - "dns-pod:%%host%%"
 
-    ## @param send_histogram_buckets - boolean - optional - default: True
-    ## Set send_histograms_buckets to true to send the histograms buckets.
+    ## @param send_histogram_buckets - boolean - optional - default: true
+    ## Set send_histograms_buckets to `true` to send the histograms buckets.
     #
-    # send_histograms_buckets: True
+    # send_histograms_buckets: true
 
-    ## @param send_monotonic_counter - boolean - optional - default: True
+    ## @param send_monotonic_counter - boolean - optional - default: true
     ## To send counters as monotonic counter.
     ## see: https://github.com/DataDog/integrations-core/issues/1303
     #
-    # send_monotonic_counter: True
+    # send_monotonic_counter: true
 
     ## @param metrics - list of strings - optional
     ## Metrics from the CoreDNS plugins for 'metrics', 'proxy' and 'cache'

--- a/directory/datadog_checks/directory/data/conf.yaml.example
+++ b/directory/datadog_checks/directory/data/conf.yaml.example
@@ -51,8 +51,8 @@ instances:
 
     ## @param dirs_patterns_full - boolean - optional - default: false
     ## Make exclude_dirs patterns operate on the full directory path (may be slightly slower)
-    ## Setting this option to False excludes any directory in the traversal with the provided name.
-    ## Setting this option to True allows you to specify the absolute path. This ensures multiple directories with the same
+    ## Setting this option to `false` excludes any directory in the traversal with the provided name.
+    ## Setting this option to `true` allows you to specify the absolute path. This ensures multiple directories with the same
     ## name aren't all excluded.
     #
     # dirs_patterns_full: false

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -62,7 +62,7 @@ instances:
 
     ## @param count_status_by_service - boolean - optional - default: true
     ## This parameter instructs the check to tag the status counts it collects by service in addition to by host.
-    ## This only applies if `collect_status_metrics` is True.
+    ## This only applies if `collect_status_metrics` is `true`.
     #
     # count_status_by_service: true
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -80,7 +80,7 @@ instances:
     ## When using zookeeper to store consumer offsets  each level is optional.
     ## Any empty values are fetched from Zookeeper. You can have empty partitions (example: <CONSUMER_NAME_2>),
     ## topics (example: <CONSUMER_NAME_3>), and even consumer_groups. If you omit
-    ## consumer_groups, you must set 'monitor_unlisted_consumer_groups': True.
+    ## consumer_groups, you must set 'monitor_unlisted_consumer_groups': true.
     #
     # consumer_groups:
     #   <CONSUMER_NAME_1>:
@@ -90,7 +90,7 @@ instances:
     #   <CONSUMER_NAME_3>: {}
 
     ## @param monitor_unlisted_consumer_groups - boolean - required
-    ## Setting monitor_unlisted_consumer_groups to True tells the check to
+    ## Setting monitor_unlisted_consumer_groups to `true` tells the check to
     ## discover and fetch all offsets for all consumer groups stored in zookeeper.
     ## While this is convenient, it can also put a lot of load on zookeeper.
     #

--- a/kubelet/datadog_checks/kubelet/data/conf.yaml.example
+++ b/kubelet/datadog_checks/kubelet/data/conf.yaml.example
@@ -31,7 +31,7 @@ instances:
     ## The histogram buckets can be noisy and generate a lot of tags.
     ## send_histograms_buckets controls whether or not you want to pull them.
     #
-    # send_histograms_buckets: True
+    # send_histograms_buckets: true
 
     ## Metric collection for legacy (< 1.7.6) clusters via the kubelet's cadvisor port.
     ## This port is closed by default on k8s 1.7+ and OpenShift, enable it

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -95,7 +95,7 @@ instances:
     ## @param tag_replication_role - boolean - optional - default: false
     ## Tag metrics and checks with `replication_role:<master|standby>`.
     #
-    # tag_replication_role: False
+    # tag_replication_role: false
 
     ## @param custom_queries - object - optional
     ## Define custom queries to collect custom metrics from your PostgreSQL

--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -58,7 +58,7 @@ instances:
     ## acces to the full command line of processes running under a different user. This option
     ## cannot be used in such cases.
     ## https://docs.datadoghq.com/integrations/process/#configuration
-    ## Regex is also supported when this flag is set to False.
+    ## Regex is also supported when this flag is set to `false`.
     #
     # exact_match: true
 
@@ -93,7 +93,7 @@ instances:
     # user: <USER_NAME>
 
     ## @param try_sudo - boolean - optional - default: false
-    ## If set to True, the check tries to use 'sudo' to collect the 'open_fd' metric on Unix platforms.
+    ## If set to `true`, the check tries to use 'sudo' to collect the 'open_fd' metric on Unix platforms.
     #
     # try_sudo: false
 


### PR DESCRIPTION
### What does this PR do?

Fix `conf.yaml.example` typos