### PR TITLE
fix KSM job metrics

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -38,7 +38,7 @@ class KubernetesState(OpenMetricsBaseCheck):
     class JobCount:
         def __init__(self):
             self.count = 0
-            self.last_job_ts = 0
+            self.last_jobs_ts = []
 
     DEFAULT_METRIC_LIMIT = 0
 
@@ -535,9 +535,10 @@ class KubernetesState(OpenMetricsBaseCheck):
                     tags.append(self._format_tag(label_name, trimmed_job, scraper_config))
                 else:
                     tags.append(self._format_tag(label_name, label_value, scraper_config))
-            if job_ts != 0 and job_ts > self.failed_job_counts[frozenset(tags)].last_job_ts:
+            if job_ts != 0 and job_ts not in self.failed_job_counts[frozenset(tags)].last_jobs_ts:
+                print("Add value to fail")
                 self.failed_job_counts[frozenset(tags)].count += sample[self.SAMPLE_VALUE]
-                self.failed_job_counts[frozenset(tags)].last_job_ts = job_ts
+                self.failed_job_counts[frozenset(tags)].last_jobs_ts.append(job_ts)
 
     def kube_job_status_succeeded(self, metric, scraper_config):
         for sample in metric.samples:
@@ -550,9 +551,10 @@ class KubernetesState(OpenMetricsBaseCheck):
                     tags.append(self._format_tag(label_name, trimmed_job, scraper_config))
                 else:
                     tags.append(self._format_tag(label_name, label_value, scraper_config))
-            if job_ts != 0 and job_ts > self.succeeded_job_counts[frozenset(tags)].last_job_ts:
+            if job_ts != 0 and job_ts not in self.succeeded_job_counts[frozenset(tags)].last_jobs_ts:
+                print("Add value to success")
                 self.succeeded_job_counts[frozenset(tags)].count += sample[self.SAMPLE_VALUE]
-                self.succeeded_job_counts[frozenset(tags)].last_job_ts = job_ts
+                self.succeeded_job_counts[frozenset(tags)].last_jobs_ts.append(job_ts)
 
     def kube_node_status_condition(self, metric, scraper_config):
         """ The ready status of a cluster node. v1.0+"""

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -404,10 +404,15 @@ class KubernetesState(OpenMetricsBaseCheck):
 
     def _extract_job_timestamp(self, name):
         """
-        Extract timestamp of job names if they match -(\\^.+\\-) - match everything until a `-`
+        Extract timestamp of job names
         """
         ts = name.split('-')[-1]
-        return int(ts) if ts.isdigit() else 0
+        if ts.isdigit():
+            return int(ts)
+        else:
+            msg = 'Cannot extract ts from job name {}'.format(name)
+            self.log.debug(msg)
+            return 0
 
     # Labels attached: namespace, pod
     # As a message the phase=Pending|Running|Succeeded|Failed|Unknown

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -38,7 +38,7 @@ class KubernetesState(OpenMetricsBaseCheck):
     class JobCount:
         def __init__(self):
             self.count = 0
-            self.last_jobs_ts = []
+            self.last_job_ts = 0
 
     DEFAULT_METRIC_LIMIT = 0
 
@@ -90,15 +90,23 @@ class KubernetesState(OpenMetricsBaseCheck):
         self.succeeded_job_counts = defaultdict(KubernetesState.JobCount)
 
     def check(self, instance):
+        self.failed_ts = defaultdict(list)
+        self.succeeded_ts = defaultdict(list)
+
         endpoint = instance.get('kube_state_url')
 
         scraper_config = self.config_map[endpoint]
         self.process(scraper_config, metric_transformers=self.METRIC_TRANSFORMERS)
 
