### PR TITLE
Automatically fetch MIBs that we don't know about

### DIFF
--- a/snmp/README.md
+++ b/snmp/README.md
@@ -117,7 +117,10 @@ There are a few ways to specify the metrics to collect. See the [sample snmp.d/c
 
 ##### Use your own MIB
 
-To use your own MIB with the Datadog Agent, convert it to the [PySNMP][5] format. This can be done using the `build-pysnmp-mibs` script that ships with PySNMP < 4.3. `mibdump.py` replaces `build-pysnmp-mib` which was made obsolete in [PySNMP 4.3+][6].
+Since Agent v6.15, MIBs hosted at http://mibs.snmplabs.com/asn1 will be fetched automatically the first
+time the check finds a reference in the configuration.
+
+To use your own MIB with the Datadog Agent, convert it to the [PySNMP][5] format. This can be done using the `mibdump.py` script that ships with PySNMP. `mibdump.py` replaces `build-pysnmp-mib` which was made obsolete in [PySNMP 4.3+][6].
 
 Since Datadog Agent v5.14, the Agent's PySNMP dependency has been upgraded from version 4.25 to 4.3.5 (refer to the [changelog][7]). This means that the `build-pysnmp-mib` which shipped with the Agent from version 5.13.x and earlier has also been replaced with `mibdump.py`.
 
@@ -197,7 +200,7 @@ Example using the `CISCO-TCP-MIB.my`:
  Ignored MIBs:
  Failed MIBs:
 
- #ls /opt/datadog-agent/pysnmp/custom_mibpy/
+ # ls /opt/datadog-agent/pysnmp/custom_mibpy/
 CISCO-SMI.py CISCO-SMI.pyc CISCO-TCP-MIB.py CISCO-TCP-MIB.pyc
 
 ```

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -27,7 +27,7 @@ class InstanceConfig:
     DEFAULT_ALLOWED_FAILURES = 3
     DEFAULT_BULK_THRESHOLD = 5
 
-    def __init__(self, instance, warning, debug, global_metrics, mibs_path, profiles, profiles_by_oid):
+    def __init__(self, instance, warning, log, global_metrics, mibs_path, profiles, profiles_by_oid):
         self.instance = instance
         self.tags = instance.get('tags', [])
         self.metrics = instance.get('metrics', [])
@@ -74,16 +74,16 @@ class InstanceConfig:
             raise ConfigurationError('Instance should specify at least one metric or profiles should be defined')
 
         self.table_oids, self.raw_oids, self.mibs_to_load = self.parse_metrics(
-            self.metrics, self.enforce_constraints, warning, debug
+            self.metrics, self.enforce_constraints, warning, log
         )
 
         self.auth_data = self.get_auth_data(instance)
         self.context_data = hlapi.ContextData(*self.get_context_data(instance))
 
-    def refresh_with_profile(self, profile, warning, debug):
+    def refresh_with_profile(self, profile, warning, log):
         self.metrics.extend(profile['definition'])
         self.table_oids, self.raw_oids, self.mibs_to_load = self.parse_metrics(
-            self.metrics, self.enforce_constraints, warning, debug
+            self.metrics, self.enforce_constraints, warning, log
         )
 
     def call_cmd(self, cmd, *args, **kwargs):
@@ -170,7 +170,7 @@ class InstanceConfig:
 
         return context_engine_id, context_name
 
-    def parse_metrics(self, metrics, enforce_constraints, warning, debug):
+    def parse_metrics(self, metrics, enforce_constraints, warning, log):
         """Parse configuration and returns data to be used for SNMP queries.
 
         `raw_oids` is a list of SNMP numerical OIDs to query.
@@ -228,7 +228,7 @@ class InstanceConfig:
             try:
                 self.mib_view_controller.mibBuilder.loadModule(mib)
             except MibNotFoundError:
-                debug("Couldn't found mib %s, trying to fetch it", mib)
+                log.debug("Couldn't found mib %s, trying to fetch it", mib)
                 self.fetch_mib(mib)
 
         return table_oids, raw_oids, mibs_to_load

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -27,7 +27,7 @@ class InstanceConfig:
     DEFAULT_ALLOWED_FAILURES = 3
     DEFAULT_BULK_THRESHOLD = 5
 
-    def __init__(self, instance, warning, global_metrics, mibs_path, profiles, profiles_by_oid):
+    def __init__(self, instance, warning, debug, global_metrics, mibs_path, profiles, profiles_by_oid):
         self.instance = instance
         self.tags = instance.get('tags', [])
         self.metrics = instance.get('metrics', [])
@@ -74,16 +74,16 @@ class InstanceConfig:
             raise ConfigurationError('Instance should specify at least one metric or profiles should be defined')
 
         self.table_oids, self.raw_oids, self.mibs_to_load = self.parse_metrics(
-            self.metrics, self.enforce_constraints, warning
+            self.metrics, self.enforce_constraints, warning, debug
         )
 
         self.auth_data = self.get_auth_data(instance)
         self.context_data = hlapi.ContextData(*self.get_context_data(instance))
 
-    def refresh_with_profile(self, profile, warning):
+    def refresh_with_profile(self, profile, warning, debug):
         self.metrics.extend(profile['definition'])
         self.table_oids, self.raw_oids, self.mibs_to_load = self.parse_metrics(
-            self.metrics, self.enforce_constraints, warning
+            self.metrics, self.enforce_constraints, warning, debug
         )
 
     def call_cmd(self, cmd, *args, **kwargs):
@@ -170,7 +170,7 @@ class InstanceConfig:
 
         return context_engine_id, context_name
 
-    def parse_metrics(self, metrics, enforce_constraints, warning):
+    def parse_metrics(self, metrics, enforce_constraints, warning, debug):
         """Parse configuration and returns data to be used for SNMP queries.
 
         `raw_oids` is a list of SNMP numerical OIDs to query.
@@ -228,6 +228,7 @@ class InstanceConfig:
             try:
                 self.mib_view_controller.mibBuilder.loadModule(mib)
             except MibNotFoundError:
+                debug("Couldn't found mib %s, trying to fetch it", mib)
                 self.fetch_mib(mib)
 
         return table_oids, raw_oids, mibs_to_load

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -2,11 +2,19 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import ipaddress
+import os
 from collections import defaultdict
 
+import pysnmp_mibs
 from pyasn1.type.univ import OctetString
+from pysmi.codegen import PySnmpCodeGen
+from pysmi.compiler import MibCompiler
+from pysmi.parser import SmiStarParser
+from pysmi.reader import HttpReader
+from pysmi.writer import PyFileWriter
 from pysnmp import hlapi
 from pysnmp.smi import builder, view
+from pysnmp.smi.error import MibNotFoundError
 
 from datadog_checks.base import ConfigurationError, is_affirmative
 
@@ -162,8 +170,7 @@ class InstanceConfig:
 
         return context_engine_id, context_name
 
-    @staticmethod
-    def parse_metrics(metrics, enforce_constraints, warning):
+    def parse_metrics(self, metrics, enforce_constraints, warning):
         """Parse configuration and returns data to be used for SNMP queries.
 
         `raw_oids` is a list of SNMP numerical OIDs to query.
@@ -217,4 +224,21 @@ class InstanceConfig:
             else:
                 raise ConfigurationError('Unsupported metric in config file: {}'.format(metric))
 
+        for mib in mibs_to_load:
+            try:
+                self.mib_view_controller.mibBuilder.loadModule(mib)
+            except MibNotFoundError:
+                self.fetch_mib(mib)
+
         return table_oids, raw_oids, mibs_to_load
+
+    @staticmethod
+    def fetch_mib(mib):
+        target_directory = os.path.dirname(pysnmp_mibs.__file__)
+
+        reader = HttpReader('mibs.snmplabs.com', 80, '/asn1/@mib@')
+        mibCompiler = MibCompiler(SmiStarParser(), PySnmpCodeGen(), PyFileWriter(target_directory))
+
+        mibCompiler.addSources(reader)
+
+        mibCompiler.compile(mib)

--- a/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
@@ -1,6 +1,7 @@
 # Profile for F5 BIG-IP devices
 #
-# You need the MIB compiled to get the data. For example, run:
+# You need the MIB compiled to get the data. The check will fetch it
+# automatically for you, but otherwise you can run the following command:
 # $ /opt/datadog-agent/embedded/bin/python /opt/datadog-agent/embedded/bin/mibdump.py  --destination-directory=/opt/datadog-agent/embedded/lib/python2.7/site-packages/pysnmp_mibs F5-BIGIP-SYSTEM-MIB
 #
 # Then you can use it this way in your SNMP configuration:

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -93,6 +93,7 @@ class SnmpCheck(AgentCheck):
         self._config = InstanceConfig(
             self.instance,
             self.warning,
+            self.log.debug,
             self.init_config.get('global_metrics', []),
             self.mibs_path,
             self.profiles,
@@ -133,6 +134,7 @@ class SnmpCheck(AgentCheck):
                 host_config = InstanceConfig(
                     instance,
                     self.warning,
+                    self.log.debug,
                     self.init_config.get('global_metrics', []),
                     self.mibs_path,
                     self.profiles,
@@ -149,7 +151,7 @@ class SnmpCheck(AgentCheck):
                         continue
                 else:
                     profile = self.profiles_by_oid[sys_object_oid]
-                    host_config.refresh_with_profile(self.profiles[profile], self.warning)
+                    host_config.refresh_with_profile(self.profiles[profile], self.warning, self.log.debug)
                 config.discovered_instances[host] = host_config
             time_elapsed = time.time() - start_time
             if discovery_interval - time_elapsed > 0:
@@ -358,7 +360,7 @@ class SnmpCheck(AgentCheck):
                 if sys_object_oid not in self.profiles_by_oid:
                     raise ConfigurationError('No profile matching sysObjectID {}'.format(sys_object_oid))
                 profile = self.profiles_by_oid[sys_object_oid]
-                config.refresh_with_profile(self.profiles[profile], self.warning)
+                config.refresh_with_profile(self.profiles[profile], self.warning, self.log.debug)
 
             if config.table_oids:
                 self.log.debug('Querying device %s for %s oids', config.ip_address, len(config.table_oids))

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -93,7 +93,7 @@ class SnmpCheck(AgentCheck):
         self._config = InstanceConfig(
             self.instance,
             self.warning,
-            self.log.debug,
+            self.log,
             self.init_config.get('global_metrics', []),
             self.mibs_path,
             self.profiles,
@@ -134,7 +134,7 @@ class SnmpCheck(AgentCheck):
                 host_config = InstanceConfig(
                     instance,
                     self.warning,
-                    self.log.debug,
+                    self.log,
                     self.init_config.get('global_metrics', []),
                     self.mibs_path,
                     self.profiles,
@@ -151,7 +151,7 @@ class SnmpCheck(AgentCheck):
                         continue
                 else:
                     profile = self.profiles_by_oid[sys_object_oid]
-                    host_config.refresh_with_profile(self.profiles[profile], self.warning, self.log.debug)
+                    host_config.refresh_with_profile(self.profiles[profile], self.warning, self.log)
                 config.discovered_instances[host] = host_config
             time_elapsed = time.time() - start_time
             if discovery_interval - time_elapsed > 0:
@@ -360,7 +360,7 @@ class SnmpCheck(AgentCheck):
                 if sys_object_oid not in self.profiles_by_oid:
                     raise ConfigurationError('No profile matching sysObjectID {}'.format(sys_object_oid))
                 profile = self.profiles_by_oid[sys_object_oid]
-                config.refresh_with_profile(self.profiles[profile], self.warning, self.log.debug)
+                config.refresh_with_profile(self.profiles[profile], self.warning, self.log)
 
             if config.table_oids:
                 self.log.debug('Querying device %s for %s oids', config.ip_address, len(config.table_oids))

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -26,7 +26,7 @@ def test_parse_metrics(hlapi_mock):
     config = InstanceConfig(
         {"ip_address": "127.0.0.1", "community_string": "public", "metrics": [{"OID": "1.2.3"}]},
         check.warning,
-        check.log.debug,
+        check.log,
         [],
         None,
         {},
@@ -34,11 +34,11 @@ def test_parse_metrics(hlapi_mock):
     )
     hlapi_mock.reset_mock()
     with pytest.raises(Exception):
-        config.parse_metrics(metrics, False, check.warning, check.log.debug)
+        config.parse_metrics(metrics, False, check.warning, check.log)
 
     # Simple OID
     metrics = [{"OID": "1.2.3"}]
-    table, raw, mibs = config.parse_metrics(metrics, False, check.warning, check.log.debug)
+    table, raw, mibs = config.parse_metrics(metrics, False, check.warning, check.log)
     assert table == {}
     assert mibs == set()
     assert len(raw) == 1
@@ -48,11 +48,11 @@ def test_parse_metrics(hlapi_mock):
     # MIB with no symbol or table
     metrics = [{"MIB": "foo_mib"}]
     with pytest.raises(Exception):
-        config.parse_metrics(metrics, False, check.warning, check.log.debug)
+        config.parse_metrics(metrics, False, check.warning, check.log)
 
     # MIB with symbol
     metrics = [{"MIB": "foo_mib", "symbol": "foo"}]
-    table, raw, mibs = config.parse_metrics(metrics, False, check.warning, check.log.debug)
+    table, raw, mibs = config.parse_metrics(metrics, False, check.warning, check.log)
     assert raw == []
     assert mibs == {"foo_mib"}
     assert len(table) == 1
@@ -62,11 +62,11 @@ def test_parse_metrics(hlapi_mock):
     # MIB with table, no symbols
     metrics = [{"MIB": "foo_mib", "table": "foo"}]
     with pytest.raises(Exception):
-        config.parse_metrics(metrics, False, check.warning, check.log.debug)
+        config.parse_metrics(metrics, False, check.warning, check.log)
 
     # MIB with table and symbols
     metrics = [{"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"]}]
-    table, raw, mibs = config.parse_metrics(metrics, True, check.warning, check.log.debug)
+    table, raw, mibs = config.parse_metrics(metrics, True, check.warning, check.log)
     assert raw == []
     assert mibs == set()
     assert len(table) == 1
@@ -78,18 +78,18 @@ def test_parse_metrics(hlapi_mock):
     # MIB with table, symbols, bad metrics_tags
     metrics = [{"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{}]}]
     with pytest.raises(Exception):
-        config.parse_metrics(metrics, False, check.warning, check.log.debug)
+        config.parse_metrics(metrics, False, check.warning, check.log)
 
     # MIB with table, symbols, bad metrics_tags
     metrics = [{"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{"tag": "foo"}]}]
     with pytest.raises(Exception):
-        config.parse_metrics(metrics, False, check.warning, check.log.debug)
+        config.parse_metrics(metrics, False, check.warning, check.log)
 
     # MIB with table, symbols, metrics_tags index
     metrics = [
         {"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{"tag": "foo", "index": "1"}]}
     ]
-    table, raw, mibs = config.parse_metrics(metrics, True, check.warning, check.log.debug)
+    table, raw, mibs = config.parse_metrics(metrics, True, check.warning, check.log)
     assert raw == []
     assert mibs == set()
     assert len(table) == 1
@@ -102,7 +102,7 @@ def test_parse_metrics(hlapi_mock):
     metrics = [
         {"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{"tag": "foo", "column": "baz"}]}
     ]
-    table, raw, mibs = config.parse_metrics(metrics, True, check.warning, check.log.debug)
+    table, raw, mibs = config.parse_metrics(metrics, True, check.warning, check.log)
     assert raw == []
     assert mibs == set()
     assert len(table) == 1

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -25,12 +25,21 @@ def warning(*args):
 def test_parse_metrics(hlapi_mock):
     # Unsupported metric
     metrics = [{"foo": "bar"}]
+    config = InstanceConfig(
+        {"ip_address": "127.0.0.1", "community_string": "public", "metrics": [{"OID": "1.2.3"}]},
+        warning,
+        [],
+        None,
+        {},
+        {},
+    )
+    hlapi_mock.reset_mock()
     with pytest.raises(Exception):
-        InstanceConfig.parse_metrics(metrics, False, warning)
+        config.parse_metrics(metrics, False, warning)
 
     # Simple OID
     metrics = [{"OID": "1.2.3"}]
-    table, raw, mibs = InstanceConfig.parse_metrics(metrics, False, warning)
+    table, raw, mibs = config.parse_metrics(metrics, False, warning)
     assert table == {}
     assert mibs == set()
     assert len(raw) == 1
@@ -40,11 +49,11 @@ def test_parse_metrics(hlapi_mock):
     # MIB with no symbol or table
     metrics = [{"MIB": "foo_mib"}]
     with pytest.raises(Exception):
-        InstanceConfig.parse_metrics(metrics, False, warning)
+        config.parse_metrics(metrics, False, warning)
 
     # MIB with symbol
     metrics = [{"MIB": "foo_mib", "symbol": "foo"}]
-    table, raw, mibs = InstanceConfig.parse_metrics(metrics, False, warning)
+    table, raw, mibs = config.parse_metrics(metrics, False, warning)
     assert raw == []
     assert mibs == {"foo_mib"}
     assert len(table) == 1
@@ -54,11 +63,11 @@ def test_parse_metrics(hlapi_mock):
     # MIB with table, no symbols
     metrics = [{"MIB": "foo_mib", "table": "foo"}]
     with pytest.raises(Exception):
-        InstanceConfig.parse_metrics(metrics, False, warning)
+        config.parse_metrics(metrics, False, warning)
 
     # MIB with table and symbols
     metrics = [{"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"]}]
-    table, raw, mibs = InstanceConfig.parse_metrics(metrics, True, warning)
+    table, raw, mibs = config.parse_metrics(metrics, True, warning)
     assert raw == []
     assert mibs == set()
     assert len(table) == 1
@@ -70,18 +79,18 @@ def test_parse_metrics(hlapi_mock):
     # MIB with table, symbols, bad metrics_tags
     metrics = [{"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{}]}]
     with pytest.raises(Exception):
-        InstanceConfig.parse_metrics(metrics, False, warning)
+        config.parse_metrics(metrics, False, warning)
 
     # MIB with table, symbols, bad metrics_tags
     metrics = [{"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{"tag": "foo"}]}]
     with pytest.raises(Exception):
-        InstanceConfig.parse_metrics(metrics, False, warning)
+        config.parse_metrics(metrics, False, warning)
 
     # MIB with table, symbols, metrics_tags index
     metrics = [
         {"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{"tag": "foo", "index": "1"}]}
     ]
-    table, raw, mibs = InstanceConfig.parse_metrics(metrics, True, warning)
+    table, raw, mibs = config.parse_metrics(metrics, True, warning)
     assert raw == []
     assert mibs == set()
     assert len(table) == 1
@@ -94,7 +103,7 @@ def test_parse_metrics(hlapi_mock):
     metrics = [
         {"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{"tag": "foo", "column": "baz"}]}
     ]
-    table, raw, mibs = InstanceConfig.parse_metrics(metrics, True, warning)
+    table, raw, mibs = config.parse_metrics(metrics, True, warning)
     assert raw == []
     assert mibs == set()
     assert len(table) == 1


### PR DESCRIPTION
This uses pysmi code to fetch and save MIBs that are referenced in
configuration but that we don't know yet.