### PR TITLE
Morgan.lupton/modify statistic set ibmwas

### DIFF
--- a/ibm_was/README.md
+++ b/ibm_was/README.md
@@ -24,7 +24,7 @@ The performance servlet is deployed exactly as any other servlet. Deploy the ser
 ### Modify the Currently Monitored Statistic Set
 By default, your application server is only configured for "Basic" monitoring. In order to gain complete visibility into your JVM, JDBC connections, and servlet connections, change the currently monitored statistic set for your application server from "Basic" to "All". 
 
-You can find this setting in `Application servers > <YOUR_APP_SERVER> > Performance Monitoring Infrastructure (PMI)`.
+From the Websphere Administration Console, you can find this setting in `Application servers > <YOUR_APP_SERVER> > Performance Monitoring Infrastructure (PMI)`.
 
 Once you've made this change, click "Apply" to save the configuration and restart your application server. Additional JDBC, JVM, and servlet metrics should appear in Datadog shortly after this change. 
 

--- a/ibm_was/README.md
+++ b/ibm_was/README.md
@@ -21,6 +21,13 @@ The performance servlet is deployed exactly as any other servlet. Deploy the ser
 
 **Note**: Starting with version 6.1, you must enable application security to get the PerfServlet working.
 
+### Modify the Currently Monitored Statistic Set
+By default, your application server is only configured for "Basic" monitoring. In order to gain complete visibility into your JVM, JDBC connections, and servlet connections, change the currently monitored statistic set for your application server from "Basic" to "All". 
+
+You can find this setting in `Application servers > <YOUR_APP_SERVER> > Performance Monitoring Infrastructure (PMI)`.
+
+Once you've made this change, click "Apply" to save the configuration and restart your application server. Additional JDBC, JVM, and servlet metrics should appear in Datadog shortly after this change. 
+
 ### Configuration
 
 1. Edit the `ibm_was.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to collect your IBM WAS performance data. See the [sample ibm_was.d/conf.yaml][2] for all available configuration options.


### PR DESCRIPTION
### What does this PR do?

Docs don't currently include info about changing the currently monitored statistic set from "Basic" to "All" which is required in order to have all the timeseries graphs populate in our default dashboard for IBM WAS. 

### Motivation

Customer, SAIC, complained about not having all metrics populated in the default dashboard when they configured the integration. I was able to populate these metrics by completing the steps I listed in this docs page. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
