### PR TITLE
Stop documenting `min_collection_interval` at `init_config` level

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -20,16 +20,6 @@ init_config:
   #
   # kafka_retries: 3
 
-  ## @param min_collection_interval - integer - optional - default: 600
-  ## Customize the number of seconds that must elapse between running this check.
-  ## When checking Kafka offsets stored in Zookeeper, a single run of this check
-  ## must stat zookeeper more than the number of consumers * topic_partitions
-  ## that you're monitoring. If that number is greater than 100, it's recommended
-  ## to increase this value to avoid hitting zookeeper too hard.
-  ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
-  #
-  # min_collection_interval: 600
-
 instances:
 
     ## @param kafka_connect_str - list of strings - required


### PR DESCRIPTION
In Agent v6, this is now set at a per-instance level rather than in
`init_config`.

Given that the Zookeeper functionality is deprecated and fetching
consumer offsets from Kafka should be a fast / low-load operation, I
think it best to remove the documentation entirely rather than moving it
down to the `instance` level.

If someone wants it for some reason, it's easy to look up.

cc @ofek 