### PR TITLE
[ibm_mq] add ibm_mq.channel.count metric and ibm_mq.channel.status service check

### DIFF
--- a/ibm_mq/README.md
+++ b/ibm_mq/README.md
@@ -174,13 +174,21 @@ See [metadata.csv][7] for a list of metrics provided by this integration.
 
 ### Service Checks
 
-There are three service checks:
+**ibm_mq.can_connect**:
+Returns `CRITICAL` if the Agent cannot connect to the MQ server for any reason. Returns `OK` otherwise.
 
-`ibm_mq.can_connect`: checks if we can connect to IBM MQ
-`ibm_mq.queue_manager`: checks if the Queue Manager is working
-`ibm_mq.queue`: checks if the queue exists
-`ibm_mq.channel`: checks if can connect to channel
-`ibm_mq.channel.status`: checks if channel is running based on it's status
+**ibm_mq.queue_manager**:
+Returns `CRITICAL` if the Agent cannot retrieve stats from the queue manager. Returns `OK` otherwise.
+
+**ibm_mq.queue**:
+Returns `CRITICAL` if the Agent cannot retrieve queue stats. Returns `OK` otherwise.
+
+**ibm_mq.channel**:
+Returns `CRITICAL` if the Agent cannot retrieve channel stats. Returns `OK` otherwise.
+
+**ibm_mq.channel**:
+Return `CRITICAL` if the status is INACTIVE/STOPPED/STOPPING. Returns `OK` if the status is RUNNING. Returns `WARNING` if the status might lead to running.
+
 
 ### Events
 

--- a/ibm_mq/README.md
+++ b/ibm_mq/README.md
@@ -179,6 +179,8 @@ There are three service checks:
 `ibm_mq.can_connect`: checks if we can connect to IBM MQ
 `ibm_mq.queue_manager`: checks if the Queue Manager is working
 `ibm_mq.queue`: checks if the queue exists
+`ibm_mq.channel`: checks if can connect to channel
+`ibm_mq.channel.status`: checks if channel is running based on it's status
 
 ### Events
 

--- a/ibm_mq/README.md
+++ b/ibm_mq/README.md
@@ -186,7 +186,7 @@ Returns `CRITICAL` if the Agent cannot retrieve queue stats. Returns `OK` otherw
 **ibm_mq.channel**:<br/>
 Returns `CRITICAL` if the Agent cannot retrieve channel stats. Returns `OK` otherwise.
 
-**ibm_mq.channel**:<br/>
+**ibm_mq.channel.status**:<br/>
 Return `CRITICAL` if the status is INACTIVE/STOPPED/STOPPING. Returns `OK` if the status is RUNNING. Returns `WARNING` if the status might lead to running.
 
 

--- a/ibm_mq/README.md
+++ b/ibm_mq/README.md
@@ -174,19 +174,19 @@ See [metadata.csv][7] for a list of metrics provided by this integration.
 
 ### Service Checks
 
-**ibm_mq.can_connect**:
+**ibm_mq.can_connect**:<br/>
 Returns `CRITICAL` if the Agent cannot connect to the MQ server for any reason. Returns `OK` otherwise.
 
-**ibm_mq.queue_manager**:
+**ibm_mq.queue_manager**:<br/>
 Returns `CRITICAL` if the Agent cannot retrieve stats from the queue manager. Returns `OK` otherwise.
 
-**ibm_mq.queue**:
+**ibm_mq.queue**:<br/>
 Returns `CRITICAL` if the Agent cannot retrieve queue stats. Returns `OK` otherwise.
 
-**ibm_mq.channel**:
+**ibm_mq.channel**:<br/>
 Returns `CRITICAL` if the Agent cannot retrieve channel stats. Returns `OK` otherwise.
 
-**ibm_mq.channel**:
+**ibm_mq.channel**:<br/>
 Return `CRITICAL` if the status is INACTIVE/STOPPED/STOPPING. Returns `OK` if the status is RUNNING. Returns `WARNING` if the status might lead to running.
 
 

--- a/ibm_mq/assets/service_checks.json
+++ b/ibm_mq/assets/service_checks.json
@@ -34,5 +34,14 @@
         "statuses": ["ok", "critical"],
         "name": "Channel Can Connect",
         "description": "Returns `CRITICAL` if the Agent cannot retrieve channel stats. Returns `OK` otherwise."
