### PR TITLE
Add e2e test

### DIFF
--- a/mongo/tests/test_e2e.py
+++ b/mongo/tests/test_e2e.py
@@ -1,0 +1,54 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.mongo import MongoDb
+
+METRICS = [
+    'mongodb.connections.available',
+    'mongodb.metrics.cursor.open.pinned',
+    'mongodb.stats.filesize',
+    'mongodb.stats.indexsize',
+    'mongodb.connections.totalcreated',
+    'mongodb.uptime',
+    'mongodb.mem.bits',
+    'mongodb.stats.datasize',
+    'mongodb.stats.numextents',
+    'mongodb.stats.indexes',
+    'mongodb.mem.resident',
+    'mongodb.metrics.cursor.open.total',
+    'mongodb.stats.avgobjsize',
+    'mongodb.stats.storagesize',
+    'mongodb.mem.virtual',
+    'mongodb.dbs',
+    'mongodb.fsynclocked',
+    'mongodb.stats.objects',
+    'mongodb.connections.current',
+    'mongodb.network.bytesinps',
+    'mongodb.asserts.msgps',
+    'mongodb.opcounters.queryps',
+    'mongodb.opcounters.getmoreps',
+    'mongodb.asserts.rolloversps',
+    'mongodb.opcounters.deleteps',
+    'mongodb.asserts.regularps',
+    'mongodb.opcounters.insertps',
+    'mongodb.asserts.warningps',
+    'mongodb.metrics.getlasterror.wtime.numps',
+    'mongodb.network.numrequestsps',
+    'mongodb.opcounters.updateps',
+    'mongodb.asserts.userps',
+    'mongodb.opcounters.commandps',
+    'mongodb.extra_info.page_faultsps',
+    'mongodb.network.bytesoutps',
+    'mongodb.metrics.getlasterror.wtime.totalmillisps',
+]
+
+
+@pytest.mark.e2e
+def test_e2e(dd_agent_check, instance_authdb):
+    aggregator = dd_agent_check(instance_authdb, rate=True)
+    for metric in METRICS:
+        aggregator.assert_metric(metric)
+
+    aggregator.assert_service_check('mongodb.can_connect', status=MongoDb.OK)

--- a/mongo/tests/test_e2e.py
+++ b/mongo/tests/test_e2e.py
@@ -34,14 +34,12 @@ METRICS = [
     'mongodb.asserts.regularps',
     'mongodb.opcounters.insertps',
     'mongodb.asserts.warningps',
-    'mongodb.metrics.getlasterror.wtime.numps',
     'mongodb.network.numrequestsps',
     'mongodb.opcounters.updateps',
     'mongodb.asserts.userps',
     'mongodb.opcounters.commandps',
     'mongodb.extra_info.page_faultsps',
     'mongodb.network.bytesoutps',
-    'mongodb.metrics.getlasterror.wtime.totalmillisps',
 ]
 
 

--- a/mongo/tests/test_mongo.py
+++ b/mongo/tests/test_mongo.py
@@ -2,9 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
-from six import itervalues
 
-from datadog_checks.base import to_string
+from datadog_checks.mongo import MongoDb
 
 from . import common
 
@@ -44,92 +43,60 @@ METRIC_VAL_CHECKS_OLD = {
 }
 
 
-@pytest.mark.usefixtures('dd_environment')
+pytestmark = pytest.mark.usefixtures('dd_environment')
+
+
 def test_mongo(aggregator, check, instance_authdb):
-    # Run the check against our running server
     check.check(instance_authdb)
 
-    # Metric assertions
-    metrics = list(itervalues(aggregator._metrics))
-    assert metrics
+    metric_names = aggregator.metric_names
+    assert metric_names
 
-    assert isinstance(metrics, list)
-    assert len(metrics) > 0
-
-    for m in metrics:
-        metric = m[0]
-        metric_name = metric.name
+    for metric_name in metric_names:
         if metric_name in METRIC_VAL_CHECKS:
+            metric = aggregator.metrics(metric_name)[0]
             assert METRIC_VAL_CHECKS[metric_name](metric.value)
 
 
-@pytest.mark.usefixtures('dd_environment')
 def test_mongo2(aggregator, check, instance_user):
-    # Run the check against our running server
     check.check(instance_user)
 
-    # Service checks
-    service_checks = list(itervalues(aggregator._service_checks))
-    service_checks_count = len(service_checks)
-    assert service_checks_count > 0
-    assert len(service_checks[0]) == 1
-    # Assert that all service checks have the proper tags: host and port
-    for sc in service_checks[0]:
-        assert to_string('host:{}'.format(common.HOST)) in sc.tags
-        assert (
-            to_string('port:{}'.format(common.PORT1)) in sc.tags or to_string('port:{}'.format(common.PORT2)) in sc.tags
-        )
-        assert 'db:test' in sc.tags
+    tags = ['host:{}'.format(common.HOST), 'port:{}'.format(common.PORT1), 'db:test']
+    aggregator.assert_service_check('mongodb.can_connect', status=MongoDb.OK, tags=tags)
 
-    # Metric assertions
-    metrics = list(itervalues(aggregator._metrics))
-    assert metrics
-    assert len(metrics) > 0
+    metric_names = aggregator.metric_names
+    assert metric_names
 
