### PR TITLE
Only test on Python 2

### DIFF
--- a/tokumx/tox.ini
+++ b/tokumx/tox.ini
@@ -2,11 +2,11 @@
 minversion = 2.0
 basepython = py27
 envlist =
-    py{27,37}
+    py27
 
 [testenv]
 description =
-    py{27,37}: e2e ready
+    py27: e2e ready
 dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32


### PR DESCRIPTION
### Motivation

Tokumx does not support Python 3 as it requires an old version of the dependency, see https://github.com/DataDog/integrations-core/pull/3001