### PR TITLE
Fix AZP for forks

### DIFF
--- a/.azure-pipelines/templates/checkout-code.yml
+++ b/.azure-pipelines/templates/checkout-code.yml
@@ -3,6 +3,13 @@ steps:
 - checkout: self
   fetchDepth: 3
 
+# Azure checks out the code from the PR but leaves us in a detached state.
+# Because ddev cannot work in that state, we create a branch.
+# Only applies to PRs
+- script: git checkout -B $(System.PullRequest.SourceBranch)
+  condition: eq(variables['Build.Reason'], 'PullRequest')
+  displayName: 'Create branch from PR'
+
 # Azure pulls a commit hash via git fetch rather than clone so
 # we checkout the branches we need which also gets us out of a
 # detached HEAD state. This may be fixed soon, see:


### PR DESCRIPTION
Azure pipelines were not checking out the correct branch when a PR comes from a fork