### PR TITLE
Implement Python API for setting check metadata

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -31,6 +31,10 @@ def debug(msg, *args, **kwargs):
     pass
 
 
+def set_check_metadata(*args, **kwargs):
+    pass
+
+
 def set_external_tags(*args, **kwargs):
     pass
 

--- a/datadog_checks_base/datadog_checks/base/utils/common.py
+++ b/datadog_checks_base/datadog_checks/base/utils/common.py
@@ -5,7 +5,7 @@ import os
 import re
 from decimal import ROUND_HALF_UP, Decimal
 
-from six import PY3, text_type
+from six import PY3, iteritems, text_type
 from six.moves.urllib.parse import urlparse
 
 
@@ -22,6 +22,10 @@ def ensure_unicode(s):
 
 
 to_string = ensure_unicode if PY3 else ensure_bytes
+
+
+def exclude_undefined_keys(mapping):
+    return {key: value for key, value in iteritems(mapping) if value is not None}
 
 
 def round_value(value, precision=0, rounding_method=ROUND_HALF_UP):

--- a/datadog_checks_base/datadog_checks/base/utils/metadata/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/utils/metadata/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from .core import MetadataManager

--- a/datadog_checks_base/datadog_checks/base/utils/metadata/constants.py
+++ b/datadog_checks_base/datadog_checks/base/utils/metadata/constants.py
@@ -1,0 +1,17 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Keep in sync with relevant fields from:
+# https://github.com/DataDog/datadog-agent/blob/1fdb5e1746f9834d627f8fa1611d3753c1f9db10/pkg/process/config/data_scrubber.go#L14-L20
+DEFAULT_BLACKLIST = (
+    'access_token',
+    'api_key',
+    'apikey',
+    'auth_token',
+    'credentials',
+    'passwd',
+    'password',
+    'secret',
+    'stripetoken',
+)

