### PR TITLE
Add VPA metrics to kubernetes_state integration

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -194,10 +194,18 @@ class KubernetesState(OpenMetricsBaseCheck):
                         'kube_statefulset_status_replicas_current': 'statefulset.replicas_current',
                         'kube_statefulset_status_replicas_ready': 'statefulset.replicas_ready',
                         'kube_statefulset_status_replicas_updated': 'statefulset.replicas_updated',
-                        'kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound' : 'vpa.lower_bound',
-                        'kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target' : 'vpa.target',
-                        'kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget' : 'vpa.uncapped_target',
-                        'kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound' : 'vpa.upperbound',
+                        'kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound': (
+                            'vpa.lower_bound'
+                        ),
+                        'kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target': (
+                            'vpa.target'
+                        ),
+                        'kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget': (
+                            'vpa.uncapped_target'
+                        ),
+                        'kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound': (
+                            'vpa.upperbound'
+                        ),
                         'kube_verticalpodautoscaler_spec_updatepolicy_updatemode' : 'vpa.update_mode',
                     }
                 ],
@@ -262,7 +270,7 @@ class KubernetesState(OpenMetricsBaseCheck):
                     'kube_job_status_active',
                     'kube_job_status_completion_time',  # We could compute the duration=completion-start as a gauge
                     'kube_job_status_start_time',
-                    'kube_verticalpodautoscaler_labels'
+                    'kube_verticalpodautoscaler_labels',
                 ],
                 'label_joins': {
                     'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node']},

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -206,7 +206,7 @@ class KubernetesState(OpenMetricsBaseCheck):
                         'kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound': (
                             'vpa.upperbound'
                         ),
-                        'kube_verticalpodautoscaler_spec_updatepolicy_updatemode' : 'vpa.update_mode',
+                        'kube_verticalpodautoscaler_spec_updatepolicy_updatemode': 'vpa.update_mode',
                     }
                 ],
                 'ignore_metrics': [

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -194,6 +194,11 @@ class KubernetesState(OpenMetricsBaseCheck):
                         'kube_statefulset_status_replicas_current': 'statefulset.replicas_current',
                         'kube_statefulset_status_replicas_ready': 'statefulset.replicas_ready',
                         'kube_statefulset_status_replicas_updated': 'statefulset.replicas_updated',
+                        'kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound' : 'vpa.lower_bound',
+                        'kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target' : 'vpa.target',
+                        'kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget' : 'vpa.uncapped_target',
+                        'kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound' : 'vpa.upperbound',
+                        'kube_verticalpodautoscaler_spec_updatepolicy_updatemode' : 'vpa.update_mode',
                     }
                 ],
                 'ignore_metrics': [
@@ -257,6 +262,7 @@ class KubernetesState(OpenMetricsBaseCheck):
                     'kube_job_status_active',
                     'kube_job_status_completion_time',  # We could compute the duration=completion-start as a gauge
                     'kube_job_status_start_time',
+                    'kube_verticalpodautoscaler_labels'
                 ],
                 'label_joins': {
                     'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node']},

--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -104,3 +104,8 @@ kubernetes_state.telemetry.metrics.input.count,counter,,,,The number of metrics 
 kubernetes_state.telemetry.metrics.blacklist.count,counter,,,,The number of metrics blacklisted by the check,0,kubernetes,k8s_state.telemetry.metrics.blacklist.count
 kubernetes_state.telemetry.metrics.ignored.count,counter,,,,The number of metrics ignored by the check,0,kubernetes,k8s_state.telemetry.metrics.ignored.count
 kubernetes_state.telemetry.collector.metrics.count,counter,,,,The number of metrics by collector (kubernetes object kind) by kubernetes namespaces,0,kubernetes,k8s_state.telemetry.collector.metrics.count
+kubernetes_state.vpa.lower_bound,,,,The vpa lower bound recommendation,0,kubernetes,k8s_state.vpa.lower_bound
+kubernetes_state.vpa.target,,,,The vpa target recommendation,0,kubernetes,k8s_state.vpa.target
+kubernetes_state.vpa.uncapped_target,,,,The vpa uncapped recommendation recommendation,0,kubernetes,k8s_state.vpa.uncapped_target
+kubernetes_state.vpa.upperbound,,,,The vpa upper bound recommendation,0,kubernetes,k8s_state.vpa.upper_bound
+kubernetes_state.vpa.update_mode,,,,The vpa update mode,0,kubernetes,k8s_state.vpa.update_mode

--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -104,8 +104,8 @@ kubernetes_state.telemetry.metrics.input.count,counter,,,,The number of metrics 
 kubernetes_state.telemetry.metrics.blacklist.count,counter,,,,The number of metrics blacklisted by the check,0,kubernetes,k8s_state.telemetry.metrics.blacklist.count
 kubernetes_state.telemetry.metrics.ignored.count,counter,,,,The number of metrics ignored by the check,0,kubernetes,k8s_state.telemetry.metrics.ignored.count
 kubernetes_state.telemetry.collector.metrics.count,counter,,,,The number of metrics by collector (kubernetes object kind) by kubernetes namespaces,0,kubernetes,k8s_state.telemetry.collector.metrics.count
