### PR TITLE
Fix mesos_master service check

### DIFF
--- a/mesos_master/datadog_checks/mesos_master/mesos_master.py
+++ b/mesos_master/datadog_checks/mesos_master/mesos_master.py
@@ -189,6 +189,7 @@ class MesosMaster(AgentCheck):
     def _send_service_check(self, url, status, failure_expected=False, tags=None, message=None):
         skip_service_check = False
         if status is AgentCheck.CRITICAL and failure_expected:
+            # skip service check when failure is expected
             skip_service_check = True
             message = "Error when calling {}: {}".format(url, message)
         elif status is AgentCheck.CRITICAL and not failure_expected:

--- a/mesos_master/datadog_checks/mesos_master/mesos_master.py
+++ b/mesos_master/datadog_checks/mesos_master/mesos_master.py
@@ -161,11 +161,12 @@ class MesosMaster(AgentCheck):
         msg = None
         status = None
         timeout = self.http.options['timeout']
+        response = None
         try:
-            r = self.http.get(url)
-            if r.status_code != 200:
+            response = self.http.get(url)
+            if response.status_code != 200:
                 status = AgentCheck.CRITICAL
-                msg = "Got %s when hitting %s" % (r.status_code, url)
+                msg = "Got %s when hitting %s" % (response.status_code, url)
             else:
                 status = AgentCheck.OK
                 msg = "Mesos master instance detected at %s " % url
@@ -178,28 +179,31 @@ class MesosMaster(AgentCheck):
             status = AgentCheck.CRITICAL
         finally:
             self.log.debug('Request to url : {0}, timeout: {1}, message: {2}'.format(url, timeout, msg))
-            self._send_service_check(url, r, status, failure_expected=failure_expected, tags=tags, message=msg)
+            self._send_service_check(url, status, failure_expected=failure_expected, tags=tags, message=msg)
 
-        if r.encoding is None:
-            r.encoding = 'UTF8'
+        if response.encoding is None:
+            response.encoding = 'UTF8'
 
-        return r.json()
+        return response.json()
 
-    def _send_service_check(self, url, response, status, failure_expected=False, tags=None, message=None):
+    def _send_service_check(self, url, status, failure_expected=False, tags=None, message=None):
+        skip_service_check = False
         if status is AgentCheck.CRITICAL and failure_expected:
-            status = AgentCheck.OK
-            message = "Got %s when hitting %s" % (response.status_code, url)
-            raise CheckException(message)
+            skip_service_check = True
+            message = "Error when calling {}: {}".format(url, message)
         elif status is AgentCheck.CRITICAL and not failure_expected:
-            raise CheckException('Cannot connect to mesos. Error: {0}'.format(message))
-        if self.service_check_needed:
+            message = 'Cannot connect to mesos. Error: {0}'.format(message)
+        if self.service_check_needed and not skip_service_check:
             self.service_check(self.SERVICE_CHECK_NAME, status, tags=tags, message=message)
             self.service_check_needed = False
 
+        if status is AgentCheck.CRITICAL:
+            raise CheckException(message)
+
     def _get_master_state(self, url, tags):
+        # Mesos version >= 0.25
+        endpoint = url + '/state'
         try:
-            # Mesos version >= 0.25
-            endpoint = url + '/state'
             master_state = self._get_json(endpoint, failure_expected=True, tags=tags)
         except CheckException:
             # Mesos version < 0.25

--- a/mesos_master/tests/common.py
+++ b/mesos_master/tests/common.py
@@ -12,6 +12,8 @@ PORT = '5050'
 
 INSTANCE = {'url': 'http://{}:{}'.format(HOST, PORT), 'tags': ['instance:mytag1']}
 
+BAD_INSTANCE = {'url': 'http://localhost:9999', 'tasks': ['hello']}
+
 CHECK_NAME = "mesos_master"
 
 FIXTURE_DIR = os.path.join(HERE, 'fixtures')

--- a/mesos_master/tests/compose/docker-compose.yml
+++ b/mesos_master/tests/compose/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       ZK_ID: 1
 
   mesos-master:
