### PR TITLE
Support submitting memory profiling metrics during E2E

### DIFF
--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -12,8 +12,10 @@ steps:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
 
 - ${{ if eq(parameters.test_e2e, 'true') }}:
-  - script: ddev env test --new-env --retry 3 ${{ parameters.check }}
+  - script: ddev env test --base --new-env --profile-memory --retry 3 ${{ parameters.check }}
     displayName: 'Run E2E tests'
+    env:
+      DD_API_KEY: $(DD_API_KEY)
 
 - ${{ if eq(parameters.benchmark, 'true') }}:
   - script: ddev test --bench --pytest-args="--junitxml=junit/test-bench-results.xml" ${{ parameters.check }}

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -17,6 +17,7 @@ from six import PY3, iteritems, text_type
 
 from ..config import is_affirmative
 from ..constants import ServiceCheck
+from ..utils.agent.utils import should_profile_memory
 from ..utils.common import ensure_bytes, ensure_unicode, to_string
 from ..utils.http import RequestsWrapper
 from ..utils.limiter import Limiter
@@ -565,7 +566,9 @@ class __AgentCheck(object):
                 from ..utils.agent.debug import enter_pdb
 
                 enter_pdb(self.check, line=self.init_config['set_breakpoint'], args=(instance,))
-            elif 'profile_memory' in self.init_config or datadog_agent.tracemalloc_enabled():
+            elif 'profile_memory' in self.init_config or (
+                datadog_agent.tracemalloc_enabled() and should_profile_memory(datadog_agent, self.name)
+            ):
                 from ..utils.agent.memory import profile_memory
 
                 metrics = profile_memory(
@@ -573,6 +576,7 @@ class __AgentCheck(object):
                 )
 
                 tags = ['check_name:{}'.format(self.name), 'check_version:{}'.format(self.check_version)]
+                tags.extend(instance.get('__memory_profiling_tags', []))
                 for m in metrics:
                     self.gauge(m.name, m.value, tags=tags)
             else:

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -578,7 +578,7 @@ class __AgentCheck(object):
                 tags = ['check_name:{}'.format(self.name), 'check_version:{}'.format(self.check_version)]
                 tags.extend(instance.get('__memory_profiling_tags', []))
                 for m in metrics:
-                    self.gauge(m.name, m.value, tags=tags)
+                    self.gauge(m.name, m.value, tags=tags, raw=True)
             else:
                 self.check(instance)
 

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -44,6 +44,7 @@ class AggregatorStub(object):
     )
     GAUGE, RATE, COUNT, MONOTONIC_COUNT, COUNTER, HISTOGRAM, HISTORATE = list(METRIC_ENUM_MAP.values())
     AGGREGATE_TYPES = {COUNT, COUNTER}
+    IGNORED_METRICS = {'datadog.agent.profile.memory.check_run_alloc'}
 
     def __init__(self):
         self._metrics = defaultdict(list)
@@ -56,8 +57,13 @@ class AggregatorStub(object):
     def is_aggregate(cls, mtype):
         return mtype in cls.AGGREGATE_TYPES
 
+    @classmethod
+    def ignore_metric(cls, name):
+        return name in cls.IGNORED_METRICS
+
     def submit_metric(self, check, check_id, mtype, name, value, tags, hostname):
-        self._metrics[name].append(MetricStub(name, mtype, value, tags, hostname))
+        if not self.ignore_metric(name):
+            self._metrics[name].append(MetricStub(name, mtype, value, tags, hostname))
 
     def submit_service_check(self, check, check_id, name, status, tags, hostname, message):
         self._service_checks[name].append(ServiceCheckStub(check_id, name, status, tags, hostname, message))

--- a/datadog_checks_base/datadog_checks/base/utils/agent/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/agent/utils.py
@@ -6,11 +6,11 @@
 def should_profile_memory(datadog_agent, check_name):
     tracemalloc_whitelist = datadog_agent.get_config('tracemalloc_whitelist') or ''
     if tracemalloc_whitelist:
-        tracemalloc_whitelist = [check for check in tracemalloc_whitelist.split(',') if check]
+        tracemalloc_whitelist = [check.strip() for check in tracemalloc_whitelist.split(',') if check]
 
     tracemalloc_blacklist = datadog_agent.get_config('tracemalloc_blacklist') or ''
     if tracemalloc_blacklist:
