### PR TITLE
Drastically reduce `ss` output

### DIFF
--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -12,12 +12,12 @@ import socket
 from collections import defaultdict
 
 import psutil
-from six import PY3, iteritems
+from six import PY3, iteritems, itervalues
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.utils.common import pattern_filter
-from datadog_checks.utils.platform import Platform
-from datadog_checks.utils.subprocess_output import SubprocessOutputEmptyError, get_subprocess_output
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.utils.common import pattern_filter
+from datadog_checks.base.utils.platform import Platform
+from datadog_checks.base.utils.subprocess_output import SubprocessOutputEmptyError, get_subprocess_output
 
 if PY3:
     long = int
@@ -290,32 +290,32 @@ class Network(AgentCheck):
             try:
                 self.log.debug("Using `ss` to collect connection state")
                 # Try using `ss` for increased performance over `netstat`
+                metrics = self._get_metrics()
                 for ip_version in ['4', '6']:
-                    for protocol in ['tcp', 'udp']:
-                        # Call `ss` for each IP version because there's no built-in way of distinguishing
-                        # between the IP versions in the output
-                        # Also calls `ss` for each protocol, because on some systems (e.g. Ubuntu 14.04), there is a
-                        # bug that print `tcp` even if it's `udp`
-                        output, _, _ = get_subprocess_output(
-                            ["ss", "-n", "-{0}".format(protocol[0]), "-a", "-{0}".format(ip_version)], self.log
-                        )
-                        lines = output.splitlines()
+                    # Call `ss` for each IP version because there's no built-in way of distinguishing
+                    # between the IP versions in the output
+                    # Also calls `ss` for each protocol, because on some systems (e.g. Ubuntu 14.04), there is a
+                    # bug that print `tcp` even if it's `udp`
+                    # The `-H` flag isn't available on old versions of `ss`.
+                    cmd = "ss -n -t -a -{} | cut -d ' ' -f 1 | sort | uniq -c".format(ip_version)
+                    output, _, _ = get_subprocess_output(["sh", "-c", cmd], self.log)
 
-                        # State      Recv-Q Send-Q     Local Address:Port       Peer Address:Port
-                        # UNCONN     0      0              127.0.0.1:8125                  *:*
-                        # ESTAB      0      0              127.0.0.1:37036         127.0.0.1:8125
-                        # UNCONN     0      0        fe80::a00:27ff:fe1c:3c4:123          :::*
-                        # TIME-WAIT  0      0          90.56.111.177:56867        46.105.75.4:143
-                        # LISTEN     0      0       ::ffff:127.0.0.1:33217  ::ffff:127.0.0.1:7199
-                        # ESTAB      0      0       ::ffff:127.0.0.1:58975  ::ffff:127.0.0.1:2181
+                    # 7624 CLOSE-WAIT
+                    #   72 ESTAB
+                    #    9 LISTEN
+                    #    1 State
+                    #   37 TIME-WAIT
+                    lines = output.splitlines()
 
-                        metrics = self._parse_linux_cx_state(
-                            lines[1:], self.tcp_states['ss'], 0, protocol=protocol, ip_version=ip_version
-                        )
-                        # Only send the metrics which match the loop iteration's ip version
-                        for stat, metric in iteritems(self.cx_state_gauge):
-                            if stat[0].endswith(ip_version) and stat[0].startswith(protocol):
-                                self.gauge(metric, metrics.get(metric), tags=custom_tags)
+                    self._parse_short_state_lines(lines, metrics, self.tcp_states['ss'], ip_version=ip_version)
+
+                    cmd = "ss -n -u -a -{} | wc -l".format(ip_version)
+                    output, _, _ = get_subprocess_output(["sh", "-c", cmd], self.log)
+                    metric = self.cx_state_gauge[('udp{}'.format(ip_version), 'connections')]
+                    metrics[metric] = int(output) - 1  # Remove header
+
+                for metric, value in iteritems(metrics):
+                    self.gauge(metric, value, tags=custom_tags)
 
             except OSError:
                 self.log.info("`ss` not found: using `netstat` as a fallback")
@@ -493,14 +493,23 @@ class Network(AgentCheck):
         except SubprocessOutputEmptyError:
             self.log.debug("Couldn't use {} to get conntrack stats".format(conntrack_path))
 
+    def _get_metrics(self):
+        return {val: 0 for val in itervalues(self.cx_state_gauge)}
+
+    def _parse_short_state_lines(self, lines, metrics, tcp_states, ip_version):
+        for line in lines:
+            value, state = line.split()
+            proto = "tcp{0}".format(ip_version)
+            if state in tcp_states:
+                metric = self.cx_state_gauge[proto, tcp_states[state]]
+                metrics[metric] = int(value)
+
     def _parse_linux_cx_state(self, lines, tcp_states, state_col, protocol=None, ip_version=None):
         """
         Parse the output of the command that retrieves the connection state (either `ss` or `netstat`)
         Returns a dict metric_name -> value
         """
-        metrics = {}
-        for _, val in iteritems(self.cx_state_gauge):
-            metrics[val] = 0
+        metrics = self._get_metrics()
         for l in lines:
             cols = l.split()
             if cols[0].startswith('tcp') or protocol == 'tcp':

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -297,7 +297,7 @@ class Network(AgentCheck):
                     # Also calls `ss` for each protocol, because on some systems (e.g. Ubuntu 14.04), there is a
                     # bug that print `tcp` even if it's `udp`
                     # The `-H` flag isn't available on old versions of `ss`.
