### PR TITLE
Fix the missing Kafka producer metrics

### DIFF
--- a/kafka/datadog_checks/kafka/data/conf.yaml.example
+++ b/kafka/datadog_checks/kafka/data/conf.yaml.example
@@ -230,7 +230,7 @@ init_config:
             metric_type: gauge
             alias: kafka.producer.batch_size_max
           compression-rate-avg:
-            metric_type: rate
+            metric_type: gauge
             alias: kafka.producer.compression_rate_avg
           record-queue-time-avg:
             metric_type: gauge

--- a/kafka/datadog_checks/kafka/data/conf.yaml.example
+++ b/kafka/datadog_checks/kafka/data/conf.yaml.example
@@ -209,71 +209,71 @@ init_config:
 
     - include:
         domain: 'kafka.producer'
-        bean_regex: 'kafka.producer:type=producer-metrics,client-id=([-.\w]+)'
+        bean_regex: 'kafka\.producer:type=producer-metrics,client-id=([-.\w]+)'
         attribute:
-          - waiting-threads:
-              metric_type: gauge
-              alias: kafka.producer.waiting_threads
-          - buffer-total-bytes:
-              metric_type: gauge
-              alias: kafka.producer.buffer_bytes_total
-          - buffer-available-bytes:
-              metric_type: gauge
-              alias: kafka.producer.available_buffer_bytes
-          - bufferpool-wait-time:
-              metric_type: gauge
-              alias: kafka.producer.bufferpool_wait_time
-          - batch-size-avg:
-              metric_type: gauge
-              alias: kafka.producer.batch_size_avg
-          - batch-size-max:
-              metric_type: gauge
-              alias: kafka.producer.batch_size_max
-          - compression-rate-avg:
-              metric_type: rate
-              alias: kafka.producer.compression_rate_avg
-          - record-queue-time-avg:
-              metric_type: gauge
-              alias: kafka.producer.record_queue_time_avg
-          - record-queue-time-max:
-              metric_type: gauge
-              alias: kafka.producer.record_queue_time_max
-          - request-latency-avg:
-              metric_type: gauge
-              alias: kafka.producer.request_latency_avg
-          - request-latency-max:
-              metric_type: gauge
-              alias: kafka.producer.request_latency_max
-          - record-send-rate:
-              metric_type: gauge
-              alias: kafka.producer.records_send_rate
-          - records-per-request-avg:
-              metric_type: gauge
-              alias: kafka.producer.records_per_request
-          - record-retry-rate:
-              metric_type: gauge
-              alias: kafka.producer.record_retry_rate
-          - record-error-rate:
-              metric_type: gauge
-              alias: kafka.producer.record_error_rate
-          - record-size-max:
-              metric_type: gauge
-              alias: kafka.producer.record_size_max
-          - record-size-avg:
-              metric_type: gauge
-              alias: kafka.producer.record_size_avg
-          - requests-in-flight:
-              metric_type: gauge
-              alias: kafka.producer.requests_in_flight
-          - metadata-age:
-              metric_type: gauge
-              alias: kafka.producer.metadata_age
-          - produce-throttle-time-max:
-              metric_type: gauge
-              alias: kafka.producer.throttle_time_max
-          - produce-throttle-time-avg:
-              metric_type: gauge
-              alias: kafka.producer.throttle_time_avg
+          waiting-threads:
+            metric_type: gauge
+            alias: kafka.producer.waiting_threads
+          buffer-total-bytes:
+            metric_type: gauge
+            alias: kafka.producer.buffer_bytes_total
+          buffer-available-bytes:
+            metric_type: gauge
+            alias: kafka.producer.available_buffer_bytes
+          bufferpool-wait-time:
+            metric_type: gauge
+            alias: kafka.producer.bufferpool_wait_time
+          batch-size-avg:
+            metric_type: gauge
+            alias: kafka.producer.batch_size_avg
+          batch-size-max:
+            metric_type: gauge
+            alias: kafka.producer.batch_size_max
+          compression-rate-avg:
+            metric_type: rate
+            alias: kafka.producer.compression_rate_avg
+          record-queue-time-avg:
+            metric_type: gauge
+            alias: kafka.producer.record_queue_time_avg
+          record-queue-time-max:
+            metric_type: gauge
+            alias: kafka.producer.record_queue_time_max
+          request-latency-avg:
+            metric_type: gauge
+            alias: kafka.producer.request_latency_avg
+          request-latency-max:
+            metric_type: gauge
+            alias: kafka.producer.request_latency_max
+          record-send-rate:
+            metric_type: gauge
+            alias: kafka.producer.records_send_rate
+          records-per-request-avg:
+            metric_type: gauge
+            alias: kafka.producer.records_per_request
+          record-retry-rate:
+            metric_type: gauge
+            alias: kafka.producer.record_retry_rate
+          record-error-rate:
+            metric_type: gauge
+            alias: kafka.producer.record_error_rate
+          record-size-max:
+            metric_type: gauge
+            alias: kafka.producer.record_size_max
+          record-size-avg:
+            metric_type: gauge
+            alias: kafka.producer.record_size_avg
+          requests-in-flight:
+            metric_type: gauge
+            alias: kafka.producer.requests_in_flight
+          metadata-age:
+            metric_type: gauge
+            alias: kafka.producer.metadata_age
+          produce-throttle-time-max:
+            metric_type: gauge
+            alias: kafka.producer.throttle_time_max
+          produce-throttle-time-avg:
+            metric_type: gauge
+            alias: kafka.producer.throttle_time_avg
 
     ## Producers: Per Topic Metrics
 