-        tracemalloc_blacklist = [check for check in tracemalloc_blacklist.split(',') if check]
+        tracemalloc_blacklist = [check.strip() for check in tracemalloc_blacklist.split(',') if check]
 
     return check_name not in tracemalloc_blacklist and (
         check_name in tracemalloc_whitelist if tracemalloc_whitelist else True

--- a/datadog_checks_base/datadog_checks/base/utils/agent/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/agent/utils.py
@@ -6,11 +6,13 @@
 def should_profile_memory(datadog_agent, check_name):
     tracemalloc_whitelist = datadog_agent.get_config('tracemalloc_whitelist') or ''
     if tracemalloc_whitelist:
-        tracemalloc_whitelist = [check.strip() for check in tracemalloc_whitelist.split(',') if check]
+        tracemalloc_whitelist = [check.strip() for check in tracemalloc_whitelist.split(',')]
+        tracemalloc_whitelist = [check for check in tracemalloc_whitelist if check]
 
     tracemalloc_blacklist = datadog_agent.get_config('tracemalloc_blacklist') or ''
     if tracemalloc_blacklist:
-        tracemalloc_blacklist = [check.strip() for check in tracemalloc_blacklist.split(',') if check]
+        tracemalloc_blacklist = [check.strip() for check in tracemalloc_blacklist.split(',')]
+        tracemalloc_blacklist = [check for check in tracemalloc_blacklist if check]
 
     return check_name not in tracemalloc_blacklist and (
         check_name in tracemalloc_whitelist if tracemalloc_whitelist else True

--- a/datadog_checks_base/datadog_checks/base/utils/agent/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/agent/utils.py
@@ -1,0 +1,17 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+
+def should_profile_memory(datadog_agent, check_name):
+    tracemalloc_whitelist = datadog_agent.get_config('tracemalloc_whitelist') or ''
+    if tracemalloc_whitelist:
+        tracemalloc_whitelist = [check for check in tracemalloc_whitelist.split(',') if check]
+
+    tracemalloc_blacklist = datadog_agent.get_config('tracemalloc_blacklist') or ''
+    if tracemalloc_blacklist:
+        tracemalloc_blacklist = [check for check in tracemalloc_blacklist.split(',') if check]
+
+    return check_name not in tracemalloc_blacklist and (
+        check_name in tracemalloc_whitelist if tracemalloc_whitelist else True
+    )

--- a/datadog_checks_base/tests/test_utils_agent_utils.py
+++ b/datadog_checks_base/tests/test_utils_agent_utils.py
@@ -1,0 +1,54 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import mock
+
+from datadog_checks.base import stubs
+from datadog_checks.base.utils.agent.utils import should_profile_memory
+
+
+class TestShouldProfileMemory:
+    def test_default(self):
+        with mock.patch('datadog_checks.base.stubs.datadog_agent.get_config', return_value=''):
+            assert should_profile_memory(stubs.datadog_agent, 'test') is True
+
+    def test_whitelist_enable(self):
+        # Keep a reference for use during mock
+        get_config = stubs.datadog_agent.get_config
+
+        def mock_get_config(key):
+            if key == 'tracemalloc_whitelist':
+                return 'test'
+
+            return get_config(key)
+
+        with mock.patch('datadog_checks.base.stubs.datadog_agent.get_config', side_effect=mock_get_config):
+            assert should_profile_memory(stubs.datadog_agent, 'test') is True
+
+    def test_whitelist_disable(self):
+        # Keep a reference for use during mock
+        get_config = stubs.datadog_agent.get_config
+
+        def mock_get_config(key):
+            if key == 'tracemalloc_whitelist':
+                return 'test1,test2'
+
+            return get_config(key)
+
+        with mock.patch('datadog_checks.base.stubs.datadog_agent.get_config', side_effect=mock_get_config):
+            assert should_profile_memory(stubs.datadog_agent, 'test') is False
+
+    def test_whitelist_blacklist(self):
+        # Keep a reference for use during mock
+        get_config = stubs.datadog_agent.get_config
+
+        def mock_get_config(key):
+            if key == 'tracemalloc_whitelist':
+                return 'test'
+            elif key == 'tracemalloc_blacklist':
+                return 'test'
+
+            return get_config(key)
+
+        with mock.patch('datadog_checks.base.stubs.datadog_agent.get_config', side_effect=mock_get_config):
+            assert should_profile_memory(stubs.datadog_agent, 'test') is False

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -202,21 +202,6 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, profile_memory):
 
         echo_success('success!')
 
-        echo_waiting('Reloading the environment to reflect changes... ', nl=False)
-        result = environment.restart_agent()
-
-        if result.code:
-            click.echo()
-            echo_info(result.stdout + result.stderr)
-            echo_failure('An error occurred.')
-            echo_waiting('Stopping the environment...')
-            stop_environment(check, env, metadata=metadata)
-            echo_waiting('Stopping the Agent...')
-            environment.stop_agent()
-            environment.remove_config()
-        else:
-            echo_success('success!')
-
     if base and not dev:
         dev = True
         echo_info(
@@ -243,6 +228,22 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, profile_memory):
             echo_success('skipping')
         else:
             environment.update_check()
+            echo_success('success!')
+
+    if dev or base or start_commands:
+        echo_waiting('Reloading the environment to reflect changes... ', nl=False)
+        result = environment.restart_agent()
+
+        if result.code:
+            click.echo()
+            echo_info(result.stdout + result.stderr)
+            echo_failure('An error occurred.')
+            echo_waiting('Stopping the environment...')
+            stop_environment(check, env, metadata=metadata)
+            echo_waiting('Stopping the Agent...')
+            environment.stop_agent()
+            environment.remove_config()
+        else:
             echo_success('success!')
 
     # Ensure this happens after all time-consuming steps

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -146,6 +146,7 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, profile_memory):
             branch = get_current_branch()
         except Exception:
             branch = 'unknown'
