### PR TITLE
Use utcnow instead of now

### DIFF
--- a/cisco_aci/datadog_checks/cisco_aci/cisco.py
+++ b/cisco_aci/datadog_checks/cisco_aci/cisco.py
@@ -34,7 +34,7 @@ class CiscoACICheck(AgentCheck):
 
     def check(self, instance):
         self.log.info("Starting Cisco Check")
-        start = datetime.datetime.now()
+        start = datetime.datetime.utcnow()
         aci_url = instance.get('aci_url')
         aci_urls = instance.get('aci_urls', [])
         if aci_url:
@@ -147,7 +147,7 @@ class CiscoACICheck(AgentCheck):
         self.set_external_tags(self.get_external_host_tags())
 
         api.close()
-        end = datetime.datetime.now()
+        end = datetime.datetime.utcnow()
         log_line = "finished running Cisco Check"
         if _is_affirmative(instance.get('report_timing', False)):
             log_line += ", took {}".format(end - start)

--- a/datadog_checks_base/tests/test_kube_leader.py
+++ b/datadog_checks_base/tests/test_kube_leader.py
@@ -129,7 +129,7 @@ class TestElectionRecord:
             make_record(
                 holder="me", duration=30, renew="2018-12-18T12:32:22Z"
             ): "Invalid record: no acquire time recorded",
-            make_record(holder="me", duration=30, renew=datetime.now(), acquire="2018-12-18T12:32:22Z"): None,
+            make_record(holder="me", duration=30, renew=datetime.utcnow(), acquire="2018-12-18T12:32:22Z"): None,
             make_record(
                 holder="me", duration=30, renew="invalid", acquire="2018-12-18T12:32:22Z"
             ): "Invalid record: bad format for renewTime field",
@@ -215,7 +215,7 @@ class TestBaseCheck:
 
     def test_ok_configmap(self, aggregator, mock_read_configmap, mock_incluster):
         mock_read_configmap.return_value = make_fake_object(
-            make_record(holder="me", duration=30, renew=datetime.now(), acquire="2018-12-18T12:32:22Z")
+            make_record(holder="me", duration=30, renew=datetime.utcnow(), acquire="2018-12-18T12:32:22Z")
         )
         c = KubeLeaderElectionBaseCheck()
         c.check(CM_INSTANCE)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
@@ -779,7 +779,7 @@ def changelog(ctx, check, version, old_version, initial, quiet, dry_run):
     new_entry = StringIO()
 
     # the header contains version and date
-    header = '## {} / {}\n'.format(version, datetime.now().strftime('%Y-%m-%d'))
+    header = '## {} / {}\n'.format(version, datetime.utcnow().strftime('%Y-%m-%d'))
     new_entry.write(header)
 
     # one bullet point for each PR

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -42,7 +42,7 @@ def construct_template_fields(integration_name, repo_choice, **kwargs):
         license_header = (
             '# (C) Datadog, Inc. {year}\n'
             '# All rights reserved\n'
-            '# Licensed under a 3-clause BSD style license (see LICENSE)\n'.format(year=str(datetime.now().year))
+            '# Licensed under a 3-clause BSD style license (see LICENSE)\n'.format(year=str(datetime.utcnow().year))
         )
         support_type = 'core'
         test_dev_dep = '-e ../datadog_checks_dev'

--- a/openldap/tests/test_unit.py
+++ b/openldap/tests/test_unit.py
@@ -16,7 +16,7 @@ def test_check(check, aggregator, mocker):
     server_mock = ldap3.Server("fake_server")
     conn_mock = ldap3.Connection(server_mock, client_strategy=ldap3.MOCK_SYNC, collect_usage=True)
     # usage.last_received_time is not populated when using mock connection, let's set a value
