### PR TITLE
Install odbc only when needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,7 @@ services:
 language: python
 python:
   - '2.7.15'
-addons:
-  apt:
-    packages:
-      - tdsodbc
-      - unixodbc-dev
+
 cache:
   directories:
     - "$HOME/.cache/pip"
@@ -136,6 +132,9 @@ jobs:
       env: CHECK=exchange_server PYTHON3=true
     - stage: test
       env: CHECK=fluentd PYTHON3=true
+      before_script:
+        - echo before script
+        - ls
     - stage: test
       env: CHECK=gearmand PYTHON3=true
     - stage: test
@@ -304,6 +303,7 @@ install:
   # since on PRs it only runs test_changed we have to do this globally
   - bash .travis/install_ibm_mq.sh
   - bash .travis/install_rrdtool.sh
+  - bash .travis/install_odbc.sh
 # we should clean generated files before we save the cache
 # We don't want to save .pyc files, so we'll use find and -delete
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
 language: python
 python:
   - '2.7.15'
-
 cache:
   directories:
     - "$HOME/.cache/pip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,9 +132,6 @@ jobs:
       env: CHECK=exchange_server PYTHON3=true
     - stage: test
       env: CHECK=fluentd PYTHON3=true
-      before_script:
-        - echo before script
-        - ls
     - stage: test
       env: CHECK=gearmand PYTHON3=true
     - stage: test

--- a/.travis/install_odbc.sh
+++ b/.travis/install_odbc.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -ex
+
+if [ -z "$CHECK" ]; then
+    OUT=$(ddev test --list)
+    if [[ "$OUT" != *"sqlserver"* ]]; then
+        exit 0
+    fi
+else
+    if [ $CHECK != "sqlserver" ]; then
+        exit 0
+    fi
+fi
+
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+  tdsodbc \
+  unixodbc-dev
+
+set +ex


### PR DESCRIPTION
### What does this PR do?

Install odbc only when needed

### Motivation

Build for al integration (except sqlserver) is 15 second faster.

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
