### PR TITLE
Add env check for jmx integrations

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
@@ -34,7 +34,8 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_suc
     help='Line number to start a PDB session (0: first line, -1: last line)',
 )
 @click.option('--config', 'config_file', help='Path to a JSON check configuration to use')
-def check_run(check, env, rate, times, pause, delay, log_level, as_json, break_point, config_file):
+@click.option('--jmx-list', 'jmx_list', default='matching', help='JMX metrics listing method')
+def check_run(check, env, rate, times, pause, delay, log_level, as_json, break_point, config_file, jmx_list):
     """Run an Agent check."""
     envs = get_configured_envs(check)
     if not envs:
@@ -57,7 +58,7 @@ def check_run(check, env, rate, times, pause, delay, log_level, as_json, break_p
 
     environment = create_interface(check, env)
     check_args = dict(
-        rate=rate, times=times, pause=pause, delay=delay, log_level=log_level, as_json=as_json, break_point=break_point
+        rate=rate, times=times, pause=pause, delay=delay, log_level=log_level, as_json=as_json, break_point=break_point, jmx_list=jmx_list
     )
 
     if config_file:
@@ -69,4 +70,4 @@ def check_run(check, env, rate, times, pause, delay, log_level, as_json, break_p
 
         if not rate:
             echo_success('Note: ', nl=False)
-            echo_info('If some metrics are missing, you may want to try again with the -r / --rate flag.')
+            echo_info('If some metrics are missing, you may want to try again with the -r / --rate flag for a classic integration.')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
@@ -58,7 +58,14 @@ def check_run(check, env, rate, times, pause, delay, log_level, as_json, break_p
 
     environment = create_interface(check, env)
     check_args = dict(
-        rate=rate, times=times, pause=pause, delay=delay, log_level=log_level, as_json=as_json, break_point=break_point, jmx_list=jmx_list
+        rate=rate,
+        times=times,
+        pause=pause,
+        delay=delay,
+        log_level=log_level,
+        as_json=as_json,
+        break_point=break_point,
+        jmx_list=jmx_list,
     )
 
     if config_file:
@@ -70,4 +77,7 @@ def check_run(check, env, rate, times, pause, delay, log_level, as_json, break_p
 
         if not rate:
             echo_success('Note: ', nl=False)
-            echo_info('If some metrics are missing, you may want to try again with the -r / --rate flag for a classic integration.')
+            echo_info(
+                'If some metrics are missing, you may want to try again with the -r / --rate flag '
+                'for a classic integration.'
+            )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -123,7 +123,7 @@ class DockerInterface(object):
                 command += ' --breakpoint {}'.format(break_point)
 
         if log_level is not None:
-                command += ' --log-level {}'.format(log_level)
+            command += ' --log-level {}'.format(log_level)
 
         return self.exec_command(command, capture=capture, interactive=break_point is not None)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -94,30 +94,36 @@ class DockerInterface(object):
         log_level=None,
         as_json=False,
         break_point=None,
+        jmx_list='matching',
     ):
-        command = '{} check {}'.format(self.agent_command, self.check)
+        # JMX check
+        if self.metadata.get('use_jmx', False):
+            command = '{} jmx list {}'.format(self.agent_command, jmx_list)
+        # Classic check
+        else:
+            command = '{} check {}'.format(self.agent_command, self.check)
 
-        if rate:
-            command += ' {}'.format(get_rate_flag(self.agent_version))
+            if rate:
+                command += ' {}'.format(get_rate_flag(self.agent_version))
 
-        # These are only available for Agent 6+
-        if times is not None:
-            command += ' --check-times {}'.format(times)
+            # These are only available for Agent 6+
+            if times is not None:
+                command += ' --check-times {}'.format(times)
 
-        if pause is not None:
-            command += ' --pause {}'.format(pause)
+            if pause is not None:
+                command += ' --pause {}'.format(pause)
 
-        if delay is not None:
-            command += ' --delay {}'.format(delay)
+            if delay is not None:
+                command += ' --delay {}'.format(delay)
+
+            if as_json:
+                command += ' --json {}'.format(as_json)
+
+            if break_point is not None:
+                command += ' --breakpoint {}'.format(break_point)
 
         if log_level is not None:
-            command += ' --log-level {}'.format(log_level)
-
-        if as_json:
-            command += ' --json {}'.format(as_json)
-
-        if break_point is not None:
-            command += ' --breakpoint {}'.format(break_point)
+                command += ' --log-level {}'.format(log_level)
 
         return self.exec_command(command, capture=capture, interactive=break_point is not None)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -160,7 +160,7 @@ class LocalAgentInterface(object):
                 command += ' --breakpoint {}'.format(break_point)
 
         if log_level is not None:
-                command += ' --log-level {}'.format(log_level)
+            command += ' --log-level {}'.format(log_level)
 
         return run_command(command, capture=capture)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -131,30 +131,36 @@ class LocalAgentInterface(object):
         log_level=None,
         as_json=False,
         break_point=None,
+        jmx_list='matching',
     ):
-        command = '{} check {}'.format(self.agent_command, self.check)
+        # JMX check
+        if self.metadata.get('use_jmx', False):
+            command = '{} jmx list {}'.format(self.agent_command, jmx_list)
+        # Classic check
+        else:
+            command = '{} check {}'.format(self.agent_command, self.check)
 
-        if rate:
-            command += ' {}'.format(get_rate_flag(self.agent_version))
+            if rate:
+                command += ' {}'.format(get_rate_flag(self.agent_version))
 
-        # These are only available for Agent 6+
-        if times is not None:
-            command += ' --check-times {}'.format(times)
+            # These are only available for Agent 6+
+            if times is not None:
+                command += ' --check-times {}'.format(times)
 
-        if pause is not None:
-            command += ' --pause {}'.format(pause)
+            if pause is not None:
+                command += ' --pause {}'.format(pause)
 
-        if delay is not None:
-            command += ' --delay {}'.format(delay)
+            if delay is not None:
+                command += ' --delay {}'.format(delay)
+
+            if as_json:
+                command += ' --json {}'.format(as_json)
+
+            if break_point is not None:
+                command += ' --breakpoint {}'.format(break_point)
 
         if log_level is not None:
-            command += ' --log-level {}'.format(log_level)
-
-        if as_json:
-            command += ' --json {}'.format(as_json)
-
-        if break_point is not None:
-            command += ' --breakpoint {}'.format(break_point)
+                command += ' --log-level {}'.format(log_level)
 
         return run_command(command, capture=capture)
 


### PR DESCRIPTION
### What does this PR do?

Add the possibility to use `ddev env check integ env` for JMX integration.
It uses `datadog-agent jmx list [...]`. The default list method is `matching`, but it can be set using `--jmx-list`. 

### Motivation

Using `ddev env check jmx_integ py37-latest` for JMX integration like the classic ones.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
