### PR TITLE
Make iowrite_bytes and ioread_bytes counts

### DIFF
--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -417,14 +417,17 @@ class ProcessCheck(AgentCheck):
             vals = [x for x in proc_state[attr] if x is not None]
             # skip []
             if vals:
+                sum_vals = sum(vals)
                 if attr == 'run_time':
-                    self.gauge('system.processes.{}.avg'.format(mname), sum(vals) / len(vals), tags=tags)
+                    self.gauge('system.processes.{}.avg'.format(mname), sum_vals / len(vals), tags=tags)
                     self.gauge('system.processes.{}.max'.format(mname), max(vals), tags=tags)
                     self.gauge('system.processes.{}.min'.format(mname), min(vals), tags=tags)
 
                 # FIXME 8.x: change this prefix?
                 else:
-                    self.gauge('system.processes.{}'.format(mname), sum(vals), tags=tags)
+                    self.gauge('system.processes.{}'.format(mname), sum_vals, tags=tags)
+                    if mname in ['ioread_bytes', 'iowrite_bytes']:
+                        self.count('system.processes.{}_count'.format(mname), sum_vals, tags=tags)
 
         for attr, mname in iteritems(ATTR_TO_METRIC_RATE):
             vals = [x for x in proc_state[attr] if x is not None]

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -427,7 +427,7 @@ class ProcessCheck(AgentCheck):
                 else:
                     self.gauge('system.processes.{}'.format(mname), sum_vals, tags=tags)
                     if mname in ['ioread_bytes', 'iowrite_bytes']:
-                        self.count('system.processes.{}_count'.format(mname), sum_vals, tags=tags)
+                        self.monotonic_count('system.processes.{}_count'.format(mname), sum_vals, tags=tags)
 
         for attr, mname in iteritems(ATTR_TO_METRIC_RATE):
             vals = [x for x in proc_state[attr] if x is not None]

--- a/process/metadata.csv
+++ b/process/metadata.csv
@@ -3,8 +3,10 @@ system.processes.cpu.pct,gauge,,percent,,The CPU utilization of a process.,0,sys
 system.processes.cpu.normalized_pct,gauge,,percent,,The normalized CPU utilization of a process.,0,system,processes cpu normalized pct
 system.processes.involuntary_ctx_switches,gauge,,event,,The number of involuntary context switches performed by this process.,0,system,processes invol ctx switches
 system.processes.ioread_bytes,gauge,,byte,,The number of bytes read from disk by this process. In Windows: the number of bytes read.,0,system,processes io r bytes
+system.processes.ioread_bytes_count,count,,byte,,The number of bytes read from disk by this process. In Windows: the number of bytes read.,0,system,processes io r bytes
 system.processes.ioread_count,gauge,,read,,The number of disk reads by this process. In Windows: the number of reads by this process.,0,system,processes io r count
 system.processes.iowrite_bytes,gauge,,byte,,The number of bytes written to disk by this process. In Windows: the number of bytes written by this process.,0,system,processes io w bytes
+system.processes.iowrite_bytes_count,count,,byte,,The number of bytes written to disk by this process. In Windows: the number of bytes written by this process.,0,system,processes io w bytes
 system.processes.iowrite_count,gauge,,write,,The number of disk writes by this process. In Windows: the number of writes by this process.,0,system,processes io w count
 system.processes.mem.page_faults.minor_faults,gauge,,occurrence,second,The number of minor page faults per second for this process.,0,system,minor page faults
 system.processes.mem.page_faults.children_minor_faults,gauge,,occurrence,second,The number of minor page faults per second for children of this process.,0,system,children minor page faults

--- a/process/tests/common.py
+++ b/process/tests/common.py
@@ -10,8 +10,10 @@ CHECK_NAME = 'process'
 PROCESS_METRIC = [
     'system.processes.involuntary_ctx_switches',
     'system.processes.ioread_bytes',
+    'system.processes.ioread_bytes_count',
     'system.processes.ioread_count',
     'system.processes.iowrite_bytes',
+    'system.processes.iowrite_bytes_count',
     'system.processes.iowrite_count',
     'system.processes.mem.pct',
     'system.processes.mem.real',


### PR DESCRIPTION
These metrics, which are collected with psutil, are currently sent with gauge even though they're monotonic counters, which makes them very hard to use in-app.