### PR TITLE
[nagios] use event_type passed to create_event method

### DIFF
--- a/nagios/datadog_checks/nagios/nagios.py
+++ b/nagios/datadog_checks/nagios/nagios.py
@@ -351,7 +351,7 @@ class NagiosEventLogTailer(NagiosTailer):
         event_payload = fields._asdict()
 
         msg_text = {
-            'event_type': event_payload.pop('event_type', None),
+            'event_type': event_type,
             'event_soft_hard': event_payload.pop('event_soft_hard', None),
             'check_name': event_payload.pop('check_name', None),
             'event_state': event_payload.pop('event_state', None),


### PR DESCRIPTION
# What does this PR do?

 use `event_type` passed to `create_event` method as the `msg_text['event_type']`.

### Motivation

1200-host-alert-event-incorrectly-shows-up-as-unknown-check

`event_payload.pop('event_soft_hard', None)` will always be null since none of the event types in `EVENT_FIELDS` contain an `event_type` field.

### Additional Notes



### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
