### PR TITLE
[kubernetes_state] fix example yaml file

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
@@ -30,7 +30,7 @@ instances:
     #    labels_to_get:
     #      - label_addonmanager_kubernetes_io_mode
 
-    ## @param hostname_override - boolean - optional - default: false
+    ## @param hostname_override - boolean - optional - default: true
     ## By default the hostname for metrics containing the node label is
     ## overriden by the value of the label, this can be deactivated (all metrics
     ## will be attached to the host running KSM)

--- a/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
@@ -27,12 +27,12 @@ instances:
     #     labels_to_get:
     #       - label_addonmanager_kubernetes_io_mode
 
-    ## @param hostname_override - boolean - optional - default: false
+    ## @param hostname_override - boolean - optional - default: true
     ## By default the hostname for metrics containing the node label is
     ## overriden by the value of the label, this can be deactivated (all metrics
     ## will be attached to the host running KSM)
     #
-    # hostname_override: false
+    # hostname_override: true
 
     ## @param tags - list of key:value element - optional
     ## List of tags to attach to every metric, event and service check emitted by this integration.


### PR DESCRIPTION
### What does this PR do?

the default value for the `hostname_override` parameter is true not false. this PR corrects an error in the kubernetes state example yaml files

### Motivation

johanan and grant found this

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
