### PR TITLE
Fix tests: wait for mysql-slave to be fully ready

### DIFF
--- a/mysql/tests/compose/mysql.yaml
+++ b/mysql/tests/compose/mysql.yaml
@@ -9,6 +9,7 @@ services:
       - "${MYSQL_PORT}:3306"
 
   mysql-slave:
+    container_name: mysql-slave
     image: "${MYSQL_DOCKER_REPO}:${MYSQL_VERSION}"
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=1

--- a/mysql/tests/compose/mysql8.yaml
+++ b/mysql/tests/compose/mysql8.yaml
@@ -15,6 +15,7 @@ services:
       - "${MYSQL_PORT}:3306"
 
   mysql-slave:
+    container_name: mysql-slave
     image: "${MYSQL_DOCKER_REPO}:${MYSQL_VERSION}"
     environment:
       - ALLOW_EMPTY_PASSWORD=yes

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -7,6 +7,7 @@ import pymysql
 import pytest
 
 from datadog_checks.dev import WaitFor, docker_run
+from datadog_checks.dev.conditions import CheckDockerLogs
 
 from . import common, tags
 
@@ -25,7 +26,12 @@ def dd_environment(instance_basic):
             'MYSQL_SLAVE_PORT': str(common.SLAVE_PORT),
             'WAIT_FOR_IT_SCRIPT_PATH': _wait_for_it_script(),
         },
-        conditions=[WaitFor(init_master, wait=2), WaitFor(init_slave, wait=2), populate_database],
+        conditions=[
+            WaitFor(init_master, wait=2),
+            WaitFor(init_slave, wait=2),
+            CheckDockerLogs('mysql-slave', "ready for connections"),
+            populate_database,
+        ],
     ):
         yield instance_basic
 


### PR DESCRIPTION
### What does this PR do?

mysql tests are a bit flaky on travis. It appeared to be related to how the tests wait for the slave container to be ready. With the mysql8 docker image, the server starts, shutdowns and then restart. The tests should wait for the restart to happen.

### Motivation

Flaky tests.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
