### PR TITLE
Update class signature to support the RequestsWrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ stages:
 script:
   - ddev validate logos ${CHECK}
   - travis_retry ddev test --cov ${CHECK}
-  - travis_retry ddev env test --new-env ${CHECK}
+  - travis_retry ddev env test --base --new-env ${CHECK}
   - ddev test ${CHECK} --bench || true
   - if [ -n "$PYTHON3" ]; then ddev validate py3 ${CHECK}; fi
 

--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -1,12 +1,9 @@
 # (C) Datadog, Inc. 2010-2017
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-import warnings
-
 from six.moves.urllib.parse import urlparse
-from urllib3.exceptions import InsecureRequestWarning
 
-from datadog_checks.base import AgentCheck, is_affirmative
+from datadog_checks.base import AgentCheck
 
 
 class Apache(AgentCheck):
@@ -38,8 +35,8 @@ class Apache(AgentCheck):
         'connect_timeout': {'name': 'connect_timeout', 'default': 5},
     }
 
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+    def __init__(self, name, init_config, instances):
+        super(Apache, self).__init__(name, init_config, instances)
         self.assumed_url = {}
 
     def check(self, instance):
@@ -60,11 +57,8 @@ class Apache(AgentCheck):
                 'apache check initiating request, connect timeout %d receive %d'
                 % (self.http.options['timeout'][0], self.http.options['timeout'][1])
             )
-            with warnings.catch_warnings():
-                if is_affirmative(instance.get('tls_ignore_warning', False)):
-                    warnings.simplefilter('ignore', InsecureRequestWarning)
 
-                r = self.http.get(url)
+            r = self.http.get(url)
             r.raise_for_status()
 
         except Exception as e:

--- a/apache/tests/conftest.py
+++ b/apache/tests/conftest.py
@@ -36,4 +36,4 @@ def generate_metrics():
 
 @pytest.fixture
 def check():
-    return Apache(CHECK_NAME, {}, {})
+    return lambda instance: Apache(CHECK_NAME, {}, [instance])

--- a/apache/tests/test_apache.py
+++ b/apache/tests/test_apache.py
@@ -11,6 +11,7 @@ from .common import APACHE_GAUGES, APACHE_RATES, AUTO_CONFIG, BAD_CONFIG, HOST, 
 
 @pytest.mark.usefixtures("dd_environment")
 def test_connection_failure(aggregator, check):
+    check = check(BAD_CONFIG)
     with pytest.raises(Exception):
         check.check(BAD_CONFIG)
 
@@ -21,6 +22,7 @@ def test_connection_failure(aggregator, check):
 
 @pytest.mark.usefixtures("dd_environment")
 def test_check(aggregator, check):
+    check = check(STATUS_CONFIG)
     check.check(STATUS_CONFIG)
 
     tags = STATUS_CONFIG['tags']
@@ -35,6 +37,7 @@ def test_check(aggregator, check):
 
 @pytest.mark.usefixtures("dd_environment")
 def test_check_auto(aggregator, check):
+    check = check(AUTO_CONFIG)
     check.check(AUTO_CONFIG)
 
     tags = AUTO_CONFIG['tags']

--- a/couch/datadog_checks/couch/couch.py
+++ b/couch/datadog_checks/couch/couch.py
@@ -22,8 +22,8 @@ class CouchDb(AgentCheck):
     SOURCE_TYPE_NAME = 'couchdb'
     MAX_DB = 50
 
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+    def __init__(self, name, init_config, instances):
+        super(CouchDb, self).__init__(name, init_config, instances)
         self.checker = None
 
     def get(self, url, service_check_tags, run_check=False):

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -24,9 +24,9 @@ def check():
     couch_version = env["COUCH_VERSION"][0]
 
     if couch_version == '1':
-        return CouchDb(common.CHECK_NAME, {}, {}, instances=[common.BASIC_CONFIG])
+        return CouchDb(common.CHECK_NAME, {}, instances=[common.BASIC_CONFIG])
     elif couch_version == '2':
-        return CouchDb(common.CHECK_NAME, {}, {}, instances=[common.BASIC_CONFIG_V2])
+        return CouchDb(common.CHECK_NAME, {}, instances=[common.BASIC_CONFIG_V2])
 
 
 @pytest.fixture

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -66,13 +66,14 @@ def gauges():
 
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_check(aggregator, check, gauges, instance):
+def test_check(aggregator, gauges):
     """
     Testing Couchdb2 check.
     """
     configs = [deepcopy(common.NODE1), deepcopy(common.NODE2), deepcopy(common.NODE3)]
 
     for config in configs:
+        check = CouchDb(common.CHECK_NAME, {}, [config])
         check.check(config)
 
     for config in configs:
@@ -100,14 +101,14 @@ def test_check(aggregator, check, gauges, instance):
     for node in [common.NODE2, common.NODE3]:
         expected_tags = ["instance:{}".format(node["name"])]
         # One for the server stats, the version is already loaded
