### PR TITLE
Remove unused var

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
@@ -35,7 +35,6 @@ class LegacyKafkaCheck_0_10_2(AgentCheck):
         super(LegacyKafkaCheck_0_10_2, self).__init__(name, init_config, instances)
         self._context_limit = int(init_config.get('max_partition_contexts', CONTEXT_UPPER_BOUND))
         self._custom_tags = self.instance.get('tags', [])
-        self._kafka_timeout = int(init_config.get('kafka_timeout', DEFAULT_KAFKA_TIMEOUT))
         self._kafka_client = self._create_kafka_client()
         self._zk_timeout = int(init_config.get('zk_timeout', 5))
 


### PR DESCRIPTION
The one place this is used directly access `init_config` and bypasses
this. So its pointless to store on the object.

Note: This PR has multiple commits which I've pulled off into other PR's... please merge those before merging this as that will make the diff much smaller... Alternatively you can do a merge commit, but please do **NOT** merge by squashing all of these into a single commit.