### PR TITLE
Fix ddev testable command to properly use the tag, fallback on the branch if absent.

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
@@ -283,11 +283,14 @@ def testable(ctx, start_id, agent_version, milestone, dry_run):
     echo_info('Branch `{}` will be compared to `master`.'.format(current_release_branch))
 
     echo_waiting('Getting diff... ', nl=False)
-    diif_command = 'git --no-pager log "--pretty=format:%H %s" {}..master'
+    diff_command = 'git --no-pager log "--pretty=format:%H %s" {}..master'
 
     with chdir(root):
-        result = run_command(diif_command.format(current_release_branch), capture=True)
+        # compare with the local tag first
+        reftag = '{}{}'.format('refs/tags/', current_release_branch)
+        result = run_command(diff_command.format(reftag), capture=True)
         if result.code:
+            # if it didn't work, compare with a branch.
             origin_release_branch = 'origin/{}'.format(current_release_branch)
             echo_failure('failed!')
             echo_waiting(
@@ -297,9 +300,9 @@ def testable(ctx, start_id, agent_version, milestone, dry_run):
                 nl=False,
             )
 
-            result = run_command(diif_command.format(origin_release_branch), capture=True)
+            result = run_command(diff_command.format(origin_release_branch), capture=True)
             if result.code:
-                abort('Unable to get the diif.')
+                abort('Unable to get the diff.')
             else:
                 echo_success('success!')
         else:


### PR DESCRIPTION
### What does this PR do?

Fix ddev testable command to properly use the tag (and fallback on the branch if absent).

### Motivation

It could use the branch with the same name instead.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
~- [ ] If PR adds a configuration option, it must be added to the configuration file.~
