### PR TITLE
Add missing HTTP options to example config

### DIFF
--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -1,5 +1,32 @@
 init_config:
 
+    ## @param proxy - object - optional
+    ## Set HTTP or HTTPS proxies for all instances. Use the `no_proxy` list
+    ## to specify hosts that must bypass proxies.
+    ##
+    ## The SOCKS protocol is also supported like so:
+    ##
+    ## socks5://user:pass@host:port
+    ##
+    ## Using the scheme `socks5` causes the DNS resolution to happen on the
+    ## client, rather than on the proxy server. This is in line with `curl`,
+    ## which uses the scheme to decide whether to do the DNS resolution on
+    ## the client or proxy. If you want to resolve the domains on the proxy
+    ## server, use `socks5h` as the scheme.
+    #
+    # proxy:
+    #   http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
+    #   https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
+    #   no_proxy:
+    #     - <HOSTNAME_1>
+    #     - <HOSTNAME_2>
+
+    ## @param skip_proxy - boolean - optional - default: false
+    ## If set to `true`, this makes the check bypass any proxy
+    ## settings enabled and attempt to reach services directly.
+    #
+    # skip_proxy: false
+
 instances:
 
     ## @param url - string - required
@@ -7,74 +34,6 @@ instances:
     ## fetch statistics from the nodes and information about the cluster health.
     #
   - url: http://localhost:9200
-
-    ## @param username - string - optional
-    ## The username to use if services are behind basic auth.
-    #
-    # username: <USERNAME>
-
-    ## @param password - string - optional
-    ## The password to use if services are behind basic or NTLM auth.
-    #
-    # password: <PASSWORD>
-
-    ## @param tls_verify - boolean - optional - default: true
-    ## Instructs the check to validate the TLS certificate of services.
-    #
-    # tls_verify: true
-
-    ## @param tls_ignore_warning - boolean - optional - default: false
-    ## If `tls_verify` is disabled, security warnings are logged by the check.
-    ## Disable those by setting `tls_ignore_warning` to true.
-    #
-    # tls_ignore_warning: false
-
-    ## @param tls_cert - string - optional
-    ## The path to a single file in PEM format containing a certificate as well as any
-    ## number of CA certificates needed to establish the certificate’s authenticity for
-    ## use when connecting to services. It may also contain an unencrypted private key to use.
-    #
-    # tls_cert: <CERT_PATH>
-
-    ## @param tls_private_key - string - optional
-    ## The unencrypted private key to use for `tls_cert` when connecting to services. This is
-    ## required if `tls_cert` is set and it does not already contain a private key.
-    #
-    # tls_private_key: <PRIVATE_KEY_PATH>
-
-    ## @param tls_ca_cert - string - optional
-    ## The path to a file of concatenated CA certificates in PEM format or a directory
-    ## containing several CA certificates in PEM format. If a directory, the directory
-    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
-    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
-    #
-    # tls_ca_cert: <CA_CERT_PATH>
-
-    ## @param headers - list of key:value elements - optional
-    ## The headers parameter allows you to send specific headers with every request.
-    ## You can use it for explicitly specifying the host header or adding headers for
-    ## authorization purposes.
-    ##
-    ## This overrides any default headers.
-    #
-    # headers:
-    #   Host: <ALTERNATIVE_HOSTNAME>
-    #   X-Auth-Token: <AUTH_TOKEN>
-
-    ## @param timeout - integer - optional - default: 10
-    ## The timeout for connecting to services.
-    #
-    # timeout: 10
-
-    ## @param log_requests - boolean - optional - default: false
-    ## Whether or not to debug log the HTTP(S) requests made, including the method and URL.
-    #
-    # log_requests: false
-
-    ## @param persist_connections - boolean - optional - default: false
-    ## Whether or not to persist cookies and use connection pooling for increased performance.
-    #
-    # persist_connections: false
 
     ## @param node_name_as_host - boolean - optional - default: false
     ## If each machine only runs a single Elasticsearch node per cluster, you
@@ -160,6 +119,132 @@ instances:
     #   no_proxy:
     #     - <HOSTNAME_1>
     #     - <HOSTNAME_2>
