### PR TITLE
Fix kafka_consumer python3 compatibility check regression

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
@@ -422,7 +422,7 @@ class LegacyKafkaCheck_0_10_2(AgentCheck):
             # Kafka protocol uses OffsetFetchRequests to retrieve consumer offsets:
             # https://kafka.apache.org/protocol#The_Messages_OffsetFetch
             # https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-OffsetFetchRequest
-            request = OffsetFetchRequest[1](consumer_group, tps.items())
+            request = OffsetFetchRequest[1](consumer_group, list(tps.items()))
             response = self._make_blocking_req(request, node_id=coordinator_id)
             for (topic, partition_offsets) in response.topics:
                 for partition, offset, _, error_code in partition_offsets:


### PR DESCRIPTION
### What does this PR do?

Fix kafka_consumer python3 compatibility check regression.

The list wrapper was initially there https://github.com/DataDog/integrations-core/pull/4379/files#diff-a721109aa2a97d8c0c57206d437a2457R443

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
