### PR TITLE
[WIP] Update aggregator to make metric_type and count assertion easier

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -9,6 +9,7 @@ from six import binary_type, iteritems
 
 from datadog_checks.base.stubs.common import MetricStub, ServiceCheckStub
 from datadog_checks.base.stubs.similar import build_similar_elements_msg
+from datadog_checks.dev._env import e2e_testing
 
 from ..utils.common import ensure_unicode, to_string
 
@@ -154,10 +155,29 @@ class AggregatorStub(object):
         else:
             assert len(candidates) >= at_least, msg
 
-    def assert_metric(self, name, value=None, tags=None, count=None, at_least=1, hostname=None, metric_type=None):
+    def assert_metric(
+        self,
+        name,
+        value=None,
+        tags=None,
+        count=None,
+        at_least=1,
+        hostname=None,
+        metric_type=None,
+    ):
         """
         Assert a metric was processed by this stub
         """
+
+        if e2e_testing():
+            if count is not None:
+                if metric_type is None:
+                    raise Exception("assert_metric: `metric_type` must be set when using `count` in e2e")
+                if metric_type == self.RATE:
+                    count -= 1
+            if metric_type is not None:
+                if metric_type == self.RATE:
+                    metric_type = self.GAUGE
 
         self._asserted.add(name)
         tags = normalize_tags(tags, sort=True)

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -155,16 +155,7 @@ class AggregatorStub(object):
         else:
             assert len(candidates) >= at_least, msg
 
-    def assert_metric(
-        self,
-        name,
-        value=None,
-        tags=None,
-        count=None,
-        at_least=1,
-        hostname=None,
-        metric_type=None,
-    ):
+    def assert_metric(self, name, value=None, tags=None, count=None, at_least=1, hostname=None, metric_type=None):
         """
         Assert a metric was processed by this stub
         """

--- a/datadog_checks_base/tests/test_aggregator.py
+++ b/datadog_checks_base/tests/test_aggregator.py
@@ -1,0 +1,76 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from datetime import datetime
+
+import pytest
+
+from datadog_checks.base import AgentCheck
+from datadog_checks.dev import EnvVars
+
+
+def test_gauge(aggregator):
+    c = AgentCheck()
+
+    c.gauge("my.gauge_one", 10, tags=['foo1'])
+    c.gauge("my.gauge_two", 20, tags=['foo2'])
+    c.gauge("my.gauge_three", 30, tags=['foo3'])
+
+    aggregator.assert_metric("my.gauge_one", metric_type=aggregator.GAUGE, value=10, tags=['foo1'])
+    aggregator.assert_metric("my.gauge_two", metric_type=aggregator.GAUGE, value=20, tags=['foo2'])
+    aggregator.assert_metric("my.gauge_three", metric_type=aggregator.GAUGE, value=30, tags=['foo3'])
+    aggregator.assert_all_metrics_covered()
+
+
+def test_rate_unit(aggregator):
+    c = AgentCheck()
+
+    c.rate("my.gauge_one", 10, tags=['foo1'])
+    c.rate("my.gauge_two", 20, tags=['foo2'])
+    c.rate("my.gauge_three", 30, tags=['foo3'])
+
+    aggregator.assert_metric("my.gauge_one", metric_type=aggregator.RATE, value=10, tags=['foo1'])
+    aggregator.assert_metric("my.gauge_two", metric_type=aggregator.RATE, value=20, tags=['foo2'])
+    aggregator.assert_metric("my.gauge_three", metric_type=aggregator.RATE, value=30, tags=['foo3'])
+    aggregator.assert_all_metrics_covered()
+
+
+def test_rate_e2e_metric_type(aggregator):
+    with EnvVars({'DDEV_E2E_PYTHON_PATH': 'true'}):
+        c = AgentCheck()
+
+        # In e2e, submission type rate is converted to gauge
+        # below we simulate the check c.gauge() from e2e agent check data
+        c.gauge("my.gauge_one", value=1, tags=['foo1'])
+        c.gauge("my.gauge_two", value=1, tags=['foo2'])
+
+        aggregator.assert_metric("my.gauge_one", metric_type=aggregator.RATE, tags=['foo1'])
+        aggregator.assert_metric("my.gauge_two", metric_type=aggregator.RATE, tags=['foo2'])
+        aggregator.assert_all_metrics_covered()
+
+
+def test_e2e_count_success(aggregator):
+    with EnvVars({'DDEV_E2E_PYTHON_PATH': 'true'}):
+        c = AgentCheck()
+
+        # In e2e, submission type rate is converted to gauge
+        # below we simulate the check c.gauge() from e2e agent check data
+        c.gauge("my.gauge_one", value=1, tags=['foo1'])
+        c.gauge("my.gauge_two", value=1, tags=['foo2'])
+        c.gauge("my.gauge_tree", value=1, tags=['foo2'])
+
+        aggregator.assert_metric("my.gauge_one", count=2, metric_type=aggregator.RATE, tags=['foo1'])
+        aggregator.assert_metric("my.gauge_two", count=2, metric_type=aggregator.RATE, tags=['foo2'])
+        aggregator.assert_metric("my.gauge_tree", count=1, metric_type=aggregator.GAUGE, tags=['foo2'])
+        aggregator.assert_all_metrics_covered()
+
+
+def test_e2e_count_without_metric_type(aggregator):
+    with EnvVars({'DDEV_E2E_PYTHON_PATH': 'true'}):
+        c = AgentCheck()
+
+        c.gauge("my.gauge_one", value=1)
+
+        with pytest.raises(Exception):
+            aggregator.assert_metric("my.gauge_one", count=2)

