### PR TITLE
Add possibility to disable a threshold boundary

### DIFF
--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -71,9 +71,11 @@ instances:
     ## @param thresholds - object - optional
     ## The threshold parameter is composed of two ranges: critical and warning
     ##   * warning: (optional) List of two values: If the number of processes found is below the first value or
-    ##             above the second one, the process check returns WARNING. Set to .inf or -.inf to disable a boundary.
+    ##             above the second one, the process check returns WARNING. To make an semi-unbounded interval, 
+    ##             use `.inf` for the upper bound.
     ##   * critical: (optional) List of two values: If the number of processes found is below the first value or
-    ##             above the second one, the process check returns CRITICAL. Set to .inf or -.inf to disable a boundary.
+    ##             above the second one, the process check returns CRITICAL. To make an semi-unbounded interval, 
+    ##             use `.inf` for the upper bound.
     #
     # thresholds:
     #   warning: [<BELOW_VALUE> , <TOP_VALUE>]

--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -69,11 +69,11 @@ instances:
     # ignore_denied_access: true
 
     ## @param thresholds - object - optional
-    ## The threshold paramter is composed of two ranges: critical and warning
+    ## The threshold parameter is composed of two ranges: critical and warning
     ##   * warning: (optional) List of two values: If the number of processes found is below the first value or
-    ##             above the second one, the process check will return WARNING. Set to -1 to disable a boundary.
+    ##             above the second one, the process check will return WARNING. Set to .inf or -.inf to disable a boundary.
     ##   * critical: (optional) List of two values: If the number of processes found is below the first value or
-    ##             above the second one, the process check will return CRITICAL. Set to -1 to disable a boundary.
+    ##             above the second one, the process check will return CRITICAL. Set to .inf or -.inf to disable a boundary.
     #
     # thresholds:
     #   warning: [<BELOW_VALUE> , <TOP_VALUE>]

--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -71,9 +71,9 @@ instances:
     ## @param thresholds - object - optional
     ## The threshold paramter is composed of two ranges: critical and warning
     ##   * warning: (optional) List of two values: If the number of processes found is below the first value or
-    ##             above the second one, the process check will return WARNING.
+    ##             above the second one, the process check will return WARNING. Put -1 to disable a boundary.
     ##   * critical: (optional) List of two values: If the number of processes found is below the first value or
-    ##             above the second one, the process check will return CRITICAL.
+    ##             above the second one, the process check will return CRITICAL. Put -1 to disable a boundary.
     #
     # thresholds:
     #   warning: [<BELOW_VALUE> , <TOP_VALUE>]

--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -71,9 +71,9 @@ instances:
     ## @param thresholds - object - optional
     ## The threshold paramter is composed of two ranges: critical and warning
     ##   * warning: (optional) List of two values: If the number of processes found is below the first value or
-    ##             above the second one, the process check will return WARNING. Put -1 to disable a boundary.
+    ##             above the second one, the process check will return WARNING. Set to -1 to disable a boundary.
     ##   * critical: (optional) List of two values: If the number of processes found is below the first value or
-    ##             above the second one, the process check will return CRITICAL. Put -1 to disable a boundary.
+    ##             above the second one, the process check will return CRITICAL. Set to -1 to disable a boundary.
     #
     # thresholds:
     #   warning: [<BELOW_VALUE> , <TOP_VALUE>]

--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -71,9 +71,9 @@ instances:
     ## @param thresholds - object - optional
     ## The threshold parameter is composed of two ranges: critical and warning
     ##   * warning: (optional) List of two values: If the number of processes found is below the first value or
-    ##             above the second one, the process check will return WARNING. Set to .inf or -.inf to disable a boundary.
+    ##             above the second one, the process check returns WARNING. Set to .inf or -.inf to disable a boundary.
     ##   * critical: (optional) List of two values: If the number of processes found is below the first value or
-    ##             above the second one, the process check will return CRITICAL. Set to .inf or -.inf to disable a boundary.
+    ##             above the second one, the process check returns CRITICAL. Set to .inf or -.inf to disable a boundary.
     #
     # thresholds:
     #   warning: [<BELOW_VALUE> , <TOP_VALUE>]

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -458,9 +458,9 @@ class ProcessCheck(AgentCheck):
             critical = bounds.get('critical', [1, float('inf')])
 
             # -1 disable the boundary
-            if (warning[1] != -1 and warning[1] < nb_procs) or nb_procs < warning[0]:
+            if warning[1] < nb_procs or nb_procs < warning[0]:
                 status = AgentCheck.WARNING
