### PR TITLE
Remove rarely used zookeeper-specific min collection interval

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -63,12 +63,6 @@ instances:
     - localhost:2181
     # - <ZOOKEEPER_ENDPOINT>:2181
 
-    ## @param zk_iteration_ival - integer - optional
-    ## Set how many seconds the check should wait between two ZK consumer offset
-    ## collections. If kafka consumer offsets is disabled, this has no effect.
-    #
-    # zk_iteration_ival: 1
-
     ## @param zk_prefix - string - optional
     ## Zookeeper chroot prefix under which kafka data is living in zookeeper.
     ## If kafka is connecting to `my-zookeeper:2181/kafka` then the `zk_prefix` is `/kafka`.

--- a/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
@@ -17,7 +17,6 @@ from kazoo.exceptions import NoNodeError
 from six import iteritems, itervalues, string_types, text_type
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
-from datadog_checks.base.utils.containers import hash_mutable
 
 from .constants import CONTEXT_UPPER_BOUND, DEFAULT_KAFKA_RETRIES, DEFAULT_KAFKA_TIMEOUT, DEFAULT_ZK_TIMEOUT
 
@@ -39,7 +38,6 @@ class LegacyKafkaCheck_0_10_2(AgentCheck):
         self._kafka_timeout = int(init_config.get('kafka_timeout', DEFAULT_KAFKA_TIMEOUT))
         self.context_limit = int(init_config.get('max_partition_contexts', CONTEXT_UPPER_BOUND))
         self._broker_retries = int(init_config.get('kafka_retries', DEFAULT_KAFKA_RETRIES))
-        self._zk_last_ts = {}
 
         self.kafka_clients = {}
 
@@ -55,7 +53,6 @@ class LegacyKafkaCheck_0_10_2(AgentCheck):
         # Fetch consumer group offsets from Zookeeper
         zk_hosts_ports = instance.get('zk_connect_str')
         zk_prefix = instance.get('zk_prefix', '')
-        zk_interval = int(instance.get('zk_iteration_ival', 0))
         get_kafka_consumer_offsets = is_affirmative(instance.get('kafka_consumer_offsets', zk_hosts_ports is None))
 
         custom_tags = instance.get('tags', [])
@@ -69,7 +66,7 @@ class LegacyKafkaCheck_0_10_2(AgentCheck):
             self._validate_explicit_consumer_groups(consumer_groups)
 
         zk_consumer_offsets = None
-        if zk_hosts_ports and self._should_zk(zk_hosts_ports, zk_interval, get_kafka_consumer_offsets):
+        if zk_hosts_ports:
             zk_consumer_offsets, consumer_groups = self._get_zk_consumer_offsets(
                 zk_hosts_ports, consumer_groups, zk_prefix
             )
@@ -516,20 +513,6 @@ class LegacyKafkaCheck_0_10_2(AgentCheck):
                     consumer_offsets[(topic, partition)] = offset
 
         return consumer_offsets
-
-    def _should_zk(self, zk_hosts_ports, interval, kafka_collect=False):
-        if not kafka_collect or not interval:
-            return True
-        zk_hosts_ports_hash = hash_mutable(zk_hosts_ports)
-        now = time()
-        last = self._zk_last_ts.get(zk_hosts_ports_hash, 0)
-
-        should_zk = False
-        if now - last >= interval:
-            self._zk_last_ts[zk_hosts_ports_hash] = last
-            should_zk = True
-
-        return should_zk
 
     @classmethod
     def _validate_explicit_consumer_groups(cls, val):

--- a/kafka_consumer/tests/test_kafka_consumer_zk.py
+++ b/kafka_consumer/tests/test_kafka_consumer_zk.py
@@ -2,11 +2,9 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import copy
-import time
 
 import pytest
 
-from datadog_checks.base.utils.containers import hash_mutable
 from datadog_checks.kafka_consumer import KafkaCheck
 
 from .common import HOST, KAFKA_CONNECT_STR, PARTITIONS, TOPICS, ZK_CONNECT_STR, is_supported
@@ -115,15 +113,3 @@ def test_check_nogroups_zk(aggregator, zk_instance):
                 aggregator.assert_metric(mname, at_least=1)
 
     aggregator.assert_all_metrics_covered()
-
-
-def test_should_zk():
-    check = KafkaCheck('kafka_consumer', {}, [{}])
-    # Kafka Consumer Offsets set to True and we have a zk_connect_str that hasn't been run yet
-    assert check._should_zk([ZK_CONNECT_STR, ZK_CONNECT_STR], 10, True) is True
-    # Kafka Consumer Offsets is set to False, should immediately ZK
-    assert check._should_zk(ZK_CONNECT_STR, 10, False) is True
-    # Last time we checked ZK_CONNECT_STR was less than interval ago, shouldn't ZK
-    zk_connect_hash = hash_mutable(ZK_CONNECT_STR)
-    check._zk_last_ts[zk_connect_hash] = time.time()
-    assert check._should_zk(ZK_CONNECT_STR, 100, True) is False


### PR DESCRIPTION
This was a feature I'd pushed for several years ago to support fetching
consumer offsets from Zookeeper at a different rate than from Kafka.

However, now that Agent v6 supports setting `min_collection_interval` at
the instance level, this is no longer needed... instead, just configure
two separate instances of the check--one for kafka and one for
zookeeper.

So removing this code to simplify the legacy check. I would be very surprised if anyone ever actually used this, so I think it's very safe to make this a no-op, especially as fetching consumer offsets from Zookeeper is in the process of being deprecated.

Also, my apologies @truthbk for wasting your time when I pushed for implementing this feature!