### PR TITLE
Fix http invert without explicit default

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -133,8 +133,13 @@ class RequestsWrapper(object):
             if field in instance:
                 continue
 
+            # Invert default booleans if need be
+            default = default_fields[field]
+            if data.get('invert'):
+                default = not default
+
             # Get value, with a possible default
-            value = instance.get(remapped_field, data.get('default', default_fields[field]))
+            value = instance.get(remapped_field, data.get('default', default))
 
             # Invert booleans if need be
             if data.get('invert'):

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -567,6 +567,14 @@ class TestRemapper:
 
         assert http.options['verify'] is True
 
+    def test_invert_without_explicit_default(self):
+        instance = {}
+        init_config = {}
+        remapper = {'disable_ssl_validation': {'name': 'tls_verify', 'invert': True}}
+        http = RequestsWrapper(instance, init_config, remapper)
+
+        assert http.options['verify'] is True
+
     def test_standard_override(self):
         instance = {'disable_ssl_validation': True, 'tls_verify': False}
         init_config = {}


### PR DESCRIPTION
### What does this PR do?

Fix http invert without explicit default.

### Motivation

Inverting the default defined in http.py for boolean seems semantically more correct when `invert` is used in remapper.

However, when using `HTTP_CONFIG_REMAPPER`, it's better to provide an explicit default along with `invert`.

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
