### PR TITLE
[windows_service] search patterns in reverse sort order

### DIFF
--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -57,7 +57,7 @@ class WindowsService(AgentCheck):
 
         for short_name, _, service_status in service_statuses:
             if 'ALL' not in services:
-                for service, service_pattern in iteritems(service_patterns):
+                for service, service_pattern in sorted(iteritems(service_patterns), reverse=True):
                     self.log.debug(
                         'Service: {} with Short Name: {} and Pattern: {}'.format(
                             service, short_name, service_pattern.pattern


### PR DESCRIPTION
### What does this PR do?

checks patterns in reverse sorted order.
Given 2 services `foobar` and `foobarbaz`

```
  services:
    - foobar
    - foobarbaz
```

the order in which this currently runs is (unable to determine the order)

```
service: foobar, pattern: foobar
service: foobarbaz, pattern: foobarbaz
```
Result: 
- `service: foobar` will match both `foobar` and `foobarbaz`
- `service: foobarbaz` will return status 2 since `foobarbaz` was already removed from services_unseen in previous iteration.
---
with this PR it would check in this order

```
service: foobarbaz, pattern: foobarbaz
service: foobar, pattern: foobar
```

### Motivation

There have been several cases where similarly named services return incorrect statuses. Workaround was to enclose the regex with `^$` to perform an exact match.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
