### PR TITLE
Handle other Agent images in E2E

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -167,7 +167,9 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, profile_memory):
                     'sampling_collection_interval', DEFAULT_SAMPLING_COLLECTION_INTERVAL
                 )
 
-    environment = interface(check, env, base_package, config, env_vars, metadata, agent_build, api_key, python)
+    environment = interface(
+        check, env, base_package, config, env_vars, metadata, agent_build, api_key, python, not bool(agent)
+    )
 
     echo_waiting('Updating `{}`... '.format(agent_build), nl=False)
     environment.update_agent()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -35,6 +35,7 @@ class DockerInterface(object):
         agent_build=None,
         api_key=None,
         python_version=DEFAULT_PYTHON_VERSION,
+        default_agent=False,
     ):
         self.check = check
         self.env = env
@@ -52,7 +53,8 @@ class DockerInterface(object):
         self.config_file = locate_config_file(check, env)
         self.config_file_name = config_file_name(self.check)
 
-        if self.agent_build and 'py' not in self.agent_build:
+        # If we use a default build, and it's missing the py suffix, adds it
+        if default_agent and self.agent_build and 'py' not in self.agent_build:
             self.agent_build = '{}-py{}'.format(self.agent_build, self.python_version)
 
         if self.agent_build and self.metadata.get('use_jmx', False):
@@ -185,7 +187,7 @@ class DockerInterface(object):
         run_command(command, capture=True, check=True)
 
     def update_agent(self):
-        if self.agent_build:
+        if self.agent_build and '/' in self.agent_build:
             run_command(['docker', 'pull', self.agent_build], capture=True, check=True)
 
     def start_agent(self):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -40,6 +40,7 @@ class LocalAgentInterface(object):
         agent_build=None,
         api_key=None,
         python_version=DEFAULT_PYTHON_VERSION,
+        default_agent=False,
     ):
         self.check = check
         self.env = env


### PR DESCRIPTION
Fix changes ddev env start to only adds the py suffix if an agent build
is not specified. That means that in other cases the full build needs to
be passed, with seems acceptable. It also removes the pull when using a
local build.