-    for m in metrics:
-        metric = m[0]
-        metric_name = metric.name
+    for metric_name in metric_names:
         if metric_name in METRIC_VAL_CHECKS:
+            metric = aggregator.metrics(metric_name)[0]
             assert METRIC_VAL_CHECKS[metric_name](metric.value)
 
 
-@pytest.mark.usefixtures('dd_environment')
 def test_mongo_old_config(aggregator, check, instance):
-    # Run the check against our running server
     check.check(instance)
 
-    # Metric assertions
-    metrics = list(itervalues(aggregator._metrics))
-    assert metrics
-    assert isinstance(metrics, list)
-    assert len(metrics) > 0
+    metric_names = aggregator.metric_names
+    assert metric_names
 
-    for m in metrics:
-        metric = m[0]
-        metric_name = metric.name
+    for metric_name in metric_names:
         if metric_name in METRIC_VAL_CHECKS_OLD:
+            metric = aggregator.metrics(metric_name)[0]
             assert METRIC_VAL_CHECKS_OLD[metric_name](metric.value)
 
 
-@pytest.mark.usefixtures('dd_environment')
 def test_mongo_old_config_2(aggregator, check, instance):
-    # Run the check against our running server
     check.check(instance)
 
-    # Metric assertions
-    metrics = list(itervalues(aggregator._metrics))
-    assert metrics
-    assert isinstance(metrics, list)
-    assert len(metrics) > 0
+    metric_names = aggregator.metric_names
+    assert metric_names
 
-    for m in metrics:
-        metric = m[0]
-        metric_name = metric.name
+    for metric_name in metric_names:
         if metric_name in METRIC_VAL_CHECKS_OLD:
+            metric = aggregator.metrics(metric_name)[0]
             assert METRIC_VAL_CHECKS_OLD[metric_name](metric.value)
 
 
-@pytest.mark.usefixtures('dd_environment')
 def test_mongo_1valid_and_1invalid_custom_queries(aggregator, check, instance_1valid_and_1invalid_custom_queries):
     # Run the check against our running server
     check.check(instance_1valid_and_1invalid_custom_queries)
@@ -139,7 +106,6 @@ def test_mongo_1valid_and_1invalid_custom_queries(aggregator, check, instance_1v
     aggregator.assert_metric("dd.custom.mongo.query_a.amount", count=0)
 
 
-@pytest.mark.usefixtures('dd_environment')
 def test_mongo_custom_queries(aggregator, check, instance_custom_queries):
     # Run the check against our running server
     check.check(instance_custom_queries)

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -1,21 +1,18 @@
 # (C) Datadog, Inc. 2018-2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import logging
-
 import mock
 import pytest
 from six import iteritems
 
 from datadog_checks.mongo import MongoDb
 
-log = logging.getLogger('test_mongo')
-
 RATE = MongoDb.rate
 GAUGE = MongoDb.gauge
 
+pytestmark = pytest.mark.unit
 
-@pytest.mark.unit
+
 def test_build_metric_list(check):
     """
     Build the metric list according to the user configuration.
@@ -54,7 +51,6 @@ def test_build_metric_list(check):
     assert check.log.warning.call_count == 2
 
 
-@pytest.mark.unit
 def test_metric_resolution(check):
     """
     Resolve metric names and types.
@@ -77,7 +73,6 @@ def test_metric_resolution(check):
     assert (GAUGE, 'mongodb.qux.foobar') == resolve_metric('fOoBaR', metrics_to_collect, prefix="qux")
 
 
-@pytest.mark.unit
 def test_metric_normalization(check):
     """
     Metric names suffixed with `.R`, `.r`, `.W`, `.w` are renamed.
@@ -95,7 +90,6 @@ def test_metric_normalization(check):
     assert (GAUGE, 'mongodb.foobar.exclusive') == resolve_metric('foobar.W', metrics_to_collect)
 
 
-@pytest.mark.unit
 def test_state_translation(check):
     """
     Check that resolving replset member state IDs match to names and descriptions properly.
@@ -112,7 +106,6 @@ def test_state_translation(check):
     assert unknown_desc.find('500') != -1
 
 
-@pytest.mark.unit
 def test_server_uri_sanitization(check):
     _parse_uri = check._parse_uri
 

--- a/mongo/tox.ini
+++ b/mongo/tox.ini
@@ -2,9 +2,11 @@
 minversion = 2.0
 basepython = py37
 envlist =
-  py{27,37}-{3.2.10,3.4,3.5,4.1,unit}
+  py{27,37}-{3.2.10,3.4,3.5,4.1}
 
 [testenv]
+description =
+    py{27,37} = e2e ready
 dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
@@ -16,8 +18,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install -r requirements.in
-    {3.2.10,3.4,3.5,4.1}: pytest -v -m"not unit"
-    unit: pytest -v -m"unit"
+    pytest -v {posargs}
 setenv =
     3.2.10: MONGO_VERSION=3.2.10
     3.4: MONGO_VERSION=3.4

--- a/mongo/tox.ini
+++ b/mongo/tox.ini
@@ -6,7 +6,7 @@ envlist =
 
 [testenv]
 description =
-    py{27,37} = e2e ready
+    py{27,37}: e2e ready
 dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32


### PR DESCRIPTION
This adds a new e2e test for all supported versions, and cleans up the
integration tests a bit to not use private APIs.