### PR TITLE
Optim Apache.check

### DIFF
--- a/apache/datadog_checks/apache/consumer_builder.py
+++ b/apache/datadog_checks/apache/consumer_builder.py
@@ -1,0 +1,104 @@
+# @TODO see if we cannot move this functions at common level
+
+
+def _build_metric_consumer_fct(transform_value=None, **kwargs):
+    """
+    Optimized for cases where we convert to one or 2 calls
+    This function will build a shortcut function to publish a metric
+
+    Example: function to manage 'Total kBytes' from apache
+
+    fct = _build_metric_consumer_fct(transform_value=lambda x: float(x) * 1024,
+                                     gauge='apache.net.bytes',
+                                     rate='apache.net.bytes_per_s')
+
+    fct(self, '10')
+
+    will do:
+
+    value = float('10') * 1024
+    self.gauge('apache.net.bytes', value)
+    self.rate('apache.net.bytes_per_s', value)
+    """
+    if transform_value is None:
+        if len(kwargs) == 1:
+            fct_name, name = kwargs.popitem()
+
+            def fct(self, value, tags=None, hostname=None, device_name=None):
+                getattr(self, fct_name)(name, value, tags, hostname, device_name)
+
+        elif len(kwargs) == 2:
+            f1, n1 = kwargs.popitem()
+            f2, n2 = kwargs.popitem()
+
+            def fct(self, value, tags=None, hostname=None, device_name=None):
+                getattr(self, f1)(n1, value, tags, hostname, device_name)
+                getattr(self, f2)(n2, value, tags, hostname, device_name)
+        else:
+            def fct(self, value, tags, hostname=None, device_name=None):
+                for fct_n, m_name in kwargs.items():
+                    getattr(self, fct_n)(m_name, value, tags, hostname, device_name)
+    else:
+        if len(kwargs) == 1:
+            fct_name, name = kwargs.popitem()
+
+            def fct(self, value, tags=None, hostname=None, device_name=None):
+                getattr(self, fct_name)(name, transform_value(value), tags, hostname, device_name)
+
+        elif len(kwargs) == 2:
+            f1, n1 = kwargs.popitem()
+            f2, n2 = kwargs.popitem()
+
+            def fct(self, value, tags=None, hostname=None, device_name=None):
+                value = transform_value(value)
+                getattr(self, f1)(n1, value, tags, hostname, device_name)
+                getattr(self, f2)(n2, value, tags, hostname, device_name)
+        else:
+            def fct(self, value, tags=None, hostname=None, device_name=None):
+                value = transform_value(value)
+                for fct_n, m_name in kwargs.items():
+                    getattr(self, fct_n)(m_name, value, tags, hostname, device_name)
+
+    return fct
+
+
+def build_metric_consumer_fct_map(metric_mappings, default_transform_value=None):
+    """
+    This methods will provide a map of function for your class,
+    to redirect depending on a key, to one or multiple method call(s).
+
+    Example:
+
+    class MyAgent(AgentCheck):
+
+        METRIC_FCT_MAP = build_metric_consumer_fct_map({
+            'Total kBytes': {'gauge': 'apache.net.bytes',
+                             'rate': 'apache.net.bytes_per_s',
+                             'transform_value': lambda value: float(value) * 1024},
+            'ConnsTotal': {'gauge': 'apache.conns_total'},
+        }, default_transform_value=float)
+
+        def consume_lines(lines):
+            for line in lines:
+                metric, value = line.split(': ')
+                fct = self.METRIC_FCT_MAP.get(metric, None)
+                if fct is not None:
+                    fct(self, value, tags)
+
+    a = MyAgent()
+
+    a.consume_lines(['Total kBytes: 10', 'ConnsTotal: 42'])
+
+    Will do the same as:
+
+    a.gauge('apache.net.bytes', 10240)
+    a.rate('apache.net.bytes_per_s', 10240)
+    a.gauge('apache.conns_total', 42)
+    """
+
+    metric_fct_map = {}
+    for name, args in metric_mappings.items():
+        if 'transform_value' not in args:
+            args['transform_value'] = default_transform_value
+        metric_fct_map[name] = _build_metric_consumer_fct(**args)
+    return metric_fct_map


### PR DESCRIPTION
### What does this PR do?

The goal was to optimize Apache.check, essentially avoiding to access dict value for every line.
To do so i have introduced also a way to declare to conversion of metrics at a single spot like:

```python
{'Total kBytes': {'gauge': 'apache.net.bytes',
                         'rate': 'apache.net.bytes_per_s',
                         'transform_value': lambda value: float(value) * 1024}}
```

Note i did some benchmarks:
```
Running tests 100000 times
- with MANAGED lines: ['IdleWorkers: 0', 'BusyWorkers: 1', 'CPULoad: 2', 'Uptime: 3', 'Total kBytes: 4', 'Total Accesses: 5', 'ConnsTotal: 6', 'ConnsAsyncWriting: 7', 'ConnsAsyncKeepAlive: 8', 'ConnsAsyncClosing: 9']
  * REF: 1.1273348
  * NEW: 1.1135298
=> 98%
- with NOT MANAGED lines: ['other_not_in_0: 0', 'other_not_in_1: 1', 'other_not_in_2: 2', 'other_not_in_3: 3', 'other_not_in_4: 4', 'other_not_in_5: 5', 'other_not_in_6: 6', 'other_not_in_7: 7', 'other_not_in_8: 8', 'other_not_in_9: 9']
  * REF: 0.8162859
  * NEW: 0.3532454999999999
=> 43%
- with a mix lines: ['IdleWorkers: 0', 'BusyWorkers: 1', 'CPULoad: 2', 'Uptime: 3', 'Total kBytes: 4', 'Total Accesses: 5', 'ConnsTotal: 6', 'ConnsAsyncWriting: 7', 'ConnsAsyncKeepAlive: 8', 'ConnsAsyncClosing: 9', 'other_not_in_0: 0', 'other_not_in_1: 1', 'other_not_in_2: 2', 'other_not_in_3: 3', 'other_not_in_4: 4', 'other_not_in_5: 5', 'other_not_in_6: 6', 'other_not_in_7: 7', 'other_not_in_8: 8', 'other_not_in_9: 9']
  * REF: 1.9315037999999998
  * NEW: 1.4546872000000004
=> 75%
```


### Motivation

Have a single point to fully declare conversion and speedup thanks to that.

### Additional Notes

Might be a good thing to generalize, i guess this kind of mapping can be used in other agents

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
