### PR TITLE
Fix kubelet tests

### DIFF
--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -181,18 +181,16 @@ def mock_kubelet_check(monkeypatch, instances):
         scraper_config = args[0]
         prometheus_url = scraper_config['prometheus_url']
 
-        attrs = None
         if prometheus_url.endswith('/metrics/cadvisor'):
             # Mock response for "/metrics/cadvisor"
             content = mock_from_file('cadvisor_metrics.txt')
-            attrs = {'close.return_value': True, 'iter_lines.return_value': content.split('\n'), 'content': content}
         elif prometheus_url.endswith('/metrics'):
             # Mock response for "/metrics"
             content = mock_from_file('kubelet_metrics.txt')
-            attrs = {'close.return_value': True, 'iter_lines.return_value': content.split('\n'), 'content': content}
         else:
             raise Exception("Must be a valid endpoint")
 
+        attrs = {'close.return_value': True, 'iter_lines.return_value': content.split('\n'), 'content': content}
         return mock.Mock(headers={'Content-Type': 'text/plain'}, **attrs)
 
     monkeypatch.setattr(check, 'poll', mock.Mock(side_effect=mocked_poll))

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -185,19 +185,11 @@ def mock_kubelet_check(monkeypatch, instances):
         if prometheus_url.endswith('/metrics/cadvisor'):
             # Mock response for "/metrics/cadvisor"
             content = mock_from_file('cadvisor_metrics.txt')
-            attrs = {
-                'close.return_value': True,
-                'iter_lines.return_value': content.split('\n'),
-                'content': content,
-            }
+            attrs = {'close.return_value': True, 'iter_lines.return_value': content.split('\n'), 'content': content}
         elif prometheus_url.endswith('/metrics'):
             # Mock response for "/metrics"
             content = mock_from_file('kubelet_metrics.txt')
-            attrs = {
-                'close.return_value': True,
-                'iter_lines.return_value': content.split('\n'),
-                'content': content,
-            }
+            attrs = {'close.return_value': True, 'iter_lines.return_value': content.split('\n'), 'content': content}
         else:
             raise Exception("Must be a valid endpoint")
 

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -184,15 +184,19 @@ def mock_kubelet_check(monkeypatch, instances):
         attrs = None
         if prometheus_url.endswith('/metrics/cadvisor'):
             # Mock response for "/metrics/cadvisor"
+            content = mock_from_file('cadvisor_metrics.txt')
             attrs = {
                 'close.return_value': True,
-                'iter_lines.return_value': mock_from_file('cadvisor_metrics.txt').split('\n'),
+                'iter_lines.return_value': content.split('\n'),
+                'content': content,
             }
         elif prometheus_url.endswith('/metrics'):
             # Mock response for "/metrics"
+            content = mock_from_file('kubelet_metrics.txt')
             attrs = {
                 'close.return_value': True,
-                'iter_lines.return_value': mock_from_file('kubelet_metrics.txt').split('\n'),
+                'iter_lines.return_value': content.split('\n'),
+                'content': content,
             }
         else:
             raise Exception("Must be a valid endpoint")


### PR DESCRIPTION
### What does this PR do?

Fix kubelet tests due to change in https://github.com/DataDog/integrations-core/pull/4025

This line has been added https://github.com/DataDog/integrations-core/pull/4025/files#diff-85fd7415439d33e481bee8605a392317R296

### Motivation

Error on Travis on master branch: https://travis-ci.com/DataDog/integrations-core/builds/118998306

Since the response object is a mock `response.content` has no `len`.
