### PR TITLE
Make e2e work

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -113,6 +113,12 @@ def start(ctx, check, env, agent, dev, base, env_vars):
         stop_environment(check, env, metadata=metadata)
         abort()
 
+    metadata_env_vars = metadata.get('env_vars', {})
+    if metadata_env_vars:
+        env_vars = list(env_vars)
+        for key, value in metadata_env_vars.items():
+            env_vars.append('{}={}'.format(key, value))
+
     environment = interface(check, env, base_package, config, env_vars, metadata, agent_build, api_key)
 
     echo_waiting('Updating `{}`... '.format(agent_build), nl=False)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -173,7 +173,8 @@ class DockerInterface(object):
             ]
 
             # Any environment variables passed to the start command
-            command.extend('-e {}'.format(var) for var in self.env_vars)
+            for var in self.env_vars:
+                command.extend(['-e', var])
 
             if self.base_package:
                 # Mount the check directory

--- a/ibm_mq/tests/common.py
+++ b/ibm_mq/tests/common.py
@@ -71,3 +71,13 @@ INSTANCE_QUEUE_REGEX_TAG = {
     'queues': [QUEUE],
     'queue_tag_re': {'DEV.QUEUE.*': "foo:bar"},
 }
+
+E2E_METADATA = {
+    'start_commands': [
+        'mkdir /opt/mqm',
+        'curl -o /opt/mqm/mq-client.tar.gz '
+        'https://dd-agent-tarball-mirror.s3.amazonaws.com/9.0.0.6-IBM-MQC-Redist-LinuxX64.tar.gz',
+        'tar -C /opt/mqm -xf /opt/mqm/mq-client.tar.gz',
+    ],
+    'env_vars': {'LD_LIBRARY_PATH': '/opt/mqm/lib64:/opt/mqm/lib'},
+}

--- a/ibm_mq/tests/compose/docker-compose-v8.yml
+++ b/ibm_mq/tests/compose/docker-compose-v8.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   ibmmq:
+    container_name: ibm_mq
     image: datadog/docker-library:ibm_mq_v8
     environment:
       - MQ_QMGR_NAME=datadog

--- a/ibm_mq/tests/compose/docker-compose-v9.yml
+++ b/ibm_mq/tests/compose/docker-compose-v9.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   ibmmq:
+    container_name: ibm_mq
     image: ibmcom/mq:${IBM_MQ_VERSION}
     environment:
       - MQ_QMGR_NAME=datadog

--- a/ibm_mq/tests/conftest.py
+++ b/ibm_mq/tests/conftest.py
@@ -5,7 +5,6 @@ import copy
 import logging
 import re
 
-import pymqi
 import pytest
 from six.moves import range
 
@@ -53,6 +52,9 @@ def seed_data():
 
 
 def publish():
+    # Late import to not require it for e2e
+    import pymqi
+
     conn_info = "%s(%s)" % (common.HOST, common.PORT)
 
     qmgr = pymqi.connect(common.QUEUE_MANAGER, common.CHANNEL, conn_info, common.USERNAME, common.PASSWORD)
@@ -75,6 +77,9 @@ def publish():
 
 
 def consume():
+    # Late import to not require it for e2e
+    import pymqi
+
     conn_info = "%s(%s)" % (common.HOST, common.PORT)
 
     qmgr = pymqi.connect(common.QUEUE_MANAGER, common.CHANNEL, conn_info, common.USERNAME, common.PASSWORD)
@@ -109,4 +114,4 @@ def dd_environment():
     env = {'COMPOSE_DIR': common.COMPOSE_DIR}
 
     with docker_run(common.COMPOSE_FILE_PATH, env_vars=env, log_patterns=log_pattern, sleep=10):
-        yield common.INSTANCE
+        yield common.INSTANCE, common.E2E_METADATA

--- a/ibm_mq/tests/conftest.py
+++ b/ibm_mq/tests/conftest.py
@@ -9,6 +9,7 @@ import pytest
 from six.moves import range
 
 from datadog_checks.dev import docker_run
+from datadog_checks.dev.conditions import CheckDockerLogs
 from datadog_checks.ibm_mq import IbmMqCheck
 
 from . import common
@@ -113,5 +114,10 @@ def dd_environment():
 
     env = {'COMPOSE_DIR': common.COMPOSE_DIR}
 
-    with docker_run(common.COMPOSE_FILE_PATH, env_vars=env, log_patterns=log_pattern, sleep=10):
+    with docker_run(
+        common.COMPOSE_FILE_PATH,
+        env_vars=env,
+        conditions=[CheckDockerLogs('ibm_mq', log_pattern)],
+        sleep=10,
+    ):
         yield common.INSTANCE, common.E2E_METADATA

--- a/ibm_mq/tests/conftest.py
+++ b/ibm_mq/tests/conftest.py
@@ -115,9 +115,6 @@ def dd_environment():
     env = {'COMPOSE_DIR': common.COMPOSE_DIR}
 
     with docker_run(
-        common.COMPOSE_FILE_PATH,
-        env_vars=env,
-        conditions=[CheckDockerLogs('ibm_mq', log_pattern)],
-        sleep=10,
+        common.COMPOSE_FILE_PATH, env_vars=env, conditions=[CheckDockerLogs('ibm_mq', log_pattern)], sleep=10
     ):
         yield common.INSTANCE, common.E2E_METADATA

--- a/ibm_mq/tox.ini
+++ b/ibm_mq/tox.ini
@@ -7,7 +7,7 @@ envlist =
 
 [testenv]
 dd_check_style = true
-platform = linux|darwin
+platform = linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt


### PR DESCRIPTION
Enable e2e to work by adding start commands in the agent to install the
mq client lib. This also late import pymqi so that the env starting e2e
doesn't require those libs.