### PR TITLE
Upgrade Paramiko to version 2.6.0

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -23,7 +23,7 @@ ldap3==2.5
 lxml==4.4.1
 meld3==1.0.2
 openstacksdk==0.24.0
-paramiko==2.1.5
+paramiko==2.6.0
 ply==3.10
 prometheus-client==0.3.0
 protobuf==3.7.0

--- a/ssh_check/requirements.in
+++ b/ssh_check/requirements.in
@@ -1,1 +1,1 @@
-paramiko==2.1.5
+paramiko==2.6.0


### PR DESCRIPTION
### What does this PR do?

Increasing the Paramiko version used by the SSH check integration.

### Motivation

Datadog's SSH check integration currently uses a version of Paramiko (2.1.5) that only supports older KEX algorithms. Increasing the version to 2.6.0 will allow Datadog clients to use SSH check on endpoints that have deprecated these algorithms, while supporting more recent ones such as `curve25519-sha256@libssh.org`.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
