### PR TITLE
Fix metric type

### DIFF
--- a/hive/datadog_checks/hive/data/conf.yaml.example
+++ b/hive/datadog_checks/hive/data/conf.yaml.example
@@ -555,7 +555,7 @@ init_config:
         attribute:
           Value:
             alias: hive.metastore.db.init
-            metric_type: gauge
+            metric_type: monotonic_count
 
     - include:
         bean: metrics:name=create_total_count_tables
@@ -576,7 +576,7 @@ init_config:
         attribute:
           Value:
             alias: hive.metastore.table.init
-            metric_type: gauge
+            metric_type: monotonic_count
 
     - include:
         bean: metrics:name=create_total_count_partitions
@@ -686,7 +686,7 @@ init_config:
         attribute:
           Count:
             alias: hive.metastore.api.create_table
-            metric_type: gauge
+            metric_type: monotonic_count
     - include:
         bean: metrics:name=active_calls_api_create_table
         attribute:
@@ -698,7 +698,7 @@ init_config:
         attribute:
           Count:
             alias: hive.metastore.api.get_table
-            metric_type: gauge
+            metric_type: monotonic_count
     - include:
         bean: metrics:name=active_calls_api_get_table
         attribute:
@@ -710,7 +710,7 @@ init_config:
         attribute:
           Count:
             alias: hive.metastore.api.drop_table
-            metric_type: gauge
+            metric_type: monotonic_count
     - include:
         bean: metrics:name=active_calls_api_drop_table
         attribute:
@@ -722,7 +722,7 @@ init_config:
         attribute:
           Count:
             alias: hive.metastore.api.init
-            metric_type: gauge
+            metric_type: monotonic_count
     - include:
         bean: metrics:name=active_calls_api_init
         attribute:
@@ -734,7 +734,7 @@ init_config:
         attribute:
           Count:
             alias: hive.metastore.api.get_all_databases
-            metric_type: gauge
+            metric_type: monotonic_count
     - include:
         bean: metrics:name=active_calls_api_get_all_databases
         attribute:
@@ -746,7 +746,7 @@ init_config:
         attribute:
           Count:
             alias: hive.metastore.api.get_database
-            metric_type: gauge
+            metric_type: monotonic_count
     - include:
         bean: metrics:name=active_calls_api_get_database
         attribute:
@@ -758,7 +758,7 @@ init_config:
         attribute:
           Count:
             alias: hive.metastore.api.get_all_tables
-            metric_type: gauge
+            metric_type: monotonic_count
     - include:
         bean: metrics:name=active_calls_api_get_all_tables
         attribute:
@@ -770,7 +770,7 @@ init_config:
         attribute:
           Count:
             alias: hive.metastore.api.shutdown
-            metric_type: gauge
+            metric_type: monotonic_count
     - include:
         bean: metrics:name=active_calls_api_shutdown
         attribute:
@@ -782,7 +782,7 @@ init_config:
         attribute:
           Count:
             alias: hive.metastore.api.flushcache
-            metric_type: gauge
+            metric_type: monotonic_count
     - include:
         bean: metrics:name=active_calls_api_flushCache
         attribute:
@@ -794,7 +794,7 @@ init_config:
         attribute:
           Count:
             alias: hive.metastore.api.alter_table
-            metric_type: gauge
+            metric_type: monotonic_count
     - include:
         bean: metrics:name=active_calls_api_alter_table
         attribute:
@@ -806,7 +806,7 @@ init_config:
         attribute:
           Count:
             alias: hive.metastore.api.get_all_functions
-            metric_type: gauge
+            metric_type: monotonic_count
     - include:
         bean: metrics:name=active_calls_api_get_all_functions
         attribute:
@@ -818,7 +818,7 @@ init_config:
         attribute:
           Count:
             alias: hive.metastore.api.get_table_req
-            metric_type: gauge
+            metric_type: monotonic_count
     - include:
         bean: metrics:name=active_calls_api_get_table_req
         attribute:

--- a/hive/datadog_checks/hive/data/metrics.yaml
+++ b/hive/datadog_checks/hive/data/metrics.yaml
@@ -462,7 +462,7 @@ jmx_metrics:
       attribute:
         Value:
           alias: hive.metastore.db.init
-          metric_type: gauge
+          metric_type: monotonic_count
 
   - include:
       bean: metrics:name=create_total_count_tables
@@ -483,7 +483,7 @@ jmx_metrics:
       attribute:
         Value:
           alias: hive.metastore.table.init
-          metric_type: gauge
+          metric_type: monotonic_count
 
   - include:
       bean: metrics:name=create_total_count_partitions
@@ -605,7 +605,7 @@ jmx_metrics:
       attribute:
         Count:
           alias: hive.metastore.api.create_table
-          metric_type: gauge
+          metric_type: monotonic_count
   - include:
       bean: metrics:name=active_calls_api_create_table
       attribute:
@@ -617,7 +617,7 @@ jmx_metrics:
       attribute:
         Count:
           alias: hive.metastore.api.get_table
-          metric_type: gauge
+          metric_type: monotonic_count
   - include:
       bean: metrics:name=active_calls_api_get_table
       attribute:
@@ -629,7 +629,7 @@ jmx_metrics:
       attribute:
         Count:
           alias: hive.metastore.api.drop_table
-          metric_type: gauge
+          metric_type: monotonic_count
   - include:
       bean: metrics:name=active_calls_api_drop_table
       attribute:
@@ -641,7 +641,7 @@ jmx_metrics:
       attribute:
         Count:
           alias: hive.metastore.api.init
-          metric_type: gauge
+          metric_type: monotonic_count
   - include:
       bean: metrics:name=active_calls_api_init
       attribute:
@@ -653,7 +653,7 @@ jmx_metrics:
       attribute:
         Count:
           alias: hive.metastore.api.get_all_databases
-          metric_type: gauge
+          metric_type: monotonic_count
   - include:
       bean: metrics:name=active_calls_api_get_all_databases
       attribute:
@@ -665,7 +665,7 @@ jmx_metrics:
       attribute:
         Count:
           alias: hive.metastore.api.get_database
-          metric_type: gauge
+          metric_type: monotonic_count
   - include:
       bean: metrics:name=active_calls_api_get_database
       attribute:
@@ -677,7 +677,7 @@ jmx_metrics:
       attribute:
         Count:
           alias: hive.metastore.api.get_all_tables
-          metric_type: gauge
+          metric_type: monotonic_count
   - include:
       bean: metrics:name=active_calls_api_get_all_tables
       attribute:
@@ -689,7 +689,7 @@ jmx_metrics:
       attribute:
         Count:
           alias: hive.metastore.api.shutdown
-          metric_type: gauge
+          metric_type: monotonic_count
   - include:
       bean: metrics:name=active_calls_api_shutdown
       attribute:
