### PR TITLE
Update metric type for JVM Metrics

### DIFF
--- a/ibm_was/datadog_checks/ibm_was/ibm_was.py
+++ b/ibm_was/datadog_checks/ibm_was/ibm_was.py
@@ -96,7 +96,7 @@ class IbmWasCheck(AgentCheck):
         metric_name = self.normalize(
             ensure_unicode(child.get('name')), prefix='{}.{}'.format(self.METRIC_PREFIX, prefix), fix_case=True
         )
-        
+
         # includes deprecated JVM metrics that were reporting as count instead of gauge
         self.metric_type_mapping[child.tag](metric_name, value, tags=tags)
 

--- a/ibm_was/datadog_checks/ibm_was/ibm_was.py
+++ b/ibm_was/datadog_checks/ibm_was/ibm_was.py
@@ -96,10 +96,14 @@ class IbmWasCheck(AgentCheck):
         metric_name = self.normalize(
             ensure_unicode(child.get('name')), prefix='{}.{}'.format(self.METRIC_PREFIX, prefix), fix_case=True
         )
+        
+        # includes deprecated JVM metrics that were reporting as count instead of gauge
+        self.metric_type_mapping[child.tag](metric_name, value, tags=tags)
+
+        # creates new VJM metrics correctly as gauges
         if prefix == "jvm":
-            self.gauge(metric_name, value, tags=tags)
-        else:
-            self.metric_type_mapping[child.tag](metric_name, value, tags=tags)
+            jvm_metric_name = "{}_gauge".format(metric_name)
+            self.gauge(jvm_metric_name, value, tags=tags)
 
     def make_request(self, instance, url, tags):
         try:

--- a/ibm_was/datadog_checks/ibm_was/ibm_was.py
+++ b/ibm_was/datadog_checks/ibm_was/ibm_was.py
@@ -100,7 +100,7 @@ class IbmWasCheck(AgentCheck):
         # includes deprecated JVM metrics that were reporting as count instead of gauge
         self.metric_type_mapping[child.tag](metric_name, value, tags=tags)
 
-        # creates new VJM metrics correctly as gauges
+        # creates new JVM metrics correctly as gauges
         if prefix == "jvm":
             jvm_metric_name = "{}_gauge".format(metric_name)
             self.gauge(jvm_metric_name, value, tags=tags)

--- a/ibm_was/datadog_checks/ibm_was/ibm_was.py
+++ b/ibm_was/datadog_checks/ibm_was/ibm_was.py
@@ -96,7 +96,10 @@ class IbmWasCheck(AgentCheck):
         metric_name = self.normalize(
             ensure_unicode(child.get('name')), prefix='{}.{}'.format(self.METRIC_PREFIX, prefix), fix_case=True
         )
-        self.metric_type_mapping[child.tag](metric_name, value, tags=tags)
+        if prefix == "jvm":
+            self.gauge(metric_name, value, tags=tags)
+        else:
+            self.metric_type_mapping[child.tag](metric_name, value, tags=tags)
 
     def make_request(self, instance, url, tags):
         try:

--- a/ibm_was/metadata.csv
+++ b/ibm_was/metadata.csv
@@ -1,53 +1,53 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 ibm_was.can_connect,gauge,,,,The ability of the integration to connect to the Perf Servlet to collect metrics,0,ibm_was,was can connect
-ibm_was.jdbc.create_count,count,,connection,,The total number of managed connections that were created since pool creation.,0,ibm_was,jdbc create count
-ibm_was.jdbc.close_count,count,,connection,,The total number of managed connections that were destroyed since pool creation.,0,ibm_was,jdbc close count
-ibm_was.jdbc.allocate_count,count,,connection,,The total number of managed connections that were allocated since pool creation.,0,ibm_was,jdbc allocated count
-ibm_was.jdbc.return_count,count,,connection,,The total number of managed connections that were returned since pool creation.,0,ibm_was,jdbc return count
+ibm_was.jdbc.create_count,gauge,,connection,,The total number of managed connections that were created since pool creation.,0,ibm_was,jdbc create count
+ibm_was.jdbc.close_count,gauge,,connection,,The total number of managed connections that were destroyed since pool creation.,0,ibm_was,jdbc close count
+ibm_was.jdbc.allocate_count,gauge,,connection,,The total number of managed connections that were allocated since pool creation.,0,ibm_was,jdbc allocated count
+ibm_was.jdbc.return_count,gauge,,connection,,The total number of managed connections that were returned since pool creation.,0,ibm_was,jdbc return count
 ibm_was.jdbc.pool_size,gauge,,,,The size of the connection pool.,0,ibm_was,jdbc pool size
 ibm_was.jdbc.free_pool_size,gauge,,connection,,The number of managed connections that are in the free pool.,0,ibm_was,jdbc free pool size
 ibm_was.jdbc.waiting_thread_count,gauge,,thread,,The number of threads that are currently waiting for a connection.,0,ibm_was,jdbc waiting thread count
-ibm_was.jdbc.fault_count,count,,,,"The total number of faults, such as timeouts, in the connection pool.",0,ibm_was,jdbc Fault Count
-ibm_was.jdbc.percent_used,gauge,,percent,,The percent of the pool that is in use.,0,ibm_was,jdbc percent used
-ibm_was.jdbc.percent_maxed,gauge,,percent,,The percent of the time that all connections are in use.,0,ibm_was,jdbc percent maxed
+ibm_was.jdbc.fault_count,gauge,,,,"The total number of faults, such as timeouts, in the connection pool.",0,ibm_was,jdbc Fault Count
+ibm_was.jdbc.percent_used,gauge,,,,The percent of the pool that is in use.,0,ibm_was,jdbc percent used
+ibm_was.jdbc.percent_maxed,gauge,,,,The percent of the time that all connections are in use.,0,ibm_was,jdbc percent maxed
 ibm_was.jdbc.use_time,gauge,,millisecond,,The average time in milliseconds that a connection is in use.,0,ibm_was,jdbc used time
 ibm_was.jdbc.wait_time,gauge,,millisecond,,The average waiting time in milliseconds until a connection is granted if a connection is not currently available.,0,ibm_was,jdbc wait time
