### PR TITLE
Remove default version from env test

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
@@ -18,7 +18,6 @@ from .stop import stop
 @click.option(
     '--agent',
     '-a',
-    default='6',
     help=(
         'The agent build to use e.g. a Docker image like `datadog/agent:6.5.2`. For '
         'Docker environments you can use an integer corresponding to fields in the '


### PR DESCRIPTION
We get the version properly in start, no need to duplicate the value,
and it breaks default detection.