### PR TITLE
Add postgresql application name to connection

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -870,13 +870,28 @@ GROUP BY datid, datname
             try:
                 if host == 'localhost' and password == '':
                     # Use ident method
-                    connection = psycopg2.connect("user=%s dbname=%s" % (user, dbname))
+                    connection = psycopg2.connect(
+                        "user=%s dbname=%s, application_name=%s" % (user, dbname, "datadog-agent")
+                    )
                 elif port != '':
                     connection = psycopg2.connect(
-                        host=host, port=port, user=user, password=password, database=dbname, sslmode=ssl
+                        host=host,
+                        port=port,
+                        user=user,
+                        password=password,
+                        database=dbname,
+                        sslmode=ssl,
+                        application_name="datadog-agent",
                     )
                 else:
-                    connection = psycopg2.connect(host=host, user=user, password=password, database=dbname, sslmode=ssl)
+                    connection = psycopg2.connect(
+                        host=host,
+                        user=user,
+                        password=password,
+                        database=dbname,
+                        sslmode=ssl,
+                        application_name="datadog-agent",
+                    )
                 self.dbs[key] = connection
                 return connection
             except Exception as e:


### PR DESCRIPTION
### What does this PR do?

Add the application name to the connection of the postgresql integration

### Motivation

When displaying stats about usage of your database or debugging slowness, it's useful to know which client (tool) is doing what. This help identifying distinct tools.


### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