-ibm_was.jdbc.managed_connection_count,count,,connection,,"The total number of managed connections in the free, shared, and unshared pools.",0,ibm_was,jdbc managed connection count
-ibm_was.jdbc.connection_handle_count,count,,connection,,The number of connections that are in use. Can include multiple connections that are shared from a single managed connection.,0,ibm_was,jdbc connection handle count
-ibm_was.jdbc.prep_stmt_cache_discard_count,count,,,,The total number of statements that are discarded by the least recently used (LRU) algorithm of the statement cache.,0,ibm_was,jdbc cache discard count
+ibm_was.jdbc.managed_connection_count,gauge,,connection,,"The total number of managed connections in the free, shared, and unshared pools.",0,ibm_was,jdbc managed connection count
+ibm_was.jdbc.connection_handle_count,gauge,,connection,,The number of connections that are in use. Can include multiple connections that are shared from a single managed connection.,0,ibm_was,jdbc connection handle count
+ibm_was.jdbc.prep_stmt_cache_discard_count,gauge,,,,The total number of statements that are discarded by the least recently used (LRU) algorithm of the statement cache.,0,ibm_was,jdbc cache discard count
 ibm_was.jdbc.jdbc_time,gauge,,millisecond,,"The average time in milliseconds spent running in the JDBC driver that includes time that is spent in the JDBC driver, network, and database.",0,ibm_was,jdbc time
-ibm_was.jvm.heap_size,count,,,,Deprecated use ibm_was.jvm.heap_size_gauge instead,0,ibm_was,jvm heap size
-ibm_was.jvm.free_memory,count,,,,Deprecated use ibm_was.jvm.free_memory_gauge instead,0,ibm_was,jvm free memory
-ibm_was.jvm.used_memory,count,,,,Deprecated use ibm_was.jvm.used_memory_gauge instead,0,ibm_was,jvm used memory
-ibm_was.jvm.up_time,count,,,,Deprecated use ibm_was.jvm.up_time_gauge instead,0,ibm_was,jvm uptime
-ibm_was.jvm.process_cpu_usage,count,,percent,,Deprecated use ibm_was.jvm.process_cpu_usage_gauge instead,0,ibm_was,jvm process cpu usage
-ibm_was.jvm.heap_size_gauge,gauge,,byte,,The total memory in the JVM run time,0,ibm_was,jvm heap size
-ibm_was.jvm.free_memory_gauge,gauge,,byte,,The free memory in the JVM run time,0,ibm_was,jvm free memory
+ibm_was.jvm.heap_size,gauge,,,,"Deprecated, use ibm_was.jvm.heap_size_gauge instead",0,ibm_was,jvm heap size
+ibm_was.jvm.free_memory,gauge,,,,"Deprecated, use ibm_was.jvm.free_memory_gauge instead",0,ibm_was,jvm free memory
+ibm_was.jvm.used_memory,gauge,,,,"Deprecated, use ibm_was.jvm.used_memory_gauge instead",0,ibm_was,jvm used memory
+ibm_was.jvm.up_time,gauge,,,,"Deprecated, use ibm_was.jvm.up_time_gauge instead",0,ibm_was,jvm uptime
+ibm_was.jvm.process_cpu_usage,gauge,,percent,,"Deprecated, use ibm_was.jvm.process_cpu_usage_gauge instead",0,ibm_was,jvm process cpu usage
+ibm_was.jvm.heap_size_gauge,gauge,,thread,,The total memory in the JVM run time,0,ibm_was,jvm heap size
+ibm_was.jvm.free_memory_gauge,gauge,,thread,,The free memory in the JVM run time,0,ibm_was,jvm free memory
 ibm_was.jvm.used_memory_gauge,gauge,,byte,,The used memory in the JVM run time,0,ibm_was,jvm used memory
 ibm_was.jvm.up_time_gauge,gauge,,second,,The amount of time that the JVM is running,0,ibm_was,jvm uptime
 ibm_was.jvm.process_cpu_usage_gauge,gauge,,percent,,The CPU Usage (in percent) of the Java virtual machine.,0,ibm_was,jvm process cpu usage
-ibm_was.thread_pools.create_count,count,,thread,,The total number of threads created,0,ibm_was,thread pools create count
-ibm_was.thread_pools.destroy_count,count,,thread,,The total number of threads destroyed,0,ibm_was,thread pools destroy count
+ibm_was.thread_pools.create_count,gauge,,thread,,The total number of threads created,0,ibm_was,thread pools create count
+ibm_was.thread_pools.destroy_count,gauge,,thread,,The total number of threads destroyed,0,ibm_was,thread pools destroy count
 ibm_was.thread_pools.active_count,gauge,,thread,,The number of concurrently active threads,0,ibm_was,thread pools active count
 ibm_was.thread_pools.pool_size,gauge,,thread,,The average number of threads in pool,0,ibm_was,thread pools size
 ibm_was.thread_pools.percent_maxed,gauge,,percent,,The average percent of the time that all threads are in use,0,ibm_was,thread pools percent max
