### PR TITLE
rename public title for kubernetes metric server

### DIFF
--- a/kube_metrics_server/manifest.json
+++ b/kube_metrics_server/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Kube_metrics_server Integration",
+  "public_title": "Datadog-Kubernetes Metric Server Integration",
   "categories": [
     "orchestration",
     "containers"

--- a/kube_metrics_server/manifest.json
+++ b/kube_metrics_server/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Kubernetes Metric Server Integration",
+  "public_title": "Datadog-Kubernetes Metrics Server Integration",
   "categories": [
     "orchestration",
     "containers"


### PR DESCRIPTION
### What does this PR do?

Renames public title for kubernetes metric server

### Motivation

The public title was ugly/typo'd before
