### PR TITLE
[Fix] Use tagger with container_id prefix in Fargate

### DIFF
--- a/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
@@ -90,7 +90,7 @@ class FargateCheck(AgentCheck):
         container_tags = {}
         for container in metadata['Containers']:
             c_id = container['DockerId']
-            tagger_tags = get_tags('docker://%s' % c_id, True) or []
+            tagger_tags = get_tags('container_id://%s' % c_id, True) or []
 
             # Compatibility with previous versions of the check
             compat_tags = []

--- a/ecs_fargate/tests/test_unit.py
+++ b/ecs_fargate/tests/test_unit.py
@@ -49,7 +49,7 @@ def mocked_requests_get(*args, **kwargs):
 def mocked_get_tags(entity, _):
     # Values taken from Agent6's TestParseMetadataV10 test
     tag_store = {
-        "docker://e8d4a9a20a0d931f8f632ec166b3f71a6ff00450aa7e99607f650e586df7d068": [
+        "container_id://e8d4a9a20a0d931f8f632ec166b3f71a6ff00450aa7e99607f650e586df7d068": [
             "docker_image:datadog/docker-dd-agent:latest",
             "image_name:datadog/docker-dd-agent",
             "short_image:docker-dd-agent",
@@ -62,7 +62,7 @@ def mocked_get_tags(entity, _):
             "container_name:ecs-redis-datadog-1-dd-agent-8085fa82d1d3ada5a601",
             "task_arn:arn:aws:ecs:eu-west-1:172597598159:task/648ca535-cbe0-4de7-b102-28e50b81e888",
         ],
-        "docker://c912d0f0f204360ee90ce67c0d083c3514975f149b854f38a48deac611e82e48": [
+        "container_id://c912d0f0f204360ee90ce67c0d083c3514975f149b854f38a48deac611e82e48": [
             "docker_image:redis:latest",
             "image_name:redis",
             "short_image:redis",
@@ -75,7 +75,7 @@ def mocked_get_tags(entity, _):
             "container_name:ecs-redis-datadog-1-redis-ce99d29f8ce998ed4a00",
             "task_arn:arn:aws:ecs:eu-west-1:172597598159:task/648ca535-cbe0-4de7-b102-28e50b81e888",
         ],
-        "docker://39e13ccc425e7777187a603fe33f466a18515030707c4063de1dc1b63d14d411": [
+        "container_id://39e13ccc425e7777187a603fe33f466a18515030707c4063de1dc1b63d14d411": [
             "docker_image:amazon/amazon-ecs-pause:0.1.0",
             "image_name:amazon/amazon-ecs-pause",
             "short_image:amazon-ecs-pause",


### PR DESCRIPTION
### What does this PR do?

Update the `ecs_fargate` integration to call the tagger with the `container_id` prefix

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
