### PR TITLE
Add test for sqlserver config `adoprovider`

### DIFF
--- a/sqlserver/tests/test_sqlserver.py
+++ b/sqlserver/tests/test_sqlserver.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from copy import deepcopy
+
 import pytest
 
 from datadog_checks.sqlserver import SQLServer
@@ -123,6 +125,18 @@ def test_check_local(aggregator, init_config, instance_sql2017):
     sqlserver_check = SQLServer(CHECK_NAME, init_config, {}, [instance_sql2017])
     sqlserver_check.check(instance_sql2017)
     expected_tags = instance_sql2017.get('tags', []) + [r'host:(local)\SQL2017', 'db:master']
+    _assert_metrics(aggregator, expected_tags)
+
+
+@pytest.mark.local
+@pytest.mark.parametrize('adoprovider', ['SQLOLEDB', 'SQLNCLI11'])
+def test_check_adoprovider(aggregator, init_config, instance_sql2017, adoprovider):
+    instance = deepcopy(instance_sql2017)
+    instance['adoprovider'] = adoprovider
+
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, {}, [instance])
+    sqlserver_check.check(instance)
+    expected_tags = instance.get('tags', []) + [r'host:(local)\SQL2017', 'db:master']
     _assert_metrics(aggregator, expected_tags)
 
 


### PR DESCRIPTION
### What does this PR do?

Add test for adoprovider as part of QA to verify that `SQLNCLI11` works (only run on win/appveyor).

`MSOLEDBSQL` is not tested at the moment since it must be installed first:

```
    ## @param adoprovider - string - optional - default: SQLOLEDB
    ## Choose the ADO provider.  Note that the (default) provider
    ## SQLOLEDB is being deprecated.  To use the newer MSOLEDBSQL
    ## provider, set the adoprovider to "MSOLEDBSQL" below. You will also need
    ## to download the new provider from
    ## https://docs.microsoft.com/en-us/sql/connect/oledb/oledb-driver-for-sql-server?view=sql-server-2017
    #
    # adoprovider: SQLOLEDB

```

### Motivation


### Additional Notes


### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
