### PR TITLE
Make integration test work on OSX

### DIFF
--- a/mesos_slave/tests/compose/docker-compose.yml
+++ b/mesos_slave/tests/compose/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3.5"
 # - https://github.com/mesosphere/docker-containers/tree/master/mesos
 services:
   zookeeper:
-    image: zookeeper:3.5
+    image: bobrik/zookeeper
     environment:
       ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=no,clientPort=2181
       ZK_ID: 1

--- a/mesos_slave/tests/compose/docker-compose.yml
+++ b/mesos_slave/tests/compose/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3.5"
 # - https://github.com/mesosphere/docker-containers/tree/master/mesos
 services:
   zookeeper:
-    image: bobrik/zookeeper
+    image: zookeeper:3.5
     environment:
       ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=no,clientPort=2181
       ZK_ID: 1

--- a/mesos_slave/tests/compose/docker-compose.yml
+++ b/mesos_slave/tests/compose/docker-compose.yml
@@ -5,22 +5,18 @@ version: "3.5"
 services:
   zookeeper:
     image: bobrik/zookeeper
-    network_mode: host
     environment:
       ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=no,clientPort=2181
       ZK_ID: 1
 
   mesos-slave:
     image: mesosphere/mesos-slave:${MESOS_SLAVE_VERSION}
-    network_mode: host
     pid: host
     environment:
-      - MESOS_MASTER=zk://127.0.0.1:2181/mesos
+      - MESOS_MASTER=zk://zookeeper:2181/mesos
       - MESOS_CONTAINERIZERS=docker,mesos
       - MESOS_PORT=5051
       - MESOS_RESOURCES=ports(*):[11000-11999]
-      - MESOS_HOSTNAME=127.0.0.1
-      - LIBPROCESS_IP=127.0.0.1
       - MESOS_WORK_DIR=/tmp/mesos
       - MESOS_SYSTEMD_ENABLE_SUPPORT=false
     ports:

--- a/mesos_slave/tests/test_integration.py
+++ b/mesos_slave/tests/test_integration.py
@@ -9,8 +9,9 @@ from datadog_checks.base import AgentCheck
 from datadog_checks.base.errors import CheckException
 from datadog_checks.mesos_slave import MesosSlave
 
-# Linux only: https://github.com/docker/for-mac/issues/1031
-pytest.mark.skipif(platform.system() != 'Linux', reason="Only runs on Unix systems")
+# Does not work on windows. The zookeeper image are not compatible with windows architecture.
+# Error: "no matching manifest for windows/amd64 10.0.17763 in the manifest list entries"
+pytest.mark.skipif(platform.system() == 'Windows', reason="Docker images not compatible with windows architecture")
 
 
 @pytest.mark.integration

--- a/mesos_slave/tests/test_integration_e2e.py
+++ b/mesos_slave/tests/test_integration_e2e.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import platform
+
 import pytest
 from six import iteritems
 
@@ -8,6 +10,10 @@ from datadog_checks.base import AgentCheck
 from datadog_checks.mesos_slave import MesosSlave
 
 from .common import CHECK_NAME
+
+# Does not work on windows. The zookeeper image are not compatible with windows architecture.
+# Error: "no matching manifest for windows/amd64 10.0.17763 in the manifest list entries"
+pytest.mark.skipif(platform.system() == 'Windows', reason="Docker images not compatible with windows architecture")
 
 
 @pytest.mark.integration

--- a/mesos_slave/tests/test_integration_e2e.py
+++ b/mesos_slave/tests/test_integration_e2e.py
@@ -1,8 +1,6 @@
 # (C) Datadog, Inc. 2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import platform
-
 import pytest
 from six import iteritems
 
@@ -12,8 +10,6 @@ from datadog_checks.mesos_slave import MesosSlave
 from .common import CHECK_NAME
 
 
-# Linux only: https://github.com/docker/for-mac/issues/1031
-@pytest.mark.skipif(platform.system() != 'Linux', reason='Only runs on Unix systems')
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
 def test_check_integration(instance, aggregator):


### PR DESCRIPTION
Make integration test work on OSX

Apply the same fix that has been done for `mesos master`: https://github.com/DataDog/integrations-core/pull/4481