-            if (critical[1] != -1 and critical[1] < nb_procs) or nb_procs < critical[0]:
+            if critical[1] < nb_procs or nb_procs < critical[0]:
                 status = AgentCheck.CRITICAL
 
         self.service_check(

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -457,9 +457,10 @@ class ProcessCheck(AgentCheck):
             warning = bounds.get('warning', [1, float('inf')])
             critical = bounds.get('critical', [1, float('inf')])
 
-            if warning[1] < nb_procs or nb_procs < warning[0]:
+            # -1 disable the boundary
+            if (warning[1] != -1 and warning[1] < nb_procs) or nb_procs < warning[0]:
                 status = AgentCheck.WARNING
-            if critical[1] < nb_procs or nb_procs < critical[0]:
+            if (warning[1] != -1 and critical[1] < nb_procs) or nb_procs < critical[0]:
                 status = AgentCheck.CRITICAL
 
         self.service_check(

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -457,7 +457,6 @@ class ProcessCheck(AgentCheck):
             warning = bounds.get('warning', [1, float('inf')])
             critical = bounds.get('critical', [1, float('inf')])
 
-            # -1 disable the boundary
             if warning[1] < nb_procs or nb_procs < warning[0]:
                 status = AgentCheck.WARNING
             if critical[1] < nb_procs or nb_procs < critical[0]:

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -460,7 +460,7 @@ class ProcessCheck(AgentCheck):
             # -1 disable the boundary
             if (warning[1] != -1 and warning[1] < nb_procs) or nb_procs < warning[0]:
                 status = AgentCheck.WARNING
-            if (warning[1] != -1 and critical[1] < nb_procs) or nb_procs < critical[0]:
+            if (critical[1] != -1 and critical[1] < nb_procs) or nb_procs < critical[0]:
                 status = AgentCheck.CRITICAL
 
         self.service_check(

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -329,3 +329,15 @@ def test_relocated_procfs(aggregator):
     expected_tags = generate_expected_tags(config['instances'][0])
     expected_tags += ['process:moved_procfs']
     aggregator.assert_service_check('process.up', count=1, tags=expected_tags)
+
+
+def test_process_service_check(aggregator):
+    process = ProcessCheck(common.CHECK_NAME, {}, {})
+
+    process._process_service_check('warning', 3, {'warning': [4, 6], 'critical': [2, 10]}, [])
+    process._process_service_check('no_top_ok', 3, {'warning': [2, -1], 'critical': [2, -1]}, [])
+    process._process_service_check('no_top_critical', 0, {'warning': [2, -1], 'critical': [2, -1]}, [])
+
+    aggregator.assert_service_check('process.up', count=1, tags=['process:warning'], status=process.WARNING)
+    aggregator.assert_service_check('process.up', count=1, tags=['process:no_top_ok'], status=process.OK)
+    aggregator.assert_service_check('process.up', count=1, tags=['process:no_top_critical'], status=process.CRITICAL)

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -335,8 +335,10 @@ def test_process_service_check(aggregator):
     process = ProcessCheck(common.CHECK_NAME, {}, {})
 
     process._process_service_check('warning', 3, {'warning': [4, 6], 'critical': [2, 10]}, [])
-    process._process_service_check('no_top_ok', 3, {'warning': [2, .inf], 'critical': [2, .inf]}, [])
-    process._process_service_check('no_top_critical', 0, {'warning': [2, .inf], 'critical': [2, .inf]}, [])
+    process._process_service_check('no_top_ok', 3, {'warning': [2, float('inf')], 'critical': [2, float('inf')]}, [])
+    process._process_service_check(
+        'no_top_critical', 0, {'warning': [2, float('inf')], 'critical': [2, float('inf')]}, []
+    )
 
     aggregator.assert_service_check('process.up', count=1, tags=['process:warning'], status=process.WARNING)
     aggregator.assert_service_check('process.up', count=1, tags=['process:no_top_ok'], status=process.OK)

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -335,8 +335,8 @@ def test_process_service_check(aggregator):
     process = ProcessCheck(common.CHECK_NAME, {}, {})
 
     process._process_service_check('warning', 3, {'warning': [4, 6], 'critical': [2, 10]}, [])
-    process._process_service_check('no_top_ok', 3, {'warning': [2, -1], 'critical': [2, -1]}, [])
-    process._process_service_check('no_top_critical', 0, {'warning': [2, -1], 'critical': [2, -1]}, [])
+    process._process_service_check('no_top_ok', 3, {'warning': [2, .inf], 'critical': [2, .inf]}, [])
+    process._process_service_check('no_top_critical', 0, {'warning': [2, .inf], 'critical': [2, .inf]}, [])
 
     aggregator.assert_service_check('process.up', count=1, tags=['process:warning'], status=process.WARNING)
     aggregator.assert_service_check('process.up', count=1, tags=['process:no_top_ok'], status=process.OK)


### PR DESCRIPTION
### What does this PR do?

Add the possibility to disable the top boundary of the threshold by setting it to `-1`
Addresses #3071

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
