### PR TITLE
Fix allowed host failure retry logic

### DIFF
--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -365,7 +365,7 @@ class SnmpCheck(AgentCheck):
             for host, discovered in list(config.discovered_instances.items()):
                 if self._check_with_config(discovered):
                     config.failing_instances[host] += 1
-                    if config.failing_instances[host] > config.allowed_failures:
+                    if config.failing_instances[host] >= config.allowed_failures:
                         # Remove it from discovered instances, we'll re-discover it later if it reappears
                         config.discovered_instances.pop(host)
                         # Reset the failure counter as well

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -171,15 +171,12 @@ def test_removing_host():
 
     check.check(instance)
     assert warnings == [msg, msg, msg]
-
-    check.check(instance)
-    assert warnings == [msg, msg, msg, msg]
     # Instance has been removed
     assert check._config.discovered_instances == {}
 
     check.check(instance)
     # No new warnings produced
-    assert warnings == [msg, msg, msg, msg]
+    assert warnings == [msg, msg, msg]
 
 
 @mock.patch("datadog_checks.snmp.snmp.read_persistent_cache")


### PR DESCRIPTION
### Motivation

The documentation says hosts will be removed after the specified number of failures