### PR TITLE
[twistlock] fix date format matching

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -46,6 +46,7 @@ pysnmp==4.4.3
 pysnmp-mibs==0.1.6
 pysocks==1.7.0
 python-binary-memcached==0.26.1; sys_platform != 'win32'
+python-dateutil==2.8.0
 python3-gearman==0.1.0; sys_platform != 'win32' and python_version > '3.0'
 pyvmomi==v6.5.0.2017.5-1
 pywin32==224; sys_platform == 'win32'

--- a/twistlock/datadog_checks/twistlock/twistlock.py
+++ b/twistlock/datadog_checks/twistlock/twistlock.py
@@ -38,7 +38,7 @@ class TwistlockCheck(AgentCheck):
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
 
-        self.last_run = datetime.now(tz.tzutc())
+        self.last_run = datetime.utcnow()
 
         self.config = None
         if instances:
@@ -68,7 +68,7 @@ class TwistlockCheck(AgentCheck):
 
         self.report_vulnerabilities()
 
-        self.last_run = datetime.now(tz.tzutc())
+        self.last_run = datetime.utcnow()
 
     def report_license_expiration(self):
         service_check_name = self.NAMESPACE + ".license_ok"

--- a/twistlock/datadog_checks/twistlock/twistlock.py
+++ b/twistlock/datadog_checks/twistlock/twistlock.py
@@ -115,12 +115,7 @@ class TwistlockCheck(AgentCheck):
             image_tags = ["scanned_image:" + image_name] + self.config.tags
 
             self._report_layer_count(image, namespace, image_tags)
-            self._report_service_check(
-                image,
-                namespace,
-                tags=image_tags,
-                message="Last scan: " + image.get("scanTime"),
-            )
+            self._report_service_check(image, namespace, tags=image_tags, message="Last scan: " + image.get("scanTime"))
             self._report_vuln_info(namespace, image, image_tags)
             self._report_compliance_information(namespace, image, image_tags)
 
@@ -150,9 +145,7 @@ class TwistlockCheck(AgentCheck):
             image_tags = ["scanned_image:" + image_name] + self.config.tags
 
             self._report_layer_count(image, namespace, image_tags)
-            self._report_service_check(
-                image, namespace, tags=image_tags, message="Last scan: " + image.get("scanTime")
-            )
+            self._report_service_check(image, namespace, tags=image_tags, message="Last scan: " + image.get("scanTime"))
             self._report_vuln_info(namespace, image, image_tags)
             self._report_compliance_information(namespace, image, image_tags)
 
@@ -175,9 +168,7 @@ class TwistlockCheck(AgentCheck):
             hostname = host['hostname']
             host_tags = ["scanned_host:" + hostname] + self.config.tags
 
-            self._report_service_check(
-                host, namespace, tags=host_tags, message="Last scan: " + host.get("scanTime")
-            )
+            self._report_service_check(host, namespace, tags=host_tags, message="Last scan: " + host.get("scanTime"))
             self._report_vuln_info(namespace, host, host_tags)
             self._report_compliance_information(namespace, host, host_tags)
 
@@ -208,10 +199,7 @@ class TwistlockCheck(AgentCheck):
             container_tags += self.config.tags
 
             self._report_service_check(
-                container,
-                namespace,
-                tags=container_tags,
-                message="Last scan: " + container.get("scanTime"),
+                container, namespace, tags=container_tags, message="Last scan: " + container.get("scanTime")
             )
             self._report_compliance_information(namespace, container, container_tags)
 

--- a/twistlock/datadog_checks/twistlock/twistlock.py
+++ b/twistlock/datadog_checks/twistlock/twistlock.py
@@ -308,7 +308,7 @@ class TwistlockCheck(AgentCheck):
         self.gauge(namespace + '.size', float(layer_sizes), tags)
         self.gauge(namespace + '.layer_count', float(layer_count), tags)
 
-    def _report_service_check(self, data, prefix, format, tags=None, message=""):
+    def _report_service_check(self, data, prefix, tags=None, message=""):
         # Last scan service check
         scan_date = parser.isoparse(data.get("scanTime"))
         scan_status = AgentCheck.OK

--- a/twistlock/requirements.in
+++ b/twistlock/requirements.in
@@ -1,0 +1,1 @@
+python-dateutil==2.8.0


### PR DESCRIPTION
### What does this PR do?

Will use dateutil.parse.isoparse to parse the dates. Would match any of the following using ISO 8601 date formats

date_str_seconds = "2019-07-24T13:08:37Z"
date_str_milliseconds = "2019-07-24T13:08:37.123Z"
date_str_microseconds = "2019-07-24T13:08:37.123456Z"
date_str_nanoseconds = "2019-07-24T13:08:37.123456789Z"

### Motivation

- 1310-twistlock-registry-scan-date-format-does-not-match
- 1287-license-expiration-for-twistlock-integration

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
