### PR TITLE
Run master branch nightly using Travis cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ env:
 stages:
   - name: test_changed
     if: ((type = pull_request) AND (NOT commit_message =~ /ci run all/))
-  - name: validate
-    if: ((branch = master) AND (type != pull_request))
   - name: test
     if: ((branch = master) AND (type = cron)) OR ((commit_message =~ /ci run all/) AND (type = pull_request))
 
@@ -65,7 +63,8 @@ jobs:
         - ddev test --cov
         - ddev env test
         - ddev test --bench || true
-    - stage: validate
+    - stage: test
+      env: CHECK=datadog_checks_base PYTHON3=true
       script:
         - ddev validate agent-reqs
         - ddev validate config
@@ -74,9 +73,6 @@ jobs:
         - ddev validate manifest --include-extras
         - ddev validate metadata
         - ddev validate service-checks
-    - stage: test
-      env: CHECK=datadog_checks_base PYTHON3=true
-      script:
         - travis_retry ddev test --cov ${CHECK}
         - ddev test ${CHECK} --bench || true
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,10 @@ env:
 stages:
   - name: test_changed
     if: ((type = pull_request) AND (NOT commit_message =~ /ci run all/))
+  - name: validate
+    if: ((branch = master) AND (type != pull_request))
   - name: test
-    if: ((branch = master) AND (type != pull_request)) OR ((commit_message =~ /ci run all/) AND (type = pull_request))
+    if: ((branch = master) AND (type = cron)) OR ((commit_message =~ /ci run all/) AND (type = pull_request))
 
 script:
   - ddev validate logos ${CHECK}
@@ -63,8 +65,7 @@ jobs:
         - ddev test --cov
         - ddev env test
         - ddev test --bench || true
-    - stage: test
-      env: CHECK=datadog_checks_base PYTHON3=true
+    - stage: validate
       script:
         - ddev validate agent-reqs
         - ddev validate config
@@ -73,6 +74,9 @@ jobs:
         - ddev validate manifest --include-extras
         - ddev validate metadata
         - ddev validate service-checks
+    - stage: test
+      env: CHECK=datadog_checks_base PYTHON3=true
+      script:
         - travis_retry ddev test --cov ${CHECK}
         - ddev test ${CHECK} --bench || true
     - stage: test


### PR DESCRIPTION
# What

Run all tests on daily basis instead of each time something is merged on master.

Change travis `test` condition + add cron to travis config (todo after the PR is merged):

![image](https://user-images.githubusercontent.com/49917914/60208809-3614f380-9827-11e9-990d-be0ca186657a.png)

Once this PR is merged we can schedule a cron at midnight CET time.

# Motivation

Running all test at each merge on master is costly and have low value.

Running it once a day should be enough.

Docs: https://docs.travis-ci.com/user/cron-jobs/