### PR TITLE
Allow multiple docker Agents to coexist for E2E by randomly assigning ports

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -200,6 +200,15 @@ class DockerInterface(object):
                 # Agent 6 will simply fail without an API key
                 '-e',
                 'DD_API_KEY={}'.format(self.api_key),
+                # Run expvar on a random port
+                '-e',
+                'DD_EXPVAR_PORT=0',
+                # Run API on a random port
+                '-e',
+                'DD_CMD_PORT=0',
+                # Disable trace agent
+                '-e',
+                'DD_APM_ENABLED=false',
                 # Mount the config directory, not the file, to ensure updates are propagated
                 # https://github.com/moby/moby/issues/15793#issuecomment-135411504
                 '-v',


### PR DESCRIPTION
This uses random ports for the 2 servers, so that we could run several
agents, and disable the trace agent, as we don't need it.