### PR TITLE
Increase default Agent flush timeout

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -151,6 +151,10 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, profile_memory):
         env_vars['DD_TRACEMALLOC_DEBUG'] = '1'
         env_vars['DD_TRACEMALLOC_WHITELIST'] = check
 
+        if on_ci:
+            env_vars.setdefault('DD_AGGREGATOR_STOP_TIMEOUT', '10')
+            env_vars.setdefault('DD_FORWARDER_STOP_TIMEOUT', '10')
+
         instances = config
         if isinstance(config, dict):
             instances = config.get('instances', [config])


### PR DESCRIPTION
### Motivation

Occasionally the Agent shuts down too fast for memory profiling metrics to come in