### PR TITLE
Support E2E testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ stages:
 script:
   - ddev validate logos ${CHECK}
   - travis_retry ddev test --cov ${CHECK}
-  - ddev env test --clean ${CHECK}
+  - ddev env test --new-env ${CHECK}
   - ddev test ${CHECK} --bench || true
   - if [ -n "$PYTHON3" ]; then ddev validate py3 ${CHECK}; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ stages:
 script:
   - ddev validate logos ${CHECK}
   - travis_retry ddev test --cov ${CHECK}
+  - ddev env test --clean ${CHECK}
   - ddev test ${CHECK} --bench || true
   - if [ -n "$PYTHON3" ]; then ddev validate py3 ${CHECK}; fi
 
@@ -61,6 +62,7 @@ jobs:
         - ddev validate metadata
         - ddev validate service-checks
         - ddev test --cov
+        - ddev env test
         - ddev test --bench || true
     - stage: test
       env: CHECK=datadog_checks_base PYTHON3=true

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
-from collections import defaultdict, namedtuple
+from collections import OrderedDict, defaultdict, namedtuple
 
 from six import binary_type, iteritems
 
@@ -31,7 +31,18 @@ class AggregatorStub(object):
     """
 
     # Replicate the Enum we have on the Agent
-    GAUGE, RATE, COUNT, MONOTONIC_COUNT, COUNTER, HISTOGRAM, HISTORATE = range(7)
+    METRIC_ENUM_MAP = OrderedDict(
+        (
+            ('gauge', 0),
+            ('rate', 1),
+            ('count', 2),
+            ('monotonic_count', 3),
+            ('counter', 4),
+            ('histogram', 5),
+            ('historate', 6),
+        )
+    )
+    GAUGE, RATE, COUNT, MONOTONIC_COUNT, COUNTER, HISTOGRAM, HISTORATE = list(METRIC_ENUM_MAP.values())
     AGGREGATE_TYPES = {COUNT, COUNTER}
 
     def __init__(self):

--- a/datadog_checks_dev/datadog_checks/dev/_env.py
+++ b/datadog_checks_dev/datadog_checks/dev/_env.py
@@ -9,6 +9,8 @@ E2E_PREFIX = 'DDEV_E2E'
 E2E_ENV_VAR_PREFIX = '{}_ENV_'.format(E2E_PREFIX)
 E2E_SET_UP = '{}_UP'.format(E2E_PREFIX)
 E2E_TEAR_DOWN = '{}_DOWN'.format(E2E_PREFIX)
+E2E_PARENT_PYTHON = '{}_PYTHON_PATH'.format(E2E_PREFIX)
+AGENT_COLLECTOR_SEPARATOR = '=== JSON ==='
 
 E2E_FIXTURE_NAME = 'dd_environment'
 TESTING_PLUGIN = 'DDEV_TESTING_PLUGIN'
@@ -16,6 +18,10 @@ TESTING_PLUGIN = 'DDEV_TESTING_PLUGIN'
 
 def e2e_active():
     return any(ev.startswith(E2E_PREFIX) for ev in os.environ)
+
+
+def e2e_testing():
+    return E2E_PARENT_PYTHON in os.environ
 
 
 def set_env_vars(env_vars):
@@ -50,3 +56,38 @@ def set_up_env():
 
 def tear_down_env():
     return os.getenv(E2E_TEAR_DOWN, 'true') != 'false'
+
+
+def format_config(config):
+    if 'instances' not in config:
+        config = {'instances': [config]}
+
+    # Agent 5 requires init_config
+    if 'init_config' not in config:
+        config = dict(init_config={}, **config)
+
+    return config
+
+
+def replay_check_run(agent_collector, stub_aggregator):
+    # We assume a test only uses one instance
+    agent_collector = agent_collector[0]
+    aggregator = agent_collector['aggregator']
+    runner = agent_collector['runner']
+    check_id = runner['CheckID']
+    check_name = runner['CheckName']
+
+    for data in aggregator.get('metrics', []):
+        for _, value in data['points']:
+            metric_type = stub_aggregator.METRIC_ENUM_MAP[data['type']]
+            stub_aggregator.submit_metric(
+                check_name, check_id, metric_type, data['metric'], value, data['tags'], data['host']
+            )
+
+    for data in aggregator.get('service_checks', []):
+        stub_aggregator.submit_service_check(
+            check_name, check_id, data['check'], data['status'], data['tags'], data['host_name'], data['message']
+        )
+
+    if runner['LastError']:
+        raise Exception(runner['LastError'])

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -9,7 +9,17 @@ from base64 import urlsafe_b64encode
 
 import pytest
 
-from .._env import E2E_FIXTURE_NAME, TESTING_PLUGIN, e2e_active, get_env_vars
+from .._env import (
+    AGENT_COLLECTOR_SEPARATOR,
+    E2E_FIXTURE_NAME,
+    E2E_PARENT_PYTHON,
+    TESTING_PLUGIN,
+    e2e_active,
+    e2e_testing,
+    format_config,
+    get_env_vars,
+    replay_check_run,
+)
 
 __aggregator = None
 
@@ -37,6 +47,15 @@ def dd_environment_runner(request):
 
     # Do nothing if no e2e action is triggered and continue with tests
     if not testing_plugin and not e2e_active():  # no cov
+        return
+    # If e2e tests are being run it means the environment has
+    # already been spun up so we prevent another invocation
+    elif e2e_testing():  # no cov
+        # Since the scope is `session` there should only ever be one definition
+        fixture_def = request._fixturemanager._arg2fixturedefs[E2E_FIXTURE_NAME][0]
+
+        # Make the underlying function a no-op
+        fixture_def.func = lambda: None
         return
 
     try:
@@ -85,3 +104,76 @@ def dd_environment_runner(request):
     else:  # no cov
         # Exit testing and pass data back up to command
         pytest.exit(message)
+
+
+@pytest.fixture
+def dd_agent_check(request, aggregator):
+    if not e2e_testing():
+        pytest.skip('Not running E2E tests')
+
+    # Lazily import to reduce plugin load times for everyone
+    from datadog_checks.dev import TempDir, run_command
+
+    def run_check(config, **kwargs):
+        root = os.path.dirname(request.module.__file__)
+        while True:
+            if os.path.isfile(os.path.join(root, 'setup.py')):
+                check = os.path.basename(root)
+                break
+
+            new_root = os.path.dirname(root)
+            if new_root == root:
+                raise OSError('No Datadog Agent check found')
+
+            root = new_root
+
+        config = format_config(config)
+        env = os.environ['TOX_ENV_NAME']
+        python_path = os.environ[E2E_PARENT_PYTHON]
+        config_file = os.path.join(temp_dir, '{}-{}-{}.json'.format(check, env, urlsafe_b64encode(os.urandom(6))))
+
+        with open(config_file, 'wb') as f:
+            output = json.dumps(config).encode('utf-8')
+            f.write(output)
+
+        check_command = [
+            python_path,
+            '-m',
+            'datadog_checks.dev',
+            'env',
+            'check',
+            check,
+            env,
+            '--config',
+            config_file,
+            '--json',
+        ]
+        for key, value in kwargs.items():
+            if value is not False:
+                check_command.append('--{}'.format(key.replace('_', '-')))
+
+                if value is not True:
+                    check_command.append(value)
+
+        result = run_command(check_command, capture=True)
+        if AGENT_COLLECTOR_SEPARATOR not in result.stdout:
+            raise ValueError(
+                '{}{}\nCould find `{}` in the output'.format(result.stdout, result.stderr, AGENT_COLLECTOR_SEPARATOR)
+            )
+
+        _, _, collector_output = result.stdout.partition(AGENT_COLLECTOR_SEPARATOR)
+        collector = json.loads(collector_output.strip())
+
+        replay_check_run(collector, aggregator)
+
+        return aggregator
+
+    with TempDir() as temp_dir:
+        yield run_check
+
+
+def pytest_configure(config):
+    # pytest will emit warnings if these aren't registered ahead of time
+    config.addinivalue_line('markers', 'unit: marker for unit tests')
+    config.addinivalue_line('markers', 'integration: marker for integration tests')
+    config.addinivalue_line('markers', 'e2e: marker for end-to-end Datadog Agent tests')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/__init__.py
@@ -10,8 +10,9 @@ from .prune import prune
 from .reload import reload_env
 from .start import start
 from .stop import stop
+from .test import test
 
-ALL_COMMANDS = (check_run, ls, prune, reload_env, start, stop)
+ALL_COMMANDS = (check_run, ls, prune, reload_env, start, stop, test)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Manage environments')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
@@ -1,8 +1,11 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+
 import click
 
+from ....utils import read_file
 from ...e2e import create_interface, get_configured_envs
 from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
 
@@ -30,7 +33,8 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_suc
     type=click.INT,
     help='Line number to start a PDB session (0: first line, -1: last line)',
 )
-def check_run(check, env, rate, times, pause, delay, log_level, as_json, break_point):
+@click.option('--config', 'config_file', help='Path to a JSON check configuration to use')
+def check_run(check, env, rate, times, pause, delay, log_level, as_json, break_point, config_file):
     """Run an Agent check."""
     envs = get_configured_envs(check)
     if not envs:
@@ -52,9 +56,17 @@ def check_run(check, env, rate, times, pause, delay, log_level, as_json, break_p
         abort()
 
     environment = create_interface(check, env)
-
-    environment.run_check(
+    check_args = dict(
         rate=rate, times=times, pause=pause, delay=delay, log_level=log_level, as_json=as_json, break_point=break_point
     )
-    echo_success('Note: ', nl=False)
-    echo_info('If some metrics are missing, you may want to try again with the -r / --rate flag.')
+
+    if config_file:
+        config = json.loads(read_file(config_file))
+        with environment.use_config(config):
+            environment.run_check(**check_args)
+    else:
+        environment.run_check(**check_args)
+
+        if not rate:
+            echo_success('Note: ', nl=False)
+            echo_info('If some metrics are missing, you may want to try again with the -r / --rate flag.')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
@@ -1,0 +1,69 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import click
+
+from ...testing import get_tox_envs
+from ..console import CONTEXT_SETTINGS, echo_info, echo_warning
+from ..test import test as test_command
+from .start import start
+from .stop import stop
+
+
+@click.command(context_settings=CONTEXT_SETTINGS, short_help='Test an environment')
+@click.argument('checks', nargs=-1)
+@click.option(
+    '--agent',
+    '-a',
+    default='6',
+    help=(
+        'The agent build to use e.g. a Docker image like `datadog/agent:6.5.2`. For '
+        'Docker environments you can use an integer corresponding to fields in the '
+        'config (agent5, agent6, etc.)'
+    ),
+)
+@click.option('--dev/--prod', help='Whether to use the latest version of a check or what is shipped')
+@click.option('--base', is_flag=True, help='Whether to use the latest version of the base check or what is shipped')
+@click.option(
+    '--env-vars',
+    '-e',
+    multiple=True,
+    help=(
+        'ENV Variable that should be passed to the Agent container. '
+        'Ex: -e DD_URL=app.datadoghq.com -e DD_API_KEY=123456'
+    ),
+)
+@click.option('--clean', '-c', is_flag=True, help='Execute setup and tear down actions')
+@click.pass_context
+def test(ctx, checks, agent, dev, base, env_vars, clean):
+    """Test an environment."""
+    check_envs = get_tox_envs(checks, e2e_tests_only=True)
+    tests_ran = False
+
+    # If no checks are specified it means we're testing what has changed compared
+    # to master, probably on CI rather than during local development. In this case,
+    # ensure environments and Agents are spun up and down.
+    if not checks:
+        clean = True
+
+    for check, envs in check_envs:
+        if not envs:
+            echo_warning('No end-to-end environments found for `{}`'.format(check))
+            continue
+
+        # For performance reasons we're generating what to test on the fly and therefore
+        # need a way to tell if anything ran since we don't know anything upfront.
+        tests_ran = True
+
+        for env in envs:
+            if clean:
+                ctx.invoke(start, check=check, env=env, agent=agent, dev=dev, base=base, env_vars=env_vars)
+
+            try:
+                ctx.invoke(test_command, checks=['{}:{}'.format(check, env)], e2e=True)
+            finally:
+                if clean:
+                    ctx.invoke(stop, check=check, env=env)
+
+    if not tests_ran:
+        echo_info('Nothing to test!')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
@@ -33,9 +33,9 @@ from .stop import stop
         'Ex: -e DD_URL=app.datadoghq.com -e DD_API_KEY=123456'
     ),
 )
-@click.option('--clean', '-c', is_flag=True, help='Execute setup and tear down actions')
+@click.option('--new-env', '-ne', is_flag=True, help='Execute setup and tear down actions')
 @click.pass_context
-def test(ctx, checks, agent, dev, base, env_vars, clean):
+def test(ctx, checks, agent, dev, base, env_vars, new_env):
     """Test an environment."""
     check_envs = get_tox_envs(checks, e2e_tests_only=True)
     tests_ran = False
@@ -44,7 +44,7 @@ def test(ctx, checks, agent, dev, base, env_vars, clean):
     # to master, probably on CI rather than during local development. In this case,
     # ensure environments and Agents are spun up and down.
     if not checks:
-        clean = True
+        new_env = True
 
     for check, envs in check_envs:
         if not envs:
@@ -56,13 +56,13 @@ def test(ctx, checks, agent, dev, base, env_vars, clean):
         tests_ran = True
 
         for env in envs:
-            if clean:
+            if new_env:
                 ctx.invoke(start, check=check, env=env, agent=agent, dev=dev, base=base, env_vars=env_vars)
 
             try:
                 ctx.invoke(test_command, checks=['{}:{}'.format(check, env)], e2e=True)
             finally:
-                if clean:
+                if new_env:
                     ctx.invoke(stop, check=check, env=env)
 
     if not tests_ran:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/config.py
@@ -6,6 +6,7 @@ import os
 
 import yaml
 
+from ..._env import format_config
 from ...utils import dir_exists, ensure_dir_exists, file_exists, path_join, read_file, remove_path, write_file
 from ..config import APP_DIR
 
@@ -93,16 +94,7 @@ def write_env_data(check, env, config=None, metadata=None):
 
 
 def config_to_yaml(config):
-    if 'instances' not in config:
-        config = {'instances': [config]}
-
-    # Agent 5 requires init_config
-    if 'init_config' not in config:
-        _config = {'init_config': {}}
-        _config.update(config)
-        config = _config
-
-    return yaml.safe_dump(config, default_flow_style=False)
+    return yaml.safe_dump(format_config(config), default_flow_style=False)
 
 
 def metadata_to_json(metadata):


### PR DESCRIPTION
### What does this PR do?

Adds the ability to test against the real Datadog Agent collector.

### Implementation

A new command `test` is added to the `ddev env` namespace to facilitate the testing of _only_ e2e tests e.g. any tests decorated with `@pytest.mark.e2e`. By default, it will assume an environment & Agent has already been spun up via `ddev env start ...` so you can rapidly iterate by repeated invocations to test. A flag `-c`/`--clean` will instruct the command to also run `ddev env start ...` and `ddev env stop ...` for you. Just like `ddev test ...`, it accepts an optional list of checks to test, each with optional envs specified. If no checks are selected, it will test what checks have changed in git compared to master ([example](https://travis-ci.com/DataDog/integrations-core/builds/115000056#L1756)) and force the behavior of `--clean`. You can also use the `ddev test ...` command directly if you pass the new `--e2e` flag, though you can only test one environment per invocation.

A new global fixture `dd_agent_check` is introduced. This fixture yields a function which accepts a config and arbitrary keyword arguments. The function will call `ddev env check ...` using the configuration passed in as well as any additional args we specified, and feed the results to our standard `aggregator` stub, which it will then return. Here is a full example:

```python
@pytest.mark.e2e
def test_e2e(dd_agent_check, some_instance):
    aggregator = dd_agent_check(some_instance, rate=True)
```

Note that it will not call the `ddev` within the virtualenv, but rather the `ddev` used to invoke the test run since the CLI requires many more dependencies than we require for testing.

Finally, as we may not want to run e2e tests for all environments (especially due to the increased CI pressure), it is necessary to mark them for e2e test automation in `tox.ini`. For example:

```ini
[tox]
...
envlist =
    py{27,37}-{1.0,5.2,latest}

[testenv]
description =
    py27: e2e ready
...
```

would mark the envs `py27-1.0`, `py27-5.2`, and `py27-latest` as supporting e2e tests. When the Agent supports Python 3, we will make the Python versions actually influence what the spun up Agents use.

### Additional Notes

- In order to see for example monotonic counts or rates in the Agent aggregator output you logically need to run the check more than once using the rate flag. However, in doing so you receive more than one submission of other metrics, which may break being able to simply copy/paste things like `aggregator.assert_metric(metric_submitted_twice, count=1)`. In future we should look into how to deduplicate results.
- Currently, code coverage of e2e tests is not able to be reported alongside regular tests. Until we implement that we should ignore them from affecting percentages with `# no cov`.