### PR TITLE
Fix tests running on non localhost

### DIFF
--- a/couch/tests/test_unit.py
+++ b/couch/tests/test_unit.py
@@ -38,4 +38,4 @@ def test_config(test_case, extra_config, expected_http_kwargs):
         )
         http_wargs.update(expected_http_kwargs)
 
-        r.get.assert_called_with('http://localhost:5984/_all_dbs/', **http_wargs)
+        r.get.assert_called_with('http://{}:5984/_all_dbs/'.format(common.HOST), **http_wargs)


### PR DESCRIPTION
Common is refering to the docker host, we need to use it in the results
as well.