### PR TITLE
Add metric_to_check

### DIFF
--- a/tcp_check/manifest.json
+++ b/tcp_check/manifest.json
@@ -14,6 +14,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "network.",
+  "metric_to_check": "network.tcp.can_connect",
   "name": "tcp_check",
   "public_title": "Datadog-TCP Check Integration",
   "short_description": "Monitor TCP connectivity to remote hosts.",


### PR DESCRIPTION
### What does this PR do?

Add the `metric_to_check` to `tcp_check` to have this integration shown as `installed` when it is.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
