### PR TITLE
Add spark driver support

### DIFF
--- a/spark/README.md
+++ b/spark/README.md
@@ -38,6 +38,7 @@ Follow the instructions below to configure this check for an Agent running on a 
             spark_cluster_mode: spark_standalone_mode # default
         #   spark_cluster_mode: spark_mesos_mode
         #   spark_cluster_mode: spark_yarn_mode
+        #   spark_cluster_mode: spark_driver_mode
 
             cluster_name: <CLUSTER_NAME> # required; adds a tag 'cluster_name:<CLUSTER_NAME>' to all metrics
         #   spark_pre_20_mode: true   # if you use Standalone Spark < v2.0
@@ -80,6 +81,9 @@ Returns `CRITICAL` if the Agent is unable to connect to the Spark instance's Mes
 Returns `CRITICAL` if the Agent is unable to connect to the Spark instance's ApplicationMaster. Returns `OK` otherwise.
 
 **spark.resource_manager.can_connect**<br>
+Returns `CRITICAL` if the Agent is unable to connect to the Spark instance's ResourceManager. Returns `OK` otherwise.
+
+**spark.driver.can_connect**<br>
 Returns `CRITICAL` if the Agent is unable to connect to the Spark instance's ResourceManager. Returns `OK` otherwise.
 
 ## Troubleshooting

--- a/spark/datadog_checks/spark/data/conf.yaml.example
+++ b/spark/datadog_checks/spark/data/conf.yaml.example
@@ -45,6 +45,10 @@ instances:
     ## For Mesos, `spark_url` must be set to the Mesos master's web UI. This is
     ## "http://<master_ip>:5050" by default, where `<master_ip>` is the IP
     ## address or resolvable host name for the Mesos master.
+    ##
+    ## For Kubernetes or a standalone spark driver, `spark_url` must be set to the spark application driver IP.
+    ## "http://<driver_ip>:4040" by default, where `<driver_ip>` is the IP
+    ## address or resolvable spark driver service name.
     #
   - spark_url: http://localhost:8088
 
@@ -59,6 +63,7 @@ instances:
     ##  * `spark_yarn_mode`
     ##  * `spark_standalone_mode`
     ##  * `spark_mesos_mode`
+    ##  * `spark_driver_mode`
     #
     # spark_cluster_mode: spark_yarn_mode
 

--- a/spark/datadog_checks/spark/spark.py
+++ b/spark/datadog_checks/spark/spark.py
@@ -17,6 +17,7 @@ DEPRECATED_MASTER_ADDRESS = 'resourcemanager_uri'
 # Switch that determines the mode Spark is running in. Can be either
 # 'yarn' or 'standalone'
 SPARK_CLUSTER_MODE = 'spark_cluster_mode'
+SPARK_DRIVER_MODE = 'spark_driver_mode'
 SPARK_YARN_MODE = 'spark_yarn_mode'
 SPARK_STANDALONE_MODE = 'spark_standalone_mode'
 SPARK_MESOS_MODE = 'spark_mesos_mode'
@@ -26,6 +27,7 @@ SPARK_PRE_20_MODE = 'spark_pre_20_mode'
 
 # Service Checks
 SPARK_STANDALONE_SERVICE_CHECK = 'spark.standalone_master.can_connect'
+SPARK_DRIVER_SERVICE_CHECK = 'spark.driver.can_connect'
 YARN_SERVICE_CHECK = 'spark.resource_manager.can_connect'
 SPARK_SERVICE_CHECK = 'spark.application_master.can_connect'
 MESOS_SERVICE_CHECK = 'spark.mesos_master.can_connect'
@@ -261,8 +263,35 @@ class SparkCheck(AgentCheck):
             running_apps = self._yarn_init(master_address, tags)
             return self._get_spark_app_ids(running_apps, tags)
 
+        elif cluster_mode == SPARK_DRIVER_MODE:
+            return self._driver_init(master_address, tags)
+
         else:
             raise Exception('Invalid setting for %s. Received %s.' % (SPARK_CLUSTER_MODE, cluster_mode))
+
+    def _driver_init(self, spark_driver_address, tags):
+        """
+        Return a dictionary of {app_id: (app_name, tracking_url)} for the running Spark applications
+        """
+        running_apps = {}
+        metrics_json = self._rest_request_to_json(
+            spark_driver_address, SPARK_APPS_PATH, SPARK_DRIVER_SERVICE_CHECK, tags
+        )
+
+        for app_json in metrics_json:
+            app_id = app_json.get('id')
+            app_name = app_json.get('name')
+            running_apps[app_id] = (app_name, spark_driver_address)
+
+        # Report success after gathering metrics from k8s spark driver
+        self.service_check(
+            SPARK_DRIVER_SERVICE_CHECK,
+            AgentCheck.OK,
+            tags=['url:%s' % spark_driver_address] + tags,
+            message='Connection to k8s spark driver "%s" was successful' % spark_driver_address,
+        )
+        self.log.info("Returning running apps %s" % running_apps)
+        return running_apps
 
     def _standalone_init(self, spark_master_address, pre_20_mode, tags):
         """


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.
We are running spark in our kubernetes cluster with the spark k8s native support, it uses k8s scheduler/api as the spark resource manager(https://spark.apache.org/docs/latest/running-on-kubernetes.html), we want to integrate spark checks to monitor our spark apps in k8s in the autodiscovory mode

### Motivation

What inspired you to submit this pull request?
Be able to monitor spark cluster running in k8s mode

### Additional Notes

Anything else we should know when reviewing?

I have tested the change in my local minikube with datadog daemon-set agent and the metric collection works fine, I will roll it out into our dev cluster soon

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
