### PR TITLE
Resolve AWS MSK TLS Certificate Failure

### DIFF
--- a/kafka_consumer/requirements.in
+++ b/kafka_consumer/requirements.in
@@ -1,2 +1,2 @@
-kafka-python==1.4.4; sys_platform != 'win32'
+kafka-python==1.4.7; sys_platform != 'win32'
 kazoo==2.6.1; sys_platform != 'win32'


### PR DESCRIPTION
### What does this PR do?

kafka-python 1.4.7 adds support for loading the system default certificates which appears to be required for newer root CAs such as Amazon's which are used by AWS services like MSK. This allows Datadog kafka_consumer check to pass the certificate validation step of the TLS handshake with MSK for valid certs because it now loads the CA chain of trust.

### Motivation

Currently the kafka_consumer check fails to connect to MSK clusters via TLS because of certificate validation failure (it doesn't load the system's CA chain of trust).

### Additional Notes

See https://github.com/dpkp/kafka-python/pull/1883.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
