### PR TITLE
Fix tagging for custom queries using custom tags

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -927,7 +927,7 @@ GROUP BY datid, datname
                         continue
 
                     metric_info = []
-                    query_tags = custom_query.get('tags', [])
+                    query_tags = list(custom_query.get('tags', []))
                     query_tags.extend(tags)
 
                     for column, value in zip(columns, row):

--- a/postgres/tests/test_custom_metrics.py
+++ b/postgres/tests/test_custom_metrics.py
@@ -43,6 +43,7 @@ def test_custom_queries(aggregator, pg_instance):
                     'metric_prefix': 'custom',
                     'query': "SELECT letter, num FROM (VALUES (97, 'a'), (98, 'b'), (99, 'c')) AS t (num,letter)",
                     'columns': [{'name': 'customtag', 'type': 'tag'}, {'name': 'num', 'type': 'gauge'}],
+                    'tags': ['query:custom'],
                 },
                 {
                     'metric_prefix': 'another_custom_one',
@@ -67,5 +68,5 @@ def test_custom_queries(aggregator, pg_instance):
         custom_tags = ['customtag:{}'.format(tag)]
         custom_tags.extend(tags)
 
-        aggregator.assert_metric('custom.num', value=value, tags=custom_tags)
+        aggregator.assert_metric('custom.num', value=value, tags=custom_tags + ['query:custom'])
         aggregator.assert_metric('another_custom_one.num', value=value, tags=custom_tags + ['query:another_custom_one'])

--- a/postgres/tests/test_custom_metrics.py
+++ b/postgres/tests/test_custom_metrics.py
@@ -48,6 +48,7 @@ def test_custom_queries(aggregator, pg_instance):
                     'metric_prefix': 'another_custom_one',
                     'query': "SELECT letter, num FROM (VALUES (97, 'a'), (98, 'b'), (99, 'c')) AS t (num,letter)",
                     'columns': [{'name': 'customtag', 'type': 'tag'}, {'name': 'num', 'type': 'gauge'}],
+                    'tags': ['query:another_custom_one'],
                 },
             ]
         }
@@ -67,4 +68,4 @@ def test_custom_queries(aggregator, pg_instance):
         custom_tags.extend(tags)
 
         aggregator.assert_metric('custom.num', value=value, tags=custom_tags)
-        aggregator.assert_metric('another_custom_one.num', value=value, tags=custom_tags)
+        aggregator.assert_metric('another_custom_one.num', value=value, tags=custom_tags + ['query:another_custom_one'])


### PR DESCRIPTION
### What does this PR do?

reinitialized `query_tags` list for each row.

### Motivation

client issue.

given below:

```
 letter | num
--------+-----
 a      |  97
 b      |  98
 c      |  99
```

metrics returned: Screenshot (https://cl.ly/1d43d3d59e4c)

- `num=97`, `tags=letter:a`
- `num=98`, `tags=letter:a,letter:b`
- `num=99`, `tags=letter:a,letter:b,letter:c`

instead of: Screenshot (https://cl.ly/8ad1a10eb140)

- `num=97`, `tags=letter:a`
- `num=98`, `tags=letter:b`
- `num=99`, `tags=letter:c`


### Additional Notes

The tests seems to work fine even after the change; not sure if that needs fixing or not.

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
