### PR TITLE
Separate realtime from historical

### DIFF
--- a/vsphere/datadog_checks/vsphere/__about__.py
+++ b/vsphere/datadog_checks/vsphere/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "4.1.3"
+__version__ = "4.1.4rc5"

--- a/vsphere/datadog_checks/vsphere/__about__.py
+++ b/vsphere/datadog_checks/vsphere/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "4.1.4rc5"
+__version__ = "4.1.3"

--- a/vsphere/datadog_checks/vsphere/common.py
+++ b/vsphere/datadog_checks/vsphere/common.py
@@ -2,3 +2,5 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 SOURCE_TYPE = 'vsphere'
+REALTIME_RESOURCES = {'vm', 'host'}
+HISTORICAL_RESOURCES = {'datastore', 'datacenter', 'cluster'}

--- a/vsphere/datadog_checks/vsphere/common.py
+++ b/vsphere/datadog_checks/vsphere/common.py
@@ -3,4 +3,3 @@
 # Licensed under Simplified BSD License (see LICENSE)
 SOURCE_TYPE = 'vsphere'
 REALTIME_RESOURCES = {'vm', 'host'}
-HISTORICAL_RESOURCES = {'datastore', 'datacenter', 'cluster'}

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -146,3 +146,14 @@ instances:
     # tags:
     #   - <KEY_1>:<VALUE_1>
     #   - <KEY_2>:<VALUE_2>
+
+    ## @param collect_realtime_only - boolean - optional - default: true
+    ## DEPRECATED: Tries to collect realtime and historical metrics together
+    ##             and has a significant impact on performance.
+    ##             Use 'collect_historical_only' and two instances instead.
+    ## Set to true to collect only host and VM metrics. Set to false to collect
+    ## cluster, datastore and datacenter metrics as well.
+    ## Collecting non realtime metrics will decrease performance as it
+    ## requires computation from the vCenter server.
+    #
+    # collect_realtime_only: true

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -98,13 +98,6 @@ instances:
     #
     # include_only_marked: false
 
-    ## @param all_metrics - boolean - optional - default: false
-    ## This parameter has been deprecated in favor of `collection_level`
-    ## Please set `collection_level: 4` if you want to collect all the metrics
-    ## available on your system.
-    #
-    # all_metrics: false
-
     ## @param collection_level - integer - optional - default: 1
     ## A number between 1 and 4 to specify how many metrics will be sent
     ## 1: Only basic metrics - 4: every metric available.
@@ -113,13 +106,20 @@ instances:
     #
     # collection_level: 1
 
-    ## @param collect_realtime_only - boolean - optional - default: true
-    ## Set to true to collect only host and VM metrics. Set to false to collect
-    ## cluster, datastore and datacenter metrics as well.
-    ## Collecting non realtime metrics will decrease performance as it
-    ## requires computation from the vCenter server.
+    ## @param collect_historical_only - boolean - optional - default: false
+    ## By default the check collects metrics from realtime resources (hosts and VMs).
+    ## Set this to true to only collect metrics from historical resources
+    ## (cluster, datastore and datacenter).
+    ## In order to collect metrics from those two types of resources, create two
+    ## 'instances' in this config file pointing to the same vcenter server, one with this flag
+    ## to false, the other with this flag to true.
+    ## The reason for this requirement is that collecting historical resources decreases
+    ## the performance of the check; having two instances allows realtime metrics collection
+    ## not to be slowed down by the collection of historical metrics.
+    ## Note: An instance with this flag set to true does not submit any service check, events or host tags.
+    ##       It is designed to be used only when next to another instance of the check.
     #
-    # collect_realtime_only: true
+    # collect_historical_only: false
 
     ## @param use_guest_hostname - boolean - optional - default: false
     ## If true, the check will use the guest hostname for VMs instead of the VM name

