### PR TITLE
Add metric_to_check

### DIFF
--- a/kube_proxy/manifest.json
+++ b/kube_proxy/manifest.json
@@ -10,6 +10,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "kubeproxy.",
+  "metric_to_check": "kubeproxy.cpu.time",
   "name": "kube_proxy",
   "public_title": "Datadog-Kube Proxy Integration",
   "short_description": "kube_proxy description.",


### PR DESCRIPTION
### What does this PR do?

Add the `metric_to_check` to `kube_proxy` to have this integration shown as `installed` when it is.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
