### PR TITLE
[cri] update cri.cpu.usage metric description

### DIFF
--- a/cri/metadata.csv
+++ b/cri/metadata.csv
@@ -1,5 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 cri.mem.rss,gauge,,byte,,The amount of working set memory in bytes ,0,cri,mem rss
-cri.cpu.usage,rate,,nanocore,,Cumulative CPU usage (sum across all cores) since object creation,0,cri,cpu
+cri.cpu.usage,rate,,nanosecond,,Cumulative CPU usage (sum across all cores) since object creation in nanoseconds,0,cri,cpu
 cri.disk.used,gauge,,byte,,Represents the bytes used for images on the filesystem,0,cri,disk used
 cri.disk.inodes,gauge,,inode,,Represents the inodes used by the images,0,cri,disk inodes


### PR DESCRIPTION
### What does this PR do?

Update `cri.cpu.usage` metric unit and description from nanocore to nanosecond.

### Motivation

https://github.com/DataDog/datadog-agent/blob/master/pkg/collector/corechecks/containers/cri.go#L108

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