-    image: mesosphere/mesos-master:1.1.0-2.0.107.ubuntu1404
+    image: mesosphere/mesos-master:${MESOS_MASTER_VERSION}
     network_mode: host
     environment:
       - MESOS_ZK=zk://127.0.0.1:2181/mesos

--- a/mesos_master/tests/conftest.py
+++ b/mesos_master/tests/conftest.py
@@ -38,3 +38,8 @@ def mock(init_config, instance):
 @pytest.fixture
 def instance():
     return common.INSTANCE
+
+
+@pytest.fixture
+def bad_instance():
+    return common.BAD_INSTANCE

--- a/mesos_master/tests/test_integration.py
+++ b/mesos_master/tests/test_integration.py
@@ -4,13 +4,10 @@
 import platform
 
 import pytest
-from six import iteritems
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.errors import CheckException
 from datadog_checks.mesos_master import MesosMaster
-
-from .common import BASIC_METRICS, CHECK_NAME, INSTANCE
 
 # Linux only: https://github.com/docker/for-mac/issues/1031
 pytestmark = pytest.mark.skipif(platform.system() != 'Linux', reason='Only runs on Unix systems')

--- a/mesos_master/tests/test_integration.py
+++ b/mesos_master/tests/test_integration.py
@@ -1,0 +1,27 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import platform
+
+import pytest
+from six import iteritems
+
+from datadog_checks.base import AgentCheck
+from datadog_checks.base.errors import CheckException
+from datadog_checks.mesos_master import MesosMaster
+
+from .common import BASIC_METRICS, CHECK_NAME, INSTANCE
+
+# Linux only: https://github.com/docker/for-mac/issues/1031
+pytestmark = pytest.mark.skipif(platform.system() != 'Linux', reason='Only runs on Unix systems')
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("dd_environment")
+def test_service_check(bad_instance, aggregator):
+    check = MesosMaster('mesos_master', {}, [bad_instance])
+
+    with pytest.raises(CheckException):
+        check.check(bad_instance)
+
+    aggregator.assert_service_check('mesos_master.can_connect', count=1, status=AgentCheck.CRITICAL)

--- a/mesos_master/tests/test_integration_e2e.py
+++ b/mesos_master/tests/test_integration_e2e.py
@@ -6,10 +6,7 @@ import platform
 import pytest
 from six import iteritems
 
-from datadog_checks.base import AgentCheck
-from datadog_checks.base.errors import CheckException
 from datadog_checks.mesos_master import MesosMaster
-
 from .common import BASIC_METRICS, CHECK_NAME, INSTANCE
 
 

--- a/mesos_master/tests/test_integration_e2e.py
+++ b/mesos_master/tests/test_integration_e2e.py
@@ -13,7 +13,7 @@ from datadog_checks.mesos_master import MesosMaster
 from .common import BASIC_METRICS, CHECK_NAME, INSTANCE
 
 # Linux only: https://github.com/docker/for-mac/issues/1031
-pytest.mark.skipif(platform.system() != 'Linux', reason="Only runs on Unix systems")
+pytestmark = pytest.mark.skipif(platform.system() != 'Linux', reason='Only runs on Unix systems')
 
 
 @pytest.mark.e2e

