### PR TITLE
Fix prometheus and openmetric unicode labels

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -628,7 +628,7 @@ class OpenMetricsScraperMixin(object):
                     hostname=custom_hostname,
                 )
             else:
-                sample[self.SAMPLE_LABELS]["quantile"] = str(float(sample[self.SAMPLE_LABELS]["quantile"]))
+                sample[self.SAMPLE_LABELS]["quantile"] = float(sample[self.SAMPLE_LABELS]["quantile"])
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname=custom_hostname)
                 self.gauge(
                     "{}.{}.quantile".format(scraper_config['namespace'], metric_name),
@@ -670,7 +670,7 @@ class OpenMetricsScraperMixin(object):
                 and sample[self.SAMPLE_NAME].endswith("_bucket")
                 and "Inf" not in sample[self.SAMPLE_LABELS]["le"]
             ):
-                sample[self.SAMPLE_LABELS]["le"] = str(float(sample[self.SAMPLE_LABELS]["le"]))
+                sample[self.SAMPLE_LABELS]["le"] = float(sample[self.SAMPLE_LABELS]["le"])
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname)
                 self.gauge(
                     "{}.{}.count".format(scraper_config['namespace'], metric_name),

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -628,7 +628,7 @@ class OpenMetricsScraperMixin(object):
                     hostname=custom_hostname,
                 )
             else:
-                sample[self.SAMPLE_LABELS]["quantile"] = float(sample[self.SAMPLE_LABELS]["quantile"])
+                sample[self.SAMPLE_LABELS]["quantile"] = str(float(sample[self.SAMPLE_LABELS]["quantile"]))
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname=custom_hostname)
                 self.gauge(
                     "{}.{}.quantile".format(scraper_config['namespace'], metric_name),
@@ -670,7 +670,7 @@ class OpenMetricsScraperMixin(object):
                 and sample[self.SAMPLE_NAME].endswith("_bucket")
                 and "Inf" not in sample[self.SAMPLE_LABELS]["le"]
             ):
