### PR TITLE
Remove timeout when stopping containers

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -145,7 +145,7 @@ class ComposeFileDown(LazyFunction):
     def __init__(self, compose_file, check=True):
         self.compose_file = compose_file
         self.check = check
-        self.command = ['docker-compose', '-f', self.compose_file, 'down']
+        self.command = ['docker-compose', '-f', self.compose_file, 'down', '-t', '0']
 
     def __call__(self):
         return run_command(self.command, check=self.check)


### PR DESCRIPTION
We waste 10s every time we stop an environment, but we don't really care
for graceful shutdown, so let's kill them right away. It saves us quite
some time on smaller tests.