### PR TITLE
Support referencing metrics by profile

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -14,11 +14,16 @@ class InstanceConfig:
     DEFAULT_RETRIES = 5
     DEFAULT_TIMEOUT = 1
 
-    def __init__(self, instance, warning, global_metrics, mibs_path):
+    def __init__(self, instance, warning, global_metrics, mibs_path, profiles):
         self.tags = instance.get('tags', [])
         self.metrics = instance.get('metrics', [])
+        self.profile = instance.get('profile')
         if is_affirmative(instance.get('use_global_metrics', True)):
             self.metrics.extend(global_metrics)
+        if self.profile:
+            if self.profile not in profiles:
+                raise ConfigurationError("Unknown profile '{}'".format(self.profile))
+            self.metrics.extend(profiles[self.profile]['definition'])
         self.enforce_constraints = is_affirmative(instance.get('enforce_mib_constraints', True))
         self.snmp_engine, self.mib_view_controller = self.create_snmp_engine(mibs_path)
 

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -83,6 +83,14 @@ init_config:
   #     metric_tags:
   #       - TCP
 
+  ## @param profiles - dictionary - optional
+  ## Specify profiles to be able to reference a set of metrics by name.
+  ## It points to a file with the same structure as global_metrics.
+  #
+  # profiles:
+  #   profile1:
+  #   	definition: profile1.yaml
+
 instances:
 
     ## @param ip_address - string - required
@@ -175,6 +183,11 @@ instances:
     ## Whether or not global_metrics should be included for this instance.
     #
     # use_global_metrics: true
+
+    ## @param profile - string - optional
+    ## Name of the profile to use, if any.
+    #
+    # profile: <PROFILE_NAME>
 
     ## @param metrics - list of elements - optional
     ## Specify metrics you want to monitor by using MIBS for Counter and Gauge.

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -85,11 +85,14 @@ init_config:
 
   ## @param profiles - dictionary - optional
   ## Specify profiles to be able to reference a set of metrics by name.
-  ## It points to a file with the same structure as global_metrics.
+  ## One of definition_file or definition needs to be defined.
+  ## definition_file points to a file with the same structure as
+  ## global_metrics, whereas defintion inlines it directly here.
   #
   # profiles:
   #   profile1:
-  #   	definition: profile1.yaml
+  #   	definition_file: <PROFILE_FILE>
+  #   	defintion: <PROFILE>
 
 instances:
 

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -58,7 +58,7 @@ class SnmpCheck(AgentCheck):
         self.mibs_path = init_config.get('mibs_folder')
         self.ignore_nonincreasing_oid = is_affirmative(init_config.get('ignore_nonincreasing_oid', False))
         self.profiles = init_config.get('profiles', {})
-        for profile, profile_data in list(self.profiles.items()):
+        for profile, profile_data in self.profiles.items():
             filename = profile_data.get('definition_file')
             if filename:
                 try:

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -59,12 +59,15 @@ class SnmpCheck(AgentCheck):
         self.ignore_nonincreasing_oid = is_affirmative(init_config.get('ignore_nonincreasing_oid', False))
         self.profiles = init_config.get('profiles', {})
         for profile, profile_data in list(self.profiles.items()):
-            filename = profile_data['definition']
-            try:
-                with open(filename) as f:
-                    data = yaml.safe_load(f)
-            except Exception:
-                raise ConfigurationError("Couldn't read profile '{}' in '{}'".format(profile, filename))
+            filename = profile_data.get('definition_file')
+            if filename:
+                try:
+                    with open(filename) as f:
+                        data = yaml.safe_load(f)
+                except Exception:
+                    raise ConfigurationError("Couldn't read profile '{}' in '{}'".format(profile, filename))
+            else:
+                data = profile_data['definition']
             self.profiles[profile] = {'definition': data}
 
         self.instance['name'] = self._get_instance_key(self.instance)

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -462,11 +462,24 @@ def test_cast_metrics(aggregator):
 def test_profile(aggregator):
     instance = common.generate_instance_config([])
     instance['profile'] = 'profile1'
+    init_config = {'profiles': {'profile1': {'definition': common.SUPPORTED_METRIC_TYPES}}}
+    check = SnmpCheck('snmp', init_config, [instance])
+    check.check(instance)
+
+    for metric in common.SUPPORTED_METRIC_TYPES:
+        metric_name = "snmp." + metric['name']
+        aggregator.assert_metric(metric_name, tags=common.CHECK_TAGS, count=1)
+    aggregator.assert_all_metrics_covered()
+
+
+def test_profile_by_file(aggregator):
+    instance = common.generate_instance_config([])
+    instance['profile'] = 'profile1'
     with temp_dir() as tmp:
         profile_file = os.path.join(tmp, 'profile1.yaml')
         with open(profile_file, 'w') as f:
             f.write(yaml.safe_dump(common.SUPPORTED_METRIC_TYPES))
-        init_config = {'profiles': {'profile1': {'definition': profile_file}}}
+        init_config = {'profiles': {'profile1': {'definition_file': profile_file}}}
         check = SnmpCheck('snmp', init_config, [instance])
         check.check(instance)
 

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -113,7 +113,7 @@ def test_profile_error():
     with pytest.raises(ConfigurationError):
         SnmpCheck('snmp', {}, [instance])
 
-    init_config = {'profiles': {'profile1': {'definition': 'doesntexistfile'}}}
+    init_config = {'profiles': {'profile1': {'definition_file': 'doesntexistfile'}}}
     with pytest.raises(ConfigurationError):
         SnmpCheck('snmp', init_config, [instance])
 
@@ -121,6 +121,6 @@ def test_profile_error():
         profile_file = os.path.join(tmp, 'profile1.yaml')
         with open(profile_file, 'w') as f:
             f.write("not yaml: {")
-        init_config = {'profiles': {'profile1': {'definition': profile_file}}}
+        init_config = {'profiles': {'profile1': {'definition_file': profile_file}}}
         with pytest.raises(ConfigurationError):
             SnmpCheck('snmp', init_config, [instance])


### PR DESCRIPTION
This adds a new configuration section to specify the list of metrics by
name. Profiles are defined in `init_config`, and then retrieved in
instance after. The format of the profile file is the same as the metric
list.