### PR TITLE
Fix swapped metric descriptions

### DIFF
--- a/mcache/metadata.csv
+++ b/mcache/metadata.csv
@@ -22,8 +22,8 @@ memcache.get_misses_rate,gauge,,miss,second,Rate at which keys are requested and
 memcache.limit_maxbytes,gauge,,byte,,Number of bytes this server is allowed to use for storage.,0,memcached,maxbytes
 memcache.listen_disabled_num_rate,gauge,,event,second,Rate at which the server has reached the max connection limit.,-1,memcached,listen dsbl rate
 memcache.pointer_size,gauge,,bit,,Default size of pointers on the host OS (generally 32 or 64),0,memcached,ptr size
-memcache.rusage_system_rate,gauge,,fraction,,Fraction of user time the CPU spent executing this server process.,0,memcached,rusage sys rate
-memcache.rusage_user_rate,gauge,,fraction,,Fraction of time the CPU spent executing kernel code on behalf of this server process.,0,memcached,rusage usr rate
+memcache.rusage_system_rate,gauge,,fraction,,Fraction of time the CPU spent executing kernel code on behalf of this server process.,0,memcached,rusage sys rate
+memcache.rusage_user_rate,gauge,,fraction,,Fraction of user time the CPU spent executing this server process.,0,memcached,rusage usr rate
 memcache.threads,gauge,,thread,,Number of threads used by the current Memcached server process.,0,memcached,threads
 memcache.total_connections_rate,gauge,,connection,second,Rate at which connections to this server are opened.,0,memcached,tot conn rate
 memcache.total_items,gauge,,item,,Total number of items stored by this server since it started.,0,memcached,tot items


### PR DESCRIPTION
### What does this PR do?

Swaps two metadata descriptions.

### Motivation

It was confusing that a "user" stat was described as kernel time and vice versa.

### Additional Notes

Officially documented at https://github.com/memcached/memcached/blob/master/doc/protocol.txt

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