--- a/kafka/datadog_checks/kafka/data/metrics.yaml
+++ b/kafka/datadog_checks/kafka/data/metrics.yaml
@@ -73,71 +73,71 @@ jmx_metrics:
 
     - include:
         domain: 'kafka.producer'
-        bean_regex: 'kafka.producer:type=producer-metrics,client-id=([-.\w]+)'
+        bean_regex: 'kafka\.producer:type=producer-metrics,client-id=([-.\w]+)'
         attribute:
-          - waiting-threads:
-              metric_type: gauge
-              alias: kafka.producer.waiting_threads
-          - buffer-total-bytes:
-              metric_type: gauge
-              alias: kafka.producer.buffer_bytes_total
-          - buffer-available-bytes:
-              metric_type: gauge
-              alias: kafka.producer.available_buffer_bytes
-          - bufferpool-wait-time:
-              metric_type: gauge
-              alias: kafka.producer.bufferpool_wait_time
-          - batch-size-avg:
-              metric_type: gauge
-              alias: kafka.producer.batch_size_avg
-          - batch-size-max:
-              metric_type: gauge
-              alias: kafka.producer.batch_size_max
-          - compression-rate-avg:
-              metric_type: gauge
-              alias: kafka.producer.compression_rate_avg
-          - record-queue-time-avg:
-              metric_type: gauge
-              alias: kafka.producer.record_queue_time_avg
-          - record-queue-time-max:
-              metric_type: gauge
-              alias: kafka.producer.record_queue_time_max
-          - request-latency-avg:
-              metric_type: gauge
-              alias: kafka.producer.request_latency_avg
-          - request-latency-max:
-              metric_type: gauge
-              alias: kafka.producer.request_latency_max
-          - record-send-rate:
-              metric_type: gauge
-              alias: kafka.producer.records_send_rate
-          - records-per-request-avg:
-              metric_type: gauge
-              alias: kafka.producer.records_per_request
-          - record-retry-rate:
-              metric_type: gauge
-              alias: kafka.producer.record_retry_rate
-          - record-error-rate:
-              metric_type: gauge
-              alias: kafka.producer.record_error_rate
-          - record-size-max:
-              metric_type: gauge
-              alias: kafka.producer.record_size_max
-          - record-size-avg:
-              metric_type: gauge
-              alias: kafka.producer.record_size_avg
-          - requests-in-flight:
-              metric_type: gauge
-              alias: kafka.producer.requests_in_flight
-          - metadata-age:
-              metric_type: gauge
-              alias: kafka.producer.metadata_age
-          - produce-throttle-time-max:
-              metric_type: gauge
-              alias: kafka.producer.throttle_time_max
-          - produce-throttle-time-avg:
-              metric_type: gauge
-              alias: kafka.producer.throttle_time_avg
+          waiting-threads:
+            metric_type: gauge
+            alias: kafka.producer.waiting_threads
+          buffer-total-bytes:
+            metric_type: gauge
+            alias: kafka.producer.buffer_bytes_total
+          buffer-available-bytes:
+            metric_type: gauge
+            alias: kafka.producer.available_buffer_bytes
+          bufferpool-wait-time:
+            metric_type: gauge
+            alias: kafka.producer.bufferpool_wait_time
+          batch-size-avg:
+            metric_type: gauge
+            alias: kafka.producer.batch_size_avg
+          batch-size-max:
+            metric_type: gauge
+            alias: kafka.producer.batch_size_max
+          compression-rate-avg:
+            metric_type: rate
+            alias: kafka.producer.compression_rate_avg
+          record-queue-time-avg:
+            metric_type: gauge
+            alias: kafka.producer.record_queue_time_avg
+          record-queue-time-max:
+            metric_type: gauge
+            alias: kafka.producer.record_queue_time_max
+          request-latency-avg:
+            metric_type: gauge
+            alias: kafka.producer.request_latency_avg
+          request-latency-max:
+            metric_type: gauge
+            alias: kafka.producer.request_latency_max
+          record-send-rate:
+            metric_type: gauge
+            alias: kafka.producer.records_send_rate
+          records-per-request-avg:
+            metric_type: gauge
+            alias: kafka.producer.records_per_request
+          record-retry-rate:
+            metric_type: gauge
+            alias: kafka.producer.record_retry_rate
+          record-error-rate:
+            metric_type: gauge
+            alias: kafka.producer.record_error_rate
+          record-size-max:
+            metric_type: gauge
+            alias: kafka.producer.record_size_max
+          record-size-avg:
+            metric_type: gauge
+            alias: kafka.producer.record_size_avg
+          requests-in-flight:
+            metric_type: gauge
+            alias: kafka.producer.requests_in_flight
+          metadata-age:
+            metric_type: gauge
+            alias: kafka.producer.metadata_age
+          produce-throttle-time-max:
+            metric_type: gauge
+            alias: kafka.producer.throttle_time_max
+          produce-throttle-time-avg:
+            metric_type: gauge
+            alias: kafka.producer.throttle_time_avg
 
 
     #