+    },
+    {
+        "agent_version": "6.8.1",
+        "integration":"IBM MQ",
+        "groups": ["queue_manager", "mq_host", "port", "channel"],
+        "check": "ibm_mq.channel.status",
+        "statuses": ["ok", "critical", "warning", "unknown"],
+        "name": "Channel Status",
+        "description": "Return `CRITICAL` if the status is INACTIVE/STOPPED/STOPPING. Returns `OK` if the status is RUNNING. Returns `WARNING` if the status might lead to running."
     }
 ]

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -144,7 +144,7 @@ class IbmMqCheck(AgentCheck):
             else:
                 for queue_info in response:
                     queue = queue_info[pymqi.CMQC.MQCA_Q_NAME]
-                    queues.append(ensure_unicode(queue).strip())
+                    queues.append(str(ensure_unicode(queue.strip())))
 
         return queues
 

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -6,7 +6,7 @@ import logging
 
 from six import iteritems
 
-from datadog_checks.base import ensure_bytes
+from datadog_checks.base import ensure_bytes, ensure_unicode
 from datadog_checks.checks import AgentCheck
 
 from . import connection, errors, metrics
@@ -144,7 +144,7 @@ class IbmMqCheck(AgentCheck):
             else:
                 for queue_info in response:
                     queue = queue_info[pymqi.CMQC.MQCA_Q_NAME]
-                    queues.append(str(queue.strip().decode()))
+                    queues.append(ensure_unicode(queue).strip())
 
         return queues
 
@@ -246,7 +246,7 @@ class IbmMqCheck(AgentCheck):
             self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.CRITICAL, search_channel_tags)
         else:
             for channel_info in response:
-                channel_name = channel_info[pymqi.CMQCFC.MQCACH_CHANNEL_NAME].decode().strip()
+                channel_name = ensure_unicode(channel_info[pymqi.CMQCFC.MQCACH_CHANNEL_NAME]).strip()
                 channel_tags = tags + ["channel:{}".format(channel_name)]
 
                 channel_status = channel_info[pymqi.CMQCFC.MQIACH_CHANNEL_STATUS]

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -31,8 +31,39 @@ class IbmMqCheck(AgentCheck):
     QUEUE_SERVICE_CHECK = 'ibm_mq.queue'
 
     CHANNEL_SERVICE_CHECK = 'ibm_mq.channel'
+    CHANNEL_STATUS_SERVICE_CHECK = 'ibm_mq.channel.status'
+
+    CHANNEL_COUNT_CHECK = 'ibm_mq.channel.count'
 
     SUPPORTED_QUEUE_TYPES = [pymqi.CMQC.MQQT_LOCAL, pymqi.CMQC.MQQT_MODEL]
+
+    STATUS_MQCHS_UNKNOWN = -1
+    CHANNEL_STATUS_MAP = {
+        pymqi.CMQCFC.MQCHS_INACTIVE: "inactive",
+        pymqi.CMQCFC.MQCHS_BINDING: "binding",
+        pymqi.CMQCFC.MQCHS_STARTING: "starting",
+        pymqi.CMQCFC.MQCHS_RUNNING: "running",
+        pymqi.CMQCFC.MQCHS_STOPPING: "stopping",
+        pymqi.CMQCFC.MQCHS_RETRYING: "retrying",
+        pymqi.CMQCFC.MQCHS_STOPPED: "stopped",
+        pymqi.CMQCFC.MQCHS_REQUESTING: "requesting",
+        pymqi.CMQCFC.MQCHS_PAUSED: "paused",
+        pymqi.CMQCFC.MQCHS_INITIALIZING: "initializing",
+        STATUS_MQCHS_UNKNOWN: "unknown",
+    }
+
+    SERVICE_CHECK_MAP = {
+        pymqi.CMQCFC.MQCHS_INACTIVE: AgentCheck.CRITICAL,
+        pymqi.CMQCFC.MQCHS_BINDING: AgentCheck.WARNING,
+        pymqi.CMQCFC.MQCHS_STARTING: AgentCheck.WARNING,
+        pymqi.CMQCFC.MQCHS_RUNNING: AgentCheck.OK,
+        pymqi.CMQCFC.MQCHS_STOPPING: AgentCheck.CRITICAL,
+        pymqi.CMQCFC.MQCHS_RETRYING: AgentCheck.WARNING,
+        pymqi.CMQCFC.MQCHS_STOPPED: AgentCheck.CRITICAL,
+        pymqi.CMQCFC.MQCHS_REQUESTING: AgentCheck.WARNING,
+        pymqi.CMQCFC.MQCHS_PAUSED: AgentCheck.WARNING,
+        pymqi.CMQCFC.MQCHS_INITIALIZING: AgentCheck.WARNING,
+    }
 
     def check(self, instance):
         config = IBMMQConfig(instance)
@@ -66,7 +97,7 @@ class IbmMqCheck(AgentCheck):
 
                 try:
                     queue = pymqi.Queue(queue_manager, queue_name)
