### PR TITLE
Adding Autodiscovery instructions to MySQL

### DIFF
--- a/marathon/README.md
+++ b/marathon/README.md
@@ -13,10 +13,10 @@ The Agent's Marathon check lets you:
 The Marathon check is included in the [Datadog Agent][1] package, so you don't need to install anything else on your Marathon master.
 
 ### Configuration
-#### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
+#### Host
 ##### Metrics collection
 
 1. Edit the `marathon.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2].
@@ -110,9 +110,9 @@ For containerized environments, see the [Autodiscovery Integration Templates][5]
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][6].
 
-| Parameter      | Value                                               |
-|----------------|------------------------------------------------------|
-| `<LOG_CONFIG>` | `{"source": "marathon", "service": "<SERVICE_NAME>"}`|
+| Parameter      | Value                                                 |
+|----------------|-------------------------------------------------------|
+| `<LOG_CONFIG>` | `{"source": "marathon", "service": "<SERVICE_NAME>"}` |
 
 
 ### Validation

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -113,11 +113,11 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 
 ##### Metric collection
 
-| Parameter            | Value                                                                                                                                                                                            |
-|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `mongodb`                                                                                                                                                                                        |
-| `<INIT_CONFIG>`      | blank or `{}`                                                                                                                                                                                    |
-| `<INSTANCE_CONFIG>`  | <pre>{"server": "mongodb://datadog:<UNIQUEPASSWORD>@%%host%%:%%port%%/<DB_NAME>", <br>"replica_check": true, <br>"additional_metrics": ["metrics.commands","tcmalloc","top","collection"]}</pre> |
+| Parameter            | Value                                                                                                                                                                           |
+|----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `<INTEGRATION_NAME>` | `mongodb`                                                                                                                                                                       |
+| `<INIT_CONFIG>`      | blank or `{}`                                                                                                                                                                   |
+| `<INSTANCE_CONFIG>`  | `{"server": "mongodb://datadog:<UNIQUEPASSWORD>@%%host%%:%%port%%/<DB_NAME>", "replica_check": true, "additional_metrics": ["metrics.commands","tcmalloc","top","collection"]}` |
 
 ##### Log collection
 

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -18,10 +18,9 @@ The MongoDB check is included in the [Datadog Agent][2] package. No additional i
 
 ### Configuration
 
-#### Host
-
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
+#### Host
 ##### Prepare MongoDB
 
 In a Mongo shell, create a read-only user for the Datadog Agent in the `admin` database:
@@ -143,22 +142,23 @@ See the [MongoDB 3.0 Manual][9] for more detailed descriptions of some of these 
 
 **NOTE**: The following metrics are NOT collected by default, use the `additional_metrics` parameter in your `mongo.d/conf.yaml` file to collect them:
 
-|                          |                                                   |
-|--------------------------|---------------------------------------------------|
-| metric prefix            | what to add to `additional_metrics` to collect it |
-| mongodb.collection       | collection                                        |
-| mongodb.commands         | top                                               |
-| mongodb.getmore          | top                                               |
-| mongodb.insert           | top                                               |
-| mongodb.queries          | top                                               |
-| mongodb.readLock         | top                                               |
-| mongodb.writeLock        | top                                               |
-| mongodb.remove           | top                                               |
-| mongodb.total            | top                                               |
-| mongodb.update           | top                                               |
-| mongodb.writeLock        | top                                               |
-| mongodb.tcmalloc         | tcmalloc                                          |
-| mongodb.metrics.commands | metrics.commands                                  |
+|----------------------------|-----------------------------------------------------|
+| -------------------------- | --------------------------------------------------- |
+| metric prefix              | what to add to `additional_metrics` to collect it   |
+| mongodb.collection         | collection                                          |
+| mongodb.commands           | top                                                 |
+| mongodb.getmore            | top                                                 |
+| mongodb.insert             | top                                                 |
+| mongodb.queries            | top                                                 |
+| mongodb.readLock           | top                                                 |
+| mongodb.writeLock          | top                                                 |
+| mongodb.remove             | top                                                 |
+| mongodb.total              | top                                                 |
+| mongodb.update             | top                                                 |
+| mongodb.writeLock          | top                                                 |
+| mongodb.tcmalloc           | tcmalloc                                            |
+| mongodb.metrics.commands   | metrics.commands                                    |
+|                            |                                                     ||
 
 ### Events
 

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -142,23 +142,22 @@ See the [MongoDB 3.0 Manual][9] for more detailed descriptions of some of these 
 
 **NOTE**: The following metrics are NOT collected by default, use the `additional_metrics` parameter in your `mongo.d/conf.yaml` file to collect them:
 
-|----------------------------|-----------------------------------------------------|
-| -------------------------- | --------------------------------------------------- |
-| metric prefix              | what to add to `additional_metrics` to collect it   |
-| mongodb.collection         | collection                                          |
-| mongodb.commands           | top                                                 |
-| mongodb.getmore            | top                                                 |
-| mongodb.insert             | top                                                 |
-| mongodb.queries            | top                                                 |
-| mongodb.readLock           | top                                                 |
-| mongodb.writeLock          | top                                                 |
-| mongodb.remove             | top                                                 |
-| mongodb.total              | top                                                 |
-| mongodb.update             | top                                                 |
-| mongodb.writeLock          | top                                                 |
-| mongodb.tcmalloc           | tcmalloc                                            |
-| mongodb.metrics.commands   | metrics.commands                                    |
-|                            |                                                     ||
+| metric prefix            | what to add to `additional_metrics` to collect it |
+|--------------------------|---------------------------------------------------|
+| mongodb.collection       | collection                                        |
+| mongodb.commands         | top                                               |
+| mongodb.getmore          | top                                               |
+| mongodb.insert           | top                                               |
+| mongodb.queries          | top                                               |
+| mongodb.readLock         | top                                               |
+| mongodb.writeLock        | top                                               |
+| mongodb.remove           | top                                               |
+| mongodb.total            | top                                               |
+| mongodb.update           | top                                               |
+| mongodb.writeLock        | top                                               |
+| mongodb.tcmalloc         | tcmalloc                                          |
+| mongodb.metrics.commands | metrics.commands                                  |
+
 
 ### Events
 

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -16,16 +16,9 @@ You can also create your own metrics using custom SQL queries.
 **Note:** This integration is also compatible with [MariaDB](https://mariadb.org/), as it serves as a ["drop-in replacement"][24] for MySQL.
 
 ## Setup
-
-Follow the instructions below to install and configure this check for an Agent running on a host. For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying these instructions.
-
 ### Installation
 
 The MySQL check is included in the [Datadog Agent][3] package. No additional installation is needed on your MySQL server.
-
-### Configuration
-
-Edit the `mysql.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4] to start collecting your MySQL [metrics](#metric-collection) and [logs](#log-collection). See the [sample mysql.d/conf.yaml][5] for all available configuration options.
 
 #### Prepare MySQL
 
@@ -91,7 +84,15 @@ mysql> GRANT SELECT ON performance_schema.* TO 'datadog'@'localhost';
 Query OK, 0 rows affected (0.00 sec)
 ```
 
-#### Metric collection
+### Configuration
+
+Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
+
+#### Host
+
+Edit the `mysql.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4] to start collecting your MySQL [metrics](#metric-collection) and [logs](#log-collection). See the [sample mysql.d/conf.yaml][5] for all available configuration options.
+
+##### Metric collection
 
 * Add this configuration block to your `mysql.d/conf.yaml` to collect your [MySQL metrics](#metrics):
 
@@ -123,7 +124,7 @@ See our [sample mysql.yaml][8] for all available configuration options, includin
 
 [Restart the Agent][9] to start sending MySQL metrics to Datadog.
 
-#### Log collection
+##### Log collection
 
 **Available for Agent >6.0**
 
@@ -196,12 +197,40 @@ See our [sample mysql.yaml][8] for all available configuration options, includin
 
 4. [Restart the Agent][9].
 
+##### Validation
+
+[Run the Agent's status subcommand][11] and look for `mysql` under the Checks section.
+
+#### Containerized
+
+For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying the parameters below.
+
+##### Metric collection
+
+| Parameter            | Value                                                                                    |
+|----------------------|------------------------------------------------------------------------------------------|
+| `<INTEGRATION_NAME>` | `mysql`                                                                                  |
+| `<INIT_CONFIG>`      | blank or `{}`                                                                            |
+| `<INSTANCE_CONFIG>`  | <pre>{"server": "%%host%%", <br>"user": "datadog", <br>"pass": "<UNIQUEPASSWORD>"}</pre> |
+
+
+See the [Autodiscovery template variables documentation][25] to learn how to pass `<UNIQUEPASSWORD>` as an Environment variable instead of a label.
+
+##### Log collection
+
+**Available for Agent v6.5+**
+
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][5].
+
+| Parameter      | Value                                     |
+|----------------|-------------------------------------------|
+| `<LOG_CONFIG>` | `{"source": "mysql", "service": "mysql"}` |
+
 ### Validation
 
 [Run the Agent's status subcommand][11] and look for `mysql` under the Checks section.
 
 ## Data Collected
-
 ### Metrics
 
 See [metadata.csv][12] for a list of metrics provided by this integration.
@@ -399,3 +428,4 @@ Read our [series of blog posts][23] about monitoring MySQL with Datadog.
 [22]: https://docs.datadoghq.com/integrations/faq/how-to-collect-metrics-with-sql-stored-procedure
 [23]: https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics
 [24]: https://mariadb.com/kb/en/library/mariadb-vs-mysql-compatibility
+[25]: https://docs.datadoghq.com/agent/autodiscovery/template_variables/

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -197,10 +197,6 @@ See our [sample mysql.yaml][8] for all available configuration options, includin
 
 4. [Restart the Agent][9].
 
-##### Validation
-
-[Run the Agent's status subcommand][11] and look for `mysql` under the Checks section.
-
 #### Containerized
 
 For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying the parameters below.

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -203,11 +203,11 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 
 ##### Metric collection
 
-| Parameter            | Value                                                                                    |
-|----------------------|------------------------------------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `mysql`                                                                                  |
-| `<INIT_CONFIG>`      | blank or `{}`                                                                            |
-| `<INSTANCE_CONFIG>`  | <pre>{"server": "%%host%%", <br>"user": "datadog", <br>"pass": "<UNIQUEPASSWORD>"}</pre> |
+| Parameter            | Value                                                                  |
+|----------------------|------------------------------------------------------------------------|
+| `<INTEGRATION_NAME>` | `mysql`                                                                |
+| `<INIT_CONFIG>`      | blank or `{}`                                                          |
+| `<INSTANCE_CONFIG>`  | `{"server": "%%host%%", "user": "datadog","pass": "<UNIQUEPASSWORD>"}` |
 
 
 See the [Autodiscovery template variables documentation][25] to learn how to pass `<UNIQUEPASSWORD>` as an Environment variable instead of a label.


### PR DESCRIPTION
### What does this PR do?

Adds Autodiscovery instructions to the MySQL integration documentation

Fixes layout for mongo and marathon