### PR TITLE
Add job duration time metrics

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -676,7 +676,7 @@ class KubernetesState(OpenMetricsBaseCheck):
                 start_time = self.job_start_time[job_tags]
                 tags = list(scraper_config['custom_tags'])
                 for job_tag in job_tags:
-                    label_name, label_value = job_tag.split(":", 2)
+                    label_name, label_value = job_tag.split(":", 1)
                     if label_name in ('job', 'job_name'):
                         trimmed_job = self._trim_job_tag(label_value)
                         tags.append(self._format_tag(label_name, label_value, scraper_config))

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -657,7 +657,7 @@ class KubernetesState(OpenMetricsBaseCheck):
 
     def kube_job_status_start_time(self, metric, scraper_config):
         for sample in metric.samples:
-            tags = [] + scraper_config['custom_tags']
+            tags = list(scraper_config['custom_tags'])
             for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
                 tags.append(self._format_tag(label_name, label_value, scraper_config))
             self.job_start_time[frozenset(tags)] += int(sample[self.SAMPLE_VALUE])
@@ -674,12 +674,10 @@ class KubernetesState(OpenMetricsBaseCheck):
         for job_tags, completion_time in iteritems(self.job_completion_time):
             if job_tags in self.job_start_time:
                 start_time = self.job_start_time[job_tags]
-                tags = [] + scraper_config['custom_tags']
-                for job_tag in list(job_tags):
-                    label = job_tag.split(":")
-                    label_name = label[0]
-                    label_value = label[1]
-                    if label_name == 'job' or label_name == 'job_name':
+                tags = list(scraper_config['custom_tags'])
+                for job_tag in job_tags:
+                    label_name, label_value = job_tag.split(":", 2)
+                    if label_name in ('job', 'job_name'):
                         trimmed_job = self._trim_job_tag(label_value)
                         tags.append(self._format_tag(label_name, label_value, scraper_config))
                         tags.append(self._format_tag(label_name, trimmed_job, scraper_config))

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -148,7 +148,7 @@ class KubernetesState(OpenMetricsBaseCheck):
             job.set_previous_and_reset_current_ts()
 
         # Logic for Jobs
-        self.kube_job_status_execution_time(scraper_config)
+        self.kube_job_status_duration_time(scraper_config)
 
         for job_tags, job_count in iteritems(self.job_succeeded_count):
             self.monotonic_count(scraper_config['namespace'] + '.job.succeeded', job_count, list(job_tags))
@@ -669,8 +669,8 @@ class KubernetesState(OpenMetricsBaseCheck):
                 tags.append(self._format_tag(label_name, label_value, scraper_config))
             self.job_completion_time[frozenset(tags)] = int(sample[self.SAMPLE_VALUE])
 
-    def kube_job_status_execution_time(self, scraper_config):
-        metric_name = scraper_config['namespace'] + '.job.execution_time'
+    def kube_job_status_duration_time(self, scraper_config):
+        metric_name = scraper_config['namespace'] + '.job.duration_time'
         for job_tags, completion_time in iteritems(self.job_completion_time):
             if job_tags in self.job_start_time:
                 start_time = self.job_start_time[job_tags]

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -128,8 +128,8 @@ class KubernetesState(OpenMetricsBaseCheck):
         self.job_succeeded_count = defaultdict(int)
         self.job_failed_count = defaultdict(int)
 
-        self.job_start_time = defaultdict(int)
-        self.job_completion_time = defaultdict(int)
+        self.job_start_time = {}
+        self.job_completion_time = {}
 
     def check(self, instance):
         endpoint = instance.get('kube_state_url')
@@ -660,14 +660,14 @@ class KubernetesState(OpenMetricsBaseCheck):
             tags = list(scraper_config['custom_tags'])
             for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
                 tags.append(self._format_tag(label_name, label_value, scraper_config))
-            self.job_start_time[frozenset(tags)] += int(sample[self.SAMPLE_VALUE])
+            self.job_start_time[frozenset(tags)] = int(sample[self.SAMPLE_VALUE])
 
     def kube_job_status_completion_time(self, metric, scraper_config):
         for sample in metric.samples:
             tags = [] + scraper_config['custom_tags']
             for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
                 tags.append(self._format_tag(label_name, label_value, scraper_config))
