### PR TITLE
Add support for selecting an Agent build via environment

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -54,6 +54,9 @@ class DockerInterface(object):
 
         self.env_vars['DD_PYTHON_VERSION'] = self.python_version
 
+        if self.metadata.get('use_jmx', False):
+            self.agent_build = '{}-jmx'.format(self.agent_build)
+
     @property
     def agent_version(self):
         return self._agent_version or DEFAULT_AGENT_VERSION


### PR DESCRIPTION
### What does this PR do?

1. Adds `DDEV_E2E_AGENT` env var
2. Remove old logic for original config format
3. Move jmx logic just to the Docker interface

### Motivation

For e2e tests in CI