### PR TITLE
Add support for string types

### DIFF
--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -4,6 +4,7 @@
 from collections import defaultdict
 
 import pysnmp.proto.rfc1902 as snmp_type
+from pyasn1.codec.ber import decoder
 from pyasn1.type.univ import OctetString
 from pysnmp import hlapi
 from pysnmp.error import PySnmpError
@@ -585,6 +586,25 @@ class SnmpCheck(NetworkCheck):
             return
         if snmp_class in SNMP_GAUGES:
             value = int(snmp_value)
+            self.gauge(metric_name, value, tags)
+            return
+
+        if snmp_class == 'Opaque':
+            # Try support for floats
+            try:
+                value = float(decoder.decode(bytes(snmp_value))[0])
+            except Exception:
+                pass
+            else:
+                self.gauge(metric_name, value, tags)
+                return
+
+        # Falls back to try to cast the value.
+        try:
+            value = float(snmp_value)
+        except ValueError:
+            pass
+        else:
             self.gauge(metric_name, value, tags)
             return
 

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -50,8 +50,8 @@ SUPPORTED_METRIC_TYPES = [
 UNSUPPORTED_METRICS = [{'OID': "1.3.6.1.2.1.25.6.3.1.5.1", 'name': "IAmString"}]  # String (not supported)
 
 CAST_METRICS = [
-    {'OID': "1.3.6.1.4.1.2021.10.1.3.1", 'name': "cpuload1"},  # Counter32
-    {'OID': "1.3.6.1.4.1.2021.10.1.6.1", 'name': "cpuload2"},  # Counter32
+    {'OID': "1.3.6.1.4.1.2021.10.1.3.1", 'name': "cpuload1"},  # OctetString
+    {'OID': "1.3.6.1.4.1.2021.10.1.6.1", 'name': "cpuload2"},  # Opaque
 ]
 
 CONSTRAINED_OID = [{"MIB": "RFC1213-MIB", "symbol": "tcpRtoAlgorithm"}]

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -49,6 +49,11 @@ SUPPORTED_METRIC_TYPES = [
 
 UNSUPPORTED_METRICS = [{'OID': "1.3.6.1.2.1.25.6.3.1.5.1", 'name': "IAmString"}]  # String (not supported)
 
+CAST_METRICS = [
+    {'OID': "1.3.6.1.4.1.2021.10.1.3.1", 'name': "cpuload1"},  # Counter32
+    {'OID': "1.3.6.1.4.1.2021.10.1.6.1", 'name': "cpuload2"},  # Counter32
+]
+
 CONSTRAINED_OID = [{"MIB": "RFC1213-MIB", "symbol": "tcpRtoAlgorithm"}]
 
 DUMMY_MIB_OID = [{"MIB": "DUMMY-MIB", "symbol": "scalar"}]

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -412,3 +412,14 @@ def test_network_failure(aggregator, check):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.CRITICAL, tags=common.CHECK_TAGS, at_least=1)
 
     aggregator.all_metrics_asserted()
+
+
+def test_cast_metrics(aggregator, check):
+    metrics = common.CAST_METRICS
+    instance = common.generate_instance_config(metrics)
+
+    check.check(instance)
+    aggregator.assert_metric('snmp.cpuload1', value=0.06)
+    aggregator.assert_metric('snmp.cpuload2', value=0.06)
+
+    aggregator.all_metrics_asserted()

--- a/snmp/tox.ini
+++ b/snmp/tox.ini
@@ -17,8 +17,8 @@ passenv =
     COMPOSE*
 commands =
     pip install -r requirements.in
-    snmp: pytest -v -m"not unit"
-    unit: pytest -v -m"unit"
+    snmp: pytest -v -m"not unit" {posargs}
+    unit: pytest -v -m"unit" {posargs}
 
 [testenv:bench]
 commands =


### PR DESCRIPTION
SNMP can return float values as string, either directly as a OctetString
or via a Opaque value. Let's support those types of OIDs.