-                    cmd = "ss -n -t -a -{} | cut -d ' ' -f 1 | sort | uniq -c".format(ip_version)
+                    cmd = "ss --numeric --tcp --all --ipv{} | cut -d ' ' -f 1 | sort | uniq -c".format(ip_version)
                     output, _, _ = get_subprocess_output(["sh", "-c", cmd], self.log)
 
                     # 7624 CLOSE-WAIT
@@ -309,7 +309,7 @@ class Network(AgentCheck):
 
                     self._parse_short_state_lines(lines, metrics, self.tcp_states['ss'], ip_version=ip_version)
 
-                    cmd = "ss -n -u -a -{} | wc -l".format(ip_version)
+                    cmd = "ss --numeric --udp --all --ipv{} | wc -l".format(ip_version)
                     output, _, _ = get_subprocess_output(["sh", "-c", cmd], self.log)
                     metric = self.cx_state_gauge[('udp{}'.format(ip_version), 'connections')]
                     metrics[metric] = int(output) - 1  # Remove header

--- a/network/tests/fixtures/ss_ipv4_tcp_short
+++ b/network/tests/fixtures/ss_ipv4_tcp_short
@@ -1,0 +1,4 @@
+   1 ESTAB
+   2 LISTEN
+   1 State
+   2 TIME-WAIT

--- a/network/tests/fixtures/ss_ipv6_tcp_short
+++ b/network/tests/fixtures/ss_ipv6_tcp_short
@@ -1,0 +1,5 @@
+   1 CLOSING
+   1 ESTAB
+   1 LISTEN
+   1 State
+   1 TIME-WAIT

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -64,13 +64,13 @@ else:
 
 
 def ss_subprocess_mock(*args, **kwargs):
-    if '-u -a -4' in args[0][2]:
+    if '--udp --all --ipv4' in args[0][2]:
         return '3', None, None
-    elif '-u -a -6' in args[0][2]:
+    elif '--udp --all --ipv6' in args[0][2]:
         return '4', None, None
-    elif '-t -a -4' in args[0][2]:
+    elif '--tcp --all --ipv4' in args[0][2]:
         file_name = 'ss_ipv4_tcp_short'
-    elif '-t -a -6' in args[0][2]:
+    elif '--tcp --all --ipv6' in args[0][2]:
         file_name = 'ss_ipv6_tcp_short'
 
     with open(os.path.join(FIXTURE_DIR, file_name), 'rb') as f:

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -64,14 +64,14 @@ else:
 
 
 def ss_subprocess_mock(*args, **kwargs):
-    if args[0][-1] == '-4' and args[0][-3] == '-u':
-        file_name = 'ss_ipv4_udp'
-    elif args[0][-1] == '-4' and args[0][-3] == '-t':
-        file_name = 'ss_ipv4_tcp'
-    elif args[0][-1] == '-6' and args[0][-3] == '-u':
-        file_name = 'ss_ipv6_udp'
-    elif args[0][-1] == '-6' and args[0][-3] == '-t':
-        file_name = 'ss_ipv6_tcp'
+    if '-u -a -4' in args[0][2]:
+        return '3', None, None
+    elif '-u -a -6' in args[0][2]:
+        return '4', None, None
+    elif '-t -a -4' in args[0][2]:
+        file_name = 'ss_ipv4_tcp_short'
+    elif '-t -a -6' in args[0][2]:
+        file_name = 'ss_ipv6_tcp_short'
 
     with open(os.path.join(FIXTURE_DIR, file_name), 'rb') as f:
         contents = f.read()
@@ -79,8 +79,8 @@ def ss_subprocess_mock(*args, **kwargs):
 
 
 def netstat_subprocess_mock(*args, **kwargs):
-    if args[0][0] == 'ss':
-        raise OSError
+    if args[0][0] == 'sh':
+        raise OSError()
     elif args[0][0] == 'netstat':
         with open(os.path.join(FIXTURE_DIR, 'netstat'), 'rb') as f:
             contents = f.read()
@@ -93,6 +93,25 @@ def test_cx_state(aggregator, check):
     with mock.patch('datadog_checks.network.network.get_subprocess_output') as out:
         out.side_effect = ss_subprocess_mock
         check._collect_cx_state = True
+        check.check(instance)
+        for metric, value in iteritems(CX_STATE_GAUGES_VALUES):
+            aggregator.assert_metric(metric, value=value)
+        aggregator.reset()
+
+        out.side_effect = netstat_subprocess_mock
+        check.check(instance)
+        for metric, value in iteritems(CX_STATE_GAUGES_VALUES):
+            aggregator.assert_metric(metric, value=value)
+
+
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=True)
+def test_cx_state_mocked(is_linux, aggregator, check):
+    instance = {'collect_connection_state': True}
+    with mock.patch('datadog_checks.network.network.get_subprocess_output') as out:
+        out.side_effect = ss_subprocess_mock
+        check._collect_cx_state = True
+        check._is_collect_cx_state_runnable = lambda x: True
+        check._get_net_proc_base_location = lambda x: FIXTURE_DIR
         check.check(instance)
         for metric, value in iteritems(CX_STATE_GAUGES_VALUES):
             aggregator.assert_metric(metric, value=value)


### PR DESCRIPTION
Instead of retrieving the whole output of the `ss` command, pass it through shell calls to only get the bits that we need.