### PR TITLE
Add coredns prometheus health and ksm cronjob sc

### DIFF
--- a/coredns/README.md
+++ b/coredns/README.md
@@ -48,7 +48,7 @@ The CoreDNS check does not include any events.
 
 `coredns.prometheus.health`:
 
-Returns CRITICAL if the Agent cannot reach the metrics endpoints.
+Returns `CRITICAL` if the Agent cannot reach the metrics endpoints.
 
 ## Troubleshooting
 

--- a/coredns/README.md
+++ b/coredns/README.md
@@ -46,7 +46,9 @@ The CoreDNS check does not include any events.
 
 ### Service Checks
 
-The CoreDNS check does not include any service checks.
+`coredns.prometheus.health`:
+
+Returns CRITICAL if the Agent cannot reach the metrics endpoints.
 
 ## Troubleshooting
 

--- a/coredns/assets/service_checks.json
+++ b/coredns/assets/service_checks.json
@@ -1,1 +1,11 @@
-[]
+[
+  {
+      "agent_version": "6.11.0",
+      "integration":"coredns",
+      "check": "coredns.prometheus.health",
+      "statuses": ["ok", "critical"],
+      "groups": ["endpoint"],
+      "name": "CoreDNS prometheus health",
+      "description": "Returns `CRITICAL` if the check cannot access the metrics endpoint. Returns `OK` otherwise."
+  }
+]

--- a/kubernetes_state/README.md
+++ b/kubernetes_state/README.md
@@ -53,6 +53,10 @@ Returns `OK` otherwise.
 Returns `CRITICAL` if a cluster node is in a network unavailable state.
 Returns `OK` otherwise.
 
+**kubernetes_state.cronjob.next_schedule_time**
+Returns `CRITICAL` if a cron job does not have a next scheduled time for execution.
+Returns `OK` otherwise.
+
 ## Troubleshooting
 Need help? Contact [Datadog support][6].
 

--- a/kubernetes_state/assets/service_checks.json
+++ b/kubernetes_state/assets/service_checks.json
@@ -43,5 +43,14 @@
         "groups": ["host", "node"],
         "name": "Node Network Unavailable",
         "description": "Returns `CRITICAL` if a cluster node is in a network unavailable state. Returns `UNKNOWN` if status is unknown. Returns `OK` otherwise."
+    },
+    {
+        "agent_version": "5.6.0",
+        "integration":"kubernetes",
+        "check": "kubernetes_state.cronjob.next_schedule_time",
+        "statuses": ["ok", "unknown", "critical"],
+        "groups": ["host", "node"],
+        "name": "CronJob next scheduled time",
+        "description": "Returns `CRITICAL` if a cron job does not have a next scheduled time for execution. Returns `UNKNOWN` if the scheduled time is unknown. Returns `OK` otherwise."
     }
 ]


### PR DESCRIPTION
### What does this PR do?

Adds service checks for CoreDNS and ksm. Those were missing when creating integration monitors.

### Motivation

Customer request.

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
