### PR TITLE
Fix log adapter on Python 2

### DIFF
--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -44,6 +44,7 @@ class CheckLoggingAdapter(logging.LoggerAdapter):
         self.log(TRACE_LEVEL, msg, *args, **kwargs)
 
     if PY2:
+
         def warn(self, msg, *args, **kwargs):
             self.log(logging.WARNING, msg, *args, **kwargs)
 

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -43,6 +43,10 @@ class CheckLoggingAdapter(logging.LoggerAdapter):
     def trace(self, msg, *args, **kwargs):
         self.log(TRACE_LEVEL, msg, *args, **kwargs)
 
+    if PY2:
+        def warn(self, msg, *args, **kwargs):
+            self.log(logging.WARNING, msg, *args, **kwargs)
+
 
 class AgentLogHandler(logging.Handler):
     """


### PR DESCRIPTION
### Motivation

Python 2 version has no `warn` method