### PR TITLE
Revert "Revert "Better default conf.yaml.example (#4752)" (#4755)"

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/datadog_checks/{check_name}/data/conf.yaml.example
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/datadog_checks/{check_name}/data/conf.yaml.example
@@ -1,4 +1,14 @@
 init_config:
 
 instances:
-  - {{}}
+
+  -
+
+    ## @param tags - list of key:value elements - optional
+    ## List of tags to attach to every metric, event and service check emitted by this integration.
+    ##
+    ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/datadog_checks/{check_name}/data/conf.yaml.example
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/datadog_checks/{check_name}/data/conf.yaml.example
@@ -1,4 +1,23 @@
 init_config:
 
+  ## Whether or not this file is a configuration for a JMX integration
+  #
+  is_jmx: true
+
+  ## @param collect_default_metrics - boolean - required
+  ## Whether or not the check should collect all default metrics for this integration.
+  #
+  collect_default_metrics: true
+
 instances:
-  - {{}}
+
+  -
+
+    ## @param tags - list of key:value elements - optional
+    ## List of tags to attach to every metric, event and service check emitted by this integration.
+    ##
+    ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>


### PR DESCRIPTION
PR #4752 was merged too early and blocked the release process, it has been reverted in #4755 then is re-reverted now.

Safe to ignore