### PR TITLE
Revert "Julia/couchbase e2e"

### DIFF
--- a/couchbase/datadog_checks/couchbase/couchbase.py
+++ b/couchbase/datadog_checks/couchbase/couchbase.py
@@ -59,7 +59,9 @@ class Couchbase(AgentCheck):
 
         # Get bucket metrics
         for bucket_name, bucket_stats in data['buckets'].items():
-            metric_tags = ['bucket:{}'.format(bucket_name), 'device:{}'.format(bucket_name)] + tags or []
+            metric_tags = [] if tags is None else tags[:]
+            metric_tags.append('bucket:{}'.format(bucket_name))
+            metric_tags.append('device:{}'.format(bucket_name))
             for metric_name, val in bucket_stats.items():
                 if val is not None:
                     norm_metric_name = self.camel_case_to_joined_lower(metric_name)
@@ -69,7 +71,9 @@ class Couchbase(AgentCheck):
 
         # Get node metrics
         for node_name, node_stats in data['nodes'].items():
-            metric_tags = ['node:{}'.format(node_name), 'device:{}'.format(node_name)] + tags or []
+            metric_tags = [] if tags is None else tags[:]
+            metric_tags.append('node:{}'.format(node_name))
+            metric_tags.append('device:{}'.format(node_name))
             for metric_name, val in node_stats['interestingStats'].items():
                 if val is not None:
                     metric_name = 'couchbase.by_node.{}'.format(self.camel_case_to_joined_lower(metric_name))

--- a/couchbase/tests/test_couchbase.py
+++ b/couchbase/tests/test_couchbase.py
@@ -48,16 +48,6 @@ def test_metrics(aggregator, instance, couchbase_container_ip):
     assert_basic_couchbase_metrics(aggregator, couchbase_container_ip)
 
 
-@pytest.mark.e2e
-@pytest.mark.usefixtures("dd_environment")
-def test_e2e(dd_agent_check, instance, couchbase_container_ip):
-    """
-    Test couchbase metrics not including 'couchbase.query.'
-    """
-    aggregator = dd_agent_check(instance, rate=True)
-    assert_basic_couchbase_metrics(aggregator, couchbase_container_ip, extract_device=True)
-
-
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
 def test_query_monitoring_metrics(aggregator, instance_query, couchbase_container_ip):
