### PR TITLE
Patch for parse_labels of prometheus-client 0.3.0 to improve perf

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -7,7 +7,9 @@ from math import isinf, isnan
 from os.path import isfile
 
 import requests
-from prometheus_client.parser import text_fd_to_metric_families
+# from patch_prometheus_client import text_fd_to_metric_families
+# using the patched version to improve perf
+from ..patch_prometheus_client import text_fd_to_metric_families
 from six import PY3, iteritems, itervalues, string_types
 from urllib3 import disable_warnings
 from urllib3.exceptions import InsecureRequestWarning

--- a/datadog_checks_base/datadog_checks/base/checks/patch_prometheus_client.py
+++ b/datadog_checks_base/datadog_checks/base/checks/patch_prometheus_client.py
@@ -1,0 +1,106 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+# The goal is to improve performances or internal _parse_labels in prometheus_client
+# No functional changes were made (just refactor the code)
+#
+# Original method as around 150% execution time than this one
+# As long as this methods take around 50% of overall processing of open metrics that's a big gain
+# Note: Compatible/Tested with prometheus-client 0.3.0
+#
+# Usage:
+#
+# replace:
+#
+# from prometheus_client.parser import text_fd_to_metric_families
+#
+# to:
+#
+# from .patch_prometheus_client import text_fd_to_metric_families
+
+import re
+from prometheus_client import parser
+
+text_fd_to_metric_families = parser.text_fd_to_metric_families
+
+
+ESCAPE_SEQUENCES = {
+    '\\\\': '\\',
+    '\\n': '\n',
+    '\\"': '"',
+}
+
+
+def replace_escape_sequence(match):
+    return ESCAPE_SEQUENCES[match.group(0)]
+
+
+ESCAPING_RE = re.compile(r'\\[\\n"]')
+
+
+def _replace_escaping(s):
+    return ESCAPING_RE.sub(replace_escape_sequence, s)
+
+
+def _is_character_escaped(s, charpos):
+    num_bslashes = 0
+    while (charpos > num_bslashes and
+           s[charpos - 1 - num_bslashes] == '\\'):
+        num_bslashes += 1
+    return num_bslashes % 2 == 1
+
+
+def _last_unescaped_quote(v):
+    i = 0
+    lv = len(v)
+    while i < lv:
+        i = v.index('"', i)
+        if not _is_character_escaped(v, i):
+            break
+        i += 1
+    return i
+
+
+def _parse_labels(labels_string):
+    # Return if we don't have valid labels
+    try:
+        value_start = labels_string.index("=")
+    except ValueError:
+        return {}
+    try:
+        # Copy original labels
+        sub_labels = labels_string
+        labels = {}
+        # Process one label at a time
+        escaping = "\\" in labels_string
+        while True:
+            # The label name is before the equal
+            label_name = sub_labels[:value_start].strip()
+            sub_labels = sub_labels[value_start + 1:].lstrip()
+            # Find the first quote after the equal
+            if escaping:
+                quote_start = sub_labels.index('"') + 1
+                # Find the last unescaped quote
+                # The label value is inbetween the first and last quote
+                quote_end = _last_unescaped_quote(sub_labels[quote_start:]) + 1
+                labels[label_name] = _replace_escaping(sub_labels[quote_start:quote_end])
+            else:
+                quote_start = sub_labels.index('"') + 1
+                quote_end = sub_labels.index('"', quote_start)
+                labels[label_name] = sub_labels[quote_start:quote_end]
+
+            # Remove the processed label from the sub-slice for next iteration
+            sub_labels = sub_labels[quote_end + 1:]
+            if not sub_labels:
+                break
+            sub_labels = sub_labels[sub_labels.find(",") + 1:]
+            value_start = sub_labels.index("=")
+        return labels
+
+    except ValueError:
+        raise ValueError("Invalid labels: %s" % labels_string)
+
+
+# Replace current method with the fastest one
+parser._parse_labels = _parse_labels

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -9,7 +9,9 @@ from math import isinf, isnan
 
 import requests
 from google.protobuf.internal.decoder import _DecodeVarint32  # pylint: disable=E0611,E0401
-from prometheus_client.parser import text_fd_to_metric_families
+# from patch_prometheus_client import text_fd_to_metric_families
+# using the patched version to improve perf
+from ..patch_prometheus_client import text_fd_to_metric_families
 from six import PY3, iteritems, itervalues, string_types
 from urllib3 import disable_warnings
 from urllib3.exceptions import InsecureRequestWarning


### PR DESCRIPTION
The goal is to improve performances or internal _parse_labels in prometheus_client
No functional changes were made (just refactor the code)

Original method as around 150% execution time than this one
As long as this methods take around 50% of overall processing of open metrics that's a big gain
Note: Compatible/Tested with prometheus-client 0.3.0

Usage:

replace:
from prometheus_client.parser import text_fd_to_metric_families

to:
from .patch_prometheus_client import text_fd_to_metric_families

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

Doing some performance test, i found out that this _parse_labels method was occupying more that 50% of the processing time when processing openmetric datas.

![perf_parse_labels](https://user-images.githubusercontent.com/3374336/64879472-539f6f80-d656-11e9-91be-2f9135b33ac3.PNG)


### Additional Notes

Note that this patch will need to be replaced if prometheus-client lib is changed or at least make sure that the method is still valid. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