-                    self.queue_stats(queue, queue_tags)
+                    self.queue_stats(queue, queue_name, queue_tags)
                     # some system queues don't have PCF metrics
                     # so we don't collect those metrics from those queues
                     if queue_name not in config.DISALLOWED_QUEUES:
@@ -131,7 +162,7 @@ class IbmMqCheck(AgentCheck):
                 self.warning("Error getting queue manager stats: {}".format(e))
                 self.service_check(self.QUEUE_MANAGER_SERVICE_CHECK, AgentCheck.CRITICAL, tags)
 
-    def queue_stats(self, queue, tags):
+    def queue_stats(self, queue, queue_name, tags):
         """
         Grab stats from queues
         """
@@ -141,7 +172,7 @@ class IbmMqCheck(AgentCheck):
                 m = queue.inquire(pymqi_value)
                 self.gauge(mname, m, tags=tags)
             except pymqi.Error as e:
-                self.warning("Error getting queue stats for {}: {}".format(queue, e))
+                self.warning("Error getting queue stats for {}: {}".format(queue_name, e))
 
         for mname, func in iteritems(metrics.queue_metrics_functions()):
             try:
@@ -149,7 +180,7 @@ class IbmMqCheck(AgentCheck):
                 m = func(queue)
                 self.gauge(mname, m, tags=tags)
             except pymqi.Error as e:
-                self.warning("Error getting queue stats for {}: {}".format(queue, e))
+                self.warning("Error getting queue stats for {}: {}".format(queue_name, e))
 
     def get_pcf_queue_metrics(self, queue_manager, queue_name, tags):
         try:
@@ -161,7 +192,7 @@ class IbmMqCheck(AgentCheck):
             pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_INQUIRE_Q_STATUS(args)
         except pymqi.MQMIError as e:
-            self.warning("Error getting queue stats for {}: {}".format(queue_name, e))
+            self.warning("Error getting queue metrics for {}: {}".format(queue_name, e))
         else:
             # Response is a list. It likely has only one member in it.
             for queue_info in response:
@@ -192,31 +223,50 @@ class IbmMqCheck(AgentCheck):
             self.gauge(mname, channels, tags=tags)
 
         # grab all the discoverable channels
-        self._get_channel_status(queue_manager, '*', tags, config)
+        self._submit_channel_status(queue_manager, '*', tags, config)
 
         # check specific channels as well
         # if a channel is not listed in the above one, a user may want to check it specifically,
         # in this case it'll fail
         for channel in config.channels:
-            self._get_channel_status(queue_manager, channel, tags, config)
+            self._submit_channel_status(queue_manager, channel, tags, config)
 
-    def _get_channel_status(self, queue_manager, channel, tags, config):
-        channel_tags = tags + ["channel:{}".format(channel)]
+    def _submit_channel_status(self, queue_manager, search_channel_name, tags, config):
+        """Submit channel status
+        :param search_channel_name might contain wildcard characters
+        """
+        search_channel_tags = tags + ["channel:{}".format(search_channel_name)]
         try:
-            args = {pymqi.CMQCFC.MQCACH_CHANNEL_NAME: ensure_bytes(channel)}
+            args = {pymqi.CMQCFC.MQCACH_CHANNEL_NAME: ensure_bytes(search_channel_name)}
             pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_INQUIRE_CHANNEL_STATUS(args)
+            self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.OK, search_channel_tags)
         except pymqi.MQMIError as e:
             self.log.warning("Error getting CHANNEL stats {}".format(e))
-            self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.CRITICAL, channel_tags)
+            self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.CRITICAL, search_channel_tags)
         else:
             for channel_info in response:
-                name = channel_info[pymqi.CMQCFC.MQCACH_CHANNEL_NAME]
-                name = name.strip()
+                channel_name = channel_info[pymqi.CMQCFC.MQCACH_CHANNEL_NAME].decode().strip()
+                channel_tags = tags + ["channel:{}".format(channel_name)]
 
