### PR TITLE
Make integration test work on OSX

### DIFF
--- a/mesos_master/tests/compose/docker-compose.yml
+++ b/mesos_master/tests/compose/docker-compose.yml
@@ -5,22 +5,18 @@ version: "3.5"
 services:
   zookeeper:
     image: bobrik/zookeeper
-    network_mode: host
     environment:
       ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=no,clientPort=2181
       ZK_ID: 1
 
   mesos-master:
     image: mesosphere/mesos-master:${MESOS_MASTER_VERSION}
-    network_mode: host
     environment:
-      - MESOS_ZK=zk://127.0.0.1:2181/mesos
+      - MESOS_ZK=zk://zookeeper:2181/mesos
       - MESOS_QUORUM=1
       - MESOS_CLUSTER=docker-compose
       # default is in_memory for some reason
       - MESOS_REGISTRY=replicated_log
-      - MESOS_HOSTNAME=127.0.0.1
-      - LIBPROCESS_IP=127.0.0.1
     ports:
       - 5050:5050
     depends_on:

--- a/mesos_master/tests/test_integration_e2e.py
+++ b/mesos_master/tests/test_integration_e2e.py
@@ -1,8 +1,6 @@
 # (C) Datadog, Inc. 2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import platform
-
 import pytest
 from six import iteritems
 
@@ -11,8 +9,6 @@ from datadog_checks.mesos_master import MesosMaster
 from .common import BASIC_METRICS, CHECK_NAME, INSTANCE
 
 
-# Linux only: https://github.com/docker/for-mac/issues/1031
-@pytest.mark.skipif(platform.system() != 'Linux', reason='Only runs on Unix systems')
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
 def test_check_integration(instance, aggregator):


### PR DESCRIPTION
Bridge mode is not advised, but it should be good enough for our tests,
and it allows running it on Mac.