### PR TITLE
Add test for socks5 proxy

### DIFF
--- a/datadog_checks_base/tests/compose/socks5-proxy.yaml
+++ b/datadog_checks_base/tests/compose/socks5-proxy.yaml
@@ -1,0 +1,13 @@
+version: '3.5'
+
+services:
+  socks5:
+    image: "serjs/go-socks5-proxy:latest"
+    ports:
+      - 1080:1080
+    container_name: socks5
+    environment:
+      - PROXY_USER=proxy_user
+      - PROXY_PASSWORD=proxy_password
+  nginx:
+    image: nginx:stable-alpine

--- a/datadog_checks_base/tests/conftest.py
+++ b/datadog_checks_base/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+
+import pytest
+
+from datadog_checks.dev import docker_run, get_here
+
+HERE = get_here()
+
+
+@pytest.fixture(scope="session")
+def socks5_proxy():
+    with docker_run(compose_file=os.path.join(HERE, "compose", "socks5-proxy.yaml")):
+        yield "proxy_user:proxy_password@localhost:1080"

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -17,6 +17,7 @@ from urllib3.exceptions import InsecureRequestWarning
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.utils.http import STANDARD_FIELDS, RequestsWrapper
 from datadog_checks.dev import EnvVars
+from datadog_checks.dev.utils import running_on_appveyor
 
 pytestmark = pytest.mark.http
 
@@ -423,6 +424,7 @@ class TestProxies:
 
         http.get('https://www.google.com')
 
+    @pytest.mark.skipif(running_on_appveyor(), reason="Cannot run on appveyor")
     def test_socks5_proxy(self, socks5_proxy):
         instance = {'proxy': {'http': 'socks5h://{}'.format(socks5_proxy)}}
         init_config = {}

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -423,6 +423,13 @@ class TestProxies:
 
         http.get('https://www.google.com')
 
+    def test_socks5_proxy(self, socks5_proxy):
+        instance = {'proxy': {'http': 'socks5h://{}'.format(socks5_proxy)}}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+        http.get('http://www.google.com')
+        http.get('http://nginx')
+
 
 class TestIgnoreTLSWarning:
     def test_config_default(self):

--- a/datadog_checks_base/tox.ini
+++ b/datadog_checks_base/tox.ini
@@ -10,6 +10,10 @@ usedevelop = true
 deps =
   -e../datadog_checks_tests_helper
   -rrequirements-dev.txt
+passenv =
+    DOCKER*
+    COMPOSE*
+    APPVEYOR*
 commands =
   pip install -r requirements.in
   pytest -v {posargs}


### PR DESCRIPTION
Socks5 proxy have been introduced recently (see https://github.com/DataDog/integrations-core/pull/4021) by leveraging `requests` official support for it. Let's add a test to make sure our code always support using a socks5 proxy