### PR TITLE
Add docker_volumes option to E2E metadata

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -205,6 +205,8 @@ class DockerInterface(object):
                 '-v',
                 '/proc:/host/proc',
             ]
+            for volume in self.metadata.get('docker_volumes', []):
+                command.extend(['-v', volume])
 
             # Any environment variables passed to the start command
             for key, value in sorted(self.env_vars.items()):


### PR DESCRIPTION
Adds ability to mount volumes on the agent image