### PR TITLE
Add travis_retry for e2e for master branch builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ stages:
 script:
   - ddev validate logos ${CHECK}
   - travis_retry ddev test --cov ${CHECK}
-  - ddev env test --new-env ${CHECK}
+  - travis_retry ddev env test --new-env ${CHECK}
   - ddev test ${CHECK} --bench || true
   - if [ -n "$PYTHON3" ]; then ddev validate py3 ${CHECK}; fi
 


### PR DESCRIPTION
### What does this PR do?

Add travis_retry for e2e for master branch builds

### Motivation

Reduce failure due to network issues (e.g. pull docker images, download dependencies, etc)

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
