### PR TITLE
Fix integration test

### DIFF
--- a/mesos_slave/tests/compose/docker-compose.yml
+++ b/mesos_slave/tests/compose/docker-compose.yml
@@ -26,7 +26,6 @@ services:
       - 5051:5051
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup
-      - /usr/local/bin/docker:/usr/bin/docker
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - zookeeper

--- a/mesos_slave/tests/test_check.py
+++ b/mesos_slave/tests/test_check.py
@@ -3,35 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from six import iteritems
 
-# TODO: Fix docker-compose.yml networking set up
-#
-# @pytest.mark.usefixtures('dd_environment')
-# def test_check(check, instance, aggregator):
-#     check.check(instance)
-#     metrics = {}
-#     for d in (
-#         check.SLAVE_TASKS_METRICS,
-#         check.SYSTEM_METRICS,
-#         check.SLAVE_RESOURCE_METRICS,
-#         check.SLAVE_EXECUTORS_METRICS,
-#         check.STATS_METRICS,
-#     ):
-#         metrics.update(d)
-
-#     for _, v in iteritems(check.TASK_METRICS):
-#         aggregator.assert_metric(v[0])
-#     for _, v in iteritems(metrics):
-#         aggregator.assert_metric(v[0])
-
-#     service_check_tags = [
-#         'instance:mytag1',
-#         'mesos_cluster:test',
-#         'mesos_node:slave',
-#         'mesos_pid:slave(1)@127.0.0.1:5051',
-#         'task_name:hello',
-#     ]
-#     aggregator.assert_service_check('hello.ok', tags=service_check_tags, count=1, status=check.OK)
-
 
 def test_fixtures(check_mock, instance, aggregator):
     check_mock.check(instance)

--- a/mesos_slave/tests/test_integration.py
+++ b/mesos_slave/tests/test_integration.py
@@ -1,0 +1,40 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import platform
+
+import pytest
+from six import iteritems
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.integration
+# Linux only: https://github.com/docker/for-mac/issues/1031
+@pytest.mark.skipif(platform.system() != 'Linux', reason="Only runs on Unix systems")
+@pytest.mark.usefixtures("dd_environment")
+def test_integration(check, instance, aggregator):
+    check.check(instance)
+    metrics = {}
+    for d in (
+        check.SLAVE_TASKS_METRICS,
+        check.SYSTEM_METRICS,
+        check.SLAVE_RESOURCE_METRICS,
+        check.SLAVE_EXECUTORS_METRICS,
+        check.STATS_METRICS,
+    ):
+        metrics.update(d)
+
+    for _, v in iteritems(check.TASK_METRICS):
+        aggregator.assert_metric(v[0])
+    for _, v in iteritems(metrics):
+        aggregator.assert_metric(v[0])
+
+    service_check_tags = [
+        'instance:mytag1',
+        'mesos_cluster:test',
+        'mesos_node:slave',
+        'mesos_pid:slave(1)@127.0.0.1:5051',
+        'task_name:hello',
+    ]
+    aggregator.assert_service_check('hello.ok', tags=service_check_tags, count=1, status=check.OK)

--- a/mesos_slave/tests/test_integration.py
+++ b/mesos_slave/tests/test_integration.py
@@ -6,8 +6,6 @@ import platform
 import pytest
 from six import iteritems
 
-pytestmark = pytest.mark.integration
-
 
 @pytest.mark.integration
 # Linux only: https://github.com/docker/for-mac/issues/1031
@@ -25,16 +23,9 @@ def test_integration(check, instance, aggregator):
     ):
         metrics.update(d)
 
-    for _, v in iteritems(check.TASK_METRICS):
-        aggregator.assert_metric(v[0])
     for _, v in iteritems(metrics):
         aggregator.assert_metric(v[0])
 
-    service_check_tags = [
-        'instance:mytag1',
-        'mesos_cluster:test',
-        'mesos_node:slave',
-        'mesos_pid:slave(1)@127.0.0.1:5051',
-        'task_name:hello',
-    ]
-    aggregator.assert_service_check('hello.ok', tags=service_check_tags, count=1, status=check.OK)
+    aggregator.assert_all_metrics_covered()
+
+    aggregator.assert_service_check('mesos_slave.can_connect', count=1, status=check.OK)

--- a/mesos_slave/tox.ini
+++ b/mesos_slave/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py37
 envlist =
-    py{27,37}
+    py{27,37}-{integration,unit}
 
 [testenv]
 dd_check_style = true
@@ -16,4 +16,5 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install -r requirements.in
-    pytest -v
+    unit: pytest -m"not integration" -v
+    integration: pytest -m"integration" -v


### PR DESCRIPTION
### What does this PR do?

The integration test works only on linux due to `network_mode: host`.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
