### PR TITLE
Add unknown status to etcd health check

### DIFF
--- a/etcd/assets/service_checks.json
+++ b/etcd/assets/service_checks.json
@@ -12,7 +12,7 @@
         "agent_version": "5.21.0",
         "integration":"etcd",
         "check": "etcd.healthy",
-        "statuses": ["ok", "critical"],
+        "statuses": ["ok", "critical", "unknown"],
         "groups": ["host", "url"],
         "name": "Healthy",
         "description": "Returns `CRITICAL` when a member is unhealthy"


### PR DESCRIPTION
Health service check can potentially be unknown:
```
       # Gather self health status
        sc_state = self.UNKNOWN
        health_status = self._get_health_status(url, timeout)
        if health_status is not None:
            sc_state = self.OK if self._is_healthy(health_status) else self.CRITICAL
        self.service_check(self.HEALTH_SERVICE_CHECK_NAME, sc_state, tags=instance_tags)
```