### PR TITLE
Pass docker variables in tox

### DIFF
--- a/marathon/tox.ini
+++ b/marathon/tox.ini
@@ -13,6 +13,9 @@ platform = linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
+passenv =
+    DOCKER*
+    COMPOSE*
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
It makes the tests pass on non local docker.