### PR TITLE
[WIP] Execute tox env one by one

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -10,7 +10,7 @@ from ..._env import E2E_PARENT_PYTHON
 from ...subprocess import run_command
 from ...utils import chdir, file_exists, get_ci_env_vars, remove_path, running_on_ci
 from ..constants import get_root
-from ..testing import construct_pytest_options, fix_coverage_report, get_tox_envs, pytest_coverage_sources
+from ..testing import STYLE_ENVS, construct_pytest_options, fix_coverage_report, get_tox_envs, pytest_coverage_sources
 from .console import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_waiting, echo_warning
 from .utils import run_command_with_retry
 
@@ -163,16 +163,20 @@ def test(
                 echo_waiting(wait_text)
                 echo_waiting('-' * len(wait_text) + '\n')
 
-                result = run_command_with_retry(
-                    retry=retry,
-                    command='tox '
+                command = (
+                    'tox '
                     # so users won't get failures for our possibly strict CI requirements
                     '--skip-missing-interpreters '
                     # so coverage tracks the real locations instead of .tox virtual envs
                     '--develop '
                     # comma-separated list of environments
-                    '-e {}'.format(env),
+                    '-e {}'.format(env)
                 )
+                if env in STYLE_ENVS:
+                    result = run_command(command=command)
+                else:
+                    result = run_command_with_retry(retry=retry, command=command)
+
                 if result.code:
                     abort('\nFailed!', code=result.code)
 


### PR DESCRIPTION
### What does this PR do?

Execute `tox` env one by one.

The diff is mostly due to indent. There are only two changes:

1) iterate per env
```python
for env in envs:
```

2) Skip style envs
```python
                if env in STYLE_ENVS:
                    result = run_command(command=command)
                else:
                    result = run_command_with_retry(retry=retry, command=command)
```

### Motivation

Retrying by tox env is the initial intent, so this PR will fix that.

### Additional Notes

After few tests, this does not have impact on execution time.

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
