### PR TITLE
Explain filetagname logic

### DIFF
--- a/directory/datadog_checks/directory/data/conf.yaml.example
+++ b/directory/datadog_checks/directory/data/conf.yaml.example
@@ -25,7 +25,7 @@ instances:
     ## @param filetagname - string - optional - default: <FILE_NAME>
     ## The name of the key for the tag used for each file, the value is the filename.
     ## The resulting tag is "<filetagname>:<filename>". Only used if filegauges is set to true and if the directory
-    ## contains 20 files or less.
+    ## contains 20 files or less (including sub-directories).
     #
     # filetagname: <TAG_KEY_FILENAME>
 

--- a/directory/datadog_checks/directory/data/conf.yaml.example
+++ b/directory/datadog_checks/directory/data/conf.yaml.example
@@ -24,7 +24,8 @@ instances:
 
     ## @param filetagname - string - optional - default: <FILE_NAME>
     ## The name of the key for the tag used for each file, the value is the filename.
-    ## The resulting tag is "<filetagname>:<filename>".
+    ## The resulting tag is "<filetagname>:<filename>". Only used if filegauges is set to true and if the directory
+    ## contains 20 files or less.
     #
     # filetagname: <TAG_KEY_FILENAME>
 


### PR DESCRIPTION
### What does this PR do?

`"<filetagname>:<filename>"` will only be added as tag if `filegauges` is set to `True` and if the directory contains up to 20 files.

https://github.com/DataDog/integrations-core/blob/fd72528a2f40bbfd0be40b7b76461f5e6d392298/directory/datadog_checks/directory/directory.py#L140-L141.

### Motivation

Customer reported issue.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.