### PR TITLE
Rename kube_scheduler display name to Kubernetes Scheduler

### DIFF
--- a/kube_scheduler/README.md
+++ b/kube_scheduler/README.md
@@ -1,14 +1,14 @@
-# Agent Check: Kube_scheduler
+# Agent Check: Kubernetes Scheduler
 
 ## Overview
 
-This check monitors [Kube_scheduler][1], part of the Kubernetes control plane.
+This check monitors [Kubernetes Scheduler][1], part of the Kubernetes control plane.
 
 ## Setup
 
 ### Installation
 
-The Kube_scheduler check is included in the [Datadog Agent][2] package.
+The Kubernetes Scheduler check is included in the [Datadog Agent][2] package.
 No additional installation is needed on your server.
 
 ### Configuration

--- a/kube_scheduler/manifest.json
+++ b/kube_scheduler/manifest.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "Kube_scheduler",
+  "display_name": "Kubernetes Scheduler",
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "name": "kube_scheduler",
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Kube_scheduler Integration",
+  "public_title": "Datadog-Kubernetes Scheduler Integration",
   "categories": [
     "orchestration",
     "containers",

--- a/kube_scheduler/setup.py
+++ b/kube_scheduler/setup.py
@@ -24,7 +24,7 @@ CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 setup(
     name='datadog-kube_scheduler',
     version=ABOUT['__version__'],
-    description='The Kube_scheduler check',
+    description='The Kubernetes Scheduler check',
     long_description=long_description,
     long_description_content_type='text/markdown',
     keywords='datadog agent kube_scheduler check',


### PR DESCRIPTION
### What does this PR do?

Renames the kube_Scheduler display name to Kubernetes Scheduler to fix the integration tile.

### Motivation

The naming was inconsistent with the rest of the integrations.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
