### PR TITLE
Add yarn.apps.<METRIC>_gauge metrics

### DIFF
--- a/yarn/README.md
+++ b/yarn/README.md
@@ -10,6 +10,9 @@ This check collects metrics from your YARN ResourceManager, including (but not l
 * Per-application metrics (e.g. app progress, elapsed running time, running containers, memory use, etc.)
 * Node metrics (e.g. available vCores, time of last health update, etc/)
 
+### Deprecation notice
+`yarn.apps.<METRIC>` metrics have been deprecated in favour of `yarn.apps.<METRIC>_gauge` metrics. This is because `yarn.apps` metrics
+are incorrectly reported as a `RATE` instead of a `GAUGE`
 
 ## Setup
 ### Installation

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -11,7 +11,7 @@ This check collects metrics from your YARN ResourceManager, including (but not l
 * Node metrics (e.g. available vCores, time of last health update, etc/)
 
 ### Deprecation notice
-`yarn.apps.<METRIC>` metrics have been deprecated in favour of `yarn.apps.<METRIC>_gauge` metrics. This is because `yarn.apps` metrics
+`yarn.apps.<METRIC>` metrics have been deprecated in favor of `yarn.apps.<METRIC>_gauge` metrics, because `yarn.apps` metrics are incorrectly reported as a `RATE` instead of a `GAUGE`.
 are incorrectly reported as a `RATE` instead of a `GAUGE`
 
 ## Setup

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -12,7 +12,6 @@ This check collects metrics from your YARN ResourceManager, including (but not l
 
 ### Deprecation notice
 `yarn.apps.<METRIC>` metrics have been deprecated in favor of `yarn.apps.<METRIC>_gauge` metrics, because `yarn.apps` metrics are incorrectly reported as a `RATE` instead of a `GAUGE`.
-are incorrectly reported as a `RATE` instead of a `GAUGE`
 
 ## Setup
 ### Installation

--- a/yarn/datadog_checks/yarn/yarn.py
+++ b/yarn/datadog_checks/yarn/yarn.py
@@ -79,6 +79,18 @@ YARN_CLUSTER_METRICS = {
 
 # Application metrics for YARN
 YARN_APP_METRICS = {
+    'progress': ('yarn.apps.progress_gauge', GAUGE),
+    'startedTime': ('yarn.apps.started_time_gauge', GAUGE),
+    'finishedTime': ('yarn.apps.finished_time_gauge', GAUGE),
+    'elapsedTime': ('yarn.apps.elapsed_time_gauge', GAUGE),
+    'allocatedMB': ('yarn.apps.allocated_mb_gauge', GAUGE),
+    'allocatedVCores': ('yarn.apps.allocated_vcores_gauge', GAUGE),
+    'runningContainers': ('yarn.apps.running_containers_gauge', GAUGE),
+    'memorySeconds': ('yarn.apps.memory_seconds_gauge', GAUGE),
+    'vcoreSeconds': ('yarn.apps.vcore_seconds_gauge', GAUGE),
+}
+# These are deprecated because increment is the wrong type as it becomes a RATE on the dogweb side
+DEPRECATED_YARN_APP_METRICS = {
     'progress': ('yarn.apps.progress', INCREMENT),
     'startedTime': ('yarn.apps.started_time', INCREMENT),
     'finishedTime': ('yarn.apps.finished_time', INCREMENT),
@@ -219,6 +231,7 @@ class YarnCheck(AgentCheck):
 
                 tags.extend(addl_tags)
 
+                self._set_yarn_metrics_from_json(tags, app_json, DEPRECATED_YARN_APP_METRICS)
                 self._set_yarn_metrics_from_json(tags, app_json, YARN_APP_METRICS)
 
     def _yarn_node_metrics(self, rm_address, instance, addl_tags):

--- a/yarn/metadata.csv
+++ b/yarn/metadata.csv
@@ -23,7 +23,7 @@ yarn.metrics.unhealthy_nodes,gauge,,node,,The number of unhealthy nodes,0,yarn,n
 yarn.metrics.decommissioned_nodes,gauge,,node,,The number of decommissioned nodes,0,yarn,nds decomm
 yarn.metrics.rebooted_nodes,gauge,,node,,The number of rebooted nodes,0,yarn,nds rbtd
 yarn.apps.progress_gauge,gauge,,percent,,The progress of the application as a percent,0,yarn,app prog
-yarn.apps.started_time_gauge,gauge,,second,,The time in which application started (in ms since epoch),0,yarn,app strt tim g
+yarn.apps.started_time_gauge,gauge,,millisecond,,The time in which application started (in ms since epoch),0,yarn,app strt tim g
 yarn.apps.finished_time_gauge,gauge,,second,,The time in which the application finished (in ms since epoch),0,yarn,app fin tim g
 yarn.apps.elapsed_time_gauge,gauge,,second,,The elapsed time since the application started (in ms),0,yarn,app elapsd tm g
 yarn.apps.allocated_mb_gauge,gauge,,mebibyte,,The sum of memory in MB allocated to the applications running containers,0,yarn,app mem alloc g

--- a/yarn/metadata.csv
+++ b/yarn/metadata.csv
@@ -28,7 +28,7 @@ yarn.apps.finished_time_gauge,gauge,,second,,The time in which the application f
 yarn.apps.elapsed_time_gauge,gauge,,millisecond,,The elapsed time since the application started (in ms),0,yarn,app elapsd tm g
 yarn.apps.allocated_mb_gauge,gauge,,mebibyte,,The sum of memory in MB allocated to the applications running containers,0,yarn,app mem alloc g
 yarn.apps.allocated_vcores_gauge,gauge,,core,,The sum of virtual cores allocated to the applications running containers,0,yarn,app cros alloc g
-yarn.apps.running_containers_gauge,gauge,,,,The number of containers currently running for the application,0,yarn,app ctrs rrun g
+yarn.apps.running_containers_gauge,gauge,,container,,The number of containers currently running for the application,0,yarn,app ctrs rrun g
 yarn.apps.memory_seconds_gauge,gauge,,second,,The amount of memory the application has allocated (megabyte-seconds),0,yarn,app mem tm g
 yarn.apps.vcore_seconds_gauge,gauge,,second,,The amount of CPU resources the application has allocated (virtual core-seconds),0,yarn,app cor tm g
 yarn.apps.progress,rate,,percent,,Deprecated use yarn.apps.progress_gauge instead,0,yarn,app prog

--- a/yarn/metadata.csv
+++ b/yarn/metadata.csv
@@ -29,7 +29,7 @@ yarn.apps.elapsed_time_gauge,gauge,,millisecond,,The elapsed time since the appl
 yarn.apps.allocated_mb_gauge,gauge,,mebibyte,,The sum of memory in MB allocated to the applications running containers,0,yarn,app mem alloc g
 yarn.apps.allocated_vcores_gauge,gauge,,core,,The sum of virtual cores allocated to the applications running containers,0,yarn,app cros alloc g
 yarn.apps.running_containers_gauge,gauge,,container,,The number of containers currently running for the application,0,yarn,app ctrs rrun g
-yarn.apps.memory_seconds_gauge,gauge,,second,,The amount of memory the application has allocated (megabyte-seconds),0,yarn,app mem tm g
+yarn.apps.memory_seconds_gauge,gauge,,mebibyte,second,The amount of memory the application has allocated (megabyte-seconds),0,yarn,app mem tm g
 yarn.apps.vcore_seconds_gauge,gauge,,second,,The amount of CPU resources the application has allocated (virtual core-seconds),0,yarn,app cor tm g
 yarn.apps.progress,rate,,percent,,Deprecated use yarn.apps.progress_gauge instead,0,yarn,app prog
 yarn.apps.started_time,rate,,second,,Deprecated use yarn.apps.started_time_gauge instead,0,yarn,app strt tim

--- a/yarn/metadata.csv
+++ b/yarn/metadata.csv
@@ -30,7 +30,7 @@ yarn.apps.allocated_mb_gauge,gauge,,mebibyte,,The sum of memory in MB allocated 
 yarn.apps.allocated_vcores_gauge,gauge,,core,,The sum of virtual cores allocated to the applications running containers,0,yarn,app cros alloc g
 yarn.apps.running_containers_gauge,gauge,,container,,The number of containers currently running for the application,0,yarn,app ctrs rrun g
 yarn.apps.memory_seconds_gauge,gauge,,mebibyte,second,The amount of memory the application has allocated (megabyte-seconds),0,yarn,app mem tm g
-yarn.apps.vcore_seconds_gauge,gauge,,second,,The amount of CPU resources the application has allocated (virtual core-seconds),0,yarn,app cor tm g
+yarn.apps.vcore_seconds_gauge,gauge,,core,second,The amount of CPU resources the application has allocated (virtual core-seconds),0,yarn,app cor tm g
 yarn.apps.progress,rate,,percent,,Deprecated use yarn.apps.progress_gauge instead,0,yarn,app prog
 yarn.apps.started_time,rate,,second,,Deprecated use yarn.apps.started_time_gauge instead,0,yarn,app strt tim
 yarn.apps.finished_time,rate,,second,,Deprecated use yarn.apps.finished_time_gauge instead,0,yarn,app fin tim

--- a/yarn/metadata.csv
+++ b/yarn/metadata.csv
@@ -24,7 +24,7 @@ yarn.metrics.decommissioned_nodes,gauge,,node,,The number of decommissioned node
 yarn.metrics.rebooted_nodes,gauge,,node,,The number of rebooted nodes,0,yarn,nds rbtd
 yarn.apps.progress_gauge,gauge,,percent,,The progress of the application as a percent,0,yarn,app prog
 yarn.apps.started_time_gauge,gauge,,millisecond,,The time in which application started (in ms since epoch),0,yarn,app strt tim g
-yarn.apps.finished_time_gauge,gauge,,second,,The time in which the application finished (in ms since epoch),0,yarn,app fin tim g
+yarn.apps.finished_time_gauge,gauge,,millisecond,,The time in which the application finished (in ms since epoch),0,yarn,app fin tim g
 yarn.apps.elapsed_time_gauge,gauge,,millisecond,,The elapsed time since the application started (in ms),0,yarn,app elapsd tm g
 yarn.apps.allocated_mb_gauge,gauge,,mebibyte,,The sum of memory in MB allocated to the applications running containers,0,yarn,app mem alloc g
 yarn.apps.allocated_vcores_gauge,gauge,,core,,The sum of virtual cores allocated to the applications running containers,0,yarn,app cros alloc g

--- a/yarn/metadata.csv
+++ b/yarn/metadata.csv
@@ -22,15 +22,24 @@ yarn.metrics.lost_nodes,gauge,,node,,The number of lost nodes,0,yarn,nds lst
 yarn.metrics.unhealthy_nodes,gauge,,node,,The number of unhealthy nodes,0,yarn,nds unhlthy
 yarn.metrics.decommissioned_nodes,gauge,,node,,The number of decommissioned nodes,0,yarn,nds decomm
 yarn.metrics.rebooted_nodes,gauge,,node,,The number of rebooted nodes,0,yarn,nds rbtd
-yarn.apps.progress,rate,,percent,,The progress of the application as a percent,0,yarn,app prog
-yarn.apps.started_time,rate,,second,,The time in which application started (in ms since epoch),0,yarn,app strt tim
-yarn.apps.finished_time,rate,,second,,The time in which the application finished (in ms since epoch),0,yarn,app fin tim
-yarn.apps.elapsed_time,rate,,second,,The elapsed time since the application started (in ms),0,yarn,app elapsd tm
-yarn.apps.allocated_mb,rate,,mebibyte,,The sum of memory in MB allocated to the applications running containers,0,yarn,app mem alloc
-yarn.apps.allocated_vcores,rate,,core,,The sum of virtual cores allocated to the applications running containers,0,yarn,app cros alloc
-yarn.apps.running_containers,rate,,,,The number of containers currently running for the application,0,yarn,app ctrs rrun
-yarn.apps.memory_seconds,rate,,second,,The amount of memory the application has allocated (megabyte-seconds),0,yarn,app mem tm
-yarn.apps.vcore_seconds,rate,,second,,The amount of CPU resources the application has allocated (virtual core-seconds),0,yarn,app cor tm
+yarn.apps.progress_gauge,gauge,,percent,,The progress of the application as a percent,0,yarn,app prog
+yarn.apps.started_time_gauge,gauge,,second,,The time in which application started (in ms since epoch),0,yarn,app strt tim g
+yarn.apps.finished_time_gauge,gauge,,second,,The time in which the application finished (in ms since epoch),0,yarn,app fin tim g
+yarn.apps.elapsed_time_gauge,gauge,,second,,The elapsed time since the application started (in ms),0,yarn,app elapsd tm g
+yarn.apps.allocated_mb_gauge,gauge,,mebibyte,,The sum of memory in MB allocated to the applications running containers,0,yarn,app mem alloc g
+yarn.apps.allocated_vcores_gauge,gauge,,core,,The sum of virtual cores allocated to the applications running containers,0,yarn,app cros alloc g
+yarn.apps.running_containers_gauge,gauge,,,,The number of containers currently running for the application,0,yarn,app ctrs rrun g
+yarn.apps.memory_seconds_gauge,rate,,gauge,,The amount of memory the application has allocated (megabyte-seconds),0,yarn,app mem tm g
+yarn.apps.vcore_seconds_gauge,rate,,gauge,,The amount of CPU resources the application has allocated (virtual core-seconds),0,yarn,app cor tm g
+yarn.apps.progress,rate,,percent,,Deprecated use yarn.apps.progress_gauge instead,0,yarn,app prog
+yarn.apps.started_time,rate,,second,,Deprecated use yarn.apps.started_time_gauge instead,0,yarn,app strt tim
+yarn.apps.finished_time,rate,,second,,Deprecated use yarn.apps.finished_time_gauge instead,0,yarn,app fin tim
+yarn.apps.elapsed_time,rate,,second,,Deprecated use yarn.apps.elapsed_time_gauge instead,0,yarn,app elapsd tm
+yarn.apps.allocated_mb,rate,,mebibyte,,Deprecated use yarn.apps.allocated_mb_gauge instead,0,yarn,app mem alloc
+yarn.apps.allocated_vcores,rate,,core,,Deprecated use yarn.apps.allocated_vcores_gauge instead,0,yarn,app cros alloc
+yarn.apps.running_containers,rate,,,,Deprecated use yarn.apps.running_containers_gauge instead,0,yarn,app ctrs rrun
+yarn.apps.memory_seconds,rate,,second,,Deprecated use yarn.apps.memory_seconds_gauge instead,0,yarn,app mem tm
+yarn.apps.vcore_seconds,rate,,second,,Deprecated use yarn.apps.vcore_seconds_gauge instead,0,yarn,app cor tm
 yarn.node.last_health_update,gauge,,millisecond,,The last time the node reported its health (in ms since epoch),0,yarn,nd lst hlth updt
 yarn.node.used_memory_mb,gauge,,mebibyte,,The total amount of memory currently used on the node (in MB),0,yarn,nd mem usd
 yarn.node.avail_memory_mb,gauge,,mebibyte,,The total amount of memory currently available on the node (in MB),0,yarn,nd mem avail

--- a/yarn/metadata.csv
+++ b/yarn/metadata.csv
@@ -25,7 +25,7 @@ yarn.metrics.rebooted_nodes,gauge,,node,,The number of rebooted nodes,0,yarn,nds
 yarn.apps.progress_gauge,gauge,,percent,,The progress of the application as a percent,0,yarn,app prog
 yarn.apps.started_time_gauge,gauge,,millisecond,,The time in which application started (in ms since epoch),0,yarn,app strt tim g
 yarn.apps.finished_time_gauge,gauge,,second,,The time in which the application finished (in ms since epoch),0,yarn,app fin tim g
-yarn.apps.elapsed_time_gauge,gauge,,second,,The elapsed time since the application started (in ms),0,yarn,app elapsd tm g
+yarn.apps.elapsed_time_gauge,gauge,,millisecond,,The elapsed time since the application started (in ms),0,yarn,app elapsd tm g
 yarn.apps.allocated_mb_gauge,gauge,,mebibyte,,The sum of memory in MB allocated to the applications running containers,0,yarn,app mem alloc g
 yarn.apps.allocated_vcores_gauge,gauge,,core,,The sum of virtual cores allocated to the applications running containers,0,yarn,app cros alloc g
 yarn.apps.running_containers_gauge,gauge,,,,The number of containers currently running for the application,0,yarn,app ctrs rrun g

--- a/yarn/metadata.csv
+++ b/yarn/metadata.csv
@@ -29,8 +29,8 @@ yarn.apps.elapsed_time_gauge,gauge,,second,,The elapsed time since the applicati
 yarn.apps.allocated_mb_gauge,gauge,,mebibyte,,The sum of memory in MB allocated to the applications running containers,0,yarn,app mem alloc g
 yarn.apps.allocated_vcores_gauge,gauge,,core,,The sum of virtual cores allocated to the applications running containers,0,yarn,app cros alloc g
 yarn.apps.running_containers_gauge,gauge,,,,The number of containers currently running for the application,0,yarn,app ctrs rrun g
-yarn.apps.memory_seconds_gauge,rate,,gauge,,The amount of memory the application has allocated (megabyte-seconds),0,yarn,app mem tm g
-yarn.apps.vcore_seconds_gauge,rate,,gauge,,The amount of CPU resources the application has allocated (virtual core-seconds),0,yarn,app cor tm g
+yarn.apps.memory_seconds_gauge,gauge,,second,,The amount of memory the application has allocated (megabyte-seconds),0,yarn,app mem tm g
+yarn.apps.vcore_seconds_gauge,gauge,,second,,The amount of CPU resources the application has allocated (virtual core-seconds),0,yarn,app cor tm g
 yarn.apps.progress,rate,,percent,,Deprecated use yarn.apps.progress_gauge instead,0,yarn,app prog
 yarn.apps.started_time,rate,,second,,Deprecated use yarn.apps.started_time_gauge instead,0,yarn,app strt tim
 yarn.apps.finished_time,rate,,second,,Deprecated use yarn.apps.finished_time_gauge instead,0,yarn,app fin tim

--- a/yarn/tests/common.py
+++ b/yarn/tests/common.py
@@ -183,7 +183,7 @@ YARN_CLUSTER_METRICS_VALUES = {
 
 YARN_CLUSTER_METRICS_TAGS = ['cluster_name:{}'.format(CLUSTER_NAME)]
 
-YARN_APP_METRICS_VALUES = {
+DEPRECATED_YARN_APP_METRICS_VALUES = {
     'yarn.apps.progress': 100,
     'yarn.apps.started_time': 1326815573334,
     'yarn.apps.finished_time': 1326815598530,
@@ -193,6 +193,18 @@ YARN_APP_METRICS_VALUES = {
     'yarn.apps.running_containers': 0,
     'yarn.apps.memory_seconds': 151730,
     'yarn.apps.vcore_seconds': 103,
+}
+
+YARN_APP_METRICS_VALUES = {
+    'yarn.apps.progress_gauge': 100,
+    'yarn.apps.started_time_gauge': 1326815573334,
+    'yarn.apps.finished_time_gauge': 1326815598530,
+    'yarn.apps.elapsed_time_gauge': 25196,
+    'yarn.apps.allocated_mb_gauge': 0,
+    'yarn.apps.allocated_vcores_gauge': 0,
+    'yarn.apps.running_containers_gauge': 0,
+    'yarn.apps.memory_seconds_gauge': 151730,
+    'yarn.apps.vcore_seconds_gauge': 103,
 }
 
 YARN_APP_METRICS_TAGS = ['cluster_name:{}'.format(CLUSTER_NAME), 'app_name:word count', 'app_queue:default']

--- a/yarn/tests/test_yarn.py
+++ b/yarn/tests/test_yarn.py
@@ -9,6 +9,7 @@ from datadog_checks.yarn.yarn import SERVICE_CHECK_NAME, YARN_APP_METRICS, YARN_
 
 from .common import (
     CUSTOM_TAGS,
+    DEPRECATED_YARN_APP_METRICS_VALUES,
     RM_ADDRESS,
     YARN_APP_METRICS_TAGS,
     YARN_APP_METRICS_VALUES,
@@ -48,6 +49,8 @@ def test_check(aggregator, mocked_request):
 
     # Check the YARN App Metrics
     for metric, value in iteritems(YARN_APP_METRICS_VALUES):
+        aggregator.assert_metric(metric, value=value, tags=YARN_APP_METRICS_TAGS + CUSTOM_TAGS, count=1)
+    for metric, value in iteritems(DEPRECATED_YARN_APP_METRICS_VALUES):
         aggregator.assert_metric(metric, value=value, tags=YARN_APP_METRICS_TAGS + CUSTOM_TAGS, count=1)
 
     # Check the YARN Node Metrics


### PR DESCRIPTION
Since yarn.apps metrics were reported using the wrong type this PR introduces new metrics of the right type. Better naming suggestions welcome