@@ -701,7 +701,7 @@ jmx_metrics:
       attribute:
         Count:
           alias: hive.metastore.api.flushcache
-          metric_type: gauge
+          metric_type: monotonic_count
   - include:
       bean: metrics:name=active_calls_api_flushCache
       attribute:
@@ -713,7 +713,7 @@ jmx_metrics:
       attribute:
         Count:
           alias: hive.metastore.api.alter_table
-          metric_type: gauge
+          metric_type: monotonic_count
   - include:
       bean: metrics:name=active_calls_api_alter_table
       attribute:
@@ -725,7 +725,7 @@ jmx_metrics:
       attribute:
         Count:
           alias: hive.metastore.api.get_all_functions
-          metric_type: gauge
+          metric_type: monotonic_count
   - include:
       bean: metrics:name=active_calls_api_get_all_functions
       attribute:
@@ -737,7 +737,7 @@ jmx_metrics:
       attribute:
         Count:
           alias: hive.metastore.api.get_table_req
-          metric_type: gauge
+          metric_type: monotonic_count
   - include:
       bean: metrics:name=active_calls_api_get_table_req
       attribute:

--- a/hive/metadata.csv
+++ b/hive/metadata.csv
@@ -1,14 +1,14 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 hive.metastore.open_connections,gauge,10,connection,,Number of connection opened.,0,hive,hms open connection
-hive.metastore.db.created,rate,10,unit,,Total number of created database.,0,hive,hms db created
-hive.metastore.db.deleted,rate,10,unit,,Total number of deleted database.,0,hive,hms db deleted
-hive.metastore.db.init,rate,10,unit,,Number of initialized database.,0,hive,hms db init
+hive.metastore.db.created,rate,10,database,,Total number of created database.,0,hive,hms db created
+hive.metastore.db.deleted,rate,10,database,,Total number of deleted database.,0,hive,hms db deleted
+hive.metastore.db.init,rate,10,database,,Number of initialized database.,0,hive,hms db init
 hive.metastore.table.created,rate,10,table,,Total number of created table.,0,hive,hms table created
 hive.metastore.table.deleted,rate,10,table,,Total number of deleted table.,0,hive,hms table deleted
 hive.metastore.table.init,rate,10,table,,Number of initialized table.,0,hive,hms table init
-hive.metastore.partition.created,rate,10,unit,,Total number of created partition.,0,hive,hms partition created
-hive.metastore.partition.deleted,rate,10,unit,,Total number of deleted partition.,0,hive,hms partition deleted
-hive.metastore.partition.init,rate,10,unit,,Number of initialized partition.,0,hive,hms partition init
+hive.metastore.partition.created,rate,10,partition,,Total number of created partition.,0,hive,hms partition created
+hive.metastore.partition.deleted,rate,10,partition,,Total number of deleted partition.,0,hive,hms partition deleted
+hive.metastore.partition.init,rate,10,partition,,Number of initialized partition.,0,hive,hms partition init
 hive.metastore.directsql_errors,gauge,10,unit,,Number of SQL error.,0,hive,hms sql error
 hive.metastore.memory.heap.init,gauge,10,byte,,Memory used at the initialization by the metastore.,0,hive,hms mem heap init
 hive.metastore.memory.heap.used,gauge,10,byte,,Memory used by the metastore.,0,hive,hms mem heap used
@@ -22,34 +22,34 @@ hive.metastore.memory.total.init,gauge,10,byte,,Total memory at the initializati
 hive.metastore.memory.total.used,gauge,10,byte,,Total memory used by the metastore.,0,hive,hms total used
 hive.metastore.memory.total.max,gauge,10,byte,,Total maximum memory that can be used for the metastore.,0,hive,hms mem total max
 hive.metastore.memory.total.committed,gauge,10,byte,,Total committed memory for the metastore.,0,hive,hms mem total committed
-hive.metastore.api.create_table,rate,10,unit,,API call to create a table.,0,hive,hms api create table
+hive.metastore.api.create_table,rate,10,call,,API call to create a table.,0,hive,hms api create table
 hive.metastore.api.create_table.active_call,gauge,10,unit,,Active API call to create a table.,0,hive,hms active api create table
-hive.metastore.api.get_table,rate,10,unit,,API call to get a table.,0,hive,hms api get table
+hive.metastore.api.get_table,rate,10,call,,API call to get a table.,0,hive,hms api get table
 hive.metastore.api.get_table.active_call,gauge,10,unit,,Active API call to get a table.,0,hive,hms active api get table
-hive.metastore.api.drop_table,rate,10,unit,,API call to drop a table.,0,hive,hms api drop table
+hive.metastore.api.drop_table,rate,10,call,,API call to drop a table.,0,hive,hms api drop table
 hive.metastore.api.drop_table.active_call,gauge,10,unit,,Active API call to drop a table.,0,hive,hms active api drop table
-hive.metastore.api.init,rate,10,unit,,API initialization.,0,hive,hms api init
+hive.metastore.api.init,rate,10,call,,API initialization.,0,hive,hms api init
 hive.metastore.api.init.active_call,gauge,10,unit,,Active API initialization.,0,hive,hms active api init
-hive.metastore.api.get_all_databases,rate,10,unit,,API call to get all databases.,0,hive,hms api get all get all dbs
+hive.metastore.api.get_all_databases,rate,10,call,,API call to get all databases.,0,hive,hms api get all get all dbs
 hive.metastore.api.get_all_databases.active_call,gauge,10,unit,,Active API call to get all databases.,0,hive,hms active api get all dbs
-hive.metastore.api.get_database,rate,10,unit,,API call to get a database.,0,hive,hms api get db
+hive.metastore.api.get_database,rate,10,call,,API call to get a database.,0,hive,hms api get db
 hive.metastore.api.get_database.active_call,gauge,10,unit,,Active API call to get a database.,0,hive,hms active api get db
-hive.metastore.api.get_all_tables,rate,10,unit,,API call to get all tables.,0,hive,hms api get all tables
+hive.metastore.api.get_all_tables,rate,10,call,,API call to get all tables.,0,hive,hms api get all tables
 hive.metastore.api.get_all_tables.active_call,gauge,10,unit,,Active API call to get all tables.,0,hive,hms active api get all tables
-hive.metastore.api.shutdown,rate,10,unit,,API shutdown.,0,hive,hms api shutdown
+hive.metastore.api.shutdown,rate,10,call,,API shutdown.,0,hive,hms api shutdown
 hive.metastore.api.shutdown.active_call,gauge,10,unit,,Active API shutdown.,0,hive,hms active api shutdown
-hive.metastore.api.flushcache,rate,10,unit,,API flushcache.,0,hive,hms api flushcache
+hive.metastore.api.flushcache,rate,10,call,,API flushcache.,0,hive,hms api flushcache
 hive.metastore.api.flushcache.active_call,gauge,10,unit,,Active API flushcache.,0,hive,hms active api flushcache
