### PR TITLE
Fix event payload

### DIFF
--- a/nagios/datadog_checks/nagios/nagios.py
+++ b/nagios/datadog_checks/nagios/nagios.py
@@ -351,7 +351,7 @@ class NagiosEventLogTailer(NagiosTailer):
         event_payload = fields._asdict()
 
         msg_text = {
-            'event_type': event_payload.pop('event_type', None),
+            'event_type': event_type,
             'event_soft_hard': event_payload.pop('event_soft_hard', None),
             'check_name': event_payload.pop('check_name', None),
             'event_state': event_payload.pop('event_state', None),


### PR DESCRIPTION
### Motivation

`event_type` is not a parsed field. Matches behavior here:

https://github.com/DataDog/integrations-core/blob/ef49b25b6b63c8b1541520f22bff53bd5396c540/nagios/datadog_checks/nagios/nagios.py#L368