### PR TITLE
Add mem_limit to RabbitMQ Checks

### DIFF
--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -74,6 +74,7 @@ NODE_ATTRIBUTES = [
     ('fd_used', 'fd_used', float),
     ('disk_free', 'disk_free', float),
     ('mem_used', 'mem_used', float),
+    ('mem_limit', 'mem_limit', float),
     ('run_queue', 'run_queue', float),
     ('sockets_used', 'sockets_used', float),
     ('partitions', 'partitions', len),

--- a/rabbitmq/metadata.csv
+++ b/rabbitmq/metadata.csv
@@ -2,6 +2,7 @@ metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation
 rabbitmq.node.fd_used,gauge,,,,Used file descriptors,0,rabbitmq,fd used
 rabbitmq.node.disk_free,gauge,,byte,,Current free disk space,0,rabbitmq,disk free
 rabbitmq.node.mem_used,gauge,,byte,,Memory used in bytes,0,rabbitmq,mem used
+rabbitmq.node.mem_limit,gauge,,byte,,Memory usage high watermark in bytes,0,rabbitmq,mem limit
 rabbitmq.node.run_queue,gauge,,process,,Average number of Erlang processes waiting to run,0,rabbitmq,run queue
 rabbitmq.node.sockets_used,gauge,,,,Number of file descriptors used as sockets,0,rabbitmq,skts used
 rabbitmq.node.partitions,gauge,,,,Number of network partitions this node is seeing,0,rabbitmq,partitions

--- a/rabbitmq/tests/metrics.py
+++ b/rabbitmq/tests/metrics.py
@@ -6,6 +6,7 @@ COMMON_METRICS = [
     'rabbitmq.node.fd_used',
     'rabbitmq.node.disk_free',
     'rabbitmq.node.mem_used',
+    'rabbitmq.node.mem_limit',
     'rabbitmq.node.run_queue',
     'rabbitmq.node.sockets_used',
     'rabbitmq.node.partitions',


### PR DESCRIPTION
### What does this PR do?

This pull request adds `mem_limit` as a metric to be collected from a RabbitMQ Node.

### Motivation

Having the `mem_limit` allows planning for RabbitMQ capacity by measuring current memory consumption in `mem_used` against `mem_limit`

### Additional Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
