### PR TITLE
Update kube_apiserver_metrics example configuration URL

### DIFF
--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -5,7 +5,7 @@ instances:
     ## @param prometheus_url - string - required
     ## The URL where your application metrics are exposed by Prometheus.
     #
-  - prometheus_url: localhost:443/metrics
+  - prometheus_url: https://localhost:443/metrics
     
     ## @param scheme - string - optional
     ## Used to specify the scheme to reach the APIServer endpoints. Default to https.


### PR DESCRIPTION
### What does this PR do?

Update kube_apiserver_metrics example configuration URL in line with all other check example files which include the scheme in the URL.

### Motivation

Consistency.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