-            self.job_completion_time[frozenset(tags)] += int(sample[self.SAMPLE_VALUE])
+            self.job_completion_time[frozenset(tags)] = int(sample[self.SAMPLE_VALUE])
 
     def kube_job_status_execution_time(self, scraper_config):
         metric_name = scraper_config['namespace'] + '.job.execution_time'

--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -29,7 +29,7 @@ kubernetes_state.endpoint.address_not_ready,gauge,,,,Number of addresses not rea
 kubernetes_state.endpoint.created,gauge,,,,Unix creation timestamp,0,kubernetes,k8s_state.endpoint.creation_time
 kubernetes_state.job.status.failed,count,,,,Observed number of failed pods in a job,0,kubernetes,k8s_state.job.failed
 kubernetes_state.job.status.succeeded,count,,,,Observed number of succeeded pods in a job,0,kubernetes,k8s_state.job.succeeded
-kuberentes_state..job.execution_time,gauge,,,,Job execution time,0,kubernetes,k8s_state.job.execution_time
+kuberentes_state.job.execution_time,gauge,,,,Job execution time,0,kubernetes,k8s_state.job.execution_time
 kubernetes_state.limitrange.cpu.min,gauge,,,,Minimum CPU request for this type,0,kubernetes,k8s_state.cpu.min
 kubernetes_state.limitrange.cpu.max,gauge,,,,Maximum CPU limit for this type,0,kubernetes,k8s_state.cpu.max
 kubernetes_state.limitrange.cpu.default,gauge,,,,Default CPU limit if not specified,0,kubernetes,k8s_state.cpu.default

--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -29,6 +29,7 @@ kubernetes_state.endpoint.address_not_ready,gauge,,,,Number of addresses not rea
 kubernetes_state.endpoint.created,gauge,,,,Unix creation timestamp,0,kubernetes,k8s_state.endpoint.creation_time
 kubernetes_state.job.status.failed,count,,,,Observed number of failed pods in a job,0,kubernetes,k8s_state.job.failed
 kubernetes_state.job.status.succeeded,count,,,,Observed number of succeeded pods in a job,0,kubernetes,k8s_state.job.succeeded
+kuberentes_state..job.execution_time,gauge,,,,Job execution time,0,kubernetes,k8s_state.job.execution_time
 kubernetes_state.limitrange.cpu.min,gauge,,,,Minimum CPU request for this type,0,kubernetes,k8s_state.cpu.min
 kubernetes_state.limitrange.cpu.max,gauge,,,,Maximum CPU limit for this type,0,kubernetes,k8s_state.cpu.max
 kubernetes_state.limitrange.cpu.default,gauge,,,,Default CPU limit if not specified,0,kubernetes,k8s_state.cpu.default

--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -29,7 +29,7 @@ kubernetes_state.endpoint.address_not_ready,gauge,,,,Number of addresses not rea
 kubernetes_state.endpoint.created,gauge,,,,Unix creation timestamp,0,kubernetes,k8s_state.endpoint.creation_time
 kubernetes_state.job.status.failed,count,,,,Observed number of failed pods in a job,0,kubernetes,k8s_state.job.failed
 kubernetes_state.job.status.succeeded,count,,,,Observed number of succeeded pods in a job,0,kubernetes,k8s_state.job.succeeded
