### PR TITLE
[preview] Send histogram buckets

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -238,6 +238,17 @@ class __AgentCheck(object):
     def _context_uid(self, mtype, name, tags=None, hostname=None):
         return '{}-{}-{}-{}'.format(mtype, name, tags if tags is None else hash(frozenset(tags)), hostname)
 
+    def _submit_histogram_bucket(self, check_id, name, value, lower_bound, upper_bound, monotonic, hostname, tags):
+        if value is None:
+            # ignore metric sample
+            return
+
+        tags = self._normalize_tags_type(tags, name)
+        if hostname is None:
+            hostname = ''
+
+        aggregator.submit_histogram_bucket(self, self.check_id, name, value, lower_bound, upper_bound, monotonic, hostname, tags)
+
     def _submit_metric(self, mtype, name, value, tags=None, hostname=None, device_name=None):
         if value is None:
             # ignore metric sample

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -250,7 +250,9 @@ class __AgentCheck(object):
         if hostname is None:
             hostname = ''
 
-        aggregator.submit_histogram_bucket(self, self.check_id, name, value, lower_bound, upper_bound, monotonic, hostname, tags)
+        aggregator.submit_histogram_bucket(
+            self, self.check_id, name, value, lower_bound, upper_bound, monotonic, hostname, tags
+        )
 
     def _submit_metric(self, mtype, name, value, tags=None, hostname=None, device_name=None):
         if value is None:

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -238,13 +238,22 @@ class __AgentCheck(object):
     def _context_uid(self, mtype, name, tags=None, hostname=None):
         return '{}-{}-{}-{}'.format(mtype, name, tags if tags is None else hash(frozenset(tags)), hostname)
 
-    def submit_histogram_bucket(self, check_id, name, value, lower_bound, upper_bound, monotonic, hostname, tags):
+    def submit_histogram_bucket(self, name, value, lower_bound, upper_bound, monotonic, hostname, tags):
         if value is None:
             # ignore metric sample
             return
 
         # make sure the value (bucket count) is an integer
-        value = int(value)
+        try:
+            value = int(value)
+        except ValueError:
+            err_msg = 'Histogram: {} has non integer value: {}. Only integer are valid bucket values (count).'.format(
+                repr(name), repr(value)
+            )
+            if using_stub_aggregator:
+                raise ValueError(err_msg)
+            self.warning(err_msg)
+            return
 
         tags = self._normalize_tags_type(tags, metric_name=name)
         if hostname is None:

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -243,6 +243,9 @@ class __AgentCheck(object):
             # ignore metric sample
             return
 
+        # make sure the value (bucket count) is an integer
+        value = int(value)
+
         tags = self._normalize_tags_type(tags, metric_name=name)
         if hostname is None:
             hostname = ''

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -238,7 +238,7 @@ class __AgentCheck(object):
     def _context_uid(self, mtype, name, tags=None, hostname=None):
         return '{}-{}-{}-{}'.format(mtype, name, tags if tags is None else hash(frozenset(tags)), hostname)
 
-    def _submit_histogram_bucket(self, check_id, name, value, lower_bound, upper_bound, monotonic, hostname, tags):
+    def submit_histogram_bucket(self, check_id, name, value, lower_bound, upper_bound, monotonic, hostname, tags):
         if value is None:
             # ignore metric sample
             return

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -243,7 +243,7 @@ class __AgentCheck(object):
             # ignore metric sample
             return
 
-        tags = self._normalize_tags_type(tags, name)
+        tags = self._normalize_tags_type(tags, metric_name=name)
         if hostname is None:
             hostname = ''
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -745,16 +745,14 @@ class OpenMetricsScraperMixin(object):
             return
         sample[self.SAMPLE_LABELS]["le"] = str(float(sample[self.SAMPLE_LABELS]["le"]))
         sample[self.SAMPLE_LABELS]["lower_bound"] = str(float(sample[self.SAMPLE_LABELS]["lower_bound"]))