-        for job_tags, job_count in iteritems(self.failed_job_counts):
-            self.monotonic_count(scraper_config['namespace'] + '.job.failed', job_count.count, list(job_tags))
-        for job_tags, job_count in iteritems(self.succeeded_job_counts):
-            self.monotonic_count(scraper_config['namespace'] + '.job.succeeded', job_count.count, list(job_tags))
+        for job_tags, job in iteritems(self.failed_job_counts):
+            self.monotonic_count(scraper_config['namespace'] + '.job.failed', job.count, list(job_tags))
+            if len(self.failed_ts[job_tags]) > 0:
+                job.last_job_ts = max(self.failed_ts[job_tags])
+
+        for job_tags, job in iteritems(self.succeeded_job_counts):
+            self.monotonic_count(scraper_config['namespace'] + '.job.succeeded', job.count, list(job_tags))
+            if len(self.succeeded_ts[job_tags]) > 0:
+                job.last_job_ts = max(self.succeeded_ts[job_tags])
 
     def _filter_metric(self, metric, scraper_config):
         if scraper_config['telemetry']:
@@ -535,10 +543,9 @@ class KubernetesState(OpenMetricsBaseCheck):
                     tags.append(self._format_tag(label_name, trimmed_job, scraper_config))
                 else:
                     tags.append(self._format_tag(label_name, label_value, scraper_config))
-            if job_ts != 0 and job_ts not in self.failed_job_counts[frozenset(tags)].last_jobs_ts:
-                print("Add value to fail")
+            if job_ts != 0 and job_ts > self.failed_job_counts[frozenset(tags)].last_job_ts and job_ts not in self.failed_ts[frozenset(tags)]:
                 self.failed_job_counts[frozenset(tags)].count += sample[self.SAMPLE_VALUE]
-                self.failed_job_counts[frozenset(tags)].last_jobs_ts.append(job_ts)
+                self.failed_ts[frozenset(tags)].append(job_ts)
 
     def kube_job_status_succeeded(self, metric, scraper_config):
         for sample in metric.samples:
@@ -551,10 +558,9 @@ class KubernetesState(OpenMetricsBaseCheck):
                     tags.append(self._format_tag(label_name, trimmed_job, scraper_config))
                 else:
                     tags.append(self._format_tag(label_name, label_value, scraper_config))
-            if job_ts != 0 and job_ts not in self.succeeded_job_counts[frozenset(tags)].last_jobs_ts:
-                print("Add value to success")
+            if job_ts != 0 and job_ts > self.succeeded_job_counts[frozenset(tags)].last_job_ts and job_ts not in self.succeeded_ts[frozenset(tags)]:
                 self.succeeded_job_counts[frozenset(tags)].count += sample[self.SAMPLE_VALUE]
-                self.succeeded_job_counts[frozenset(tags)].last_jobs_ts.append(job_ts)
+                self.succeeded_ts[frozenset(tags)].append(job_ts)
 
     def kube_node_status_condition(self, metric, scraper_config):
         """ The ready status of a cluster node. v1.0+"""

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -91,9 +91,6 @@ class KubernetesState(OpenMetricsBaseCheck):
         self.succeeded_job_counts = defaultdict(KubernetesState.JobCount)
 
     def check(self, instance):
-        self.last_failed_ts = defaultdict(int)
-        self.last_succeeded_ts = defaultdict(int)
-
         endpoint = instance.get('kube_state_url')
 
         scraper_config = self.config_map[endpoint]

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -406,14 +406,8 @@ class KubernetesState(OpenMetricsBaseCheck):
         """
         Extract timestamp of job names if they match -(\\^.+\\-) - match everything until a `-`
         """
-        pattern = r"(^.+\-)"
-        job_ts = 0
-        try:
-            job_ts = int(re.sub(pattern, '', name))
-        except ValueError:
-            msg = 'Cannot extract ts from job name {}'.format(name)
-            self.log.debug(msg)
-        return job_ts
+        ts = name.split('-')[-1]
+        return int(ts) if ts.isdigit() else 0
 
     # Labels attached: namespace, pod
     # As a message the phase=Pending|Running|Succeeded|Failed|Unknown

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -539,7 +539,6 @@ class KubernetesState(OpenMetricsBaseCheck):
             if job_ts != 0 and job_ts > self.failed_job_counts[frozenset(tags)].last_job_ts:
                 self.failed_job_counts[frozenset(tags)].count += sample[self.SAMPLE_VALUE]
                 self.failed_job_counts[frozenset(tags)].last_job_ts = job_ts
