### PR TITLE
Fix metadata bootstrap workflow

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
@@ -606,6 +606,7 @@ def make(ctx, checks, version, initial_release, skip_sign, sign_only):
     updated_checks = []
     for check in checks:
         if sign_only:
+            updated_checks.append(check)
             break
         elif initial_release and check in BETA_PACKAGES:
             continue


### PR DESCRIPTION
### Motivation

https://github.com/DataDog/integrations-core/pull/3944 broke `ddev release make --sign-only all`