### PR TITLE
Fix request wrapper timeout and add test

### DIFF
--- a/fluentd/datadog_checks/fluentd/fluentd.py
+++ b/fluentd/datadog_checks/fluentd/fluentd.py
@@ -20,12 +20,14 @@ class Fluentd(AgentCheck):
         super(Fluentd, self).__init__(name, init_config, instances)
         if not ('read_timeout' in self.instance or 'connect_timeout' in self.instance):
             # `default_timeout` config option will be removed with Agent 5
-            self.http.options['timeout'] = (
+            timeout = (
                 self.instance.get('timeout')
+                or self.instance.get('default_timeout')
                 or self.init_config.get('timeout')
                 or self.init_config.get('default_timeout')
                 or self.DEFAULT_TIMEOUT
             )
+            self.http.options['timeout'] = (timeout, timeout)
 
     """Tracks basic fluentd metrics via the monitor_agent plugin
     * number of retry_count

--- a/fluentd/tests/conftest.py
+++ b/fluentd/tests/conftest.py
@@ -37,4 +37,9 @@ def dd_environment():
 
 @pytest.fixture
 def check():
-    return Fluentd(CHECK_NAME, {}, [DEFAULT_INSTANCE])
+    return lambda init_config, instance: Fluentd(CHECK_NAME, init_config, [instance])
+
+
+@pytest.fixture
+def instance():
+    return DEFAULT_INSTANCE

--- a/fluentd/tests/conftest.py
+++ b/fluentd/tests/conftest.py
@@ -36,10 +36,5 @@ def dd_environment():
 
 
 @pytest.fixture
-def check():
-    return lambda init_config, instance: Fluentd(CHECK_NAME, init_config, [instance])
-
-
-@pytest.fixture
 def instance():
     return DEFAULT_INSTANCE

--- a/fluentd/tests/conftest.py
+++ b/fluentd/tests/conftest.py
@@ -7,9 +7,8 @@ import os
 import pytest
 
 from datadog_checks.dev import docker_run
-from datadog_checks.fluentd import Fluentd
 
-from .common import CHECK_NAME, DEFAULT_INSTANCE, HERE, URL
+from .common import DEFAULT_INSTANCE, HERE, URL
 
 
 @pytest.fixture(scope="session")

--- a/fluentd/tests/test_integration.py
+++ b/fluentd/tests/test_integration.py
@@ -12,9 +12,9 @@ from .common import BAD_PORT, BAD_URL, CHECK_NAME, DEFAULT_INSTANCE, EXPECTED_GA
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_fluentd_exception(aggregator, check):
+def test_fluentd_exception(aggregator):
     instance = {"monitor_agent_url": BAD_URL, "plugin_ids": ["plg2"], "tags": ["test"]}
-    check = check({}, instance)
+    check = Fluentd(CHECK_NAME, {}, instance)
     with pytest.raises(Exception):
         check.check(instance)
 
@@ -25,10 +25,10 @@ def test_fluentd_exception(aggregator, check):
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_fluentd_with_tag_by_type(aggregator, check):
+def test_fluentd_with_tag_by_type(aggregator):
     instance = copy.deepcopy(DEFAULT_INSTANCE)
     instance["tag_by"] = "type"
-    check = check({}, instance)
+    check = Fluentd(CHECK_NAME, {}, instance)
     check.check(instance)
 
     for m in EXPECTED_GAUGES:
@@ -44,11 +44,11 @@ def test_fluentd_with_tag_by_type(aggregator, check):
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_fluentd_with_tag_by_plugin_id(aggregator, check):
+def test_fluentd_with_tag_by_plugin_id(aggregator):
     instance = copy.deepcopy(DEFAULT_INSTANCE)
     instance["tag_by"] = "plugin_id"
 
-    check = check({}, instance)
+    check = Fluentd(CHECK_NAME, {}, instance)
     check.check(instance)
 
     for m in EXPECTED_GAUGES:
@@ -63,11 +63,11 @@ def test_fluentd_with_tag_by_plugin_id(aggregator, check):
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_fluentd_with_custom_tags(aggregator, check):
+def test_fluentd_with_custom_tags(aggregator):
     instance = copy.deepcopy(DEFAULT_INSTANCE)
     custom_tags = ['test', 'tast:tast']
     instance["tags"] = custom_tags
-    check = check({}, instance)
+    check = Fluentd(CHECK_NAME, {}, instance)
 
     check.check(instance)
 

--- a/fluentd/tests/test_integration.py
+++ b/fluentd/tests/test_integration.py
@@ -14,7 +14,7 @@ from .common import BAD_PORT, BAD_URL, CHECK_NAME, DEFAULT_INSTANCE, EXPECTED_GA
 @pytest.mark.usefixtures("dd_environment")
 def test_fluentd_exception(aggregator, check):
     instance = {"monitor_agent_url": BAD_URL, "plugin_ids": ["plg2"], "tags": ["test"]}
-
+    check = check({}, instance)
     with pytest.raises(Exception):
         check.check(instance)
 
@@ -28,7 +28,7 @@ def test_fluentd_exception(aggregator, check):
 def test_fluentd_with_tag_by_type(aggregator, check):
     instance = copy.deepcopy(DEFAULT_INSTANCE)
     instance["tag_by"] = "type"
-
+    check = check({}, instance)
     check.check(instance)
 
     for m in EXPECTED_GAUGES:
@@ -48,6 +48,7 @@ def test_fluentd_with_tag_by_plugin_id(aggregator, check):
     instance = copy.deepcopy(DEFAULT_INSTANCE)
     instance["tag_by"] = "plugin_id"
 
+    check = check({}, instance)
     check.check(instance)
 
     for m in EXPECTED_GAUGES:
@@ -66,6 +67,7 @@ def test_fluentd_with_custom_tags(aggregator, check):
     instance = copy.deepcopy(DEFAULT_INSTANCE)
     custom_tags = ['test', 'tast:tast']
     instance["tags"] = custom_tags
+    check = check({}, instance)
 
     check.check(instance)
 

--- a/fluentd/tests/test_integration.py
+++ b/fluentd/tests/test_integration.py
@@ -14,7 +14,7 @@ from .common import BAD_PORT, BAD_URL, CHECK_NAME, DEFAULT_INSTANCE, EXPECTED_GA
 @pytest.mark.usefixtures("dd_environment")
 def test_fluentd_exception(aggregator):
     instance = {"monitor_agent_url": BAD_URL, "plugin_ids": ["plg2"], "tags": ["test"]}
-    check = Fluentd(CHECK_NAME, {}, instance)
+    check = Fluentd(CHECK_NAME, {}, [instance])
     with pytest.raises(Exception):
         check.check(instance)
 
@@ -28,7 +28,7 @@ def test_fluentd_exception(aggregator):
 def test_fluentd_with_tag_by_type(aggregator):
     instance = copy.deepcopy(DEFAULT_INSTANCE)
     instance["tag_by"] = "type"
-    check = Fluentd(CHECK_NAME, {}, instance)
+    check = Fluentd(CHECK_NAME, {}, [instance])
     check.check(instance)
 
     for m in EXPECTED_GAUGES:
@@ -48,7 +48,7 @@ def test_fluentd_with_tag_by_plugin_id(aggregator):
     instance = copy.deepcopy(DEFAULT_INSTANCE)
     instance["tag_by"] = "plugin_id"
 
-    check = Fluentd(CHECK_NAME, {}, instance)
+    check = Fluentd(CHECK_NAME, {}, [instance])
     check.check(instance)
 
     for m in EXPECTED_GAUGES:
@@ -67,7 +67,7 @@ def test_fluentd_with_custom_tags(aggregator):
     instance = copy.deepcopy(DEFAULT_INSTANCE)
     custom_tags = ['test', 'tast:tast']
     instance["tags"] = custom_tags
-    check = Fluentd(CHECK_NAME, {}, instance)
+    check = Fluentd(CHECK_NAME, {}, [instance])
 
     check.check(instance)
 

--- a/fluentd/tests/test_integration_and_e2e.py
+++ b/fluentd/tests/test_integration_and_e2e.py
@@ -25,6 +25,7 @@ def assert_basic_case(aggregator):
 @pytest.mark.usefixtures("dd_environment")
 def test_basic_case_integration(aggregator, check):
     instance = copy.deepcopy(INSTANCE_WITH_PLUGIN)
+    check = check({}, instance)
     check.check(instance)
     check.check(instance)
 

--- a/fluentd/tests/test_integration_and_e2e.py
+++ b/fluentd/tests/test_integration_and_e2e.py
@@ -25,7 +25,7 @@ def assert_basic_case(aggregator):
 @pytest.mark.usefixtures("dd_environment")
 def test_basic_case_integration(aggregator):
     instance = copy.deepcopy(INSTANCE_WITH_PLUGIN)
-    check = Fluentd(CHECK_NAME, {}, instance)
+    check = Fluentd(CHECK_NAME, {}, [instance])
     check.check(instance)
     check.check(instance)
 

--- a/fluentd/tests/test_integration_and_e2e.py
+++ b/fluentd/tests/test_integration_and_e2e.py
@@ -23,9 +23,9 @@ def assert_basic_case(aggregator):
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_basic_case_integration(aggregator, check):
+def test_basic_case_integration(aggregator):
     instance = copy.deepcopy(INSTANCE_WITH_PLUGIN)
-    check = check({}, instance)
+    check = Fluentd(CHECK_NAME, {}, instance)
     check.check(instance)
     check.check(instance)
 

--- a/fluentd/tests/test_unit.py
+++ b/fluentd/tests/test_unit.py
@@ -1,11 +1,13 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from .common import CHECK_NAME
+from datadog_checks.fluentd import Fluentd
 
 
 def test_default_timeout(check, instance):
     # test default timeout
-    check = check({}, instance)
+    check = Fluentd(CHECK_NAME, {}, instance)
     check.check(instance)
 
     assert check.http.options['timeout'] == (5, 5)
@@ -13,14 +15,14 @@ def test_default_timeout(check, instance):
 
 def test_init_config_old_timeout(check, instance):
     # test init_config timeout
-    check = check({'default_timeout': 2}, instance)
+    check = Fluentd(CHECK_NAME, {'default_timeout': 2}, instance)
     check.check(instance)
     assert check.http.options['timeout'] == (2, 2)
 
 
 def test_init_config_timeout(check, instance):
     # test init_config timeout
-    check = check({'timeout': 7}, instance)
+    check = Fluentd(CHECK_NAME, {'timeout': 7}, instance)
     check.check(instance)
 
     assert check.http.options['timeout'] == (7, 7)
@@ -29,16 +31,16 @@ def test_init_config_timeout(check, instance):
 def test_instance_old_timeout(check, instance):
     # test instance default_timeout
     instance['default_timeout'] = 13
-    check = check({'default_timeout': 9}, instance)
+    check =  Fluentd(CHECK_NAME, {'default_timeout': 9}, instance)
     check.check(instance)
 
     assert check.http.options['timeout'] == (13, 13)
 
 
-def test_instance_timeout(check, instance):
+def test_instance_timeout(instance):
     # test instance timeout
     instance['timeout'] = 15
-    check = check({}, instance)
+    check = Fluentd(CHECK_NAME, {}, instance)
     check.check(instance)
 
     assert check.http.options['timeout'] == (15, 15)

--- a/fluentd/tests/test_unit.py
+++ b/fluentd/tests/test_unit.py
@@ -1,0 +1,44 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+
+def test_default_timeout(check, instance):
+    # test default timeout
+    check = check({}, instance)
+    check.check(instance)
+
+    assert check.http.options['timeout'] == (5, 5)
+
+
+def test_init_config_old_timeout(check, instance):
+    # test init_config timeout
+    check = check({'default_timeout': 2}, instance)
+    check.check(instance)
+    assert check.http.options['timeout'] == (2, 2)
+
+
+def test_init_config_timeout(check, instance):
+    # test init_config timeout
+    check = check({'timeout': 7}, instance)
+    check.check(instance)
+
+    assert check.http.options['timeout'] == (7, 7)
+
+
+def test_instance_old_timeout(check, instance):
+    # test instance default_timeout
+    instance['default_timeout'] = 13
+    check = check({'default_timeout': 9}, instance)
+    check.check(instance)
+
+    assert check.http.options['timeout'] == (13, 13)
+
+
+def test_instance_timeout(check, instance):
+    # test instance timeout
+    instance['timeout'] = 15
+    check = check({}, instance)
+    check.check(instance)
+
+    assert check.http.options['timeout'] == (15, 15)

--- a/fluentd/tests/test_unit.py
+++ b/fluentd/tests/test_unit.py
@@ -1,37 +1,38 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from .common import CHECK_NAME
 from datadog_checks.fluentd import Fluentd
 
+from .common import CHECK_NAME
 
-def test_default_timeout(check, instance):
+
+def test_default_timeout(instance):
     # test default timeout
-    check = Fluentd(CHECK_NAME, {}, instance)
+    check = Fluentd(CHECK_NAME, {}, [instance])
     check.check(instance)
 
     assert check.http.options['timeout'] == (5, 5)
 
 
-def test_init_config_old_timeout(check, instance):
+def test_init_config_old_timeout(instance):
     # test init_config timeout
-    check = Fluentd(CHECK_NAME, {'default_timeout': 2}, instance)
+    check = Fluentd(CHECK_NAME, {'default_timeout': 2}, [instance])
     check.check(instance)
     assert check.http.options['timeout'] == (2, 2)
 
 
-def test_init_config_timeout(check, instance):
+def test_init_config_timeout(instance):
     # test init_config timeout
-    check = Fluentd(CHECK_NAME, {'timeout': 7}, instance)
+    check = Fluentd(CHECK_NAME, {'timeout': 7}, [instance])
     check.check(instance)
 
     assert check.http.options['timeout'] == (7, 7)
 
 
-def test_instance_old_timeout(check, instance):
+def test_instance_old_timeout(instance):
     # test instance default_timeout
     instance['default_timeout'] = 13
-    check =  Fluentd(CHECK_NAME, {'default_timeout': 9}, instance)
+    check = Fluentd(CHECK_NAME, {'default_timeout': 9}, [instance])
     check.check(instance)
 
     assert check.http.options['timeout'] == (13, 13)
@@ -40,7 +41,7 @@ def test_instance_old_timeout(check, instance):
 def test_instance_timeout(instance):
     # test instance timeout
     instance['timeout'] = 15
-    check = Fluentd(CHECK_NAME, {}, instance)
+    check = Fluentd(CHECK_NAME, {}, [instance])
     check.check(instance)
 
     assert check.http.options['timeout'] == (15, 15)


### PR DESCRIPTION
### What does this PR do?

Adding tests to the mesos integrations, I noticed that the timeout does not support the format we have in the requests wrapper. Fixed the issue and added tests.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
