### PR TITLE
Submit version metadata

### DIFF
--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -884,6 +884,7 @@ class MongoDb(AgentCheck):
             self.set_metadata('version', mongo_version)
         except Exception:
             self.log.exception("Error when collecting the version from the mongo server.")
+            mongo_version = '0.0'
 
         # Handle replica data, if any
         # See
@@ -1036,7 +1037,7 @@ class MongoDb(AgentCheck):
                 submit_method, metric_name_alias = self._resolve_metric(metric_name, metrics_to_collect)
                 submit_method(self, metric_name_alias, val, tags=metrics_tags)
 
-        if is_affirmative(instance.get('collections_indexes_stats')) and mongo_version:
+        if is_affirmative(instance.get('collections_indexes_stats')):
             if LooseVersion(mongo_version) >= LooseVersion("3.2"):
                 self._collect_indexes_stats(instance, db, tags)
             else:

--- a/mongo/tests/common.py
+++ b/mongo/tests/common.py
@@ -11,6 +11,7 @@ PORT2 = 27018
 MAX_WAIT = 150
 
 MONGODB_SERVER = "mongodb://%s:%s/test" % (HOST, PORT1)
+MONGODB_VERSION = os.environ['MONGO_VERSION']
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(os.path.dirname(HERE))

--- a/mongo/tests/conftest.py
+++ b/mongo/tests/conftest.py
@@ -114,7 +114,7 @@ def version_metadata():
         'version.major': major,
         'version.minor': minor,
         'version.patch': mock.ANY,
-        'version.raw': mock.ANY
+        'version.raw': mock.ANY,
     }
 
 

--- a/mongo/tests/conftest.py
+++ b/mongo/tests/conftest.py
@@ -4,6 +4,7 @@
 import os
 import time
 
+import mock
 import pymongo
 import pytest
 
@@ -103,6 +104,18 @@ def instance_1valid_and_1invalid_custom_queries():
 @pytest.fixture
 def check():
     return MongoDb('mongo', {}, {})
+
+
+@pytest.fixture(scope='session')
+def version_metadata():
+    major, minor = common.MONGODB_VERSION.split('.')[:2]
+    return {
+        'version.scheme': 'semver',
+        'version.major': major,
+        'version.minor': minor,
+        'version.patch': mock.ANY,
+        'version.raw': mock.ANY
+    }
 
 
 def setup_sharding(compose_file):

--- a/mongo/tests/test_mongo.py
+++ b/mongo/tests/test_mongo.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2018-2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import mock
+
 import pytest
 
 from datadog_checks.mongo import MongoDb
@@ -138,3 +140,14 @@ def test_mongo_custom_queries(aggregator, check, instance_custom_queries):
     aggregator.assert_metric_has_tag("dd.custom.mongo.aggregate.total", 'cluster_id:xyz1', count=1)
     aggregator.assert_metric_has_tag("dd.custom.mongo.aggregate.total", 'tag1:val1', count=2)
     aggregator.assert_metric_has_tag("dd.custom.mongo.aggregate.total", 'tag2:val2', count=2)
+
+
+def test_metadata(aggregator, check, instance, version_metadata):
+    check.check_id = 'test:123'
+
+    with mock.patch('datadog_checks.base.stubs.datadog_agent.set_check_metadata') as m:
+        check.check(instance)
+        for name, value in version_metadata.items():
+            m.assert_any_call('test:123', name, value)
+
+        assert m.call_count == len(version_metadata)

--- a/mongo/tests/test_mongo.py
+++ b/mongo/tests/test_mongo.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import mock
-
 import pytest
 
 from datadog_checks.mongo import MongoDb


### PR DESCRIPTION
Similarly to how [Redis](https://github.com/DataDog/integrations-core/pull/4705) was done, submit metrics metadata for the Mongo check.

Small improvement, the use of `mock.ANY` to run assertions on `version.raw` and `version.patch`