-ibm_was.thread_pools.declaredthread_hung_count,count,,thread,,The number of threads declared hung,0,ibm_was,thread pools declared count
-ibm_was.thread_pools.cleared_thread_hang_count,count,,thread,,The number of thread hangs cleared,0,ibm_was,thread pools cleared
+ibm_was.thread_pools.declaredthread_hung_count,gague,,thread,,The number of threads declared hung,0,ibm_was,thread pools declared count
+ibm_was.thread_pools.cleared_thread_hang_count,gauge,,thread,,The number of thread hangs cleared,0,ibm_was,thread pools cleared
 ibm_was.thread_pools.concurrent_hung_thread_count,gauge,,thread,,The number of concurrently hung threads,0,ibm_was,thread pools concurrent hung
 ibm_was.thread_pools.active_time,gauge,,millisecond,,The average time in milliseconds the threads are in active state,0,ibm_was,thread pools active time
-ibm_was.servlet_session.create_count,count,,session,,The number of sessions that were created,0,ibm_was,servlet session create count
-ibm_was.servlet_session.invalidate_count,count,,session,,The number of sessions that were invalidated,0,ibm_was,servlet session invalidate count
+ibm_was.servlet_session.create_count,gauge,,session,,The number of sessions that were created,0,ibm_was,servlet session create count
+ibm_was.servlet_session.invalidate_count,gauge,,session,,The number of sessions that were invalidated,0,ibm_was,servlet session invalidate count
 ibm_was.servlet_session.life_time,gauge,,millisecond,,The average session life time in milliseconds (time invalidated - time created),0,ibm_was,servlet session life time
 ibm_was.servlet_session.active_count,gauge,,session,,The number of concurrently active sessions. A session is active if the WebSphere® Application Server is currently processing a request that uses that session.,0,ibm_was,servlet session active count
 ibm_was.servlet_session.live_count,gauge,,session,,The number of local sessions that are currently cached in memory from the time at which this metric is enabled.,0,ibm_was,servlet session live count
 ibm_was.servlet_session.no_room_for_new_session_count,gauge,,,,Applies only to session in memory with AllowOverflow=false. The number of times that a request for a new session cannot be handled because it exceeds the maximum session count.,0,ibm_was,
-ibm_was.servlet_session.cache_discard_count,count,,session,,The number of session objects that have been forced out of the cache. A least recently used (LRU) algorithm removes old entries to make room for new sessions and cache misses. Applicable only for persistent sessions.,0,ibm_was,servlet session cache discard count
+ibm_was.servlet_session.cache_discard_count,gauge,,session,,The number of session objects that have been forced out of the cache. A least recently used (LRU) algorithm removes old entries to make room for new sessions and cache misses. Applicable only for persistent sessions.,0,ibm_was,servlet session cache discard count
 ibm_was.servlet_session.external_read_time,gauge,,millisecond,,"The time (ms) taken in reading the session data from the persistent store. For multirow sessions, the metrics are for the attribute; for single row sessions, the metrics are for the entire session. Applicable only for persistent sessions. When using a JMS persistent store, only available if replicated data is serialized.",0,ibm_was,servlet session external read time
-ibm_was.servlet_session.external_read_size,gauge,,byte,,Size of the session data read from persistent store. Applicable only for (serialized) persistent sessions; similar to external Read Time.,0,ibm_was,servlet session external read size
+ibm_was.servlet_session.external_read_size,gauge,,,,Size of the session data read from persistent store. Applicable only for (serialized) persistent sessions; similar to external Read Time.,0,ibm_was,servlet session external read size
 ibm_was.servlet_session.external_write_time,gauge,,millisecond,,The time (milliseconds) taken to write the session data from the persistent store. Applicable only for (serialized) persistent sessions. Similar to external Read Time.,0,ibm_was,servlet session external write time
 ibm_was.servlet_session.external_write_size,gauge,,request,,The size of the session data written to persistent store. Applicable only for (serialized) persistent sessions. Similar to external Read Time.,0,ibm_was,servlet session external write size
-ibm_was.servlet_session.affinity_break_count,count,,request,,The number of requests that are received for sessions that were last accessed from another web application. This value can indicate failover processing or a corrupt plug-in configuration.,0,ibm_was,servlet session affinity break
+ibm_was.servlet_session.affinity_break_count,gauge,,request,,The number of requests that are received for sessions that were last accessed from another web application. This value can indicate failover processing or a corrupt plug-in configuration.,0,ibm_was,servlet session affinity break
 ibm_was.servlet_session.time_since_last_activated,gauge,,millisecond,,The time difference in milliseconds between previous and current access time stamps. Does not include session time out.,0,ibm_was,servlet session last activated
-ibm_was.servlet_session.timeout_invalidation_count,count,,session,,The number of sessions that are invalidated by timeout.,0,ibm_was,servlet session timeout invalidation
-ibm_was.servlet_session.activate_non_exist_session_count,count,,request,,"The number of requests for a session that no longer exists, presumably because the session timed out. Use this counter to help determine if the timeout is too short.",0,ibm_was,
-ibm_was.servlet_session.session_object_size,gauge,,byte,,The size in bytes of (the serializable attributes of ) in-memory sessions. Only session objects that contain at least one serializable attribute object is counted. A session can contain some attributes that are serializable and some that are not. The size in bytes is at a session level.,0,ibm_was,servlet session object size
+ibm_was.servlet_session.timeout_invalidation_count,gauge,,session,,The number of sessions that are invalidated by timeout.,0,ibm_was,servlet session timeout invalidation
+ibm_was.servlet_session.activate_non_exist_session_count,gauge,,request,,"The number of requests for a session that no longer exists, presumably because the session timed out. Use this counter to help determine if the timeout is too short.",0,ibm_was,
+ibm_was.servlet_session.session_object_size,gauge,,,,The size in bytes of (the serializable attributes of ) in-memory sessions. Only session objects that contain at least one serializable attribute object is counted. A session can contain some attributes that are serializable and some that are not. The size in bytes is at a session level.,0,ibm_was,servlet session object size

