### PR TITLE
Fix dashboard title

### DIFF
--- a/nginx/assets/dashboards/plus_overview.json
+++ b/nginx/assets/dashboards/plus_overview.json
@@ -1,5 +1,5 @@
 {
-  "board_title": "NGINX Plus Overview",
+  "board_title": "NGINX Plus - Overview",
   "read_only": false,
   "author_info": {
     "author_name": "Datadog"


### PR DESCRIPTION
### What does this PR do?

Fix the NGINX Plus dashboard title (adding `-`).

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
