### PR TITLE
Fix decumulating bucket on multiple contexts

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -705,9 +705,7 @@ class OpenMetricsScraperMixin(object):
     def _compute_bucket_hash(self, tags):
         # we need the unique context for all the buckets
         # hence we remove the "le" tag
-        hash_dict = tags.copy()
-        del hash_dict["le"]
-        return hash(frozenset(sorted(iteritems(hash_dict))))
+        return hash(frozenset(sorted((k, v) for k, v in iteritems(tags) if k != 'le')))
 
     def _decumulate_histogram_buckets(self, metric):
         """

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -702,41 +702,72 @@ class OpenMetricsScraperMixin(object):
                         hostname=custom_hostname,
                     )
 
+    def _compute_bucket_hash(self, tags):
+        # we need the unique context for all the buckets
+        # hence we remove the "le" tag
+        hash_dict = tags.copy()
+        del hash_dict["le"]
+        return hash(frozenset(sorted(iteritems(hash_dict))))
+
     def _decumulate_histogram_buckets(self, metric):
         """
         Decumulate buckets in a given histogram metric and adds the lower_bound label (le being upper_bound)
         """
-        bucket_values_by_upper_bound = {}
+        bucket_values_by_context_upper_bound = {}
         for sample in metric.samples:
             if sample[self.SAMPLE_NAME].endswith("_bucket"):
-                bucket_values_by_upper_bound[float(sample[self.SAMPLE_LABELS]["le"])] = sample[self.SAMPLE_VALUE]
+                context_key = self._compute_bucket_hash(sample[self.SAMPLE_LABELS])
+                if context_key not in bucket_values_by_context_upper_bound:
+                    bucket_values_by_context_upper_bound[context_key] = {}
+                bucket_values_by_context_upper_bound[context_key][float(sample[self.SAMPLE_LABELS]["le"])] = sample[
+                    self.SAMPLE_VALUE
+                ]
 
-        sorted_buckets = sorted(bucket_values_by_upper_bound)
+        sorted_buckets_by_context = {}
+        for context in bucket_values_by_context_upper_bound:
+            sorted_buckets_by_context[context] = sorted(bucket_values_by_context_upper_bound[context])
 
         # Tuples (lower_bound, upper_bound, value)
-        bucket_tuples_by_upper_bound = {}
-        for i, upper_b in enumerate(sorted_buckets):
-            if i == 0:
-                if upper_b > 0:
-                    # positive buckets start at zero
-                    bucket_tuples_by_upper_bound[upper_b] = (0, upper_b, bucket_values_by_upper_bound[upper_b])
-                else:
-                    # negative buckets start at -inf
-                    bucket_tuples_by_upper_bound[upper_b] = (
-                        self.MINUS_INF,
-                        upper_b,
-                        bucket_values_by_upper_bound[upper_b],
-                    )
-                continue
-            tmp = bucket_values_by_upper_bound[upper_b] - bucket_values_by_upper_bound[sorted_buckets[i - 1]]
-            bucket_tuples_by_upper_bound[upper_b] = (sorted_buckets[i - 1], upper_b, tmp)
+        bucket_tuples_by_context_upper_bound = {}
+        for context in sorted_buckets_by_context:
+            for i, upper_b in enumerate(sorted_buckets_by_context[context]):
+                if i == 0:
+                    if context not in bucket_tuples_by_context_upper_bound:
+                        bucket_tuples_by_context_upper_bound[context] = {}
+                    if upper_b > 0:
+                        # positive buckets start at zero
+                        bucket_tuples_by_context_upper_bound[context][upper_b] = (
+                            0,
+                            upper_b,
+                            bucket_values_by_context_upper_bound[context][upper_b],
+                        )
+                    else:
+                        # negative buckets start at -inf
+                        bucket_tuples_by_context_upper_bound[context][upper_b] = (
+                            self.MINUS_INF,
+                            upper_b,
+                            bucket_values_by_context_upper_bound[context][upper_b],
+                        )
+                    continue
+                tmp = (
+                    bucket_values_by_context_upper_bound[context][upper_b]
+                    - bucket_values_by_context_upper_bound[context][sorted_buckets_by_context[context][i - 1]]
+                )
+                bucket_tuples_by_context_upper_bound[context][upper_b] = (
+                    sorted_buckets_by_context[context][i - 1],
+                    upper_b,
+                    tmp,
+                )
 
         # modify original metric to inject lower_bound & modified value
         for i, sample in enumerate(metric.samples):
             if not sample[self.SAMPLE_NAME].endswith("_bucket"):
                 continue
 
-            matching_bucket_tuple = bucket_tuples_by_upper_bound[float(sample[self.SAMPLE_LABELS]["le"])]
+            context_key = self._compute_bucket_hash(sample[self.SAMPLE_LABELS])
+            matching_bucket_tuple = bucket_tuples_by_context_upper_bound[context_key][
+                float(sample[self.SAMPLE_LABELS]["le"])
+            ]
             # Replacing the sample tuple
             sample[self.SAMPLE_LABELS]["lower_bound"] = str(matching_bucket_tuple[0])
             metric.samples[i] = (sample[self.SAMPLE_NAME], sample[self.SAMPLE_LABELS], matching_bucket_tuple[2])

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -984,12 +984,18 @@ def test_decumulate_histogram_buckets_single_bucket(p_check, mocked_prometheus_s
 def test_compute_bucket_hash(p_check):
     check = p_check
 
+    # two different buckets should have the same hash for the same other tags values
     tags1 = {"url": "http://127.0.0.1:8080/api", "verb": "GET", "le": "1"}
     tags2 = {"url": "http://127.0.0.1:8080/api", "verb": "GET", "le": "2"}
     assert check._compute_bucket_hash(tags1) == check._compute_bucket_hash(tags2)
 
-    tags3 = {"url": "http://127.0.0.1:8080/api", "verb": "DELETE", "le": "1"}
-    assert check._compute_bucket_hash(tags1) != check._compute_bucket_hash(tags3)
+    # tag order should not matter
+    tags3 = {"verb": "GET", "le": "+inf", "url": "http://127.0.0.1:8080/api"}
+    assert check._compute_bucket_hash(tags1) == check._compute_bucket_hash(tags3)
+
+    # changing a tag value should change the context hash
+    tags4 = {"url": "http://127.0.0.1:8080/api", "verb": "DELETE", "le": "1"}
+    assert check._compute_bucket_hash(tags1) != check._compute_bucket_hash(tags4)
 
 
 def test_decumulate_histogram_buckets_multiple_contexts(p_check, mocked_prometheus_scraper_config):

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -981,6 +981,87 @@ def test_decumulate_histogram_buckets_single_bucket(p_check, mocked_prometheus_s
     assert sorted(expected_metric.samples, key=lambda i: i[0]) == sorted(current_metric.samples, key=lambda i: i[0])
 
 
+def test_compute_bucket_hash(p_check):
+    check = p_check
+
+    tags1 = {"url": "http://127.0.0.1:8080/api", "verb": "GET", "le": "1"}
+    tags2 = {"url": "http://127.0.0.1:8080/api", "verb": "GET", "le": "2"}
+    assert check._compute_bucket_hash(tags1) == check._compute_bucket_hash(tags2)
+
+    tags3 = {"url": "http://127.0.0.1:8080/api", "verb": "DELETE", "le": "1"}
+    assert check._compute_bucket_hash(tags1) != check._compute_bucket_hash(tags3)
+
+
+def test_decumulate_histogram_buckets_multiple_contexts(p_check, mocked_prometheus_scraper_config):
+    # buckets are not necessary ordered
+    text_data = (
+        '# HELP rest_client_request_latency_seconds Request latency in seconds. Broken down by verb and URL.\n'
+        '# TYPE rest_client_request_latency_seconds histogram\n'
+        'rest_client_request_latency_seconds_bucket{url="http://127.0.0.1:8080/api",verb="GET",le="1"} 100\n'
+        'rest_client_request_latency_seconds_bucket{url="http://127.0.0.1:8080/api",verb="GET",le="2"} 200\n'
+        'rest_client_request_latency_seconds_bucket{url="http://127.0.0.1:8080/api",verb="GET",le="+Inf"} 300\n'
+        'rest_client_request_latency_seconds_sum{url="http://127.0.0.1:8080/api",verb="GET"} 256\n'
+        'rest_client_request_latency_seconds_count{url="http://127.0.0.1:8080/api",verb="GET"} 300\n'
+        'rest_client_request_latency_seconds_bucket{url="http://127.0.0.1:8080/api",verb="POST",le="1"} 50\n'
+        'rest_client_request_latency_seconds_bucket{url="http://127.0.0.1:8080/api",verb="POST",le="2"} 100\n'
+        'rest_client_request_latency_seconds_bucket{url="http://127.0.0.1:8080/api",verb="POST",le="+Inf"} 150\n'
+        'rest_client_request_latency_seconds_sum{url="http://127.0.0.1:8080/api",verb="POST"} 200\n'
+        'rest_client_request_latency_seconds_count{url="http://127.0.0.1:8080/api",verb="POST"} 150\n'
+    )
+
+    response = MockResponse(text_data, text_content_type)
+    check = p_check
+    metrics = [k for k in check.parse_metric_family(response, mocked_prometheus_scraper_config)]
+
+    assert 1 == len(metrics)
+
+    expected_metric = HistogramMetricFamily(
+        'rest_client_request_latency_seconds_bucket', 'Request latency in seconds. Broken down by verb and URL.'
+    )
+
+    expected_metric.samples = [
+        (
+            'rest_client_request_latency_seconds_bucket',
+            {'url': 'http://127.0.0.1:8080/api', 'le': '1', 'lower_bound': '0', 'verb': 'GET'},
+            100.0,
+        ),
+        (
+            'rest_client_request_latency_seconds_bucket',
+            {'url': 'http://127.0.0.1:8080/api', 'le': '2', 'lower_bound': '1.0', 'verb': 'GET'},
+            100.0,
+        ),
+        (
+            'rest_client_request_latency_seconds_bucket',
+            {'url': 'http://127.0.0.1:8080/api', 'le': '+Inf', 'lower_bound': '2.0', 'verb': 'GET'},
+            100.0,
+        ),
+        ('rest_client_request_latency_seconds_sum', {'url': 'http://127.0.0.1:8080/api', 'verb': 'GET'}, 256.0),
+        ('rest_client_request_latency_seconds_count', {'url': 'http://127.0.0.1:8080/api', 'verb': 'GET'}, 300.0),
+        (
+            'rest_client_request_latency_seconds_bucket',
+            {'url': 'http://127.0.0.1:8080/api', 'le': '1', 'lower_bound': '0', 'verb': 'POST'},
+            50.0,
+        ),
+        (
+            'rest_client_request_latency_seconds_bucket',
+            {'url': 'http://127.0.0.1:8080/api', 'le': '2', 'lower_bound': '1.0', 'verb': 'POST'},
+            50.0,
+        ),
+        (
+            'rest_client_request_latency_seconds_bucket',
+            {'url': 'http://127.0.0.1:8080/api', 'le': '+Inf', 'lower_bound': '2.0', 'verb': 'POST'},
+            50.0,
+        ),
+        ('rest_client_request_latency_seconds_sum', {'url': 'http://127.0.0.1:8080/api', 'verb': 'POST'}, 200.0),
+        ('rest_client_request_latency_seconds_count', {'url': 'http://127.0.0.1:8080/api', 'verb': 'POST'}, 150.0),
+    ]
+
+    current_metric = metrics[0]
+    check._decumulate_histogram_buckets(current_metric)
+
+    assert sorted(expected_metric.samples, key=lambda i: i[0]) == sorted(current_metric.samples, key=lambda i: i[0])
+
+
 def test_decumulate_histogram_buckets_negative_buckets(p_check, mocked_prometheus_scraper_config):
     text_data = (
         '# HELP random_histogram Nonsense histogram.\n'


### PR DESCRIPTION
### What does this PR do?

Fix overidding buckets when they have different tag context

### Motivation

Support histograms having a cardinality > 1

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
