### PR TITLE
Add dashboard validation

### DIFF
--- a/.azure-pipelines/templates/run-validations.yml
+++ b/.azure-pipelines/templates/run-validations.yml
@@ -9,6 +9,11 @@ steps:
 - script: ddev validate config
   displayName: 'Validate default configuration files'
 
+# Only test on core until ddev is released with this validation available
+- ${{ if eq(parameters.repo, 'core') }}:
+  - script: ddev validate dashboards
+    displayName: "Validate dashboard definition files"
+
 - ${{ if eq(parameters.repo, 'core') }}:
   - script: ddev validate dep
     displayName: 'Validate dependencies'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
@@ -6,6 +6,7 @@ import click
 from ..console import CONTEXT_SETTINGS
 from .agent_reqs import agent_reqs
 from .config import config
+from .dashboards import dashboards
 from .dep import dep
 from .logos import logos
 from .manifest import manifest
@@ -13,7 +14,7 @@ from .metadata import metadata
 from .py3 import py3
 from .service_checks import service_checks
 
-ALL_COMMANDS = (agent_reqs, config, dep, logos, manifest, metadata, py3, service_checks)
+ALL_COMMANDS = (agent_reqs, config, dashboards, dep, logos, manifest, metadata, py3, service_checks)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Verify certain aspects of the repo')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dashboards.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dashboards.py
@@ -1,0 +1,78 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+import os
+from collections import OrderedDict
+
+import click
+
+from ....compat import JSONDecodeError
+from ....utils import file_exists, read_file
+from ...constants import get_root
+from ...utils import get_valid_integrations, load_manifest
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
+
+REQUIRED_ATTRIBUTES = {'agent_version', 'check', 'description', 'groups', 'integration', 'name', 'statuses'}
+
+
+@click.command('dashboards', context_settings=CONTEXT_SETTINGS, short_help='Validate dashboard definition JSON files')
+def dashboards():
+    """Validate all Dashboard definition files."""
+    root = get_root()
+    echo_info("Validating all Dashboard definition files...")
+    failed_checks = 0
+    ok_checks = 0
+
+    for check_name in sorted(get_valid_integrations()):
+        display_queue = []
+        file_failed = False
+        manifest = load_manifest(check_name)
+        dashboard_relative_locations = manifest.get('assets', {}).get('dashboards', {}).values()
+
+        for dashboard_relative_location in dashboard_relative_locations:
+
+            dashboard_file = os.path.join(root, check_name, *dashboard_relative_location.split('/'))
+            if not file_exists(dashboard_file):
+                echo_info('{}... '.format(check_name), nl=False)
+                echo_info(' FAILED')
+                echo_failure('  {} does not exist'.format(dashboard_file))
+                failed_checks += 1
+                continue
+
+            try:
+                decoded = json.loads(read_file(dashboard_file).strip(), object_pairs_hook=OrderedDict)
+            except JSONDecodeError as e:
+                failed_checks += 1
+                echo_info('{}... '.format(check_name), nl=False)
+                echo_failure(' FAILED')
+                echo_failure('  invalid json: {}'.format(e))
+                continue
+
+            # Confirm the dashboard payload comes from the old API for now
+            if 'layout_type' in decoded:
+                file_failed = True
+                display_queue.append(
+                    (
+                        echo_failure,
+                        '    {} is using the new /dash payload format which isn\'t currently supported. Please use the format from the /screen or /time API endpoints instead.'.format(
+                            dashboard_file
+                        ),
+                    )
+                )
+
+            if file_failed:
+                failed_checks += 1
+                # Display detailed info if file is invalid
+                echo_info('{}... '.format(check_name), nl=False)
+                echo_failure(' FAILED'.format(check_name))
+                for display_func, message in display_queue:
+                    display_func(message)
+            else:
+                ok_checks += 1
+
+    if ok_checks:
+        echo_success("{} valid files".format(ok_checks))
+    if failed_checks:
+        echo_failure("{} invalid files".format(failed_checks))
+        abort()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dashboards.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dashboards.py
@@ -55,7 +55,8 @@ def dashboards():
                 display_queue.append(
                     (
                         echo_failure,
-                        '    {} is using the new /dash payload format which isn\'t currently supported. Please use the format from the /screen or /time API endpoints instead.'.format(
+                        '    {} is using the new /dash payload format which isn\'t currently supported.'
+                        ' Please use the format from the /screen or /time API endpoints instead.'.format(
                             dashboard_file
                         ),
                     )


### PR DESCRIPTION
### What does this PR do?

Add small validations to the dashboard definition files. 

### Motivation

Fail early/fast if there are any known issues with the dashboards definition json files. 

### Additional Notes

I updated the azure template to have this validate command only be run for integrations-core. This is because we need to wait for ddev to be released with these changes in order to work against integrations-extras. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
