### PR TITLE
Make the kubelet check resilient to the tagger returning None

### DIFF
--- a/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
@@ -90,7 +90,7 @@ class FargateCheck(AgentCheck):
         container_tags = {}
         for container in metadata['Containers']:
             c_id = container['DockerId']
-            tagger_tags = get_tags('docker://%s' % c_id, True)
+            tagger_tags = get_tags('docker://%s' % c_id, True) or []
 
             # Compatibility with previous versions of the check
             compat_tags = []

--- a/kubelet/datadog_checks/kubelet/cadvisor.py
+++ b/kubelet/datadog_checks/kubelet/cadvisor.py
@@ -169,7 +169,7 @@ class CadvisorScraper(object):
             # FIXME static pods don't have container statuses so we can't
             # get the container id with the scheme, assuming docker here
             tags = tags_for_docker(subcontainer_id, tagger.HIGH) or []
-            tags += tags_for_pod(pod_uid, tagger.HIGH)
+            tags += tags_for_pod(pod_uid, tagger.HIGH) or []
             tags.append("kube_container_name:%s" % k_container_name)
         else:  # Standard container
             cid = pod_list_utils.get_cid_by_name_tuple(

--- a/kubelet/datadog_checks/kubelet/cadvisor.py
+++ b/kubelet/datadog_checks/kubelet/cadvisor.py
@@ -164,11 +164,11 @@ class CadvisorScraper(object):
 
         # Let's see who we have here
         if is_pod:
-            tags = tags_for_pod(pod_uid, tagger.HIGH)
+            tags = tags_for_pod(pod_uid, tagger.HIGH) or []
         elif in_static_pod and k_container_name:
             # FIXME static pods don't have container statuses so we can't
             # get the container id with the scheme, assuming docker here
-            tags = tags_for_docker(subcontainer_id, tagger.HIGH)
+            tags = tags_for_docker(subcontainer_id, tagger.HIGH) or []
             tags += tags_for_pod(pod_uid, tagger.HIGH)
             tags.append("kube_container_name:%s" % k_container_name)
         else:  # Standard container

--- a/kubelet/datadog_checks/kubelet/cadvisor.py
+++ b/kubelet/datadog_checks/kubelet/cadvisor.py
@@ -164,12 +164,12 @@ class CadvisorScraper(object):
 
         # Let's see who we have here
         if is_pod:
-            tags = tags_for_pod(pod_uid, tagger.HIGH) or []
+            tags = tags_for_pod(pod_uid, tagger.HIGH)
         elif in_static_pod and k_container_name:
             # FIXME static pods don't have container statuses so we can't
             # get the container id with the scheme, assuming docker here
-            tags = tags_for_docker(subcontainer_id, tagger.HIGH) or []
-            tags += tags_for_pod(pod_uid, tagger.HIGH) or []
+            tags = tags_for_docker(subcontainer_id, tagger.HIGH)
+            tags += tags_for_pod(pod_uid, tagger.HIGH)
             tags.append("kube_container_name:%s" % k_container_name)
         else:  # Standard container
             cid = pod_list_utils.get_cid_by_name_tuple(
@@ -182,7 +182,7 @@ class CadvisorScraper(object):
             if pod_list_utils.is_excluded(cid):
                 self.log.debug("Filtering out " + cid)
                 return
-            tags = tagger.tag(cid, tagger.HIGH)
+            tags = tagger.tag(cid, tagger.HIGH) or []
 
         if not tags:
             self.log.debug("Subcontainer {} doesn't have tags, skipping.".format(subcontainer_id))

--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -27,7 +27,7 @@ def tags_for_pod(pod_id, cardinality):
     Queries the tagger for a given pod uid
     :return: string array, empty if pod not found
     """
-    return tagger.tag('kubernetes_pod://%s' % pod_id, cardinality)
+    return tagger.tag('kubernetes_pod://%s' % pod_id, cardinality) or []
 
 
 def tags_for_docker(cid, cardinality):
@@ -35,7 +35,7 @@ def tags_for_docker(cid, cardinality):
     Queries the tagger for a given container id
     :return: string array, empty if container not found
     """
-    return tagger.tag('docker://%s' % cid, cardinality)
+    return tagger.tag('docker://%s' % cid, cardinality) or []
 
 
 def get_pod_by_uid(uid, podlist):

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -416,7 +416,8 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
                 if self.pod_list_utils.is_excluded(cid, pod_uid):
                     continue
 
-                tags = tagger.tag('%s' % cid, tagger.HIGH) + instance_tags
+                tags = tagger.tag('%s' % cid, tagger.HIGH) or []
+                tags += instance_tags
 
                 try:
                     for resource, value_str in iteritems(ctr.get('resources', {}).get('requests', {})):
@@ -453,7 +454,8 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
                 if self.pod_list_utils.is_excluded(cid, pod_uid):
                     continue
 
-                tags = tagger.tag('%s' % cid, tagger.ORCHESTRATOR) + instance_tags
+                tags = tagger.tag('%s' % cid, tagger.ORCHESTRATOR) or []
+                tags += instance_tags
 
                 restart_count = ctr_status.get('restartCount', 0)
                 self.gauge(self.NAMESPACE + '.containers.restarts', restart_count, tags)

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -285,7 +285,7 @@ class CadvisorPrometheusScraperMixin(object):
             if self.pod_list_utils.is_excluded(c_id, pod_uid):
                 continue
 
-            tags = tagger.tag(c_id, tagger.HIGH)
+            tags = tagger.tag(c_id, tagger.HIGH) or []
             tags += scraper_config['custom_tags']
 
             # FIXME we are forced to do that because the Kubelet PodList isn't updated
@@ -324,7 +324,7 @@ class CadvisorPrometheusScraperMixin(object):
         for pod_uid, sample in iteritems(samples):
             if '.network.' in metric_name and self._is_pod_host_networked(pod_uid):
                 continue
-            tags = tagger.tag('kubernetes_pod://%s' % pod_uid, tagger.HIGH)
+            tags = tagger.tag('kubernetes_pod://%s' % pod_uid, tagger.HIGH) or []
             tags += scraper_config['custom_tags']
             for label in labels:
                 value = sample[self.SAMPLE_LABELS].get(label)
@@ -354,7 +354,7 @@ class CadvisorPrometheusScraperMixin(object):
             if self.pod_list_utils.is_excluded(c_id, pod_uid):
                 continue
 
-            tags = tagger.tag(c_id, tagger.HIGH)
+            tags = tagger.tag(c_id, tagger.HIGH) or []
             tags += scraper_config['custom_tags']
 
             # FIXME we are forced to do that because the Kubelet PodList isn't updated
@@ -393,7 +393,7 @@ class CadvisorPrometheusScraperMixin(object):
             if self.pod_list_utils.is_excluded(c_id, pod_uid):
                 continue
 
-            tags = tagger.tag(c_id, tagger.HIGH)
+            tags = tagger.tag(c_id, tagger.HIGH) or []
             tags += scraper_config['custom_tags']
 
             if m_name:

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -292,7 +292,7 @@ class CadvisorPrometheusScraperMixin(object):
             # for static pods, see https://github.com/kubernetes/kubernetes/pull/59948
             pod = self._get_pod_by_metric_label(sample[self.SAMPLE_LABELS])
             if pod is not None and is_static_pending_pod(pod):
-                tags += tagger.tag('kubernetes_pod://%s' % pod["metadata"]["uid"], tagger.HIGH)
+                tags += tagger.tag('kubernetes_pod://%s' % pod["metadata"]["uid"], tagger.HIGH) or []
                 tags += self._get_kube_container_name(sample[self.SAMPLE_LABELS])
                 tags = list(set(tags))
 
@@ -361,7 +361,7 @@ class CadvisorPrometheusScraperMixin(object):
             # for static pods, see https://github.com/kubernetes/kubernetes/pull/59948
             pod = self._get_pod_by_metric_label(sample[self.SAMPLE_LABELS])
             if pod is not None and is_static_pending_pod(pod):
-                tags += tagger.tag('kubernetes_pod://%s' % pod["metadata"]["uid"], tagger.HIGH)
+                tags += tagger.tag('kubernetes_pod://%s' % pod["metadata"]["uid"], tagger.HIGH) or []
                 tags += self._get_kube_container_name(sample[self.SAMPLE_LABELS])
                 tags = list(set(tags))
 


### PR DESCRIPTION
### What does this PR do?

Make the kubelet check resilient to the tagger returning None

### Motivation

Avoid `unsupported operand type(s) for +=: 'NoneType' and 'list'` error

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
