### PR TITLE
Fix proc location for conntrack files

### DIFF
--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -284,10 +284,7 @@ class Network(AgentCheck):
         proc_location = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
         custom_tags = instance.get('tags', [])
 
-        if Platform.is_containerized() and proc_location != "/proc":
-            net_proc_base_location = "%s/1" % proc_location
-        else:
-            net_proc_base_location = proc_location
+        net_proc_base_location = self._get_net_proc_base_location(proc_location)
 
         if self._is_collect_cx_state_runnable(net_proc_base_location):
             try:
@@ -460,6 +457,14 @@ class Network(AgentCheck):
                         self.log.debug("{} is not an integer".format(metric_name))
             except IOError as e:
                 self.log.debug("Unable to read {}, skipping {}.".format(metric_file_location, e))
+
+    @staticmethod
+    def _get_net_proc_base_location(proc_location):
+        if Platform.is_containerized() and proc_location != "/proc":
+            net_proc_base_location = "%s/1" % proc_location
+        else:
+            net_proc_base_location = proc_location
+        return net_proc_base_location
 
     def _add_conntrack_stats_metrics(self, conntrack_path, tags):
         """

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -285,9 +285,11 @@ class Network(AgentCheck):
         custom_tags = instance.get('tags', [])
 
         if Platform.is_containerized() and proc_location != "/proc":
-            proc_location = "%s/1" % proc_location
+            net_proc_base_location = "%s/1" % proc_location
+        else:
+            net_proc_base_location = proc_location
 
-        if self._is_collect_cx_state_runnable(proc_location):
+        if self._is_collect_cx_state_runnable(net_proc_base_location):
             try:
                 self.log.debug("Using `ss` to collect connection state")
                 # Try using `ss` for increased performance over `netstat`
@@ -338,7 +340,7 @@ class Network(AgentCheck):
             except SubprocessOutputEmptyError:
                 self.log.exception("Error collecting connection stats.")
 
-        proc_dev_path = "{}/net/dev".format(proc_location)
+        proc_dev_path = "{}/net/dev".format(net_proc_base_location)
         with open(proc_dev_path, 'r') as proc:
             lines = proc.readlines()
         # Inter-|   Receive                                                 |  Transmit
@@ -364,7 +366,7 @@ class Network(AgentCheck):
 
         netstat_data = {}
         for f in ['netstat', 'snmp']:
-            proc_data_path = "{}/net/{}".format(proc_location, f)
+            proc_data_path = "{}/net/{}".format(net_proc_base_location, f)
             try:
                 with open(proc_data_path, 'r') as netstat:
                     while True:

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -11,6 +11,7 @@ import mock
 import pytest
 from six import PY3, iteritems
 
+from datadog_checks.dev import EnvVars
 from datadog_checks.network import Network
 
 from . import common
@@ -290,3 +291,18 @@ def test_parse_protocol_psutil(aggregator, check):
     conn.family = socket.AF_INET
     protocol = check._parse_protocol_psutil(conn)
     assert protocol == 'udp4'
+
+
+@pytest.mark.parametrize(
+    "proc_location, envs, expected_net_proc_base_location",
+    [
+        ("/something/proc", {'DOCKER_DD_AGENT': 'true'}, "/something/proc/1"),
+        ("/something/proc", {}, "/something/proc"),
+        ("/proc", {'DOCKER_DD_AGENT': 'true'}, "/proc"),
+        ("/proc", {}, "/proc"),
+    ],
+)
+def test_get_net_proc_base_location(aggregator, check, proc_location, envs, expected_net_proc_base_location):
+    with EnvVars(envs):
+        actual = check._get_net_proc_base_location(proc_location)
+        assert expected_net_proc_base_location == actual


### PR DESCRIPTION
### What does this PR do?

Avoid suffixing with `/1` when reading conntrack proc files.

In a docker container the `proc_location` is [suffixed with /1](https://github.com/DataDog/integrations-core/blob/caa8e8303048b2a7a9fa895de2416a7b4ec70421/network/datadog_checks/network/network.py#L287) for `net` files.

But there is not need to suffix with `/1` for [conntrack files](https://github.com/DataDog/integrations-core/blob/caa8e8303048b2a7a9fa895de2416a7b4ec70421/network/datadog_checks/network/network.py#L424)

Conntrack files always reside in `/proc/sys/net/*`. Commands executed inside a container:

```
root@ffcad4dd91a8:/# cat /host/proc/sys/net/netfilter/nf_conntrack_events
1
root@ffcad4dd91a8:/# cat /proc/sys/net/netfilter/nf_conntrack_events
1
```

Note: `nf_conntrack_count` has a different value inside a container. See additional notes below.

### Motivation
User getting this error `Unable to read /host/proc/1/sys/net/nf_conntrack_max`

```
datadog [ AGENT ] 2019-06-25 02:04:46 UTC | DEBUG | (pkg/collector/py/datadog_agent.go:152 in LogMessage) | (network.py:463) | Unable to read /host/proc/1/sys/net/nf_conntrack_max. Skipping nf_conntrack_max metrics pull.
```

### Additional Notes

It seems that some `host conntrack stats` are not available inside a container.

Inside container:
```
root@ffcad4dd91a8:/# cat /host/proc/sys/net/netfilter/nf_conntrack_count
0
root@ffcad4dd91a8:/# cat /host/proc/sys/net/netfilter/nf_conntrack_max
262144
```

On host:
```
➜  ~ cat /proc/sys/net/netfilter/nf_conntrack_count
24
➜  ~ cat /proc/sys/net/netfilter/nf_conntrack_max
262144
```

But it seems that `nf_conntrack_count` has a different value inside a container (the only one):
[conntrack_metrics.txt](https://github.com/DataDog/integrations-core/files/3411970/conntrack_metrics.txt)



### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
