### PR TITLE
Add the version of an AgentCheck as a property

### DIFF
--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -8,6 +8,7 @@ import pytest
 from six import PY3
 
 from datadog_checks.base import AgentCheck
+from datadog_checks.base import __version__ as base_package_version
 from datadog_checks.base.checks.base import datadog_agent
 
 
@@ -26,6 +27,12 @@ def test_instance():
     check = AgentCheck(init_config=init_config, instances=instances)
     assert check.init_config == {'foo': 'bar'}
     assert check.instances == [{'bar': 'baz'}]
+
+
+def test_check_version():
+    check = AgentCheck()
+
+    assert check.check_version == base_package_version
 
 
 def test_load_config():


### PR DESCRIPTION
### Motivation

1. Need for tagging memory profiling metrics
2. Upcoming metadata submissions