### PR TITLE
Add flag `monitor_all_broker_highwatermarks`, refactor

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/constants.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/constants.py
@@ -3,4 +3,4 @@
 # Licensed under Simplified BSD License (see LICENSE)
 DEFAULT_KAFKA_TIMEOUT = 5
 
-CONTEXT_UPPER_BOUND = 200
+CONTEXT_UPPER_BOUND = 500

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -1,7 +1,6 @@
 ## WARNING: To avoid blindly collecting offsets and lag for an unbounded number
-## of partitions (as could be the case after introducing the self discovery
-## of consumer groups, topics and partitions) the check collects metrics
-## for at most 200 partitions.
+## of partitions (as could be the case after enabling monitor_unlisted_consumer_groups
+## or monitor_all_broker_highwatermarks) the check collects metrics for at most 500 partitions.
 
 ## DEPRECATION NOTICE: In the early days of Kafka, consumer offsets were stored in Zookeeper.
 ## So this check currently supports fetching consumer offsets from both Kafka and Zookeeper.
@@ -61,12 +60,22 @@ instances:
     #     <TOPIC_NAME_2>: []
     #   <CONSUMER_NAME_3>: {}
 
-    ## @param monitor_unlisted_consumer_groups - boolean - required
+    ## @param monitor_unlisted_consumer_groups - boolean - optional
     ## Setting monitor_unlisted_consumer_groups to `true` tells the check to
     ## discover and fetch all offsets for all consumer groups stored in zookeeper.
     ## While this is convenient, it can also put a lot of load on zookeeper.
+    ## If this is not set to true, you must specify consumer_groups.
     #
-    monitor_unlisted_consumer_groups: false
+    # monitor_unlisted_consumer_groups: false
+
+    ## @param monitor_all_broker_highwatermarks - boolean - optional
+    ## Setting monitor_all_broker_highwatermarks to `true` tells the check to
+    ## discover and fetch the broker highwater mark offsets for all kafka topics in
+    ## the cluster. Otherwise highwater mark offsets will only be fetched for topic
+    ## partitions where that check run has already fetched a consumer offset. Internal
+    ## Kafka topics like __consumer_offsets, __transaction_state, etc are always excluded.
+    #
+    # monitor_all_broker_highwatermarks: false
 
     ## @param tags - list of key:value string - optional
     ## List of tags to attach to every metric and service check emitted by this integration.
@@ -77,11 +86,11 @@ instances:
     #   - <KEY_1>:<VALUE_1>
     #   - <KEY_2>:<VALUE_2>
 
-    ## @param security_protocol - string - required
+    ## @param security_protocol - string - optional
     ## Protocol used to communicate with brokers.
     ## Valid values are: PLAINTEXT, SSL. Default: PLAINTEXT.
     #
-    security_protocol: PLAINTEXT
+    # security_protocol: PLAINTEXT
 
     ## @param sasl_mechanism - string - optional
     ## String picking sasl mechanism when security_protocol is SASL_PLAINTEXT or SASL_SSL.

--- a/kafka_consumer/tests/common.py
+++ b/kafka_consumer/tests/common.py
@@ -11,7 +11,7 @@ HOST = get_docker_hostname()
 HOST_IP = socket.gethostbyname(HOST)
 KAFKA_CONNECT_STR = '{}:9092'.format(HOST_IP)
 ZK_CONNECT_STR = '{}:2181'.format(HOST)
-TOPICS = ['marvel', 'dc', '__consumer_offsets']
+TOPICS = ['marvel', 'dc']
 PARTITIONS = [0, 1]
 
 

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -36,6 +36,4 @@ def test_check_kafka(aggregator, kafka_instance):
                         mname, tags=tags + ["source:kafka", "consumer_group:{}".format(name)], at_least=1
                     )
 
-    # let's reassert for the __consumer_offsets - multiple partitions
-    aggregator.assert_metric('kafka.broker_offset', at_least=1)
     aggregator.assert_all_metrics_covered()

--- a/kafka_consumer/tests/test_kafka_consumer_zk.py
+++ b/kafka_consumer/tests/test_kafka_consumer_zk.py
@@ -7,7 +7,7 @@ import pytest
 
 from datadog_checks.kafka_consumer import KafkaCheck
 
-from .common import HOST, KAFKA_CONNECT_STR, PARTITIONS, TOPICS, ZK_CONNECT_STR, is_supported
+from .common import HOST, PARTITIONS, TOPICS, is_supported
 
 pytestmark = pytest.mark.skipif(
     not is_supported('zookeeper'), reason='zookeeper consumer offsets not supported in current environment'
@@ -38,26 +38,7 @@ def test_check_zk(aggregator, zk_instance):
                         mname, tags=tags + ["source:zk", "consumer_group:{}".format(name)], at_least=1
                     )
 
