### PR TITLE
Make internal topics a constant

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/constants.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/constants.py
@@ -4,3 +4,10 @@
 DEFAULT_KAFKA_TIMEOUT = 5
 
 CONTEXT_UPPER_BOUND = 500
+
+# No sense fetching highwatever offsets for internal topics
+KAFKA_INTERNAL_TOPICS = {
+    '__consumer_offsets',
+    '__transaction_state',
+    '_schema',  # _schema is a topic used by the Confluent registry
+}


### PR DESCRIPTION
### What does this PR do?

Make internal topics a constant. These will be shared between new and legacy versions of the check.