### PR TITLE
Openstack: introduce artificial metric in controller

### DIFF
--- a/openstack_controller/README.md
+++ b/openstack_controller/README.md
@@ -35,11 +35,29 @@ The openstack_controller integration is designed to collect information from all
 
 ### Metrics
 
-Openstack_controller does not include any metrics.
+See [metadata.csv][6] for a list of metrics provided by this integration.
 
 ### Service Checks
+**openstack.neutron.api.up**
 
-Openstack_controller does not include any service checks.
+Returns `CRITICAL` if the Agent is unable to query the Neutron API, `UNKNOWN` if there is an issue with the Keystone API. Returns `OK` otherwise.
+
+**openstack.nova.api.up**
+
+Returns `CRITICAL` if the Agent is unable to query the Nova API, `UNKNOWN` if there is an issue with the Keystone API. Returns `OK` otherwise.
+
+**openstack.keystone.api.up**
+
+Returns `CRITICAL` if the Agent is unable to query the Keystone API. Returns `OK` otherwise.
+
+**openstack.nova.hypervisor.up**
+
+Returns `UNKNOWN` if the Agent is unable to get the Hypervisor state, `CRITICAL` if the Hypervisor is down. Returns `OK` otherwise.
+
+**openstack.neutron.network.up**
+
+Returns `UNKNOWN` if the Agent is unable to get the Network state, `CRITICAL` if the Network is down. Returns `OK` otherwise.
+
 
 ### Events
 
@@ -54,3 +72,5 @@ Need help? Contact [Datadog support][5].
 [3]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#start-stop-and-restart-the-agent
 [4]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
 [5]: https://docs.datadoghq.com/help
+[6]: https://github.com/DataDog/integrations-core/blob/master/openstack_controller/metadata.csv
+

--- a/openstack_controller/README.md
+++ b/openstack_controller/README.md
@@ -56,7 +56,7 @@ Returns `UNKNOWN` if the Agent is unable to get the Hypervisor state, `CRITICAL`
 
 **openstack.neutron.network.up**
 
-Returns `UNKNOWN` if the Agent is unable to get the Network state, `CRITICAL` if the Network is down. Returns `OK` otherwise.
+Returns `CRITICAL` if the Network is down. Returns `OK` otherwise.
 
 
 ### Events

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -708,6 +708,8 @@ class OpenStackControllerCheck(AgentCheck):
             self.log.debug("Running check with credentials: \n")
 
             self._send_api_service_checks(keystone_server_url, custom_tags)
+            # Artificial metric introduced to distinguish between old and new openstack integrations
+            self.gauge("openstack.controller", 1)
 
             # List projects and filter them
             # TODO: NOTE: During authentication we use /v3/auth/projects and here we use /v3/projects.

--- a/openstack_controller/manifest.json
+++ b/openstack_controller/manifest.json
@@ -4,7 +4,7 @@
   "manifest_version": "1.0.0",
   "name": "openstack_controller",
   "metric_prefix": "openstack.",
-  "metric_to_check": "openstack.nova.limits.max_total_cores",
+  "metric_to_check": "openstack.controller",
   "creates_events": false,
   "short_description": "Track hypervisor and VM-level resource usage, plus Neutron metrics.",
   "guid": "49979592-9096-460a-b086-f173f26c6626",

--- a/openstack_controller/tests/test_end_to_end.py
+++ b/openstack_controller/tests/test_end_to_end.py
@@ -7116,6 +7116,10 @@ def test_scenario(make_request, aggregator):
                     'project_name:admin',
                 ],
                 hostname='',
+            ),
+            aggregator.assert_metric(
+                'openstack.controller',
+                value=1
             )
 
         # Assert coverage for this check on this instance

--- a/openstack_controller/tests/test_end_to_end.py
+++ b/openstack_controller/tests/test_end_to_end.py
@@ -7117,10 +7117,7 @@ def test_scenario(make_request, aggregator):
                 ],
                 hostname='',
             ),
-            aggregator.assert_metric(
-                'openstack.controller',
-                value=1
-            )
+            aggregator.assert_metric('openstack.controller', value=1)
 
         # Assert coverage for this check on this instance
         aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

To be able to include a tile for openstack_controller we need to be able to distinguish it from open sack with some unique metric. There is not an already existing one that is always there so we are introducing an artificial one. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
