### PR TITLE
Fix get_current_agent_version sorting in ddev

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -34,9 +34,11 @@ def get_current_agent_version():
     for version in release_data:
         parts = version.split('.')
         if len(parts) > 1:
-            versions.add((parts[0], parts[1]))
+            versions.add((int(parts[0]), int(parts[1])))
 
-    return '.'.join(sorted(versions)[-1][:2])
+    most_recent = sorted(versions)[-1]
+
+    return "{}.{}".format(most_recent[0], most_recent[1])
 
 
 def is_package(d):


### PR DESCRIPTION
### What does this PR do?

Version parts need to be converted to int before sorting to get a correct ordering.

### Motivation

Currently, version parts are sorted in lexicographical order using strings, which doesn't give the right result for versions ordering.

Example: 6.12 is before 6.9