--- a/ibm_was/metadata.csv
+++ b/ibm_was/metadata.csv
@@ -17,9 +17,9 @@ ibm_was.jdbc.connection_handle_count,count,,connection,,The number of connection
 ibm_was.jdbc.prep_stmt_cache_discard_count,count,,,,The total number of statements that are discarded by the least recently used (LRU) algorithm of the statement cache.,0,ibm_was,jdbc cache discard count
 ibm_was.jdbc.jdbc_time,gauge,,millisecond,,"The average time in milliseconds spent running in the JDBC driver that includes time that is spent in the JDBC driver, network, and database.",0,ibm_was,jdbc time
 ibm_was.jvm.heap_size,count,,,,Deprecated use ibm_was.jvm.heap_size_gauge instead,0,ibm_was,jvm heap size
-ibm_was.jvm.free_memory,count,,,,Deprecated use ibm_was.jvm.free_memory,count_gauge instead,0,ibm_was,jvm free memory
+ibm_was.jvm.free_memory,count,,,,Deprecated use ibm_was.jvm.free_memory_gauge instead,0,ibm_was,jvm free memory
 ibm_was.jvm.used_memory,count,,,,Deprecated use ibm_was.jvm.used_memory_gauge instead,0,ibm_was,jvm used memory
-ibm_was.jvm.up_time,count,,,,Deprecated use ibm_was.jvm.up_time,count_gauge instead,0,ibm_was,jvm uptime
+ibm_was.jvm.up_time,count,,,,Deprecated use ibm_was.jvm.up_time_gauge instead,0,ibm_was,jvm uptime
 ibm_was.jvm.process_cpu_usage,count,,percent,,Deprecated use ibm_was.jvm.process_cpu_usage_gauge instead,0,ibm_was,jvm process cpu usage
 ibm_was.jvm.heap_size_gauge,gauge,,byte,,The total memory in the JVM run time,0,ibm_was,jvm heap size
 ibm_was.jvm.free_memory_gauge,gauge,,byte,,The free memory in the JVM run time,0,ibm_was,jvm free memory

--- a/ibm_was/metadata.csv
+++ b/ibm_was/metadata.csv
@@ -31,7 +31,7 @@ ibm_was.thread_pools.destroy_count,gauge,,thread,,The total number of threads de
 ibm_was.thread_pools.active_count,gauge,,thread,,The number of concurrently active threads,0,ibm_was,thread pools active count
 ibm_was.thread_pools.pool_size,gauge,,thread,,The average number of threads in pool,0,ibm_was,thread pools size
 ibm_was.thread_pools.percent_maxed,gauge,,percent,,The average percent of the time that all threads are in use,0,ibm_was,thread pools percent max
-ibm_was.thread_pools.declaredthread_hung_count,gague,,thread,,The number of threads declared hung,0,ibm_was,thread pools declared count
+ibm_was.thread_pools.declaredthread_hung_count,gauge,,thread,,The number of threads declared hung,0,ibm_was,thread pools declared count
 ibm_was.thread_pools.cleared_thread_hang_count,gauge,,thread,,The number of thread hangs cleared,0,ibm_was,thread pools cleared
 ibm_was.thread_pools.concurrent_hung_thread_count,gauge,,thread,,The number of concurrently hung threads,0,ibm_was,thread pools concurrent hung
 ibm_was.thread_pools.active_time,gauge,,millisecond,,The average time in milliseconds the threads are in active state,0,ibm_was,thread pools active time

--- a/ibm_was/metadata.csv
+++ b/ibm_was/metadata.csv
@@ -1,48 +1,48 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 ibm_was.can_connect,gauge,,,,The ability of the integration to connect to the Perf Servlet to collect metrics,0,ibm_was,was can connect
-ibm_was.jdbc.create_count,gauge,,connection,,The total number of managed connections that were created since pool creation.,0,ibm_was,jdbc create count
-ibm_was.jdbc.close_count,gauge,,connection,,The total number of managed connections that were destroyed since pool creation.,0,ibm_was,jdbc close count
-ibm_was.jdbc.allocate_count,gauge,,connection,,The total number of managed connections that were allocated since pool creation.,0,ibm_was,jdbc allocated count
-ibm_was.jdbc.return_count,gauge,,connection,,The total number of managed connections that were returned since pool creation.,0,ibm_was,jdbc return count
+ibm_was.jdbc.create_count,count,,connection,,The total number of managed connections that were created since pool creation.,0,ibm_was,jdbc create count
+ibm_was.jdbc.close_count,count,,connection,,The total number of managed connections that were destroyed since pool creation.,0,ibm_was,jdbc close count
+ibm_was.jdbc.allocate_count,count,,connection,,The total number of managed connections that were allocated since pool creation.,0,ibm_was,jdbc allocated count
+ibm_was.jdbc.return_count,count,,connection,,The total number of managed connections that were returned since pool creation.,0,ibm_was,jdbc return count
 ibm_was.jdbc.pool_size,gauge,,,,The size of the connection pool.,0,ibm_was,jdbc pool size
 ibm_was.jdbc.free_pool_size,gauge,,connection,,The number of managed connections that are in the free pool.,0,ibm_was,jdbc free pool size
 ibm_was.jdbc.waiting_thread_count,gauge,,thread,,The number of threads that are currently waiting for a connection.,0,ibm_was,jdbc waiting thread count
-ibm_was.jdbc.fault_count,gauge,,,,"The total number of faults, such as timeouts, in the connection pool.",0,ibm_was,jdbc Fault Count
+ibm_was.jdbc.fault_count,count,,,,"The total number of faults, such as timeouts, in the connection pool.",0,ibm_was,jdbc Fault Count
 ibm_was.jdbc.percent_used,gauge,,,,The percent of the pool that is in use.,0,ibm_was,jdbc percent used
 ibm_was.jdbc.percent_maxed,gauge,,,,The percent of the time that all connections are in use.,0,ibm_was,jdbc percent maxed
 ibm_was.jdbc.use_time,gauge,,millisecond,,The average time in milliseconds that a connection is in use.,0,ibm_was,jdbc used time
 ibm_was.jdbc.wait_time,gauge,,millisecond,,The average waiting time in milliseconds until a connection is granted if a connection is not currently available.,0,ibm_was,jdbc wait time
