### PR TITLE
Retrieve floating IPs from network quotas

### DIFF
--- a/openstack_controller/datadog_checks/openstack_controller/api.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api.py
@@ -212,10 +212,11 @@ class OpenstackSDKApi(AbstractApi):
 
         try:
             network_quotas = self.connection.get_network_quotas(project_id, details=True)
+        except Exception:
+            self.logger.exception('There was a problem getting network quotas')
+        else:
             project_limits['totalFloatingIpsUsed'] = network_quotas['floatingip']['used']
             project_limits['maxTotalFloatingIps'] = network_quotas['floatingip']['limit']
-        except Exception:
-            pass
 
         return project_limits
 
@@ -375,10 +376,11 @@ class SimpleApi(AbstractApi):
         try:
             url = '{}/{}/quotas/{}/details'.format(self.neutron_endpoint, DEFAULT_NEUTRON_API_VERSION, tenant_id)
             network_quotas = self._make_request(url, self.headers)
+        except Exception:
+            self.logger.exception('There was a problem getting network quotas')
+        else:
             limits['totalFloatingIpsUsed'] = network_quotas['quota']['floatingip']['used']
             limits['maxTotalFloatingIps'] = network_quotas['quota']['floatingip']['limit']
-        except Exception:
-            pass
 
         return limits
 

--- a/openstack_controller/tests/common.py
+++ b/openstack_controller/tests/common.py
@@ -335,7 +335,7 @@ EXAMPLE_GET_PROJECT_LIMITS_RETURN_VALUE = {
     "totalInstancesUsed": 0,
     "totalRAMUsed": 0,
     "totalSecurityGroupsUsed": 0,
-    "totalFloatingIpsUsed": 0,
+    "totalFloatingIpsUsed": 1,
     "totalServerGroupsUsed": 0,
 }
 

--- a/openstack_controller/tests/test_openstack_sdk_api.py
+++ b/openstack_controller/tests/test_openstack_sdk_api.py
@@ -314,6 +314,11 @@ class MockOpenstackConnection:
     def search_flavors(self, filters):
         return EXAMPLE_FLAVORS_VALUE
 
+    def get_network_quotas(self, project, details=False):
+        if not details:
+            return {}
+        return {'floatingip': {'used': 1, 'limit': 10}}
+
 
 def test_get_endpoint():
     api = OpenstackSDKApi(None)

--- a/openstack_controller/tests/test_simple_api.py
+++ b/openstack_controller/tests/test_simple_api.py
@@ -887,7 +887,7 @@ def test_get_server_diagnostics(aggregator):
         }
 
 
-def get_project_limits_response(url, headers, params=None, timeout=None):
+def get_project_limits_response():
     return json.loads(
         """{
         "limits": {
@@ -918,9 +918,64 @@ def get_project_limits_response(url, headers, params=None, timeout=None):
     )
 
 
+def get_network_quotas_response():
+    return json.loads(
+        """{
+          "quota": {
+            "subnet": {
+              "reserved": 0,
+              "used": 2,
+              "limit": 100
+            },
+            "network": {
+              "reserved": 0,
+              "used": 1,
+              "limit": 100
+            },
+            "floatingip": {
+              "reserved": 0,
+              "used": 1,
+              "limit": 10
+            },
+            "subnetpool": {
+              "reserved": 0,
+              "used": 0,
+              "limit": -1
+            },
+            "security_group_rule": {
+              "reserved": 0,
+              "used": 4,
+              "limit": 100
+            },
+            "security_group": {
+              "reserved": 0,
+              "used": 1,
+              "limit": 10
+            },
+            "router": {
+              "reserved": 0,
+              "used": 1,
+              "limit": 10
+            },
+            "rbac_policy": {
+              "reserved": 0,
+              "used": 0,
+              "limit": 10
+            },
+            "port": {
+              "reserved": 0,
+              "used": 3,
+              "limit": 500
+            }
+          }
+        }"""
+    )
+
+
 def test_get_project_limits(aggregator):
     with mock.patch(
-        'datadog_checks.openstack_controller.api.SimpleApi._make_request', side_effect=get_project_limits_response
+        'datadog_checks.openstack_controller.api.SimpleApi._make_request',
+        side_effect=[get_project_limits_response(), get_network_quotas_response()],
     ):
         api = SimpleApi(None, None)
         assert api.get_project_limits(None) == common.EXAMPLE_GET_PROJECT_LIMITS_RETURN_VALUE

--- a/openstack_controller/tox.ini
+++ b/openstack_controller/tox.ini
@@ -16,4 +16,4 @@ passenv =
     COMPOSE*
 commands =
     pip install -r requirements.in
-    pytest -v
+    pytest -v {posargs}


### PR DESCRIPTION
Calls the neutron endpoint to retrieve floating IP quotas, instead of
relying on the nova endpoint to return them. This ignore errors to falls
back on previous behavior.