### PR TITLE
Better Azure Pipelines analytics

### DIFF
--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -1,5 +1,5 @@
 parameters:
-  job_name: ''
+  test_run: ''
   check: ''
   test: false
   test_e2e: false
@@ -7,7 +7,7 @@ parameters:
 
 steps:
 - ${{ if eq(parameters.test, 'true') }}:
-  - script: ddev test --cov --pytest-args="--junit-xml=junit/test-results.xml --junit-prefix='${{ parameters.job_name }}'" ${{ parameters.check }}
+  - script: ddev test --cov --pytest-args="--junit-xml=junit/test-results.xml --junit-prefix='${{ parameters.test_run }}'" ${{ parameters.check }}
     displayName: 'Run tests'
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
@@ -26,4 +26,4 @@ steps:
   condition: succeededOrFailed()
   inputs:
     testResultsFiles: '**/test-*.xml'
-    testRunTitle: '${{ parameters.job_name }}'
+    testRunTitle: '${{ parameters.test_run }}'

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -6,7 +6,7 @@ parameters:
 
 steps:
 - ${{ if eq(parameters.test, 'true') }}:
-  - script: ddev test --cov --pytest-args="--junitxml=junit/test-results.xml" ${{ parameters.check }}
+  - script: ddev test --cov --pytest-args="--junit-xml=junit/test-results.xml --junit-prefix='${{ parameters.check }}'" ${{ parameters.check }}
     displayName: 'Run tests'
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -1,4 +1,5 @@
 parameters:
+  job_name: ''
   check: ''
   test: false
   test_e2e: false
@@ -6,7 +7,7 @@ parameters:
 
 steps:
 - ${{ if eq(parameters.test, 'true') }}:
-  - script: ddev test --cov --pytest-args="--junit-xml=junit/test-results.xml --junit-prefix='${{ parameters.check }}'" ${{ parameters.check }}
+  - script: ddev test --cov --pytest-args="--junit-xml=junit/test-results.xml --junit-prefix='${{ parameters.job_name }}'" ${{ parameters.check }}
     displayName: 'Run tests'
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
@@ -25,4 +26,4 @@ steps:
   condition: succeededOrFailed()
   inputs:
     testResultsFiles: '**/test-*.xml'
-    testRunTitle: '${{ parameters.check }}'
+    testRunTitle: '${{ parameters.job_name }}'

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -25,4 +25,4 @@ steps:
   condition: succeededOrFailed()
   inputs:
     testResultsFiles: '**/test-*.xml'
-    testRunTitle: 'Publish test results'
+    testRunTitle: '${{ parameters.check }}'

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -33,7 +33,7 @@ jobs:
 
   - template: './run-tests.yml'
     parameters:
-      job_name: '${{ coalesce(parameters.job_name, parameters.check) }}_linux'
+      test_run: '${{ coalesce(parameters.job_name, parameters.check) }}_linux'
       check: ${{ parameters.check }}
       test: ${{ parameters.test }}
       test_e2e: ${{ parameters.test_e2e }}

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -33,6 +33,7 @@ jobs:
 
   - template: './run-tests.yml'
     parameters:
+      job_name: '${{ coalesce(parameters.job_name, parameters.check) }}_linux'
       check: ${{ parameters.check }}
       test: ${{ parameters.test }}
       test_e2e: ${{ parameters.test_e2e }}

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -33,7 +33,7 @@ jobs:
 
   - template: './run-tests.yml'
     parameters:
-      test_run: '${{ coalesce(parameters.job_name, parameters.check) }}_linux'
+      test_run: '${{ coalesce(parameters.job_name, parameters.check) }}.linux'
       check: ${{ parameters.check }}
       test: ${{ parameters.test }}
       test_e2e: ${{ parameters.test_e2e }}

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -35,7 +35,7 @@ jobs:
 
   - template: './run-tests.yml'
     parameters:
-      test_run: '${{ coalesce(parameters.job_name, parameters.check) }}_windows'
+      test_run: '${{ coalesce(parameters.job_name, parameters.check) }}.windows'
       check: ${{ parameters.check }}
       test: ${{ parameters.test }}
       test_e2e: ${{ parameters.test_e2e }}

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -35,7 +35,7 @@ jobs:
 
   - template: './run-tests.yml'
     parameters:
-      job_name: '${{ coalesce(parameters.job_name, parameters.check) }}_windows'
+      test_run: '${{ coalesce(parameters.job_name, parameters.check) }}_windows'
       check: ${{ parameters.check }}
       test: ${{ parameters.test }}
       test_e2e: ${{ parameters.test_e2e }}

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -35,6 +35,7 @@ jobs:
 
   - template: './run-tests.yml'
     parameters:
+      job_name: '${{ coalesce(parameters.job_name, parameters.check) }}_windows'
       check: ${{ parameters.check }}
       test: ${{ parameters.test }}
       test_e2e: ${{ parameters.test_e2e }}


### PR DESCRIPTION
### What does this PR do?

Add junit prefix for better Azure Pipelines stats

### Motivation

Better AZP test analytics per `test run` (aka an integration) and `test file`

That will help investigate which integration and tests are flaky on CI and prioritise which one to fix first.

---

Currently analytics are not very clean because I tried multiple naming. Since the results are filtered for last 7 or 14 days. In a week or two, the analytics will be cleaner.

https://dev.azure.com/datadoghq/integrations-core/_test/analytics?definitionId=4&contextType=build

![image](https://user-images.githubusercontent.com/49917914/66605966-62276b00-ebb1-11e9-8c5c-a6f6f8b76bbc.png)