-        if sample[self.SAMPLE_LABELS]["le"] ==  sample[self.SAMPLE_LABELS]["lower_bound"]:
+        if sample[self.SAMPLE_LABELS]["le"] == sample[self.SAMPLE_LABELS]["lower_bound"]:
             # this can happen for -inf/-inf bucket that we don't want to send (always 0)
             self.log.warning(
-                "Metric: {} has bucket boundaries equal, skipping: {}".format(
-                    metric_name, sample[self.SAMPLE_LABELS]
-                )
+                "Metric: {} has bucket boundaries equal, skipping: {}".format(metric_name, sample[self.SAMPLE_LABELS])
             )
             return
         tags = self._metric_tags(metric_name, sample[self.SAMPLE_VALUE], sample, scraper_config, hostname)
-        self._submit_histogram_bucket(
+        self.submit_histogram_bucket(
             self.check_id,
             metric_name,
             sample[self.SAMPLE_VALUE],

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -32,6 +32,8 @@ class OpenMetricsScraperMixin(object):
     SAMPLE_LABELS = 1
     SAMPLE_VALUE = 2
 
+    MINUS_INF = float("-inf")
+
     TELEMETRY_GAUGE_MESSAGE_SIZE = "payload.size"
     TELEMETRY_COUNTER_METRICS_BLACKLIST_COUNT = "metrics.blacklist.count"
     TELEMETRY_COUNTER_METRICS_INPUT_COUNT = "metrics.input.count"
@@ -709,7 +711,7 @@ class OpenMetricsScraperMixin(object):
             if sample[self.SAMPLE_NAME].endswith("_bucket"):
                 bucket_values_by_upper_bound[float(sample[self.SAMPLE_LABELS]["le"])] = sample[self.SAMPLE_VALUE]
 
-        sorted_buckets = sorted(bucket_values_by_upper_bound.keys())
+        sorted_buckets = sorted(bucket_values_by_upper_bound)
 
         # Tuples (lower_bound, upper_bound, value)
         bucket_tuples_by_upper_bound = {}
@@ -721,7 +723,7 @@ class OpenMetricsScraperMixin(object):
                 else:
                     # negative buckets start at -inf
                     bucket_tuples_by_upper_bound[upper_b] = (
-                        float("-inf"),
+                        self.MINUS_INF,
                         upper_b,
                         bucket_values_by_upper_bound[upper_b],
                     )

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -754,7 +754,7 @@ class OpenMetricsScraperMixin(object):
         tags = self._metric_tags(metric_name, sample[self.SAMPLE_VALUE], sample, scraper_config, hostname)
         self.submit_histogram_bucket(
             self.check_id,
-            metric_name,
+            "{}.{}".format(scraper_config['namespace'], metric_name),
             sample[self.SAMPLE_VALUE],
             float(sample[self.SAMPLE_LABELS]["lower_bound"]),
             float(sample[self.SAMPLE_LABELS]["le"]),

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -718,6 +718,7 @@ class OpenMetricsScraperMixin(object):
         bucket_tuples_by_upper_bound = {}
         for i, v in enumerate(sorted_buckets):
             if i == 0:
+                # TODO: handle negative buckets
                 bucket_tuples_by_upper_bound[v] = (0, v, bucket_values_by_upper_bound[v])
                 continue
             tmp = bucket_values_by_upper_bound[v] - bucket_values_by_upper_bound[sorted_buckets[i-1]]
@@ -740,7 +741,7 @@ class OpenMetricsScraperMixin(object):
 
     def _submit_sample_histogram_buckets(self, metric_name, sample, scraper_config, hostname=None):
         if "lower_bound" not in sample[self.SAMPLE_LABELS] or "le" not in sample[self.SAMPLE_LABELS]:
-            self.log.warning("Metric: {} was not containing required bucket boundaries labels".format(metric_name))
+            self.log.warning("Metric: {} was not containing required bucket boundaries labels: {}".format(metric_name, sample[self.SAMPLE_LABELS]))
             return
         sample[self.SAMPLE_LABELS]["le"] = str(float(sample[self.SAMPLE_LABELS]["le"]))
         sample[self.SAMPLE_LABELS]["lower_bound"] = str(float(sample[self.SAMPLE_LABELS]["lower_bound"]))

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -7,7 +7,7 @@ from collections import OrderedDict, defaultdict
 
 from six import binary_type, iteritems
 
-from datadog_checks.base.stubs.common import MetricStub, ServiceCheckStub
+from datadog_checks.base.stubs.common import MetricStub, ServiceCheckStub, HistogramBucketStub
 from datadog_checks.base.stubs.similar import build_similar_elements_msg
 
 from ..utils.common import ensure_unicode, to_string
@@ -50,6 +50,7 @@ class AggregatorStub(object):
         self._asserted = set()
         self._service_checks = defaultdict(list)
         self._events = []
+        self._histogram_buckets = defaultdict(list)
 
     @classmethod
     def is_aggregate(cls, mtype):
@@ -63,6 +64,9 @@ class AggregatorStub(object):
 
     def submit_event(self, check, check_id, event):
         self._events.append(event)
+
+    def submit_histogram_bucket(self, check, check_id, name, value, lower_bound, upper_bound, monotonic, hostname, tags):
+        self._histogram_buckets[name].append(HistogramBucketStub(name, value, lower_bound, upper_bound, monotonic, hostname, tags))
 
     def metrics(self, name):
         """
@@ -115,6 +119,23 @@ class AggregatorStub(object):
 
         return all_events
 
+    def histogram_bucket(self, name):
+        """
+        Return the histogram buckets received under the given name
+        """
+        return [
+            HistogramBucketStub(
+                ensure_unicode(stub.name),
+                stub.value,
+                stub.lower_bound,
+                stub.upper_bound,
+                stub.monotonic,
+                ensure_unicode(stub.hostname),
+                normalize_tags(stub.tags),
+            )
+            for stub in self._histogram_buckets.get(to_string(name), [])
+        ]
+
     def assert_metric_has_tag(self, metric_name, tag, count=None, at_least=1):
         """
         Assert a metric is tagged with tag
@@ -153,6 +174,32 @@ class AggregatorStub(object):
             assert len(candidates) == count, msg
         else:
             assert len(candidates) >= at_least, msg
+
+    def assert_histogram_bucket(self, name, value, lower_bound, upper_bound, monotonic, hostname, tags, count=None, at_least=1):
+        candidates = []
+        for bucket in self.histogram_bucket(name):
+            if value is not None and value != bucket.value:
+                continue
+
+            if tags and tags != sorted(bucket.tags):
+                continue
+
+            if hostname and hostname != bucket.hostname:
+                continue
+
+            candidates.append(bucket)
+
+        expected_bucket = HistogramBucketStub(name, value, lower_bound, upper_bound, monotonic, hostname, tags)
+
+        if count is not None:
+            msg = "Needed exactly {} candidates for '{}', got {}".format(count, name, len(candidates))
+            condition = len(candidates) == count
+        else:
+            msg = "Needed at least {} candidates for '{}', got {}".format(at_least, name, len(candidates))
+            condition = len(candidates) >= at_least
+        self._assert(
+            condition=condition, msg=msg, expected_stub=expected_bucket, submitted_elements=self._histogram_buckets
+        )
 
     def assert_metric(self, name, value=None, tags=None, count=None, at_least=1, hostname=None, metric_type=None):
         """

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -7,7 +7,7 @@ from collections import OrderedDict, defaultdict
 
 from six import binary_type, iteritems
 
-from datadog_checks.base.stubs.common import MetricStub, ServiceCheckStub, HistogramBucketStub
+from datadog_checks.base.stubs.common import HistogramBucketStub, MetricStub, ServiceCheckStub
 from datadog_checks.base.stubs.similar import build_similar_elements_msg
 
 from ..utils.common import ensure_unicode, to_string
@@ -65,8 +65,12 @@ class AggregatorStub(object):
     def submit_event(self, check, check_id, event):
         self._events.append(event)
 
-    def submit_histogram_bucket(self, check, check_id, name, value, lower_bound, upper_bound, monotonic, hostname, tags):
-        self._histogram_buckets[name].append(HistogramBucketStub(name, value, lower_bound, upper_bound, monotonic, hostname, tags))
+    def submit_histogram_bucket(
+        self, check, check_id, name, value, lower_bound, upper_bound, monotonic, hostname, tags
+    ):
+        self._histogram_buckets[name].append(
+            HistogramBucketStub(name, value, lower_bound, upper_bound, monotonic, hostname, tags)
+        )
 
     def metrics(self, name):
         """
@@ -175,7 +179,9 @@ class AggregatorStub(object):
         else:
             assert len(candidates) >= at_least, msg
 
-    def assert_histogram_bucket(self, name, value, lower_bound, upper_bound, monotonic, hostname, tags, count=None, at_least=1):
+    def assert_histogram_bucket(
+        self, name, value, lower_bound, upper_bound, monotonic, hostname, tags, count=None, at_least=1
+    ):
         candidates = []
         for bucket in self.histogram_bucket(name):
             if value is not None and value != bucket.value:

--- a/datadog_checks_base/datadog_checks/base/stubs/common.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/common.py
@@ -7,3 +7,4 @@ from collections import namedtuple
 
 MetricStub = namedtuple('MetricStub', 'name type value tags hostname')
 ServiceCheckStub = namedtuple('ServiceCheckStub', 'check_id name status tags hostname message')
+HistogramBucketStub = namedtuple('HistogramBucketStub', 'name value lower_bound upper_bound monotonic hostname tags')

--- a/datadog_checks_base/datadog_checks/base/stubs/similar.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/similar.py
@@ -2,7 +2,7 @@ from difflib import SequenceMatcher
 
 from six import iteritems
 
-from datadog_checks.base.stubs.common import MetricStub, ServiceCheckStub, HistogramBucketStub
+from datadog_checks.base.stubs.common import HistogramBucketStub, MetricStub, ServiceCheckStub
 
 '''
 Build similar message for better test assertion failure message.
@@ -100,6 +100,7 @@ def _get_similarity_score_for_service_check(expected_service_check, candidate_se
         scores.append((score, 1))
 
     return _compute_score(scores)
+
 
 def _get_similarity_score_for_histogram_bucket(expected_histogram_bucket, candidate_histogram_bucket):
     # Tuple of (score, weight)

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -395,10 +395,18 @@ def test_submit_histogram_bucket(aggregator, mocked_prometheus_check, mocked_pro
     aggregator.assert_metric('prometheus.custom.histogram.count', 4, tags=['upper_bound:none'], count=1)
     # assert buckets
     aggregator.assert_histogram_bucket(
-        'custom.histogram', 1, 0.0, 1.0, True, "", tags=['lower_bound:0.0', 'upper_bound:1.0'], count=None, at_least=1
+        'prometheus.custom.histogram',
+        1,
+        0.0,
+        1.0,
+        True,
+        "",
+        tags=['lower_bound:0.0', 'upper_bound:1.0'],
+        count=None,
+        at_least=1,
     )
     aggregator.assert_histogram_bucket(
-        'custom.histogram',
+        'prometheus.custom.histogram',
         1,
         1.0,
         31104000.0,
@@ -409,7 +417,7 @@ def test_submit_histogram_bucket(aggregator, mocked_prometheus_check, mocked_pro
         at_least=1,
     )
     aggregator.assert_histogram_bucket(
-        'custom.histogram',
+        'prometheus.custom.histogram',
         1,
         31104000.0,
         432400000.0,
@@ -420,7 +428,7 @@ def test_submit_histogram_bucket(aggregator, mocked_prometheus_check, mocked_pro
         at_least=1,
     )
     aggregator.assert_histogram_bucket(
-        'custom.histogram',
+        'prometheus.custom.histogram',
         1,
         432400000.0,
         float('inf'),

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -383,6 +383,23 @@ def test_submit_histogram(aggregator, mocked_prometheus_check, mocked_prometheus
     aggregator.assert_metric('prometheus.custom.histogram.count', 3, tags=['upper_bound:432400000.0'], count=1)
     aggregator.assert_all_metrics_covered()
 
+def test_submit_histogram_bucket(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+    _histo = HistogramMetricFamily('my_histogram', 'my_histogram')
+    _histo.add_metric(
+        [], buckets=[("1", 1), ("3.1104e+07", 2), ("4.324e+08", 3), ("+Inf", 4)], sum_value=1337
+    )
+    check = mocked_prometheus_check
+    mocked_prometheus_scraper_config['send_distribution_buckets'] = True
+    mocked_prometheus_scraper_config['non_cumulative_buckets'] = True
+    check.submit_openmetric('custom.histogram', _histo, mocked_prometheus_scraper_config)
+    aggregator.assert_metric('prometheus.custom.histogram.sum', 1337, tags=[], count=1)
+    aggregator.assert_metric('prometheus.custom.histogram.count', 4, tags=['upper_bound:none'], count=1)
+    # assert buckets
+    aggregator.assert_histogram_bucket('custom.histogram', 1, 0.0, 1.0, True, "", tags=['lower_bound:0.0', 'upper_bound:1.0'], count=None, at_least=1)
+    aggregator.assert_histogram_bucket('custom.histogram', 1, 1.0, 31104000.0, True, "", tags=['lower_bound:1.0', 'upper_bound:31104000.0'], count=None, at_least=1)
+    aggregator.assert_histogram_bucket('custom.histogram', 1, 31104000.0, 432400000.0, True, "", tags=['lower_bound:31104000.0', 'upper_bound:432400000.0'], count=None, at_least=1)
+    aggregator.assert_histogram_bucket('custom.histogram', 1, 432400000.0, float('inf'), True, "", tags=['lower_bound:432400000.0', 'upper_bound:inf'], count=None, at_least=1)
+
 
 def test_submit_rate(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
     _rate = GaugeMetricFamily('my_rate', 'Random rate')
@@ -786,6 +803,7 @@ def test_parse_two_histograms_with_label(p_check, mocked_prometheus_scraper_conf
         current_metric.samples, key=lambda i: i[0]
     )
 
+
 def test_decumulate_histogram_buckets(p_check, mocked_prometheus_scraper_config):
     # buckets are not necessary ordered
     text_data = (
@@ -837,6 +855,7 @@ def test_decumulate_histogram_buckets(p_check, mocked_prometheus_scraper_config)
         current_metric.samples, key=lambda i: i[0]
     )
 
+
 def test_decumulate_histogram_buckets_single_bucket(p_check, mocked_prometheus_scraper_config):
     # buckets are not necessary ordered
     text_data = (
@@ -867,6 +886,7 @@ def test_decumulate_histogram_buckets_single_bucket(p_check, mocked_prometheus_s
     assert sorted(expected_metric.samples, key=lambda i: i[0]) == sorted(
         current_metric.samples, key=lambda i: i[0]
     )
+
 
 def test_decumulate_histogram_buckets_no_buckets(p_check, mocked_prometheus_scraper_config):
     # buckets are not necessary ordered

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -992,9 +992,7 @@ def test_decumulate_histogram_buckets_negative_buckets(p_check, mocked_prometheu
 
     assert 1 == len(metrics)
 
-    expected_metric = HistogramMetricFamily(
-        'random_histogram_bucket', 'Nonsense histogram.'
-    )
+    expected_metric = HistogramMetricFamily('random_histogram_bucket', 'Nonsense histogram.')
     expected_metric.samples = [
         (
             'random_histogram_bucket',
@@ -1021,11 +1019,7 @@ def test_decumulate_histogram_buckets_negative_buckets(p_check, mocked_prometheu
             {'url': 'http://127.0.0.1:8080/api', 'le': '+Inf', 'lower_bound': '15.0', 'verb': 'GET'},
             5.0,
         ),
-        (
-            'random_histogram_sum',
-            {'url': 'http://127.0.0.1:8080/api', 'verb': 'GET'},
-            3.14,
-        ),
+        ('random_histogram_sum', {'url': 'http://127.0.0.1:8080/api', 'verb': 'GET'}, 3.14),
         ('random_histogram_count', {'url': 'http://127.0.0.1:8080/api', 'verb': 'GET'}, 70.0),
     ]
 

--- a/datadog_checks_base/tests/test_similar.py
+++ b/datadog_checks_base/tests/test_similar.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.stubs import similar
-from datadog_checks.base.stubs.common import MetricStub, ServiceCheckStub
+from datadog_checks.base.stubs.common import HistogramBucketStub, MetricStub, ServiceCheckStub
 
 
 class TestSimilarAssertionMessages(object):
@@ -178,3 +178,18 @@ Score   Most similar
 
         # expect similar metrics in a similarity order
         assert similar_service_checks[0][1].name == 'test.similar3'
+
+    def test__build_similar_elements__histogram_buckets(self, aggregator):
+        check = AgentCheck()
+
+        check.submit_histogram_bucket('check', 'histogram.bucket', 1, 10.0, 125.0, True, "hostname", ["tag2"])
+        check.submit_histogram_bucket('check', 'histogram.bucket', 1, 125.0, 312.0, True, "hostname", ["tag1"])
+        check.submit_histogram_bucket('check', 'histogram.bucket', 1, 0.0, 10.0, True, "hostname", ["tag1"])
+
+        expected_histogram_bucket = HistogramBucketStub('histogram.bucket', 1, 0.0, 10.0, True, "hostname", ["tag1"])
+        similar_histogram_bucket = similar._build_similar_elements(
+            expected_histogram_bucket, aggregator._histogram_buckets
+        )
+
+        # expect similar metrics in a similarity order
+        assert similar_histogram_bucket[0][1].name == 'histogram.bucket'

--- a/datadog_checks_base/tests/test_similar.py
+++ b/datadog_checks_base/tests/test_similar.py
@@ -182,9 +182,9 @@ Score   Most similar
     def test__build_similar_elements__histogram_buckets(self, aggregator):
         check = AgentCheck()
 
-        check.submit_histogram_bucket('check', 'histogram.bucket', 1, 10.0, 125.0, True, "hostname", ["tag2"])
-        check.submit_histogram_bucket('check', 'histogram.bucket', 1, 125.0, 312.0, True, "hostname", ["tag1"])
-        check.submit_histogram_bucket('check', 'histogram.bucket', 1, 0.0, 10.0, True, "hostname", ["tag1"])
+        check.submit_histogram_bucket('histogram.bucket', 1, 10.0, 125.0, True, "hostname", ["tag2"])
+        check.submit_histogram_bucket('histogram.bucket', 1, 125.0, 312.0, True, "hostname", ["tag1"])
+        check.submit_histogram_bucket('histogram.bucket', 1, 0.0, 10.0, True, "hostname", ["tag1"])
 
         expected_histogram_bucket = HistogramBucketStub('histogram.bucket', 1, 0.0, 10.0, True, "hostname", ["tag1"])
         similar_histogram_bucket = similar._build_similar_elements(


### PR DESCRIPTION
### What does this PR do?

Add the possibility for the openmetrics check to send directly histogram buckets to the agent.

### Motivation

Send histograms as distribution metrics.

### Additional Notes

Agent PR: https://github.com/DataDog/datadog-agent/pull/3937

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
