### PR TITLE
Fix ecs_fargate timeout

### DIFF
--- a/ecs_fargate/tests/test_unit.py
+++ b/ecs_fargate/tests/test_unit.py
@@ -223,3 +223,23 @@ def test_successful_check(check, instance, aggregator):
             aggregator.assert_metric(metric, count=1, tags=tags)
 
     aggregator.assert_all_metrics_covered()
+
+
+@pytest.mark.parametrize(
+    'test_case, extra_config, expected_http_kwargs',
+    [("explicit timeout", {'timeout': 30}, {'timeout': (30, 30)}), ("default timeout", {}, {'timeout': (5, 5)})],
+)
+def test_config(instance, test_case, extra_config, expected_http_kwargs):
+    instance = extra_config
+    check = FargateCheck('ecs_fargate', {}, instances=[instance])
+
+    with mock.patch('datadog_checks.base.utils.http.requests') as r:
+        r.get.return_value = mock.MagicMock(status_code=200)
+
+        check.check(instance)
+
+        http_wargs = dict(
+            auth=mock.ANY, cert=mock.ANY, headers=mock.ANY, proxies=mock.ANY, timeout=mock.ANY, verify=mock.ANY
+        )
+        http_wargs.update(expected_http_kwargs)
+        r.get.assert_called_with('http://169.254.170.2/v2/metadata', **http_wargs)

--- a/ecs_fargate/tests/test_unit.py
+++ b/ecs_fargate/tests/test_unit.py
@@ -229,7 +229,7 @@ def test_successful_check(check, instance, aggregator):
     'test_case, extra_config, expected_http_kwargs',
     [("explicit timeout", {'timeout': 30}, {'timeout': (30, 30)}), ("default timeout", {}, {'timeout': (5, 5)})],
 )
-def test_config(instance, test_case, extra_config, expected_http_kwargs):
+def test_config(test_case, extra_config, expected_http_kwargs):
     instance = extra_config
     check = FargateCheck('ecs_fargate', {}, instances=[instance])
 


### PR DESCRIPTION
### What does this PR do?

Fix ecs_fargate timeout. Related to this PR https://github.com/DataDog/integrations-core/pull/3477

The issue is that, the `DEFAULT_TIMEOUT = 5` from the integration should be used and it's not.

So, at the moment, we are using the default timeout from RequestWrapper which is 2 secs, instead of 5 secs from the integration.


### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
