### PR TITLE
Fix for commits name with PR ids

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/github.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/github.py
@@ -90,9 +90,10 @@ def from_contributor(pr_payload):
 
 
 def parse_pr_number(log_line):
-    match = re.search(PR_PATTERN, log_line)
+    """If there are multiple matches, the PR id is always the latest one"""
+    match = re.findall(PR_PATTERN, log_line)
     if match:
-        return match.group(1)
+        return match[-1]
 
 
 def parse_pr_numbers(git_log_lines):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/github.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/github.py
@@ -91,9 +91,9 @@ def from_contributor(pr_payload):
 
 def parse_pr_number(log_line):
     """If there are multiple matches, the PR id is always the latest one"""
-    match = re.findall(PR_PATTERN, log_line)
-    if match:
-        return match[-1]
+    matches = re.findall(PR_PATTERN, log_line)
+    if matches:
+        return matches[-1]
 
 
 def parse_pr_numbers(git_log_lines):


### PR DESCRIPTION
Sometimes the commit name includes a reference to an issue or another PR, then when merged github adds the relevant PR id to the end of the merge commit message. We should always use the last match