### PR TITLE
Fix typo for couchbase.by_node.cluster_membership service check

### DIFF
--- a/couchbase/datadog_checks/couchbase/couchbase_consts.py
+++ b/couchbase/datadog_checks/couchbase/couchbase_consts.py
@@ -14,7 +14,7 @@ NODE_HEALTH_SERVICE_CHECK_NAME = 'couchbase.by_node.health'
 NODE_MEMBERSHIP_TRANSLATION = {
     'active': AgentCheck.OK,
     'inactiveAdded': AgentCheck.WARNING,
-    'activeFailed': AgentCheck.CRITICAL,
+    'inactiveFailed': AgentCheck.CRITICAL,
     None: AgentCheck.UNKNOWN,
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes a typo in the couchbase.by_node.cluster_membership service check

### Motivation

Matches our check to the Couchbase documentation [here](https://github.com/couchbase/ns_server/blob/master/doc/api.txt#L173-L175).