### PR TITLE
Fix misleading gearman.workers metric (#4515)

### DIFF
--- a/gearmand/datadog_checks/gearmand/gearmand.py
+++ b/gearmand/datadog_checks/gearmand/gearmand.py
@@ -32,15 +32,13 @@ class Gearman(AgentCheck):
 
         return self.gearman_clients[(host, port)]
 
-    def _get_aggregate_metrics(self, tasks, tags):
+    def _get_aggregate_metrics(self, tasks, workers, tags):
         running = 0
         queued = 0
-        workers = 0
 
         for stat in tasks:
             running += stat['running']
             queued += stat['queued']
-            workers += stat['workers']
 
         unique_tasks = len(tasks)
 
@@ -108,7 +106,8 @@ class Gearman(AgentCheck):
 
         try:
             tasks = client.get_status()
-            self._get_aggregate_metrics(tasks, tags)
+            workers = len([w for w in client.get_workers() if w['tasks']])
+            self._get_aggregate_metrics(tasks, workers, tags)
             self._get_per_task_metrics(tasks, task_filter, tags)
             self.service_check(
                 self.SERVICE_CHECK_NAME,


### PR DESCRIPTION
Fix misleading gearman.workers metric by gettingt the correct number of workers from get_workers instead of get_status.

### What does this PR do?

Fix #4515 

### Motivation

gearman.workers metric returns a misleading value

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
