### PR TITLE
Add warning to create command if name is lowercase

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
@@ -10,7 +10,7 @@ from ...utils import resolve_path
 from ..constants import get_root
 from ..create import construct_template_fields, create_template_files, get_valid_templates
 from ..utils import normalize_package_name
-from .console import CONTEXT_SETTINGS, abort, echo_info, echo_success
+from .console import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_warning
 
 HYPHEN = b'\xe2\x94\x80\xe2\x94\x80'.decode('utf-8')
 PIPE = b'\xe2\x94\x82'.decode('utf-8')
@@ -94,6 +94,10 @@ def display_path_tree(path_tree):
 @click.pass_context
 def create(ctx, name, integration_type, location, non_interactive, quiet, dry_run):
     """Create scaffolding for a new integration."""
+
+    if name.islower():
+        echo_warning('Make sure to use use display name. e.g. MapR, Ambari, IBM MQ, vSphere, ...')
+
     repo_choice = ctx.obj['repo_choice']
     root = resolve_path(location) if location else get_root()
     path_sep = os.path.sep


### PR DESCRIPTION
### What does this PR do?

Add warning to create command if name is lowercase.

### Motivation

If name is lower, that might produce the wrong `display_name`, `public_title`, etc for `manifest.json`

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
