### PR TITLE
Remove unnecessary constants and cleanup error handling

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/constants.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/constants.py
@@ -1,14 +1,6 @@
 # (C) Datadog, Inc. 2019
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-from kafka import errors as kafka_errors
-
-# Kafka Errors
-KAFKA_NO_ERROR = kafka_errors.NoError.errno
-KAFKA_UNKNOWN_ERROR = kafka_errors.UnknownError.errno
-KAFKA_UNKNOWN_TOPIC_OR_PARTITION = kafka_errors.UnknownTopicOrPartitionError.errno
-KAFKA_NOT_LEADER_FOR_PARTITION = kafka_errors.NotLeaderForPartitionError.errno
-
 DEFAULT_KAFKA_TIMEOUT = 5
 DEFAULT_ZK_TIMEOUT = 5
 DEFAULT_KAFKA_RETRIES = 3


### PR DESCRIPTION
There's no value in storing these as constants... better to just access
them directly in the code. Also re-ordered the error tree in order of
likelihood of hitting the error. This also makes the code consistent
with the upcoming refactoring.

cc @ofek as I'm working with him on some stuff related to this check