-kuberentes_state.job.execution_time,gauge,,,,Job execution time,0,kubernetes,k8s_state.job.execution_time
+kuberentes_state.job.duration_time,gauge,,,,Job duration time,0,kubernetes,k8s_state.job.duration_time
 kubernetes_state.limitrange.cpu.min,gauge,,,,Minimum CPU request for this type,0,kubernetes,k8s_state.cpu.min
 kubernetes_state.limitrange.cpu.max,gauge,,,,Maximum CPU limit for this type,0,kubernetes,k8s_state.cpu.max
 kubernetes_state.limitrange.cpu.default,gauge,,,,Default CPU limit if not specified,0,kubernetes,k8s_state.cpu.default

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -109,7 +109,7 @@ METRICS = [
     NAMESPACE + '.vpa.uncapped_target',
     NAMESPACE + '.vpa.upperbound',
     NAMESPACE + '.vpa.update_mode',
-    NAMESPACE + '.job.execution_time',
+    NAMESPACE + '.job.duration_time',
 ]
 
 TAGS = {
@@ -167,7 +167,7 @@ TAGS = {
     NAMESPACE + '.job.succeeded': ['job:hello', 'job_name:hello2'],
     NAMESPACE + '.hpa.condition': ['namespace:default', 'hpa:myhpa', 'condition:true', 'status:abletoscale'],
     NAMESPACE
-    + '.job.execution_time': ['job:hello', 'job:hello-1509998340', 'job:hello-1509998400', 'job:hello-1509998460'],
+    + '.job.duration_time': ['job:hello', 'job:hello-1509998340', 'job:hello-1509998400', 'job:hello-1509998460'],
 }
 
 JOINED_METRICS = {
@@ -336,13 +336,13 @@ def test_update_kube_state_metrics(aggregator, instance, check):
     )
 
     aggregator.assert_metric(
-        NAMESPACE + '.job.execution_time', tags=['job:hello', 'job:hello-1509998340', 'optional:tag1'], value=4
+        NAMESPACE + '.job.duration_time', tags=['job:hello', 'job:hello-1509998340', 'optional:tag1'], value=4
     )
     aggregator.assert_metric(
-        NAMESPACE + '.job.execution_time', tags=['job:hello', 'job:hello-1509998400', 'optional:tag1'], value=4
+        NAMESPACE + '.job.duration_time', tags=['job:hello', 'job:hello-1509998400', 'optional:tag1'], value=4
     )
     aggregator.assert_metric(
-        NAMESPACE + '.job.execution_time', tags=['job:hello', 'job:hello-1509998460', 'optional:tag1'], value=5
+        NAMESPACE + '.job.duration_time', tags=['job:hello', 'job:hello-1509998460', 'optional:tag1'], value=5
     )
 
     for metric in METRICS:

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -109,6 +109,7 @@ METRICS = [
     NAMESPACE + '.vpa.uncapped_target',
     NAMESPACE + '.vpa.upperbound',
     NAMESPACE + '.vpa.update_mode',
+    NAMESPACE + '.job.execution_time',
 ]
 
 TAGS = {
@@ -165,6 +166,8 @@ TAGS = {
     NAMESPACE + '.job.failed': ['job:hello', 'job_name:hello2'],
     NAMESPACE + '.job.succeeded': ['job:hello', 'job_name:hello2'],
     NAMESPACE + '.hpa.condition': ['namespace:default', 'hpa:myhpa', 'condition:true', 'status:abletoscale'],
+    NAMESPACE
+    + '.job.execution_time': ['job:hello', 'job:hello-1509998340', 'job:hello-1509998400', 'job:hello-1509998460'],
 }
 
 JOINED_METRICS = {
@@ -330,6 +333,16 @@ def test_update_kube_state_metrics(aggregator, instance, check):
         NAMESPACE + '.persistentvolumes.by_phase',
         tags=['storageclass:local-data', 'phase:released', 'optional:tag1'],
         value=0,
+    )
+
+    aggregator.assert_metric(
+        NAMESPACE + '.job.execution_time', tags=['job:hello', 'job:hello-1509998340', 'optional:tag1'], value=4
+    )
+    aggregator.assert_metric(
+        NAMESPACE + '.job.execution_time', tags=['job:hello', 'job:hello-1509998400', 'optional:tag1'], value=4
+    )
+    aggregator.assert_metric(
+        NAMESPACE + '.job.execution_time', tags=['job:hello', 'job:hello-1509998460', 'optional:tag1'], value=5
     )
 
     for metric in METRICS:


### PR DESCRIPTION
### What does this PR do?
Added the execution time of job executed on kubernetes as a metric

### Motivation
By acquiring the job execution time, it can be used in various use cases such as execution time monitoring and alert settings.

### Additional Notes

Generating metrics with the following calculations

`kube_job_status_completion_time - kube_job_status_start_time = execution_time`

Calculated on integration for the following two reasons

* Since kube_job_status_completion_time and kube_job_status_start_time are unixtime, I decided that they would not work on the monitor as they are.
* If calculated on the graph, only kube_job_status_start_time will be sent if the job is running, so it will be negative values when calculated.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
