### PR TITLE
Improve ddev release

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
@@ -314,9 +314,13 @@ def testable(ctx, start_id, agent_version, milestone, dry_run):
     echo_info('Branch `{}` will be compared to `master`.'.format(current_release_branch))
 
     echo_waiting('Getting diff... ', nl=False)
-    diif_command = 'git --no-pager log "--pretty=format:%H %s" {}..master'
+    diif_command = 'git --no-pager log "--pretty=format:%H %s" origin/{}..origin/master'
 
     with chdir(root):
+        result = run_command('git fetch')
+        if result.code:
+            abort('Unable to run git fetch.')
+
         result = run_command(diif_command.format(current_release_branch), capture=True)
         if result.code:
             origin_release_branch = 'origin/{}'.format(current_release_branch)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
@@ -71,11 +71,20 @@ def validate_version(ctx, param, value):
         raise click.BadParameter('needs to be in semver format x.y[.z]')
 
 
-def create_trello_card(client, teams, pr_title, pr_url, pr_body, pr_author, config):
+def create_trello_card(client, teams, pr_title, pr_url, pr_body, pr_author, config, dry_run):
     body = u'Pull request: {}\n\n{}'.format(pr_url, pr_body)
 
     for team in teams:
         members = pick_card_members(config, pr_author, team)
+        if dry_run:
+            echo_success(
+                'Will create a card for team {}: '.format(team), nl=False)
+            if members:
+                echo_info('({}) {}'.format(members, pr_title))
+            else:
+                echo_info(pr_title)
+            continue
+
         creation_attempts = 3
         for attempt in range(3):
             rate_limited, error, response = client.create_card(team, pr_title, body, members)
@@ -331,11 +340,6 @@ def testable(ctx, start_id, agent_version, milestone, dry_run):
     diff_data = [tuple(line.split(None, 1)) for line in reversed(result.stdout.splitlines())]
     num_changes = len(diff_data)
 
-    if dry_run:
-        for _, commit_subject in diff_data:
-            echo_info(commit_subject)
-        return
-
     if repo == 'integrations-core':
         options = OrderedDict(
             (('1', 'Integrations'), ('2', 'Containers'), ('3', 'Core'), ('4', 'Platform'), ('s', 'Skip'), ('q', 'Quit'))
@@ -444,7 +448,7 @@ def testable(ctx, start_id, agent_version, milestone, dry_run):
 
         teams = [trello.label_team_map[label] for label in pr_labels if label in trello.label_team_map]
         if teams:
-            create_trello_card(trello, teams, pr_title, pr_url, pr_body, pr_author, user_config)
+            create_trello_card(trello, teams, pr_title, pr_url, pr_body, pr_author, user_config, dry_run)
             continue
 
         finished = False
@@ -507,7 +511,7 @@ def testable(ctx, start_id, agent_version, milestone, dry_run):
                 echo_warning('Exited at {}'.format(format_commit_id(commit_id)))
                 return
             else:
-                create_trello_card(trello, [value], pr_title, pr_url, pr_body, pr_author, user_config)
+                create_trello_card(trello, [value], pr_title, pr_url, pr_body, pr_author, user_config, dry_run)
 
             finished = True
 


### PR DESCRIPTION
### What does this PR do?
- Dry mode:
  - Before: `dry` mode only display git diff output.
  - After: The `dry` mode is the same as normal mode except it does not create the Trello cards.
- The diff is computed using remote branches (origin/master instead of master)

### Motivation

`dry` mode: It is nice to see what will be really created.
Using remote branches: the local `master` branch can be out of date. 

### Additional Notes

I will recreate a PR once https://github.com/DataDog/integrations-core/pull/4765 will be merged (And add the changelog).

We need to check the use cases to see if using remote branches for diff is a good idea or https://github.com/DataDog/integrations-core/pull/4775 is better.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
