### PR TITLE
Revert "Fix queue, node and echange limit"

### DIFF
--- a/rabbitmq/tests/test_unit.py
+++ b/rabbitmq/tests/test_unit.py
@@ -7,7 +7,7 @@ import pytest
 import requests
 
 from datadog_checks.rabbitmq import RabbitMQ
-from datadog_checks.rabbitmq.rabbitmq import NODE_TYPE, RabbitMQException
+from datadog_checks.rabbitmq.rabbitmq import RabbitMQException
 
 pytestmark = pytest.mark.unit
 
@@ -80,12 +80,3 @@ def test__check_aliveness(check, aggregator):
     with pytest.raises(RabbitMQException) as e:
         check._get_vhosts(instance, '')
         assert isinstance(e, RabbitMQException)
-
-
-@pytest.mark.unit
-def test__get_metrics(check, aggregator):
-    data = {'fd_used': 3.14, 'disk_free': 4242, 'mem_used': 9000}
-
-    assert check._get_metrics(data, NODE_TYPE, []) == 3
-    assert check._get_metrics(data, NODE_TYPE, [], 2) == 2
-    assert check._get_metrics(data, NODE_TYPE, [], 5) == 3


### PR DESCRIPTION
The PR introduces some backward-incompatible changes: when we used to collect all metrics for up to `X` objects (queues/exchange/node), we now collect up to `X` metrics for any number of objects.

Because each object can have a lot of metrics, the new behavior submits way less metrics than it used to do. Let's revert for the agent 6.14 release until we find a more appropriate way to redo the same thing