-            job_count=self.failed_job_counts[frozenset(tags)]
 
     def kube_job_status_succeeded(self, metric, scraper_config):
         for sample in metric.samples:
@@ -555,7 +554,6 @@ class KubernetesState(OpenMetricsBaseCheck):
             if job_ts != 0 and job_ts > self.succeeded_job_counts[frozenset(tags)].last_job_ts:
                 self.succeeded_job_counts[frozenset(tags)].count += sample[self.SAMPLE_VALUE]
                 self.succeeded_job_counts[frozenset(tags)].last_job_ts = job_ts
-            job_count=self.succeeded_job_counts[frozenset(tags)]
 
     def kube_node_status_condition(self, metric, scraper_config):
         """ The ready status of a cluster node. v1.0+"""

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -35,7 +35,7 @@ class KubernetesState(OpenMetricsBaseCheck):
     See https://github.com/kubernetes/kube-state-metrics
     """
 
-    class JobCount():
+    class JobCount:
         def __init__(self):
             self.count = 0
             self.last_job_ts = 0
@@ -539,6 +539,7 @@ class KubernetesState(OpenMetricsBaseCheck):
             if job_ts != 0 and job_ts > self.failed_job_counts[frozenset(tags)].last_job_ts:
                 self.failed_job_counts[frozenset(tags)].count += sample[self.SAMPLE_VALUE]
                 self.failed_job_counts[frozenset(tags)].last_job_ts = job_ts
+            job_count=self.failed_job_counts[frozenset(tags)]
 
     def kube_job_status_succeeded(self, metric, scraper_config):
         for sample in metric.samples:
@@ -554,6 +555,7 @@ class KubernetesState(OpenMetricsBaseCheck):
             if job_ts != 0 and job_ts > self.succeeded_job_counts[frozenset(tags)].last_job_ts:
                 self.succeeded_job_counts[frozenset(tags)].count += sample[self.SAMPLE_VALUE]
                 self.succeeded_job_counts[frozenset(tags)].last_job_ts = job_ts
+            job_count=self.succeeded_job_counts[frozenset(tags)]
 
     def kube_node_status_condition(self, metric, scraper_config):
         """ The ready status of a cluster node. v1.0+"""

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -423,10 +423,12 @@ def test_job_counts(aggregator, instance):
     # Edit the payload and rerun the check
     payload = payload.replace(
         b'kube_job_status_succeeded{job="hello-1509998340",namespace="default"} 1',
-        b'kube_job_status_succeeded{job="hello-1509998500",namespace="default"} 1')
+        b'kube_job_status_succeeded{job="hello-1509998500",namespace="default"} 1'
+    )
     payload = payload.replace(
         b'kube_job_status_failed{job="hello-1509998340",namespace="default"} 0',
-        b'kube_job_status_failed{job="hello-1509998510",namespace="default"} 1')
+        b'kube_job_status_failed{job="hello-1509998510",namespace="default"} 1'
+    )
 
     check.poll = mock.MagicMock(return_value=MockResponse(payload, 'text/plain'))
     for _ in range(1):

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -421,9 +421,11 @@ def test_job_counts(aggregator, instance):
     )
 
     # Edit the payload and rerun the check
-    payload = payload.replace(b'kube_job_status_succeeded{job="hello-1509998340",namespace="default"} 1', 
+    payload = payload.replace(
+        b'kube_job_status_succeeded{job="hello-1509998340",namespace="default"} 1',
         b'kube_job_status_succeeded{job="hello-1509998500",namespace="default"} 1')
-    payload = payload.replace(b'kube_job_status_failed{job="hello-1509998340",namespace="default"} 0', 
+    payload = payload.replace(
+        b'kube_job_status_failed{job="hello-1509998340",namespace="default"} 0',
         b'kube_job_status_failed{job="hello-1509998510",namespace="default"} 1')
 
     check.poll = mock.MagicMock(return_value=MockResponse(payload, 'text/plain'))

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -383,10 +383,13 @@ def test_pod_phase_gauges(aggregator, instance, check):
 def test_extract_timestamp(check):
     job_name = "hello2-1509998340"
     job_name2 = "hello-2-1509998340"
+    job_name3 = "hello2"
     result = check._extract_job_timestamp(job_name)
     assert result == 1509998340
     result = check._extract_job_timestamp(job_name2)
     assert result == 1509998340
+    result = check._extract_job_timestamp(job_name3)
+    assert result == 0
 
 def test_job_counts(aggregator, instance, check):
     for _ in range(2):

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -411,8 +411,7 @@ def test_job_counts(aggregator, instance):
     )
 
     # Re-run check to make sure we don't count the same jobs
-    for _ in range(1):
-        check.check(instance)
+    check.check(instance)
     aggregator.assert_metric(
         NAMESPACE + '.job.failed', tags=['namespace:default', 'job:hello', 'optional:tag1'], value=0
     )
@@ -431,8 +430,7 @@ def test_job_counts(aggregator, instance):
     )
 
     check.poll = mock.MagicMock(return_value=MockResponse(payload, 'text/plain'))
-    for _ in range(1):
-        check.check(instance)
+    check.check(instance)
     aggregator.assert_metric(
         NAMESPACE + '.job.failed', tags=['namespace:default', 'job:hello', 'optional:tag1'], value=1
     )

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -380,6 +380,7 @@ def test_pod_phase_gauges(aggregator, instance, check):
         NAMESPACE + '.pod.status_phase', tags=['namespace:default', 'phase:Failed', 'optional:tag1'], value=2
     )
 
+
 def test_job_counts(aggregator, instance, check):
     for _ in range(2):
         check.check(instance)
@@ -399,6 +400,7 @@ def test_job_counts(aggregator, instance, check):
     aggregator.assert_metric(
         NAMESPACE + '.job.succeeded', tags=['namespace:default', 'job:hello', 'optional:tag1'], value=3
     )
+
 
 def test_telemetry(aggregator, instance):
     instance['telemetry'] = True

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -423,11 +423,11 @@ def test_job_counts(aggregator, instance):
     # Edit the payload and rerun the check
     payload = payload.replace(
         b'kube_job_status_succeeded{job="hello-1509998340",namespace="default"} 1',
-        b'kube_job_status_succeeded{job="hello-1509998500",namespace="default"} 1'
+        b'kube_job_status_succeeded{job="hello-1509998500",namespace="default"} 1',
     )
     payload = payload.replace(
         b'kube_job_status_failed{job="hello-1509998340",namespace="default"} 0',
-        b'kube_job_status_failed{job="hello-1509998510",namespace="default"} 1'
+        b'kube_job_status_failed{job="hello-1509998510",namespace="default"} 1',
     )
 
     check.poll = mock.MagicMock(return_value=MockResponse(payload, 'text/plain'))

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -212,6 +212,7 @@ def mock_from_file(fname):
     with open(os.path.join(HERE, 'fixtures', fname), 'rb') as f:
         return f.read()
 
+
 @pytest.fixture
 def instance():
     return {'host': 'foo', 'kube_state_url': 'http://foo', 'tags': ['optional:tag1'], 'telemetry': False}
@@ -382,6 +383,7 @@ def test_pod_phase_gauges(aggregator, instance, check):
         NAMESPACE + '.pod.status_phase', tags=['namespace:default', 'phase:Failed', 'optional:tag1'], value=2
     )
 
+
 def test_extract_timestamp(check):
     job_name = "hello2-1509998340"
     job_name2 = "hello-2-1509998340"
@@ -392,6 +394,7 @@ def test_extract_timestamp(check):
     assert result == 1509998340
     result = check._extract_job_timestamp(job_name3)
     assert result == 0
+
 
 def test_job_counts(aggregator, instance):
     check = KubernetesState(CHECK_NAME, {}, {}, [instance])
@@ -418,8 +421,10 @@ def test_job_counts(aggregator, instance):
     )
 
     # Edit the payload and rerun the check
-    payload = payload.replace(b'kube_job_status_succeeded{job="hello-1509998340",namespace="default"} 1', b'kube_job_status_succeeded{job="hello-1509998500",namespace="default"} 1')
-    payload = payload.replace(b'kube_job_status_failed{job="hello-1509998340",namespace="default"} 0', b'kube_job_status_failed{job="hello-1509998510",namespace="default"} 1')
+    payload = payload.replace(b'kube_job_status_succeeded{job="hello-1509998340",namespace="default"} 1', 
+        b'kube_job_status_succeeded{job="hello-1509998500",namespace="default"} 1')
+    payload = payload.replace(b'kube_job_status_failed{job="hello-1509998340",namespace="default"} 0', 
+        b'kube_job_status_failed{job="hello-1509998510",namespace="default"} 1')
 
     check.poll = mock.MagicMock(return_value=MockResponse(payload, 'text/plain'))
     for _ in range(1):
@@ -430,6 +435,7 @@ def test_job_counts(aggregator, instance):
     aggregator.assert_metric(
         NAMESPACE + '.job.succeeded', tags=['namespace:default', 'job:hello', 'optional:tag1'], value=4
     )
+
 
 def test_telemetry(aggregator, instance):
     instance['telemetry'] = True

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -380,6 +380,25 @@ def test_pod_phase_gauges(aggregator, instance, check):
         NAMESPACE + '.pod.status_phase', tags=['namespace:default', 'phase:Failed', 'optional:tag1'], value=2
     )
 
+def test_job_counts(aggregator, instance, check):
+    for _ in range(2):
+        check.check(instance)
+    aggregator.assert_metric(
+        NAMESPACE + '.job.failed', tags=['namespace:default', 'job:hello', 'optional:tag1'], value=0
+    )
+    aggregator.assert_metric(
+        NAMESPACE + '.job.succeeded', tags=['namespace:default', 'job:hello', 'optional:tag1'], value=3
+    )
+
+    # Re-run check to make sure we don't count the same jobs
+    for _ in range(1):
+        check.check(instance)
+    aggregator.assert_metric(
+        NAMESPACE + '.job.failed', tags=['namespace:default', 'job:hello', 'optional:tag1'], value=0
+    )
+    aggregator.assert_metric(
+        NAMESPACE + '.job.succeeded', tags=['namespace:default', 'job:hello', 'optional:tag1'], value=3
+    )
 
 def test_telemetry(aggregator, instance):
     instance['telemetry'] = True

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -380,6 +380,13 @@ def test_pod_phase_gauges(aggregator, instance, check):
         NAMESPACE + '.pod.status_phase', tags=['namespace:default', 'phase:Failed', 'optional:tag1'], value=2
     )
 
+def test_extract_timestamp(check):
+    job_name = "hello2-1509998340"
+    job_name2 = "hello-2-1509998340"
+    result = check._extract_job_timestamp(job_name)
+    assert result == 1509998340
+    result = check._extract_job_timestamp(job_name2)
+    assert result == 1509998340
 
 def test_job_counts(aggregator, instance, check):
     for _ in range(2):


### PR DESCRIPTION
### What does this PR do?

This PR fixes the KSM job succeeded and failed metrics by keeping the last timestamp of each job to not count them multiple times.
It also adds a test to test values of these metrics after multiple runs.

### Motivation

Customers reported these metrics were broken multiple times.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
