### PR TITLE
Remove intg-tools-libs from checks base as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,7 @@ assets/               @DataDog/agent-integrations @DataDog/integrations-tools-an
 /openmetrics/              @DataDog/container-integrations @DataDog/agent-integrations
 
 # Checks base
-/datadog_checks_base/ @DataDog/agent-core @DataDog/agent-integrations @DataDog/integrations-tools-and-libraries @DataDog/container-integrations
+/datadog_checks_base/ @DataDog/agent-core @DataDog/agent-integrations @DataDog/container-integrations
 
 # To keep ProdSec up-to-date with changes to requirements.txt.
 requirements.in                                           @DataDog/prodsec


### PR DESCRIPTION
### What does this PR do?

Remove the intg-tools-libs team from codeowners

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
