### PR TITLE
Fix sqlserver metrics tests

### DIFF
--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -25,7 +25,8 @@ PORT = 1433
 HERE = os.path.dirname(os.path.abspath(__file__))
 CHECK_NAME = "sqlserver"
 
-EXPECTED_METRICS = [m[0] for m in SQLServer.METRICS]
+CUSTOM_METRICS = ['sqlserver.clr.execution', 'sqlserver.exec.in_progress']
+EXPECTED_METRICS = [m[0] for m in SQLServer.METRICS] + CUSTOM_METRICS
 
 INSTANCE_DOCKER = {
     'host': '{},1433'.format(HOST),

--- a/sqlserver/tests/test_sqlserver.py
+++ b/sqlserver/tests/test_sqlserver.py
@@ -135,4 +135,4 @@ def _assert_metrics(aggregator, expected_tags):
     for mname in EXPECTED_METRICS:
         aggregator.assert_metric(mname, count=1)
     aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK, tags=expected_tags)
-    aggregator.assert_all_metrics_covered
+    aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

Fix sqlserver tests. The `aggregator.assert_all_metrics_covered` was not called, so tests where always passing.

Also added few metrics that where not asserted.

### Motivation


### Additional Notes


### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
