### PR TITLE
Fix fluentd documentation

### DIFF
--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -55,7 +55,7 @@ In your fluentd configuration file, add a `monitor_agent` source:
 
 #### Log Collection
 
-As long as you can forward your FluentD logs over tcp/udp to a specific port, you can use that approach to forward your FluentD logs to your Datadog agent. But another option is to use the [Datadog FluentD plugin][7] to forward the logs directly from FluentD to your Datadog account.
+You can use the [Datadog FluentD plugin][7] to forward the logs directly from FluentD to your Datadog account.
 
 ##### Add metadata to your logs
 


### PR DESCRIPTION
Forwarding fluentd logs over tcp/udp to the agent is not possible. Logs are formatted in "messagepack" format which is not parsed correctly by our backend.