### PR TITLE
Update KE version

### DIFF
--- a/istio/tests/terraform/main.tf
+++ b/istio/tests/terraform/main.tf
@@ -37,7 +37,6 @@ resource "local_file" "kubeconfig" {
 resource "google_container_cluster" "gke_cluster" {
   name = replace("istio-cluster-${var.user}-${random_string.suffix.result}", ".", "-")
   location = random_shuffle.az.result[0]
-  node_version = "1.13.7-gke.24"
   min_master_version = "1.13.7-gke.24"
 
   lifecycle {

--- a/istio/tests/terraform/main.tf
+++ b/istio/tests/terraform/main.tf
@@ -37,8 +37,8 @@ resource "local_file" "kubeconfig" {
 resource "google_container_cluster" "gke_cluster" {
   name = replace("istio-cluster-${var.user}-${random_string.suffix.result}", ".", "-")
   location = random_shuffle.az.result[0]
-  node_version = "1.13.7-gke.8"
-  min_master_version = "1.13.7-gke.8"
+  node_version = "1.13.7-gke.24"
+  min_master_version = "1.13.7-gke.24"
 
   lifecycle {
     ignore_changes = ["node_pool"]

--- a/linkerd/tests/terraform/main.tf
+++ b/linkerd/tests/terraform/main.tf
@@ -94,8 +94,8 @@ resource "null_resource" "linkerd-init" {
 resource "google_container_cluster" "gke_cluster" {
   name = replace("linkerd-cluster-${var.user}-${random_string.suffix.result}", ".", "-")
   location = random_shuffle.az.result[0]
-  node_version = "1.13.7-gke.8"
-  min_master_version = "1.13.7-gke.8"
+  node_version = "1.13.7-gke.24"
+  min_master_version = "1.13.7-gke.24"
 
   lifecycle {
     ignore_changes = ["node_pool"]

--- a/linkerd/tests/terraform/main.tf
+++ b/linkerd/tests/terraform/main.tf
@@ -94,7 +94,6 @@ resource "null_resource" "linkerd-init" {
 resource "google_container_cluster" "gke_cluster" {
   name = replace("linkerd-cluster-${var.user}-${random_string.suffix.result}", ".", "-")
   location = random_shuffle.az.result[0]
-  node_version = "1.13.7-gke.24"
   min_master_version = "1.13.7-gke.24"
 
   lifecycle {


### PR DESCRIPTION
Reason:
```
Error: googleapi: Error 400: Master version "1.13.7-gke.8" is unsupported., badRequest

  on main.tf line 37, in resource "google_container_cluster" "gke_cluster":
  37: resource "google_container_cluster" "gke_cluster" {
```
Default version changed to `.24` on Sept 26 https://cloud.google.com/kubernetes-engine/docs/release-notes