--- a/datadog_checks_base/datadog_checks/base/utils/metadata/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/metadata/core.py
@@ -1,0 +1,138 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+import logging
+
+from six import iteritems
+
+from .utils import is_primitive
+from .version import parse_version
+
+try:
+    import datadog_agent
+except ImportError:
+    from ...stubs import datadog_agent
+
+LOGGER = logging.getLogger(__file__)
+
+
+class MetadataManager(object):
+    __slots__ = ('check_id', 'check_name', 'logger', 'metadata_transformers')
+
+    def __init__(self, check_name, check_id, logger=None, metadata_transformers=None):
+        self.check_name = check_name
+        self.check_id = check_id
+        self.logger = logger or LOGGER
+        self.metadata_transformers = {'config': self.transform_config, 'version': self.transform_version}
+
+        if metadata_transformers:
+            self.metadata_transformers.update(metadata_transformers)
+
+    def submit_raw(self, name, value):
+        datadog_agent.set_check_metadata(self.check_id, name, value)
+
+    def submit(self, name, value, options):
+        transformer = self.metadata_transformers.get(name)
+        if transformer:
+            try:
+                transformed = transformer(value, options)
+            except Exception as e:
+                if is_primitive(value):
+                    self.logger.error('Unable to transform `%s` metadata value `%s`: %s', name, value, e)
+                else:
+                    self.logger.error('Unable to transform `%s` metadata: %s', name, e)
+
+                return
+
+            if isinstance(transformed, str):
+                self.submit_raw(name, transformed)
+            else:
+                for transformed_name, transformed_value in iteritems(transformed):
+                    self.submit_raw(transformed_name, transformed_value)
+        else:
+            self.submit_raw(name, value)
+
+    def transform_version(self, version, options):
+        """Transforms a version like ``1.2.3-rc.4+5`` to its constituent parts. In all cases,
+        the metadata names ``version.raw`` and ``version.scheme`` will be sent.
+
+        If a ``scheme`` is defined then it will be looked up from our known schemes. If no
+        scheme is defined then it will default to semver.
+
+        The scheme may be set to ``regex`` in which case a ``pattern`` must also be defined. Any matching named
+        subgroups will then be sent as ``version.<GROUP_NAME>``. In this case, the check name will be used as
+        the value of ``version.scheme`` unless ``final_scheme`` is also set, which will take precedence.
+        """
+        scheme, version_parts = parse_version(version, options)
+        if scheme == 'regex':
+            scheme = options.get('final_scheme', self.check_name)
+
+        data = {'version.{}'.format(part_name): part_value for part_name, part_value in iteritems(version_parts)}
+        data['version.raw'] = version
+        data['version.scheme'] = scheme
+
+        return data
+
+    def transform_config(self, config, options):
+        """This transforms a ``dict`` of arbitrary user configuration. A ``section`` must be defined indicating
+        what the configuration represents e.g. ``init_config``.
+
+        The metadata name submitted will become ``config.<section>``.
+
+        The value will be a JSON ``str`` with the root being an array. There will be one map element for every
+        allowed field. Every map may have 2 entries:
+
+        1. ``is_set`` - a boolean indicating whether or not the field exists
+        2. ``value`` - the value of the field. this is only set if the field exists and the value is a
+                       primitive type (``None`` | ``bool`` | ``float`` | ``int`` | ``str``)
+
+        The allowed fields are derived from the optional ``whitelist`` and ``blacklist``. By default, nothing
+        will be sent.
+
+        User configuration can override defaults allowing complete, granular control of metadata submissions. In
+        any section, one may set ``metadata_whitelist`` and/or ``metadata_blacklist`` which will override their
+        keyword argument counterparts. In following our standard, blacklists take precedence over whitelists.
+        """
+        section = options.get('section')
+        if section is None:
+            raise ValueError('The `section` option is required')
+
+        # Although we define the default fields to send in code i.e. the default whitelist, there
+        # may be cases where a subclass (for example of OpenMetricsBaseCheck) would want to ignore
+        # just a few fields, hence for convenience we have the ability to also pass a blacklist.
+        whitelist = config.get('metadata_whitelist', options.get('whitelist', []))
+        blacklist = config.get('metadata_blacklist', options.get('blacklist', []))
+        allowed_fields = set(whitelist).difference(blacklist)
+
+        transformed_data = {}
+
+        data = []
+        for field in allowed_fields:
+            field_data = {}
+
+            if field in config:
+                field_data['is_set'] = True
+
+                value = config[field]
+                if is_primitive(value):
+                    field_data['value'] = value
+                else:
+                    self.logger.warning(
+                        'Skipping metadata submission of non-primitive type `%s` for field `%s` in section `%s`',
+                        type(value).__name__,
+                        field,
+                        section,
+                    )
+            else:
+                field_data['is_set'] = False
+
+            data.append(field_data)
+
+        if data:
+            # To avoid the backend having to parse a potentially unbounded number of unique keys, we
+            # send `config.<SECTION_NAME>` rather than `config.<SECTION_NAME>.<OPTION_NAME>` since
+            # the number of sections is finite (currently only `instance` and `init_config`).
+            transformed_data['config.{}'.format(section)] = json.dumps(data)
+
+        return transformed_data

--- a/datadog_checks_base/datadog_checks/base/utils/metadata/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/metadata/core.py
@@ -3,9 +3,11 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
 import logging
+import re
 
 from six import iteritems
 
+from .constants import DEFAULT_BLACKLIST
 from .utils import is_primitive
 from .version import parse_version
 
@@ -93,6 +95,8 @@ class MetadataManager(object):
         User configuration can override defaults allowing complete, granular control of metadata submissions. In
         any section, one may set ``metadata_whitelist`` and/or ``metadata_blacklist`` which will override their
         keyword argument counterparts. In following our standard, blacklists take precedence over whitelists.
