### PR TITLE
verifies if `root` is dict before doing `.get`

### DIFF
--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -534,7 +534,9 @@ class RabbitMQ(AgentCheck):
             for path in keys[:-1]:
                 root = root.get(path, {})
 
-            value = root.get(keys[-1], None) if isinstance(root, dict) else None  # In RabbitMQ 3.1.x queue_totals is a list instead of a dict
+            value = (
+                root.get(keys[-1], None) if isinstance(root, dict) else None
+            )  # In RabbitMQ 3.1.x queue_totals is a list instead of a dict
             if value is not None:
                 try:
                     self.gauge(

--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -534,7 +534,7 @@ class RabbitMQ(AgentCheck):
             for path in keys[:-1]:
                 root = root.get(path, {})
 
-            value = root.get(keys[-1], None)
+            value = root.get(keys[-1], None) if isinstance(root, dict) else None
             if value is not None:
                 try:
                     self.gauge(

--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -534,7 +534,7 @@ class RabbitMQ(AgentCheck):
             for path in keys[:-1]:
                 root = root.get(path, {})
 
-            value = root.get(keys[-1], None) if isinstance(root, dict) else None
+            value = root.get(keys[-1], None) if isinstance(root, dict) else None  # In RabbitMQ 3.1.x queue_totals is a list instead of a dict
             if value is not None:
                 try:
                     self.gauge(


### PR DESCRIPTION
### What does this PR do?

Fixes below error which happens of `root` is not a dictionary.

```
Error: 'list' object has no attribute 'get' 
Traceback (most recent call last): 
    File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/base.py", line 556, in run 
self.check(instance) 
    File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/rabbitmq/rabbitmq.py", line 257, in check 
self.get_overview_stats(base_url, custom_tags) 
    File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/rabbitmq/rabbitmq.py", line 517, in get_overview_stats 
self._get_metrics(data, OVERVIEW_TYPE, custom_tags) 
    File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/rabbitmq/rabbitmq.py", line 528, in _get_metrics 
    value = root.get(keys[-1], None) 
AttributeError: 'list' object has no attribute 'get'
```
### Motivation

1532-list-get-error-being-thrown-by-rabbitmq-check

### Additional Notes

Happens on an EOL RabbitMQ 3.1.x where `"queue_totals": []` is returned instead of `"queue_totals": {..}`

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
