### PR TITLE
Use kafka client consistently

### DIFF
--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -22,7 +22,7 @@ def test_check_kafka(aggregator, kafka_instance):
     """
     Testing Kafka_consumer check.
     """
-    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [{}])
+    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
     kafka_consumer_check.check(kafka_instance)
 
     for name, consumer_group in kafka_instance['consumer_groups'].items():

--- a/kafka_consumer/tests/test_kafka_consumer_zk.py
+++ b/kafka_consumer/tests/test_kafka_consumer_zk.py
@@ -24,7 +24,7 @@ def test_check_zk(aggregator, zk_instance):
     """
     Testing Kafka_consumer check.
     """
-    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [{}])
+    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [zk_instance])
     kafka_consumer_check.check(zk_instance)
 
     for name, consumer_group in zk_instance['consumer_groups'].items():
@@ -71,7 +71,7 @@ def test_multiple_servers_zk(aggregator, zk_instance):
         '{}:9092'.format(HOST),
     ]
 
-    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [{}])
+    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [multiple_server_zk_instance])
     kafka_consumer_check.check(multiple_server_zk_instance)
 
     for name, consumer_group in multiple_server_zk_instance['consumer_groups'].items():
@@ -97,7 +97,7 @@ def test_check_nogroups_zk(aggregator, zk_instance):
     nogroup_instance.pop('consumer_groups')
     nogroup_instance['monitor_unlisted_consumer_groups'] = True
 
-    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [{}])
+    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [nogroup_instance])
     kafka_consumer_check.check(nogroup_instance)
 
     for topic in TOPICS:


### PR DESCRIPTION
Agent v6 only has one instance per instances, so we don't need to have a
separate cache... just cache the client on the instance.

This cleanup will make life simpler when the check is refactored as part
of #3957.