### PR TITLE
[skip ci] update doc with new manifest.json output

### DIFF
--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -302,7 +302,7 @@ Arguments:
   * *double*
   * *float*
   * *dictionary*
-  * *list\**
+  * *list✱*
   * *object*
 * `defval`: default value for the parameter; can be empty (optional).
 
@@ -408,7 +408,7 @@ Our example integration has a very simple `awesome/manifest.json`, the bulk of w
 
 ```json
 {
-  "display_name": "Awesome",
+  "display_name": "awesome",
   "maintainer": "email@example.org",
   "manifest_version": "1.0.0",
   "name": "awesome",
@@ -416,20 +416,25 @@ Our example integration has a very simple `awesome/manifest.json`, the bulk of w
   "metric_to_check": "",
   "creates_events": false,
   "short_description": "",
-  "guid": "x23b0c2c-dc39-4196-95fd-bddf93254a0x",
+  "guid": "x16b8750-df1e-46c0-839a-2056461b604x",
   "support": "contrib",
   "supported_os": [
     "linux",
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Awesome Integration",
+  "public_title": "Datadog-awesome Integration",
   "categories": [
     "web"
   ],
   "type": "check",
   "is_public": false,
-  "integration_id": "awesome"
+  "integration_id": "awesome",
+  "assets": {
+    "dashboards": {},
+    "monitors": {},
+    "service_checks": "assets/service_checks.json"
+  }
 }
 ```
 

--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -302,7 +302,7 @@ Arguments:
   * *double*
   * *float*
   * *dictionary*
-  * *list✱*
+  * *list&#42;*
   * *object*
 * `defval`: default value for the parameter; can be empty (optional).
 


### PR DESCRIPTION
### What does this PR do?

This updates the "new check docs" (which should probably be renamed but…) with a more recent `manifest.json` sample.

I also replaced an asterisk with a slightly different asterisk because it was _destroying_ IDE highlighting. :P 

### Motivation

Keeping things up to date (and highlighting).

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
