### PR TITLE
Add tuple timeout format to Request Remapper

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -32,7 +32,10 @@ requests_ntlm = None
 
 LOGGER = logging.getLogger(__file__)
 
+DEFAULT_TIMEOUT = 10
+
 STANDARD_FIELDS = {
+    'connect_timeout': None,
     'headers': None,
     'kerberos_auth': None,
     'kerberos_delegate': False,
@@ -45,13 +48,14 @@ STANDARD_FIELDS = {
     'password': None,
     'persist_connections': False,
     'proxy': None,
+    'read_timeout': None,
     'skip_proxy': False,
     'tls_ca_cert': None,
     'tls_cert': None,
     'tls_ignore_warning': False,
     'tls_private_key': None,
     'tls_verify': True,
-    'timeout': 10,
+    'timeout': DEFAULT_TIMEOUT,
     'username': None,
 }
 # For any known legacy fields that may be widespread
@@ -134,10 +138,12 @@ class RequestsWrapper(object):
             config[field] = value
 
         # http://docs.python-requests.org/en/master/user/advanced/#timeouts
-        if type(config['timeout']) is tuple:
-            timeout = (float(config['timeout'][0]), float(config['timeout'][1]))
-        else:
-            timeout = float(config['timeout'])
+        connect_timeout = read_timeout = float(config['timeout'])
+        if config['connect_timeout'] is not None:
+            connect_timeout = float(config['connect_timeout'])
+
+        if config['read_timeout'] is not None:
+            read_timeout = float(config['read_timeout'])
 
         # http://docs.python-requests.org/en/master/user/quickstart/#custom-headers
         # http://docs.python-requests.org/en/master/user/advanced/#header-ordering
@@ -226,7 +232,7 @@ class RequestsWrapper(object):
             'cert': cert,
             'headers': headers,
             'proxies': proxies,
-            'timeout': timeout,
+            'timeout': (connect_timeout, read_timeout),
             'verify': verify,
         }
 

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -134,7 +134,10 @@ class RequestsWrapper(object):
             config[field] = value
 
         # http://docs.python-requests.org/en/master/user/advanced/#timeouts
-        timeout = float(config['timeout'])
+        if type(config['timeout']) is tuple:
+            timeout = (float(config['timeout'][0]), float(config['timeout'][1]))
+        else:
+            timeout = float(config['timeout'])
 
         # http://docs.python-requests.org/en/master/user/quickstart/#custom-headers
         # http://docs.python-requests.org/en/master/user/advanced/#header-ordering

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -52,6 +52,13 @@ class TestTimeout:
 
         assert http.options['timeout'] == 24.5
 
+    def test_config_tuple_timeout(self):
+        instance = {'timeout': (10, 4)}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['timeout'] == (10, 4)
+
 
 class TestHeaders:
     def test_config_default(self):

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -43,17 +43,17 @@ class TestTimeout:
         # Assert the timeout is slightly larger than a multiple of 3,
         # which is the default TCP packet retransmission window. See:
         # https://tools.ietf.org/html/rfc2988
-        assert 0 < http.options['timeout'] % 3 <= 1
+        assert 0 < http.options['timeout'][0] % 3 <= 1
 
     def test_config_timeout(self):
         instance = {'timeout': 24.5}
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
-        assert http.options['timeout'] == 24.5
+        assert http.options['timeout'] == (24.5, 24.5)
 
-    def test_config_tuple_timeout(self):
-        instance = {'timeout': (10, 4)}
+    def test_config_multiple_timeouts(self):
+        instance = {'read_timeout': 4, 'connect_timeout': 10}
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
@@ -524,7 +524,7 @@ class TestRemapper:
         remapper = {'prometheus_timeout': {'name': 'timeout'}}
         http = RequestsWrapper(instance, init_config, remapper)
 
-        assert http.options['timeout'] == STANDARD_FIELDS['timeout']
+        assert http.options['timeout'] == (STANDARD_FIELDS['timeout'], STANDARD_FIELDS['timeout'])
 
     def test_invert(self):
         instance = {'disable_ssl_validation': False}


### PR DESCRIPTION
### What does this PR do?
Allows timeout to handle tuple configs as well.
### Motivation

What inspired you to submit this pull request?

Timeouts can also be specified as a tuple. Integrations like `apache` use the tuple format and this will make remapping easier.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