-hive.metastore.api.alter_table,rate,10,unit,,API call to alter table.,0,hive,hms api alter table
+hive.metastore.api.alter_table,rate,10,call,,API call to alter table.,0,hive,hms api alter table
 hive.metastore.api.alter_table.active_call,gauge,10,unit,,Active API call to alter table.,0,hive,hms active api alter table
-hive.metastore.api.get_all_functions,rate,10,unit,,API call to get all functions.,0,hive,hms api get all functions
+hive.metastore.api.get_all_functions,rate,10,call,,API call to get all functions.,0,hive,hms api get all functions
 hive.metastore.api.get_all_functions.active_call,gauge,10,unit,,Active API call to get all functions.,0,hive,hms active api get all functions
-hive.metastore.api.get_table_req,rate,10,unit,,,0,hive,hms api get table req
+hive.metastore.api.get_table_req,rate,10,call,,,0,hive,hms api get table req
 hive.metastore.api.get_table_req.active_call,gauge,10,unit,,,0,hive,hms active api get table req
 hive.server.open_operations,gauge,10,operation,,Operation opened in the HiveServer2.,0,hive,hs2 open operation
-hive.server.session.active,gauge,10,unit,,Number of active session.,0,hive,hs2 active session
+hive.server.session.active,gauge,10,session,,Number of active session.,0,hive,hs2 active session
 hive.server.session.active.time_mean,gauge,10,millisecond,,Average time a session has been active.,0,hive,hs2 active session time mean
-hive.server.session.open,gauge,10,unit,,Number of opened session.,0,hive,hs2 open session
+hive.server.session.open,gauge,10,session,,Number of opened session.,0,hive,hs2 open session
 hive.server.session.open.time_mean,gauge,10,millisecond,,Average time a session has been opened.,0,hive,hs2 open session time mean
 hive.server.queries.submitted.active_call,gauge,10,query,,Active submitted queries.,0,hive,hs2 active submitted query
 hive.server.queries.submitted.max,gauge,10,millisecond,,Max time for a submitted query.,0,hive,hs2 submitted query max
@@ -83,7 +83,7 @@ hive.server.api.sql_operation.pending.mean,gauge,10,millisecond,,Mean time in pe
 hive.server.api.sql_operation.pending.min,gauge,10,millisecond,,Min time in pending state for an sql operation.,0,hive,hs2 sql operation pending min
 hive.server.api.sql_operation.pending.75percentile,gauge,10,millisecond,,P75 time in pending state for an sql operation.,0,hive,hs2 sql operation pending p75
 hive.server.api.sql_operation.pending.95percentile,gauge,10,millisecond,,P95 time in pending state for an sql operation.,0,hive,hs2 sql operation pending p95
-hive.server.api.sql_operation.pending.count,rate,10,unit,,Number of sql operation in pending state.,0,hive,hs2 sql operation pending count
+hive.server.api.sql_operation.pending.count,rate,10,operation,,Number of sql operation in pending state.,0,hive,hs2 sql operation pending count
 hive.server.api.sql_operation.pending.meanrate,gauge,10,operation,second,Pending sql operation rate.,0,hive,hs2 sql operation pending rate
 hive.server.api.sql_operation.running.active_call,gauge,10,operation,,Active running sql operation.,0,hive,hs2 active sql operation running
 hive.server.api.sql_operation.running.max,gauge,10,millisecond,,Max time for running state for a sql operation.,0,hive,hs2 sql operation running max
@@ -91,7 +91,7 @@ hive.server.api.sql_operation.running.mean,gauge,10,millisecond,,Mean time for r
 hive.server.api.sql_operation.running.min,gauge,10,millisecond,,Min time for running state for a sql operation.,0,hive,hs2 sql operation running min
 hive.server.api.sql_operation.running.75percentile,gauge,10,millisecond,,P75 time for running state for a sql operation.,0,hive,hs2 sql operation running p75
 hive.server.api.sql_operation.running.95percentile,gauge,10,millisecond,,P95 time for running state for a sql operation.,0,hive,hs2 sql operation running p95
-hive.server.api.sql_operation.running.count,rate,10,unit,,Number of sql operation in running state.,0,hive,hs2 sql operation running count
+hive.server.api.sql_operation.running.count,rate,10,operation,,Number of sql operation in running state.,0,hive,hs2 sql operation running count
 hive.server.api.sql_operation.running.meanrate,gauge,10,operation,second,Running sql operation rate.,0,hive,hs2 sql operation running rate
 hive.server.sql_operation.completed.closed,rate,10,operation,,Number of closed sql operation.,0,hive,hs2 sql operation completed closed
 hive.server.sql_operation.completed.finished,rate,10,operation,,Number of finished sql operation.,0,hive,hs2 sql operation completed finished

--- a/hive/metadata.csv
+++ b/hive/metadata.csv
@@ -110,7 +110,7 @@ hive.server.api.operation.pending.mean,gauge,10,millisecond,,Mean time in pendin
 hive.server.api.operation.pending.min,gauge,10,millisecond,,Min time in pending state for an sql operation.,0,hive,hs2 operation pending min
 hive.server.api.operation.pending.75percentile,gauge,10,millisecond,,P75 time in pending state for an sql operation.,0,hive,hs2 operation pending p75
 hive.server.api.operation.pending.95percentile,gauge,10,millisecond,,P95 time in pending state for an sql operation.,0,hive,hs2 operation pending p95
-hive.server.api.operation.pending.count,rate,10,millisecond,,Number of operation in pending state.,0,hive,hs2 operation pending count
+hive.server.api.operation.pending.count,rate,10,operation,,Number of operation in pending state.,0,hive,hs2 operation pending count
 hive.server.api.operation.pending.meanrate,gauge,10,operation,second,Operation pending rate.,0,hive,hs2 operation pending rate
 hive.server.api.operation.running.active_call,gauge,10,operation,,Active running operation.,0,hive,hs2 active operation running
 hive.server.api.operation.running.max,gauge,10,millisecond,,Max time in running state for an sql operation.,0,hive,hs2 operation running max

