### PR TITLE
Submit critical service check with 500 server errors

### DIFF
--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -5,6 +5,7 @@ import warnings
 from time import time as timestamp
 
 import requests
+from simplejson import JSONDecodeError
 from six import string_types
 from urllib3.exceptions import InsecureRequestWarning
 
@@ -43,13 +44,13 @@ class Vault(AgentCheck):
             api['check_leader'](config, tags)
             api['check_health'](config, tags)
         except ApiUnreachable:
-            return
+            raise
 
         self.service_check(self.SERVICE_CHECK_CONNECT, AgentCheck.OK, tags=tags)
 
     def check_leader_v1(self, config, tags):
         url = config['api_url'] + '/sys/leader'
-        leader_data = self.access_api(url, config, tags).json()
+        leader_data = self.access_api(url, config, tags)
 
         is_leader = is_affirmative(leader_data.get('is_self'))
         tags.append('is_leader:{}'.format('true' if is_leader else 'false'))
@@ -76,7 +77,7 @@ class Vault(AgentCheck):
 
     def check_health_v1(self, config, tags):
         url = config['api_url'] + '/sys/health'
-        health_data = self.access_api(url, config, tags).json()
+        health_data = self.access_api(url, config, tags)
 
         cluster_name = health_data.get('cluster_name')
         if cluster_name:
@@ -171,6 +172,18 @@ class Vault(AgentCheck):
                     timeout=config['timeout'],
                     headers=config['headers'],
                 )
+                response.raise_for_status()
+                json_data = response.json()
+        except requests.exceptions.HTTPError:
+            msg = 'The Vault endpoint `{}` returned {}.'.format(url, response.status_code)
+            self.service_check(self.SERVICE_CHECK_CONNECT, AgentCheck.CRITICAL, message=msg, tags=tags)
+            self.log.exception(msg)
+            raise ApiUnreachable
+        except JSONDecodeError:
+            msg = 'The Vault endpoint `{}` returned invalid json data.'.format(url)
+            self.service_check(self.SERVICE_CHECK_CONNECT, AgentCheck.CRITICAL, message=msg, tags=tags)
+            self.log.exception(msg)
+            raise ApiUnreachable
         except requests.exceptions.Timeout:
             msg = 'Vault endpoint `{}` timed out after {} seconds'.format(url, config['timeout'])
             self.service_check(self.SERVICE_CHECK_CONNECT, AgentCheck.CRITICAL, message=msg, tags=tags)
@@ -182,4 +195,4 @@ class Vault(AgentCheck):
             self.log.exception(msg)
             raise ApiUnreachable
 
-        return response
+        return json_data

--- a/vault/tests/common.py
+++ b/vault/tests/common.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import requests
+
 from datadog_checks.dev import get_docker_hostname
 
 HOST = get_docker_hostname()
@@ -19,9 +21,13 @@ INSTANCES = {
 
 
 class MockResponse:
-    def __init__(self, j):
+    def __init__(self, j, status_code=200):
         self.j = j
-        self.status_code = 200
+        self.status_code = status_code
 
     def json(self):
         return self.j
+
+    def raise_for_status(self):
+        if self.status_code >= 300:
+            raise requests.exceptions.HTTPError


### PR DESCRIPTION
The check will now submit a `CRITICAL` status check if the api server with invalid data or non-standard status-code.