### PR TITLE
Add support for /state endpoint

### DIFF
--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -145,7 +145,7 @@ class MesosSlave(AgentCheck):
         except Exception as e:
             msg = str(e)
             self.log.warning('Encounted error getting state at {}{}, message: {}'.format(url, endpoint, msg))
-        # version >= 1.8.0
+            # version >= 1.8.0
             endpoint = '/state'
             master_state = self._get_json(url + endpoint, timeout, verify, tags)
             if master_state is not None:

--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -101,7 +101,7 @@ class MesosSlave(AgentCheck):
             parsed_url = urlparse(url)
             ssl_verify = not _is_affirmative(instance.get('disable_ssl_validation', False))
             if not ssl_verify and parsed_url.scheme == 'https':
-                self.log.warning('Skipping SSL cert validation for %s based on configuration.' % url)
+                self.log.warning('Skipping SSL cert validation for {0} based on configuration.'.format(url))
 
     def _get_json(self, url, timeout, verify, failure_expected=False, tags=None):
         tags = tags + ["url:%s" % url] if tags else ["url:%s" % url]
@@ -138,22 +138,21 @@ class MesosSlave(AgentCheck):
     def _get_state(self, url, timeout, verify, tags):
         try:
             # Mesos version >= 0.25
-            endpoint = '/state'
-            master_state = self._get_json(url + endpoint, timeout, verify, failure_expected=True, tags=tags)
+            endpoint = url + '/state'
+            master_state = self._get_json(endpoint, timeout, verify, failure_expected=True, tags=tags)
         except CheckException as e:
-            msg = str(e)
-            self.log.warning('Encounted error getting state at {}{}, message: {}'.format(url, endpoint, msg))
+            self.log.warning('Encountered error getting state at {0}, message: {1}'.format(endpoint, str(e)))
             # Mesos version < 0.25
-            endpoint = '/state.json'
-            master_state = self._get_json(url + endpoint, timeout, verify, tags=tags)
+            endpoint = url + '/state.json'
+            master_state = self._get_json(endpoint, timeout, verify, tags=tags)
         return master_state
 
     def _get_stats(self, url, timeout, verify, tags):
         if self.version >= [0, 22, 0]:
-            endpoint = '/metrics/snapshot'
+            endpoint = url + '/metrics/snapshot'
         else:
-            endpoint = '/stats.json'
-        return self._get_json(url + endpoint, timeout, verify, tags=tags)
+            endpoint = url + '/stats.json'
+        return self._get_json(endpoint, timeout, verify, tags=tags)
 
     def _get_constant_attributes(self, url, timeout, master_port, verify, tags):
         state_metrics = None

--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -144,7 +144,7 @@ class MesosSlave(AgentCheck):
                 self.version = list(map(int, master_state['version'].split('.')))
         except Exception as e:
             msg = str(e)
-            self.log.info('Encounted error getting state at {}{}, message: {}'.format(url, endpoint, msg))
+            self.log.warning('Encounted error getting state at {}{}, message: {}'.format(url, endpoint, msg))
         # version >= 1.8.0
             endpoint = '/state'
             master_state = self._get_json(url + endpoint, timeout, verify, tags)

--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -140,11 +140,15 @@ class MesosSlave(AgentCheck):
             # Mesos version >= 0.25
             endpoint = url + '/state'
             master_state = self._get_json(endpoint, timeout, verify, failure_expected=True, tags=tags)
-        except CheckException as e:
-            self.log.warning('Encountered error getting state at {0}, message: {1}'.format(endpoint, str(e)))
+        except CheckException:
             # Mesos version < 0.25
-            endpoint = url + '/state.json'
-            master_state = self._get_json(endpoint, timeout, verify, tags=tags)
+            old_endpoint = endpoint + '.json'
+            self.log.info(
+                'Unable to fetch state from {0}. Retrying with the deprecated endpoint: {1}.'.format(
+                    endpoint, old_endpoint
+                )
+            )
+            master_state = self._get_json(old_endpoint, timeout, verify, tags=tags)
         return master_state
 
     def _get_stats(self, url, timeout, verify, tags):

--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -136,8 +136,8 @@ class MesosSlave(AgentCheck):
         return r.json()
 
     def _get_state(self, url, timeout, verify, tags):
-        # version < 1.8.0
         try:
+            # version < 1.8.0
             endpoint = '/state.json'
             master_state = self._get_json(url + endpoint, timeout, verify, tags)
             if master_state is not None:

--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -124,7 +124,7 @@ class MesosSlave(AgentCheck):
             status = AgentCheck.CRITICAL
         finally:
             self.log.debug('Request to url : {0}, timeout: {1}, message: {2}'.format(url, timeout, msg))
-            self.send_service_check(url, r, status, failure_expected=failure_expected, tags=tags, message=msg)
+            self._send_service_check(url, r, status, failure_expected=failure_expected, tags=tags, message=msg)
         if r.encoding is None:
             r.encoding = 'UTF8'
 

--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -130,7 +130,7 @@ class MesosSlave(AgentCheck):
 
         return r.json()
 
-    def send_service_check(self, url, response, status, failure_expected=False, tags=None, message=None):
+    def _send_service_check(self, url, response, status, failure_expected=False, tags=None, message=None):
         if status is AgentCheck.CRITICAL and failure_expected:
             status = AgentCheck.OK
             message = "Got %s when hitting %s" % (response.status_code, url)


### PR DESCRIPTION
### What does this PR do?

Starting from Mesos 1.8.0, the previously deprecated HTTP endpoints with `.json` suffix have been dropped: https://issues.apache.org/jira/browse/MESOS-4509.

Updates check to use the `/state` endpoint and maintain previous logic for getting state from `/state.json` for versions < 0.25.

### Motivation

Community PR: https://github.com/andersenleo/integrations-core/pull/1

### Additional Notes

Deprecation of `/state.json` since Mesos v0.25.x: 
https://github.com/apache/mesos/blob/master/docs/upgrades.md#upgrading-from-024x-to-025x

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
