### PR TITLE
Remove zk_timeout from constants

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/constants.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/constants.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 DEFAULT_KAFKA_TIMEOUT = 5
-DEFAULT_ZK_TIMEOUT = 5
 DEFAULT_KAFKA_RETRIES = 3
 
 CONTEXT_UPPER_BOUND = 200

--- a/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
@@ -19,7 +19,7 @@ from six import iteritems, itervalues, string_types, text_type
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.utils.containers import hash_mutable
 
-from .constants import CONTEXT_UPPER_BOUND, DEFAULT_KAFKA_RETRIES, DEFAULT_KAFKA_TIMEOUT, DEFAULT_ZK_TIMEOUT
+from .constants import CONTEXT_UPPER_BOUND, DEFAULT_KAFKA_RETRIES, DEFAULT_KAFKA_TIMEOUT
 
 
 class LegacyKafkaCheck_0_10_2(AgentCheck):
@@ -35,7 +35,7 @@ class LegacyKafkaCheck_0_10_2(AgentCheck):
 
     def __init__(self, name, init_config, instances):
         super(LegacyKafkaCheck_0_10_2, self).__init__(name, init_config, instances)
-        self._zk_timeout = int(init_config.get('zk_timeout', DEFAULT_ZK_TIMEOUT))
+        self._zk_timeout = int(init_config.get('zk_timeout', 5))
         self._kafka_timeout = int(init_config.get('kafka_timeout', DEFAULT_KAFKA_TIMEOUT))
         self.context_limit = int(init_config.get('max_partition_contexts', CONTEXT_UPPER_BOUND))
         self._broker_retries = int(init_config.get('kafka_retries', DEFAULT_KAFKA_RETRIES))


### PR DESCRIPTION
Since this is only used in the legacy codepath, and zookeeper
functionality will be removed in the future, no need to put this as a
constant.

cc @ofek 