### PR TITLE
Make nameserver optional in the configuration

### DIFF
--- a/dns_check/datadog_checks/dns_check/data/conf.yaml.example
+++ b/dns_check/datadog_checks/dns_check/data/conf.yaml.example
@@ -21,7 +21,7 @@ instances:
     ## @param nameserver - string - optional
     ## IP address of the name server to query.
     #
-    nameserver: <NAMESERVER>
+    # nameserver: <NAMESERVER>
 
     ## @param nameserver_port - string - optional - default: 53
     ## Port for the name server.

--- a/dns_check/datadog_checks/dns_check/data/conf.yaml.example
+++ b/dns_check/datadog_checks/dns_check/data/conf.yaml.example
@@ -18,10 +18,10 @@ instances:
     #
     hostname: <HOSTNAME>
 
-    ## @param nameserver - string - required
+    ## @param nameserver - string - optional
     ## IP address of the name server to query.
     #
-    nameserver: 127.0.0.1
+    nameserver: <NAMESERVER>
 
     ## @param nameserver_port - string - optional - default: 53
     ## Port for the name server.


### PR DESCRIPTION
### What does this PR do?

`nameserver` should be optional in the configuration file of the `dns_check`.

### Motivation

Attempts to address #4206.

### Review checklist (to be filled by reviewers)
 
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.