### PR TITLE
Fix error handling

### DIFF
--- a/go_expvar/datadog_checks/go_expvar/go_expvar.py
+++ b/go_expvar/datadog_checks/go_expvar/go_expvar.py
@@ -166,7 +166,7 @@ class GoExpvar(AgentCheck):
 
                 try:
                     float(value)
-                except TypeError:
+                except (TypeError, ValueError):
                     self.log.warning("Unreportable value for path %s: %s" % (path, value))
                     continue
 

--- a/go_expvar/datadog_checks/go_expvar/go_expvar.py
+++ b/go_expvar/datadog_checks/go_expvar/go_expvar.py
@@ -166,7 +166,7 @@ class GoExpvar(AgentCheck):
 
                 try:
                     float(value)
-                except ValueError:
+                except TypeError:
                     self.log.warning("Unreportable value for path %s: %s" % (path, value))
                     continue
 


### PR DESCRIPTION
### Motivation

```
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/base.py", line 556, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/go_expvar/go_expvar.py", line 128, in check
          self.parse_expvar_data(data, tags, metrics, max_metrics, namespace)
        File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/go_expvar/go_expvar.py", line 168, in parse_expvar_data
          float(value)
      TypeError: float() argument must be a string or a number
```

![Capture](https://user-images.githubusercontent.com/9677399/64269204-81264380-cf07-11e9-8f81-e94eb9470fcc.PNG)