-    conn_mock.usage.last_received_time = datetime.datetime.now()
+    conn_mock.usage.last_received_time = datetime.datetime.utcnow()
     conn_mock.strategy.entries_from_json(os.path.join(HERE, "fixtures", "monitor.json"))
     instance = {
         "url": "fake_server",

--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -1039,12 +1039,12 @@ class OpenStackCheck(AgentCheck):
         assert entry in ["aggregates", "physical_hosts", "hypervisors"]
         ttl = self.CACHE_TTL.get(entry)
         last_fetch_time = getattr(self, self.FETCH_TIME_ACCESSORS.get(entry))
-        return datetime.now() - last_fetch_time > timedelta(seconds=ttl)
+        return datetime.utcnow() - last_fetch_time > timedelta(seconds=ttl)
 
     def _get_and_set_aggregate_list(self):
         if not self._aggregate_list or self._is_expired("aggregates"):
             self._aggregate_list = self.get_all_aggregate_hypervisors()
-            self._last_aggregate_fetch_time = datetime.now()
+            self._last_aggregate_fetch_time = datetime.utcnow()
 
         return self._aggregate_list
 

--- a/twistlock/datadog_checks/twistlock/twistlock.py
+++ b/twistlock/datadog_checks/twistlock/twistlock.py
@@ -40,7 +40,7 @@ class TwistlockCheck(AgentCheck):
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
 
-        self.last_run = datetime.now()
+        self.last_run = datetime.utcnow()
 
         self.config = None
         if instances:
@@ -58,7 +58,7 @@ class TwistlockCheck(AgentCheck):
 
         # alert if a scan hasn't been able to run in a few hours and then in a day
         # only calculate this once per check run
-        self.current_date = datetime.now()
+        self.current_date = datetime.utcnow()
         self.warning_date = self.current_date - timedelta(hours=7)
         self.critical_date = self.current_date - timedelta(days=1)
 
@@ -70,7 +70,7 @@ class TwistlockCheck(AgentCheck):
 
         self.report_vulnerabilities()
 
-        self.last_run = datetime.now()
+        self.last_run = datetime.utcnow()
 
     def report_license_expiration(self):
         service_check_name = self.NAMESPACE + ".license_ok"
@@ -83,7 +83,7 @@ class TwistlockCheck(AgentCheck):
 
         # alert if your license will expire in 30 days and then in a week
         expiration_date = datetime.strptime(license.get("expiration_date"), LICENSE_DATE_FORMAT)
-        current_date = datetime.now()
+        current_date = datetime.utcnow()
         warning_date = current_date + timedelta(days=30)
         critical_date = current_date + timedelta(days=7)
 

--- a/vsphere/tests/test_vsphere.py
+++ b/vsphere/tests/test_vsphere.py
@@ -638,7 +638,7 @@ def test__should_cache(instance):
 
 
 def alarm_event(from_status='green', to_status='red', message='Some error'):
-    now = datetime.now()
+    now = datetime.utcnow()
     vm = MockedMOR(spec='VirtualMachine')
     dc = MockedMOR(spec="Datacenter")
     dc_arg = vim.event.DatacenterEventArgument(datacenter=dc, name='dc1')
@@ -653,7 +653,7 @@ def alarm_event(from_status='green', to_status='red', message='Some error'):
 
 
 def migrated_event():
-    now = datetime.now()
+    now = datetime.utcnow()
     vm = MockedMOR(spec='VirtualMachine', name='vm1')
     vm_arg = vim.event.VmEventArgument(vm=vm)
     host = MockedMOR(spec='HostSystem')

--- a/vsphere/tests/utils.py
+++ b/vsphere/tests/utils.py
@@ -131,7 +131,7 @@ def get_mocked_server():
     # mock pyvmomi stuff
     all_mors = create_topology(os.path.join(HERE, 'fixtures', 'vsphere_topology.json'))
     root_folder_mock = next(mor for mor in all_mors if mor.name == "rootFolder")
-    event_mock = MagicMock(createdTime=datetime.now())
+    event_mock = MagicMock(createdTime=datetime.utcnow())
     eventmanager_mock = MagicMock(latestEvent=event_mock)
     property_collector_mock = MagicMock()
     property_collector_mock.RetrievePropertiesEx.return_value = retrieve_properties_mock(all_mors)


### PR DESCRIPTION
### What does this PR do?

Use `utcnow` instead of `now` to avoid possible DST and timezone issues.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
