### PR TITLE
Fix lint flake8-logging-format command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -65,7 +65,7 @@ def add_style_checker(config, sections, make_envconfig, reader):
                 'isort --check-only --diff --recursive .',
                 'python -c "print(\'\\n[WARNING] Complying with following lint rules is recommended, '
                 'but not mandatory, yet.\')"',
-                '- flake8 --enable-extensions=G --select=G .',  # lint `flake8-logging-format`
+                '- flake8 --config=../.flake8 --enable-extensions=G --select=G .',  # lint `flake8-logging-format`
             ]
         ),
     }


### PR DESCRIPTION
Fix lint flake8-logging-format command

Need to use `--config=../.flake8` for exclusions etc.