### PR TITLE
Update wording on installing extras in ddev create command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -52,14 +52,16 @@ def construct_template_fields(integration_name, repo_choice, **kwargs):
         email = email_packages = 'friend@datadog.community'
         install_info = (
             'To install the {integration_name} check on your host:\n\n'
-            '    1. Install the [developer toolkit]'
+            '1. Install the [developer toolkit]'
             '(https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit)'
             ' on any machine.\n'
-            '    2. Run ddev release build {integration_name} to build the package.\n'
-            '    3. [Download the Datadog Agent](https://app.datadoghq.com/account/settings#agent).\n'
-            '    4. Upload the build artifact to any host with an Agent and'
-            'run datadog-agent integration install -w path/to/{integration_name}/dist/<ARTIFACT_NAME>.whl.\n'
-            .format(integration_name=integration_name)
+            '2. Run ddev release build {normalized_integration_name} to build the package.\n'
+            '3. [Download the Datadog Agent](https://app.datadoghq.com/account/settings#agent).\n'
+            '4. Upload the build artifact to any host with an Agent and'
+            'run datadog-agent integration install -w'
+            ' path/to/{normalized_integration_name}/dist/<ARTIFACT_NAME>.whl.\n'.format(
+                integration_name=integration_name, normalized_integration_name=normalized_integration_name
+            )
         )
         license_header = ''
         support_type = 'contrib'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -55,11 +55,11 @@ def construct_template_fields(integration_name, repo_choice, **kwargs):
             '1. Install the [developer toolkit]'
             '(https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit)'
             ' on any machine.\n'
-            '2. Run ddev release build {normalized_integration_name} to build the package.\n'
+            '2. Run `ddev release build {normalized_integration_name}` to build the package.\n'
             '3. [Download the Datadog Agent](https://app.datadoghq.com/account/settings#agent).\n'
             '4. Upload the build artifact to any host with an Agent and'
-            'run datadog-agent integration install -w'
-            ' path/to/{normalized_integration_name}/dist/<ARTIFACT_NAME>.whl.\n'.format(
+            'run `datadog-agent integration install -w'
+            ' path/to/{normalized_integration_name}/dist/<ARTIFACT_NAME>.whl`.'.format(
                 integration_name=integration_name, normalized_integration_name=normalized_integration_name
             )
         )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -52,9 +52,10 @@ def construct_template_fields(integration_name, repo_choice, **kwargs):
         email = email_packages = 'friend@datadog.community'
         install_info = (
             'To install the {integration_name} check on your host:\n\n'
-            '    1. Install the [developer toolkit](https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit)'
+            '    1. Install the [developer toolkit]'
+            '(https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit)'
             ' on any machine.\n'
-            '    2. Run ddev release build {integration_name} to build the package.\n'.format(integration_name=integration_name)
+            '    2. Run ddev release build {integration_name} to build the package.\n'
             '    3. [Download the Datadog Agent](https://app.datadoghq.com/account/settings#agent).\n'
             '    4. Upload the build artifact to any host with an Agent and'
             'run datadog-agent integration install -w path/to/{integration_name}/dist/<ARTIFACT_NAME>.whl.\n'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -52,11 +52,12 @@ def construct_template_fields(integration_name, repo_choice, **kwargs):
         email = email_packages = 'friend@datadog.community'
         install_info = (
             'To install the {integration_name} check on your host:\n\n'
-            '    1. Install the developer toolkit on any machine.\n'
+            '    1. Install the [developer toolkit](https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit)'
+            ' on any machine.\n'
             '    2. Run ddev release build aqua to build the package.\n'
-            '    3. Download the Datadog Agent.\n'
+            '    3. [Download the Datadog Agent](https://app.datadoghq.com/account/settings#agent).\n'
             '    4. Upload the build artifact to any host with an Agent and'
-            'run datadog-agent integration install -w path/to/{integration_name}}/dist/<ARTIFACT_NAME>.whl.\n'
+            'run datadog-agent integration install -w path/to/{integration_name}/dist/<ARTIFACT_NAME>.whl.\n'
             .format(integration_name=integration_name)
         )
         license_header = ''

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -56,7 +56,7 @@ def construct_template_fields(integration_name, repo_choice, **kwargs):
             '    2. Run ddev release build aqua to build the package.\n'
             '    3. Download the Datadog Agent.\n'
             '    4. Upload the build artifact to any host with an Agent and'
-            'run datadog-agent integration install -w path/to/aqua/dist/<ARTIFACT_NAME>.whl.\n'
+            'run datadog-agent integration install -w path/to/{integration_name}}/dist/<ARTIFACT_NAME>.whl.\n'
             .format(integration_name=integration_name)
         )
         license_header = ''

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -54,7 +54,7 @@ def construct_template_fields(integration_name, repo_choice, **kwargs):
             'To install the {integration_name} check on your host:\n\n'
             '    1. Install the [developer toolkit](https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit)'
             ' on any machine.\n'
-            '    2. Run ddev release build aqua to build the package.\n'
+            '    2. Run ddev release build {integration_name} to build the package.\n'.format(integration_name=integration_name)
             '    3. [Download the Datadog Agent](https://app.datadoghq.com/account/settings#agent).\n'
             '    4. Upload the build artifact to any host with an Agent and'
             'run datadog-agent integration install -w path/to/{integration_name}/dist/<ARTIFACT_NAME>.whl.\n'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -51,8 +51,13 @@ def construct_template_fields(integration_name, repo_choice, **kwargs):
         author = 'U.N. Owen'
         email = email_packages = 'friend@datadog.community'
         install_info = (
-            'The {} check is not included in the [Datadog Agent][2] package, so it must\n'
-            'be installed manually.'.format(integration_name)
+            'To install the {integration_name} check on your host:\n\n'
+            '    1. Install the developer toolkit on any machine.\n'
+            '    2. Run ddev release build aqua to build the package.\n'
+            '    3. Download the Datadog Agent.\n'
+            '    4. Upload the build artifact to any host with an Agent and'
+            'run datadog-agent integration install -w path/to/aqua/dist/<ARTIFACT_NAME>.whl.\n'
+            .format(integration_name=integration_name)
         )
         license_header = ''
         support_type = 'contrib'


### PR DESCRIPTION
### What does this PR do?

Updates the wording of how to install an integration extra within the `ddev create` command. 

### Motivation

The existing instruction was out of date, this change brings it more in line with whats currently in the README's of integrations-extras. 

See [Aqua](https://github.com/DataDog/integrations-extras/tree/master/aqua) as an example

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
