### PR TITLE
Add telemetry metrics counter by ksm collector

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -71,7 +71,7 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
         """
         return _tags
 
-    def _filter_metric(self, metric):
+    def _filter_metric(self, metric, scraper_config):
         """
         Used to filter metrics at the begining of the processing, by default no metric is filtered
         """

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -413,7 +413,7 @@ class OpenMetricsScraperMixin(object):
 
         self._send_telemetry_counter(self.TELEMETRY_COUNTER_METRICS_PROCESS_COUNT, 1, scraper_config)
 
-        if self._filter_metric(metric):
+        if self._filter_metric(metric, scraper_config):
             return  # Ignore the metric
 
         # Filter metric to see if we can enrich with joined labels

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -340,13 +340,15 @@ class OpenMetricsScraperMixin(object):
             tags.extend(scraper_config['_metric_tags'])
             self.gauge(metric_name_with_namespace, val, tags=tags)
 
-    def _send_telemetry_counter(self, metric_name, val, scraper_config):
+    def _send_telemetry_counter(self, metric_name, val, scraper_config, extra_tags=None):
         if scraper_config['telemetry']:
             metric_name_with_namespace = self._telemetry_metric_name_with_namespace(metric_name, scraper_config)
             # Determine the tags to send
             custom_tags = scraper_config['custom_tags']
             tags = list(custom_tags)
             tags.extend(scraper_config['_metric_tags'])
+            if extra_tags:
+                tags.extend(extra_tags)
             self.count(metric_name_with_namespace, val, tags=tags)
 
     def _store_labels(self, metric, scraper_config):

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -1562,7 +1562,7 @@ def mock_filter_get():
 
 
 class FilterOpenMetricsCheck(OpenMetricsBaseCheck):
-    def _filter_metric(self, metric):
+    def _filter_metric(self, metric, scraper_config):
         return metric.documentation.startswith("(Deprecated)")
 
 

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
@@ -154,7 +154,7 @@ class KubeControllerManagerCheck(KubeLeaderElectionMixin, OpenMetricsBaseCheck):
             leader_config["tags"] = instance.get("tags", [])
             self.check_election_status(leader_config)
 
-    def _ignore_deprecated_metric(self, metric):
+    def _ignore_deprecated_metric(self, metric, scraper_config):
         return metric.documentation.startswith("(Deprecated)")
 
     def _tag_and_submit(self, metric, scraper_config, metric_name, tag_name, tag_value_trim):

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -100,11 +100,13 @@ class KubernetesState(OpenMetricsBaseCheck):
         if scraper_config['telemetry']:
             # name is like "kube_pod_execution_duration"
             name_part = metric.name.split("_", 3)
+            if len(name_part) < 2:
+                return False
             family = name_part[1]
             tags = ["name:" + family]
             for sample in metric.samples:
-                if "namespace" in sample[1]:
-                    ns = sample[1]["namespace"]
+                if "namespace" in sample[self.SAMPLE_LABELS]:
+                    ns = sample[self.SAMPLE_LABELS]["namespace"]
                     tags.append("kube_namespace:" + ns)
                     break
             self._send_telemetry_counter(

--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -98,3 +98,9 @@ kubernetes_state.statefulset.replicas_desired,gauge,,,,The number of desired rep
 kubernetes_state.statefulset.replicas_current,gauge,,,,The number of current replicas per StatefulSet,0,kubernetes,k8s_state.statefulset.replicas_current
 kubernetes_state.statefulset.replicas_ready,gauge,,,,The number of ready replicas per StatefulSet,0,kubernetes,k8s_state.statefulset.replicas_ready
 kubernetes_state.statefulset.replicas_updated,gauge,,,,The number of updated replicas per StatefulSet,0,kubernetes,k8s_state.statefulset.replicas_updated
+kubernetes_state.telemetry.payload.size,gauge,,byte,,The message size received from kube-state-metrics,0,kubernetes,k8s_state.telemetry.payload.size
+kubernetes_state.telemetry.metrics.processed.count,counter,,,,The number of metrics processed,0,kubernetes,k8s_state.telemetry.metrics.processed.count
+kubernetes_state.telemetry.metrics.input.count,counter,,,,The number of metrics received,0,kubernetes,k8s_state.telemetry.metrics.input.count
+kubernetes_state.telemetry.metrics.blacklist.count,counter,,,,The number of metrics blacklisted by the check,0,kubernetes,k8s_state.telemetry.metrics.blacklist.count
+kubernetes_state.telemetry.metrics.ignored.count,counter,,,,The number of metrics ignored by the check,0,kubernetes,k8s_state.telemetry.metrics.ignored.count
+kubernetes_state.telemetry.collector.metrics.count,counter,,,,The number of metrics by collector (kubernetes object kind) by kubernetes namespaces,0,kubernetes,k8s_state.telemetry.collector.metrics.count

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -399,3 +399,9 @@ def test_telemetry(aggregator, instance):
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=230.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.blacklist.count', tags=['optional:tag1'], value=24.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.ignored.count', tags=['optional:tag1'], value=76.0)
+    aggregator.assert_metric(
+        NAMESPACE + '.telemetry.collector.metrics.count', tags=['name:pod', 'kube_namespace:default'], value=600.0
+    )
+    aggregator.assert_metric(
+        NAMESPACE + '.telemetry.collector.metrics.count', tags=['name:hpa', 'kube_namespace:ns1'], value=8.0
+    )

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -400,8 +400,12 @@ def test_telemetry(aggregator, instance):
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.blacklist.count', tags=['optional:tag1'], value=24.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.ignored.count', tags=['optional:tag1'], value=76.0)
     aggregator.assert_metric(
-        NAMESPACE + '.telemetry.collector.metrics.count', tags=['name:pod', 'kube_namespace:default'], value=600.0
+        NAMESPACE + '.telemetry.collector.metrics.count',
+        tags=['name:pod', 'kube_namespace:default', 'optional:tag1'],
+        value=600.0,
     )
     aggregator.assert_metric(
-        NAMESPACE + '.telemetry.collector.metrics.count', tags=['name:hpa', 'kube_namespace:ns1'], value=8.0
+        NAMESPACE + '.telemetry.collector.metrics.count',
+        tags=['name:hpa', 'kube_namespace:ns1', 'optional:tag1'],
+        value=8.0,
     )


### PR DESCRIPTION
### What does this PR do?

Add additional telemetry metrics to know how many metrics are return in the ksm prometheus payload.
the `.telemetry.collector.metrics.count` can have two tag keys: 
* `name`: the name of the collector, corresponding to the object type.
* `kube_namespace`: the kubernetes namespace if the object is namespaced in kube.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
