### PR TITLE
Ignore tests for test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,8 +6,8 @@ disable_warnings =
 
 # All paths are relative to each tox.ini
 omit =
+    # Ignore tests
     */tests/*
-    */test_bench.py
 
     # These are things that are simply stored in the base package
     ../datadog_checks_base/datadog_checks/base/checks/libs/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ disable_warnings =
 
 # All paths are relative to each tox.ini
 omit =
+    */tests/*
     */test_bench.py
 
     # These are things that are simply stored in the base package


### PR DESCRIPTION
### What does this PR do?

Ignore `*/tests/*` for test coverage

Before

```
---------- Coverage report ----------

Name                                       Stmts   Miss Branch BrPart  Cover
----------------------------------------------------------------------------
datadog_checks/vsphere/__about__.py            1      0      0      0   100%
datadog_checks/vsphere/__init__.py             3      0      0      0   100%
datadog_checks/vsphere/cache_config.py        30      0      2      0   100%
datadog_checks/vsphere/common.py               1      0      0      0   100%
datadog_checks/vsphere/errors.py               5      0      0      0   100%
datadog_checks/vsphere/event.py              130     46     34     11    63%
datadog_checks/vsphere/metadata_cache.py      32      0      2      0   100%
datadog_checks/vsphere/mor_cache.py           61      1     18      1    97%
datadog_checks/vsphere/objects_queue.py       18      0      0      0   100%
datadog_checks/vsphere/vsphere.py            531     71    196     26    84%
tests/__init__.py                              0      0      0      0   100%
tests/conftest.py                             17      0      0      0   100%
tests/test_cache_config.py                    29      0      4      0   100%
tests/test_metadata_cache.py                  31      0      0      0   100%
tests/test_mor_cache.py                       76      0      8      0   100%
tests/test_objects_queue.py                   26      0      0      0   100%
tests/test_vsphere.py                        377      1     14      1    99%
tests/utils.py                                92      2     48      5    95%
----------------------------------------------------------------------------
TOTAL                                       1460    121    326     44    90%
```

After


```
---------- Coverage report ----------

Name                                       Stmts   Miss Branch BrPart  Cover
----------------------------------------------------------------------------
datadog_checks/vsphere/__about__.py            1      0      0      0   100%
datadog_checks/vsphere/__init__.py             3      0      0      0   100%
datadog_checks/vsphere/cache_config.py        30      0      2      0   100%
datadog_checks/vsphere/common.py               1      0      0      0   100%
datadog_checks/vsphere/errors.py               5      0      0      0   100%
datadog_checks/vsphere/event.py              130     46     34     11    63%
datadog_checks/vsphere/metadata_cache.py      32      0      2      0   100%
datadog_checks/vsphere/mor_cache.py           61      1     18      1    97%
datadog_checks/vsphere/objects_queue.py       18      0      0      0   100%
datadog_checks/vsphere/vsphere.py            531     71    196     26    84%
----------------------------------------------------------------------------
TOTAL
```

### Motivation

There is no value having coverage report for tests.

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