-ibm_was.jdbc.managed_connection_count,gauge,,connection,,"The total number of managed connections in the free, shared, and unshared pools.",0,ibm_was,jdbc managed connection count
-ibm_was.jdbc.connection_handle_count,gauge,,connection,,The number of connections that are in use. Can include multiple connections that are shared from a single managed connection.,0,ibm_was,jdbc connection handle count
-ibm_was.jdbc.prep_stmt_cache_discard_count,gauge,,,,The total number of statements that are discarded by the least recently used (LRU) algorithm of the statement cache.,0,ibm_was,jdbc cache discard count
+ibm_was.jdbc.managed_connection_count,count,,connection,,"The total number of managed connections in the free, shared, and unshared pools.",0,ibm_was,jdbc managed connection count
+ibm_was.jdbc.connection_handle_count,count,,connection,,The number of connections that are in use. Can include multiple connections that are shared from a single managed connection.,0,ibm_was,jdbc connection handle count
+ibm_was.jdbc.prep_stmt_cache_discard_count,count,,,,The total number of statements that are discarded by the least recently used (LRU) algorithm of the statement cache.,0,ibm_was,jdbc cache discard count
 ibm_was.jdbc.jdbc_time,gauge,,millisecond,,"The average time in milliseconds spent running in the JDBC driver that includes time that is spent in the JDBC driver, network, and database.",0,ibm_was,jdbc time
 ibm_was.jvm.heap_size,gauge,,,,The total memory in the JVM run time,0,ibm_was,jvm heap size
 ibm_was.jvm.free_memory,gauge,,,,The free memory in the JVM run time,0,ibm_was,jvm free memory
 ibm_was.jvm.used_memory,gauge,,,,The used memory in the JVM run time,0,ibm_was,jvm used memory
 ibm_was.jvm.up_time,gauge,,second,,The amount of time that the JVM is running,0,ibm_was,jvm uptime
 ibm_was.jvm.process_cpu_usage,gauge,,percent,,The CPU Usage (in percent) of the Java virtual machine.,0,ibm_was,jvm process cpu usage
-ibm_was.thread_pools.create_count,gauge,,thread,,The total number of threads created,0,ibm_was,thread pools create count
-ibm_was.thread_pools.destroy_count,gauge,,thread,,The total number of threads destroyed,0,ibm_was,thread pools destroy count
+ibm_was.thread_pools.create_count,count,,thread,,The total number of threads created,0,ibm_was,thread pools create count
+ibm_was.thread_pools.destroy_count,count,,thread,,The total number of threads destroyed,0,ibm_was,thread pools destroy count
 ibm_was.thread_pools.active_count,gauge,,thread,,The number of concurrently active threads,0,ibm_was,thread pools active count
 ibm_was.thread_pools.pool_size,gauge,,thread,,The average number of threads in pool,0,ibm_was,thread pools size
 ibm_was.thread_pools.percent_maxed,gauge,,percent,,The average percent of the time that all threads are in use,0,ibm_was,thread pools percent max
-ibm_was.thread_pools.declaredthread_hung_count,gauge,,thread,,The number of threads declared hung,0,ibm_was,thread pools declared count
-ibm_was.thread_pools.cleared_thread_hang_count,gauge,,thread,,The number of thread hangs cleared,0,ibm_was,thread pools cleared
+ibm_was.thread_pools.declaredthread_hung_count,count,,thread,,The number of threads declared hung,0,ibm_was,thread pools declared count
+ibm_was.thread_pools.cleared_thread_hang_count,count,,thread,,The number of thread hangs cleared,0,ibm_was,thread pools cleared
 ibm_was.thread_pools.concurrent_hung_thread_count,gauge,,thread,,The number of concurrently hung threads,0,ibm_was,thread pools concurrent hung
 ibm_was.thread_pools.active_time,gauge,,millisecond,,The average time in milliseconds the threads are in active state,0,ibm_was,thread pools active time
-ibm_was.servlet_session.create_count,gauge,,session,,The number of sessions that were created,0,ibm_was,servlet session create count
-ibm_was.servlet_session.invalidate_count,gauge,,session,,The number of sessions that were invalidated,0,ibm_was,servlet session invalidate count
+ibm_was.servlet_session.create_count,count,,session,,The number of sessions that were created,0,ibm_was,servlet session create count
+ibm_was.servlet_session.invalidate_count,count,,session,,The number of sessions that were invalidated,0,ibm_was,servlet session invalidate count
 ibm_was.servlet_session.life_time,gauge,,millisecond,,The average session life time in milliseconds (time invalidated - time created),0,ibm_was,servlet session life time
 ibm_was.servlet_session.active_count,gauge,,session,,The number of concurrently active sessions. A session is active if the WebSphere® Application Server is currently processing a request that uses that session.,0,ibm_was,servlet session active count
 ibm_was.servlet_session.live_count,gauge,,session,,The number of local sessions that are currently cached in memory from the time at which this metric is enabled.,0,ibm_was,servlet session live count
 ibm_was.servlet_session.no_room_for_new_session_count,gauge,,,,Applies only to session in memory with AllowOverflow=false. The number of times that a request for a new session cannot be handled because it exceeds the maximum session count.,0,ibm_was,
