### PR TITLE
Better default conf.yaml.example

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/datadog_checks/{check_name}/data/conf.yaml.example
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/datadog_checks/{check_name}/data/conf.yaml.example
@@ -1,4 +1,14 @@
 init_config:
 
 instances:
-  - {{}}
+
+  -
+
+    ## @param tags - list of key:value elements - optional
+    ## List of tags to attach to every metric, event and service check emitted by this integration.
+    ##
+    ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/datadog_checks/{check_name}/data/conf.yaml.example
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/datadog_checks/{check_name}/data/conf.yaml.example
@@ -1,4 +1,14 @@
 init_config:
 
 instances:
-  - {{}}
+
+  -
+
+    ## @param tags - list of key:value elements - optional
+    ## List of tags to attach to every metric, event and service check emitted by this integration.
+    ##
+    ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/datadog_checks/{check_name}/data/conf.yaml.example
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/datadog_checks/{check_name}/data/conf.yaml.example
@@ -1,5 +1,14 @@
 init_config:
 
+  ## Whether or not this file is a configuration for a JMX integration
+  #
+  is_jmx: true
+
+  ## @param collect_default_metrics - boolean - required
+  ## Whether or not the check should collect all default metrics for this integration.
+  #
+  collect_default_metrics: true
+
 instances:
 
   -


### PR DESCRIPTION
Better default `conf.yaml.example`

The previous default `conf.yaml.example` generate does not pass `ddev validate config`. Is that intended or should be something to fix ? @FlorianVeaux