### PR TITLE
[documentation] adding h4s to the how to build an integration docs testing section

### DIFF
--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -145,6 +145,8 @@ There are two basic types of tests: unit tests for specific functionality, and i
 
 For more information, see the [Datadog Checks Dev documentation][8].
 
+#### Unit test
+
 The first part of the `check` method retrieves and verifies two pieces of information we need from the configuration file. This is a good candidate for a unit test. Open the file at `awesome/tests/test_awesome.py` and replace the contents with something like this:
 
 ```python
@@ -183,6 +185,8 @@ The scaffolding has already been set up to run all tests located in `awesome/tes
 ```
 ddev test awesome
 ```
+
+#### Basic integration test
 
 This test doesn't check our collection _logic_ though, so let's add an integration test. We use `docker` to spin up an Nginx container and let the check retrieve the welcome page. Create a compose file at `awesome/tests/docker-compose.yml` with the following contents:
 
@@ -227,6 +231,8 @@ def dd_environment():
 def instance():
     return INSTANCE.copy()
 ```
+
+#### Integration test
 
 Finally, add an integration test to our `awesome/tests/test_awesome.py` file:
 


### PR DESCRIPTION
### What does this PR do?

Adding h4s to the how to build an integration docs testing section.

### Motivation

So we can have direct links for the introduction to integrations workshop at DASH 