-        aggregator.assert_service_check(CouchDb.SERVICE_CHECK_NAME, status=CouchDb.OK, tags=expected_tags, count=1)
+        aggregator.assert_service_check(CouchDb.SERVICE_CHECK_NAME, status=CouchDb.OK, tags=expected_tags, count=2)
 
     aggregator.assert_all_metrics_covered()
 
 
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_db_whitelisting(aggregator, check, gauges, instance):
+def test_db_whitelisting(aggregator, gauges):
     configs = []
 
     for n in [common.NODE1, common.NODE2, common.NODE3]:
@@ -116,6 +117,7 @@ def test_db_whitelisting(aggregator, check, gauges, instance):
         configs.append(node)
 
     for config in configs:
+        check = CouchDb(common.CHECK_NAME, {}, [config])
         check.check(config)
 
     for _ in configs:
@@ -131,7 +133,7 @@ def test_db_whitelisting(aggregator, check, gauges, instance):
 
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_db_blacklisting(aggregator, check, gauges, instance):
+def test_db_blacklisting(aggregator, gauges):
     configs = []
 
     for node in [common.NODE1, common.NODE2, common.NODE3]:
@@ -140,6 +142,7 @@ def test_db_blacklisting(aggregator, check, gauges, instance):
         configs.append(config)
 
     for config in configs:
+        check = CouchDb(common.CHECK_NAME, {}, [config])
         check.check(config)
 
     for _ in configs:
@@ -155,9 +158,10 @@ def test_db_blacklisting(aggregator, check, gauges, instance):
 
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_check_without_names(aggregator, check, gauges, instance):
+def test_check_without_names(aggregator, gauges):
     config = deepcopy(common.NODE1)
     config.pop('name')
+    check = CouchDb(common.CHECK_NAME, {}, [config])
     check.check(config)
 
     configs = [common.NODE1, common.NODE2, common.NODE3]
@@ -194,11 +198,12 @@ def test_check_without_names(aggregator, check, gauges, instance):
 
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_only_max_nodes_are_scanned(aggregator, check, gauges, instance):
+def test_only_max_nodes_are_scanned(aggregator, gauges):
     config = deepcopy(common.NODE1)
     config.pop("name")
     config['max_nodes_per_check'] = 2
 
+    check = CouchDb(common.CHECK_NAME, {}, [config])
     check.check(config)
 
     for gauge in gauges["erlang_gauges"]:
@@ -245,7 +250,7 @@ def test_only_max_nodes_are_scanned(aggregator, check, gauges, instance):
 
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_only_max_dbs_are_scanned(aggregator, check, gauges, instance):
+def test_only_max_dbs_are_scanned(aggregator, gauges):
     configs = []
     for node in [common.NODE1, common.NODE2, common.NODE3]:
         config = deepcopy(node)
@@ -253,6 +258,7 @@ def test_only_max_dbs_are_scanned(aggregator, check, gauges, instance):
         configs.append(config)
 
     for config in configs:
+        check = CouchDb(common.CHECK_NAME, {}, [config])
         check.check(config)
 
     for db in ['kennel', '_replicator']:
