### PR TITLE
Add regex matching for per-relation metrics

### DIFF
--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -51,20 +51,26 @@ instances:
     #   - <KEY_1>:<VALUE_1>
     #   - <KEY_2>:<VALUE_2>
 
-    ## @param relations - list of strings (or objects) - optional
+    ## @param relations - list of objects (or strings) - optional
     ## The list of relations/tables must be specified here to track per-relation (table) metrics.
+    ## You can either specify a single relation by its exact name in 'relation_name' or use a regex to track metrics
+    ## from all matching relations.
     ## Each relation generates many metrics (10 + 10 per index)
     ## By default all schemas are included. To track relations from specific schemas only,
-    ## use the following syntax:
+    ## you can specify the `schemas` attribute and provide a list of schemas to use for filtering.
     ##
+    ## Note: For compatibility reasons you can also use the following syntax to track relations metrics by specifying
+    ## the list of table names. All schemas are included and regex are not supported.
     ## relations:
-    ##   - relation_name: <TABLE_NAME>
-    ##     schemas:
-    ##         - <SCHEMA_NAME>
+    ##   - <TABLE_NAME1>
+    ##   - <TABLE_NAME2>
+    ##
     #
     # relations:
-    #   - <TABLE_NAME_1>
-    #   - <TABLE_NAME_1>
+    #   - relation_name: <TABLE_NAME>
+    #     schemas:
+    #       - <SCHEMA_NAME1>
+    #   - relation_regex: <TABLE_PATTERN>
 
     ## @param collect_function_metrics - boolean - optional - default: false
     ## If set to true, collects metrics regarding PL/pgSQL functions from pg_stat_user_functions

--- a/postgres/tests/compose/resources/02_load_data.sh
+++ b/postgres/tests/compose/resources/02_load_data.sh
@@ -4,6 +4,10 @@ set -e
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" datadog_test <<-EOSQL
     CREATE TABLE persons (personid SERIAL, lastname VARCHAR(255), firstname VARCHAR(255), address VARCHAR(255), city VARCHAR(255));
     INSERT INTO persons (lastname, firstname, address, city) VALUES ('Cavaille', 'Leo', 'Midtown', 'New York'), ('Someveryveryveryveryveryveryveryveryveryverylongname', 'something', 'Avenue des Champs Elysees', 'Beautiful city of lights');
+    CREATE TABLE personsdup1 (personid SERIAL, lastname VARCHAR(255), firstname VARCHAR(255), address VARCHAR(255), city VARCHAR(255));
+    INSERT INTO personsdup1 (lastname, firstname, address, city) VALUES ('Cavaille', 'Leo', 'Midtown', 'New York'), ('Someveryveryveryveryveryveryveryveryveryverylongname', 'something', 'Avenue des Champs Elysees', 'Beautiful city of lights');
+    CREATE TABLE Personsdup2 (personid SERIAL, lastname VARCHAR(255), firstname VARCHAR(255), address VARCHAR(255), city VARCHAR(255));
+    INSERT INTO Personsdup2 (lastname, firstname, address, city) VALUES ('Cavaille', 'Leo', 'Midtown', 'New York'), ('Someveryveryveryveryveryveryveryveryveryverylongname', 'something', 'Avenue des Champs Elysees', 'Beautiful city of lights');
     SELECT * FROM persons;
     SELECT * FROM persons;
     SELECT * FROM persons;

--- a/postgres/tests/test_common.py
+++ b/postgres/tests/test_common.py
@@ -106,7 +106,7 @@ def test_schema_metrics(aggregator, check, pg_instance):
     check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + ['server:{}'.format(HOST), 'port:{}'.format(PORT), 'schema:public']
-    aggregator.assert_metric('postgresql.table.count', value=1, count=1, tags=expected_tags)
+    aggregator.assert_metric('postgresql.table.count', value=3, count=1, tags=expected_tags)
     aggregator.assert_metric('postgresql.db.count', value=2, count=1)
 
 

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -71,6 +71,47 @@ def test_relations_metrics(aggregator, pg_instance):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
+def test_relations_metrics2(aggregator, pg_instance):
+    pg_instance['relations'] = [
+        {'relation_regex': '.*', 'schemas': ['hello', 'hello2']},
+        # Empty schemas means all schemas, even though the first relation matches first.
+        {'relation_regex': r'[pP]ersons[-_]?(dup\d)?'},
+    ]
+    relations = ['persons', 'personsdup1', 'Personsdup2']
+    posgres_check = PostgreSql('postgres', {}, {})
+    posgres_check.check(pg_instance)
+
+    expected_tags = {}
+    expected_size_tags = {}
+    for relation in relations:
+        expected_tags[relation] = pg_instance['tags'] + [
+            'server:{}'.format(pg_instance['host']),
+            'port:{}'.format(pg_instance['port']),
+            'db:%s' % pg_instance['dbname'],
+            'table:{}'.format(relation.lower()),
+            'schema:public',
+        ]
+        expected_size_tags[relation] = pg_instance['tags'] + [
+            'server:{}'.format(pg_instance['host']),
+            'port:{}'.format(pg_instance['port']),
+            'db:%s' % pg_instance['dbname'],
+            'table:{}'.format(relation.lower()),
+        ]
+
+    for relation in relations:
+        for name in RELATION_METRICS:
+            aggregator.assert_metric(name, count=1, tags=expected_tags[relation])
+
+        # 'persons' db don't have any indexes
+        for name in RELATION_INDEX_METRICS:
+            aggregator.assert_metric(name, count=0, tags=expected_tags[relation])
+
+        for name in RELATION_SIZE_METRICS:
+            aggregator.assert_metric(name, count=1, tags=expected_size_tags[relation])
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
 def test_index_metrics(aggregator, pg_instance):
     pg_instance['relations'] = ['breed']
     pg_instance['dbname'] = 'dogs'

--- a/postgres/tox.ini
+++ b/postgres/tox.ini
@@ -20,7 +20,7 @@ commands =
     {93,94,95,96,10,11}: pytest -v -m"integration"
     unit: pytest -v -m"unit"
 setenv =
-    psycopg2: use_psycopg2=true
+    psycopg2: USE_PSYCOPG2=true
     93: POSTGRES_VERSION=9.3
     94: POSTGRES_VERSION=9.4
     95: POSTGRES_VERSION=9.5


### PR DESCRIPTION
### Overview
The postgres integration is able to retrieve specific metrics for relations. Current configuration options require to list every single relation from which to track metrics. We've seen feature requests to add the ability to do pattern matching.

### What does this PR do?

It adds the ability to use a regex for relations metrics.

### Additional Notes

The `relations` parameter could already be configured in two different ways, with either a simple list of relations names, or with a list of `{'relation_name': <0>, 'schemas': <1>}`. This newer format helps to solve a situation where there is two relations with the same name in the same schema.
This PR deprecates a bit more the old format and add a new parameter named `relation_regex` to be used instead of `relation_name`

The first commit cleans the way SQL queries are formatted, there is a need for partial formatting aka, having multiple placeholders in the string and fill the placeholders progressively when the right value becomes available. This needs was kind of solved by using tricks like mixing `%s` and `.format` formatting, and by doing things like

```python
"There is %d tables in schema %s database named %s" % ('%d', schema_name, '%s')
```

This PR adds a PartialFormatter to do this thing more easily.

The second commit is the actual implementation.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
