### PR TITLE
Add a way to submit non-namespaced metrics and service checks

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -263,7 +263,7 @@ class __AgentCheck(object):
             self, self.check_id, name, value, lower_bound, upper_bound, monotonic, hostname, tags
         )
 
-    def _submit_metric(self, mtype, name, value, tags=None, hostname=None, device_name=None):
+    def _submit_metric(self, mtype, name, value, tags=None, hostname=None, device_name=None, raw=False):
         if value is None:
             # ignore metric sample
             return
@@ -294,9 +294,9 @@ class __AgentCheck(object):
             self.warning(err_msg)
             return
 
-        aggregator.submit_metric(self, self.check_id, mtype, self._format_namespace(name), value, tags, hostname)
+        aggregator.submit_metric(self, self.check_id, mtype, self._format_namespace(name, raw), value, tags, hostname)
 
-    def gauge(self, name, value, tags=None, hostname=None, device_name=None):
+    def gauge(self, name, value, tags=None, hostname=None, device_name=None, raw=False):
         """Sample a gauge metric.
 
         :param str name: the name of the metric.
@@ -305,10 +305,13 @@ class __AgentCheck(object):
         :param str hostname: (optional) a hostname to associate with this metric. Defaults to the current host.
         :param str device_name: **deprecated** add a tag in the form :code:`device:<device_name>` to the :code:`tags`
             list instead.
+        :param bool raw: (optional) whether to ignore any defined namespace prefix
         """
-        self._submit_metric(aggregator.GAUGE, name, value, tags=tags, hostname=hostname, device_name=device_name)
+        self._submit_metric(
+            aggregator.GAUGE, name, value, tags=tags, hostname=hostname, device_name=device_name, raw=raw
+        )
 
-    def count(self, name, value, tags=None, hostname=None, device_name=None):
+    def count(self, name, value, tags=None, hostname=None, device_name=None, raw=False):
         """Sample a raw count metric.
 
         :param str name: the name of the metric.
@@ -317,10 +320,13 @@ class __AgentCheck(object):
         :param str hostname: (optional) a hostname to associate with this metric. Defaults to the current host.
         :param str device_name: **deprecated** add a tag in the form :code:`device:<device_name>` to the :code:`tags`
             list instead.
+        :param bool raw: (optional) whether to ignore any defined namespace prefix
         """
-        self._submit_metric(aggregator.COUNT, name, value, tags=tags, hostname=hostname, device_name=device_name)
+        self._submit_metric(
+            aggregator.COUNT, name, value, tags=tags, hostname=hostname, device_name=device_name, raw=raw
+        )
 
-    def monotonic_count(self, name, value, tags=None, hostname=None, device_name=None):
+    def monotonic_count(self, name, value, tags=None, hostname=None, device_name=None, raw=False):
         """Sample an increasing counter metric.
 
         :param str name: the name of the metric.
@@ -329,12 +335,13 @@ class __AgentCheck(object):
         :param str hostname: (optional) a hostname to associate with this metric. Defaults to the current host.
         :param str device_name: **deprecated** add a tag in the form :code:`device:<device_name>` to the :code:`tags`
             list instead.
+        :param bool raw: (optional) whether to ignore any defined namespace prefix
         """
         self._submit_metric(
-            aggregator.MONOTONIC_COUNT, name, value, tags=tags, hostname=hostname, device_name=device_name
+            aggregator.MONOTONIC_COUNT, name, value, tags=tags, hostname=hostname, device_name=device_name, raw=raw
         )
 
-    def rate(self, name, value, tags=None, hostname=None, device_name=None):
+    def rate(self, name, value, tags=None, hostname=None, device_name=None, raw=False):
         """Sample a point, with the rate calculated at the end of the check.
 
         :param str name: the name of the metric.
@@ -343,10 +350,13 @@ class __AgentCheck(object):
         :param str hostname: (optional) a hostname to associate with this metric. Defaults to the current host.
         :param str device_name: **deprecated** add a tag in the form :code:`device:<device_name>` to the :code:`tags`
             list instead.
+        :param bool raw: (optional) whether to ignore any defined namespace prefix
         """
-        self._submit_metric(aggregator.RATE, name, value, tags=tags, hostname=hostname, device_name=device_name)
+        self._submit_metric(
+            aggregator.RATE, name, value, tags=tags, hostname=hostname, device_name=device_name, raw=raw
+        )
 
-    def histogram(self, name, value, tags=None, hostname=None, device_name=None):
+    def histogram(self, name, value, tags=None, hostname=None, device_name=None, raw=False):
         """Sample a histogram metric.
 
         :param str name: the name of the metric.
@@ -355,10 +365,13 @@ class __AgentCheck(object):
         :param str hostname: (optional) a hostname to associate with this metric. Defaults to the current host.
         :param str device_name: **deprecated** add a tag in the form :code:`device:<device_name>` to the :code:`tags`
             list instead.
+        :param bool raw: (optional) whether to ignore any defined namespace prefix
         """
-        self._submit_metric(aggregator.HISTOGRAM, name, value, tags=tags, hostname=hostname, device_name=device_name)
+        self._submit_metric(
+            aggregator.HISTOGRAM, name, value, tags=tags, hostname=hostname, device_name=device_name, raw=raw
+        )
 
