### PR TITLE
Add an option to send histograms/summary counts as monotonic counters

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -172,8 +172,11 @@ class OpenMetricsScraperMixin(object):
             instance.get('send_monotonic_counter', default_instance.get('send_monotonic_counter', True))
         )
 
-        config['send_counts_as_monotonic'] = is_affirmative(
-            instance.get('send_counts_as_monotonic', default_instance.get('send_counts_as_monotonic', False))
+        config['send_distribution_counts_as_monotonic'] = is_affirmative(
+            instance.get(
+                'send_distribution_counts_as_monotonic',
+                default_instance.get('send_distribution_counts_as_monotonic', False),
+            )
         )
 
         # If the `labels_mapper` dictionary is provided, the metrics labels names
@@ -648,7 +651,7 @@ class OpenMetricsScraperMixin(object):
             elif sample[self.SAMPLE_NAME].endswith("_count"):
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname=custom_hostname)
                 self._submit_distribution_count(
-                    scraper_config['send_counts_as_monotonic'],
+                    scraper_config['send_distribution_counts_as_monotonic'],
                     "{}.{}.count".format(scraper_config['namespace'], metric_name),
                     val,
                     tags=tags,
@@ -689,7 +692,7 @@ class OpenMetricsScraperMixin(object):
                 if scraper_config['send_histograms_buckets']:
                     tags.append("upper_bound:none")
                 self._submit_distribution_count(
-                    scraper_config['send_counts_as_monotonic'],
+                    scraper_config['send_distribution_counts_as_monotonic'],
                     "{}.{}.count".format(scraper_config['namespace'], metric_name),
                     val,
                     tags=tags,
@@ -702,7 +705,7 @@ class OpenMetricsScraperMixin(object):
                     sample[self.SAMPLE_LABELS]["le"] = str(float(sample[self.SAMPLE_LABELS]["le"]))
                     tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname)
                     self._submit_distribution_count(
-                        scraper_config['send_counts_as_monotonic'],
+                        scraper_config['send_distribution_counts_as_monotonic'],
                         "{}.{}.count".format(scraper_config['namespace'], metric_name),
                         val,
                         tags=tags,

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -172,6 +172,10 @@ class OpenMetricsScraperMixin(object):
             instance.get('send_monotonic_counter', default_instance.get('send_monotonic_counter', True))
         )
 
+        config['send_counts_as_monotonic'] = is_affirmative(
+            instance.get('send_counts_as_monotonic', default_instance.get('send_counts_as_monotonic', False))
+        )
+
         # If the `labels_mapper` dictionary is provided, the metrics labels names
         # in the `labels_mapper` will use the corresponding value as tag name
         # when sending the gauges.
@@ -643,7 +647,8 @@ class OpenMetricsScraperMixin(object):
                 )
             elif sample[self.SAMPLE_NAME].endswith("_count"):
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname=custom_hostname)
-                self.gauge(
+                self._submit_distribution_count(
+                    scraper_config['send_counts_as_monotonic'],
                     "{}.{}.count".format(scraper_config['namespace'], metric_name),
                     val,
                     tags=tags,
@@ -683,7 +688,8 @@ class OpenMetricsScraperMixin(object):
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname)
                 if scraper_config['send_histograms_buckets']:
                     tags.append("upper_bound:none")
-                self.gauge(
+                self._submit_distribution_count(
+                    scraper_config['send_counts_as_monotonic'],
                     "{}.{}.count".format(scraper_config['namespace'], metric_name),
                     val,
                     tags=tags,
@@ -695,7 +701,8 @@ class OpenMetricsScraperMixin(object):
                 elif "Inf" not in sample[self.SAMPLE_LABELS]["le"] or scraper_config['non_cumulative_buckets']:
                     sample[self.SAMPLE_LABELS]["le"] = str(float(sample[self.SAMPLE_LABELS]["le"]))
                     tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname)
-                    self.gauge(
+                    self._submit_distribution_count(
+                        scraper_config['send_counts_as_monotonic'],
                         "{}.{}.count".format(scraper_config['namespace'], metric_name),
                         val,
                         tags=tags,
@@ -796,6 +803,12 @@ class OpenMetricsScraperMixin(object):
             hostname,
             tags,
         )
+
+    def _submit_distribution_count(self, monotonic, metric_name, value, tags=None, hostname=None):
+        if monotonic:
+            self.monotonic_count(metric_name, value, tags=tags, hostname=hostname)
+        else:
+            self.gauge(metric_name, value, tags=tags, hostname=hostname)
 
     def _metric_tags(self, metric_name, val, sample, scraper_config, hostname=None):
         custom_tags = scraper_config['custom_tags']

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -361,7 +361,26 @@ def test_submit_summary(aggregator, mocked_prometheus_check, mocked_prometheus_s
     _sum.add_sample("my_summary", {"quantile": "0.99"}, 25763.0)
     check = mocked_prometheus_check
     check.submit_openmetric('custom.summary', _sum, mocked_prometheus_scraper_config)
-    aggregator.assert_metric('prometheus.custom.summary.count', 5.0, tags=[], count=1)
+    aggregator.assert_metric('prometheus.custom.summary.count', 5.0, tags=[], count=1, metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('prometheus.custom.summary.sum', 120512.0, tags=[], count=1)
+    aggregator.assert_metric('prometheus.custom.summary.quantile', 24547.0, tags=['quantile:0.5'], count=1)
+    aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.9'], count=1)
+    aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.99'], count=1)
+    aggregator.assert_all_metrics_covered()
+
+
+def test_submit_summary_with_monotonic_count(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+    _sum = SummaryMetricFamily('my_summary', 'Random summary')
+    _sum.add_metric([], 5.0, 120512.0)
+    _sum.add_sample("my_summary", {"quantile": "0.5"}, 24547.0)
+    _sum.add_sample("my_summary", {"quantile": "0.9"}, 25763.0)
+    _sum.add_sample("my_summary", {"quantile": "0.99"}, 25763.0)
+    check = mocked_prometheus_check
+    mocked_prometheus_scraper_config['send_counts_as_monotonic'] = True
+    check.submit_openmetric('custom.summary', _sum, mocked_prometheus_scraper_config)
+    aggregator.assert_metric(
+        'prometheus.custom.summary.count', 5.0, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT
+    )
     aggregator.assert_metric('prometheus.custom.summary.sum', 120512.0, tags=[], count=1)
     aggregator.assert_metric('prometheus.custom.summary.quantile', 24547.0, tags=['quantile:0.5'], count=1)
     aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.9'], count=1)
@@ -377,10 +396,58 @@ def test_submit_histogram(aggregator, mocked_prometheus_check, mocked_prometheus
     check = mocked_prometheus_check
     check.submit_openmetric('custom.histogram', _histo, mocked_prometheus_scraper_config)
     aggregator.assert_metric('prometheus.custom.histogram.sum', 1337, tags=[], count=1)
-    aggregator.assert_metric('prometheus.custom.histogram.count', 4, tags=['upper_bound:none'], count=1)
-    aggregator.assert_metric('prometheus.custom.histogram.count', 1, tags=['upper_bound:1.0'], count=1)
-    aggregator.assert_metric('prometheus.custom.histogram.count', 2, tags=['upper_bound:31104000.0'], count=1)
-    aggregator.assert_metric('prometheus.custom.histogram.count', 3, tags=['upper_bound:432400000.0'], count=1)
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count', 4, tags=['upper_bound:none'], count=1, metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count', 1, tags=['upper_bound:1.0'], count=1, metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count', 2, tags=['upper_bound:31104000.0'], count=1, metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count', 3, tags=['upper_bound:432400000.0'], count=1, metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_all_metrics_covered()
+
+
+def test_submit_histogram_with_monotonic_count(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+    _histo = HistogramMetricFamily('my_histogram', 'my_histogram')
+    _histo.add_metric(
+        [], buckets=[("-Inf", 0), ("1", 1), ("3.1104e+07", 2), ("4.324e+08", 3), ("+Inf", 4)], sum_value=1337
+    )
+    check = mocked_prometheus_check
+    mocked_prometheus_scraper_config['send_counts_as_monotonic'] = True
+    check.submit_openmetric('custom.histogram', _histo, mocked_prometheus_scraper_config)
+    aggregator.assert_metric('prometheus.custom.histogram.sum', 1337, tags=[], count=1)
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count',
+        4,
+        tags=['upper_bound:none'],
+        count=1,
+        metric_type=aggregator.MONOTONIC_COUNT,
+    )
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count',
+        1,
+        tags=['upper_bound:1.0'],
+        count=1,
+        metric_type=aggregator.MONOTONIC_COUNT,
+    )
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count',
+        2,
+        tags=['upper_bound:31104000.0'],
+        count=1,
+        metric_type=aggregator.MONOTONIC_COUNT,
+    )
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count',
+        3,
+        tags=['upper_bound:432400000.0'],
+        count=1,
+        metric_type=aggregator.MONOTONIC_COUNT,
+    )
     aggregator.assert_all_metrics_covered()
 
 

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -376,7 +376,7 @@ def test_submit_summary_with_monotonic_count(aggregator, mocked_prometheus_check
     _sum.add_sample("my_summary", {"quantile": "0.9"}, 25763.0)
     _sum.add_sample("my_summary", {"quantile": "0.99"}, 25763.0)
     check = mocked_prometheus_check
-    mocked_prometheus_scraper_config['send_counts_as_monotonic'] = True
+    mocked_prometheus_scraper_config['send_distribution_counts_as_monotonic'] = True
     check.submit_openmetric('custom.summary', _sum, mocked_prometheus_scraper_config)
     aggregator.assert_metric(
         'prometheus.custom.summary.count', 5.0, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT
@@ -417,7 +417,7 @@ def test_submit_histogram_with_monotonic_count(aggregator, mocked_prometheus_che
         [], buckets=[("-Inf", 0), ("1", 1), ("3.1104e+07", 2), ("4.324e+08", 3), ("+Inf", 4)], sum_value=1337
     )
     check = mocked_prometheus_check
-    mocked_prometheus_scraper_config['send_counts_as_monotonic'] = True
+    mocked_prometheus_scraper_config['send_distribution_counts_as_monotonic'] = True
     check.submit_openmetric('custom.histogram', _histo, mocked_prometheus_scraper_config)
     aggregator.assert_metric('prometheus.custom.histogram.sum', 1337, tags=[], count=1)
     aggregator.assert_metric(

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -88,11 +88,11 @@ instances:
     #
     # send_monotonic_counter: true
 
-    ## @param send_counts_as_monotonic - boolean - optional - default: false
-    ## Set send_counts_as_monotonic to true to send histograms & summary
+    ## @param send_distribution_counts_as_monotonic - boolean - optional - default: false
+    ## Set send_distribution_counts_as_monotonic to true to send histograms & summary
     ## counters as monotonic counters (instead of gauges).
     #
-    # send_counts_as_monotonic: true
+    # send_distribution_counts_as_monotonic: true
 
     ## @param exclude_labels - list of strings - optional
     ## List of label to be excluded

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -88,6 +88,12 @@ instances:
     #
     # send_monotonic_counter: true
 
+    ## @param send_counts_as_monotonic - boolean - optional - default: false
+    ## Set send_counts_as_monotonic to true to send histograms & summary
+    ## counters as monotonic counters (instead of gauges).
+    #
+    # send_counts_as_monotonic: true
+
     ## @param exclude_labels - list of strings - optional
     ## List of label to be excluded
     #


### PR DESCRIPTION
### What does this PR do?

Add an option to send histograms & summaries counts as `monotonic_counter`

### Motivation

Using monotonic counts for counters is more appropriate is most cases

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
