### PR TITLE
Send configuration metadata by default

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -91,6 +91,10 @@ class __AgentCheck(object):
     # a mapping type, then each key will be considered a `name` and will be sent with its (str) value.
     METADATA_TRANSFORMERS = None
 
+    # Default fields to whitelist for metadata submission
+    METADATA_DEFAULT_CONFIG_INIT_CONFIG = None
+    METADATA_DEFAULT_CONFIG_INSTANCE = None
+
     FIRST_CAP_RE = re.compile(br'(.)([A-Z][a-z]+)')
     ALL_CAP_RE = re.compile(br'([a-z0-9])([A-Z])')
     METRIC_REPLACEMENT = re.compile(br'([^a-zA-Z0-9_.]+)|(^[^a-zA-Z]+)')
@@ -213,7 +217,7 @@ class __AgentCheck(object):
             self.metric_limiter = Limiter(self.name, 'metrics', metric_limit, self.warning)
 
         # Functions that will be called exactly once (if successful) before the first check run
-        self.check_initializations = deque()
+        self.check_initializations = deque([self.send_config_metadata])
 
     @staticmethod
     def load_config(yaml_str):
@@ -495,6 +499,12 @@ class __AgentCheck(object):
         :param options: keyword arguments to pass to any defined transformer
         """
         self.metadata_manager.submit(name, value, options)
+
+    def send_config_metadata(self):
+        self.set_metadata('config', self.instance, section='instance', whitelist=self.METADATA_DEFAULT_CONFIG_INSTANCE)
+        self.set_metadata(
+            'config', self.init_config, section='init_config', whitelist=self.METADATA_DEFAULT_CONFIG_INIT_CONFIG
+        )
 
     def set_external_tags(self, external_tags):
         # Example of external_tags format

--- a/datadog_checks_base/datadog_checks/base/utils/metadata/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/metadata/core.py
@@ -105,8 +105,8 @@ class MetadataManager(object):
         # Although we define the default fields to send in code i.e. the default whitelist, there
         # may be cases where a subclass (for example of OpenMetricsBaseCheck) would want to ignore
         # just a few fields, hence for convenience we have the ability to also pass a blacklist.
-        whitelist = config.get('metadata_whitelist', options.get('whitelist', []))
-        blacklist = config.get('metadata_blacklist', options.get('blacklist', DEFAULT_BLACKLIST))
+        whitelist = config.get('metadata_whitelist', options.get('whitelist')) or ()
+        blacklist = config.get('metadata_blacklist', options.get('blacklist', DEFAULT_BLACKLIST)) or ()
         blacklist = re.compile('|'.join(blacklist), re.IGNORECASE)
 
         transformed_data = {}

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -3,6 +3,9 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+from collections import OrderedDict
+
 import mock
 import pytest
 from six import PY3
@@ -379,6 +382,52 @@ class TestLimits:
 
 
 class TestCheckInitializations:
+    def test_default(self):
+        class TestCheck(AgentCheck):
+            def check(self, _):
+                pass
+
+        check = TestCheck('test', {}, [{}])
+        check.check_id = 'test:123'
+
+        with mock.patch('datadog_checks.base.stubs.datadog_agent.set_check_metadata') as m:
+            check.run()
+
+            assert m.call_count == 0
+
+    def test_default_config_sent(self):
+        class TestCheck(AgentCheck):
+            METADATA_DEFAULT_CONFIG_INIT_CONFIG = ['foo']
+            METADATA_DEFAULT_CONFIG_INSTANCE = ['bar']
+
+            def check(self, _):
+                pass
+
+        # Ordered by call order in `AgentCheck.send_config_metadata`
+        value_map = OrderedDict((('instance', 'mock'), ('init_config', 5)))
+
+        config = {'foo': value_map['init_config'], 'bar': value_map['instance']}
+        check = TestCheck('test', config, [config])
+        check.check_id = 'test:123'
+
+        with mock.patch('datadog_checks.base.stubs.datadog_agent.set_check_metadata') as m:
+            check.run()
+
+            assert m.call_count == 2
+            check.run()
+            assert m.call_count == 2
+
+            for (config_type, value), call_args in zip(value_map.items(), m.call_args_list):
+                args, _ = call_args
+                assert args[0] == 'test:123'
+                assert args[1] == 'config.{}'.format(config_type)
+
+                data = json.loads(args[2])[0]
+
+                assert data.pop('is_set', None) is True
+                assert data.pop('value', None) == value
+                assert not data
+
     def test_success_only_once(self):
         class TestCheck(AgentCheck):
             def __init__(self, *args, **kwargs):


### PR DESCRIPTION
### What does this PR do?

Adds a way for every check to define and automatically send metadata fields from configuration