### PR TITLE
Fix prometheus_url conf

### DIFF
--- a/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
+++ b/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
@@ -12,7 +12,7 @@ instances:
     ## enable endpoint checks alongside the service check and use autodiscovery
     ## to get pod IP by setting up `prometheus_url` to https://%%host%%/metrics
     #
-  - prometheus_url: http://localhost:443/metrics
+  - prometheus_url: https://localhost:443/metrics
 
     ## @param tags - list of key:value elements - optional
     ## List of tags to attach to every metrics, events and service checks emitted by this integration.


### PR DESCRIPTION
### What does this PR do?

Fix `prometheus_url` conf.

And match the doc: https://github.com/DataDog/integrations-core/pull/4175/files#diff-5ab528868a69e440be296b00fa6c2effL13

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
