### PR TITLE
Change WMISampler class to create a single thread, owned by the object,

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -24,12 +24,12 @@ Original discussion thread: https://github.com/DataDog/dd-agent/issues/1952
 Credits to @TheCloudlessSky (https://github.com/TheCloudlessSky)
 """
 from copy import deepcopy
+from threading import Event, Thread
 
 import pythoncom
 import pywintypes
 from six import iteritems, string_types, with_metaclass
 from six.moves import zip
-from threading import Thread, Event
 from win32com.client import Dispatch
 
 from .counter_type import UndefinedCalculator, get_calculator, get_raw
@@ -105,7 +105,7 @@ class WMISampler(Thread):
         self._previous_sample = None
 
         # Sampling state
-        _sampling = False
+        self._sampling = False
 
         self.logger = logger
 
@@ -229,8 +229,10 @@ class WMISampler(Thread):
         """
         Compute new samples.
         """
+        self._sampling = True
         self._runSampleEvent.set()
         self._sampleComplete.wait()
+        self._sampling = False
 
     def __len__(self):
         """


### PR DESCRIPTION

### What does this PR do?

Changes the implementation behavior or the WMISampler class, used to do WMI requests.

Old version created a new thread for each request, which in turn required CoInitialize() on that
new thread.  This behavior apparently triggers a memory leak in win2016.

New implementation creates a single thread per WMISampler object instance.  That thread just waits to be signaled, and when it does, it runs the WMI query.  By doing this we 
- Ensure that the WMI queries for a given instance are always run on the same underlying win32 thread
- Ensure that CoInitialize only needs to be called once per instance (at the beginning of the thread).

### Motivation

Memory leak detected in agent core process


### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
