### PR TITLE
Fix incorrect user/pass parameters in example RabbitMQ conf.yaml file

### DIFF
--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -120,15 +120,15 @@ instances:
     #   - <KEY_1>:<VALUE_1>
     #   - <KEY_2>:<VALUE_2>
     
-    ## @param username - string - optional
+    ## @param rabbitmq_user - string - optional
     ## If the API endpoint is behind basic auth, enter here the required username.
     #
-    # username: <USERNAME>
+    # rabbitmq_user: <USERNAME>
 
-    ## @param password - string - optional
+    ## @param rabbitmq_pass - string - optional
     ## If the API endpoint is behind basic auth, enter here the required password.
     #
-    # password: <PASSWORD>
+    # rabbitmq_pass: <PASSWORD>
 
     ## @param ntlm_domain - string - optional
     ## If your services uses NTLM authentication, you can


### PR DESCRIPTION
### What does this PR do?

The commented-out username and password parameters in the example RabbitMQ `conf.yaml` file are not the correct parameters, per [the documentation](https://docs.datadoghq.com/integrations/rabbitmq/#metric-collection) and the current version of the agent.

### Motivation

I was unable to determine why my RabbitMQ integration was connecting as `guest`, even when I had un-commented these parameters and provided the correct credentials. It turns out these are not the correct parameters.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