--- a/hive/metadata.csv
+++ b/hive/metadata.csv
@@ -1,14 +1,14 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 hive.metastore.open_connections,gauge,10,connection,,Number of connection opened.,0,hive,hms open connection
-hive.metastore.db.created,count,10,unit,,Total number of created database.,0,hive,hms db created
-hive.metastore.db.deleted,count,10,unit,,Total number of deleted database.,0,hive,hms db deleted
-hive.metastore.db.init,count,10,unit,,Number of initialized database.,0,hive,hms db init
-hive.metastore.table.created,count,10,table,,Total number of created table.,0,hive,hms table created
-hive.metastore.table.deleted,count,10,table,,Total number of deleted table.,0,hive,hms table deleted
-hive.metastore.table.init,count,10,table,,Number of initialized table.,0,hive,hms table init
-hive.metastore.partition.created,count,10,unit,,Total number of created partition.,0,hive,hms partition created
-hive.metastore.partition.deleted,count,10,unit,,Total number of deleted partition.,0,hive,hms partition deleted
-hive.metastore.partition.init,count,10,unit,,Number of initialized partition.,0,hive,hms partition init
+hive.metastore.db.created,rate,10,unit,,Total number of created database.,0,hive,hms db created
+hive.metastore.db.deleted,rate,10,unit,,Total number of deleted database.,0,hive,hms db deleted
+hive.metastore.db.init,rate,10,unit,,Number of initialized database.,0,hive,hms db init
+hive.metastore.table.created,rate,10,table,,Total number of created table.,0,hive,hms table created
+hive.metastore.table.deleted,rate,10,table,,Total number of deleted table.,0,hive,hms table deleted
+hive.metastore.table.init,rate,10,table,,Number of initialized table.,0,hive,hms table init
+hive.metastore.partition.created,rate,10,unit,,Total number of created partition.,0,hive,hms partition created
+hive.metastore.partition.deleted,rate,10,unit,,Total number of deleted partition.,0,hive,hms partition deleted
+hive.metastore.partition.init,rate,10,unit,,Number of initialized partition.,0,hive,hms partition init
 hive.metastore.directsql_errors,gauge,10,unit,,Number of SQL error.,0,hive,hms sql error
 hive.metastore.memory.heap.init,gauge,10,byte,,Memory used at the initialization by the metastore.,0,hive,hms mem heap init
 hive.metastore.memory.heap.used,gauge,10,byte,,Memory used by the metastore.,0,hive,hms mem heap used
@@ -22,29 +22,29 @@ hive.metastore.memory.total.init,gauge,10,byte,,Total memory at the initializati
 hive.metastore.memory.total.used,gauge,10,byte,,Total memory used by the metastore.,0,hive,hms total used
 hive.metastore.memory.total.max,gauge,10,byte,,Total maximum memory that can be used for the metastore.,0,hive,hms mem total max
 hive.metastore.memory.total.committed,gauge,10,byte,,Total committed memory for the metastore.,0,hive,hms mem total committed
-hive.metastore.api.create_table,count,10,unit,,API call to create a table.,0,hive,hms api create table
+hive.metastore.api.create_table,rate,10,unit,,API call to create a table.,0,hive,hms api create table
 hive.metastore.api.create_table.active_call,gauge,10,unit,,Active API call to create a table.,0,hive,hms active api create table
-hive.metastore.api.get_table,count,10,unit,,API call to get a table.,0,hive,hms api get table
+hive.metastore.api.get_table,rate,10,unit,,API call to get a table.,0,hive,hms api get table
 hive.metastore.api.get_table.active_call,gauge,10,unit,,Active API call to get a table.,0,hive,hms active api get table
-hive.metastore.api.drop_table,count,10,unit,,API call to drop a table.,0,hive,hms api drop table
+hive.metastore.api.drop_table,rate,10,unit,,API call to drop a table.,0,hive,hms api drop table
 hive.metastore.api.drop_table.active_call,gauge,10,unit,,Active API call to drop a table.,0,hive,hms active api drop table
-hive.metastore.api.init,count,10,unit,,API initialization.,0,hive,hms api init
+hive.metastore.api.init,rate,10,unit,,API initialization.,0,hive,hms api init
 hive.metastore.api.init.active_call,gauge,10,unit,,Active API initialization.,0,hive,hms active api init
-hive.metastore.api.get_all_databases,count,10,unit,,API call to get all databases.,0,hive,hms api get all get all dbs
+hive.metastore.api.get_all_databases,rate,10,unit,,API call to get all databases.,0,hive,hms api get all get all dbs
 hive.metastore.api.get_all_databases.active_call,gauge,10,unit,,Active API call to get all databases.,0,hive,hms active api get all dbs
-hive.metastore.api.get_database,count,10,unit,,API call to get a database.,0,hive,hms api get db
+hive.metastore.api.get_database,rate,10,unit,,API call to get a database.,0,hive,hms api get db
 hive.metastore.api.get_database.active_call,gauge,10,unit,,Active API call to get a database.,0,hive,hms active api get db
-hive.metastore.api.get_all_tables,count,10,unit,,API call to get all tables.,0,hive,hms api get all tables
+hive.metastore.api.get_all_tables,rate,10,unit,,API call to get all tables.,0,hive,hms api get all tables
 hive.metastore.api.get_all_tables.active_call,gauge,10,unit,,Active API call to get all tables.,0,hive,hms active api get all tables
-hive.metastore.api.shutdown,count,10,unit,,API shutdown.,0,hive,hms api shutdown
+hive.metastore.api.shutdown,rate,10,unit,,API shutdown.,0,hive,hms api shutdown
 hive.metastore.api.shutdown.active_call,gauge,10,unit,,Active API shutdown.,0,hive,hms active api shutdown
-hive.metastore.api.flushcache,count,10,unit,,API flushcache.,0,hive,hms api flushcache
+hive.metastore.api.flushcache,rate,10,unit,,API flushcache.,0,hive,hms api flushcache
 hive.metastore.api.flushcache.active_call,gauge,10,unit,,Active API flushcache.,0,hive,hms active api flushcache
-hive.metastore.api.alter_table,count,10,unit,,API call to alter table.,0,hive,hms api alter table
+hive.metastore.api.alter_table,rate,10,unit,,API call to alter table.,0,hive,hms api alter table
 hive.metastore.api.alter_table.active_call,gauge,10,unit,,Active API call to alter table.,0,hive,hms active api alter table
-hive.metastore.api.get_all_functions,count,10,unit,,API call to get all functions.,0,hive,hms api get all functions
+hive.metastore.api.get_all_functions,rate,10,unit,,API call to get all functions.,0,hive,hms api get all functions
 hive.metastore.api.get_all_functions.active_call,gauge,10,unit,,Active API call to get all functions.,0,hive,hms active api get all functions
-hive.metastore.api.get_table_req,count,10,unit,,,0,hive,hms api get table req
+hive.metastore.api.get_table_req,rate,10,unit,,,0,hive,hms api get table req
 hive.metastore.api.get_table_req.active_call,gauge,10,unit,,,0,hive,hms active api get table req
 hive.server.open_operations,gauge,10,operation,,Operation opened in the HiveServer2.,0,hive,hs2 open operation
 hive.server.session.active,gauge,10,unit,,Number of active session.,0,hive,hs2 active session
@@ -57,44 +57,44 @@ hive.server.queries.submitted.mean,gauge,10,millisecond,,Mean time for a submitt
 hive.server.queries.submitted.min,gauge,10,millisecond,,Min time for a submitted query.,0,hive,hs2 submitted query min
 hive.server.queries.submitted.75percentile,gauge,10,millisecond,,P75 time for a submitted query.,0,hive,hs2 submitted query p75
 hive.server.queries.submitted.95percentile,gauge,10,millisecond,,P95 time for a submitted query.,0,hive,hs2 submitted query p95
