### PR TITLE
Add `min_disk_size` option

### DIFF
--- a/disk/datadog_checks/disk/data/conf.yaml.default
+++ b/disk/datadog_checks/disk/data/conf.yaml.default
@@ -133,7 +133,7 @@ instances:
     #   /dev/sda3: role:db,disk_size:large
     #   "c:": volume:boot
 
-    ## @param min_disk_size - int - optional - default 0
+    ## @param min_disk_size - float - optional - default: 0
     ## Exclude devices with a total disk size less than a minimum value (in MiB)
     #
     # min_disk_size: 0

--- a/disk/datadog_checks/disk/data/conf.yaml.default
+++ b/disk/datadog_checks/disk/data/conf.yaml.default
@@ -132,3 +132,8 @@ instances:
     #   /san/.*: device_type:san
     #   /dev/sda3: role:db,disk_size:large
     #   "c:": volume:boot
+
+    ## @param min_disk_size - int - optional - default 0
+    ## Exclude devices with a total disk size less than a minimum value (in mb)
+    #
+    # min_disk_size: 0

--- a/disk/datadog_checks/disk/data/conf.yaml.default
+++ b/disk/datadog_checks/disk/data/conf.yaml.default
@@ -134,6 +134,6 @@ instances:
     #   "c:": volume:boot
 
     ## @param min_disk_size - int - optional - default 0
-    ## Exclude devices with a total disk size less than a minimum value (in mb)
+    ## Exclude devices with a total disk size less than a minimum value (in MiB)
     #
     # min_disk_size: 0

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -282,8 +282,13 @@ class Disk(AgentCheck):
         self.log.debug(df_out)
 
         for device in self._list_devices(df_out):
-            self.log.debug("Passed: {}".format(device))
             device_name = device[-1] if self._use_mount else device[0]
+            if float(device[2]) <= self._min_disk_size:
+                if float(device[2]) > 0:
+                    self.log.info('Excluding device {} with total disk size {}'.format(device_name, device[2]))
+                continue
+            
+            self.log.debug("Passed: {}".format(device))
 
             tags = [device[1], 'filesystem:{}'.format(device[1])] if self._tag_by_filesystem else []
             tags.extend(self._custom_tags)

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -50,7 +50,7 @@ class Disk(AgentCheck):
         self._device_tag_re = instance.get('device_tag_re', {})
         self._custom_tags = instance.get('tags', [])
         self._service_check_rw = is_affirmative(instance.get('service_check_rw', False))
-        self._min_disk_size = instance.get('min_disk_size', 0) * 1000000
+        self._min_disk_size = instance.get('min_disk_size', 0) * 1024 * 1024
 
         self._compile_pattern_filters(instance)
         self._compile_tag_re()
@@ -62,9 +62,6 @@ class Disk(AgentCheck):
         """Get disk space/inode stats"""
         if self._tag_by_label and Platform.is_linux():
             self.devices_label = self._get_devices_label()
-        if not isinstance(self._min_disk_size, int):
-            self.log.warning('min_disk_size must be an integer; exiting check.')
-            return
 
         # Windows and Mac will always have psutil
         # (we have packaged for both of them)

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -282,13 +282,8 @@ class Disk(AgentCheck):
         self.log.debug(df_out)
 
         for device in self._list_devices(df_out):
-            device_name = device[-1] if self._use_mount else device[0]
-            if float(device[2]) <= self._min_disk_size:
-                if float(device[2]) > 0:
-                    self.log.info('Excluding device {} with total disk size {}'.format(device_name, device[2]))
-                continue
-            
             self.log.debug("Passed: {}".format(device))
+            device_name = device[-1] if self._use_mount else device[0]
 
             tags = [device[1], 'filesystem:{}'.format(device[1])] if self._tag_by_filesystem else []
             tags.extend(self._custom_tags)

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -222,7 +222,7 @@ def test_get_devices_label():
 
 def test_min_disk_size():
     instance = {
-        '_min_disk_size': 6,
+        'min_disk_size': 6,
     }
     c = Disk('disk', None, {}, [instance])
 
@@ -234,6 +234,4 @@ def test_min_disk_size():
 
     with mock_output:
         c.check(instance)
-
         # need help here - not sure how to check that the proper devices were excluded
-

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -28,6 +28,7 @@ def test_default_options():
     assert check._tag_by_filesystem is False
     assert check._device_tag_re == []
     assert check._service_check_rw is False
+    assert check._min_disk_size == 0
 
 
 def test_bad_config():
@@ -218,3 +219,21 @@ def test_get_devices_label():
     ):
         labels = c._get_devices_label()
         assert labels.get("/dev/mapper/vagrant--vg-root") == "label:DATA"
+
+def test_min_disk_size():
+    instance = {
+        '_min_disk_size': 6,
+    }
+    c = Disk('disk', None, {}, [instance])
+
+    mock_output = mock.patch(
+        'datadog_checks.disk.disk.get_subprocess_output',
+        return_value=mock_df_output('freebsd-df-Tk'),
+        __name__='get_subprocess_output',
+    )
+
+    with mock_output:
+        c.check(instance)
+
+        # need help here - not sure how to check that the proper devices were excluded
+

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -246,3 +246,19 @@ def test_no_psutil_min_disk_size(aggregator, gauge_metrics):
             aggregator.assert_metric(name, tags=['device:{}'.format(device)], count=0)
 
     aggregator.assert_all_metrics_covered()
+
+@pytest.mark.usefixtures('psutil_mocks')
+def test_psutil_min_disk_size(aggregator, gauge_metrics, rate_metrics):
+    instance = {
+        'min_disk_size': 0.004,
+    }
+    c = Disk('disk', None, {}, [instance])
+    c.check(instance)
+
+    for device in ['/dev/sda1']: #expected devices
+        for name in gauge_metrics:
+            aggregator.assert_metric(name, tags=['device:{}'.format(device)])
+        for name in rate_metrics:
+            aggregator.assert_metric(name, tags=['device:{}'.format(device)])
+
+    aggregator.assert_all_metrics_covered()

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -235,6 +235,6 @@ def test_psutil_min_disk_size(aggregator, gauge_metrics, rate_metrics):
         aggregator.assert_metric(name, count=0)
 
     for name in rate_metrics:
-        aggregator.assert_metric(name, tags=['device:{}'.format(DEFAULT_DEVICE_NAME)])
+        aggregator.assert_metric_has_tag(name, 'device:{}'.format(DEFAULT_DEVICE_NAME))
 
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

Adds the ability to configure the minimum disk size threshold for devices from which to pull metrics.

### Motivation

Client Request.