### PR TITLE
Comment out mixer and mesh by default from configuration

### DIFF
--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -2,6 +2,11 @@ init_config:
 
 instances:
 
+    ## @param send_histograms_buckets - boolean - required
+    ## Set send_histograms_buckets to true to send the histograms bucket from Istio.
+    #
+  - send_histograms_buckets: true
+
     ## @param istio_mesh_endpoint - string - optional
     ## To enable Istio metrics you must specify the url exposing the API
     ##
@@ -9,7 +14,7 @@ instances:
     ## the CPP extension to process Protocol buffer messages coming from the api. Depending
     ## on the metrics volume, the check may run very slowly.
     #
-  - istio_mesh_endpoint: http://istio-telemetry.istio-system:42422/metrics
+    # istio_mesh_endpoint: http://istio-telemetry.istio-system:42422/metrics
 
     ## @param mixer_endpoint - string - optional
     ## Define the mixer endpoint in order to collect all Prometheus metrics on the Mixer process as well
@@ -17,7 +22,7 @@ instances:
     ## If using Istio < v1.1, replace port 15014 with port 9093. See the changes here:
     ## https://istio.io/about/notes/1.1/#configuration-management
     #
-    mixer_endpoint: http://istio-telemetry.istio-system:15014/metrics
+    # mixer_endpoint: http://istio-telemetry.istio-system:15014/metrics
 
     ## @param pilot_endpoint - string - optional
     ## Define the pilot endpoint in order to collect all Prometheus metrics on the Pilot process.
@@ -36,11 +41,6 @@ instances:
     ## Only available for Istio >= v1.1.
     #
     # citadel_endpoint: http://istio-citadel.istio-system:15014/metrics
-
-    ## @param send_histograms_buckets - boolean - required
-    ## Set send_histograms_buckets to true to send the histograms bucket from Istio.
-    #
-    send_histograms_buckets: true
 
     ## @param tags - list of key:value elements - optional
     ## List of tags to attach to every metric, event and service check emitted by this integration.

--- a/istio/datadog_checks/istio/istio.py
+++ b/istio/datadog_checks/istio/istio.py
@@ -28,8 +28,7 @@ class Istio(OpenMetricsBaseCheck):
 
     def check(self, instance):
         """
-        Process the istio_mesh, process_mixer, pilot, and galley endpoints
-        associated with this instance.
+        Process all the endpoints associated with this instance.
         All the endpoints themselves are optional, but at least one must be passed.
         """
         processed = False


### PR DESCRIPTION
Istio mixer and mesh endpoints have been made optional with https://github.com/DataDog/integrations-core/pull/3875

Let's also comment them out in the configuration file by default to make it clear. It also updates a comment that was out of date with the new Citadel endpoint.