@@ -71,7 +61,7 @@ def test_query_monitoring_metrics(aggregator, instance_query, couchbase_containe
         aggregator.assert_metric('couchbase.query.{}'.format(mname), tags=CHECK_TAGS, count=1)
 
 
-def assert_basic_couchbase_metrics(aggregator, couchbase_container_ip, extract_device=False):
+def assert_basic_couchbase_metrics(aggregator, couchbase_container_ip):
     """
     Assert each type of metric (buckets, nodes, totals) except query
     """
@@ -79,49 +69,32 @@ def assert_basic_couchbase_metrics(aggregator, couchbase_container_ip, extract_d
     #  Because some metrics are deprecated, we can just see if we get an arbitrary number
     #  of bucket metrics. If there are more than that number, we assume that we're getting
     #  all the bucket metrics we should be getting
-    tags = CHECK_TAGS + ['bucket:{}'.format(BUCKET_NAME)]
-
-    if extract_device:
-        device = BUCKET_NAME
-    else:
-        tags.append('device:{}'.format(BUCKET_NAME))
-        device = None
-
+    tags = CHECK_TAGS + ['device:{}'.format(BUCKET_NAME), 'bucket:{}'.format(BUCKET_NAME)]
     bucket_metric_count = 0
     for bucket_metric in aggregator.metric_names:
         if bucket_metric.find('couchbase.by_bucket.') == 0:
-            aggregator.assert_metric(bucket_metric, tags=tags, at_least=1, device=device)
+            aggregator.assert_metric(bucket_metric, tags=tags, count=1)
             bucket_metric_count += 1
 
     assert bucket_metric_count > 10
 
     # Assert 'couchbase.by_node.' metrics
-    tags = CHECK_TAGS + ['node:{}:{}'.format(couchbase_container_ip, PORT)]
-    if extract_device:
-        device = '{}:{}'.format(couchbase_container_ip, PORT)
-    else:
-        tags.append('device:{}:{}'.format(couchbase_container_ip, PORT))
-        device = None
+    tags = CHECK_TAGS + [
+        'device:{}:{}'.format(couchbase_container_ip, PORT),
+        'node:{}:{}'.format(couchbase_container_ip, PORT),
+    ]
 
     NODE_STATS = [
-        'cmd_get',
         'curr_items',
         'curr_items_tot',
         'couch_docs_data_size',
         'couch_docs_actual_disk_size',
-        'couch_spatial_data_size',
-        'couch_spatial_disk_size',
         'couch_views_data_size',
         'couch_views_actual_disk_size',
-        'ep_bg_fetched',
-        'get_hits',
-        'mem_used',
-        'ops',
-        'vb_active_num_non_resident',
         'vb_replica_curr_items',
     ]
     for mname in NODE_STATS:
-        aggregator.assert_metric('couchbase.by_node.{}'.format(mname), tags=tags, at_least=1, device=device)
+        aggregator.assert_metric('couchbase.by_node.{}'.format(mname), tags=tags, count=1)
 
     # Assert 'couchbase.' metrics
     TOTAL_STATS = [
@@ -133,11 +106,7 @@ def assert_basic_couchbase_metrics(aggregator, couchbase_container_ip, extract_d
         'ram.used',
         'ram.total',
         'ram.quota_total',
-        'ram.quota_total_per_node',
-        'ram.quota_used_per_node',
-        'ram.quota_used',
         'ram.used_by_data',
     ]
     for mname in TOTAL_STATS:
-        aggregator.assert_metric('couchbase.{}'.format(mname), tags=CHECK_TAGS, at_least=1)
-    aggregator.assert_all_metrics_covered()
+        aggregator.assert_metric('couchbase.{}'.format(mname), tags=CHECK_TAGS, count=1)

--- a/couchbase/tox.ini
+++ b/couchbase/tox.ini
@@ -5,8 +5,6 @@ envlist =
     py{27,37}-{5.5.3}
 
 [testenv]
-description =
-    py{27,37}: e2e ready
 dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -246,8 +246,6 @@ class __AgentCheck(object):
         tags = self._normalize_tags_type(tags, device_name, name)
         if hostname is None:
             hostname = ''
-        if device_name is None:
-            device_name = ''
 
         if self.metric_limiter:
             if mtype in ONE_PER_CONTEXT_METRIC_TYPES:
@@ -271,9 +269,7 @@ class __AgentCheck(object):
             self.warning(err_msg)
             return
 
-        aggregator.submit_metric(
-            self, self.check_id, mtype, self._format_namespace(name), value, tags, hostname, device_name
-        )
+        aggregator.submit_metric(self, self.check_id, mtype, self._format_namespace(name), value, tags, hostname)
 
     def gauge(self, name, value, tags=None, hostname=None, device_name=None):
         """Sample a gauge metric.

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -55,8 +55,8 @@ class AggregatorStub(object):
     def is_aggregate(cls, mtype):
         return mtype in cls.AGGREGATE_TYPES
 
-    def submit_metric(self, check, check_id, mtype, name, value, tags, hostname, device):
-        self._metrics[name].append(MetricStub(name, mtype, value, tags, hostname, device))
+    def submit_metric(self, check, check_id, mtype, name, value, tags, hostname):
+        self._metrics[name].append(MetricStub(name, mtype, value, tags, hostname))
 
     def submit_service_check(self, check, check_id, name, status, tags, hostname, message):
         self._service_checks[name].append(ServiceCheckStub(check_id, name, status, tags, hostname, message))
@@ -75,7 +75,6 @@ class AggregatorStub(object):
                 stub.value,
                 normalize_tags(stub.tags),
                 ensure_unicode(stub.hostname),
-                stub.device,
             )
             for stub in self._metrics.get(to_string(name), [])
         ]
@@ -155,22 +154,20 @@ class AggregatorStub(object):
         else:
             assert len(candidates) >= at_least, msg
 
-    def assert_metric(
-        self, name, value=None, tags=None, count=None, at_least=1, hostname=None, metric_type=None, device=None
-    ):
+    def assert_metric(self, name, value=None, tags=None, count=None, at_least=1, hostname=None, metric_type=None):
         """
         Assert a metric was processed by this stub
         """
 
         self._asserted.add(name)
-        expected_tags = normalize_tags(tags, sort=True)
+        tags = normalize_tags(tags, sort=True)
 
         candidates = []
         for metric in self.metrics(name):
             if value is not None and not self.is_aggregate(metric.type) and value != metric.value:
                 continue
 
-            if expected_tags and expected_tags != sorted(metric.tags):
+            if tags and tags != sorted(metric.tags):
                 continue
 
             if hostname and hostname != metric.hostname:
@@ -179,12 +176,9 @@ class AggregatorStub(object):
             if metric_type is not None and metric_type != metric.type:
                 continue
 
-            if device is not None and device != metric.device:
-                continue
-
             candidates.append(metric)
 
-        expected_metric = MetricStub(name, metric_type, value, tags, hostname, device)
+        expected_metric = MetricStub(name, metric_type, value, tags, hostname)
 
         if value is not None and candidates and all(self.is_aggregate(m.type) for m in candidates):
             got = sum(m.value for m in candidates)

--- a/datadog_checks_base/datadog_checks/base/stubs/common.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/common.py
@@ -5,5 +5,5 @@ from __future__ import division
 
 from collections import namedtuple
 
-MetricStub = namedtuple('MetricStub', 'name type value tags hostname device')
+MetricStub = namedtuple('MetricStub', 'name type value tags hostname')
 ServiceCheckStub = namedtuple('ServiceCheckStub', 'check_id name status tags hostname message')

--- a/datadog_checks_base/datadog_checks/base/stubs/similar.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/similar.py
@@ -72,10 +72,6 @@ def _get_similarity_score_for_metric(expected_metric, candidate_metric):
         score = _is_similar_text_score(expected_metric.hostname, candidate_metric.hostname)
         scores.append((score, 1))
 
-    if expected_metric.device:
-        score = _is_similar_text_score(expected_metric.device, candidate_metric.device)
-        scores.append((score, 1))
-
     return _compute_score(scores)
 
 

--- a/datadog_checks_base/tests/test_similar.py
+++ b/datadog_checks_base/tests/test_similar.py
@@ -1,8 +1,6 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import difflib
-
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.stubs import similar
 from datadog_checks.base.stubs.common import MetricStub, ServiceCheckStub
@@ -17,21 +15,20 @@ class TestSimilarAssertionMessages(object):
         check.gauge('test.most_similar_metric', 0)
         check.gauge('test.very_very_different', 0)
 
-        expected_metric = MetricStub("test.similar_metric", None, None, None, None, None)
-        actual_msg = similar.build_similar_elements_msg(expected_metric, aggregator._metrics).strip()
+        expected_metric = MetricStub("test.similar_metric", None, None, None, None)
+        actual_msg = similar.build_similar_elements_msg(expected_metric, aggregator._metrics)
 
         expected_msg = '''
 Expected:
-        MetricStub(name='test.similar_metric', type=None, value=None, tags=None, hostname=None, device=None)
+        MetricStub(name='test.similar_metric', type=None, value=None, tags=None, hostname=None)
 Similar submitted:
 Score   Most similar
-0.88    MetricStub(name='test.most_similar_metric', type=0, value=0.0, tags=[], hostname='', device='')
-0.83    MetricStub(name='test.another_similar_metric', type=0, value=0.0, tags=[], hostname='', device='')
-0.62    MetricStub(name='test.very_different_metric', type=0, value=0.0, tags=[], hostname='', device='')
-0.42    MetricStub(name='test.very_very_different', type=0, value=0.0, tags=[], hostname='', device='')
-        '''.strip()
-        delta = difflib.ndiff([expected_msg], [actual_msg])
-        assert expected_msg == actual_msg, delta
+0.88    MetricStub(name='test.most_similar_metric', type=0, value=0.0, tags=[], hostname='')
+0.83    MetricStub(name='test.another_similar_metric', type=0, value=0.0, tags=[], hostname='')
+0.62    MetricStub(name='test.very_different_metric', type=0, value=0.0, tags=[], hostname='')
+0.42    MetricStub(name='test.very_very_different', type=0, value=0.0, tags=[], hostname='')
+        '''
+        assert expected_msg.strip() == actual_msg.strip(), "Actual message:\n" + actual_msg
 
     def test__build_similar_elements__metric_name(self, aggregator):
         check = AgentCheck()
@@ -41,9 +38,7 @@ Score   Most similar
         check.gauge('test.most_similar_metric', 0)
         check.gauge('test.very_very_different', 0)
 
-        expected_metric = MetricStub(
-            "test.similar_metric", type=None, value=None, tags=None, hostname=None, device=None
-        )
+        expected_metric = MetricStub("test.similar_metric", type=None, value=None, tags=None, hostname=None)
         similar_metrics = similar._build_similar_elements(expected_metric, aggregator._metrics)
 
         expected_most_similar_metric = similar_metrics[0][1]
@@ -59,7 +54,7 @@ Score   Most similar
         check.gauge('test.similar_metric2', 20)
         check.gauge('test.similar_metric3', 30)
 
-        expected_metric = MetricStub("test.my_metric", type=None, value=20, tags=None, hostname=None, device=None)
+        expected_metric = MetricStub("test.my_metric", type=None, value=20, tags=None, hostname=None)
         similar_metrics = similar._build_similar_elements(expected_metric, aggregator._metrics)
 
         expected_most_similar_metric = similar_metrics[0][1]
@@ -75,7 +70,7 @@ Score   Most similar
         check.gauge('test.similar_metric3', 10, tags=['something:different'])
 
         expected_metric = MetricStub(
-            "test.test.similar_metric", type=None, value=10, tags=['name:similar_tag'], hostname=None, device=None
+            "test.test.similar_metric", type=None, value=10, tags=['name:similar_tag'], hostname=None
         )
         similar_metrics = similar._build_similar_elements(expected_metric, aggregator._metrics)
 
@@ -92,24 +87,7 @@ Score   Most similar
         check.gauge('test.similar_metric3', 10, hostname='different')
 
         expected_metric = MetricStub(
-            "test.test.similar_metric", type=None, value=10, tags=None, hostname='similar_host', device=None
-        )
-        similar_metrics = similar._build_similar_elements(expected_metric, aggregator._metrics)
-
-        # expect similar metrics in a similarity order
-        assert similar_metrics[0][1].name == 'test.similar_metric1'
-        assert similar_metrics[1][1].name == 'test.similar_metric2'
-        assert similar_metrics[2][1].name == 'test.similar_metric3'
-
-    def test__build_similar_elements__metric_device(self, aggregator):
-        check = AgentCheck()
-
-        check.gauge('test.similar_metric2', 10, hostname='localhost', device_name='less_similar_device')
-        check.gauge('test.similar_metric1', 10, hostname='localhost', device_name='similar_device')
-        check.gauge('test.similar_metric3', 10, hostname='localhost', device_name='different')
-
-        expected_metric = MetricStub(
-            "test.test.similar_metric", type=None, value=10, tags=None, hostname='localhost', device='similar_device'
+            "test.test.similar_metric", type=None, value=10, tags=None, hostname='similar_host'
         )
         similar_metrics = similar._build_similar_elements(expected_metric, aggregator._metrics)
 

--- a/datadog_checks_dev/datadog_checks/dev/_env.py
+++ b/datadog_checks_dev/datadog_checks/dev/_env.py
@@ -83,14 +83,7 @@ def replay_check_run(agent_collector, stub_aggregator):
         for _, value in data['points']:
             metric_type = stub_aggregator.METRIC_ENUM_MAP[data['type']]
             stub_aggregator.submit_metric(
-                check_name,
-                check_id,
-                metric_type,
-                data['metric'],
-                value,
-                data['tags'],
-                data['host'],
-                data.get('device', None),
+                check_name, check_id, metric_type, data['metric'], value, data['tags'], data['host']
             )
 
     for data in aggregator.get('service_checks', []):


### PR DESCRIPTION
Reverts DataDog/integrations-core#4328

Reason:

```
ofek@ozone ~\Desktop $ ddev env start --base disk py37
...
ofek@ozone ~\Desktop $ ddev env check disk py37
=========
Collector
=========

  Running Checks
  ==============

    disk (2.4.0)
    ------------
      Instance ID: disk:4d36a010bac0d6d9 [ERROR]
      Configuration Source: file:/etc/datadog-agent/conf.d/disk.d/disk.yaml
      Total Runs: 1
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 4ms
      Error: function takes exactly 7 arguments (8 given)
      Traceback (most recent call last):
        File "/home/datadog_checks_base/datadog_checks/base/checks/base.py", line 536, in run
          self.check(instance)
        File "/home/disk/datadog_checks/disk/disk.py", line 67, in check
          self.collect_metrics_psutil()
        File "/home/disk/datadog_checks/disk/disk.py", line 122, in collect_metrics_psutil
          self.gauge(metric_name, metric_value, tags=tags)
        File "/home/datadog_checks_base/datadog_checks/base/checks/base.py", line 288, in gauge
          self._submit_metric(aggregator.GAUGE, name, value, tags=tags, hostname=hostname, device_name=device_name)
        File "/home/datadog_checks_base/datadog_checks/base/checks/base.py", line 275, in _submit_metric
          self, self.check_id, mtype, self._format_namespace(name), value, tags, hostname, device_name
      TypeError: function takes exactly 7 arguments (8 given)
```