### PR TITLE
Fix typo in send_histograms_buckets

### DIFF
--- a/coredns/datadog_checks/coredns/data/auto_conf.yaml
+++ b/coredns/datadog_checks/coredns/data/auto_conf.yaml
@@ -20,7 +20,7 @@ instances:
     tags:
       - "dns-pod:%%host%%"
 
-    ## @param send_histogram_buckets - boolean - optional - default: true
+    ## @param send_histograms_buckets - boolean - optional - default: true
     ## Set send_histograms_buckets to true to send the histograms bucket.
     #
     #  send_histograms_buckets: true

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -17,7 +17,7 @@ instances:
     tags:
       - "dns-pod:%%host%%"
 
-    ## @param send_histogram_buckets - boolean - optional - default: true
+    ## @param send_histograms_buckets - boolean - optional - default: true
     ## Set send_histograms_buckets to `true` to send the histograms buckets.
     #
     # send_histograms_buckets: true

--- a/prometheus/datadog_checks/prometheus/data/conf.yaml.example
+++ b/prometheus/datadog_checks/prometheus/data/conf.yaml.example
@@ -69,7 +69,7 @@ instances:
     #   - <KEY_1>:<VALUE_1>
     #   - <KEY_2>:<VALUE_2>
 
-    ## @param send_histogram_buckets - boolean - optional - default: true
+    ## @param send_histograms_buckets - boolean - optional - default: true
     ## Set send_histograms_buckets to true to send the histograms bucket.
     #
     # send_histograms_buckets: true


### PR DESCRIPTION
The correct parameter is named `send_histograms_buckets`
See https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py#L107

Resolve issue https://github.com/DataDog/integrations-core/issues/4265