-hive.server.queries.submitted.count,count,10,query,,Number of submitted query.,0,hive,hs2 submitted query count
-hive.server.queries.submitted.meanrate,rate,10,query,second,Submitted query rate.,0,hive,hs2 submitted query rate
+hive.server.queries.submitted.count,rate,10,query,,Number of submitted query.,0,hive,hs2 submitted query count
+hive.server.queries.submitted.meanrate,gauge,10,query,second,Submitted query rate.,0,hive,hs2 submitted query rate
 hive.server.queries.compiling.active_call,gauge,10,query,,Active compiling queries.,0,hive,hs2 active compiling query
 hive.server.queries.compiling.max,gauge,10,millisecond,,Max time for compiling a query.,0,hive,hs2 compiling query max
 hive.server.queries.compiling.mean,gauge,10,millisecond,,Mean time for compiling a query.,0,hive,hs2 compiling query mean
 hive.server.queries.compiling.min,gauge,10,millisecond,,Min time for compiling a query.,0,hive,hs2 compiling query min
 hive.server.queries.compiling.75percentile,gauge,10,millisecond,,P75 time for compiling a query.,0,hive,hs2 compiling query p75
 hive.server.queries.compiling.95percentile,gauge,10,millisecond,,P95 time for compiling a query.,0,hive,hs2 compiling query p95
-hive.server.queries.compiling.count,count,10,query,,Number of compiled query.,0,hive,hs2 compiling query count
-hive.server.queries.compiling.meanrate,rate,10,query,second,Compiling query rate.,0,hive,hs2 compiling query rate
+hive.server.queries.compiling.count,rate,10,query,,Number of compiled query.,0,hive,hs2 compiling query count
+hive.server.queries.compiling.meanrate,gauge,10,query,second,Compiling query rate.,0,hive,hs2 compiling query rate
 hive.server.api.queries.executing.active_call,gauge,10,query,,Active executing queries.,0,hive,hs2 executing query
 hive.server.queries.executing.max,gauge,10,millisecond,,Max time for executing a query.,0,hive,hs2 executing query max
 hive.server.queries.executing.mean,gauge,10,millisecond,,Mean time for executing a query.,0,hive,hs2 executing query mean
 hive.server.queries.executing.min,gauge,10,millisecond,,Min time for executing a query.,0,hive,hs2 executing query min
 hive.server.queries.executing.75percentile,gauge,10,millisecond,,P75 time for executing a query.,0,hive,hs2 executing query p75
 hive.server.queries.executing.95percentile,gauge,10,millisecond,,P95 time for executing a query.,0,hive,hs2 executing query p95
-hive.server.queries.executing.count,count,10,query,,Number of executed queries.,0,hive,hs2 executing query count
-hive.server.queries.executing.meanrate,rate,10,query,second,Executing query rate.,0,hive,hs2 executing query rate
-hive.server.queries.succeeded.count,count,10,query,,Number of succeeded queries.,0,hive,hs2 succeeded query count
-hive.server.queries.succeeded.meanrate,rate,10,query,second,Succeeded queries rate.,0,hive,hs2 succeeded query rate
+hive.server.queries.executing.count,rate,10,query,,Number of executed queries.,0,hive,hs2 executing query count
+hive.server.queries.executing.meanrate,gauge,10,query,second,Executing query rate.,0,hive,hs2 executing query rate
+hive.server.queries.succeeded.count,rate,10,query,,Number of succeeded queries.,0,hive,hs2 succeeded query count
+hive.server.queries.succeeded.meanrate,gauge,10,query,second,Succeeded queries rate.,0,hive,hs2 succeeded query rate
 hive.server.api.sql_operation.pending.active_call,gauge,10,operation,,Active pending sql operation.,0,hive,hs2 active sql operation pending
 hive.server.api.sql_operation.pending.max,gauge,10,millisecond,,Max time in pending state for an sql operation.,0,hive,hs2 sql operation pending max
 hive.server.api.sql_operation.pending.mean,gauge,10,millisecond,,Mean time in pending state for an sql operation.,0,hive,hs2 sql operation pending mean
 hive.server.api.sql_operation.pending.min,gauge,10,millisecond,,Min time in pending state for an sql operation.,0,hive,hs2 sql operation pending min
 hive.server.api.sql_operation.pending.75percentile,gauge,10,millisecond,,P75 time in pending state for an sql operation.,0,hive,hs2 sql operation pending p75
 hive.server.api.sql_operation.pending.95percentile,gauge,10,millisecond,,P95 time in pending state for an sql operation.,0,hive,hs2 sql operation pending p95
-hive.server.api.sql_operation.pending.count,count,10,unit,,Number of sql operation in pending state.,0,hive,hs2 sql operation pending count
-hive.server.api.sql_operation.pending.meanrate,rate,10,operation,second,Pending sql operation rate.,0,hive,hs2 sql operation pending rate
+hive.server.api.sql_operation.pending.count,rate,10,unit,,Number of sql operation in pending state.,0,hive,hs2 sql operation pending count
+hive.server.api.sql_operation.pending.meanrate,gauge,10,operation,second,Pending sql operation rate.,0,hive,hs2 sql operation pending rate
 hive.server.api.sql_operation.running.active_call,gauge,10,operation,,Active running sql operation.,0,hive,hs2 active sql operation running
 hive.server.api.sql_operation.running.max,gauge,10,millisecond,,Max time for running state for a sql operation.,0,hive,hs2 sql operation running max
 hive.server.api.sql_operation.running.mean,gauge,10,millisecond,,Mean time for running state for a sql operation.,0,hive,hs2 sql operation running mean
 hive.server.api.sql_operation.running.min,gauge,10,millisecond,,Min time for running state for a sql operation.,0,hive,hs2 sql operation running min
 hive.server.api.sql_operation.running.75percentile,gauge,10,millisecond,,P75 time for running state for a sql operation.,0,hive,hs2 sql operation running p75
 hive.server.api.sql_operation.running.95percentile,gauge,10,millisecond,,P95 time for running state for a sql operation.,0,hive,hs2 sql operation running p95