+            echo_warning('Unable to detect the current Git branch, defaulting to `{}`.'.format(branch))
 
         env_vars['DD_TRACEMALLOC_DEBUG'] = '1'
         env_vars['DD_TRACEMALLOC_WHITELIST'] = check

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -99,6 +99,7 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, profile_memory):
 
     if profile_memory and not api_key:
         profile_memory = False
+        echo_warning('No API key is set; collecting metrics about memory usage will be disabled.')
 
     echo_waiting('Setting up environment `{}`... '.format(env), nl=False)
     config, metadata, error = start_environment(check, env)
@@ -243,6 +244,7 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, profile_memory):
             environment.update_check()
             echo_success('success!')
 
+    # Ensure this happens after all time-consuming steps
     if profile_memory and on_ci:
         environment.metadata['sampling_start_time'] = time.time()
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -141,6 +141,12 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, profile_memory):
         env_vars.setdefault(key, value)
 
     if profile_memory:
+        plat = platform.system()
+        try:
+            branch = get_current_branch()
+        except Exception:
+            branch = 'unknown'
+
         env_vars['DD_TRACEMALLOC_DEBUG'] = '1'
         env_vars['DD_TRACEMALLOC_WHITELIST'] = check
 
@@ -149,10 +155,13 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, profile_memory):
             instances = config.get('instances', [config])
 
         for instance in instances:
-            instance['__memory_profiling_tags'] = ['platform:{}'.format(platform.system()), 'env:{}'.format(env)]
+            instance['__memory_profiling_tags'] = [
+                'platform:{}'.format(plat),
+                'env:{}'.format(env),
+                'branch:{}'.format(branch),
+            ]
 
             if on_ci:
-                instance['__memory_profiling_tags'].append('branch:{}'.format(get_current_branch()))
                 instance['min_collection_interval'] = metadata.get(
                     'sampling_collection_interval', DEFAULT_SAMPLING_COLLECTION_INTERVAL
                 )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+import platform
 import time
 
 import click
@@ -148,7 +149,7 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, profile_memory):
             instances = config.get('instances', [config])
 
         for instance in instances:
-            instance['__memory_profiling_tags'] = ['env:{}'.format(env)]
+            instance['__memory_profiling_tags'] = ['platform:{}'.format(platform.system()), 'env:{}'.format(env)]
 
             if on_ci:
                 instance['__memory_profiling_tags'].append('branch:{}'.format(get_current_branch()))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/stop.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/stop.py
@@ -1,9 +1,13 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import time
+
 import click
 
+from ....utils import running_on_ci
 from ...e2e import create_interface, get_configured_checks, get_configured_envs, stop_environment
