### PR TITLE
Fix some typos in metadata.

### DIFF
--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -127,7 +127,7 @@ elasticsearch.primaries.store.size,gauge,,byte,,The total size of all the primar
 elasticsearch.process.open_fd,gauge,,file,,"The number of opened file descriptors associated with the current process, or -1 if not supported.",0,elasticsearch,open file descriptors
 elasticsearch.refresh.total,gauge,,refresh,,The total number of index refreshes.,0,elasticsearch,total refreshes
 elasticsearch.refresh.total.time,gauge,,second,,The total time spent on index refreshes.,0,elasticsearch,total refresh time
-elasticsearch.relocating_shards,gauge,,shard,,The number of shards that are reloacting from one node to another.,0,elasticsearch,reloading shards
+elasticsearch.relocating_shards,gauge,,shard,,The number of shards that are relocating from one node to another.,0,elasticsearch,relocating shards
 elasticsearch.search.fetch.current,gauge,,fetch,,The number of search fetches currently running.,0,elasticsearch,current fetches
 elasticsearch.search.fetch.open_contexts,gauge,,query,,The number of active searches.,0,elasticsearch,active searches
 elasticsearch.search.fetch.time,gauge,,second,,The total time spent on the search fetch.,0,elasticsearch,total fetch time
@@ -237,10 +237,10 @@ jvm.mem.heap_max,gauge,,byte,,The maximum amount of memory that can be used by t
 jvm.mem.heap_used,gauge,,byte,,The amount of memory in bytes currently used by the JVM heap.,0,elasticsearch,jvm heap used
 jvm.mem.non_heap_committed,gauge,,byte,,The amount of memory guaranteed to be available to JVM non-heap.,0,elasticsearch,jvm non-heap committed
 jvm.mem.non_heap_used,gauge,,byte,,The amount of memory in bytes currently used by the JVM non-heap.,0,elasticsearch,jvm non-heap used
-jvm.mem.pools.young.used,gauge,,byte,,The amount of memory in bytes currently used by the Young Generation heap reagion.,0,elasticsearch,jvm young used
-jvm.mem.pools.young.max,gauge,,byte,,The maximum amount of memory that can be used by the Young Generation heap reagion.,0,elasticsearch,jvm young max
-jvm.mem.pools.old.used,gauge,,byte,,The amount of memory in bytes currently used by the Old Generation heap reagion.,0,elasticsearch,jvm old used
-jvm.mem.pools.old.max,gauge,,byte,,The maximum amount of memory that can be used by the Old Generation heap reagion.,0,elasticsearch,jvm old max
+jvm.mem.pools.young.used,gauge,,byte,,The amount of memory in bytes currently used by the Young Generation heap region.,0,elasticsearch,jvm young used
+jvm.mem.pools.young.max,gauge,,byte,,The maximum amount of memory that can be used by the Young Generation heap region.,0,elasticsearch,jvm young max
+jvm.mem.pools.old.used,gauge,,byte,,The amount of memory in bytes currently used by the Old Generation heap region.,0,elasticsearch,jvm old used
+jvm.mem.pools.old.max,gauge,,byte,,The maximum amount of memory that can be used by the Old Generation heap region.,0,elasticsearch,jvm old max
 jvm.mem.pools.survivor.used,gauge,,byte,,The amount of memory in bytes currently used by the Survivor Space.,0,elasticsearch,jvm survivor used
 jvm.mem.pools.survivor.max,gauge,,byte,,The maximum amount of memory that can be used by the Survivor Space.,0,elasticsearch,jvm survivor max
 jvm.threads.count,gauge,,thread,,The number of active threads in the JVM.,0,elasticsearch,jvm threads

--- a/gitlab_runner/metadata.csv
+++ b/gitlab_runner/metadata.csv
@@ -3,7 +3,7 @@ gitlab_runner.ci_docker_machines_provider_machine_creation_duration_seconds_buck
 gitlab_runner.ci_docker_machines_provider_machine_creation_duration_seconds_sum,gauge,,request,second,Sum of Docker machine creation time,0,gitlab_runner,sum docker machine creation time
 gitlab_runner.ci_docker_machines_provider_machine_creation_duration_seconds_count,gauge,,request,second,Count of Docker machine creation time,0,gitlab_runner,count docker machine creation time
 gitlab_runner.ci_docker_machines_provider_machine_states,gauge,,request,second,The current number of machines per state in this provider,0,gitlab_runner,total docker machines per state
