### PR TITLE
fix naming of kubernetes metrics server

### DIFF
--- a/kube_metrics_server/assets/service_checks.json
+++ b/kube_metrics_server/assets/service_checks.json
@@ -5,7 +5,7 @@
         "check": "kube_metrics_server.prometheus.health",
         "statuses": ["ok", "critical"],
         "groups": ["host", "endpoint"],
-        "name": "Kube Metrics Server prometheus health",
+        "name": "Kubernetes Metrics Server prometheus health",
         "description": "Returns `CRITICAL` if the check cannot access the metrics endpoint."
     }
 ]

--- a/kube_metrics_server/manifest.json
+++ b/kube_metrics_server/manifest.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "Kube Metrics Server",
+  "display_name": "Kubernetes Metrics Server",
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "name": "kube_metrics_server",

--- a/kube_metrics_server/manifest.json
+++ b/kube_metrics_server/manifest.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "Kube metrics server",
+  "display_name": "Kube Metrics Server",
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "name": "kube_metrics_server",

--- a/kube_metrics_server/setup.py
+++ b/kube_metrics_server/setup.py
@@ -24,7 +24,7 @@ CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 setup(
     name='datadog-kube_metrics_server',
     version=ABOUT['__version__'],
-    description='The Kube_metrics_server check',
+    description='The Kubernetes Metrics Server check',
     long_description=long_description,
     long_description_content_type='text/markdown',
     keywords='datadog agent kube_metrics_server check',


### PR DESCRIPTION
### What does this PR do?

Small copy change to fix the text of the integration for Kubernetes Metrics Server, since the tile is mistyped