-                sample[self.SAMPLE_LABELS]["le"] = float(sample[self.SAMPLE_LABELS]["le"])
+                sample[self.SAMPLE_LABELS]["le"] = str(float(sample[self.SAMPLE_LABELS]["le"]))
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname)
                 self.gauge(
                     "{}.{}.count".format(scraper_config['namespace'], metric_name),

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -14,6 +14,7 @@ from urllib3.exceptions import InsecureRequestWarning
 
 from ...config import is_affirmative
 from ...errors import CheckException
+from ...utils.common import to_string
 from .. import AgentCheck
 
 if PY3:
@@ -685,7 +686,7 @@ class OpenMetricsScraperMixin(object):
         for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
             if label_name not in scraper_config['exclude_labels']:
                 tag_name = scraper_config['labels_mapper'].get(label_name, label_name)
-                _tags.append('{}:{}'.format(tag_name, label_value))
+                _tags.append('{}:{}'.format(to_string(tag_name), to_string(label_value)))
         return self._finalize_tags_to_submit(
             _tags, metric_name, val, sample, custom_tags=custom_tags, hostname=hostname
         )

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
@@ -4,6 +4,7 @@
 from six import string_types
 
 from ...errors import CheckException
+from ...utils.common import to_string
 from .. import AgentCheck
 from .mixins import PrometheusScraperMixin
 
@@ -61,7 +62,7 @@ class PrometheusScraper(PrometheusScraperMixin):
                 tag_name = label.name
                 if self.labels_mapper is not None and label.name in self.labels_mapper:
                     tag_name = self.labels_mapper[label.name]
-                _tags.append('{}:{}'.format(tag_name, label.value))
+                _tags.append('{}:{}'.format(to_string(tag_name), to_string(label.value)))
         return self._finalize_tags_to_submit(
             _tags, metric_name, val, metric, custom_tags=custom_tags, hostname=hostname
         )

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/prometheus_base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/prometheus_base.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from ...utils.common import to_string
 from .. import AgentCheck
 from .mixins import PrometheusScraperMixin
 
@@ -78,7 +79,7 @@ class PrometheusCheck(PrometheusScraperMixin, AgentCheck):
                 tag_name = label.name
                 if self.labels_mapper is not None and label.name in self.labels_mapper:
                     tag_name = self.labels_mapper[label.name]
-                _tags.append('{}:{}'.format(tag_name, label.value))
+                _tags.append('{}:{}'.format(to_string(tag_name), to_string(label.value)))
         return self._finalize_tags_to_submit(
             _tags, metric_name, val, metric, custom_tags=custom_tags, hostname=hostname
         )

--- a/datadog_checks_base/datadog_checks/base/utils/common.py
+++ b/datadog_checks_base/datadog_checks/base/utils/common.py
@@ -5,12 +5,12 @@ import os
 import re
 from decimal import ROUND_HALF_UP, Decimal
 
-from six import PY3, string_types
+from six import PY3
 from six.moves.urllib.parse import urlparse
 
 
 def ensure_bytes(s):
-    if isinstance(s, string_types) and not isinstance(s, bytes):
+    if not isinstance(s, bytes):
         s = s.encode('utf-8')
     return s
 

--- a/datadog_checks_base/datadog_checks/base/utils/common.py
+++ b/datadog_checks_base/datadog_checks/base/utils/common.py
@@ -8,9 +8,14 @@ from decimal import ROUND_HALF_UP, Decimal
 from six import PY3
 from six.moves.urllib.parse import urlparse
 
+if PY3:
+    text_type = str
+else:
+    text_type = unicode  # noqa: F821
+
 
 def ensure_bytes(s):
-    if not isinstance(s, bytes):
+    if isinstance(s, text_type):
         s = s.encode('utf-8')
     return s
 

--- a/datadog_checks_base/datadog_checks/base/utils/common.py
+++ b/datadog_checks_base/datadog_checks/base/utils/common.py
@@ -5,12 +5,12 @@ import os
 import re
 from decimal import ROUND_HALF_UP, Decimal
 
-from six import PY3
+from six import PY3, string_types
 from six.moves.urllib.parse import urlparse
 
 
 def ensure_bytes(s):
-    if not isinstance(s, bytes):
+    if isinstance(s, string_types) and not isinstance(s, bytes):
         s = s.encode('utf-8')
     return s
 

--- a/datadog_checks_base/datadog_checks/base/utils/common.py
+++ b/datadog_checks_base/datadog_checks/base/utils/common.py
@@ -5,13 +5,8 @@ import os
 import re
 from decimal import ROUND_HALF_UP, Decimal
 
-from six import PY3
+from six import PY3, text_type
 from six.moves.urllib.parse import urlparse
-
-if PY3:
-    text_type = str
-else:
-    text_type = unicode  # noqa: F821
 
 
 def ensure_bytes(s):

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # (C) Datadog, Inc. 2016
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
@@ -159,9 +161,13 @@ def test_poll_text_plain(mocked_prometheus_check, mocked_prometheus_scraper_conf
 def test_submit_gauge_with_labels(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
     """ submitting metrics that contain labels should result in tags on the gauge call """
     ref_gauge = GaugeMetricFamily(
-        'process_virtual_memory_bytes', 'Virtual memory size in bytes.', labels=['my_1st_label', 'my_2nd_label']
+        'process_virtual_memory_bytes',
+        'Virtual memory size in bytes.',
+        labels=['my_1st_label', 'my_2nd_label', 'labél_nat', 'labél_mix', u'labél_uni'],
     )
-    ref_gauge.add_metric(['my_1st_label_value', 'my_2nd_label_value'], 54927360.0)
+    ref_gauge.add_metric(
+        ['my_1st_label_value', 'my_2nd_label_value', 'my_labél_val', u'my_labél_val🐶', u'my_labél_val'], 54927360.0
+    )
 
     check = mocked_prometheus_check
     metric_name = mocked_prometheus_scraper_config['metrics_mapper'][ref_gauge.name]
@@ -169,7 +175,13 @@ def test_submit_gauge_with_labels(aggregator, mocked_prometheus_check, mocked_pr
     aggregator.assert_metric(
         'prometheus.process.vm.bytes',
         54927360.0,
-        tags=['my_1st_label:my_1st_label_value', 'my_2nd_label:my_2nd_label_value'],
+        tags=[
+            'my_1st_label:my_1st_label_value',
+            'my_2nd_label:my_2nd_label_value',
+            'labél_nat:my_labél_val',
+            'labél_mix:my_labél_val🐶',
+            'labél_uni:my_labél_val',
+        ],
         count=1,
     )
 

--- a/datadog_checks_base/tests/test_prometheus.py
+++ b/datadog_checks_base/tests/test_prometheus.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # (C) Datadog, Inc. 2016
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
@@ -360,12 +362,27 @@ def test_submit_gauge_with_labels(mocked_prometheus_check, ref_gauge):
     _l2 = ref_gauge.metric[0].label.add()
     _l2.name = 'my_2nd_label'
     _l2.value = 'my_2nd_label_value'
+    _l3 = ref_gauge.metric[0].label.add()
+    _l3.name = 'labél'
+    _l3.value = 'my_labél_value'
+    _l4 = ref_gauge.metric[0].label.add()
+    _l4.name = 'labél_mix'
+    _l4.value = u'my_labél_value🇫🇷🇪🇸🇺🇸'
+    _l5 = ref_gauge.metric[0].label.add()
+    _l5.name = u'labél_unicode'
+    _l5.value = u'my_labél_value'
     check = mocked_prometheus_check
     check._submit(check.metrics_mapper[ref_gauge.name], ref_gauge)
     check.gauge.assert_called_with(
         'prometheus.process.vm.bytes',
         39211008.0,
-        ['my_1st_label:my_1st_label_value', 'my_2nd_label:my_2nd_label_value'],
+        [
+            'my_1st_label:my_1st_label_value',
+            'my_2nd_label:my_2nd_label_value',
+            'labél:my_labél_value',
+            'labél_mix:my_labél_value🇫🇷🇪🇸🇺🇸',
+            'labél_unicode:my_labél_value',
+        ],
         hostname=None,
     )
 

--- a/datadog_checks_base/tests/test_utils.py
+++ b/datadog_checks_base/tests/test_utils.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from decimal import ROUND_HALF_DOWN
-
 # (C) Datadog, Inc. 2018-2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+from decimal import ROUND_HALF_DOWN
+
 import pytest
 from six import PY3
 

--- a/datadog_checks_base/tests/test_utils.py
+++ b/datadog_checks_base/tests/test_utils.py
@@ -152,14 +152,12 @@ class TestContainers:
 class TestBytesUnicode:
     @pytest.mark.skipif(PY3, reason="Python 3 does not support explicit bytestring with special characters")
     def test_ensure_bytes_py2(self):
-        assert ensure_bytes('🇫🇷🇪🇸🇺🇸') == '🇫🇷🇪🇸🇺🇸'
-        assert ensure_bytes(u'🇫🇷🇪🇸🇺🇸') == '🇫🇷🇪🇸🇺🇸'
+        assert ensure_bytes('éâû') == 'éâû'
+        assert ensure_bytes(u'éâû') == 'éâû'
 
     def test_ensure_bytes(self):
         assert ensure_bytes('qwerty') == b'qwerty'
-        assert ensure_bytes(33) == 33
 
     def test_ensure_unicode(self):
-        assert ensure_unicode('🇫🇷🇪🇸🇺🇸') == u'🇫🇷🇪🇸🇺🇸'
-        assert ensure_unicode(u'🇫🇷🇪🇸🇺🇸') == u'🇫🇷🇪🇸🇺🇸'
-        assert ensure_unicode(33) == 33
+        assert ensure_unicode('éâû') == u'éâû'
+        assert ensure_unicode(u'éâû') == u'éâû'

--- a/datadog_checks_base/tests/test_utils.py
+++ b/datadog_checks_base/tests/test_utils.py
@@ -1,9 +1,14 @@
+# -*- coding: utf-8 -*-
+
+from decimal import ROUND_HALF_DOWN
+
 # (C) Datadog, Inc. 2018-2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from decimal import ROUND_HALF_DOWN
+import pytest
+from six import PY3
 
-from datadog_checks.base.utils.common import pattern_filter, round_value
+from datadog_checks.base.utils.common import ensure_bytes, ensure_unicode, pattern_filter, round_value
 from datadog_checks.base.utils.containers import iter_unique
 from datadog_checks.base.utils.limiter import Limiter
 
@@ -142,3 +147,19 @@ class TestContainers:
         ]
 
         assert len(list(iter_unique(custom_queries))) == 1
+
+
+class TestBytesUnicode:
+    @pytest.mark.skipif(PY3, reason="Python 3 does not support explicit bytestring with special characters")
+    def test_ensure_bytes_py2(self):
+        assert ensure_bytes('🇫🇷🇪🇸🇺🇸') == '🇫🇷🇪🇸🇺🇸'
+        assert ensure_bytes(u'🇫🇷🇪🇸🇺🇸') == '🇫🇷🇪🇸🇺🇸'
+
+    def test_ensure_bytes(self):
+        assert ensure_bytes('qwerty') == b'qwerty'
+        assert ensure_bytes(33) == 33
+
+    def test_ensure_unicode(self):
+        assert ensure_unicode('🇫🇷🇪🇸🇺🇸') == u'🇫🇷🇪🇸🇺🇸'
+        assert ensure_unicode(u'🇫🇷🇪🇸🇺🇸') == u'🇫🇷🇪🇸🇺🇸'
+        assert ensure_unicode(33) == 33


### PR DESCRIPTION
### What does this PR do?

After the reverts in #4115  and #4116 , fix the encoding issues in prometheus and openmetric classes.
In python 2, formatting a string with a part as a unicode string and the other part as a byte string raises an exception if there is one special character (like `é`).

It happens sometimes like #2054 

To solve this, we convert all the strings to the native python type before formatting (bytes for py2).
The `from __future__ import unicode_literals` is not used anymore.

### Motivation

### Additional Notes

Added a condition in the `ensure_bytes` function to be sure that the argument is a string type.

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
