### PR TITLE
[skip ci] Update NTP conf.yaml.default

### DIFF
--- a/ntp/datadog_checks/ntp/data/conf.yaml.default
+++ b/ntp/datadog_checks/ntp/data/conf.yaml.default
@@ -21,7 +21,7 @@ instances:
     ## @param port - integer - optional - default: ntp
     ## In Agent version 6.13.0 and newer, port is an integer. In all previous versions,
     ## port is a string.
-    #
+    ##
     ## Port to use when reaching the NTP server.
     ## default port is the name of the service but lookup would fail if the /etc/services file
     ## is missing. The ntp port then falls back to the numeric port 123.

--- a/ntp/datadog_checks/ntp/data/conf.yaml.default
+++ b/ntp/datadog_checks/ntp/data/conf.yaml.default
@@ -18,7 +18,10 @@ instances:
     #
     # host: <X>.datadog.pool.ntp.org
 
-    ## @param port - string - optional - default: ntp
+    ## @param port - integer - optional - default: ntp
+    ## In Agent version 6.13.0 and newer, port is an integer. In all previous versions,
+    ## port is a string.
+    #
     ## Port to use when reaching the NTP server.
     ## default port is the name of the service but lookup would fail if the /etc/services file
     ## is missing. The ntp port then falls back to the numeric port 123.


### PR DESCRIPTION
### What does this PR do?

Update the NTP example conf to reflect changes released in Agent version 6.13.0. The `port` option is now an integer where previously it was a string: https://github.com/DataDog/datadog-agent/releases/tag/6.13.0

### Motivation

A customer contacted us pointing out that the differences weren't documented which led to some confusion on their end.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