--- a/mesos_master/tests/test_integration_e2e.py
+++ b/mesos_master/tests/test_integration_e2e.py
@@ -17,14 +17,14 @@ pytest.mark.skipif(platform.system() != 'Linux', reason="Only runs on Unix syste
 
 
 @pytest.mark.e2e
-def test_check_ok(dd_agent_check):
+def test_check_e2e(dd_agent_check):
     aggregator = dd_agent_check(INSTANCE, rate=True)
     assert_metric_coverage(aggregator)
 
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
-def test_integration(instance, aggregator):
+def test_check_integration(instance, aggregator):
     check = MesosMaster('mesos_master', {}, [instance])
     check.check(instance)
 

--- a/mesos_master/tests/test_integration_e2e.py
+++ b/mesos_master/tests/test_integration_e2e.py
@@ -11,12 +11,6 @@ from datadog_checks.mesos_master import MesosMaster
 from .common import BASIC_METRICS, CHECK_NAME, INSTANCE
 
 
-@pytest.mark.e2e
-def test_check_e2e(dd_agent_check):
-    aggregator = dd_agent_check(INSTANCE, rate=True)
-    assert_metric_coverage(aggregator)
-
-
 # Linux only: https://github.com/docker/for-mac/issues/1031
 @pytest.mark.skipif(platform.system() != 'Linux', reason='Only runs on Unix systems')
 @pytest.mark.integration
@@ -25,6 +19,12 @@ def test_check_integration(instance, aggregator):
     check = MesosMaster('mesos_master', {}, [instance])
     check.check(instance)
 
+    assert_metric_coverage(aggregator)
+
+
+@pytest.mark.e2e
+def test_check_e2e(dd_agent_check):
+    aggregator = dd_agent_check(INSTANCE, rate=True)
     assert_metric_coverage(aggregator)
 
 

--- a/mesos_master/tests/test_integration_e2e.py
+++ b/mesos_master/tests/test_integration_e2e.py
@@ -12,9 +12,6 @@ from datadog_checks.mesos_master import MesosMaster
 
 from .common import BASIC_METRICS, CHECK_NAME, INSTANCE
 
-# Linux only: https://github.com/docker/for-mac/issues/1031
-pytestmark = pytest.mark.skipif(platform.system() != 'Linux', reason='Only runs on Unix systems')
-
 
 @pytest.mark.e2e
 def test_check_e2e(dd_agent_check):
@@ -22,6 +19,8 @@ def test_check_e2e(dd_agent_check):
     assert_metric_coverage(aggregator)
 
 
+# Linux only: https://github.com/docker/for-mac/issues/1031
+@pytest.mark.skipif(platform.system() != 'Linux', reason='Only runs on Unix systems')
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
 def test_check_integration(instance, aggregator):
@@ -51,14 +50,3 @@ def assert_metric_coverage(aggregator):
     aggregator.assert_all_metrics_covered()
 
     aggregator.assert_service_check('mesos_master.can_connect', status=check.OK)
-
-
-@pytest.mark.integration
-@pytest.mark.usefixtures("dd_environment")
-def test_service_check(bad_instance, aggregator):
-    check = MesosMaster('mesos_master', {}, [bad_instance])
-
-    with pytest.raises(CheckException):
-        check.check(bad_instance)
-
-    aggregator.assert_service_check('mesos_master.can_connect', count=1, status=AgentCheck.CRITICAL)

--- a/mesos_master/tests/test_integration_e2e.py
+++ b/mesos_master/tests/test_integration_e2e.py
@@ -7,6 +7,7 @@ import pytest
 from six import iteritems
 
 from datadog_checks.mesos_master import MesosMaster
+
 from .common import BASIC_METRICS, CHECK_NAME, INSTANCE
 
 

--- a/mesos_master/tox.ini
+++ b/mesos_master/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py37
 envlist =
-    py{27,37}
+    py{27,37}-{1.0,1.1}
 
 [testenv]
 dd_check_style = true
@@ -16,6 +16,12 @@ deps =
 passenv =
     DOCKER*
     COMPOSE*
+setenv =
+    1.0: MESOS_MASTER_VERSION=1.0.1-2.0.93.ubuntu1404
+    1.1: MESOS_MASTER_VERSION=1.1.0-2.0.107.ubuntu1404
+    # TODO: Test newer mesos versions, seems some metrics are currently missing or not correctly collected
+    # 1.2: MESOS_MASTER_VERSION=1.2.0
+    # 1.7: MESOS_MASTER_VERSION=1.7.1
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?

Fix Mesos service check + Add tests.

Fix for https://github.com/DataDog/integrations-core/pull/4053

**Long term solution**

The service check logic should be outside of `_get_json` util method that is used multiple times. 
Currently, the logic is quite cumbersome because service check logic is inside the `_get_json` util method.



### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
