### PR TITLE
[vsphere] update metric_to_check

### DIFF
--- a/vsphere/manifest.json
+++ b/vsphere/manifest.json
@@ -12,7 +12,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "vsphere.",
-  "metric_to_check": "vsphere.cpu.usage",
+  "metric_to_check": "vsphere.vm.count",
   "name": "vsphere",
   "public_title": "Datadog-vSphere Integration",
   "short_description": "Understand how vSphere resource usage affects your application.",

--- a/vsphere/metadata.csv
+++ b/vsphere/metadata.csv
@@ -1,4 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+vsphere.vm.count,gauge,,,,The total number of VMs,0,vsphere,vm count
 vsphere.cpu.extra,gauge,,millisecond,,Milliseconds of extra CPU time,-1,vsphere,cpu extra
 vsphere.cpu.ready,gauge,,millisecond,,Milliseconds of CPU time spent in ready state,-1,vsphere,cpu ready
 vsphere.cpu.usage,gauge,,percent,,Percentage of CPU capacity being used,-1,vsphere,cpu usage


### PR DESCRIPTION
### What does this PR do?

Replace vsphere `metric_to_check` in metadata.csv from  `vsphere.cpu.usage` to  `vsphere.vm.count`.

### Motivation

The vsphere CPU usage might be reported via the metric `vsphere.cpu.usage` OR `vsphere.cpu.usage.avg` depending on the [compatibility_mode](https://github.com/DataDog/integrations-core/blob/7ebd083df211da4f53671270bfc56b133937f06d/vsphere/datadog_checks/vsphere/vsphere.py#L723-L731). `vsphere.cpu.usage` is not always reported, hence not suitable to be used as `metric_to_check` in metadata.csv.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
