### PR TITLE
Use MQCMD_INQUIRE_Q instead of queue.inquire

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -183,7 +183,10 @@ class IbmMqCheck(AgentCheck):
             metric_name = '{}.queue.{}'.format(self.METRIC_PREFIX, metric_suffix)
             if callable(mq_attr):
                 metric_value = mq_attr(queue_info)
-                self.gauge(metric_name, metric_value, tags=tags)
+                if metric_value is not None:
+                    self.gauge(metric_name, metric_value, tags=tags)
+                else:
+                    self.log.debug("Date for attribute %s not found for queue %s", metric_suffix, queue_name)
             else:
                 if mq_attr in queue_info:
                     metric_value = queue_info[mq_attr]

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -165,10 +165,7 @@ class IbmMqCheck(AgentCheck):
         Grab stats from queues
         """
         try:
-            args = {
-                pymqi.CMQC.MQCA_Q_NAME: ensure_bytes(queue_name),
-                pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_ALL,
-            }
+            args = {pymqi.CMQC.MQCA_Q_NAME: ensure_bytes(queue_name), pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_ALL}
             pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_INQUIRE_Q(args)
         except pymqi.MQMIError as e:

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -189,7 +189,7 @@ class IbmMqCheck(AgentCheck):
                     metric_value = queue_info[mq_attr]
                     self.gauge(metric_name, metric_value, tags=tags)
                 else:
-                    self.log.debug("Queue attribute `%s` not found for queue `%s`", mq_attr, queue_name)
+                    self.log.debug("Attribute %s (%s) not found for queue %s", metric_suffix, mq_attr, queue_name)
 
     def get_pcf_queue_metrics(self, queue_manager, queue_name, tags):
         try:

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -96,14 +96,12 @@ class IbmMqCheck(AgentCheck):
                         queue_tags.extend(q_tags)
 
                 try:
-                    queue = pymqi.Queue(queue_manager, ensure_bytes(queue_name))
-                    self.queue_stats(queue, queue_name, queue_tags)
+                    self.queue_stats(queue_manager, queue_name, queue_tags)
                     # some system queues don't have PCF metrics
                     # so we don't collect those metrics from those queues
                     if queue_name not in config.DISALLOWED_QUEUES:
                         self.get_pcf_queue_metrics(queue_manager, queue_name, queue_tags)
                     self.service_check(self.QUEUE_SERVICE_CHECK, AgentCheck.OK, queue_tags)
-                    queue.close()
                 except Exception as e:
                     self.warning('Cannot connect to queue {}: {}'.format(queue_name, e))
                     self.service_check(self.QUEUE_SERVICE_CHECK, AgentCheck.CRITICAL, queue_tags)
@@ -162,25 +160,36 @@ class IbmMqCheck(AgentCheck):
                 self.warning("Error getting queue manager stats: {}".format(e))
                 self.service_check(self.QUEUE_MANAGER_SERVICE_CHECK, AgentCheck.CRITICAL, tags)
 
-    def queue_stats(self, queue, queue_name, tags):
+    def queue_stats(self, queue_manager, queue_name, tags):
         """
         Grab stats from queues
         """
-        for mname, pymqi_value in iteritems(metrics.queue_metrics()):
-            try:
-                mname = '{}.queue.{}'.format(self.METRIC_PREFIX, mname)
-                m = queue.inquire(pymqi_value)
-                self.gauge(mname, m, tags=tags)
-            except pymqi.Error as e:
-                self.warning("Error getting queue stats for {}: {}".format(queue_name, e))
+        try:
+            args = {
+                pymqi.CMQC.MQCA_Q_NAME: ensure_bytes(queue_name),
+                pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_ALL,
+            }
+            pcf = pymqi.PCFExecute(queue_manager)
+            response = pcf.MQCMD_INQUIRE_Q(args)
+        except pymqi.MQMIError as e:
+            self.warning("Error getting queue stats for {}: {}".format(queue_name, e))
+        else:
+            # Response is a list. It likely has only one member in it.
+            for queue_info in response:
+                self._submit_queue_stats(queue_info, queue_name, tags)
 
-        for mname, func in iteritems(metrics.queue_metrics_functions()):
-            try:
-                mname = '{}.queue.{}'.format(self.METRIC_PREFIX, mname)
-                m = func(queue)
-                self.gauge(mname, m, tags=tags)
-            except pymqi.Error as e:
-                self.warning("Error getting queue stats for {}: {}".format(queue_name, e))
+    def _submit_queue_stats(self, queue_info, queue_name, tags):
+        for metric_suffix, mq_attr in iteritems(metrics.queue_metrics()):
+            metric_name = '{}.queue.{}'.format(self.METRIC_PREFIX, metric_suffix)
+            if callable(mq_attr):
+                metric_value = mq_attr(queue_info)
+                self.gauge(metric_name, metric_value, tags=tags)
+            else:
+                if mq_attr in queue_info:
+                    metric_value = queue_info[mq_attr]
+                    self.gauge(metric_name, metric_value, tags=tags)
+                else:
+                    self.log.debug("Queue attribute `%s` not found for queue `%s`", mq_attr, queue_name)
 
     def get_pcf_queue_metrics(self, queue_manager, queue_name, tags):
         try:
@@ -192,7 +201,7 @@ class IbmMqCheck(AgentCheck):
             pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_INQUIRE_Q_STATUS(args)
         except pymqi.MQMIError as e:
-            self.warning("Error getting queue metrics for {}: {}".format(queue_name, e))
+            self.warning("Error getting pcf queue stats for {}: {}".format(queue_name, e))
         else:
             # Response is a list. It likely has only one member in it.
             for queue_info in response:

--- a/ibm_mq/datadog_checks/ibm_mq/metrics.py
+++ b/ibm_mq/datadog_checks/ibm_mq/metrics.py
@@ -64,6 +64,9 @@ def channel_metrics():
 
 
 def depth_percent(queue_info):
+    if pymqi.CMQC.MQIA_CURRENT_Q_DEPTH not in queue_info or pymqi.CMQC.MQIA_MAX_Q_DEPTH not in queue_info:
+        return None
+
     depth_current = queue_info[pymqi.CMQC.MQIA_CURRENT_Q_DEPTH]
     depth_max = queue_info[pymqi.CMQC.MQIA_MAX_Q_DEPTH]
 

--- a/ibm_mq/datadog_checks/ibm_mq/metrics.py
+++ b/ibm_mq/datadog_checks/ibm_mq/metrics.py
@@ -40,6 +40,7 @@ def queue_metrics():
         'retention_interval': pymqi.CMQC.MQIA_RETENTION_INTERVAL,
         'open_output_count': pymqi.CMQC.MQIA_OPEN_OUTPUT_COUNT,
         'trigger_type': pymqi.CMQC.MQIA_TRIGGER_TYPE,
+        'depth_percent': depth_percent,
     }
 
 
@@ -62,15 +63,11 @@ def channel_metrics():
     }
 
 
-def depth_percent(queue):
-    depth_current = queue.inquire(queue_metrics()['depth_current'])
-    depth_max = queue.inquire(queue_metrics()['depth_max'])
+def depth_percent(queue_info):
+    depth_current = queue_info[pymqi.CMQC.MQIA_CURRENT_Q_DEPTH]
+    depth_max = queue_info[pymqi.CMQC.MQIA_MAX_Q_DEPTH]
 
     depth_fraction = depth_current / depth_max
     depth_percent = depth_fraction * 100
 
     return depth_percent
-
-
-def queue_metrics_functions():
-    return {'depth_percent': depth_percent}


### PR DESCRIPTION
### What does this PR do?


Since we added support for local queues, when a local queue is assigned to a cluster, the method `queue.inquire` will raise this warning: `WARNING: MQRC_SELECTOR_NOT_FOR_TYPE`

But using `MQCMD_INQUIRE_Q` does not have this issue. That will also avoid calling the IBM MQ server only once instead of once per attribute we want to get.

### Motivation


### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