-hive.server.api.sql_operation.running.count,count,10,unit,,Number of sql operation in running state.,0,hive,hs2 sql operation running count
-hive.server.api.sql_operation.running.meanrate,rate,10,operation,second,Running sql operation rate.,0,hive,hs2 sql operation running rate
-hive.server.sql_operation.completed.closed,count,10,operation,,Number of closed sql operation.,0,hive,hs2 sql operation completed closed
-hive.server.sql_operation.completed.finished,count,10,operation,,Number of finished sql operation.,0,hive,hs2 sql operation completed finished
+hive.server.api.sql_operation.running.count,rate,10,unit,,Number of sql operation in running state.,0,hive,hs2 sql operation running count
+hive.server.api.sql_operation.running.meanrate,gauge,10,operation,second,Running sql operation rate.,0,hive,hs2 sql operation running rate
+hive.server.sql_operation.completed.closed,rate,10,operation,,Number of closed sql operation.,0,hive,hs2 sql operation completed closed
+hive.server.sql_operation.completed.finished,rate,10,operation,,Number of finished sql operation.,0,hive,hs2 sql operation completed finished
 hive.server.sql_operation.user.active,gauge,10,user,,Number of active user.,0,hive,hs2 sql operation user active
 hive.server.api.operation.initialized.active_call,gauge,10,user,,Active initialized operation.,0,hive,hs2 active operation init
 hive.server.api.operation.initialized.max,gauge,10,millisecond,,Max time to init an operation.,0,hive,hs2 operation init max
@@ -102,26 +102,26 @@ hive.server.api.operation.initialized.mean,gauge,10,millisecond,,Mean time to in
 hive.server.api.operation.initialized.min,gauge,10,millisecond,,Min time to init an operation.,0,hive,hs2 operation init min
 hive.server.api.operation.initialized.75percentile,gauge,10,millisecond,,P75 time to init an operation.,0,hive,hs2 operation init p75
 hive.server.api.operation.initialized.95percentile,gauge,10,millisecond,,P95 time to init an operation.,0,hive,hs2 operation init p95
-hive.server.api.operation.initialized.count,count,10,operation,,Number of operation initialized.,0,hive,hs2 operation init count
-hive.server.api.operation.initialized.meanrate,rate,10,operation,,Operation initialization rate.,0,hive,hs2 operation init rate
+hive.server.api.operation.initialized.count,rate,10,operation,,Number of operation initialized.,0,hive,hs2 operation init count
+hive.server.api.operation.initialized.meanrate,gauge,10,operation,,Operation initialization rate.,0,hive,hs2 operation init rate
 hive.server.api.operation.pending.active_call,gauge,10,operation,,Active pending operation.,0,hive,hs2 active operation pending
 hive.server.api.operation.pending.max,gauge,10,millisecond,,Max time in pending state for an sql operation.,0,hive,hs2 operation pending max
 hive.server.api.operation.pending.mean,gauge,10,millisecond,,Mean time in pending state for an sql operation.,0,hive,hs2 operation pending mean
 hive.server.api.operation.pending.min,gauge,10,millisecond,,Min time in pending state for an sql operation.,0,hive,hs2 operation pending min
 hive.server.api.operation.pending.75percentile,gauge,10,millisecond,,P75 time in pending state for an sql operation.,0,hive,hs2 operation pending p75
 hive.server.api.operation.pending.95percentile,gauge,10,millisecond,,P95 time in pending state for an sql operation.,0,hive,hs2 operation pending p95
-hive.server.api.operation.pending.count,count,10,millisecond,,Number of operation in pending state.,0,hive,hs2 operation pending count
-hive.server.api.operation.pending.meanrate,rate,10,operation,second,Operation pending rate.,0,hive,hs2 operation pending rate
+hive.server.api.operation.pending.count,rate,10,millisecond,,Number of operation in pending state.,0,hive,hs2 operation pending count
+hive.server.api.operation.pending.meanrate,gauge,10,operation,second,Operation pending rate.,0,hive,hs2 operation pending rate
 hive.server.api.operation.running.active_call,gauge,10,operation,,Active running operation.,0,hive,hs2 active operation running
 hive.server.api.operation.running.max,gauge,10,millisecond,,Max time in running state for an sql operation.,0,hive,hs2 operation running max
 hive.server.api.operation.running.mean,gauge,10,millisecond,,Mean time in running state for an sql operation.,0,hive,hs2 operation running mean
 hive.server.api.operation.running.min,gauge,10,millisecond,,Min time in running state for an sql operation.,0,hive,hs2 operation running min
 hive.server.api.operation.running.75percentile,gauge,10,millisecond,,P75 time in running state for an sql operation.,0,hive,hs2 operation running p75
 hive.server.api.operation.running.95percentile,gauge,10,millisecond,,P95 time in running state for an sql operation.,0,hive,hs2 operation running p95
-hive.server.api.operation.running.count,count,10,millisecond,,Number of operation in running state.,0,hive,hs2 operation running count
-hive.server.api.operation.running.meanrate,rate,10,operation,second,Operation running rate.,0,hive,hs2 operation running rate
-hive.server.operation.completed.finished,count,10,operation,,Number of finished operation.,0,hive,hs2 operation completed finished
-hive.server.operation.completed.closed,count,10,operation,,Number of closed operation.,0,hive,hs2 operation committed closed
+hive.server.api.operation.running.count,rate,10,millisecond,,Number of operation in running state.,0,hive,hs2 operation running count
+hive.server.api.operation.running.meanrate,gauge,10,operation,second,Operation running rate.,0,hive,hs2 operation running rate
+hive.server.operation.completed.finished,rate,10,operation,,Number of finished operation.,0,hive,hs2 operation completed finished
+hive.server.operation.completed.closed,rate,10,operation,,Number of closed operation.,0,hive,hs2 operation committed closed
 hive.server.memory.heap.init,gauge,10,byte,,Memory used at the initialization by the HiveServer2.,0,hive,hs2 mem heap init
 hive.server.memory.heap.used,gauge,10,byte,,Memory used by the HiveServer2.,0,hive,hs2 mem heap used
 hive.server.memory.heap.max,gauge,10,byte,,Maximum memory that can be used by the HiveServer2.,0,hive,hs2 mem heap max

--- a/hive/metadata.csv
+++ b/hive/metadata.csv
@@ -2,10 +2,10 @@ metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation
 hive.metastore.open_connections,gauge,10,connection,,Number of connection opened.,0,hive,hms open connection
 hive.metastore.db.created,count,10,unit,,Total number of created database.,0,hive,hms db created
 hive.metastore.db.deleted,count,10,unit,,Total number of deleted database.,0,hive,hms db deleted
-hive.metastore.db.init,gauge,10,unit,,Number of initialized database.,0,hive,hms db init
+hive.metastore.db.init,count,10,unit,,Number of initialized database.,0,hive,hms db init
 hive.metastore.table.created,count,10,table,,Total number of created table.,0,hive,hms table created
 hive.metastore.table.deleted,count,10,table,,Total number of deleted table.,0,hive,hms table deleted
-hive.metastore.table.init,gauge,10,table,,Number of initialized table.,0,hive,hms table init
+hive.metastore.table.init,count,10,table,,Number of initialized table.,0,hive,hms table init
 hive.metastore.partition.created,count,10,unit,,Total number of created partition.,0,hive,hms partition created
 hive.metastore.partition.deleted,count,10,unit,,Total number of deleted partition.,0,hive,hms partition deleted
 hive.metastore.partition.init,count,10,unit,,Number of initialized partition.,0,hive,hms partition init
