### PR TITLE
Telemetry check's metrics

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -407,11 +407,11 @@ class OpenMetricsScraperMixin(object):
         # If targeted metric, store labels
         self._store_labels(metric, scraper_config)
 
-        self._send_telemetry_counter(self.TELEMETRY_COUNTER_METRICS_PROCESS_COUNT, 1, scraper_config)
-
         if metric.name in scraper_config['ignore_metrics']:
             self._send_telemetry_counter(self.TELEMETRY_COUNTER_METRICS_IGNORE_COUNT, 1, scraper_config)
             return  # Ignore the metric
+        else:
+            self._send_telemetry_counter(self.TELEMETRY_COUNTER_METRICS_PROCESS_COUNT, 1, scraper_config)
 
         if self._filter_metric(metric):
             return  # Ignore the metric

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -410,8 +410,8 @@ class OpenMetricsScraperMixin(object):
         if metric.name in scraper_config['ignore_metrics']:
             self._send_telemetry_counter(self.TELEMETRY_COUNTER_METRICS_IGNORE_COUNT, 1, scraper_config)
             return  # Ignore the metric
-        else:
-            self._send_telemetry_counter(self.TELEMETRY_COUNTER_METRICS_PROCESS_COUNT, 1, scraper_config)
+
+        self._send_telemetry_counter(self.TELEMETRY_COUNTER_METRICS_PROCESS_COUNT, 1, scraper_config)
 
         if self._filter_metric(metric):
             return  # Ignore the metric

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -244,7 +244,7 @@ class OpenMetricsScraperMixin(object):
         # The service account bearer token to be used for authentication
         config['_bearer_token'] = self._get_bearer_token(config['bearer_token_auth'], config['bearer_token_path'])
 
-        config['telemetry_enable'] = is_affirmative(instance.get('telemetry', default_instance.get('telemetry', False)))
+        config['telemetry'] = is_affirmative(instance.get('telemetry', default_instance.get('telemetry', False)))
 
         return config
 
@@ -332,7 +332,7 @@ class OpenMetricsScraperMixin(object):
         return '{}.{}.{}'.format(scraper_config['namespace'], 'telemetry', metric_name)
 
     def _send_telemetry_gauge(self, metric_name, val, scraper_config):
-        if scraper_config['telemetry_enable']:
+        if scraper_config['telemetry']:
             metric_name_with_namespace = self._telemetry_metric_name_with_namespace(metric_name, scraper_config)
             # Determine the tags to send
             custom_tags = scraper_config['custom_tags']
@@ -341,13 +341,13 @@ class OpenMetricsScraperMixin(object):
             self.gauge(metric_name_with_namespace, val, tags=tags)
 
     def _send_telemetry_counter(self, metric_name, val, scraper_config):
-        if scraper_config['telemetry_enable']:
+        if scraper_config['telemetry']:
             metric_name_with_namespace = self._telemetry_metric_name_with_namespace(metric_name, scraper_config)
             # Determine the tags to send
             custom_tags = scraper_config['custom_tags']
             tags = list(custom_tags)
             tags.extend(scraper_config['_metric_tags'])
-            self.count(metric_name_with_namespace, 1.0, tags=tags)
+            self.count(metric_name_with_namespace, val, tags=tags)
 
     def _store_labels(self, metric, scraper_config):
         # If targeted metric, store labels

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -31,6 +31,12 @@ class OpenMetricsScraperMixin(object):
     SAMPLE_LABELS = 1
     SAMPLE_VALUE = 2
 
+    TELEMETRY_GAUGE_MESSAGE_SIZE = "payload.size"
+    TELEMETRY_COUNTER_METRICS_BLACKLIST_COUNT = "metrics.blacklist.count"
+    TELEMETRY_COUNTER_METRICS_INPUT_COUNT = "metrics.input.count"
+    TELEMETRY_COUNTER_METRICS_IGNORE_COUNT = "metrics.ignored.count"
+    TELEMETRY_COUNTER_METRICS_PROCESS_COUNT = "metrics.processed.count"
+
     METRIC_TYPES = ['counter', 'gauge', 'summary', 'histogram']
 
     KUBERNETES_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
@@ -238,6 +244,8 @@ class OpenMetricsScraperMixin(object):
         # The service account bearer token to be used for authentication
         config['_bearer_token'] = self._get_bearer_token(config['bearer_token_auth'], config['bearer_token_path'])
 
+        config['telemetry_enable'] = is_affirmative(instance.get('telemetry', default_instance.get('telemetry', False)))
+
         return config
 
     def parse_metric_family(self, response, scraper_config):
@@ -252,6 +260,7 @@ class OpenMetricsScraperMixin(object):
             input_gen = self._text_filter_input(input_gen, scraper_config)
 
         for metric in text_fd_to_metric_families(input_gen):
+            self._send_telemetry_counter(self.TELEMETRY_COUNTER_METRICS_INPUT_COUNT, 1, scraper_config)
             metric.type = scraper_config['type_overrides'].get(metric.name, metric.type)
             if metric.type not in self.METRIC_TYPES:
                 continue
