### PR TITLE
Add external refresh metrics

### DIFF
--- a/elastic/datadog_checks/elastic/metrics.py
+++ b/elastic/datadog_checks/elastic/metrics.py
@@ -57,7 +57,16 @@ PRIMARY_SHARD_METRICS = {
     'elasticsearch.indices.count': ('gauge', 'indices', lambda indices: len(indices)),
 }
 
-PRIMARY_SHARD_METRICS_POST_1_0 = {
+PRIMARY_SHARD_METRICS_POST_7_2_0 = {
+    'elasticsearch.primaries.refresh.external.total': ('gauge', '_all.primaries.refresh.external_total'),
+    'elasticsearch.primaries.refresh.external.total.time': (
+        'gauge',
+        '_all.primaries.refresh.external_total_time_in_millis',
+        lambda ms: ms_to_second(ms),
+    ),
+}
+
+PRIMARY_SHARD_METRICS_POST_1_0_0 = {
     'elasticsearch.primaries.merges.current': ('gauge', '_all.primaries.merges.current'),
     'elasticsearch.primaries.merges.current.docs': ('gauge', '_all.primaries.merges.current_docs'),
     'elasticsearch.primaries.merges.current.size': ('gauge', '_all.primaries.merges.current_size_in_bytes'),
@@ -149,11 +158,6 @@ STATS_METRICS = {
     'elasticsearch.thread_pool.get.queue': ('gauge', 'thread_pool.get.queue'),
     'elasticsearch.thread_pool.get.rejected': ('rate', 'thread_pool.get.rejected'),
     'elasticsearch.thread_pool.get.completed': ('gauge', 'thread_pool.get.completed'),
-    'elasticsearch.thread_pool.index.active': ('gauge', 'thread_pool.index.active'),
-    'elasticsearch.thread_pool.index.threads': ('gauge', 'thread_pool.index.threads'),
-    'elasticsearch.thread_pool.index.queue': ('gauge', 'thread_pool.index.queue'),
-    'elasticsearch.thread_pool.index.rejected': ('rate', 'thread_pool.index.rejected'),
-    'elasticsearch.thread_pool.index.completed': ('gauge', 'thread_pool.index.completed'),
     'elasticsearch.thread_pool.management.active': ('gauge', 'thread_pool.management.active'),
     'elasticsearch.thread_pool.management.threads': ('gauge', 'thread_pool.management.threads'),
     'elasticsearch.thread_pool.management.queue': ('gauge', 'thread_pool.management.queue'),
@@ -198,6 +202,23 @@ STATS_METRICS = {
     'elasticsearch.fs.total.total_in_bytes': ('gauge', 'fs.total.total_in_bytes'),
     'elasticsearch.fs.total.free_in_bytes': ('gauge', 'fs.total.free_in_bytes'),
     'elasticsearch.fs.total.available_in_bytes': ('gauge', 'fs.total.available_in_bytes'),
+}
+
+ADDITIONAL_METRICS_POST_7_2_0 = {
+    'elasticsearch.refresh.external.total': ('gauge', 'indices.refresh.external_total'),
+    'elasticsearch.refresh.external.total.time': (
+        'gauge',
+        'indices.refresh.external_total_time_in_millis',
+        lambda ms: ms_to_second(ms),
+    ),
+}
+
+ADDITIONAL_METRICS_PRE_7_0_0 = {
+    'elasticsearch.thread_pool.index.active': ('gauge', 'thread_pool.index.active'),
+    'elasticsearch.thread_pool.index.queue': ('gauge', 'thread_pool.index.queue'),
+    'elasticsearch.thread_pool.index.threads': ('gauge', 'thread_pool.index.threads'),
+    'elasticsearch.thread_pool.index.rejected': ('rate', 'thread_pool.index.rejected'),
+    'elasticsearch.thread_pool.index.completed': ('gauge', 'thread_pool.index.completed'),
 }
 
 ADDITIONAL_METRICS_PRE_5_0_0 = {
@@ -506,6 +527,12 @@ def stats_for_version(version):
     else:
         metrics.update(ADDITIONAL_METRICS_PRE_6_3)
 
+    if version < [7, 0, 0]:
+        metrics.update(ADDITIONAL_METRICS_PRE_7_0_0)
+
+    if version >= [7, 2, 0]:
+        metrics.update(ADDITIONAL_METRICS_POST_7_2_0)
+
     return metrics
 
 
@@ -515,7 +542,10 @@ def pshard_stats_for_version(version):
     """
     pshard_stats_metrics = dict(PRIMARY_SHARD_METRICS)
     if version >= [1, 0, 0]:
-        pshard_stats_metrics.update(PRIMARY_SHARD_METRICS_POST_1_0)
+        pshard_stats_metrics.update(PRIMARY_SHARD_METRICS_POST_1_0_0)
+
+    if version >= [7, 2, 0]:
+        pshard_stats_metrics.update(PRIMARY_SHARD_METRICS_POST_7_2_0)
 
     return pshard_stats_metrics
 

--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -117,6 +117,8 @@ elasticsearch.primaries.merges.total.size,gauge,,byte,,The total size of all mer
 elasticsearch.primaries.merges.total.time,gauge,,second,,The total time spent on segment merging on the primary shards.,0,elasticsearch,primary merge total time
 elasticsearch.primaries.refresh.total,gauge,,refresh,,The total number of index refreshes on the primary shards.,0,elasticsearch,primary refresh total
 elasticsearch.primaries.refresh.total.time,gauge,,second,,The total time spent on index refreshes on the primary shards.,0,elasticsearch,primary refresh total time
+elasticsearch.primaries.refresh.external_total,gauge,,refresh,,The total number of external index refreshes on the primary shards.,0,elasticsearch,primary refresh total
+elasticsearch.primaries.refresh.external_total.time,gauge,,second,,The total time spent on external index refreshes on the primary shards.,0,elasticsearch,primary refresh total time
 elasticsearch.primaries.search.fetch.current,gauge,,fetch,,The number of query fetches currently running on the primary shards.,0,elasticsearch,primary current fetches
 elasticsearch.primaries.search.fetch.time,gauge,,second,,The total time spent on query fetches on the primary shards.,0,elasticsearch,primary fetch total time
 elasticsearch.primaries.search.fetch.total,gauge,,fetch,,The total number of query fetches on the primary shards.,0,elasticsearch,primary fetch total
@@ -127,6 +129,8 @@ elasticsearch.primaries.store.size,gauge,,byte,,The total size of all the primar
 elasticsearch.process.open_fd,gauge,,file,,"The number of opened file descriptors associated with the current process, or -1 if not supported.",0,elasticsearch,open file descriptors
 elasticsearch.refresh.total,gauge,,refresh,,The total number of index refreshes.,0,elasticsearch,total refreshes
 elasticsearch.refresh.total.time,gauge,,second,,The total time spent on index refreshes.,0,elasticsearch,total refresh time
+elasticsearch.refresh.external_total,gauge,,refresh,,The total number of external index refreshes.,0,elasticsearch,total refreshes
+elasticsearch.refresh.external_total.time,gauge,,second,,The total time spent on external index refreshes.,0,elasticsearch,total refresh time
 elasticsearch.relocating_shards,gauge,,shard,,The number of shards that are relocating from one node to another.,0,elasticsearch,relocating shards
 elasticsearch.search.fetch.current,gauge,,fetch,,The number of search fetches currently running.,0,elasticsearch,current fetches
 elasticsearch.search.fetch.open_contexts,gauge,,query,,The number of active searches.,0,elasticsearch,active searches

--- a/elastic/tests/compose/docker-compose.yaml
+++ b/elastic/tests/compose/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - "cluster.name=test-cluster"
       - "node.name=test-node"
+      - "discovery.type=single-node"
     ports:
       - "9200:9200"
     ulimits:

--- a/elastic/tests/test_metrics.py
+++ b/elastic/tests/test_metrics.py
@@ -56,6 +56,10 @@ def test_stats_for_version():
     metrics = stats_for_version([6, 3, 0])
     assert len(metrics) == 180
 
+    # v7.2.0
+    metrics = stats_for_version([7, 2, 0])
+    assert len(metrics) == 177
+
 
 @pytest.mark.unit
 def test_pshard_stats_for_version():
@@ -106,6 +110,10 @@ def test_pshard_stats_for_version():
     # v6.3.0
     pshard_metrics = pshard_stats_for_version([6, 3, 0])
     assert len(pshard_metrics) == 34
+
+    # v7.2.0
+    pshard_metrics = pshard_stats_for_version([7, 2, 0])
+    assert len(pshard_metrics) == 36
 
 
 @pytest.mark.unit

--- a/elastic/tox.ini
+++ b/elastic/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = true
 envlist =
     py{27,37}-{dd}-{0.90}
     py{27,37}-{hub}-{1,2}
-    py{27,37}-{5.4,5.5,5.6,6.0,6.1,6.2,6.3,6.4}
+    py{27,37}-{5.4,5.5,5.6,6.0,6.1,6.2,6.3,6.4,7.2}
     bench
 
 [testenv]
@@ -46,6 +46,7 @@ setenv =
     6.3: ELASTIC_IMAGE=6.3.2
     ; EOL 2020-02-23
     6.4: ELASTIC_IMAGE=6.4.2
+    7.2: ELASTIC_IMAGE=7.2.0
 
 [testenv:bench]
 setenv =


### PR DESCRIPTION
### What does this PR do?

This adds support for reporting external refresh metrics for the Elasticsearch integration. 

### Motivation

These metrics are newly emitted on ES7.2+. They are provide a better representation of when documents are searchable after being indexed than the base refresh metrics. More details can be found https://github.com/elastic/elasticsearch/pull/38643 and https://github.com/elastic/elasticsearch/issues/36712.

### Additional

Should I make more changes to the metrics.py file? I categorized these within the `PRIMARY_SHARD_METRICS_POST_1_0` and `STATSD_METRICS` maps, but this goes against the comment that they are common to all Elasticsearch versions / all versions post 1.0 since this metric was added in 7.2.0. At the same time, the test file seems to already have a way to deal with metrics added between versions. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