+
+        Blacklists are special in that each item is considered a regular expression.
         """
         section = options.get('section')
         if section is None:
@@ -102,13 +106,19 @@ class MetadataManager(object):
         # may be cases where a subclass (for example of OpenMetricsBaseCheck) would want to ignore
         # just a few fields, hence for convenience we have the ability to also pass a blacklist.
         whitelist = config.get('metadata_whitelist', options.get('whitelist', []))
-        blacklist = config.get('metadata_blacklist', options.get('blacklist', []))
-        allowed_fields = set(whitelist).difference(blacklist)
+        blacklist = config.get('metadata_blacklist', options.get('blacklist', DEFAULT_BLACKLIST))
+        blacklist = re.compile('|'.join(blacklist), re.IGNORECASE)
 
         transformed_data = {}
 
         data = []
-        for field in allowed_fields:
+        for field in whitelist:
+            if blacklist.search(field):
+                self.logger.debug(
+                    'Skipping metadata submission of blacklisted field `%s` in section `%s`', field, section
+                )
+                continue
+
             field_data = {}
 
             if field in config:

--- a/datadog_checks_base/datadog_checks/base/utils/metadata/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/metadata/utils.py
@@ -1,0 +1,8 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+
+def is_primitive(obj):
+    # https://github.com/python/cpython/blob/4f82a53c5d34df00bf2d563c2417f5e2638d1004/Lib/json/encoder.py#L357-L377
+    return obj is None or isinstance(obj, (bool, float, int, str))

--- a/datadog_checks_base/datadog_checks/base/utils/metadata/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/metadata/utils.py
@@ -1,8 +1,9 @@
 # (C) Datadog, Inc. 2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from six import binary_type, text_type
 
 
 def is_primitive(obj):
     # https://github.com/python/cpython/blob/4f82a53c5d34df00bf2d563c2417f5e2638d1004/Lib/json/encoder.py#L357-L377
-    return obj is None or isinstance(obj, (bool, float, int, str))
+    return obj is None or isinstance(obj, (binary_type, bool, float, int, text_type))

--- a/datadog_checks_base/datadog_checks/base/utils/metadata/version.py
+++ b/datadog_checks_base/datadog_checks/base/utils/metadata/version.py
@@ -1,0 +1,64 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import re
+
+from ..common import exclude_undefined_keys
+
+# https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+SEMVER_PATTERN = re.compile(
+    r"""
+    (?P<major>0|[1-9]\d*)
+    \.
+    (?P<minor>0|[1-9]\d*)
+    \.
+    (?P<patch>0|[1-9]\d*)
+    (?:-(?P<release>
+        (?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)
+        (?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*
+    ))?
+    (?:\+(?P<build>
+        [0-9a-zA-Z-]+
+        (?:\.[0-9a-zA-Z-]+)*
+    ))?
+    """,
+    re.VERBOSE,
+)
+
+
+def parse_semver(version, options):
+    match = SEMVER_PATTERN.search(version)
+    if not match:
+        raise ValueError('Version does not adhere to semantic versioning')
+
+    return exclude_undefined_keys(match.groupdict())
+
+
+def parse_regex(version, options):
+    pattern = options.get('pattern')
+    if not pattern:
+        raise ValueError('Version scheme `regex` requires a `pattern` option')
+
+    match = re.search(pattern, version)
+    if not match:
+        raise ValueError('Version does not match the regular expression pattern')
+
+    parts = match.groupdict()
+    if not parts:
+        raise ValueError('Regular expression pattern has no named subgroups')
+
+    return exclude_undefined_keys(parts)
+
+
+def parse_version(version, options):
+    scheme = options.get('scheme')
+
+    if not scheme:
+        scheme = 'semver'
+    elif scheme not in SCHEMES:
+        raise ValueError('Unsupported version scheme `{}`'.format(scheme))
+
+    return scheme, SCHEMES[scheme](version, options)
+
+
+SCHEMES = {'semver': parse_semver, 'regex': parse_regex}

--- a/datadog_checks_base/tests/test_metadata.py
+++ b/datadog_checks_base/tests/test_metadata.py
@@ -355,11 +355,20 @@ class TestConfig:
             assert not data
 
     def test_blacklist(self):
-        check = AgentCheck('test', {}, [{'foo': 'bar'}])
+        check = AgentCheck('test', {}, [{'product_pw': 'foo'}])
         check.check_id = 'test:123'
 
         with mock.patch(SET_CHECK_METADATA_METHOD) as m:
-            check.set_metadata('config', check.instance, section='instance', whitelist=['foo'], blacklist=['foo'])
+            check.set_metadata('config', check.instance, section='instance', whitelist=['product_pw'], blacklist=['pw'])
+
+            assert m.call_count == 0
+
+    def test_blacklist_default(self):
+        check = AgentCheck('test', {}, [{'product_password': 'foo'}])
+        check.check_id = 'test:123'
+
+        with mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('config', check.instance, section='instance', whitelist=['product_password'])
 
             assert m.call_count == 0
 

--- a/datadog_checks_base/tests/test_metadata.py
+++ b/datadog_checks_base/tests/test_metadata.py
@@ -1,0 +1,410 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+import logging
+import re
+from collections import OrderedDict
+
+import mock
+import pytest
+
+from datadog_checks.base import AgentCheck
+
+pytestmark = pytest.mark.metadata
+
+SET_CHECK_METADATA_METHOD = 'datadog_checks.base.stubs.datadog_agent.set_check_metadata'
+
+# The order is used to derive the display name for the regex tests
+NON_STANDARD_VERSIONS = OrderedDict()
+
+
+class TestAttribute:
+    def test_default(self):
+        check = AgentCheck('test', {}, [{}])
+
+        assert check._metadata_manager is None
+
+    def test_no_check_id_error(self):
+        check = AgentCheck('test', {}, [{}])
+
+        with pytest.raises(RuntimeError):
+            check.set_metadata('foo', 'bar')
+
+
+class TestRaw:
+    def test_default(self):
+        check = AgentCheck('test', {}, [{}])
+        check.check_id = 'test:123'
+
+        with mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('foo', 'bar')
+
+            m.assert_called_once_with('test:123', 'foo', 'bar')
+
+    def test_new_transformer(self):
+        class NewAgentCheck(AgentCheck):
+            METADATA_TRANSFORMERS = {'foo': lambda value, options: value[::-1]}
+
+        check = NewAgentCheck('test', {}, [{}])
+        check.check_id = 'test:123'
+
+        with mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('foo', 'bar')
+
+            m.assert_called_once_with('test:123', 'foo', 'rab')
+
+
+class TestVersion:
+    def test_override_allowed(self):
+        class NewAgentCheck(AgentCheck):
+            METADATA_TRANSFORMERS = {'version': lambda value, options: value[::-1]}
+
+        check = NewAgentCheck('test', {}, [{}])
+        check.check_id = 'test:123'
+
+        with mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('version', 'bar')
+
+            m.assert_called_once_with('test:123', 'version', 'rab')
+
+    def test_unknown_scheme(self, caplog):
+        check = AgentCheck('test', {}, [{}])
+        check.check_id = 'test:123'
+
+        with caplog.at_level(logging.DEBUG), mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('version', '1.0.0', scheme='foo')
+
+            assert m.call_count == 0
+
+            expected_message = 'Unable to transform `version` metadata value `1.0.0`: Unsupported version scheme `foo`'
+            for _, level, message in caplog.record_tuples:
+                if level == logging.ERROR and message == expected_message:
+                    break
+            else:
+                raise AssertionError('Expected ERROR log with message: {}'.format(expected_message))
+
+    def test_semver_default(self):
+        check = AgentCheck('test', {}, [{}])
+        check.check_id = 'test:123'
+
+        with mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('version', '1.0.5')
+
+            m.assert_any_call('test:123', 'version.major', '1')
+            m.assert_any_call('test:123', 'version.minor', '0')
+            m.assert_any_call('test:123', 'version.patch', '5')
+            m.assert_any_call('test:123', 'version.raw', '1.0.5')
+            m.assert_any_call('test:123', 'version.scheme', 'semver')
+            assert m.call_count == 5
+
+    def test_semver_release(self):
+        check = AgentCheck('test', {}, [{}])
+        check.check_id = 'test:123'
+
+        with mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('version', '1.0.5-gke.6', scheme='semver')
+
+            m.assert_any_call('test:123', 'version.major', '1')
+            m.assert_any_call('test:123', 'version.minor', '0')
+            m.assert_any_call('test:123', 'version.patch', '5')
+            m.assert_any_call('test:123', 'version.release', 'gke.6')
+            m.assert_any_call('test:123', 'version.raw', '1.0.5-gke.6')
+            m.assert_any_call('test:123', 'version.scheme', 'semver')
+            assert m.call_count == 6
+
+    def test_semver_release_and_build(self):
+        check = AgentCheck('test', {}, [{}])
+        check.check_id = 'test:123'
+
+        with mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('version', '1.0.5-gke.6+3', scheme='semver')
+
+            m.assert_any_call('test:123', 'version.major', '1')
+            m.assert_any_call('test:123', 'version.minor', '0')
+            m.assert_any_call('test:123', 'version.patch', '5')
+            m.assert_any_call('test:123', 'version.release', 'gke.6')
+            m.assert_any_call('test:123', 'version.build', '3')
+            m.assert_any_call('test:123', 'version.raw', '1.0.5-gke.6+3')
+            m.assert_any_call('test:123', 'version.scheme', 'semver')
+            assert m.call_count == 7
+
+    def test_semver_invalid(self, caplog):
+        check = AgentCheck('test', {}, [{}])
+        check.check_id = 'test:123'
+
+        with caplog.at_level(logging.DEBUG), mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('version', '1.0', scheme='semver')
+
+            assert m.call_count == 0
+
+            expected_prefix = 'Unable to transform `version` metadata value `1.0`: '
+            for _, level, message in caplog.record_tuples:
+                if level == logging.ERROR and message.startswith(expected_prefix):
+                    break
+            else:
+                raise AssertionError('Expected ERROR log starting with message: {}'.format(expected_prefix))
+
+    @pytest.mark.parametrize(
+        'version, pattern, expected_parts',
+        [
+            (
+                NON_STANDARD_VERSIONS.setdefault('Docker', '18.03.0-ce, build 0520e24'),
+                r'(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)-(?P<release>\w+), build (?P<build>\w+)',
+                {'major': '18', 'minor': '03', 'patch': '0', 'release': 'ce', 'build': '0520e24'},
+            ),
+            (
+                NON_STANDARD_VERSIONS.setdefault('Exchange Server', '2007 SP3 8.3.83.006'),
+                r'(?P<major>\d+) SP(?P<minor>\d+) (?P<build>[\w.]+)',
+                {'major': '2007', 'minor': '3', 'build': '8.3.83.006'},
+            ),
+            (NON_STANDARD_VERSIONS.setdefault('Oracle', '19c'), r'(?P<major>\d+)\w*', {'major': '19'}),
+            (
+                NON_STANDARD_VERSIONS.setdefault('Presto', '0.221'),
+                r'(?P<major>\d+).(?P<minor>\d+)',
+                {'major': '0', 'minor': '221'},
+            ),
+            (
+                NON_STANDARD_VERSIONS.setdefault('missing subgroup', '02'),
+                r'(?P<major>\d+)(\.(?P<minor>\d+))?',
+                {'major': '02'},
+            ),
+            (
+                NON_STANDARD_VERSIONS.setdefault('precompiled', '1.2.3'),
+                re.compile(r'(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'),
+                {'major': '1', 'minor': '2', 'patch': '3'},
+            ),
+        ],
+        ids=list(NON_STANDARD_VERSIONS),
+    )
+    def test_regex(self, version, pattern, expected_parts):
+        check = AgentCheck('test', {}, [{}])
+        check.check_id = 'test:123'
+
+        with mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('version', version, scheme='regex', pattern=pattern)
+
+            for name, value in expected_parts.items():
+                m.assert_any_call('test:123', 'version.{}'.format(name), value)
+
+            m.assert_any_call('test:123', 'version.raw', version)
+            m.assert_any_call('test:123', 'version.scheme', 'test')
+            assert m.call_count == len(expected_parts) + 2
+
+    def test_regex_final_scheme(self):
+        check = AgentCheck('test', {}, [{}])
+        check.check_id = 'test:123'
+
+        with mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata(
+                'version',
+                '1.2.3.beta',
+                scheme='regex',
+                final_scheme='semver',
+                pattern=r'(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+).(?P<release>\w+)',
+            )
+
+            m.assert_any_call('test:123', 'version.major', '1')
+            m.assert_any_call('test:123', 'version.minor', '2')
+            m.assert_any_call('test:123', 'version.patch', '3')
+            m.assert_any_call('test:123', 'version.release', 'beta')
+            m.assert_any_call('test:123', 'version.raw', '1.2.3.beta')
+            m.assert_any_call('test:123', 'version.scheme', 'semver')
+            assert m.call_count == 6
+
+    def test_regex_no_pattern(self, caplog):
+        check = AgentCheck('test', {}, [{}])
+        check.check_id = 'test:123'
+
+        with caplog.at_level(logging.DEBUG), mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('version', '1.0', scheme='regex')
+
+            assert m.call_count == 0
+
+            expected_message = (
+                'Unable to transform `version` metadata value `1.0`: Version scheme `regex` requires a `pattern` option'
+            )
+            for _, level, message in caplog.record_tuples:
+                if level == logging.ERROR and message == expected_message:
+                    break
+            else:
+                raise AssertionError('Expected ERROR log with message: {}'.format(expected_message))
+
+    def test_regex_no_match(self, caplog):
+        check = AgentCheck('test', {}, [{}])
+        check.check_id = 'test:123'
+
+        with caplog.at_level(logging.DEBUG), mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('version', '1.0.0', scheme='regex', pattern='foo')
+
+            assert m.call_count == 0
+
+            expected_message = (
+                'Unable to transform `version` metadata value `1.0.0`: '
+                'Version does not match the regular expression pattern'
+            )
+            for _, level, message in caplog.record_tuples:
+                if level == logging.ERROR and message == expected_message:
+                    break
+            else:
+                raise AssertionError('Expected ERROR log with message: {}'.format(expected_message))
+
+    def test_regex_no_subgroups(self, caplog):
+        check = AgentCheck('test', {}, [{}])
+        check.check_id = 'test:123'
+
+        with caplog.at_level(logging.DEBUG), mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('version', '1.0.0', scheme='regex', pattern=r'\d\.\d\.\d')
+
+            assert m.call_count == 0
+
+            expected_message = (
+                'Unable to transform `version` metadata value `1.0.0`: '
+                'Regular expression pattern has no named subgroups'
+            )
+            for _, level, message in caplog.record_tuples:
+                if level == logging.ERROR and message == expected_message:
+                    break
+            else:
+                raise AssertionError('Expected ERROR log with message: {}'.format(expected_message))
+
+
+class TestConfig:
+    def test_no_section(self, caplog):
+        check = AgentCheck('test', {}, [{}])
+        check.check_id = 'test:123'
+
+        with caplog.at_level(logging.DEBUG), mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('config', {})
+
+            assert m.call_count == 0
+
+            expected_message = 'Unable to transform `config` metadata: The `section` option is required'
+            for _, level, message in caplog.record_tuples:
+                if level == logging.ERROR and message == expected_message:
+                    break
+            else:
+                raise AssertionError('Expected ERROR log with message: {}'.format(expected_message))
+
+    def test_non_primitive(self, caplog):
+        check = AgentCheck('test', {}, [{'foo': ['bar']}])
+        check.check_id = 'test:123'
+
+        with caplog.at_level(logging.DEBUG), mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('config', check.instance, section='instance', whitelist=['foo'])
+
+            assert m.call_count == 1
+
+            args, _ = m.call_args
+            assert args[0] == 'test:123'
+            assert args[1] == 'config.instance'
+
+            expected_message = (
+                'Skipping metadata submission of non-primitive type `list` for field `foo` in section `instance`'
+            )
+            for _, level, message in caplog.record_tuples:
+                if level == logging.WARNING and message == expected_message:
+                    break
+            else:
+                raise AssertionError('Expected ERROR log with message: {}'.format(expected_message))
+
+    def test_no_whitelist(self):
+        check = AgentCheck('test', {}, [{'foo': 'bar'}])
+        check.check_id = 'test:123'
+
+        with mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('config', check.instance, section='instance')
+
+            assert m.call_count == 0
+
+    def test_whitelist(self):
+        check = AgentCheck('test', {}, [{'foo': 'bar'}])
+        check.check_id = 'test:123'
+
+        with mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('config', check.instance, section='instance', whitelist=['foo'])
+
+            assert m.call_count == 1
+
+            args, _ = m.call_args
+            assert args[0] == 'test:123'
+            assert args[1] == 'config.instance'
+
+            data = json.loads(args[2])[0]
+
+            assert data.pop('is_set', None) is True
+            assert data.pop('value', None) == 'bar'
+            assert not data
+
+    def test_whitelist_no_field(self):
+        check = AgentCheck('test', {}, [{}])
+        check.check_id = 'test:123'
+
+        with mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('config', check.instance, section='instance', whitelist=['foo'])
+
+            assert m.call_count == 1
+
+            args, _ = m.call_args
+            assert args[0] == 'test:123'
+            assert args[1] == 'config.instance'
+
+            data = json.loads(args[2])[0]
+
+            assert data.pop('is_set', None) is False
+            assert not data
+
+    def test_blacklist(self):
+        check = AgentCheck('test', {}, [{'foo': 'bar'}])
+        check.check_id = 'test:123'
+
+        with mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('config', check.instance, section='instance', whitelist=['foo'], blacklist=['foo'])
+
+            assert m.call_count == 0
+
+    def test_whitelist_user_override(self):
+        check = AgentCheck('test', {}, [{'foo': 'bar', 'bar': 'foo', 'metadata_whitelist': ['bar']}])
+        check.check_id = 'test:123'
+
+        with mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata('config', check.instance, section='instance', whitelist=['foo', 'bar'])
+
+            assert m.call_count == 1
+
+            args, _ = m.call_args
+            assert args[0] == 'test:123'
+            assert args[1] == 'config.instance'
+
+            data = json.loads(args[2])
+
+            assert len(data) == 1
+            data = data[0]
+
+            assert data.pop('is_set', None) is True
+            assert data.pop('value', None) == 'foo'
+            assert not data
+
+    def test_blacklist_user_override(self):
+        check = AgentCheck('test', {}, [{'foo': 'bar', 'bar': 'foo', 'metadata_blacklist': ['bar']}])
+        check.check_id = 'test:123'
+
+        with mock.patch(SET_CHECK_METADATA_METHOD) as m:
+            check.set_metadata(
+                'config', check.instance, section='instance', whitelist=['foo', 'bar'], blacklist=['foo']
+            )
+
+            assert m.call_count == 1
+
+            args, _ = m.call_args
+            assert args[0] == 'test:123'
+            assert args[1] == 'config.instance'
+
+            data = json.loads(args[2])
+
+            assert len(data) == 1
+            data = data[0]
+
+            assert data.pop('is_set', None) is True
+            assert data.pop('value', None) == 'bar'
+            assert not data


### PR DESCRIPTION
## What does this PR do?

### API

This adds a method `set_metadata` to the `AgentCheck` base class that updates cached metadata values, which are then sent by the Agent at regular intervals.

It requires 2 arguments:

1. `name` - the name of the metadata
2. `value` - the value for the metadata. if `name` has no transformer defined then the raw `value` will be submitted and therefore it must be a `str`

The method also accepts arbitrary keyword arguments that are forwarded to any defined transformers.

### Transformers

Transformers are defined via a class level attribute `METADATA_TRANSFORMERS`.

This is a mapping of metadata names to functions. When you call `self.set_metadata(name, value, **options)`, if `name` is in this mapping then the corresponding function will be called with the `value`, and the return value(s) will be sent instead.

Transformer functions must satisfy the following signature:

```python
def transform_<NAME>(value: Any, options: dict) -> Union[str, Dict[str, str]]:
```

If the return type is a string, then it will be sent as the value for `name`. If the return type is a mapping type, then each key will be considered a `name` and will be sent with its (`str`) value.

Initially, there are 2 default transformers: `version` and `config`

#### `version`

This transforms a version like `1.2.3-rc.4+5` to its constituent parts. In all cases, the metadata names `version.raw` and `version.scheme` will be sent.

If a `scheme` is defined then it will be looked up from our known schemes. If no scheme is defined then it will default to `semver`.

The scheme may be set to `regex` in which case a `pattern` must also be defined. Any matching named subgroups will then be sent as `version.<GROUP_NAME>`. In this case, the check name will be used as the value of `version.scheme` unless `final_scheme` is also set, which will take precedence.

#### `config`

This transforms a `dict` of arbitrary user configuration. A `section` must be defined indicating what the configuration represents e.g. `init_config`.

The metadata name submitted will become `config.<section>`.

The value will be a JSON `str` with the root being an array. There will be one map element for every allowed field. Every map may have 2 entries:

1. `is_set` - a boolean indicating whether or not the field exists
2. `value` - the value of the field. this is only set if the field exists and the value is a primitive type (`None` | `bool` | `float` | `int` | `str`)

The allowed fields are derived from the optional `whitelist` and `blacklist`. By default, nothing will be sent.

User configuration can override defaults allowing complete, granular control of metadata submissions. In any section, one may set `metadata_whitelist` and/or `metadata_blacklist` which will override their keyword argument counterparts. In following our standard, blacklists take precedence over whitelists.

Blacklists are special in that each item is considered a regular expression.

## Motivation

https://github.com/DataDog/datadog-agent/pull/4234
https://github.com/DataDog/datadog-agent/pull/4158

## Additional Notes

In another PR I will implement a mechanism to automatically perform `config` metadata collection to avoid redundant calls in every check.