### PR TITLE
Do not run mysql 5.5 in e2e

### DIFF
--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -6,7 +6,7 @@ envlist =
 
 [testenv]
 description =
-    py{27,37}: e2e ready
+    py{27,37}-{5.6,5.7,8.0,maria}: e2e ready
 dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
@@ -18,7 +18,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     pip install -r requirements.in
-    {5.5,5.6,5.7,8.0,maria}: pytest -v
+    pytest -v {posargs}
 setenv =
     COMPOSE_FILE=mysql.yaml
     MYSQL_FLAVOR=mysql


### PR DESCRIPTION
### What does this PR do?

Do not run mysql 5.5 in e2e

### Motivation

Main reason to remove Mysql 5.5 e2e:
- The test is very flaky on CI.
- Mysql 5.5 is reaching end of life

But we should still keep it for local testing:
- But we should probably keep the test for now for local testing because Mysql 5.5 is compatible with MariaDB 5.5 and Mysql 5.5 end of life is March 2020.
- There is no harm to keep the compatibility
- It preferable to remove the test at the same time as the code (there are few metrics only available on Mysql 5.5)

![image](https://user-images.githubusercontent.com/49917914/66109471-04998a00-e5c5-11e9-91f0-fde6b8f08b1a.png)