+from ...e2e.agent import DEFAULT_SAMPLING_WAIT_TIME
 from ..console import CONTEXT_SETTINGS, DEFAULT_INDENT, abort, echo_failure, echo_info, echo_success, echo_waiting
 
 
@@ -14,6 +18,7 @@ def stop(check, env):
     """Stop environments."""
     all_checks = check == 'all'
     checks = get_configured_checks() if all_checks else [check]
+    on_ci = running_on_ci()
 
     if all_checks:
         env_indent = DEFAULT_INDENT
@@ -33,6 +38,21 @@ def stop(check, env):
         for env in envs:
             echo_info('{}:'.format(env), indent=env_indent)
             environment = create_interface(check, env)
+
+            if on_ci and 'sampling_start_time' in environment.metadata:
+                start_time = environment.metadata['sampling_start_time']
+                wait_time = environment.metadata.get('sampling_wait_time', DEFAULT_SAMPLING_WAIT_TIME)
+
+                notice_displayed = False
+                while time.time() - start_time < wait_time:
+                    if not notice_displayed:
+                        echo_waiting('Collecting samples... ', nl=False, indent=status_indent)
+                        notice_displayed = True
+
+                    time.sleep(1)
+
+                if notice_displayed:
+                    echo_success('success!')
 
             echo_waiting('Stopping the Agent... ', nl=False, indent=status_indent)
             environment.stop_agent()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
@@ -43,9 +43,10 @@ from .stop import stop
     ),
 )
 @click.option('--new-env', '-ne', is_flag=True, help='Execute setup and tear down actions')
+@click.option('--profile-memory', '-pm', is_flag=True, help='Whether to collect metrics about memory usage')
 @click.option('--retry', '-r', help='Number of retries for each tox env', type=click.INT)
 @click.pass_context
-def test(ctx, checks, agent, python, dev, base, env_vars, new_env, retry):
+def test(ctx, checks, agent, python, dev, base, env_vars, new_env, profile_memory, retry):
     """Test an environment."""
     check_envs = get_tox_envs(checks, e2e_tests_only=True)
     tests_ran = False
@@ -59,6 +60,9 @@ def test(ctx, checks, agent, python, dev, base, env_vars, new_env, retry):
     # Default to testing the local development version.
     if dev is None:
         dev = True
+
+    if profile_memory and not new_env:
+        echo_warning('Ignoring --profile-memory, to utilize that you must also select --new-env')
 
     for check, envs in check_envs:
         if not envs:
@@ -74,7 +78,15 @@ def test(ctx, checks, agent, python, dev, base, env_vars, new_env, retry):
         for env in envs:
             if new_env:
                 ctx.invoke(
-                    start, check=check, env=env, agent=agent, python=python, dev=dev, base=base, env_vars=env_vars
+                    start,
+                    check=check,
+                    env=env,
+                    agent=agent,
+                    python=python,
+                    dev=dev,
+                    base=base,
+                    env_vars=env_vars,
+                    profile_memory=profile_memory,
                 )
             elif env not in config_envs:
                 continue

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/agent.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/agent.py
@@ -8,6 +8,16 @@ from .platform import LINUX, MAC, WINDOWS
 DEFAULT_AGENT_VERSION = 6
 DEFAULT_PYTHON_VERSION = 2
 
+# Make checks run at most once every second
+DEFAULT_SAMPLING_COLLECTION_INTERVAL = 1
+
+# Number of seconds to ensure the Agent is running for prior to shutting down
+#
+# We want each run to collect at least 10 samples. The time consuming parts like
+# spinning up Docker environments are done during the setup phase, so the test phase
+# is merely a tox invocation that runs E2E tests via `pytest`.
+DEFAULT_SAMPLING_WAIT_TIME = 15
+
 # Must be a certain length
 FAKE_API_KEY = 'a' * 32
 


### PR DESCRIPTION
### What does this PR do?

Adds a new option `--profile-memory`/`-pm` to start Agents with memory profiling enabled and thus send such metrics. Each integration can set its own `min_collection_interval` and total sampling time via metadata for CI runs.

The current implementation in our CI takes advantage of already spun up Agents in use for E2E tests.

### Additional Notes

Also, implements the logic of https://github.com/DataDog/datadog-agent/pull/4199