### PR TITLE
Allows certain expected HTTP error status_codes for the `/sys/health` endpoint

### DIFF
--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -164,9 +164,7 @@ class Vault(AgentCheck):
             msg = 'The Vault endpoint `{}` returned {}'.format(full_url, rsc)
             if path.endswith("/sys/health") and rsc in self.SYS_HEALTH_DEFAULT_CODES:
                 # Ignores expected HTTPError status codes for `/sys/health` endpoint.
-                msg = '{} - node is {}.'.format(msg, self.SYS_HEALTH_DEFAULT_CODES[rsc])
-                self.log.debug(msg)
-                pass
+                self.log.debug('{} - node is {}.'.format(msg, self.SYS_HEALTH_DEFAULT_CODES[rsc]))
             else:
                 self.service_check(self.SERVICE_CHECK_CONNECT, AgentCheck.CRITICAL, message=msg, tags=tags)
                 self.log.exception(msg)

--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -145,7 +145,8 @@ class Vault(AgentCheck):
 
     def access_api(self, url, path, tags, params=None):
         try:
-            response = self.http.get(url + path, params=params)
+            full_url = url + path
+            response = self.http.get(full_url, params=params)
             json_data = response.json()
             response.raise_for_status()
         except requests.exceptions.HTTPError:
@@ -154,22 +155,22 @@ class Vault(AgentCheck):
                 # https://www.vaultproject.io/api/system/health.html
                 pass
             else:
-                msg = 'The Vault endpoint `{}` returned {}.'.format(url, response.status_code)
+                msg = 'The Vault endpoint `{}` returned {}.'.format(full_url, response.status_code)
                 self.service_check(self.SERVICE_CHECK_CONNECT, AgentCheck.CRITICAL, message=msg, tags=tags)
                 self.log.exception(msg)
                 raise ApiUnreachable
         except JSONDecodeError:
-            msg = 'The Vault endpoint `{}` returned invalid json data.'.format(url)
+            msg = 'The Vault endpoint `{}` returned invalid json data.'.format(full_url)
             self.service_check(self.SERVICE_CHECK_CONNECT, AgentCheck.CRITICAL, message=msg, tags=tags)
             self.log.exception(msg)
             raise ApiUnreachable
         except requests.exceptions.Timeout:
-            msg = 'Vault endpoint `{}` timed out after {} seconds'.format(url, self.http.options['timeout'])
+            msg = 'Vault endpoint `{}` timed out after {} seconds'.format(full_url, self.http.options['timeout'])
             self.service_check(self.SERVICE_CHECK_CONNECT, AgentCheck.CRITICAL, message=msg, tags=tags)
             self.log.exception(msg)
             raise ApiUnreachable
         except (requests.exceptions.RequestException, requests.exceptions.ConnectionError):
-            msg = 'Error accessing Vault endpoint `{}`'.format(url)
+            msg = 'Error accessing Vault endpoint `{}`'.format(full_url)
             self.service_check(self.SERVICE_CHECK_CONNECT, AgentCheck.CRITICAL, message=msg, tags=tags)
             self.log.exception(msg)
             raise ApiUnreachable

--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -98,8 +98,7 @@ class Vault(AgentCheck):
     def check_health_v1(self, config, tags):
         path = '/sys/health'
         url = config['api_url']
-        health_params = {'standbyok': True, 'perfstandbyok': True}
-        health_data = self.access_api(url, path, tags, params=health_params)
+        health_data = self.access_api(url, path, tags)
 
         cluster_name = health_data.get('cluster_name')
         if cluster_name:

--- a/vault/tests/test_vault.py
+++ b/vault/tests/test_vault.py
@@ -344,7 +344,6 @@ class TestVault:
 
         def mock_requests_get(url, *args, **kwargs):
             if url == config['api_url'] + '/sys/health':
-                status_code = 200 if kwargs.get('params', {}).get('standbyok') else 429
                 return MockResponse(
                     {
                         'cluster_id': '9e25ccdb-09ea-8bd8-0521-34cf3ef7a4cc',
@@ -358,7 +357,7 @@ class TestVault:
                         'performance_standby': False,
                         'version': '0.10.2',
                     },
-                    status_code,
+                    status_code=429,
                 )
             return requests_get(url, *args, **kwargs)
 
@@ -378,7 +377,6 @@ class TestVault:
 
         def mock_requests_get(url, *args, **kwargs):
             if url == config['api_url'] + '/sys/health':
-                status_code = 200 if kwargs.get('params', {}).get('perfstandbyok') else 473
                 return MockResponse(
                     {
                         'cluster_id': '9e25ccdb-09ea-8bd8-0521-34cf3ef7a4cc',
@@ -392,7 +390,7 @@ class TestVault:
                         'performance_standby': True,
                         'version': '0.10.2',
                     },
-                    status_code,
+                    status_code=473,
                 )
             return requests_get(url, *args, **kwargs)
 

--- a/vault/tests/test_vault.py
+++ b/vault/tests/test_vault.py
@@ -170,7 +170,8 @@ class TestVault:
                         'server_time_utc': 1529357080,
                         'standby': False,
                         'version': '0.10.2',
-                    }
+                    },
+                    status_code=503,
                 )
             return requests_get(url, *args, **kwargs)
 
@@ -249,7 +250,8 @@ class TestVault:
                         'server_time_utc': 1529357080,
                         'standby': False,
                         'version': '0.10.2',
-                    }
+                    },
+                    status_code=501,
                 )
             return requests_get(url, *args, **kwargs)
 


### PR DESCRIPTION
### What does this PR do?

Allows certain expected HTTP error status_codes for the `/sys/health` endpoint

### Motivation

1547-vault-fix-sealed-nodes-management
Resolves #4706 

### Additional Notes

Status codes from https://www.vaultproject.io/api/system/health.html

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