@@ -22,29 +22,29 @@ hive.metastore.memory.total.init,gauge,10,byte,,Total memory at the initializati
 hive.metastore.memory.total.used,gauge,10,byte,,Total memory used by the metastore.,0,hive,hms total used
 hive.metastore.memory.total.max,gauge,10,byte,,Total maximum memory that can be used for the metastore.,0,hive,hms mem total max
 hive.metastore.memory.total.committed,gauge,10,byte,,Total committed memory for the metastore.,0,hive,hms mem total committed
-hive.metastore.api.create_table,gauge,10,unit,,API call to create a table.,0,hive,hms api create table
+hive.metastore.api.create_table,count,10,unit,,API call to create a table.,0,hive,hms api create table
 hive.metastore.api.create_table.active_call,gauge,10,unit,,Active API call to create a table.,0,hive,hms active api create table
-hive.metastore.api.get_table,gauge,10,unit,,API call to get a table.,0,hive,hms api get table
+hive.metastore.api.get_table,count,10,unit,,API call to get a table.,0,hive,hms api get table
 hive.metastore.api.get_table.active_call,gauge,10,unit,,Active API call to get a table.,0,hive,hms active api get table
-hive.metastore.api.drop_table,gauge,10,unit,,API call to drop a table.,0,hive,hms api drop table
+hive.metastore.api.drop_table,count,10,unit,,API call to drop a table.,0,hive,hms api drop table
 hive.metastore.api.drop_table.active_call,gauge,10,unit,,Active API call to drop a table.,0,hive,hms active api drop table
-hive.metastore.api.init,gauge,10,unit,,API initialization.,0,hive,hms api init
+hive.metastore.api.init,count,10,unit,,API initialization.,0,hive,hms api init
 hive.metastore.api.init.active_call,gauge,10,unit,,Active API initialization.,0,hive,hms active api init
-hive.metastore.api.get_all_databases,gauge,10,unit,,API call to get all databases.,0,hive,hms api get all get all dbs
+hive.metastore.api.get_all_databases,count,10,unit,,API call to get all databases.,0,hive,hms api get all get all dbs
 hive.metastore.api.get_all_databases.active_call,gauge,10,unit,,Active API call to get all databases.,0,hive,hms active api get all dbs
-hive.metastore.api.get_database,gauge,10,unit,,API call to get a database.,0,hive,hms api get db
+hive.metastore.api.get_database,count,10,unit,,API call to get a database.,0,hive,hms api get db
 hive.metastore.api.get_database.active_call,gauge,10,unit,,Active API call to get a database.,0,hive,hms active api get db
-hive.metastore.api.get_all_tables,gauge,10,unit,,API call to get all tables.,0,hive,hms api get all tables
+hive.metastore.api.get_all_tables,count,10,unit,,API call to get all tables.,0,hive,hms api get all tables
 hive.metastore.api.get_all_tables.active_call,gauge,10,unit,,Active API call to get all tables.,0,hive,hms active api get all tables
-hive.metastore.api.shutdown,gauge,10,unit,,API shutdown.,0,hive,hms api shutdown
+hive.metastore.api.shutdown,count,10,unit,,API shutdown.,0,hive,hms api shutdown
 hive.metastore.api.shutdown.active_call,gauge,10,unit,,Active API shutdown.,0,hive,hms active api shutdown
-hive.metastore.api.flushcache,gauge,10,unit,,API flushcache.,0,hive,hms api flushcache
+hive.metastore.api.flushcache,count,10,unit,,API flushcache.,0,hive,hms api flushcache
 hive.metastore.api.flushcache.active_call,gauge,10,unit,,Active API flushcache.,0,hive,hms active api flushcache
-hive.metastore.api.alter_table,gauge,10,unit,,API call to alter table.,0,hive,hms api alter table
+hive.metastore.api.alter_table,count,10,unit,,API call to alter table.,0,hive,hms api alter table
 hive.metastore.api.alter_table.active_call,gauge,10,unit,,Active API call to alter table.,0,hive,hms active api alter table
-hive.metastore.api.get_all_functions,gauge,10,unit,,API call to get all functions.,0,hive,hms api get all functions
+hive.metastore.api.get_all_functions,count,10,unit,,API call to get all functions.,0,hive,hms api get all functions
 hive.metastore.api.get_all_functions.active_call,gauge,10,unit,,Active API call to get all functions.,0,hive,hms active api get all functions
-hive.metastore.api.get_table_req,gauge,10,unit,,,0,hive,hms api get table req
+hive.metastore.api.get_table_req,count,10,unit,,,0,hive,hms api get table req
 hive.metastore.api.get_table_req.active_call,gauge,10,unit,,,0,hive,hms active api get table req
 hive.server.open_operations,gauge,10,operation,,Operation opened in the HiveServer2.,0,hive,hs2 open operation
 hive.server.session.active,gauge,10,unit,,Number of active session.,0,hive,hs2 active session
@@ -93,8 +93,8 @@ hive.server.api.sql_operation.running.75percentile,gauge,10,millisecond,,P75 tim
 hive.server.api.sql_operation.running.95percentile,gauge,10,millisecond,,P95 time for running state for a sql operation.,0,hive,hs2 sql operation running p95
 hive.server.api.sql_operation.running.count,count,10,unit,,Number of sql operation in running state.,0,hive,hs2 sql operation running count
 hive.server.api.sql_operation.running.meanrate,rate,10,operation,second,Running sql operation rate.,0,hive,hs2 sql operation running rate
-hive.server.sql_operation.completed.closed,gauge,10,operation,,Number of closed sql operation.,0,hive,hs2 sql operation completed closed
-hive.server.sql_operation.completed.finished,gauge,10,operation,,Number of finished sql operation.,0,hive,hs2 sql operation completed finished
+hive.server.sql_operation.completed.closed,count,10,operation,,Number of closed sql operation.,0,hive,hs2 sql operation completed closed
+hive.server.sql_operation.completed.finished,count,10,operation,,Number of finished sql operation.,0,hive,hs2 sql operation completed finished
 hive.server.sql_operation.user.active,gauge,10,user,,Number of active user.,0,hive,hs2 sql operation user active
 hive.server.api.operation.initialized.active_call,gauge,10,user,,Active initialized operation.,0,hive,hs2 active operation init
 hive.server.api.operation.initialized.max,gauge,10,millisecond,,Max time to init an operation.,0,hive,hs2 operation init max

