### PR TITLE
Avoid sending additional gauges for openmetrics histograms if using distribution metrics

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -679,7 +679,7 @@ class OpenMetricsScraperMixin(object):
                 self.log.debug("Metric value is not supported for metric {}".format(sample[self.SAMPLE_NAME]))
                 continue
             custom_hostname = self._get_hostname(hostname, sample, scraper_config)
-            if sample[self.SAMPLE_NAME].endswith("_sum"):
+            if sample[self.SAMPLE_NAME].endswith("_sum") and not scraper_config['send_distribution_buckets']:
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname)
                 self.gauge(
                     "{}.{}.sum".format(scraper_config['namespace'], metric_name),
@@ -687,7 +687,7 @@ class OpenMetricsScraperMixin(object):
                     tags=tags,
                     hostname=custom_hostname,
                 )
-            elif sample[self.SAMPLE_NAME].endswith("_count"):
+            elif sample[self.SAMPLE_NAME].endswith("_count") and not scraper_config['send_distribution_buckets']:
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname)
                 if scraper_config['send_histograms_buckets']:
                     tags.append("upper_bound:none")

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -451,15 +451,16 @@ def test_submit_histogram_with_monotonic_count(aggregator, mocked_prometheus_che
     aggregator.assert_all_metrics_covered()
 
 
-def test_submit_histogram_bucket(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+def test_submit_buckets_as_distribution(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
     _histo = HistogramMetricFamily('my_histogram', 'my_histogram')
     _histo.add_metric([], buckets=[("1", 1), ("3.1104e+07", 2), ("4.324e+08", 3), ("+Inf", 4)], sum_value=1337)
     check = mocked_prometheus_check
     mocked_prometheus_scraper_config['send_distribution_buckets'] = True
     mocked_prometheus_scraper_config['non_cumulative_buckets'] = True
     check.submit_openmetric('custom.histogram', _histo, mocked_prometheus_scraper_config)
-    aggregator.assert_metric('prometheus.custom.histogram.sum', 1337, tags=[], count=1)
-    aggregator.assert_metric('prometheus.custom.histogram.count', 4, tags=['upper_bound:none'], count=1)
+    # sum & count gauges should not be sent
+    aggregator.assert_metric('prometheus.custom.histogram.sum', 1337, tags=[], count=0)
+    aggregator.assert_metric('prometheus.custom.histogram.count', 4, tags=['upper_bound:none'], count=0)
     # assert buckets
     aggregator.assert_histogram_bucket(
         'prometheus.custom.histogram',


### PR DESCRIPTION

### What does this PR do?

Do not send `.count` & `.sum` gauges along the distribution metric

### Motivation

Avoid confusing people with the gauge so that they only rely on the distribution metric

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