-ibm_was.servlet_session.cache_discard_count,gauge,,session,,The number of session objects that have been forced out of the cache. A least recently used (LRU) algorithm removes old entries to make room for new sessions and cache misses. Applicable only for persistent sessions.,0,ibm_was,servlet session cache discard count
+ibm_was.servlet_session.cache_discard_count,count,,session,,The number of session objects that have been forced out of the cache. A least recently used (LRU) algorithm removes old entries to make room for new sessions and cache misses. Applicable only for persistent sessions.,0,ibm_was,servlet session cache discard count
 ibm_was.servlet_session.external_read_time,gauge,,millisecond,,"The time (ms) taken in reading the session data from the persistent store. For multirow sessions, the metrics are for the attribute; for single row sessions, the metrics are for the entire session. Applicable only for persistent sessions. When using a JMS persistent store, only available if replicated data is serialized.",0,ibm_was,servlet session external read time
 ibm_was.servlet_session.external_read_size,gauge,,,,Size of the session data read from persistent store. Applicable only for (serialized) persistent sessions; similar to external Read Time.,0,ibm_was,servlet session external read size
 ibm_was.servlet_session.external_write_time,gauge,,millisecond,,The time (milliseconds) taken to write the session data from the persistent store. Applicable only for (serialized) persistent sessions. Similar to external Read Time.,0,ibm_was,servlet session external write time
 ibm_was.servlet_session.external_write_size,gauge,,request,,The size of the session data written to persistent store. Applicable only for (serialized) persistent sessions. Similar to external Read Time.,0,ibm_was,servlet session external write size
-ibm_was.servlet_session.affinity_break_count,gauge,,request,,The number of requests that are received for sessions that were last accessed from another web application. This value can indicate failover processing or a corrupt plug-in configuration.,0,ibm_was,servlet session affinity break
+ibm_was.servlet_session.affinity_break_count,count,,request,,The number of requests that are received for sessions that were last accessed from another web application. This value can indicate failover processing or a corrupt plug-in configuration.,0,ibm_was,servlet session affinity break
 ibm_was.servlet_session.time_since_last_activated,gauge,,millisecond,,The time difference in milliseconds between previous and current access time stamps. Does not include session time out.,0,ibm_was,servlet session last activated
-ibm_was.servlet_session.timeout_invalidation_count,gauge,,session,,The number of sessions that are invalidated by timeout.,0,ibm_was,servlet session timeout invalidation
-ibm_was.servlet_session.activate_non_exist_session_count,gauge,,request,,"The number of requests for a session that no longer exists, presumably because the session timed out. Use this counter to help determine if the timeout is too short.",0,ibm_was,
+ibm_was.servlet_session.timeout_invalidation_count,count,,session,,The number of sessions that are invalidated by timeout.,0,ibm_was,servlet session timeout invalidation
+ibm_was.servlet_session.activate_non_exist_session_count,count,,request,,"The number of requests for a session that no longer exists, presumably because the session timed out. Use this counter to help determine if the timeout is too short.",0,ibm_was,
 ibm_was.servlet_session.session_object_size,gauge,,,,The size in bytes of (the serializable attributes of ) in-memory sessions. Only session objects that contain at least one serializable attribute object is counted. A session can contain some attributes that are serializable and some that are not. The size in bytes is at a session level.,0,ibm_was,servlet session object size

--- a/ibm_was/metadata.csv
+++ b/ibm_was/metadata.csv
@@ -19,7 +19,7 @@ ibm_was.jdbc.jdbc_time,gauge,,millisecond,,"The average time in milliseconds spe
 ibm_was.jvm.heap_size,gauge,,,,The total memory in the JVM run time,0,ibm_was,jvm heap size
 ibm_was.jvm.free_memory,gauge,,,,The free memory in the JVM run time,0,ibm_was,jvm free memory
 ibm_was.jvm.used_memory,gauge,,,,The used memory in the JVM run time,0,ibm_was,jvm used memory
-ibm_was.jvm.up_time,gauge,,,,The amount of time that the JVM is running,0,ibm_was,jvm uptime
+ibm_was.jvm.up_time,gauge,,second,,The amount of time that the JVM is running,0,ibm_was,jvm uptime
 ibm_was.jvm.process_cpu_usage,gauge,,percent,,The CPU Usage (in percent) of the Java virtual machine.,0,ibm_was,jvm process cpu usage
 ibm_was.thread_pools.create_count,gauge,,thread,,The total number of threads created,0,ibm_was,thread pools create count
 ibm_was.thread_pools.destroy_count,gauge,,thread,,The total number of threads destroyed,0,ibm_was,thread pools destroy count

--- a/ibm_was/metadata.csv
+++ b/ibm_was/metadata.csv
@@ -8,19 +8,24 @@ ibm_was.jdbc.pool_size,gauge,,,,The size of the connection pool.,0,ibm_was,jdbc 
 ibm_was.jdbc.free_pool_size,gauge,,connection,,The number of managed connections that are in the free pool.,0,ibm_was,jdbc free pool size
 ibm_was.jdbc.waiting_thread_count,gauge,,thread,,The number of threads that are currently waiting for a connection.,0,ibm_was,jdbc waiting thread count
 ibm_was.jdbc.fault_count,count,,,,"The total number of faults, such as timeouts, in the connection pool.",0,ibm_was,jdbc Fault Count