@@ -269,6 +278,7 @@ class OpenMetricsScraperMixin(object):
         for line in input_gen:
             for item in scraper_config['_text_filter_blacklist']:
                 if item in line:
+                    self._send_telemetry_counter(self.TELEMETRY_COUNTER_METRICS_BLACKLIST_COUNT, 1, scraper_config)
                     break
             else:
                 # No blacklist matches, passing the line through
@@ -283,6 +293,7 @@ class OpenMetricsScraperMixin(object):
         Poll the data from prometheus and return the metrics as a generator.
         """
         response = self.poll(scraper_config)
+        self._send_telemetry_gauge(self.TELEMETRY_GAUGE_MESSAGE_SIZE, len(response.content), scraper_config)
         try:
             # no dry run if no label joins
             if not scraper_config['label_joins']:
@@ -316,6 +327,27 @@ class OpenMetricsScraperMixin(object):
         """
         for metric in self.scrape_metrics(scraper_config):
             self.process_metric(metric, scraper_config, metric_transformers=metric_transformers)
+
+    def _telemetry_metric_name_with_namespace(self, metric_name, scraper_config):
+        return '{}.{}.{}'.format(scraper_config['namespace'], 'telemetry', metric_name)
+
+    def _send_telemetry_gauge(self, metric_name, val, scraper_config):
+        if scraper_config['telemetry_enable']:
+            metric_name_with_namespace = self._telemetry_metric_name_with_namespace(metric_name, scraper_config)
+            # Determine the tags to send
+            custom_tags = scraper_config['custom_tags']
+            tags = list(custom_tags)
+            tags.extend(scraper_config['_metric_tags'])
+            self.gauge(metric_name_with_namespace, val, tags=tags)
+
+    def _send_telemetry_counter(self, metric_name, val, scraper_config):
+        if scraper_config['telemetry_enable']:
+            metric_name_with_namespace = self._telemetry_metric_name_with_namespace(metric_name, scraper_config)
+            # Determine the tags to send
+            custom_tags = scraper_config['custom_tags']
+            tags = list(custom_tags)
+            tags.extend(scraper_config['_metric_tags'])
+            self.count(metric_name_with_namespace, 1.0, tags=tags)
 
     def _store_labels(self, metric, scraper_config):
         # If targeted metric, store labels
@@ -375,7 +407,10 @@ class OpenMetricsScraperMixin(object):
         # If targeted metric, store labels
         self._store_labels(metric, scraper_config)
 
+        self._send_telemetry_counter(self.TELEMETRY_COUNTER_METRICS_PROCESS_COUNT, 1, scraper_config)
+
         if metric.name in scraper_config['ignore_metrics']:
+            self._send_telemetry_counter(self.TELEMETRY_COUNTER_METRICS_IGNORE_COUNT, 1, scraper_config)
             return  # Ignore the metric
 
         if self._filter_metric(metric):

--- a/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
@@ -47,3 +47,10 @@ instances:
     ## Set a timeout for the prometheus query.
     #
     # prometheus_timeout: 10
+
+    ## @param telemetry_enable - boolean - optional - default: false
+    ## To enable the telemetry check's metrics,  you must set this parameter to true.
+    ## It will generate useful internal check metrics: message payload size, the number
+    ## of metrics received, processed, ignored....
+    #
+    # telemetry_enable: false

--- a/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
@@ -52,5 +52,6 @@ instances:
     ## To enable the telemetry check's metrics,  you must set this parameter to true.
     ## It will generate useful internal check metrics: message payload size, the number
     ## of metrics received, processed, ignored....
+    ## Metrics can be found under `kubernetes_state.telemetry`
     #
     # telemetry_enable: false

--- a/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
@@ -48,10 +48,10 @@ instances:
     #
     # prometheus_timeout: 10
 
-    ## @param telemetry_enable - boolean - optional - default: false
+    ## @param telemetry - boolean - optional - default: false
     ## To enable the telemetry check's metrics,  you must set this parameter to true.
     ## It will generate useful internal check metrics: message payload size, the number
     ## of metrics received, processed, ignored....
     ## Metrics can be found under `kubernetes_state.telemetry`
     #
-    # telemetry_enable: false
+    # telemetry: false

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -395,6 +395,7 @@ def test_telemetry(aggregator, instance, check):
     for _ in range(2):
         check.check(instance)
     aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=87416.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=230.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=154.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=230.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.blacklist.count', tags=['optional:tag1'], value=24.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.ignored.count', tags=['optional:tag1'], value=76.0)


### PR DESCRIPTION
### What does this PR do?

Add telemetry check's metrics in `kubernetes_state`
User can activate by adding the option `telemetry_enable` in the check configuration

implementation was mainly done in `OpenMetricsScraperMixin` so any other `openmetrics` checks can benefit from it. 
 
### Motivation

The `kubernetes_state` check was missing internal metrics (telemetry) for performance investigation.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