--- a/vsphere/datadog_checks/vsphere/mor_cache.py
+++ b/vsphere/datadog_checks/vsphere/mor_cache.py
@@ -118,7 +118,7 @@ class MorCache:
                     if len(mor['metrics']) >= max_historical_metrics:
                         # Too many metrics to query for a single mor, ignore it
                         self.log.warning(
-                            "Metrics for '{}' are ignored because there are more ({}) than what you allowed ({}) on vCenter Server",  # noqa: E501
+                            "Metrics for '%s' are ignored because there are more (%d) than what you allowed (%d) on vCenter Server",  # noqa: E501
                             mor_name,
                             len(mor['metrics']),
                             max_historical_metrics,
@@ -128,6 +128,7 @@ class MorCache:
                     nb_hist_metrics += len(mor['metrics'])
                     if nb_hist_metrics >= max_historical_metrics:
                         # Adding those metrics to the batch would make it too big, yield it now
+                        self.log.info("Will request %d hist metrics", nb_hist_metrics-len(mor['metrics']))
                         yield batch
                         batch = {}
                         nb_hist_metrics = len(mor['metrics'])
@@ -135,11 +136,13 @@ class MorCache:
                 batch[mor_name] = mor
 
                 if len(batch) == batch_size:
+                    self.log.info("Will request %d hist metrics", nb_hist_metrics)
                     yield batch
                     batch = {}
                     nb_hist_metrics = 0
 
             if batch:
+                self.log.info("Will request %d hist metrics", nb_hist_metrics)
                 yield batch
 
     def purge(self, key, ttl):

--- a/vsphere/datadog_checks/vsphere/mor_cache.py
+++ b/vsphere/datadog_checks/vsphere/mor_cache.py
@@ -107,9 +107,7 @@ class MorCache:
         if max_historical_metrics is None:
             max_historical_metrics = float('inf')
         with self._mor_lock:
-            mors_dict = self._mor.get(key, {})
-            if mors_dict is None:
-                raise StopIteration
+            mors_dict = self._mor.get(key) or {}
 
             batch = {}
             nb_hist_metrics = 0
@@ -118,11 +116,12 @@ class MorCache:
                     # Those metrics are historical, let's make sure we don't have too
                     # many of them in the same batch.
                     if len(mor['metrics']) >= max_historical_metrics:
-                        # Too much metrics to query for a single mor, ignore it
+                        # Too many metrics to query for a single mor, ignore it
                         self.log.warning(
-                            "Metrics for '{}' are ignored because there are more ({}) than what you allowed ({}) on vCenter Server".format(  # noqa: E501
-                                mor_name, len(mor['metrics']), max_historical_metrics
-                            )
+                            "Metrics for '{}' are ignored because there are more ({}) than what you allowed ({}) on vCenter Server",  # noqa: E501
+                            mor_name,
+                            len(mor['metrics']),
+                            max_historical_metrics,
                         )
                         continue
 

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -881,8 +881,12 @@ class VSphereCheck(AgentCheck):
 
         if self._should_collect_historical(instance):
             try:
-                vcenter_settings = server_instance.content.setting.QueryOptions("config.vpxd.stats.maxQueryMetrics")
-                max_historical_metrics = int(vcenter_settings[0].value)
+                if 'max_query_metrics' in instance:
+                    max_historical_metrics = int(instance['max_query_metrics'])
+                    self.log.info("Collecting up to %d metrics", max_historical_metrics)
+                else:
+                    vcenter_settings = server_instance.content.setting.QueryOptions("config.vpxd.stats.maxQueryMetrics")
+                    max_historical_metrics = int(vcenter_settings[0].value)
                 if max_historical_metrics < 0:
                     max_historical_metrics = float('inf')
             except Exception:

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -892,6 +892,13 @@ class VSphereCheck(AgentCheck):
             except Exception:
                 pass
 
+        # TODO: Remove me once the fix for `max_query_metrics` is here by default
+        mors_batch_method = (
+            self.mor_cache.mors_batch
+            if is_affirmative(instance.get('betafix_max_query_metrics'))
+            else self.mor_cache.legacy_mors_batch
+        )
+
         vm_count = 0
         custom_tags = instance.get('tags', [])
         tags = ["vcenter_server:{}".format(ensure_unicode(instance.get('name')))] + custom_tags
@@ -908,7 +915,7 @@ class VSphereCheck(AgentCheck):
         # Request metrics for several objects at once. We can limit the number of objects with batch_size
         # If batch_size is 0, process everything at once
         batch_size = self.batch_morlist_size or n_mors
-        for batch in self.mor_cache.mors_batch(i_key, batch_size, max_historical_metrics):
+        for batch in mors_batch_method(i_key, batch_size, max_historical_metrics):
             query_specs = []
             for mor in itervalues(batch):
                 if mor['mor_type'] == 'vm':

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -895,7 +895,7 @@ class VSphereCheck(AgentCheck):
         # TODO: Remove me once the fix for `max_query_metrics` is here by default
         mors_batch_method = (
             self.mor_cache.mors_batch
-            if is_affirmative(instance.get('betafix_max_query_metrics'))
+            if is_affirmative(instance.get('fix_max_query_metrics'))
             else self.mor_cache.legacy_mors_batch
         )
 


### PR DESCRIPTION
vSphere has the concept of realtime vs historical metrics.
Basically realtime metrics are fast to collect, but they are only for VM and Host.
Historical metrics requires more computation on the vCenter side and are only for Datastores, Datacenters and Clusters.

The current implementation of the check disables the collection of historical metrics by default, because when enable this is a severe impact on performance.

The idea of this PR is to let users create two instances of the check (pointing to the same vCenter server), one for realtime metrics, one for historical metrics. This way, the collection of historical metrics does not have an impact on the overall performance of the check.

To prevent any duplication of metric between those two instances, the flag `collect_historical_only` is used to determine which instance is the "main" which instance is the `sidecar`.


Also the integration now fetches the "maxQueryMetrics" configuration from vCenter and we now make sure not to query more than this amount of metrics in the same api call.