### PR TITLE
Filters VMs in excluded hosts

### DIFF
--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -495,9 +495,7 @@ class VSphereCheck(AgentCheck):
                         host = ensure_unicode(host_props.get("name", "unknown"))
                         if self._is_excluded(host_mor, host_props, regexes, include_only_marked):
                             self.log.debug(
-                                "Skipping VM because host %s is excluded by rule %s.",
-                                host_props.get("name", "unknown"),
-                                regexes.get('host_include'),
+                                "Skipping VM because host %s is excluded by rule %s.", host, regexes.get('host_include')
                             )
                             continue
                     instance_tags.append('vsphere_host:{}'.format(host))


### PR DESCRIPTION
### What does this PR do?

The `host_include_only_regex` config field allow users to filter the vsphere integration to a subset of hosts. Filtering is only made on the hosts themselves but the integration still collects metrics for the VMs running on the said hosts.
This PR fixes it.

### Motivation

Looks like it was introduced when we stopped going recursively over the infrastructure in https://github.com/DataDog/dd-agent/pull/3055

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
