### PR TITLE
Cleanup pointless retries that query the wrong brokers / duplicate kafka-python functionality

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/constants.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/constants.py
@@ -2,6 +2,5 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 DEFAULT_KAFKA_TIMEOUT = 5
-DEFAULT_KAFKA_RETRIES = 3
 
 CONTEXT_UPPER_BOUND = 200

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -15,11 +15,6 @@ init_config:
   #
   # kafka_timeout: 5
 
-  ## @param kafka_retries - integer - optional - default: 3
-  ## Customizes the max number of retries per failed query to Kafka.
-  #
-  # kafka_retries: 3
-
 instances:
 
     ## @param kafka_connect_str - list of strings - required


### PR DESCRIPTION
The retry functionality makes very little sense here. Exponential
backoffs are already built into the `kafka-python` client. And the rest
of the retrying... when I dug into it, is actually "retrying" by
pointlessly querying the wrong brokers.

So I cleaned it up. The timeouts within `kafka-python` will handle
killing the requests after a certain amount of time, and it's safe to
call `poll()` repeatedly because under the covers it's just doing a
local `selectors` call.