+
+    ## @param skip_proxy - boolean - optional - default: false
+    ## This overrides the `skip_proxy` setting in `init_config`.
+    ##
+    ## If set to `true`, this makes the check bypass any proxy
+    ## settings enabled and attempt to reach services directly.
+    #
+    # skip_proxy: false
+
+    ## @param username - string - optional
+    ## The username to use if services are behind basic auth.
+    #
+    # username: <USERNAME>
+
+    ## @param ntlm_domain - string - optional
+    ## If your services uses NTLM authentication, you can
+    ## specify a domain that is used in the check. For NTLM Auth,
+    ## append the username to domain, not as the `username` parameter.
+    ## Example: <NTLM_DOMAIN>/<USERNAME>
+    #
+    # ntlm_domain: <DOMAIN>
+
+    ## @param password - string - optional
+    ## The password to use if services are behind basic or NTLM auth.
+    #
+    # password: <PASSWORD>
+
+    ## @param kerberos_auth - string - optional - default: disabled
+    ## If your service uses Kerberos authentication, you can specify the Kerberos
+    ## strategy to use between:
+    ##  * required
+    ##  * optional
+    ##  * disabled
+    ##
+    ## See https://github.com/requests/requests-kerberos#mutual-authentication
+    #
+    # kerberos_auth: disabled
+
+    ## @param kerberos_delegate - boolean - optional - default: false
+    ## Set to `true` to enable kerberos delegation of credentials to a server that requests delegation.
+    ## See https://github.com/requests/requests-kerberos#delegation
+    #
+    # kerberos_delegate: false
+
+    ## @param kerberos_force_initiate - boolean - optional - default: false
+    ## Set to `true` to preemptively initiate the Kerberos GSS exchange and present a Kerberos ticket on the initial
+    ## request (and all subsequent).
+    ## See https://github.com/requests/requests-kerberos#preemptive-authentication
+    #
+    # kerberos_force_initiate: false
+
+    ## @param kerberos_hostname - string - optional
+    ## Override the hostname used for the Kerberos GSS exchange if its DNS name doesn't match its kerberos
+    ## hostname (eg, behind a content switch or load balancer).
+    ## See https://github.com/requests/requests-kerberos#hostname-override
+    #
+    # kerberos_hostname: null
+
+    ## @param kerberos_principal - string - optional
+    ## Set an explicit principal, to force Kerberos to look for a matching credential cache for the named user.
+    ## See https://github.com/requests/requests-kerberos#explicit-principal
+    #
+    # kerberos_principal: null
+
+    ## @param kerberos_keytab - string - optional
+    ## Set the path to your Kerberos key tab file.
+    #
+    # kerberos_keytab: <KEYTAB_FILE_PATH>
+
+    ## @param tls_verify - boolean - optional - default: true
+    ## Instructs the check to validate the TLS certificate of services.
+    #
+    # tls_verify: true
+
+    ## @param tls_ignore_warning - boolean - optional - default: false
+    ## If `tls_verify` is disabled, security warnings are logged by the check.
+    ## Disable those by setting `tls_ignore_warning` to true.
+    #
+    # tls_ignore_warning: false
+
+    ## @param tls_cert - string - optional
+    ## The path to a single file in PEM format containing a certificate as well as any
+    ## number of CA certificates needed to establish the certificate’s authenticity for
+    ## use when connecting to services. It may also contain an unencrypted private key to use.
+    #
+    # tls_cert: <CERT_PATH>
+
+    ## @param tls_private_key - string - optional
+    ## The unencrypted private key to use for `tls_cert` when connecting to services. This is
+    ## required if `tls_cert` is set and it does not already contain a private key.
+    #
+    # tls_private_key: <PRIVATE_KEY_PATH>
+
+    ## @param tls_ca_cert - string - optional
+    ## The path to a file of concatenated CA certificates in PEM format or a directory
+    ## containing several CA certificates in PEM format. If a directory, the directory
+    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
+    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    #
+    # tls_ca_cert: <CA_CERT_PATH>
+
+    ## @param headers - list of key:value elements - optional
+    ## The headers parameter allows you to send specific headers with every request.
+    ## You can use it for explicitly specifying the host header or adding headers for
+    ## authorization purposes.
+    ##
+    ## This overrides any default headers.
+    #
+    # headers:
+    #   Host: <ALTERNATIVE_HOSTNAME>
+    #   X-Auth-Token: <AUTH_TOKEN>
+
+    ## @param timeout - integer - optional - default: 10
+    ## The timeout for connecting to services.
+    #
+    # timeout: 10
+
+    ## @param log_requests - boolean - optional - default: false
+    ## Whether or not to debug log the HTTP(S) requests made, including the method and URL.
+    #
+    # log_requests: false
+
+    ## @param persist_connections - boolean - optional - default: false
+    ## Whether or not to persist cookies and use connection pooling for increased performance.
+    #
+    # persist_connections: false
 
 ## Log Section (Available for Agent >=6.0)
 ##


### PR DESCRIPTION
### Additional Notes

Also moved them below integration-specific options