### PR TITLE
Add monotonic_counter support to go_expvar

### DIFF
--- a/go_expvar/datadog_checks/go_expvar/go_expvar.py
+++ b/go_expvar/datadog_checks/go_expvar/go_expvar.py
@@ -21,10 +21,16 @@ TAGS = "tags"
 GAUGE = "gauge"
 RATE = "rate"
 COUNTER = "counter"
+MONOTONIC_COUNTER = "monotonic_counter"
 DEFAULT_TYPE = GAUGE
 
 
-SUPPORTED_TYPES = {GAUGE: AgentCheck.gauge, RATE: AgentCheck.rate, COUNTER: AgentCheck.increment}
+SUPPORTED_TYPES = {
+    GAUGE: AgentCheck.gauge,
+    RATE: AgentCheck.rate,
+    COUNTER: AgentCheck.increment,
+    MONOTONIC_COUNTER: AgentCheck.monotonic_count
+}
 
 DEFAULT_METRIC_NAMESPACE = "go_expvar"
 

--- a/go_expvar/datadog_checks/go_expvar/go_expvar.py
+++ b/go_expvar/datadog_checks/go_expvar/go_expvar.py
@@ -29,7 +29,7 @@ SUPPORTED_TYPES = {
     GAUGE: AgentCheck.gauge,
     RATE: AgentCheck.rate,
     COUNTER: AgentCheck.increment,
-    MONOTONIC_COUNTER: AgentCheck.monotonic_count
+    MONOTONIC_COUNTER: AgentCheck.monotonic_count,
 }
 
 DEFAULT_METRIC_NAMESPACE = "go_expvar"


### PR DESCRIPTION
### What does this PR do?

Add support for monotonic_counters in the go_expvar check.

### Motivation

I need to consume monotonic_counters.

