### PR TITLE
[twistlock] drops last 3 digits if date format in milliseconds

### DIFF
--- a/twistlock/datadog_checks/twistlock/twistlock.py
+++ b/twistlock/datadog_checks/twistlock/twistlock.py
@@ -86,7 +86,7 @@ class TwistlockCheck(AgentCheck):
         expiration_date_str = license.get("expiration_date")
 
         # %f only matches microseconds. This will look for milliseconds and drop the last 3 digits.
-        match_milliseconds = re.match('(.*\.\d{6})(?:\d{3})(Z)', expiration_date_str)
+        match_milliseconds = re.match('(.*\.\d{6})(?:\d+)(Z)', expiration_date_str)
         if match_milliseconds:
             expiration_date_str = ""
             for group in match_milliseconds.groups():


### PR DESCRIPTION
### What does this PR do?

`%f` appears to only match upto microsecond granularity (6 digits max). Any extra digits (e.g. milliseconds) will fail to match the date format

### Motivation

card: 1287-license-expiration-for-twistlock-integration

```
 File "C:\Program Files\Datadog\Datadog Agent\embedded\lib\_strptime.py", line 332, in _strptime (data_string, format)) ValueError: time data '2020-07-14T16:34:46.830900011Z' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'
```

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