--- a/hive/metadata.csv
+++ b/hive/metadata.csv
@@ -1,14 +1,14 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 hive.metastore.open_connections,gauge,10,connection,,Number of connection opened.,0,hive,hms open connection
-hive.metastore.db.created,rate,10,database,,Total number of created database.,0,hive,hms db created
-hive.metastore.db.deleted,rate,10,database,,Total number of deleted database.,0,hive,hms db deleted
-hive.metastore.db.init,rate,10,database,,Number of initialized database.,0,hive,hms db init
+hive.metastore.db.created,rate,10,item,,Total number of created database.,0,hive,hms db created
+hive.metastore.db.deleted,rate,10,item,,Total number of deleted database.,0,hive,hms db deleted
+hive.metastore.db.init,rate,10,item,,Number of initialized database.,0,hive,hms db init
 hive.metastore.table.created,rate,10,table,,Total number of created table.,0,hive,hms table created
 hive.metastore.table.deleted,rate,10,table,,Total number of deleted table.,0,hive,hms table deleted
 hive.metastore.table.init,rate,10,table,,Number of initialized table.,0,hive,hms table init
-hive.metastore.partition.created,rate,10,partition,,Total number of created partition.,0,hive,hms partition created
-hive.metastore.partition.deleted,rate,10,partition,,Total number of deleted partition.,0,hive,hms partition deleted
-hive.metastore.partition.init,rate,10,partition,,Number of initialized partition.,0,hive,hms partition init
+hive.metastore.partition.created,rate,10,item,,Total number of created partition.,0,hive,hms partition created
+hive.metastore.partition.deleted,rate,10,item,,Total number of deleted partition.,0,hive,hms partition deleted
+hive.metastore.partition.init,rate,10,item,,Number of initialized partition.,0,hive,hms partition init
 hive.metastore.directsql_errors,gauge,10,unit,,Number of SQL error.,0,hive,hms sql error
 hive.metastore.memory.heap.init,gauge,10,byte,,Memory used at the initialization by the metastore.,0,hive,hms mem heap init
 hive.metastore.memory.heap.used,gauge,10,byte,,Memory used by the metastore.,0,hive,hms mem heap used
@@ -22,29 +22,29 @@ hive.metastore.memory.total.init,gauge,10,byte,,Total memory at the initializati
 hive.metastore.memory.total.used,gauge,10,byte,,Total memory used by the metastore.,0,hive,hms total used
 hive.metastore.memory.total.max,gauge,10,byte,,Total maximum memory that can be used for the metastore.,0,hive,hms mem total max
 hive.metastore.memory.total.committed,gauge,10,byte,,Total committed memory for the metastore.,0,hive,hms mem total committed
-hive.metastore.api.create_table,rate,10,call,,API call to create a table.,0,hive,hms api create table
+hive.metastore.api.create_table,rate,10,task,,API call to create a table.,0,hive,hms api create table
 hive.metastore.api.create_table.active_call,gauge,10,unit,,Active API call to create a table.,0,hive,hms active api create table
-hive.metastore.api.get_table,rate,10,call,,API call to get a table.,0,hive,hms api get table
+hive.metastore.api.get_table,rate,10,task,,API call to get a table.,0,hive,hms api get table
 hive.metastore.api.get_table.active_call,gauge,10,unit,,Active API call to get a table.,0,hive,hms active api get table
-hive.metastore.api.drop_table,rate,10,call,,API call to drop a table.,0,hive,hms api drop table
+hive.metastore.api.drop_table,rate,10,task,,API call to drop a table.,0,hive,hms api drop table
 hive.metastore.api.drop_table.active_call,gauge,10,unit,,Active API call to drop a table.,0,hive,hms active api drop table
-hive.metastore.api.init,rate,10,call,,API initialization.,0,hive,hms api init
+hive.metastore.api.init,rate,10,task,,API initialization.,0,hive,hms api init
 hive.metastore.api.init.active_call,gauge,10,unit,,Active API initialization.,0,hive,hms active api init
-hive.metastore.api.get_all_databases,rate,10,call,,API call to get all databases.,0,hive,hms api get all get all dbs
+hive.metastore.api.get_all_databases,rate,10,task,,API call to get all databases.,0,hive,hms api get all get all dbs
 hive.metastore.api.get_all_databases.active_call,gauge,10,unit,,Active API call to get all databases.,0,hive,hms active api get all dbs
-hive.metastore.api.get_database,rate,10,call,,API call to get a database.,0,hive,hms api get db
+hive.metastore.api.get_database,rate,10,task,,API call to get a database.,0,hive,hms api get db
 hive.metastore.api.get_database.active_call,gauge,10,unit,,Active API call to get a database.,0,hive,hms active api get db
-hive.metastore.api.get_all_tables,rate,10,call,,API call to get all tables.,0,hive,hms api get all tables
+hive.metastore.api.get_all_tables,rate,10,task,,API call to get all tables.,0,hive,hms api get all tables
 hive.metastore.api.get_all_tables.active_call,gauge,10,unit,,Active API call to get all tables.,0,hive,hms active api get all tables
-hive.metastore.api.shutdown,rate,10,call,,API shutdown.,0,hive,hms api shutdown
+hive.metastore.api.shutdown,rate,10,task,,API shutdown.,0,hive,hms api shutdown
 hive.metastore.api.shutdown.active_call,gauge,10,unit,,Active API shutdown.,0,hive,hms active api shutdown
-hive.metastore.api.flushcache,rate,10,call,,API flushcache.,0,hive,hms api flushcache
+hive.metastore.api.flushcache,rate,10,task,,API flushcache.,0,hive,hms api flushcache
 hive.metastore.api.flushcache.active_call,gauge,10,unit,,Active API flushcache.,0,hive,hms active api flushcache
-hive.metastore.api.alter_table,rate,10,call,,API call to alter table.,0,hive,hms api alter table
+hive.metastore.api.alter_table,rate,10,task,,API call to alter table.,0,hive,hms api alter table
 hive.metastore.api.alter_table.active_call,gauge,10,unit,,Active API call to alter table.,0,hive,hms active api alter table
-hive.metastore.api.get_all_functions,rate,10,call,,API call to get all functions.,0,hive,hms api get all functions
+hive.metastore.api.get_all_functions,rate,10,task,,API call to get all functions.,0,hive,hms api get all functions
 hive.metastore.api.get_all_functions.active_call,gauge,10,unit,,Active API call to get all functions.,0,hive,hms active api get all functions
-hive.metastore.api.get_table_req,rate,10,call,,,0,hive,hms api get table req
+hive.metastore.api.get_table_req,rate,10,task,,,0,hive,hms api get table req
 hive.metastore.api.get_table_req.active_call,gauge,10,unit,,,0,hive,hms active api get table req
 hive.server.open_operations,gauge,10,operation,,Operation opened in the HiveServer2.,0,hive,hs2 open operation
 hive.server.session.active,gauge,10,session,,Number of active session.,0,hive,hs2 active session


### PR DESCRIPTION
### What does this PR do?

Change some metric type from `gauge` to `count` (`monotonic_count`).

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
