### PR TITLE
Enforce unicode output in requests.iter_lines call

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -313,12 +313,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
 
         try:
             req = self.perform_kubelet_query(url)
-            for line in req.iter_lines():
-                if isinstance(line, bytes):
-                    # Python 2 and Python3 compatibility
-                    # iter_lines() yields bytes in Python3
-                    line = line.decode("utf-8")
-
+            for line in req.iter_lines(decode_unicode=True):
                 # avoid noise; this check is expected to fail since we override the container hostname
                 if line.find('hostname') != -1:
                     continue

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -314,6 +314,11 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
         try:
             req = self.perform_kubelet_query(url)
             for line in req.iter_lines():
+                if isinstance(line, bytes):
+                    # Python 2 and Python3 compatibility
+                    # iter_lines() yields bytes in Python3
+                    line = line.decode("utf-8")
+
                 # avoid noise; this check is expected to fail since we override the container hostname
                 if line.find('hostname') != -1:
                     continue

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -561,7 +561,7 @@ def test_pod_expiration(monkeypatch, aggregator, tagger):
 
 class MockResponse(mock.Mock):
     @staticmethod
-    def iter_lines():
+    def iter_lines(decode_unicode=False):
         return []
 
 


### PR DESCRIPTION
### What does this PR do?

ensure python3/python2 compatibility: the `iter_lines()` method of the `requests` lib yields `bytes` in python3 instead of `str` (python2)

### Motivation

```
2019-08-13 15:33:36 UTC | CORE | WARN | (pkg/collector/python/datadog_agent.go:108 in LogMessage) | (kubelet.py:334) | kubelet check https://10.0.2.15:10250/healthz failed: argument should be integer or bytes-like object, not 'str'
```

### Additional Notes

another solution is to set `decode_unicode=True` as kw argument in `iter_items()`, it makes the function yield `unicode` in python3 and `str` in python2

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