-                # running = 3, stopped = 4
-                status = channel_info[pymqi.CMQCFC.MQIACH_CHANNEL_STATUS]
-                if status == 3:
-                    self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.OK, channel_tags)
-                elif status == 4:
-                    self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.WARNING, channel_tags)
+                channel_status = channel_info[pymqi.CMQCFC.MQIACH_CHANNEL_STATUS]
+
+                self._submit_channel_count(channel_name, channel_status, channel_tags)
+                self._submit_status_check(channel_name, channel_status, channel_tags)
+
+    def _submit_status_check(self, channel_name, channel_status, channel_tags):
+        if channel_status in self.SERVICE_CHECK_MAP:
+            service_check_status = self.SERVICE_CHECK_MAP[channel_status]
+        else:
+            self.log.warning("Status `{}` not found for channel `{}`".format(channel_status, channel_name))
+            service_check_status = AgentCheck.UNKNOWN
+        self.service_check(self.CHANNEL_STATUS_SERVICE_CHECK, service_check_status, channel_tags)
+
+    def _submit_channel_count(self, channel_name, channel_status, channel_tags):
+        if channel_status not in self.CHANNEL_STATUS_MAP:
+            self.log.warning("Status `{}` not found for channel `{}`".format(channel_status, channel_name))
+            channel_status = self.STATUS_MQCHS_UNKNOWN
+
+        for status, status_label in iteritems(self.CHANNEL_STATUS_MAP):
+            status_active = int(status == channel_status)
+            self.gauge(self.CHANNEL_COUNT_CHECK, status_active, tags=channel_tags + ["status:" + status_label])

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -96,7 +96,7 @@ class IbmMqCheck(AgentCheck):
                         queue_tags.extend(q_tags)
 
                 try:
-                    queue = pymqi.Queue(queue_manager, queue_name)
+                    queue = pymqi.Queue(queue_manager, ensure_bytes(queue_name))
                     self.queue_stats(queue, queue_name, queue_tags)
                     # some system queues don't have PCF metrics
                     # so we don't collect those metrics from those queues
@@ -144,7 +144,7 @@ class IbmMqCheck(AgentCheck):
             else:
                 for queue_info in response:
                     queue = queue_info[pymqi.CMQC.MQCA_Q_NAME]
-                    queues.append(str(ensure_unicode(queue.strip())))
+                    queues.append(ensure_unicode(queue).strip())
 
         return queues
 

--- a/ibm_mq/metadata.csv
+++ b/ibm_mq/metadata.csv
@@ -1,5 +1,6 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 ibm_mq.channel.channels,gauge,,resource,,The number of active channels,0,ibm_mq,active channel count
+ibm_mq.channel.count,gauge,,,,Sum by status to count channels. Filter by channel and status tags to create notifications.,0,ibm_mq,channel count
 ibm_mq.queue.service_interval,gauge,,millisecond,,the time since last serviced,0,ibm_mq,service interval
 ibm_mq.queue.inhibit_put,gauge,,occurrence,,puts are inhibited,0,ibm_mq,puts inhibited
 ibm_mq.queue.depth_low_limit,gauge,,item,,the low limit on the depth to create an alert,0,ibm_mq,depth low limit


### PR DESCRIPTION
### What does this PR do?

Add metrics `ibm_mq.channel.count` : Sum by status to count channels. Filter by channel and status tags to create notifications.

### Motivation

User request:

> The integration's current implementation of reporting channel statuses is via a service check.
> This is very limited on what it reports and we would like to be able to view all statuses supported by IBM MQ so that they are able to create alerts on varying severity levels (depending on what status is reported).

### Additional Notes

1) There is a small change on the behavior of the service check `ibm_mq.channel` (can connect to channel).
**Before**, `ibm_mq.channel` status check was verifying that the channel can connect, but also partially using the status (OK if RUNNING, WARNING if STOPPING). And if the status it something else than RUNNING and STOPPING, nothing was reported.
**Now**, `ibm_mq.channel` will report OK if it can connect and CRITICAL otherwise, as advertised by it's current description (no change):
```json
    {
        "agent_version": "6.8.1",
        "integration":"IBM MQ",
        "groups": ["queue_manager", "mq_host", "port", "channel"],
        "check": "ibm_mq.channel",
        "statuses": ["ok", "critical"],
        "name": "Channel Can Connect",
        "description": "Returns `CRITICAL` if the Agent cannot retrieve channel stats. Returns `OK` otherwise."
    }
```

2) A new service have been created to monitor status.
```json
    {
        "agent_version": "6.8.1",
        "integration":"IBM MQ",
        "groups": ["queue_manager", "mq_host", "port", "channel"],
        "check": "ibm_mq.channel.status",
        "statuses": ["ok", "critical", "warning", "unknown"],
        "name": "Channel Status",
        "description": "Return `CRITICAL` if the status is INACTIVE/STOPPED/STOPPING. Returns `OK` if the status is RUNNING. Returns `WARNING` if the status might lead to running."
    }
```

Some redundancy, since we can achieve similar notification with the newly added metric:
```
ibm_mq.channel.count,gauge,,,,Sum by status to count channels. Filter by channel and status tags to create notifications.,0,ibm_mq,channel count
```

But IMO, it's OK to have some redundancy like this one, the user can pick the one that suits the most his needs.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
