### PR TITLE
Remove check for user filter

### DIFF
--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -39,6 +39,10 @@ instances:
     #
     # event_priority: normal
 
+    ## FILTERS
+    ## At least one filter is required:
+    ## `log_file`, `source_name`, `type`, `event_id`, `message_filters`
+
     ## @param log_file - list of strings - optional
     ## The `log_file` filter instructs the check to only capture events
     ## that belong to one of the specified LogFiles (Application, System, Setup, Security,

--- a/win32_event_log/datadog_checks/win32_event_log/win32_event_log.py
+++ b/win32_event_log/datadog_checks/win32_event_log/win32_event_log.py
@@ -55,10 +55,10 @@ class Win32EventLogWMI(WinWMICheck):
         event_format = instance.get('event_format')
         message_filters = instance.get('message_filters', [])
 
-        if not (source_names or event_ids or message_filters or log_files or user or ltypes):
+        if not (source_names or event_ids or message_filters or log_files or ltypes):
             raise ConfigurationError(
                 'At least one of the following filters must be set: '
-                'source_name, event_id, message_filters, log_file, user, type'
+                'source_name, event_id, message_filters, log_file, type'
             )
 
         instance_hash = hash_mutable(instance)

--- a/win32_event_log/tests/test_check.py
+++ b/win32_event_log/tests/test_check.py
@@ -135,12 +135,6 @@ def test_filter_log_file(mock_from_time, mock_to_time, check, mock_get_wmi_sampl
     check.check(instance)
 
 
-def test_filter_user(mock_from_time, mock_to_time, check, mock_get_wmi_sampler):
-    instance = {'user': 'user'}
-
-    check.check(instance)
-
-
 def test_filter_type(mock_from_time, mock_to_time, check, mock_get_wmi_sampler):
     instance = {'type': ['type']}
 


### PR DESCRIPTION
### What does this PR do?
- Update Win32 Event Log yaml example with note about filter requirement
- Remove check for user filter

### Motivation
- Trello request from support

### Additional Notes
- Error message says there is a user filter but it's not listed in the example yaml. I consulted Ofek for these changes.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
