### PR TITLE
add comment about TimescaleDB

### DIFF
--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -63,7 +63,7 @@ instances:
     ## @param relations - list of objects (or strings) - optional
     ## The list of relations/tables must be specified here to track per-relation (table) metrics.
     ## You can either specify a single relation by its exact name in 'relation_name' or use a regex to track metrics
-    ## from all matching relations.
+    ## from all matching relations (useful in cases where relation names are dynamically generated, e.g. TimescaleDB).
     ## Each relation generates many metrics (10 + 10 per index)
     ## By default all schemas are included. To track relations from specific schemas only,
     ## you can specify the `schemas` attribute and provide a list of schemas to use for filtering.


### PR DESCRIPTION
### What does this PR do?

TimescaleDB links to our docs as a useful monitoring tool: https://docs.timescale.com/latest/using-timescaledb/alerting

But there's no mention anywhere in our docs about using a `relation_regex` pattern such that dynamically generated table names can be picked up by our Postgres integration. 

I spun up a small instance of TimescaleDB in AWS to verify that setting this `relation_regex` attribute would allow Datadog to ingest more metrics from TimescaleDB without requiring explicit table names. 

Proof from Postgres Dashboard in my Datadog account. 
https://cl.ly/e03ab55b5113

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
