### PR TITLE
Better `env start` error output: show available envs

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -66,7 +66,8 @@ def start(ctx, check, env, agent, python, dev, base, env_vars):
 
     if env not in envs:
         echo_failure('`{}` is not an available environment.'.format(env))
-        echo_info('See what is available via `ddev env ls {}`.'.format(check))
+        echo_info('Available environments for {}: {}'.format(check, " ".join(envs)))
+        echo_info('You can also use `ddev env ls {}` to see available environments.'.format(check))
         abort()
 
     env_python_version = get_tox_env_python_version(env)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -66,7 +66,7 @@ def start(ctx, check, env, agent, python, dev, base, env_vars):
 
     if env not in envs:
         echo_failure('`{}` is not an available environment.'.format(env))
-        echo_info('Available environments for {}:\n\t{}'.format(check, "\n\t".join(envs)))
+        echo_info('Available environments for {}:\n    {}'.format(check, '\n    '.join(envs)))
         echo_info('You can also use `ddev env ls {}` to see available environments.'.format(check))
         abort()
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -66,7 +66,7 @@ def start(ctx, check, env, agent, python, dev, base, env_vars):
 
     if env not in envs:
         echo_failure('`{}` is not an available environment.'.format(env))
-        echo_info('Available environments for {}: {}'.format(check, " ".join(envs)))
+        echo_info('Available environments for {}:\n\t{}'.format(check, "\n\t".join(envs)))
         echo_info('You can also use `ddev env ls {}` to see available environments.'.format(check))
         abort()
 


### PR DESCRIPTION
### What does this PR do?

Better env start error output

![image](https://user-images.githubusercontent.com/49917914/63866040-e54e8200-c9b2-11e9-8de7-74f866766c79.png)


### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
