### PR TITLE
Remove unit env from e2e tests

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
@@ -68,6 +68,10 @@ def test(ctx, checks, agent, python, dev, base, env_vars, new_env):
 
         for env in envs:
             if new_env:
+                if env.endswith('-unit'):
+                    echo_warning('Skipping {} environment'.format(env))
+                    continue
+
                 ctx.invoke(
                     start, check=check, env=env, agent=agent, python=python, dev=dev, base=base, env_vars=env_vars
                 )


### PR DESCRIPTION
### What does this PR do?

Remove the environments in `-unit` when doing `ddev env test -ne integration` so the test is not failing for `unit` envs.

### Motivation

### Additional Notes

I'm not sure this is the best way to do it

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
