### PR TITLE
Add metric_to_check to CoreDNS manifest.json

### DIFF
--- a/coredns/manifest.json
+++ b/coredns/manifest.json
@@ -3,6 +3,7 @@
   "manifest_version": "1.0.0",
   "name": "coredns",
   "metric_prefix": "coredns.",
+  "metric_to_check": "coredns.request_count",
   "display_name": "CoreDNS",
   "short_description": "CoreDNS collects DNS metrics in Kubernetes.",
   "support": "core",


### PR DESCRIPTION
This will allow automatic installation of the CoreDNS integration, as long as show "no-data" warning when the integration is installed but doesn't submit any metric.
This metric is one of the first metric made available by CoreDNS (see https://github.com/coredns/coredns/blame/8892a1b49042e4e9f9ca011fecee31bc367b0e53/middleware/prometheus/README.md) and should be emitted as long as the service works as expected. This makes this metric a great choice for the `metric_to_check`