### PR TITLE
Add log setup and configuration

### DIFF
--- a/ceph/README.md
+++ b/ceph/README.md
@@ -37,6 +37,23 @@ If you enabled `use_sudo`, add a line like the following to your `sudoers` file:
 dd-agent ALL=(ALL) NOPASSWD:/path/to/your/ceph
 ```
 
+#### Log Collection
+
+To enable collecting logs in the Datadog Agent, update `logs_enabled` in `datadog.yaml`:
+```
+    logs_enabled: true
+```
+
+Next, edit `ceph.d/conf.yaml` by uncommenting the `logs` lines at the bottom. Update the logs `path` with the correct path to your Ceph log files.
+
+```yaml
+logs:
+ - type: file
+   path: /var/log/ceph/*.log
+   source: ceph
+   service: <APPLICATION_NAME>
+```
+
 ### Validation
 
 [Run the Agent's `status` subcommand][6] and look for `ceph` under the Checks section.

--- a/ceph/datadog_checks/ceph/data/conf.yaml.example
+++ b/ceph/datadog_checks/ceph/data/conf.yaml.example
@@ -56,3 +56,24 @@ instances:
     # tags:
     #   - name:mars_cluster
     #   - <KEY_2>:<VALUE_2>
+
+## Log Section (Available for Agent >=6.0)
+##
+## type - mandatory - Type of log input source (tcp / udp / file / windows_event)
+## port / path / channel_path - mandatory - Set port if type is tcp or udp. Set path if type is file. Set channel_path if type is windows_event
+## service - mandatory - Name of the service that generated the log
+## source  - mandatory - Attribute that defines which Integration sent the logs
+## sourcecategory - optional - Multiple value attribute. Used to refine the source attribute
+## tags: - optional - Add tags to the collected logs
+##
+## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
+#
+# logs:
+#   - type: file
+#     path: /var/log/ceph/*.log
+#     source: ceph
+#     service: <APPLICATION_NAME>
+#     log_processing_rules:
+#       - type: multi_line
+#         name: log_start_with_date
+#         pattern: \d{4}-\d{2}-\d{2}

--- a/ceph/manifest.json
+++ b/ceph/manifest.json
@@ -1,7 +1,8 @@
 {
   "categories": [
     "data store",
-    "os & system"
+    "os & system",
+    "log collection"
   ],
   "creates_events": false,
   "display_name": "Ceph",


### PR DESCRIPTION
This adds the default configuration, and the setup instructions, to be able to
collect Ceph logs.