### PR TITLE
Remove `six` from kafka_consumer check tests

### DIFF
--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import pytest
-from six import iteritems
 
 from datadog_checks.kafka_consumer import KafkaCheck
 
@@ -26,8 +25,8 @@ def test_check_kafka(aggregator, kafka_instance):
     kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [{}])
     kafka_consumer_check.check(kafka_instance)
 
-    for name, consumer_group in iteritems(kafka_instance['consumer_groups']):
-        for topic, partitions in iteritems(consumer_group):
+    for name, consumer_group in kafka_instance['consumer_groups'].items():
+        for topic, partitions in consumer_group.items():
             for partition in partitions:
                 tags = ["topic:{}".format(topic), "partition:{}".format(partition)] + ['optional:tag1']
                 for mname in BROKER_METRICS:

--- a/kafka_consumer/tests/test_kafka_consumer_zk.py
+++ b/kafka_consumer/tests/test_kafka_consumer_zk.py
@@ -5,7 +5,6 @@ import copy
 import time
 
 import pytest
-from six import iteritems
 
 from datadog_checks.base.utils.containers import hash_mutable
 from datadog_checks.kafka_consumer import KafkaCheck
@@ -30,8 +29,8 @@ def test_check_zk(aggregator, zk_instance):
     kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [{}])
     kafka_consumer_check.check(zk_instance)
 
-    for name, consumer_group in iteritems(zk_instance['consumer_groups']):
-        for topic, partitions in iteritems(consumer_group):
+    for name, consumer_group in zk_instance['consumer_groups'].items():
+        for topic, partitions in consumer_group.items():
             for partition in partitions:
                 tags = ["topic:{}".format(topic), "partition:{}".format(partition)]
                 for mname in BROKER_METRICS:
@@ -77,8 +76,8 @@ def test_multiple_servers_zk(aggregator, zk_instance):
     kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [{}])
     kafka_consumer_check.check(multiple_server_zk_instance)
 
-    for name, consumer_group in iteritems(multiple_server_zk_instance['consumer_groups']):
-        for topic, partitions in iteritems(consumer_group):
+    for name, consumer_group in multiple_server_zk_instance['consumer_groups'].items():
+        for topic, partitions in consumer_group.items():
             for partition in partitions:
                 tags = ["topic:{}".format(topic), "partition:{}".format(partition)]
                 for mname in BROKER_METRICS:


### PR DESCRIPTION
Since this is moving to python3 long term, just start using
`items()` as there isn't enough memory pressure in this check
to worry about the python 2 case.

`six` is still used by the legacy check, not worth cleaning that up
currently as it will likely eventually get removed, vs the tests will be
kept so clean them up.

cc @ofek 