### PR TITLE
Revert "Gitlab - Prevent the release manual job to run on branches"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,8 +28,6 @@ release-manual:
   only:
     # Integration release tags e.g. any_check-X.Y.Z-rc.N
     - /.*-\d+\.\d+\.\d+(-(rc|pre|alpha|beta)\.\d+)?$/
-  except:
-    - branches
   script:
     # Get tagger info
     - tagger=$(git show "$CI_COMMIT_TAG" | head -2 | tail -1)


### PR DESCRIPTION
### Motivation

Prevents releasing rc/beta versions of checks on branches