### PR TITLE
[WIP] Fix service check logic

### DIFF
--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -138,6 +138,9 @@ class MesosSlave(AgentCheck):
             self.log.debug('Request to url : {0}, timeout: {1}, message: {2}'.format(url, timeout, msg))
             self._send_service_check(url, response, status, failure_expected=failure_expected, tags=tags, message=msg)
 
+        if not response:
+            return None
+
         if response.encoding is None:
             response.encoding = 'UTF8'
 
@@ -145,6 +148,7 @@ class MesosSlave(AgentCheck):
 
     def _send_service_check(self, url, response, status, failure_expected=False, tags=None, message=None):
         if status is AgentCheck.CRITICAL and failure_expected:
+            status = AgentCheck.OK
             status_code = response.status_code if response else 'unknown'
             message = "Got {} status code when hitting {}".format(status_code, url)
         elif status is AgentCheck.CRITICAL and not failure_expected:

--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -147,15 +147,16 @@ class MesosSlave(AgentCheck):
         return response.json()
 
     def _send_service_check(self, url, response, status, failure_expected=False, tags=None, message=None):
+        service_check_status = status
         if status is AgentCheck.CRITICAL and failure_expected:
-            status = AgentCheck.OK
+            service_check_status = AgentCheck.OK
             status_code = response.status_code if response else 'unknown'
             message = "Got {} status code when hitting {}".format(status_code, url)
         elif status is AgentCheck.CRITICAL and not failure_expected:
             message = 'Cannot connect to mesos. Error: {0}'.format(message)
 
         if self.service_check_needed:
-            self.service_check(self.SERVICE_CHECK_NAME, status, tags=tags, message=message)
+            self.service_check(self.SERVICE_CHECK_NAME, service_check_status, tags=tags, message=message)
             self.service_check_needed = False
 
         if status is AgentCheck.CRITICAL:

--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -146,8 +146,7 @@ class MesosSlave(AgentCheck):
     def _send_service_check(self, url, response, status, failure_expected=False, tags=None, message=None):
         if status is AgentCheck.CRITICAL and failure_expected:
             status_code = response.status_code if response else 'unknown'
-            message = "Got %s status code when hitting %s" % (status_code, url)
-            raise CheckException(message)
+            message = "Got {} status code when hitting {}".format(status_code, url)
         elif status is AgentCheck.CRITICAL and not failure_expected:
             message = 'Cannot connect to mesos. Error: {0}'.format(message)
 

--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -118,17 +118,17 @@ class MesosSlave(AgentCheck):
         msg = None
         status = None
         timeout = self.http.options['timeout']
+        response = None
 
         try:
-            r = self.http.get(url)
-            if r.status_code != 200:
+            response = self.http.get(url)
+            if response.status_code != 200:
                 status = AgentCheck.CRITICAL
-                msg = "Got %s when hitting %s" % (r.status_code, url)
+                msg = "Got %s when hitting %s" % (response.status_code, url)
             else:
                 status = AgentCheck.OK
                 msg = "Mesos master instance detected at %s " % url
         except requests.exceptions.Timeout:
-            # If there's a timeout
             msg = "%s seconds timeout when hitting %s" % (timeout, url)
             status = AgentCheck.CRITICAL
         except Exception as e:
@@ -136,28 +136,32 @@ class MesosSlave(AgentCheck):
             status = AgentCheck.CRITICAL
         finally:
             self.log.debug('Request to url : {0}, timeout: {1}, message: {2}'.format(url, timeout, msg))
-            self._send_service_check(url, r, status, failure_expected=failure_expected, tags=tags, message=msg)
+            self._send_service_check(url, response, status, failure_expected=failure_expected, tags=tags, message=msg)
 
-        if r.encoding is None:
-            r.encoding = 'UTF8'
+        if response.encoding is None:
+            response.encoding = 'UTF8'
 
-        return r.json()
+        return response.json()
 
     def _send_service_check(self, url, response, status, failure_expected=False, tags=None, message=None):
         if status is AgentCheck.CRITICAL and failure_expected:
-            status = AgentCheck.OK
-            message = "Got %s when hitting %s" % (response.status_code, url)
+            status_code = response.status_code if response else 'unknown'
+            message = "Got %s status code when hitting %s" % (status_code, url)
             raise CheckException(message)
         elif status is AgentCheck.CRITICAL and not failure_expected:
-            raise CheckException('Cannot connect to mesos. Error: {0}'.format(message))
+            message = 'Cannot connect to mesos. Error: {0}'.format(message)
+
         if self.service_check_needed:
             self.service_check(self.SERVICE_CHECK_NAME, status, tags=tags, message=message)
             self.service_check_needed = False
 
+        if status is AgentCheck.CRITICAL:
+            raise CheckException(message)
+
     def _get_state(self, url, tags):
+        # Mesos version >= 0.25
+        endpoint = url + '/state'
         try:
-            # Mesos version >= 0.25
-            endpoint = url + '/state'
             master_state = self._get_json(endpoint, failure_expected=True, tags=tags)
         except CheckException:
             # Mesos version < 0.25

--- a/mesos_slave/tests/test_unit.py
+++ b/mesos_slave/tests/test_unit.py
@@ -25,7 +25,7 @@ def test_get_json_ok_case(instance, aggregator, exception_class):
 
 
 @pytest.mark.parametrize('exception_class', [requests.exceptions.Timeout, Exception])
-def test_get_json_timeout_exception(instance, aggregator, exception_class):
+def test_get_json_exception(instance, aggregator, exception_class):
     check = MesosSlave('mesos_slave', {}, [instance])
 
     with mock.patch('datadog_checks.base.utils.http.requests') as req:

--- a/mesos_slave/tests/test_unit.py
+++ b/mesos_slave/tests/test_unit.py
@@ -39,8 +39,13 @@ def test_get_json_timeout_exception(instance, aggregator, exception_class):
         aggregator.assert_service_check('mesos_slave.can_connect', count=1, status=check.CRITICAL)
 
 
-@pytest.mark.parametrize('service_check_needed, service_check_count', [(True, 1), (False, 0)])
-def test_get_json_service_check_needed(instance, aggregator, service_check_needed, service_check_count):
+@pytest.mark.parametrize('service_check_needed, failure_expected, service_check_count', [
+    (True, True, 1),
+    (False, True, 0),
+    (True, False, 1),
+    (False, False, 0),
+])
+def test_get_json_service_check_needed(instance, aggregator, service_check_needed, failure_expected, service_check_count):
     check = MesosSlave('mesos_slave', {}, [instance])
     check.service_check_needed = service_check_needed
 
@@ -48,7 +53,7 @@ def test_get_json_service_check_needed(instance, aggregator, service_check_neede
         req.get = MagicMock(side_effect=requests.exceptions.Timeout)
 
         with pytest.raises(CheckException):
-            res = check._get_json("http://hello")
+            res = check._get_json("http://hello", failure_expected=failure_expected)
 
             assert res is None
 


### PR DESCRIPTION
### What does this PR do?

Fix service check logic

- `r` Unreferenced before assignement
- `self.service_check` is not called if one of the `CheckException` is raised few lines above.
- It would be better to declare `endpoint = url + '/state'` outside of the try catch since the variable is used in the exception.

### Motivation

Spotted few bugs in this PR: https://github.com/DataDog/integrations-core/pull/4054

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
