### PR TITLE
Julia/cacti custom port

### DIFF
--- a/cacti/datadog_checks/cacti/cacti.py
+++ b/cacti/datadog_checks/cacti/cacti.py
@@ -60,7 +60,9 @@ class CactiCheck(AgentCheck):
         patterns = self._get_whitelist_patterns(self.config.whitelist)
 
         # Fetch the RRD metadata from MySQL
-        rrd_meta = self._fetch_rrd_meta(connection, self.config.rrd_path, patterns, self.config.field_names, self.config.tags)
+        rrd_meta = self._fetch_rrd_meta(
+            connection, self.config.rrd_path, patterns, self.config.field_names, self.config.tags
+        )
 
         # Load the metrics from each RRD, tracking the count as we go
         metric_count = 0
@@ -71,7 +73,9 @@ class CactiCheck(AgentCheck):
         self.gauge('cacti.metrics.count', metric_count, tags=self.config.tags)
 
     def _get_connection(self):
-        return pymysql.connect(self.config.host, self.config.user, self.config.password, self.config.db, self.config.port)
+        return pymysql.connect(
+            self.config.host, self.config.user, self.config.password, self.config.db, self.config.port
+        )
 
     def _get_whitelist_patterns(self, whitelist=None):
         patterns = []

--- a/cacti/datadog_checks/cacti/cacti.py
+++ b/cacti/datadog_checks/cacti/cacti.py
@@ -37,7 +37,7 @@ CACTI_TO_DD = {
 
 class CactiCheck(AgentCheck):
     def __init__(self, name, init_config, instances):
-        AgentCheck.__init__(self, name, init_config, instances)
+        super(CactiCheck, self).__init__(name, init_config, instances)
         self.last_ts = {}
         # Load the instance config
         self.config = self._get_config(instances[0])

--- a/cacti/datadog_checks/cacti/cacti.py
+++ b/cacti/datadog_checks/cacti/cacti.py
@@ -53,7 +53,7 @@ class CactiCheck(AgentCheck):
         # Load the instance config
         config = self._get_config(instance)
 
-        connection = pymysql.connect(config.host, config.user, config.password, config.db)
+        connection = pymysql.connect(config.host, config.user, config.password, config.db, config.port)
 
         self.log.debug("Connected to MySQL to fetch Cacti metadata")
 
@@ -96,16 +96,17 @@ class CactiCheck(AgentCheck):
         user = instance.get('mysql_user')
         password = instance.get('mysql_password', '') or ''
         db = instance.get('mysql_db', 'cacti')
+        port = instance.get('mysql_port')
         rrd_path = instance.get('rrd_path')
         whitelist = instance.get('rrd_whitelist')
         field_names = instance.get('field_names', ['ifName', 'dskDevice'])
         tags = instance.get('tags', [])
 
         Config = namedtuple(
-            'Config', ['host', 'user', 'password', 'db', 'rrd_path', 'whitelist', 'field_names', 'tags']
+            'Config', ['host', 'user', 'password', 'db', 'port', 'rrd_path', 'whitelist', 'field_names', 'tags']
         )
 
-        return Config(host, user, password, db, rrd_path, whitelist, field_names, tags)
+        return Config(host, user, password, db, port, rrd_path, whitelist, field_names, tags)
 
     @staticmethod
     def _get_rrd_info(rrd_path):

--- a/cacti/datadog_checks/cacti/cacti.py
+++ b/cacti/datadog_checks/cacti/cacti.py
@@ -36,9 +36,11 @@ CACTI_TO_DD = {
 
 
 class CactiCheck(AgentCheck):
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+    def __init__(self, name, init_config, instances):
+        AgentCheck.__init__(self, name, init_config, instances)
         self.last_ts = {}
+        # Load the instance config
+        self.config = self._get_config(instances[0])
 
     @staticmethod
     def get_library_versions():
@@ -50,26 +52,26 @@ class CactiCheck(AgentCheck):
         if rrdtool is None:
             raise Exception("Unable to import python rrdtool module")
 
-        # Load the instance config
-        config = self._get_config(instance)
-
-        connection = pymysql.connect(config.host, config.user, config.password, config.db, config.port)
+        connection = self._get_connection()
 
         self.log.debug("Connected to MySQL to fetch Cacti metadata")
 
         # Get whitelist patterns, if available
-        patterns = self._get_whitelist_patterns(config.whitelist)
+        patterns = self._get_whitelist_patterns(self.config.whitelist)
 
         # Fetch the RRD metadata from MySQL
-        rrd_meta = self._fetch_rrd_meta(connection, config.rrd_path, patterns, config.field_names, config.tags)
+        rrd_meta = self._fetch_rrd_meta(connection, self.config.rrd_path, patterns, self.config.field_names, self.config.tags)
 
         # Load the metrics from each RRD, tracking the count as we go
         metric_count = 0
         for hostname, device_name, rrd_path in rrd_meta:
-            m_count = self._read_rrd(rrd_path, hostname, device_name, config.tags)
+            m_count = self._read_rrd(rrd_path, hostname, device_name, self.config.tags)
             metric_count += m_count
 
-        self.gauge('cacti.metrics.count', metric_count, tags=config.tags)
+        self.gauge('cacti.metrics.count', metric_count, tags=self.config.tags)
+
+    def _get_connection(self):
+        return pymysql.connect(self.config.host, self.config.user, self.config.password, self.config.db, self.config.port)
 
     def _get_whitelist_patterns(self, whitelist=None):
         patterns = []

--- a/cacti/datadog_checks/cacti/data/conf.yaml.example
+++ b/cacti/datadog_checks/cacti/data/conf.yaml.example
@@ -7,7 +7,7 @@ instances:
     #
   - mysql_host: localhost
 
-    ## @param mysql_port - int - optional - default: 3306
+    ## @param mysql_port - integer - optional - default: 3306
     ## port of your MySQL database
     #
     # mysql_port: 3306

--- a/cacti/datadog_checks/cacti/data/conf.yaml.example
+++ b/cacti/datadog_checks/cacti/data/conf.yaml.example
@@ -7,6 +7,11 @@ instances:
     #
   - mysql_host: localhost
 
+    ## @param mysql_port - int - optional - default: 3306
+    ## port of your MySQL database
+    #
+    # mysql_port: 3306
+
     ## @param mysql_user - string - required
     ## User to use to connect to MySQL in order to gather metrics
     #

--- a/cacti/tests/conftest.py
+++ b/cacti/tests/conftest.py
@@ -72,7 +72,7 @@ def dd_environment():
 
 @pytest.fixture
 def check():
-    return CactiCheck('cacti', {}, {})
+    return CactiCheck('cacti', {}, [{}])
 
 
 @pytest.fixture


### PR DESCRIPTION
### What does this PR do?

Adds config option to select port for cacti integration. Adapts constructor to use newer one

### Motivation

During migration to azure we found out we cannot select a different port for this