--- a/kafka/datadog_checks/kafka/data/metrics.yaml
+++ b/kafka/datadog_checks/kafka/data/metrics.yaml
@@ -94,7 +94,7 @@ jmx_metrics:
             metric_type: gauge
             alias: kafka.producer.batch_size_max
           compression-rate-avg:
-            metric_type: rate
+            metric_type: gauge
             alias: kafka.producer.compression_rate_avg
           record-queue-time-avg:
             metric_type: gauge


### PR DESCRIPTION
Datadog agent Kafka check misses to track some of the JMX metrics because configuration defined them as a yaml sequence while it should have just defined them as separate keys.

Datadog agent logs before the change(35 metrics)
```
2019-10-10 18:22:16 +03 | CORE | INFO | (pkg/jmxfetch/jmxfetch.go:218 in func1) | 2019-10-10 18:22:16,103 | INFO | Reporter | Instance kafka-localhost-9996 is sending 35 metrics to the metrics reporter during collection #1
```
Datadog agent logs after the change(73 metrics)
```
2019-10-10 18:22:54 +03 | CORE | INFO | (pkg/jmxfetch/jmxfetch.go:218 in func1) | 2019-10-10 18:22:54,124 | INFO | Reporter | Instance kafka-localhost-9996 is sending 73 metrics to the metrics reporter during collection #1
```

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
