### PR TITLE
Don't raise an error on tests for no check_id

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -229,7 +229,7 @@ class __AgentCheck(object):
     @property
     def metadata_manager(self):
         if self._metadata_manager is None:
-            if not self.check_id:
+            if not self.check_id and not using_stub_aggregator:
                 raise RuntimeError('Attribute `check_id` must be set')
 
             self._metadata_manager = MetadataManager(self.name, self.check_id, self.log, self.METADATA_TRANSFORMERS)

--- a/datadog_checks_base/tests/test_metadata.py
+++ b/datadog_checks_base/tests/test_metadata.py
@@ -28,8 +28,9 @@ class TestAttribute:
     def test_no_check_id_error(self):
         check = AgentCheck('test', {}, [{}])
 
-        with pytest.raises(RuntimeError):
-            check.set_metadata('foo', 'bar')
+        with mock.patch('datadog_checks.base.checks.base.using_stub_aggregator', False):
+            with pytest.raises(RuntimeError):
+                check.set_metadata('foo', 'bar')
 
 
 class TestRaw:


### PR DESCRIPTION
### Motivation

Without this, all current tests break when implementing metadata