@@ -268,7 +274,7 @@ def test_only_max_dbs_are_scanned(aggregator, check, gauges, instance):
 
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_replication_metrics(aggregator, check, gauges, instance):
+def test_replication_metrics(aggregator, gauges):
     url = "{}/_replicator".format(common.NODE1['server'])
     replication_body = {
         '_id': 'my_replication_id',
@@ -295,8 +301,8 @@ def test_replication_metrics(aggregator, check, gauges, instance):
         r.raise_for_status()
         count = len(r.json())
 
-    check = CouchDb(common.CHECK_NAME, {}, {}, instances=[instance])
     for config in [common.NODE1, common.NODE2, common.NODE3]:
+        check = CouchDb(common.CHECK_NAME, {}, [config])
         check.check(config)
 
     for gauge in gauges["replication_tasks_gauges"]:
@@ -305,7 +311,7 @@ def test_replication_metrics(aggregator, check, gauges, instance):
 
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_compaction_metrics(aggregator, check, gauges, instance):
+def test_compaction_metrics(aggregator, gauges):
     url = "{}/kennel".format(common.NODE1['server'])
     body = {'_id': 'fsdr2345fgwert249i9fg9drgsf4SDFGWE', 'data': str(time.time())}
     r = requests.post(
@@ -351,6 +357,7 @@ def test_compaction_metrics(aggregator, check, gauges, instance):
     r.raise_for_status()
 
     for config in [common.NODE1, common.NODE2, common.NODE3]:
+        check = CouchDb(common.CHECK_NAME, {}, [config])
         check.check(config)
 
     for gauge in gauges["compaction_tasks_gauges"]:
@@ -359,24 +366,23 @@ def test_compaction_metrics(aggregator, check, gauges, instance):
 
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_indexing_metrics(aggregator, check, gauges, active_tasks):
+def test_indexing_metrics(aggregator, gauges, active_tasks):
     """
     Testing metrics coming from a running indexer would be extremely flaky,
     let's use mock.
     """
     from datadog_checks.couch import couch
 
-    check.checker = couch.CouchDB2(check)
-
     def _get(url, tags, run_check=False):
         if '_active_tasks' in url:
             return active_tasks
         return {}
 
-    check.get = _get
-
     # run the check on all instances
     for config in [common.NODE1, common.NODE2, common.NODE3]:
+        check = CouchDb(common.CHECK_NAME, {}, [config])
+        check.checker = couch.CouchDB2(check)
+        check.get = _get
         check.check(config)
 
     for node in [common.NODE1, common.NODE2, common.NODE3]:
@@ -387,7 +393,7 @@ def test_indexing_metrics(aggregator, check, gauges, active_tasks):
 
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_view_compaction_metrics(aggregator, check, gauges, instance):
+def test_view_compaction_metrics(aggregator, gauges):
     class LoadGenerator(threading.Thread):
         STOP = 0
         RUN = 1
@@ -461,6 +467,7 @@ def test_view_compaction_metrics(aggregator, check, gauges, instance):
 
             try:
                 for config in [common.NODE1, common.NODE2, common.NODE3]:
+                    check = CouchDb(common.CHECK_NAME, {}, [config])
                     check.check(config)
             except Exception:
                 time.sleep(1)
@@ -485,11 +492,12 @@ def test_view_compaction_metrics(aggregator, check, gauges, instance):
 
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_config_tags(aggregator, check, gauges, instance):
+def test_config_tags(aggregator, gauges):
     TEST_TAG = "test_tag:test"
     config = deepcopy(common.NODE1)
     config['tags'] = [TEST_TAG]
 
+    check = CouchDb(common.CHECK_NAME, {}, [config])
     check.check(config)
 
     for gauge in gauges["erlang_gauges"]:

--- a/couchbase/datadog_checks/couchbase/couchbase.py
+++ b/couchbase/datadog_checks/couchbase/couchbase.py
@@ -42,8 +42,8 @@ class Couchbase(AgentCheck):
         def __init__(self):
             self.previous_status = None
 
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+    def __init__(self, name, init_config, instances):
+        super(Couchbase, self).__init__(name, init_config, instances)
 
         # Keep track of all instances
         self._instance_states = defaultdict(lambda: self.CouchbaseInstanceState())

--- a/couchbase/tests/test_couchbase.py
+++ b/couchbase/tests/test_couchbase.py
@@ -22,7 +22,7 @@ def test_service_check(aggregator, instance, couchbase_container_ip):
     """
     Assert the OK service check
     """
-    couchbase = Couchbase('couchbase', {}, {}, instances=[instance])
+    couchbase = Couchbase('couchbase', {}, instances=[instance])
     couchbase.check(instance)
 
     NODE_HOST = '{}:{}'.format(couchbase_container_ip, PORT)
@@ -43,7 +43,7 @@ def test_metrics(aggregator, instance, couchbase_container_ip):
     """
     Test couchbase metrics not including 'couchbase.query.'
     """
-    couchbase = Couchbase('couchbase', {}, {}, instances=[instance])
+    couchbase = Couchbase('couchbase', {}, instances=[instance])
     couchbase.check(instance)
     assert_basic_couchbase_metrics(aggregator, couchbase_container_ip)
 
@@ -54,7 +54,7 @@ def test_query_monitoring_metrics(aggregator, instance_query, couchbase_containe
     """
     Test system vitals metrics (prefixed "couchbase.query.")
     """
-    couchbase = Couchbase('couchbase', {}, {}, instances=[instance_query])
+    couchbase = Couchbase('couchbase', {}, instances=[instance_query])
     couchbase.check(instance_query)
 
     for mname in QUERY_STATS:

--- a/couchbase/tests/test_unit.py
+++ b/couchbase/tests/test_unit.py
@@ -5,7 +5,7 @@ from datadog_checks.couchbase import Couchbase
 
 
 def test_camel_case_to_joined_lower():
-    couchbase = Couchbase('couchbase', {}, {})
+    couchbase = Couchbase('couchbase', {}, [{}])
 
     CAMEL_CASE_TEST_PAIRS = {
         'camelCase': 'camel_case',
@@ -28,7 +28,7 @@ def test_camel_case_to_joined_lower():
 
 
 def test_extract_seconds_value():
-    couchbase = Couchbase('couchbase', {}, {})
+    couchbase = Couchbase('couchbase', {}, [{}])
 
     EXTRACT_SECONDS_TEST_PAIRS = {
         '3.45s': 3.45,
@@ -50,5 +50,5 @@ def test__get_query_monitoring_data():
     `query_monitoring_url` can potentially fail, be sure we don't raise when the
     endpoint is not reachable
     """
-    couchbase = Couchbase('couchbase', {}, {})
+    couchbase = Couchbase('couchbase', {}, [{}])
     couchbase._get_query_monitoring_data({'query_monitoring_url': 'http://foo/bar'})

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -23,16 +23,28 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
 
     DEFAULT_METRIC_LIMIT = 2000
 
-    def __init__(self, name, init_config, agentConfig, instances=None, default_instances=None, default_namespace=None):
-        super(OpenMetricsBaseCheck, self).__init__(name, init_config, agentConfig, instances=instances)
+    def __init__(self, *args, **kwargs):
+        args = list(args)
+        default_instances = kwargs.pop('default_instances', None) or {}
+        default_namespace = kwargs.pop('default_namespace', None)
+
+        legacy_kwargs_in_args = args[4:]
+        del args[4:]
+
+        if len(legacy_kwargs_in_args) > 1:
+            default_instances = legacy_kwargs_in_args[0]
+            default_namespace = legacy_kwargs_in_args[1]
+        elif len(legacy_kwargs_in_args) > 0:
+            default_instances = legacy_kwargs_in_args[0]
+
+        super(OpenMetricsBaseCheck, self).__init__(*args, **kwargs)
         self.config_map = {}
-        self.default_instances = {} if default_instances is None else default_instances
+        self.default_instances = default_instances
         self.default_namespace = default_namespace
 
         # pre-generate the scraper configurations
-        if instances is not None:
-            for instance in instances:
-                self.get_scraper_config(instance)
+        if self.instance is not None:
+            self.get_scraper_config(self.instance)
 
     def check(self, instance):
         # Get the configuration for this specific instance

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -43,10 +43,15 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
         self.default_namespace = default_namespace
 
         # pre-generate the scraper configurations
-        instances = kwargs.get('instances', [self.instance])
+        if 'instances' in kwargs:
+            instances = kwargs['instances']
+        elif len(args) == 4:
+            instances = args[3]
+        else:
+            instances = args[2]
+
         if instances is not None:
             for instance in instances:
-                # raise Exception('jjjjjjjjjjj')
                 self.get_scraper_config(instance)
 
     def check(self, instance):

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -43,8 +43,11 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
         self.default_namespace = default_namespace
 
         # pre-generate the scraper configurations
-        if self.instance is not None:
-            self.get_scraper_config(self.instance)
+        instances = kwargs.get('instances', [self.instance])
+        if instances is not None:
+            for instance in instances:
+                # raise Exception('jjjjjjjjjjj')
+                self.get_scraper_config(instance)
 
     def check(self, instance):
         # Get the configuration for this specific instance

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -31,11 +31,10 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
         legacy_kwargs_in_args = args[4:]
         del args[4:]
 
+        if len(legacy_kwargs_in_args) > 0:
+            default_instances = legacy_kwargs_in_args[0] or {}
         if len(legacy_kwargs_in_args) > 1:
-            default_instances = legacy_kwargs_in_args[0]
             default_namespace = legacy_kwargs_in_args[1]
-        elif len(legacy_kwargs_in_args) > 0:
-            default_instances = legacy_kwargs_in_args[0]
 
         super(OpenMetricsBaseCheck, self).__init__(*args, **kwargs)
         self.config_map = {}

--- a/datadog_checks_base/tests/test_openmetrics_base_check.py
+++ b/datadog_checks_base/tests/test_openmetrics_base_check.py
@@ -8,6 +8,50 @@ from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 FIXTURE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtures', 'bearer_tokens')
 
 
+class TestSignature:
+    def test_default_legacy_basic(self):
+        check = OpenMetricsBaseCheck('openmetrics_check', {}, {})
+
+        assert check.default_instances == {}
+        assert check.default_namespace is None
+
+    def test_default_instances(self):
+        instance = {'prometheus_url': 'endpoint'}
+        check = OpenMetricsBaseCheck('openmetrics_check', {}, [instance], default_namespace='openmetrics')
+
+        assert check.default_instances == {}
+        assert check.default_namespace == 'openmetrics'
+        assert 'endpoint' in check.config_map
+
+    def test_default_instances_legacy(self):
+        instance = {'prometheus_url': 'endpoint'}
+        check = OpenMetricsBaseCheck('openmetrics_check', {}, {}, [instance], default_namespace='openmetrics')
+
+        assert check.default_instances == {}
+        assert check.default_namespace == 'openmetrics'
+        assert 'endpoint' in check.config_map
+
+    def test_default_instances_legacy_kwarg(self):
+        instance1 = {'prometheus_url': 'endpoint1'}
+        instance2 = {'prometheus_url': 'endpoint2'}
+        check = OpenMetricsBaseCheck(
+            'openmetrics_check', {}, {}, instances=[instance1, instance2], default_namespace='openmetrics'
+        )
+
+        assert check.default_instances == {}
+        assert check.default_namespace == 'openmetrics'
+        assert 'endpoint1' in check.config_map
+        assert 'endpoint2' in check.config_map
+
+    def test_args_legacy(self):
+        instance = {'prometheus_url': 'endpoint'}
+        check = OpenMetricsBaseCheck('openmetrics_check', {}, {}, [instance], None, 'openmetrics')
+
+        assert check.default_instances == {}
+        assert check.default_namespace == 'openmetrics'
+        assert 'endpoint' in check.config_map
+
+
 def test_rate_override():
     endpoint = "none"
     instance = {

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -35,8 +35,8 @@ class ESCheck(AgentCheck):
     SERVICE_CHECK_CLUSTER_STATUS = 'elasticsearch.cluster_health'
     SOURCE_TYPE_NAME = 'elasticsearch'
 
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+    def __init__(self, name, init_config, instances):
+        super(ESCheck, self).__init__(name, init_config, instances)
         # Host status needs to persist across all checks
         self.cluster_status = {}
 

--- a/elastic/tests/conftest.py
+++ b/elastic/tests/conftest.py
@@ -43,7 +43,7 @@ def dd_environment(instance):
 
 @pytest.fixture
 def elastic_check():
-    return ESCheck('elastic', {}, {}, instances=[INSTANCE])
+    return ESCheck('elastic', {}, instances=[INSTANCE])
 
 
 @pytest.fixture(scope='session')

--- a/gitlab/datadog_checks/gitlab/gitlab.py
+++ b/gitlab/datadog_checks/gitlab/gitlab.py
@@ -33,14 +33,10 @@ class GitlabCheck(OpenMetricsBaseCheck):
         'ssl_ca_certs': {'name': 'tls_ca_cert'},
     }
 
-    def __init__(self, name, init_config, agentConfig, instances=None):
-
-        generic_instances = []
-        if instances is not None:
-            for instance in instances:
-                generic_instances.append(self._create_gitlab_prometheus_instance(instance, init_config))
-
-        super(GitlabCheck, self).__init__(name, init_config, agentConfig, instances=generic_instances)
+    def __init__(self, name, init_config, instances):
+        super(GitlabCheck, self).__init__(
+            name, init_config, [self._create_gitlab_prometheus_instance(instances[0], init_config)]
+        )
 
     def check(self, instance):
         # Metrics collection

--- a/gitlab/tests/test_bench.py
+++ b/gitlab/tests/test_bench.py
@@ -11,7 +11,7 @@ from .common import CONFIG
 @pytest.mark.usefixtures("dd_environment")
 def test_run(benchmark):
     instance = CONFIG['instances'][0]
-    c = GitlabCheck('gitlab', CONFIG['init_config'], {}, instances=CONFIG['instances'])
+    c = GitlabCheck('gitlab', CONFIG['init_config'], instances=CONFIG['instances'])
 
     # Run once to get any initialization out of the way.
     c.check(instance)

--- a/gitlab/tests/test_integration.py
+++ b/gitlab/tests/test_integration.py
@@ -16,7 +16,7 @@ def test_connection_failure(aggregator):
     Make sure we're failing when the URL isn't right
     """
 
-    gitlab = GitlabCheck('gitlab', BAD_CONFIG['init_config'], {}, instances=BAD_CONFIG['instances'])
+    gitlab = GitlabCheck('gitlab', BAD_CONFIG['init_config'], instances=BAD_CONFIG['instances'])
 
     with pytest.raises(ConnectionError):
         gitlab.check(BAD_CONFIG['instances'][0])

--- a/gitlab/tests/test_integration_e2e.py
+++ b/gitlab/tests/test_integration_e2e.py
@@ -33,7 +33,7 @@ def test_check_integration(aggregator):
     instance = CONFIG['instances'][0]
     init_config = CONFIG['init_config']
 
-    gitlab = GitlabCheck('gitlab', init_config, {}, instances=[instance])
+    gitlab = GitlabCheck('gitlab', init_config, instances=[instance])
 
     gitlab.check(instance)
     gitlab.check(instance)

--- a/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
@@ -33,14 +33,10 @@ class GitlabRunnerCheck(OpenMetricsBaseCheck):
         'ssl_ca_certs': {'name': 'tls_ca_cert'},
     }
 
-    def __init__(self, name, init_config, agentConfig, instances=None):
-
-        generic_instances = []
-        if instances is not None:
-            for instance in instances:
-                generic_instances.append(self._create_gitlab_runner_prometheus_instance(instance, init_config))
-
-        super(GitlabRunnerCheck, self).__init__(name, init_config, agentConfig, instances=generic_instances)
+    def __init__(self, name, init_config, instances):
+        super(GitlabRunnerCheck, self).__init__(
+            name, init_config, [self._create_gitlab_runner_prometheus_instance(instances[0], init_config)]
+        )
 
     def check(self, instance):
         # Metrics collection

--- a/gitlab_runner/tests/test_integration.py
+++ b/gitlab_runner/tests/test_integration.py
@@ -16,7 +16,7 @@ def test_connection_failure(aggregator):
     Make sure we're failing when the URL isn't right
     """
 
-    gitlab_runner = GitlabRunnerCheck('gitlab', BAD_CONFIG['init_config'], {}, instances=BAD_CONFIG['instances'])
+    gitlab_runner = GitlabRunnerCheck('gitlab', BAD_CONFIG['init_config'], instances=BAD_CONFIG['instances'])
 
     with pytest.raises(ConnectionError):
         gitlab_runner.check(BAD_CONFIG['instances'][0])

--- a/gitlab_runner/tests/test_integration_e2e.py
+++ b/gitlab_runner/tests/test_integration_e2e.py
@@ -31,7 +31,7 @@ def assert_check(aggregator):
 
 @pytest.mark.usefixtures("dd_environment")
 def test_check(aggregator):
-    gitlab_runner = GitlabRunnerCheck('gitlab_runner', CONFIG['init_config'], {}, instances=CONFIG['instances'])
+    gitlab_runner = GitlabRunnerCheck('gitlab_runner', CONFIG['init_config'], instances=CONFIG['instances'])
 
     gitlab_runner.check(CONFIG['instances'][0])
     gitlab_runner.check(CONFIG['instances'][0])

--- a/ibm_was/datadog_checks/ibm_was/ibm_was.py
+++ b/ibm_was/datadog_checks/ibm_was/ibm_was.py
@@ -17,8 +17,8 @@ class IbmWasCheck(AgentCheck):
     SERVICE_CHECK_CONNECT = "ibm_was.can_connect"
     METRIC_PREFIX = 'ibm_was'
 
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+    def __init__(self, name, init_config, instances):
+        super(IbmWasCheck, self).__init__(name, init_config, instances)
         self.metric_type_mapping = {
             'AverageStatistic': self.gauge,
             'BoundedRangeStatistic': self.gauge,

--- a/ibm_was/tests/conftest.py
+++ b/ibm_was/tests/conftest.py
@@ -43,4 +43,4 @@ def instance():
 
 @pytest.fixture()
 def check():
-    return IbmWasCheck('ibm_was', {}, {})
+    return lambda instance: IbmWasCheck('ibm_was', {}, [instance or common.INSTANCE])

--- a/ibm_was/tests/test_integration.py
+++ b/ibm_was/tests/test_integration.py
@@ -10,6 +10,7 @@ pytestmark = pytest.mark.integration
 
 @pytest.mark.usefixtures('dd_environment')
 def test_check(aggregator, instance, check):
+    check = check(instance)
     check.check(instance)
 
     for metric_name in common.METRICS_ALWAYS_PRESENT:

--- a/ibm_was/tests/test_unit.py
+++ b/ibm_was/tests/test_unit.py
@@ -22,6 +22,7 @@ def mock_data(file):
 
 def test_metric_collection_per_category(aggregator, instance, check):
     with mock.patch('datadog_checks.ibm_was.IbmWasCheck.make_request', return_value=mock_data('server.xml')):
+        check = check(instance)
         check.check(instance)
 
     for metric_name in common.METRICS_ALWAYS_PRESENT:
@@ -31,6 +32,7 @@ def test_metric_collection_per_category(aggregator, instance, check):
 
 def test_custom_query(aggregator, instance, check):
     with mock.patch('datadog_checks.ibm_was.IbmWasCheck.make_request', return_value=mock_data('server.xml')):
+        check = check(instance)
         check.check(instance)
 
     aggregator.assert_metric_has_tag(
@@ -41,6 +43,7 @@ def test_custom_query(aggregator, instance, check):
 
 def test_custom_queries_missing_stat_in_payload(instance, check):
     with mock.patch('datadog_checks.ibm_was.IbmWasCheck.make_request', return_value=mock_data('server.xml')):
+        check = check(instance)
         check.check(instance)
 
     assert "Error finding JDBC Connection Custom stats in XML output." in check.warnings
@@ -49,6 +52,7 @@ def test_custom_queries_missing_stat_in_payload(instance, check):
 def test_custom_query_validation(check):
     with mock.patch('datadog_checks.ibm_was.IbmWasCheck.make_request', return_value=mock_data('server.xml')):
         with pytest.raises(ConfigurationError) as e:
+            check = check(None)
             check.check(common.MALFORMED_CUSTOM_QUERY_INSTANCE)
             assert "missing required field" in str(e)
 
@@ -56,6 +60,7 @@ def test_custom_query_validation(check):
 def test_config_validation(check):
     with mock.patch('datadog_checks.ibm_was.IbmWasCheck.make_request', return_value=mock_data('server.xml')):
         with pytest.raises(ConfigurationError) as e:
+            check = check(None)
             check.check(common.MISSING_REQ_FIELD_INSTANCE)
             assert "Please specify a servlet_url" in str(e)
 
@@ -65,6 +70,7 @@ def test_critical_service_check(instance, check, aggregator):
     tags = ['url:{}'.format(instance['servlet_url']), 'key1:value1']
 
     with pytest.raises(requests.ConnectionError):
+        check = check(instance)
         check.check(instance)
 
     aggregator.assert_service_check('ibm_was.can_connect', status=AgentCheck.CRITICAL, tags=tags, count=1)

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -112,8 +112,8 @@ class OpenStackControllerCheck(AgentCheck):
 
     HTTP_CONFIG_REMAPPER = {'ssl_verify': {'name': 'tls_verify'}, 'request_timeout': {'name': 'timeout'}}
 
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        super(OpenStackControllerCheck, self).__init__(name, init_config, agentConfig, instances)
+    def __init__(self, name, init_config, instances):
+        super(OpenStackControllerCheck, self).__init__(name, init_config, instances)
         # We cache all api instances.
         # This allows to cache connection if the underlying implementation support it
         # Ex: _api = <api object>

--- a/openstack_controller/tests/test_metrics.py
+++ b/openstack_controller/tests/test_metrics.py
@@ -173,7 +173,7 @@ class MockHTTPResponse(object):
 def test_scenario(make_request, aggregator):
     instance = common.MOCK_CONFIG["instances"][0]
     init_config = common.MOCK_CONFIG['init_config']
-    check = OpenStackControllerCheck('openstack_controller', init_config, {}, instances=[instance])
+    check = OpenStackControllerCheck('openstack_controller', init_config, [instance])
 
     auth_tokens_response_path = os.path.join(common.FIXTURES_DIR, "auth_tokens_response.json")
     with open(auth_tokens_response_path, 'r') as f:

--- a/openstack_controller/tests/test_openstack.py
+++ b/openstack_controller/tests/test_openstack.py
@@ -19,7 +19,7 @@ def test_parse_uptime_string(aggregator):
     instance = copy.deepcopy(common.KEYSTONE_INSTANCE)
     instance['tags'] = ['optional:tag1']
     init_config = common.MOCK_CONFIG['init_config']
-    check = OpenStackControllerCheck('openstack_controller', init_config, {}, instances=[instance])
+    check = OpenStackControllerCheck('openstack_controller', init_config, [instance])
     response = u' 16:53:48 up 1 day, 21:34,  3 users,  load average: 0.04, 0.14, 0.19\n'
     uptime_parsed = check._parse_uptime_string(response)
     assert uptime_parsed == [0.04, 0.14, 0.19]
@@ -34,7 +34,7 @@ def test_populate_servers_cache_between_runs(servers_detail, aggregator):
     Ensure the cache contains the expected VMs between check runs.
     """
 
-    check = OpenStackControllerCheck("test", {'ssl_verify': False}, {}, instances=[common.KEYSTONE_INSTANCE])
+    check = OpenStackControllerCheck("test", {'ssl_verify': False}, [common.KEYSTONE_INSTANCE])
 
     # Start off with a list of servers
     check.servers_cache = copy.deepcopy(common.SERVERS_CACHE_MOCK)
@@ -62,9 +62,7 @@ def test_populate_servers_cache_with_project_name_none(servers_detail, aggregato
     """
     Ensure the cache contains the expected VMs between check runs.
     """
-    check = OpenStackControllerCheck(
-        "test", {'ssl_verify': False}, {}, instances=[copy.deepcopy(common.KEYSTONE_INSTANCE)]
-    )
+    check = OpenStackControllerCheck("test", {'ssl_verify': False}, [copy.deepcopy(common.KEYSTONE_INSTANCE)])
 
     # Start off with a list of servers
     check.servers_cache = copy.deepcopy(common.SERVERS_CACHE_MOCK)
@@ -86,7 +84,7 @@ def test_populate_servers_cache_with_project_name_none(servers_detail, aggregato
 
 @mock.patch('datadog_checks.openstack_controller.api.ApiFactory.create', return_value=mock.MagicMock(AbstractApi))
 def test_check(mock_api, aggregator):
-    check = OpenStackControllerCheck("test", {'ssl_verify': False}, {}, instances=[common.KEYSTONE_INSTANCE])
+    check = OpenStackControllerCheck("test", {'ssl_verify': False}, [common.KEYSTONE_INSTANCE])
 
     check.check(common.KEYSTONE_INSTANCE)
 
@@ -98,7 +96,7 @@ def test_check(mock_api, aggregator):
 
 @mock.patch('datadog_checks.openstack_controller.api.ApiFactory.create', return_value=mock.MagicMock(AbstractApi))
 def test_check_with_config_file(mock_api, aggregator):
-    check = OpenStackControllerCheck("test", {'ssl_verify': False}, {}, instances=[common.CONFIG_FILE_INSTANCE])
+    check = OpenStackControllerCheck("test", {'ssl_verify': False}, [common.CONFIG_FILE_INSTANCE])
 
     check.check(common.CONFIG_FILE_INSTANCE)
 
@@ -124,7 +122,7 @@ def test_get_paginated_server(servers_detail, aggregator):
     """
 
     check = OpenStackControllerCheck(
-        "test", {'ssl_verify': False, 'paginated_server_limit': 1}, {}, instances=[common.KEYSTONE_INSTANCE]
+        "test", {'ssl_verify': False, 'paginated_server_limit': 1}, [common.KEYSTONE_INSTANCE]
     )
     check.populate_servers_cache({'testproj': {"id": "6f70656e737461636b20342065766572", "name": "testproj"}}, [])
     servers = check.servers_cache['servers']
@@ -187,7 +185,7 @@ def get_server_diagnostics_pre_2_48_response(server_id):
 )
 def test_collect_server_metrics_pre_2_48(server_diagnostics, os_aggregates, aggregator):
     check = OpenStackControllerCheck(
-        "test", {'ssl_verify': False, 'paginated_server_limit': 1}, {}, instances=[common.KEYSTONE_INSTANCE]
+        "test", {'ssl_verify': False, 'paginated_server_limit': 1}, [common.KEYSTONE_INSTANCE]
     )
 
     check.collect_server_diagnostic_metrics({})
@@ -336,7 +334,7 @@ def test_collect_server_metrics_pre_2_48(server_diagnostics, os_aggregates, aggr
 
 def test_get_keystone_url_from_openstack_config():
     check = OpenStackControllerCheck(
-        "test", {'ssl_verify': False, 'paginated_server_limit': 1}, {}, instances=[common.CONFIG_FILE_INSTANCE]
+        "test", {'ssl_verify': False, 'paginated_server_limit': 1}, [common.CONFIG_FILE_INSTANCE]
     )
     keystone_server_url = check._get_keystone_server_url(common.CONFIG_FILE_INSTANCE)
     assert keystone_server_url == 'http://xxx.xxx.xxx.xxx:5000/v2.0/'
@@ -344,7 +342,7 @@ def test_get_keystone_url_from_openstack_config():
 
 def test_get_keystone_url_from_datadog_config():
     check = OpenStackControllerCheck(
-        "test", {'ssl_verify': False, 'paginated_server_limit': 1}, {}, instances=[common.KEYSTONE_INSTANCE]
+        "test", {'ssl_verify': False, 'paginated_server_limit': 1}, [common.KEYSTONE_INSTANCE]
     )
     keystone_server_url = check._get_keystone_server_url(common.KEYSTONE_INSTANCE)
     assert keystone_server_url == 'http://10.0.2.15:5000'
@@ -354,7 +352,7 @@ def test_get_keystone_url_from_implicit_openstack_config():
     # This test is for documentation purposes because it is really testing OpenStackConfig
     instance = copy.deepcopy(common.CONFIG_FILE_INSTANCE)
     instance['openstack_cloud_name'] = 'rackspace'
-    check = OpenStackControllerCheck("test", {}, {}, instances=[instance])
+    check = OpenStackControllerCheck("test", {}, [instance])
     keystone_server_url = check._get_keystone_server_url(instance)
     assert keystone_server_url == 'https://identity.api.rackspacecloud.com/v2.0/'
 
@@ -363,7 +361,7 @@ def test_missing_keystone_server_url():
     # This test is for documentation purposes because it is really testing OpenStackConfig
     instance = copy.deepcopy(common.KEYSTONE_INSTANCE)
     instance['keystone_server_url'] = None
-    check = OpenStackControllerCheck("test", {}, {}, instances=[instance])
+    check = OpenStackControllerCheck("test", {}, [instance])
 
     with pytest.raises(IncompleteConfig):
         check._get_keystone_server_url(instance)

--- a/twistlock/datadog_checks/twistlock/twistlock.py
+++ b/twistlock/datadog_checks/twistlock/twistlock.py
@@ -35,8 +35,8 @@ class TwistlockCheck(AgentCheck):
 
     HTTP_CONFIG_REMAPPER = {'ssl_verify': {'name': 'tls_verify'}}
 
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+    def __init__(self, name, init_config, instances):
+        super(TwistlockCheck, self).__init__(name, init_config, instances)
 
         self.last_run = datetime.utcnow()
 

--- a/twistlock/tests/test_twistlock.py
+++ b/twistlock/tests/test_twistlock.py
@@ -61,7 +61,7 @@ def mock_get(url, *args, **kwargs):
 
 def test_check(aggregator):
 
-    check = TwistlockCheck('twistlock', {}, {})
+    check = TwistlockCheck('twistlock', {}, [instance])
 
     with mock.patch('requests.get', side_effect=mock_get, autospec=True):
         check.check(instance)


### PR DESCRIPTION
### Motivation

Use of the [RequestsWrapper](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/utils/http.py) requires the Agent 6 signature. Our tests did not catch this since most options (user/pass, certs, etc.) are not used in tests.

This completes https://github.com/DataDog/integrations-core/pull/4243

### Additional Notes

`gitlab` and `gitlab_runner` also inherit from `OpenMetricsBaseCheck` so I had to modify that too