### PR TITLE
Use fetchall instead of iterating cursor

### DIFF
--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -160,7 +160,7 @@ class Oracle(AgentCheck):
 
             with closing(con.cursor()) as cursor:
                 cursor.execute(query)
-                for row in cursor:
+                for row in cursor.fetchall():
                     if len(columns) != len(row):
                         self.log.error(
                             'query result for metric_prefix {}: expected {} columns, got {}'.format(

--- a/oracle/tests/test_metrics.py
+++ b/oracle/tests/test_metrics.py
@@ -93,7 +93,7 @@ def test__get_custom_metrics_misconfigured(check):
     gauge = mock.MagicMock()
     con = mock.MagicMock()
     cursor = mock.MagicMock()
-    cursor.__iter__.side_effect = lambda: iter([["foo", "bar"], ["foo", "bar"]])
+    cursor.fetchall.side_effect = lambda: iter([["foo", "bar"], ["foo", "bar"]])
     con.cursor.return_value = cursor
     check.log = log
     check.gauge = gauge
@@ -166,7 +166,7 @@ def test__get_custom_metrics(aggregator, check):
     con = mock.MagicMock()
     cursor = mock.MagicMock()
     data = [[["tag_value1", "1"]], [[1, 2, "tag_value2"]]]
-    cursor.__iter__.side_effect = lambda: iter(data.pop(0))
+    cursor.fetchall.side_effect = lambda: iter(data.pop(0))
     con.cursor.return_value = cursor
 
     custom_queries = [
@@ -212,7 +212,7 @@ def test__get_custom_metrics_multiple_results(aggregator, check):
     con = mock.MagicMock()
     cursor = mock.MagicMock()
     data = [["tag_value1", "1"], ["tag_value2", "2"]]
-    cursor.__iter__.side_effect = lambda: iter(data)
+    cursor.fetchall.side_effect = lambda: iter(data)
     con.cursor.return_value = cursor
 
     custom_queries = [


### PR DESCRIPTION
For custom metrics we tried to iterator on the cursor, but it only works
with cx_Oracle, not JDBC. Let's use fetchall instead.