### PR TITLE
Avoid WMISampler inheriting from Thread

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -146,7 +146,8 @@ class WMISampler(object):
         self._runSampleEvent = Event()
         self._sampleCompleteEvent = Event()
 
-        thread = Thread(target=self._query_sample_loop, name=class_name, daemon=True)
+        thread = Thread(target=self._query_sample_loop, name=class_name)
+        thread.daemon = True
         thread.start()
 
     def _query_sample_loop(self):

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -73,7 +73,7 @@ class ProviderArchitecture(with_metaclass(ProviderArchitectureMeta, object)):
     _AVAILABLE_PROVIDER_ARCHITECTURES = frozenset([DEFAULT, _32BIT, _64BIT])
 
 
-class WMISampler(Thread):
+class WMISampler(object):
     """
     WMI Sampler.
     """
@@ -92,7 +92,6 @@ class WMISampler(Thread):
         and_props=None,
         timeout_duration=10,
     ):
-        Thread.__init__(self)
         # Properties
         self._provider = None
         self._formatted_filters = None
@@ -146,11 +145,11 @@ class WMISampler(Thread):
 
         self._runSampleEvent = Event()
         self._sampleComplete = Event()
-        self.setDaemon(True)
 
-        self.start()
+        thread = Thread(target=self.query_sample, name=class_name, daemon=True)
+        thread.start()
 
-    def run(self):
+    def query_sample(self):
         try:
             pythoncom.CoInitialize()
         except Exception as e:
@@ -281,13 +280,6 @@ class WMISampler(Thread):
         Equality operator is based on the current sample.
         """
         return self._current_sample == other
-
-    def __hash__(self):
-        """
-        Since we inherit from Thread.
-        We need to provide __hash__ method (seems due to Thread using weakrefset internally).
-        """
-        return hash(id(self))
 
     def __str__(self):
         """

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -144,12 +144,12 @@ class WMISampler(object):
         self._timeout_duration = timeout_duration
 
         self._runSampleEvent = Event()
-        self._sampleComplete = Event()
+        self._sampleCompleteEvent = Event()
 
-        thread = Thread(target=self.query_sample, name=class_name, daemon=True)
+        thread = Thread(target=self._query_sample_loop, name=class_name, daemon=True)
         thread.start()
 
-    def query_sample(self):
+    def _query_sample_loop(self):
         try:
             pythoncom.CoInitialize()
         except Exception as e:
@@ -164,7 +164,7 @@ class WMISampler(object):
 
             self._previous_sample = self._current_sample
             self._current_sample = self._query()
-            self._sampleComplete.set()
+            self._sampleCompleteEvent.set()
 
     @property
     def provider(self):
@@ -231,8 +231,8 @@ class WMISampler(object):
         """
         self._sampling = True
         self._runSampleEvent.set()
-        self._sampleComplete.wait()
-        self._sampleComplete.clear()
+        self._sampleCompleteEvent.wait()
+        self._sampleCompleteEvent.clear()
         self._sampling = False
 
     def __len__(self):

--- a/wmi_check/datadog_checks/wmi_check/wmi_check.py
+++ b/wmi_check/datadog_checks/wmi_check/wmi_check.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-# project
 from datadog_checks.checks.win.wmi import WinWMICheck
 from datadog_checks.utils.containers import hash_mutable
 from datadog_checks.utils.timeout import TimeoutException


### PR DESCRIPTION
### What does this PR do?

Avoid WMISampler inheriting from Thread.

Improvement to this PR: https://github.com/DataDog/integrations-core/pull/3987/files

Revert this PR: https://github.com/DataDog/integrations-core/pull/4043

### Motivation

No need to inherit Thread.

See also: https://github.com/DataDog/integrations-core/pull/3987#issuecomment-505983369

### Additional Notes

/

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
