### PR TITLE
[ibm_mq] move LD_LIBRARY_PATH from .travis.yml to tox.ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ env:
     - PIP_CACHE=$HOME/.cache/pip
     # if the c include path doesn't have the proper path pymqi will not compile
     - C_INCLUDE_PATH="/opt/mqm/inc:$C_INCLUDE_PATH"
-    - LD_LIBRARY_PATH="/opt/mqm/lib64:/opt/mqm/lib:$LD_LIBRARY_PATH"
     # https://github.com/travis-ci/travis-ci/issues/7940
     - BOTO_CONFIG=/dev/null
 

--- a/ibm_mq/tox.ini
+++ b/ibm_mq/tox.ini
@@ -16,5 +16,6 @@ commands =
     pip install -r requirements.in
     pytest -v
 setenv =
+    LD_LIBRARY_PATH=/opt/mqm/lib64:/opt/mqm/lib:{env:LD_LIBRARY_PATH:none}
     8: IBM_MQ_VERSION = 8
     9: IBM_MQ_VERSION = 9


### PR DESCRIPTION
### What does this PR do?

Move LD_LIBRARY_PATH from .travis.yml to tox.ini 

That will avoid having to set LD_LIBRARY_PATH before running tests locally: `ddev test ibm_mq:py37-9`

TODO:

- [x] Run `ci run all`