-gitlab_runner.ci_runner_errors,counter,,request,second,The number of catched errors,0,gitlab_runner,errors
+gitlab_runner.ci_runner_errors,counter,,request,second,The number of caught errors,0,gitlab_runner,errors
 gitlab_runner.ci_runner_version_info,gauge,,request,,A metric with a constant '1' value labeled by different build stats fields,0,gitlab_runner,version info
 gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_bucket,gauge,,request,second,Histogram of SSH Docker machine creation time,0,gitlab_runner,ssh docker machine creation time
 gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_sum,gauge,,request,second,Sum of SSH Docker machine creation time,0,gitlab_runner,sum ssh docker machine creation time

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -11,7 +11,7 @@ mysql.innodb.mutex_os_waits,gauge,,event,second,The rate of mutex OS waits.,0,my
 mysql.innodb.mutex_spin_rounds,gauge,,event,second,The rate of mutex spin rounds.,0,mysql,mutex spin rounds
 mysql.innodb.mutex_spin_waits,gauge,,event,second,The rate of mutex spin waits.,0,mysql,mutex spin waits
 mysql.innodb.os_log_fsyncs,gauge,,write,second,The rate of fsync writes to the log file.,0,mysql,log fsyncs
-mysql.innodb.row_lock_time,gauge,,fraction,,Fraction of time spent (ms/s) acquring row locks.,-1,mysql,row lock time
+mysql.innodb.row_lock_time,gauge,,fraction,,Fraction of time spent (ms/s) acquiring row locks.,-1,mysql,row lock time
 mysql.innodb.row_lock_waits,gauge,,event,second,The number of times per second a row lock had to be waited for.,0,mysql,innodb row lock waits
 mysql.net.connections,gauge,,connection,second,The rate of connections to the server.,0,mysql,conns per s
 mysql.net.max_connections,gauge,,connection,,The maximum number of connections that have been in use simultaneously since the server started.,-1,mysql,max used conn

--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -59,7 +59,7 @@ TAGGED_KEYS = {
 class Nginx(AgentCheck):
     """Tracks basic nginx metrics via the status module
     * number of connections
-    * number of requets per second
+    * number of requests per second
 
     Requires nginx to have the status option compiled.
     See http://wiki.nginx.org/HttpStubStatusModule for more details

--- a/nginx/metadata.csv
+++ b/nginx/metadata.csv
@@ -1,7 +1,7 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 nginx.net.writing,gauge,,connection,,The number of connections waiting on upstream responses and/or writing responses back to the client.,0,nginx,conns writing
 nginx.net.waiting,gauge,,connection,,The number of keep-alive connections waiting for work.,0,nginx,conns waiting
-nginx.net.reading,gauge,,connection,,The number of connections reading client requets.,0,nginx,conns reading
+nginx.net.reading,gauge,,connection,,The number of connections reading client requests.,0,nginx,conns reading
 nginx.net.connections,gauge,,connection,,The total number of active connections.,0,nginx,conns
 nginx.net.request_per_s,gauge,,request,second,Rate of requests processed.,0,nginx,req/s
 nginx.net.conn_opened_per_s,gauge,,connection,second,Rate of connections opened.,0,nginx,conns opened/s

--- a/redisdb/metadata.csv
+++ b/redisdb/metadata.csv
@@ -19,7 +19,7 @@ redis.keys.evicted,gauge,,key,,The total number of keys evicted due to the maxme
 redis.keys.expired,gauge,,key,,The total number of keys expired from the db.,0,redis,keys expired
 redis.mem.fragmentation_ratio,gauge,,fraction,,Ratio between used_memory_rss and used_memory.,-1,redis,frag ratio
 redis.mem.lua,gauge,,byte,,Amount of memory used by the Lua engine.,-1,redis,mem lua
-redis.mem.maxmemory,gauge,,byte,,Maximum amount of memory alloted to the Redisdb system.,-1,redis,mem maxmemory
+redis.mem.maxmemory,gauge,,byte,,Maximum amount of memory allocated to the Redisdb system.,-1,redis,mem maxmemory
 redis.mem.peak,gauge,,byte,,The peak amount of memory used by Redis.,-1,redis,mem peak
 redis.mem.rss,gauge,,byte,,Amount of memory that Redis allocated as seen by the os.,-1,redis,mem rss
 redis.mem.used,gauge,,byte,,Amount of memory allocated by Redis.,-1,redis,mem used


### PR DESCRIPTION
Found yaspeller, fix some typos. I run this:
`find . -name metadata.csv | xargs -n1 cut -d, -f 6 | yaspeller --stdin`