### PR TITLE
Update Readme with status_zone nginx configuration option

### DIFF
--- a/nginx/README.md
+++ b/nginx/README.md
@@ -89,12 +89,12 @@ For NGINX Plus releases 15+, the `status` module is deprecated. Use the [http_ap
   } 
   ```
 
-To get more detailed metrics with NGINX Plus (such as 2xx / 3xx / 4xx / 5xx response counts per second), you may need to set a `status_zone` on the servers you want to monitor. For example:
+To get more detailed metrics with NGINX Plus (such as 2xx / 3xx / 4xx / 5xx response counts per second), set a `status_zone` on the servers you want to monitor. For example:
 
   ```
   server {
     listen 80;
-    status_zone <zone_name>;
+    status_zone <ZONE_NAME>;
     ...
   }
   ```

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -89,6 +89,15 @@ For NGINX Plus releases 15+, the `status` module is deprecated. Use the [http_ap
   } 
   ```
 
+To get more detailed metrics with NGINX Plus (such as 2xx / 3xx / 4xx / 5xx response counts per second), you may need to set a `status_zone` on the servers you want to monitor. For example:
+
+  ```
+  server {
+    listen 80;
+    status_zone <zone_name>;
+    ...
+  }
+  ```
 
 Reload NGINX to enable the status or API endpoint. There's no need for a full restart.
 


### PR DESCRIPTION
### What does this PR do?

Adds explanation on how to get `2xx / 3xx / 4xx / 5xx responses per second` metrics.

### Motivation

When testing the NGINX Plus dashboard, the `2xx / 3xx / 4xx / 5xx responses per second` graphs remained empty until I added the option in the nginx config.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
