### PR TITLE
Allow autoconfiguration of instances by sysObjectId

### DIFF
--- a/snmp/README.md
+++ b/snmp/README.md
@@ -224,6 +224,44 @@ The Agent looks for the converted MIB Python files by specifying the destination
 
 [Restart the Agent][9] to start sending SNMP metrics to Datadog.
 
+#### Profiles
+
+To group configuration, the check allows defining profiles to reusing metric
+definitions on several instances. Profiles defines metrics the same way as
+instances, either inline or in seperate files. Each instance can only match for
+a single profile. For example you can define a profile in the `init_config`
+section:
+
+```
+init_config:
+  profiles:
+    my-profile:
+      definition:
+        - MIB: IP-MIB
+          table: ipSystemStatsTable
+          symbols:
+            - ipSystemStatsInReceives
+          metric_tags:
+            - tag: ipversion
+          index: 1
+      sysobjectid: '1.3.6.1.4.1.8072.3.2.10'
+```
+
+Then either reference it explicitly by name, or use sysObjectID detection:
+
+```
+instances:
+   - ip_address: 192.168.34.10
+     profile: my-profile
+   - ip_address: 192.168.34.11
+     # Don't need anything else here, the check will query the sysObjectID
+     # and use the profile if it matches.
+```
+
+If necessary, additional metrics can also be defined in the instances, and will
+be collected alongside those in the profile.
+
+
 #### Metrics collection
 The SNMP check can potentially emit [custom metrics][10], which may impact your [billing][11].
 

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -34,7 +34,7 @@ class InstanceConfig:
         self.ip_address = instance['ip_address']
 
         if not self.metrics and not profiles_by_oid:
-            raise ConfigurationError('Metrics list must contain at least one metric')
+            raise ConfigurationError('Instance should specify at least one metric or profiles should be defined')
 
         self.table_oids, self.raw_oids, self.mibs_to_load = self.parse_metrics(
             self.metrics, self.enforce_constraints, warning

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -87,12 +87,15 @@ init_config:
   ## Specify profiles to be able to reference a set of metrics by name.
   ## One of definition_file or definition needs to be defined.
   ## definition_file points to a file with the same structure as
-  ## global_metrics, whereas defintion inlines it directly here.
+  ## global_metrics, whereas definition inlines it directly here.
+  ## sysObjectID can be set to match the devices that are going to
+  ## automatically use this profile.
   #
   # profiles:
   #   profile1:
   #   	definition_file: <PROFILE_FILE>
-  #   	defintion: <PROFILE>
+  #   	definition: <PROFILE>
+  #   	sysObjectID: <OID>
 
 instances:
 

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -95,7 +95,7 @@ init_config:
   #   profile1:
   #   	definition_file: <PROFILE_FILE>
   #   	definition: <PROFILE>
-  #   	sysObjectID: <OID>
+  #   	sysobjectid: <OID>
 
 instances:
 

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -70,7 +70,7 @@ class SnmpCheck(AgentCheck):
             else:
                 data = profile_data['definition']
             self.profiles[profile] = {'definition': data}
-            sys_object_oid = profile_data.get('sysObjectID')
+            sys_object_oid = profile_data.get('sysobjectid')
             if sys_object_oid:
                 self.profiles_by_oid[sys_object_oid] = profile
 
@@ -223,6 +223,7 @@ class SnmpCheck(AgentCheck):
 
     def fetch_sysobject_oid(self, config):
         """Return the sysObjectID of the instance."""
+        # Reference sysObjectID directly, see http://oidref.com/1.3.6.1.2.1.1.2
         oid = hlapi.ObjectType(hlapi.ObjectIdentity((1, 3, 6, 1, 2, 1, 1, 2)))
         self.log.debug('Running SNMP command on OID %s', oid)
         error_indication, error_status, error_index, var_binds = next(
@@ -245,6 +246,8 @@ class SnmpCheck(AgentCheck):
         try:
             if not (config.table_oids or config.raw_oids):
                 sys_object_oid = self.fetch_sysobject_oid(config)
+                if sys_object_oid not in self.profiles_by_oid:
+                    raise ConfigurationError('No profile matching sysObjectID {}'.format(sys_object_oid))
                 profile = self.profiles_by_oid[sys_object_oid]
                 config.refresh_with_profile(self.profiles[profile], self.warning)
 

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -58,6 +58,7 @@ class SnmpCheck(AgentCheck):
         self.mibs_path = init_config.get('mibs_folder')
         self.ignore_nonincreasing_oid = is_affirmative(init_config.get('ignore_nonincreasing_oid', False))
         self.profiles = init_config.get('profiles', {})
+        self.profiles_by_oid = {}
         for profile, profile_data in self.profiles.items():
             filename = profile_data.get('definition_file')
             if filename:
@@ -69,10 +70,18 @@ class SnmpCheck(AgentCheck):
             else:
                 data = profile_data['definition']
             self.profiles[profile] = {'definition': data}
+            sys_object_oid = profile_data.get('sysObjectID')
+            if sys_object_oid:
+                self.profiles_by_oid[sys_object_oid] = profile
 
         self.instance['name'] = self._get_instance_key(self.instance)
         self._config = InstanceConfig(
-            self.instance, self.warning, self.init_config.get('global_metrics', []), self.mibs_path, self.profiles
+            self.instance,
+            self.warning,
+            self.init_config.get('global_metrics', []),
+            self.mibs_path,
+            self.profiles,
+            self.profiles_by_oid,
         )
 
     def _get_instance_key(self, instance):
@@ -212,6 +221,19 @@ class SnmpCheck(AgentCheck):
         self.log.debug('Raw results: %s', results)
         return results
 
+    def fetch_sysobject_oid(self, config):
+        """Return the sysObjectID of the instance."""
+        oid = hlapi.ObjectType(hlapi.ObjectIdentity((1, 3, 6, 1, 2, 1, 1, 2)))
+        self.log.debug('Running SNMP command on OID %s', oid)
+        error_indication, error_status, error_index, var_binds = next(
+            hlapi.nextCmd(
+                config.snmp_engine, config.auth_data, config.transport, config.context_data, oid, lookupMib=False
+            )
+        )
+        self.raise_on_error_indication(error_indication, config.ip_address)
+        self.log.debug('Returned vars: %s', var_binds)
+        return var_binds[0][1].prettyPrint()
+
     def check(self, instance):
         """
         Perform two series of SNMP requests, one for all that have MIB associated
@@ -221,6 +243,11 @@ class SnmpCheck(AgentCheck):
         self._error = self._severity = None
         config = self._config
         try:
+            if not (config.table_oids or config.raw_oids):
+                sys_object_oid = self.fetch_sysobject_oid(config)
+                profile = self.profiles_by_oid[sys_object_oid]
+                config.refresh_with_profile(self.profiles[profile], self.warning)
+
             if config.table_oids:
                 self.log.debug('Querying device %s for %s oids', config.ip_address, len(config.table_oids))
                 table_results = self.check_table(

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -487,3 +487,19 @@ def test_profile_by_file(aggregator):
         metric_name = "snmp." + metric['name']
         aggregator.assert_metric(metric_name, tags=common.CHECK_TAGS, count=1)
     aggregator.assert_all_metrics_covered()
+
+
+def test_profile_sys_object(aggregator):
+    instance = common.generate_instance_config([])
+    init_config = {
+        'profiles': {
+            'profile1': {'definition': common.SUPPORTED_METRIC_TYPES, 'sysObjectID': '1.3.6.1.4.1.8072.3.2.10'}
+        }
+    }
+    check = SnmpCheck('snmp', init_config, [instance])
+    check.check(instance)
+
+    for metric in common.SUPPORTED_METRIC_TYPES:
+        metric_name = "snmp." + metric['name']
+        aggregator.assert_metric(metric_name, tags=common.CHECK_TAGS, count=1)
+    aggregator.assert_all_metrics_covered()

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -23,11 +23,6 @@ def warning(*args):
 
 @mock.patch("datadog_checks.snmp.config.hlapi")
 def test_parse_metrics(hlapi_mock):
-    # No metrics
-    metrics = []
-    with pytest.raises(Exception):
-        InstanceConfig.parse_metrics(metrics, False, warning)
-
     # Unsupported metric
     metrics = [{"foo": "bar"}]
     with pytest.raises(Exception):


### PR DESCRIPTION
This adds a new sysObjectId value in profile definition, which allows to
not put any metrics in an instance, in which case we retrieve the ID
first and then get the corresponding profile.