-    def historate(self, name, value, tags=None, hostname=None, device_name=None):
+    def historate(self, name, value, tags=None, hostname=None, device_name=None, raw=False):
         """Sample a histogram based on rate metrics.
 
         :param str name: the name of the metric.
@@ -367,10 +380,13 @@ class __AgentCheck(object):
         :param str hostname: (optional) a hostname to associate with this metric. Defaults to the current host.
         :param str device_name: **deprecated** add a tag in the form :code:`device:<device_name>` to the :code:`tags`
             list instead.
+        :param bool raw: (optional) whether to ignore any defined namespace prefix
         """
-        self._submit_metric(aggregator.HISTORATE, name, value, tags=tags, hostname=hostname, device_name=device_name)
+        self._submit_metric(
+            aggregator.HISTORATE, name, value, tags=tags, hostname=hostname, device_name=device_name, raw=raw
+        )
 
-    def increment(self, name, value=1, tags=None, hostname=None, device_name=None):
+    def increment(self, name, value=1, tags=None, hostname=None, device_name=None, raw=False):
         """Increment a counter metric.
 
         :param str name: the name of the metric.
@@ -379,11 +395,14 @@ class __AgentCheck(object):
         :param str hostname: (optional) a hostname to associate with this metric. Defaults to the current host.
         :param str device_name: **deprecated** add a tag in the form :code:`device:<device_name>` to the :code:`tags`
             list instead.
+        :param bool raw: (optional) whether to ignore any defined namespace prefix
         """
         self._log_deprecation('increment')
-        self._submit_metric(aggregator.COUNTER, name, value, tags=tags, hostname=hostname, device_name=device_name)
+        self._submit_metric(
+            aggregator.COUNTER, name, value, tags=tags, hostname=hostname, device_name=device_name, raw=raw
+        )
 
-    def decrement(self, name, value=-1, tags=None, hostname=None, device_name=None):
+    def decrement(self, name, value=-1, tags=None, hostname=None, device_name=None, raw=False):
         """Decrement a counter metric.
 
         :param str name: the name of the metric.
@@ -392,11 +411,14 @@ class __AgentCheck(object):
         :param str hostname: (optional) a hostname to associate with this metric. Defaults to the current host.
         :param str device_name: **deprecated** add a tag in the form :code:`device:<device_name>` to the :code:`tags`
             list instead.
+        :param bool raw: (optional) whether to ignore any defined namespace prefix
         """
         self._log_deprecation('increment')
-        self._submit_metric(aggregator.COUNTER, name, value, tags=tags, hostname=hostname, device_name=device_name)
+        self._submit_metric(
+            aggregator.COUNTER, name, value, tags=tags, hostname=hostname, device_name=device_name, raw=raw
+        )
 
-    def service_check(self, name, status, tags=None, hostname=None, message=None):
+    def service_check(self, name, status, tags=None, hostname=None, message=None, raw=False):
         """Send the status of a service.
 
         :param str name: the name of the service check.
@@ -404,6 +426,7 @@ class __AgentCheck(object):
         :type status: :py:class:`datadog_checks.base.constants.ServiceCheck`
         :param list tags: (optional) a list of tags to associate with this check.
         :param str message: (optional) additional information or a description of why this status occurred.
+        :param bool raw: (optional) whether to ignore any defined namespace prefix
         """
         tags = self._normalize_tags_type(tags)
         if hostname is None:
@@ -414,7 +437,7 @@ class __AgentCheck(object):
             message = to_string(message)
 
         aggregator.submit_service_check(
-            self, self.check_id, self._format_namespace(name), status, tags, hostname, message
+            self, self.check_id, self._format_namespace(name, raw), status, tags, hostname, message
         )
 
     def _log_deprecation(self, deprecation_key):
@@ -494,8 +517,8 @@ class __AgentCheck(object):
 
         return proxies if proxies else no_proxy_settings
 
-    def _format_namespace(self, s):
-        if self.__NAMESPACE__:
+    def _format_namespace(self, s, raw=False):
+        if not raw and self.__NAMESPACE__:
             return '{}.{}'.format(self.__NAMESPACE__, to_string(s))
 
         return to_string(s)

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -116,6 +116,16 @@ class TestMetrics:
 
         aggregator.assert_metric('test.metric')
 
+    def test_namespace_override(self, aggregator):
+        check = AgentCheck()
+        check.__NAMESPACE__ = 'test'
+
+        methods = ('gauge', 'count', 'monotonic_count', 'rate', 'histogram', 'historate', 'increment', 'decrement')
+        for method in methods:
+            getattr(check, method)('metric', 0, raw=True)
+
+        aggregator.assert_metric('metric', count=len(methods))
+
     def test_non_float_metric(self, aggregator):
         check = AgentCheck()
         metric_name = 'test_metric'
@@ -182,6 +192,13 @@ class TestServiceChecks:
 
         check.service_check('service_check', AgentCheck.OK)
         aggregator.assert_service_check('test.service_check', status=AgentCheck.OK)
+
+    def test_namespace_override(self, aggregator):
+        check = AgentCheck()
+        check.__NAMESPACE__ = 'test'
+
+        check.service_check('service_check', AgentCheck.OK, raw=True)
+        aggregator.assert_service_check('service_check', status=AgentCheck.OK)
 
 
 class TestTags:


### PR DESCRIPTION
### Motivation

Occasionally we want to ignore the namespace, such as the submission of memory profiling metrics and others prefixed with `datadog.agent.`, and odd/legacy metric names