### PR TITLE
Remove failing discovered hosts

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -33,7 +33,7 @@ class InstanceConfig:
         self.network_address = None
         self.discovered_instances = {}
         self.failing_instances = defaultdict(int)
-        self.allowed_failures = int(instance.get('allowed_failures', 3))
+        self.allowed_failures = int(instance.get('discovery_allowed_failures', 3))
 
         timeout = int(instance.get('timeout', self.DEFAULT_TIMEOUT))
         retries = int(instance.get('retries', self.DEFAULT_RETRIES))

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2010-2019
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+from collections import defaultdict
+
 from pyasn1.type.univ import OctetString
 from pysnmp import hlapi
 from pysnmp.smi import builder, view
@@ -30,6 +32,8 @@ class InstanceConfig:
         self.ip_address = None
         self.network_address = None
         self.discovered_instances = {}
+        self.failing_instances = defaultdict(int)
+        self.allowed_failures = int(instance.get('allowed_failures', 3))
 
         timeout = int(instance.get('timeout', self.DEFAULT_TIMEOUT))
         retries = int(instance.get('retries', self.DEFAULT_RETRIES))

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -141,6 +141,11 @@ instances:
     #
     # discovery_interval: 3600
 
+    ## @param allowed_failures - integer - optional - default: 3
+    ## Number of times a discovered host can fail before we remove it from the discovered list.
+    #
+    # allowed_failures: 3
+
     ## @param enforce_mib_constraints - boolean - optional - default: true
     ## If set to false we will not check the values returned meet the MIB constraints.
     #

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -141,10 +141,10 @@ instances:
     #
     # discovery_interval: 3600
 
-    ## @param allowed_failures - integer - optional - default: 3
+    ## @param discovery_allowed_failures - integer - optional - default: 3
     ## Number of times a discovered host can fail before we remove it from the discovered list.
     #
-    # allowed_failures: 3
+    # discovery_allowed_failures: 3
 
     ## @param enforce_mib_constraints - boolean - optional - default: true
     ## If set to false we will not check the values returned meet the MIB constraints.

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -78,7 +78,7 @@ def test_transient_error(aggregator):
 
 def test_snmpget(aggregator):
     """
-    When failing with 'snmpget' command, SNMP check falls back to 'snpgetnext'
+    When failing with 'snmpget' command, SNMP check falls back to 'snmpgetnext'
 
         > snmpget -v2c -c public localhost:11111 1.3.6.1.2.1.25.6.3.1.4
         iso.3.6.1.2.1.25.6.3.1.4 = No Such Instance currently exists at this OID

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -135,3 +135,30 @@ def test_both_addresses():
     with pytest.raises(ConfigurationError) as e:
         SnmpCheck('snmp', {}, [instance])
     assert str(e.value) == 'Only one of IP address and network address must be specified'
+
+
+def test_removing_host():
+    """If a discovered host is failing 3 times in a row, we stop querying it."""
+    instance = common.generate_instance_config(common.SUPPORTED_METRIC_TYPES)
+    discovered_instance = instance.copy()
+    discovered_instance['ip_address'] = '1.1.1.1'
+    discovered_instance['retries'] = 0
+    instance.pop('ip_address')
+    instance['network_address'] = '192.168.0.0/24'
+    check = SnmpCheck('snmp', {}, [instance])
+    warnings = []
+    check.warning = warnings.append
+    check._config.discovered_instances['1.1.1.1'] = InstanceConfig(discovered_instance, None, [], '', {}, {})
+    msg = 'No SNMP response received before timeout for instance 1.1.1.1'
+    check.check(instance)
+    assert warnings == [msg]
+    check.check(instance)
+    assert warnings == [msg, msg]
+    check.check(instance)
+    assert warnings == [msg, msg, msg]
+    check.check(instance)
+    assert warnings == [msg, msg, msg, msg]
+    assert check._config.discovered_instances == {}
+    check.check(instance)
+    # No new warnings produced
+    assert warnings == [msg, msg, msg, msg]

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -150,15 +150,21 @@ def test_removing_host():
     check.warning = warnings.append
     check._config.discovered_instances['1.1.1.1'] = InstanceConfig(discovered_instance, None, [], '', {}, {})
     msg = 'No SNMP response received before timeout for instance 1.1.1.1'
+
     check.check(instance)
     assert warnings == [msg]
+
     check.check(instance)
     assert warnings == [msg, msg]
+
     check.check(instance)
     assert warnings == [msg, msg, msg]
+
     check.check(instance)
     assert warnings == [msg, msg, msg, msg]
+    # Instance has been removed
     assert check._config.discovered_instances == {}
+
     check.check(instance)
     # No new warnings produced
     assert warnings == [msg, msg, msg, msg]


### PR DESCRIPTION
If a discovered host is failing several times, we need to remove it from
the list of discovered. It will be added back by discover if it appears
again.