### PR TITLE
Run base and ddev on windows

### DIFF
--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -18,14 +18,14 @@ jobs:
 - template: './templates/test-all.yml'
   parameters:
     checks:
-    - checkName: datadog_checks_base (Linux)
-      displayName: Datadog Checks Base
+    - checkName: datadog_checks_base
+      displayName: Datadog Checks Base (Linux)
       os: linux
-    - checkName: datadog_checks_dev (Linux)
-      displayName: Datadog Checks Dev
+    - checkName: datadog_checks_dev
+      displayName: Datadog Checks Dev (Linux)
       os: linux
-    - checkName: datadog_checks_base (Windows)
-      displayName: Datadog Checks Base
+    - checkName: datadog_checks_base
+      displayName: Datadog Checks Base (Windows)
       os: windows
     - checkName: datadog_checks_dev
       displayName: Datadog Checks Dev (Windows)

--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -18,12 +18,18 @@ jobs:
 - template: './templates/test-all.yml'
   parameters:
     checks:
-    - checkName: datadog_checks_base
+    - checkName: datadog_checks_base (Linux)
       displayName: Datadog Checks Base
       os: linux
-    - checkName: datadog_checks_dev
+    - checkName: datadog_checks_dev (Linux)
       displayName: Datadog Checks Dev
       os: linux
+    - checkName: datadog_checks_base (Windows)
+      displayName: Datadog Checks Base
+      os: windows
+    - checkName: datadog_checks_dev
+      displayName: Datadog Checks Dev (Windows)
+      os: windows
     - checkName: datadog_checks_downloader
       displayName: Datadog Checks Downloader
       os: linux

--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -21,12 +21,12 @@ jobs:
     - checkName: datadog_checks_base
       displayName: Datadog Checks Base (Linux)
       os: linux
-    - checkName: datadog_checks_dev
-      displayName: Datadog Checks Dev (Linux)
-      os: linux
     - checkName: datadog_checks_base
       displayName: Datadog Checks Base (Windows)
       os: windows
+    - checkName: datadog_checks_dev
+      displayName: Datadog Checks Dev (Linux)
+      os: linux
     - checkName: datadog_checks_dev
       displayName: Datadog Checks Dev (Windows)
       os: windows


### PR DESCRIPTION
## Description

Run base and ddev on windows

## Motivation

Since `datadog_checks_base` and `datadog_checks_dev` are run on windows for `changes`, we should probably also run them on `all`:
 https://github.com/DataDog/integrations-core/blob/master/.azure-pipelines/changes.yml#L24