### PR TITLE
Drop `source:kafka` from tags.

### DIFF
--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -32,8 +32,6 @@ def test_check_kafka(aggregator, kafka_instance):
                 for mname in BROKER_METRICS:
                     aggregator.assert_metric(mname, tags=tags, at_least=1)
                 for mname in CONSUMER_METRICS:
-                    aggregator.assert_metric(
-                        mname, tags=tags + ["source:kafka", "consumer_group:{}".format(name)], at_least=1
-                    )
+                    aggregator.assert_metric(mname, tags=tags + ["consumer_group:{}".format(name)], at_least=1)
 
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

Going forward, there will be only one cannonical source of Kafka. If
someone is needing to disambiguate, we keep the old `'source:zk'` tag.
But drop the `'source:kafka'` tag as it is not needed in the new code
path, so the simplest thing is to make the new/old code paths the same
so that the test path is identical and the codepath is also simpler.