-kubernetes_state.vpa.lower_bound,,,,The vpa lower bound recommendation,0,kubernetes,k8s_state.vpa.lower_bound
-kubernetes_state.vpa.target,,,,The vpa target recommendation,0,kubernetes,k8s_state.vpa.target
-kubernetes_state.vpa.uncapped_target,,,,The vpa uncapped recommendation recommendation,0,kubernetes,k8s_state.vpa.uncapped_target
-kubernetes_state.vpa.upperbound,,,,The vpa upper bound recommendation,0,kubernetes,k8s_state.vpa.upper_bound
-kubernetes_state.vpa.update_mode,,,,The vpa update mode,0,kubernetes,k8s_state.vpa.update_mode
+kubernetes_state.vpa.lower_bound,gauge,,,,The vpa lower bound recommendation,0,kubernetes,k8s_state.vpa.lower_bound
+kubernetes_state.vpa.target,gauge,,,,The vpa target recommendation,0,kubernetes,k8s_state.vpa.target
+kubernetes_state.vpa.uncapped_target,gauge,,,,The vpa uncapped recommendation recommendation,0,kubernetes,k8s_state.vpa.uncapped_target
+kubernetes_state.vpa.upperbound,gauge,,,,The vpa upper bound recommendation,0,kubernetes,k8s_state.vpa.upper_bound
+kubernetes_state.vpa.update_mode,gauge,,,,The vpa update mode,0,kubernetes,k8s_state.vpa.update_mode

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -874,3 +874,21 @@ kube_hpa_status_condition{namespace="default",hpa="myhpa",condition="unknown",st
 kube_hpa_status_condition{namespace="default",hpa="myhpa",condition="true",status="ScalingLimited"} 1
 kube_hpa_status_condition{namespace="default",hpa="myhpa",condition="false",status="ScalingLimited"} 0
 kube_hpa_status_condition{namespace="default",hpa="myhpa",condition="unknown",status="ScalingLimited"} 0
+# HELP kube_verticalpodautoscaler_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_verticalpodautoscaler_labels gauge
+kube_verticalpodautoscaler_labels{label_app="foobar",namespace="ns1",target_api_version="extensions/v1beta1",target_kind="Deployment",target_name="deployment1",verticalpodautoscaler="vpa1"} 1
+# HELP kube_verticalpodautoscaler_spec_updatepolicy_updatemode Update mode of the VPA.
+# TYPE kube_verticalpodautoscaler_spec_updatepolicy_updatemode gauge
+kube_verticalpodautoscaler_spec_updatepolicy_updatemode{namespace="default",target_api_version="extensions/v1beta1",target_kind="Deployment",target_name="deployment1",update_mode="Recreate",verticalpodautoscaler="vpa1"} 1
+# HELP kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound Minimum resources the container can use before the VPA updater evicts it.
+# TYPE kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound gauge
+kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{container="container1",namespace="default",resource="cpu",target_api_version="extensions/v1beta1",target_kind="Deployment",target_name="deployment1",unit="core",verticalpodautoscaler="vpa1"} 1
+# HELP kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound Maximum resources the container can use before the VPA updater evicts it.
+# TYPE kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound gauge
+kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{container="container1",namespace="default",resource="cpu",target_api_version="extensions/v1beta1",target_kind="Deployment",target_name="deployment1",unit="core",verticalpodautoscaler="vpa1"} 4
+# HELP kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target Target resources the VPA recommends for the container.
+# TYPE kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target gauge
+kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target{container="container1",namespace="default",resource="cpu",target_api_version="extensions/v1beta1",target_kind="Deployment",target_name="deployment1",unit="core",verticalpodautoscaler="vpa1"} 3
+# HELP kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget Target resources the VPA recommends for the container ignoring bounds.
+# TYPE kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget gauge
+kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget{container="container1",namespace="default",resource="cpu",target_api_version="extensions/v1beta1",target_kind="Deployment",target_name="deployment1",unit="core",verticalpodautoscaler="vpa1"} 6

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -102,6 +102,12 @@ METRICS = [
     # jobs
     NAMESPACE + '.job.failed',
     NAMESPACE + '.job.succeeded',
+    # vpa
+    NAMESPACE + '.vpa.lower_bound',
+    NAMESPACE + '.vpa.target',
+    NAMESPACE + '.vpa.uncapped_target',
+    NAMESPACE + '.vpa.upperbound',
+    NAMESPACE + '.vpa.update_mode',
 ]
 
 TAGS = {
@@ -394,11 +400,11 @@ def test_telemetry(aggregator, instance):
 
     for _ in range(2):
         check.check(instance)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=87416.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=956.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1270.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=90270.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=966.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1282.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.blacklist.count', tags=['optional:tag1'], value=24.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.ignored.count', tags=['optional:tag1'], value=314.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.ignored.count', tags=['optional:tag1'], value=316.0)
     aggregator.assert_metric(
         NAMESPACE + '.telemetry.collector.metrics.count',
         tags=['resource_name:pod', 'resource_namespace:default', 'optional:tag1'],


### PR DESCRIPTION
### What does this PR do?

Adds the recently added Vertical Pod Autoscaler (VPA) metrics from Kubernetes State Metrics, https://github.com/kubernetes/kube-state-metrics/pull/791, to the ksm integration.  

### Motivation

We'd like to have these metrics. When we contacted support (https://help.datadoghq.com/hc/en-us/requests/226107) we were informed this was not on the roadmap, so we assumed the next step was to do it ourselves.

### Additional Notes

I used the PR that added HPA metrics as a guide https://github.com/DataDog/integrations-core/pull/801.   I also wasn't sure what metrics I should import, explicitly/implicitly ignore, and if any transformations would be helpful. 

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
