### PR TITLE
Dont set proc 1, not available in /host/proc/ on containers

### DIFF
--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -290,3 +290,21 @@ def test_parse_protocol_psutil(aggregator, check):
     conn.family = socket.AF_INET
     protocol = check._parse_protocol_psutil(conn)
     assert protocol == 'udp4'
+
+
+@mock.patch('datadog_checks.network.network.Platform.is_containerized', return_value=True)
+def test_standard_proc_location(aggregator, check):
+    proc_location = check._append_proc_1("/proc")
+    assert proc_location == "/proc"
+
+
+@mock.patch('datadog_checks.network.network.Platform.is_containerized', return_value=True)
+def test_non_standard_proc_location(aggregator, check):
+    proc_location = check._append_proc_1("/home/proc")
+    assert proc_location == "/home/proc/1"
+
+
+@mock.patch('datadog_checks.network.network.Platform.is_containerized', return_value=True)
+def test_host_network_standard_proc_location(aggregator, check):
+    proc_location = check._append_proc_1("/host/proc")
+    assert proc_location == "/host/proc"


### PR DESCRIPTION
### What does this PR do?

/host/proc/1/ <--- doesn't exist in Docker containers. 

code will append proc 1 if proc_location is not "/proc" but we use host level networking so "/host/proc" is mounted. We need to take this into account and not append the proc 1 if it is "/host/proc" as well.

### Motivation

Network plugin not working on k8s 


### Additional Notes

Snippet of logs

```
sample:  system.net.conntrack.count :  923  for hostname:    tags:  []
 datadog [ AGENT ] 2019-06-25 02:04:46 UTC | DEBUG | (pkg/collector/py/datadog_agent.go:152 in LogMessage) | (network.py:463) | Unable to read /host/proc/1/sys/net/nf_conntrack_max. Skipping nf_conntrack_max metrics pull.
```

relates to https://github.com/DataDog/integrations-core/issues/1131


### Review checklist (to be filled by reviewers)

- [ X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
