### PR TITLE
Update self.warning to accept *args

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,8 @@
 
 [flake8]
 select = B,C,E,F,W,B001,B003,B006,B007,B301,B305,B306,B902
-ignore = E203,E722,W503
+# Ignore reasons:
+# - G200: logging exception is ok, we don't always want to log the stack trace too
+ignore = E203,E722,W503,G200
 exclude = .eggs,.tox,build,compat.py,__init__.py,datadog_checks/dev/tooling/templates/*,datadog_checks/*/vendor/*
 max-line-length = 120

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -523,7 +523,7 @@ class __AgentCheck(object):
         metric_name = self.METRIC_REPLACEMENT.sub(br'_', metric_name)
         return self.DOT_UNDERSCORE_CLEANUP.sub(br'.', metric_name).strip(b'_')
 
-    def warning(self, warning_message, *args):
+    def warning(self, warning_message, *args, **kwargs):
         """Log a warning message and display it in the Agent's status page.
 
         Using *args is intended to make warning work like log.warn/debug/info/etc

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -529,8 +529,9 @@ class __AgentCheck(object):
         Using *args is intended to make warning work like log.warn/debug/info/etc
         and make it compliant with flake8 logging format linter.
 
-        :param list args: format string args used to format warning_message e.g. `warning_message % args`
         :param str warning_message: the warning message.
+        :param list args: format string args used to format warning_message e.g. `warning_message % args`
+        :param dict kwargs: not used for now, but added to match Python logger's `warning` method signature
         """
         warning_message = to_string(warning_message)
         # Interpolate message only if args is not empty. Same behavior as python logger:

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -523,13 +523,20 @@ class __AgentCheck(object):
         metric_name = self.METRIC_REPLACEMENT.sub(br'_', metric_name)
         return self.DOT_UNDERSCORE_CLEANUP.sub(br'.', metric_name).strip(b'_')
 
-    def warning(self, warning_message):
+    def warning(self, warning_message, *args):
         """Log a warning message and display it in the Agent's status page.
 
+        Using *args is intended to make warning work like log.warn/debug/info/etc
+        and make it compliant with flake8 logging format linter.
+
+        :param list args: format string args used to format warning_message e.g. `warning_message % args`
         :param str warning_message: the warning message.
         """
         warning_message = to_string(warning_message)
-
+        # Interpolate message only if args is not empty. Same behavior as python logger:
+        # https://github.com/python/cpython/blob/master/Lib/logging/__init__.py#L368-L369
+        if args:
+            warning_message = warning_message % args
         frame = inspect.currentframe().f_back
         lineno = frame.f_lineno
         # only log the last part of the filename, not the full path

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -535,7 +535,7 @@ class __AgentCheck(object):
         """
         warning_message = to_string(warning_message)
         # Interpolate message only if args is not empty. Same behavior as python logger:
-        # https://github.com/python/cpython/blob/master/Lib/logging/__init__.py#L368-L369
+        # https://github.com/python/cpython/blob/1dbe5373851acb85ba91f0be7b83c69563acd68d/Lib/logging/__init__.py#L368-L369
         if args:
             warning_message = warning_message % args
         frame = inspect.currentframe().f_back

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -68,6 +68,7 @@ def test_warning_args_errors():
 
     assert ["should not raise error: %s"] == check.warnings
 
+
 class TestMetricNormalization:
     def test_default(self):
         check = AgentCheck()

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -46,6 +46,28 @@ def test_log_critical_error():
         check.log.critical('test')
 
 
+def test_warning_ok():
+    check = AgentCheck()
+
+    check.warning("foo")
+    check.warning("hello %s%s", "world", "!")
+
+    assert ["foo", "hello world!"] == check.warnings
+
+
+def test_warning_args_errors():
+    check = AgentCheck()
+
+    check.warning("should not raise error: %s")
+
+    with pytest.raises(TypeError):
+        check.warning("not enough arguments: %s %s", "a")
+
+    with pytest.raises(TypeError):
+        check.warning("too many arguments: %s %s", "a", "b", "c")
+
+    assert ["should not raise error: %s"] == check.warnings
+
 class TestMetricNormalization:
     def test_default(self):
         check = AgentCheck()

--- a/druid/datadog_checks/druid/druid.py
+++ b/druid/datadog_checks/druid/druid.py
@@ -62,7 +62,7 @@ class DruidCheck(AgentCheck):
             return resp.json()
         except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError) as e:
             self.warning(
-                "Couldn't connect to URL: %s with exception: %s. Please verify the address is reachable", url, e
+                "Couldn't connect to URL: {} with exception: {}. Please verify the address is reachable".format(url, e)
             )
         except requests.exceptions.Timeout as e:
-            self.warning("Connection timeout when connecting to %s: %s", url, e)
+            self.warning("Connection timeout when connecting to {}: {}".format(url, e))

--- a/druid/datadog_checks/druid/druid.py
+++ b/druid/datadog_checks/druid/druid.py
@@ -62,7 +62,7 @@ class DruidCheck(AgentCheck):
             return resp.json()
         except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError) as e:
             self.warning(
-                "Couldn't connect to URL: {} with exception: {}. Please verify the address is reachable".format(url, e)
+                "Couldn't connect to URL: %s with exception: %s. Please verify the address is reachable", url, e
             )
         except requests.exceptions.Timeout as e:
-            self.warning("Connection timeout when connecting to {}: {}".format(url, e))
+            self.warning("Connection timeout when connecting to %s: %s", url, e)


### PR DESCRIPTION
### What does this PR do?

Update self.warning to accept *args

### Motivation

```
        Using *args is intended to make warning work like log.warn/debug/info/etc
        and make it compliant with flake8 logging format linter.
```