### PR TITLE
Add semver dependency

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -53,6 +53,7 @@ requests_ntlm==1.1.0
 scandir==1.8
 securesystemslib[crypto,pynacl]==0.11.3
 selectors34==1.2.0; sys_platform == 'win32' and python_version < '3.4'
+semver==2.8.1
 serpent==1.27; sys_platform == 'win32'
 service_identity[idna]==18.1.0
 simplejson==3.6.5

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -10,6 +10,7 @@ pyyaml==5.1
 requests==2.22.0
 requests-kerberos==0.12.0
 requests_ntlm==1.1.0
+semver==2.8.1
 simplejson==3.6.5
 six==1.12.0
 uptime==3.0.1


### PR DESCRIPTION
### Motivation

https://github.com/DataDog/integrations-core/pull/2508

We desire an Agent build with it so e2e tests can pass there