-    # let's reassert for the __consumer_offsets - multiple partitions
-    aggregator.assert_metric('kafka.broker_offset', at_least=1)
     aggregator.assert_all_metrics_covered()
-
-    all_partitions = {
-        'kafka_connect_str': KAFKA_CONNECT_STR,
-        'zk_connect_str': ZK_CONNECT_STR,
-        'consumer_groups': {'my_consumer': {'marvel': []}},
-    }
-    kafka_consumer_check.check(all_partitions)
-    aggregator.assert_metric(
-        'kafka.consumer_offset',
-        tags=['topic:marvel', 'partition:0', 'consumer_group:my_consumer', 'source:zk'],
-        at_least=1,
-    )
-    aggregator.assert_metric(
-        'kafka.consumer_offset',
-        tags=['topic:marvel', 'partition:1', 'consumer_group:my_consumer', 'source:zk'],
-        at_least=1,
-    )
 
 
 @pytest.mark.usefixtures('dd_environment', 'kafka_producer', 'zk_consumer')
@@ -89,7 +70,7 @@ def test_multiple_servers_zk(aggregator, zk_instance):
 
 
 @pytest.mark.usefixtures('dd_environment', 'kafka_producer', 'zk_consumer')
-def test_check_nogroups_zk(aggregator, zk_instance):
+def test_check_no_groups_zk(aggregator, zk_instance):
     """
     Testing Kafka_consumer check grabbing groups from ZK
     """
@@ -101,15 +82,33 @@ def test_check_nogroups_zk(aggregator, zk_instance):
     kafka_consumer_check.check(nogroup_instance)
 
     for topic in TOPICS:
-        if topic != '__consumer_offsets':
-            for partition in PARTITIONS:
-                tags = ["topic:{}".format(topic), "partition:{}".format(partition)]
-                for mname in BROKER_METRICS:
-                    aggregator.assert_metric(mname, tags=tags, at_least=1)
-                for mname in CONSUMER_METRICS:
-                    aggregator.assert_metric(mname, tags=tags + ['source:zk', 'consumer_group:my_consumer'], at_least=1)
-        else:
-            for mname in BROKER_METRICS + CONSUMER_METRICS:
-                aggregator.assert_metric(mname, at_least=1)
+        for partition in PARTITIONS:
+            tags = ["topic:{}".format(topic), "partition:{}".format(partition)]
+            for mname in BROKER_METRICS:
+                aggregator.assert_metric(mname, tags=tags, at_least=1)
+            for mname in CONSUMER_METRICS:
+                aggregator.assert_metric(mname, tags=tags + ['source:zk', 'consumer_group:my_consumer'], at_least=1)
+
+    aggregator.assert_all_metrics_covered()
+
+
+@pytest.mark.usefixtures('dd_environment', 'kafka_producer', 'zk_consumer')
+def test_check_no_partitions_zk(aggregator, zk_instance):
+    """
+    Testing Kafka_consumer check grabbing partitions from ZK
+    """
+    no_partitions_instance = copy.deepcopy(zk_instance)
+    topic = 'marvel'
+    no_partitions_instance['consumer_groups'] = {'my_consumer': {topic: []}}
+
+    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [no_partitions_instance])
+    kafka_consumer_check.check(no_partitions_instance)
+
+    for partition in PARTITIONS:
+        tags = ["topic:{}".format(topic), "partition:{}".format(partition)]
+        for mname in BROKER_METRICS:
+            aggregator.assert_metric(mname, tags=tags, at_least=1)
+        for mname in CONSUMER_METRICS:
+            aggregator.assert_metric(mname, tags=tags + ['source:zk', 'consumer_group:my_consumer'], at_least=1)
 
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

A large refactor, most in preparation for the new version of the check.

1. Stop pointlessly passing groups/topics around. This is much cleaner
handled at the object level no point in passing most of this around.
2. Add a flag `monitor_all_broker_highwatermarks` that allows fetching
broker offsets for topics that are not part of a consumer's
subscription.
3. Cleanup the tests slightly as one test was shoehorned onto another
test and the shared state was causing some weird breakage.
4. Streamline the overall code flow so that its more readable.
5. Change the way the context limit is enforced so that it's applied to
the sum total, rather than piecemeal. Additionally, because it's applied
to the total rather than the pieces, after discussion with @ofek I
bumped the context limit to 500. This should be a reasonable default to
prevent abuse while still handling most cases.
6. Change so that internal topics like `__consumer_offsets` are never
excluded from the broker highwater mark fetch. It's generally pointless
to fetch these as users care about the contents of the messages in that
topic, not the broker offsets of that particular topic.