### PR TITLE
Add saved_views metadata field to integration templates

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/manifest.json
@@ -23,6 +23,7 @@
   "integration_id": "{check_name_kebab}",
   "assets": {{
     "dashboards": {{}},
+    "saved_views": {{}},
     "monitors": {{}},
     "service_checks": "assets/service_checks.json"
   }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/manifest.json
@@ -23,6 +23,7 @@
   "integration_id": "{check_name_kebab}",
   "assets": {{
     "dashboards": {{}},
+    "saved_views": {{}},
     "monitors": {{}},
     "service_checks": "assets/service_checks.json"
   }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/tile/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/tile/{check_name}/manifest.json
@@ -23,6 +23,7 @@
   "integration_id": "{check_name_kebab}",
   "assets": {{
     "dashboards": {{}},
+    "saved_views": {{}},
     "monitors": {{}},
     "service_checks": "assets/service_checks.json"
   }}


### PR DESCRIPTION
### What does this PR do?
⚠️Do not merge before Integration Saved Views are supported ⚠️
- Add saved_views field to integration templates

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