--- a/datadog_checks_base/tests/test_aggregator.py
+++ b/datadog_checks_base/tests/test_aggregator.py
@@ -2,8 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from datetime import datetime
-
 import pytest
 
 from datadog_checks.base import AgentCheck

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -141,7 +141,7 @@ def dd_agent_check(request, aggregator):
                 check_command.append('--{}'.format(key.replace('_', '-')))
 
                 if value is not True:
-                    check_command.append(value)
+                    check_command.append(str(value))
 
         result = run_command(check_command, capture=True)
         if AGENT_COLLECTOR_SEPARATOR not in result.stdout:

--- a/lighttpd/tests/test_check.py
+++ b/lighttpd/tests/test_check.py
@@ -5,32 +5,20 @@ from __future__ import unicode_literals
 
 import pytest
 
+from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.lighttpd import Lighttpd
 
 from . import common
 
-CHECK_GAUGES = [
-    'lighttpd.net.bytes',
-    'lighttpd.net.bytes_per_s',
-    'lighttpd.net.hits',
-    'lighttpd.net.request_per_s',
-    'lighttpd.performance.busy_servers',
-    'lighttpd.performance.idle_server',
-    'lighttpd.performance.uptime',
+EXPECTED_METRICS = [
+    ('lighttpd.net.bytes', AggregatorStub.GAUGE),
+    ('lighttpd.net.bytes_per_s', AggregatorStub.RATE),
+    ('lighttpd.net.hits', AggregatorStub.GAUGE),
+    ('lighttpd.net.request_per_s', AggregatorStub.RATE),
+    ('lighttpd.performance.busy_servers', AggregatorStub.GAUGE),
+    ('lighttpd.performance.idle_server', AggregatorStub.GAUGE),
+    ('lighttpd.performance.uptime', AggregatorStub.GAUGE),
 ]
-
-
-@pytest.mark.usefixtures('dd_environment')
-@pytest.mark.integration
-def test_lighttpd(aggregator, check, instance):
-    tags = ['host:{}'.format(common.HOST), 'port:9449', 'instance:first']
-    check.check(instance)
-
-    aggregator.assert_service_check(check.SERVICE_CHECK_NAME, status=Lighttpd.OK, tags=tags)
-
-    for gauge in CHECK_GAUGES:
-        aggregator.assert_metric(gauge, tags=['instance:first'], count=1)
-    aggregator.assert_all_metrics_covered()
 
 
 def test_service_check_ko(aggregator, check, instance):
@@ -41,18 +29,34 @@ def test_service_check_ko(aggregator, check, instance):
     aggregator.assert_service_check(check.SERVICE_CHECK_NAME, status=Lighttpd.CRITICAL, tags=tags)
 
 
-@pytest.mark.e2e
-def test_e2e(dd_agent_check, instance):
-    aggregator = dd_agent_check(instance, rate=True)
-    tags = ['instance:first']
-    aggregator.assert_metric('lighttpd.net.bytes', tags=tags, count=2)
-    aggregator.assert_metric('lighttpd.net.hits', tags=tags, count=2)
-    aggregator.assert_metric('lighttpd.performance.busy_servers', tags=tags, count=2)
-    aggregator.assert_metric('lighttpd.performance.idle_server', tags=tags, count=2)
-    aggregator.assert_metric('lighttpd.performance.uptime', tags=tags, count=2)
-    aggregator.assert_metric('lighttpd.net.bytes_per_s', tags=tags, count=1)
-    aggregator.assert_metric('lighttpd.net.request_per_s', tags=tags, count=1)
-    aggregator.assert_all_metrics_covered()
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.integration
+def test_lighttpd(aggregator, check, instance):
+    check.check(instance)
 
+    assert_integration_e2e(aggregator, 1)
+
+
+@pytest.mark.e2e
+def test_e2e_rate(dd_agent_check, instance):
+    aggregator = dd_agent_check(instance, rate=True)
+
+    assert_integration_e2e(aggregator, 2)
+
+
+@pytest.mark.e2e
+def test_e2e_times(dd_agent_check, instance):
+    runs = 5
+    aggregator = dd_agent_check(instance, times=runs)
+
+    assert_integration_e2e(aggregator, runs)
+
+
+def assert_integration_e2e(aggregator, runs):
     tags = ['host:{}'.format(common.HOST), 'port:9449', 'instance:first']
     aggregator.assert_service_check('lighttpd.can_connect', status=Lighttpd.OK, tags=tags)
+
+    tags = ['instance:first']
+    for metric_name, metric_type in EXPECTED_METRICS:
+        aggregator.assert_metric(metric_name, metric_type=metric_type, tags=tags, count=runs)
+    aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

Update aggregator for e2e to make `metric_type` and `count` assertion easier.

Currently, it's hard to reuse the same test for integration and e2e due to the different in the metrics contained in the aggregator.
- In integration tests: the aggregator contains metrics submitted to the agent
- In e2e tests: the aggregator contains metrics that the agent intend to sent to the backend (output from agent check)

The differences are:
- the count is different for rate metrics (in e2e, the `agent check` won't return rate metric with only one data point)
- the submitted rate metrics have type gauge in e2e

The consequence are:
- we can't/don't use some tests for both integration and e2e
- we sometime remove the metric_type/count 

This PR intend to solve this issue by considering that the `aggregator.assert_metric` is asserting the submitted metrics (what we sent to the agent) for both integration and e2e. For integration, it's already the case, but for e2e, we have to adapt to compensate the differences listed above (see PR changes).

Note: there is one more different different that we don't address here: the value of rate metrics are different. the value is not high addressing it since we don't often assert metric values.

### Motivation

Better reusability of integration/e2e tests.

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