-ibm_was.jdbc.percent_used,gauge,,,,The percent of the pool that is in use.,0,ibm_was,jdbc percent used
-ibm_was.jdbc.percent_maxed,gauge,,,,The percent of the time that all connections are in use.,0,ibm_was,jdbc percent maxed
+ibm_was.jdbc.percent_used,gauge,,percent,,The percent of the pool that is in use.,0,ibm_was,jdbc percent used
+ibm_was.jdbc.percent_maxed,gauge,,percent,,The percent of the time that all connections are in use.,0,ibm_was,jdbc percent maxed
 ibm_was.jdbc.use_time,gauge,,millisecond,,The average time in milliseconds that a connection is in use.,0,ibm_was,jdbc used time
 ibm_was.jdbc.wait_time,gauge,,millisecond,,The average waiting time in milliseconds until a connection is granted if a connection is not currently available.,0,ibm_was,jdbc wait time
 ibm_was.jdbc.managed_connection_count,count,,connection,,"The total number of managed connections in the free, shared, and unshared pools.",0,ibm_was,jdbc managed connection count
 ibm_was.jdbc.connection_handle_count,count,,connection,,The number of connections that are in use. Can include multiple connections that are shared from a single managed connection.,0,ibm_was,jdbc connection handle count
 ibm_was.jdbc.prep_stmt_cache_discard_count,count,,,,The total number of statements that are discarded by the least recently used (LRU) algorithm of the statement cache.,0,ibm_was,jdbc cache discard count
 ibm_was.jdbc.jdbc_time,gauge,,millisecond,,"The average time in milliseconds spent running in the JDBC driver that includes time that is spent in the JDBC driver, network, and database.",0,ibm_was,jdbc time
-ibm_was.jvm.heap_size,gauge,,,,The total memory in the JVM run time,0,ibm_was,jvm heap size
-ibm_was.jvm.free_memory,gauge,,,,The free memory in the JVM run time,0,ibm_was,jvm free memory
-ibm_was.jvm.used_memory,gauge,,,,The used memory in the JVM run time,0,ibm_was,jvm used memory
-ibm_was.jvm.up_time,gauge,,second,,The amount of time that the JVM is running,0,ibm_was,jvm uptime
-ibm_was.jvm.process_cpu_usage,gauge,,percent,,The CPU Usage (in percent) of the Java virtual machine.,0,ibm_was,jvm process cpu usage
+ibm_was.jvm.heap_size,count,,,,Deprecated use ibm_was.jvm.heap_size_gauge instead,0,ibm_was,jvm heap size
+ibm_was.jvm.free_memory,count,,,,Deprecated use ibm_was.jvm.free_memory,count_gauge instead,0,ibm_was,jvm free memory
+ibm_was.jvm.used_memory,count,,,,Deprecated use ibm_was.jvm.used_memory_gauge instead,0,ibm_was,jvm used memory
+ibm_was.jvm.up_time,count,,,,Deprecated use ibm_was.jvm.up_time,count_gauge instead,0,ibm_was,jvm uptime
+ibm_was.jvm.process_cpu_usage,count,,percent,,Deprecated use ibm_was.jvm.process_cpu_usage_gauge instead,0,ibm_was,jvm process cpu usage
+ibm_was.jvm.heap_size_gauge,gauge,,kilobyte,,The total memory in the JVM run time,0,ibm_was,jvm heap size
+ibm_was.jvm.free_memory_gauge,gauge,,kilobyte,,The free memory in the JVM run time,0,ibm_was,jvm free memory
+ibm_was.jvm.used_memory_gauge,gauge,,kilobyte,,The used memory in the JVM run time,0,ibm_was,jvm used memory
+ibm_was.jvm.up_time_gauge,gauge,,second,,The amount of time that the JVM is running,0,ibm_was,jvm uptime
+ibm_was.jvm.process_cpu_usage_gauge,gauge,,percent,,The CPU Usage (in percent) of the Java virtual machine.,0,ibm_was,jvm process cpu usage
 ibm_was.thread_pools.create_count,count,,thread,,The total number of threads created,0,ibm_was,thread pools create count
 ibm_was.thread_pools.destroy_count,count,,thread,,The total number of threads destroyed,0,ibm_was,thread pools destroy count
 ibm_was.thread_pools.active_count,gauge,,thread,,The number of concurrently active threads,0,ibm_was,thread pools active count
@@ -38,11 +43,11 @@ ibm_was.servlet_session.live_count,gauge,,session,,The number of local sessions 
 ibm_was.servlet_session.no_room_for_new_session_count,gauge,,,,Applies only to session in memory with AllowOverflow=false. The number of times that a request for a new session cannot be handled because it exceeds the maximum session count.,0,ibm_was,
 ibm_was.servlet_session.cache_discard_count,count,,session,,The number of session objects that have been forced out of the cache. A least recently used (LRU) algorithm removes old entries to make room for new sessions and cache misses. Applicable only for persistent sessions.,0,ibm_was,servlet session cache discard count
 ibm_was.servlet_session.external_read_time,gauge,,millisecond,,"The time (ms) taken in reading the session data from the persistent store. For multirow sessions, the metrics are for the attribute; for single row sessions, the metrics are for the entire session. Applicable only for persistent sessions. When using a JMS persistent store, only available if replicated data is serialized.",0,ibm_was,servlet session external read time
-ibm_was.servlet_session.external_read_size,gauge,,,,Size of the session data read from persistent store. Applicable only for (serialized) persistent sessions; similar to external Read Time.,0,ibm_was,servlet session external read size
+ibm_was.servlet_session.external_read_size,gauge,,btye,,Size of the session data read from persistent store. Applicable only for (serialized) persistent sessions; similar to external Read Time.,0,ibm_was,servlet session external read size
 ibm_was.servlet_session.external_write_time,gauge,,millisecond,,The time (milliseconds) taken to write the session data from the persistent store. Applicable only for (serialized) persistent sessions. Similar to external Read Time.,0,ibm_was,servlet session external write time
 ibm_was.servlet_session.external_write_size,gauge,,request,,The size of the session data written to persistent store. Applicable only for (serialized) persistent sessions. Similar to external Read Time.,0,ibm_was,servlet session external write size
 ibm_was.servlet_session.affinity_break_count,count,,request,,The number of requests that are received for sessions that were last accessed from another web application. This value can indicate failover processing or a corrupt plug-in configuration.,0,ibm_was,servlet session affinity break
 ibm_was.servlet_session.time_since_last_activated,gauge,,millisecond,,The time difference in milliseconds between previous and current access time stamps. Does not include session time out.,0,ibm_was,servlet session last activated
 ibm_was.servlet_session.timeout_invalidation_count,count,,session,,The number of sessions that are invalidated by timeout.,0,ibm_was,servlet session timeout invalidation
 ibm_was.servlet_session.activate_non_exist_session_count,count,,request,,"The number of requests for a session that no longer exists, presumably because the session timed out. Use this counter to help determine if the timeout is too short.",0,ibm_was,
