### PR TITLE
Set timeout from init_config in requests wrapper as default

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -103,6 +103,7 @@ class RequestsWrapper(object):
         # Update the default behavior for global settings
         default_fields['log_requests'] = init_config.get('log_requests', default_fields['log_requests'])
         default_fields['skip_proxy'] = init_config.get('skip_proxy', default_fields['skip_proxy'])
+        default_fields['timeout'] = init_config.get('timeout', default_fields['timeout'])
 
         # Populate with the default values
         config = {field: instance.get(field, value) for field, value in iteritems(default_fields)}

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -60,6 +60,13 @@ class TestTimeout:
 
         assert http.options['timeout'] == (10, 4)
 
+    def test_config_init_config_override(self):
+        instance = {}
+        init_config = {'timeout': 16}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['timeout'] == (16, 16)
+
 
 class TestHeaders:
     def test_config_default(self):


### PR DESCRIPTION
### What does this PR do?

Sets the default field to `timeout` from `init_config` if it exists. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