-ibm_was.servlet_session.session_object_size,gauge,,,,The size in bytes of (the serializable attributes of ) in-memory sessions. Only session objects that contain at least one serializable attribute object is counted. A session can contain some attributes that are serializable and some that are not. The size in bytes is at a session level.,0,ibm_was,servlet session object size
+ibm_was.servlet_session.session_object_size,gauge,,byte,,The size in bytes of (the serializable attributes of ) in-memory sessions. Only session objects that contain at least one serializable attribute object is counted. A session can contain some attributes that are serializable and some that are not. The size in bytes is at a session level.,0,ibm_was,servlet session object size

--- a/ibm_was/metadata.csv
+++ b/ibm_was/metadata.csv
@@ -21,9 +21,9 @@ ibm_was.jvm.free_memory,count,,,,Deprecated use ibm_was.jvm.free_memory,count_ga
 ibm_was.jvm.used_memory,count,,,,Deprecated use ibm_was.jvm.used_memory_gauge instead,0,ibm_was,jvm used memory
 ibm_was.jvm.up_time,count,,,,Deprecated use ibm_was.jvm.up_time,count_gauge instead,0,ibm_was,jvm uptime
 ibm_was.jvm.process_cpu_usage,count,,percent,,Deprecated use ibm_was.jvm.process_cpu_usage_gauge instead,0,ibm_was,jvm process cpu usage
-ibm_was.jvm.heap_size_gauge,gauge,,kilobyte,,The total memory in the JVM run time,0,ibm_was,jvm heap size
-ibm_was.jvm.free_memory_gauge,gauge,,kilobyte,,The free memory in the JVM run time,0,ibm_was,jvm free memory
-ibm_was.jvm.used_memory_gauge,gauge,,kilobyte,,The used memory in the JVM run time,0,ibm_was,jvm used memory
+ibm_was.jvm.heap_size_gauge,gauge,,byte,,The total memory in the JVM run time,0,ibm_was,jvm heap size
+ibm_was.jvm.free_memory_gauge,gauge,,byte,,The free memory in the JVM run time,0,ibm_was,jvm free memory
+ibm_was.jvm.used_memory_gauge,gauge,,byte,,The used memory in the JVM run time,0,ibm_was,jvm used memory
 ibm_was.jvm.up_time_gauge,gauge,,second,,The amount of time that the JVM is running,0,ibm_was,jvm uptime
 ibm_was.jvm.process_cpu_usage_gauge,gauge,,percent,,The CPU Usage (in percent) of the Java virtual machine.,0,ibm_was,jvm process cpu usage
 ibm_was.thread_pools.create_count,count,,thread,,The total number of threads created,0,ibm_was,thread pools create count
@@ -43,7 +43,7 @@ ibm_was.servlet_session.live_count,gauge,,session,,The number of local sessions 
 ibm_was.servlet_session.no_room_for_new_session_count,gauge,,,,Applies only to session in memory with AllowOverflow=false. The number of times that a request for a new session cannot be handled because it exceeds the maximum session count.,0,ibm_was,
 ibm_was.servlet_session.cache_discard_count,count,,session,,The number of session objects that have been forced out of the cache. A least recently used (LRU) algorithm removes old entries to make room for new sessions and cache misses. Applicable only for persistent sessions.,0,ibm_was,servlet session cache discard count
 ibm_was.servlet_session.external_read_time,gauge,,millisecond,,"The time (ms) taken in reading the session data from the persistent store. For multirow sessions, the metrics are for the attribute; for single row sessions, the metrics are for the entire session. Applicable only for persistent sessions. When using a JMS persistent store, only available if replicated data is serialized.",0,ibm_was,servlet session external read time
-ibm_was.servlet_session.external_read_size,gauge,,btye,,Size of the session data read from persistent store. Applicable only for (serialized) persistent sessions; similar to external Read Time.,0,ibm_was,servlet session external read size
+ibm_was.servlet_session.external_read_size,gauge,,byte,,Size of the session data read from persistent store. Applicable only for (serialized) persistent sessions; similar to external Read Time.,0,ibm_was,servlet session external read size
 ibm_was.servlet_session.external_write_time,gauge,,millisecond,,The time (milliseconds) taken to write the session data from the persistent store. Applicable only for (serialized) persistent sessions. Similar to external Read Time.,0,ibm_was,servlet session external write time
 ibm_was.servlet_session.external_write_size,gauge,,request,,The size of the session data written to persistent store. Applicable only for (serialized) persistent sessions. Similar to external Read Time.,0,ibm_was,servlet session external write size
 ibm_was.servlet_session.affinity_break_count,count,,request,,The number of requests that are received for sessions that were last accessed from another web application. This value can indicate failover processing or a corrupt plug-in configuration.,0,ibm_was,servlet session affinity break


### PR DESCRIPTION
### What does this PR do?

Deprecated old JVM count metrics and added new ones in the format of <metric_name>_gauge to correctly match the metric type.

### Motivation

It didn't make sense for the JVM metrics to be submitted as a `count` - `gauge` is a better fit.