### PR TITLE
Fix no instances case for AgentCheck signature and add more tests

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -110,6 +110,14 @@ class __AgentCheck(object):
         the Agent might create several different Check instances and the method would be
         called as many times.
 
+        Agent 5 signature:
+
+            AgentCheck(name, init_config, agentConfig, instances=None)
+
+        Agent 6 signature:
+
+            AgentCheck(name, init_config, instances)
+
         :warning: when loading a Custom check, the Agent will inspect the module searching
             for a subclass of `AgentCheck`. If such a class exists but has been derived in
             turn, it'll be ignored - **you should never derive from an existing Check**.

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -142,14 +142,14 @@ class __AgentCheck(object):
         if len(args) > 1:
             self.init_config = args[1]
         if len(args) > 2:
-            if len(args) > 3 or 'instances' in kwargs:
+            if isinstance(args[2], list):
+                # new-style init: the 3rd argument is `instances`
+                self.instances = args[2]
+            else:
                 # old-style init: the 3rd argument is `agentConfig`
                 self.agentConfig = args[2]
                 if len(args) > 3:
                     self.instances = args[3]
-            else:
-                # new-style init: the 3rd argument is `instances`
-                self.instances = args[2]
 
         # Agent 6+ will only have one instance
         self.instance = self.instances[0] if self.instances else None

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -142,7 +142,8 @@ class __AgentCheck(object):
         if len(args) > 1:
             self.init_config = args[1]
         if len(args) > 2:
-            if len(args) > 3 or not isinstance(args[2], list) or 'instances' in kwargs:
+            # agent pass instances as tuple but in test we are usually using list, so we are testing for both
+            if len(args) > 3 or not isinstance(args[2], (list, tuple)) or 'instances' in kwargs:
                 # old-style init: the 3rd argument is `agentConfig`
                 self.agentConfig = args[2]
                 if len(args) > 3:

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -142,14 +142,14 @@ class __AgentCheck(object):
         if len(args) > 1:
             self.init_config = args[1]
         if len(args) > 2:
-            if isinstance(args[2], list):
-                # new-style init: the 3rd argument is `instances`
-                self.instances = args[2]
-            else:
+            if (len(args) > 3 or not isinstance(args[2], list)) or 'instances' in kwargs:
                 # old-style init: the 3rd argument is `agentConfig`
                 self.agentConfig = args[2]
                 if len(args) > 3:
                     self.instances = args[3]
+            else:
+                # new-style init: the 3rd argument is `instances`
+                self.instances = args[2]
 
         # Agent 6+ will only have one instance
         self.instance = self.instances[0] if self.instances else None

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -142,7 +142,7 @@ class __AgentCheck(object):
         if len(args) > 1:
             self.init_config = args[1]
         if len(args) > 2:
-            if (len(args) > 3 or not isinstance(args[2], list)) or 'instances' in kwargs:
+            if len(args) > 3 or not isinstance(args[2], list) or 'instances' in kwargs:
                 # old-style init: the 3rd argument is `agentConfig`
                 self.agentConfig = args[2]
                 if len(args) > 3:

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -113,10 +113,17 @@ class __AgentCheck(object):
         Agent 5 signature:
 
             AgentCheck(name, init_config, agentConfig, instances=None)
+            AgentCheck.check(instance)
 
-        Agent 6 signature:
+        Agent 6,7 signature:
 
             AgentCheck(name, init_config, instances)
+            AgentCheck.check(instance)
+
+        Agent 8 signature:
+
+            AgentCheck(name, init_config, instance)     # one instance
+            AgentCheck.check()                          # no more instance argument for check method
 
         :warning: when loading a Custom check, the Agent will inspect the module searching
             for a subclass of `AgentCheck`. If such a class exists but has been derived in

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -117,7 +117,7 @@ class __AgentCheck(object):
 
         Agent 6,7 signature:
 
-            AgentCheck(name, init_config, instances)
+            AgentCheck(name, init_config, instances)    # instances contain only 1 instance
             AgentCheck.check(instance)
 
         Agent 8 signature:

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -23,7 +23,8 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
 
     Agent 5 signature:
 
-        OpenMetricsBaseCheck(name, init_config, agentConfig, instances=None, default_instances=None, default_namespace=None)
+        OpenMetricsBaseCheck(name, init_config, agentConfig, instances=None, default_instances=None,
+                             default_namespace=None)
 
     Agent 6 signature:
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -19,6 +19,16 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
             metrics:
             - bar
             - foo
+
+
+    Agent 5 signature:
+
+        OpenMetricsBaseCheck(name, init_config, agentConfig, instances=None, default_instances=None, default_namespace=None)
+
+    Agent 6 signature:
+
+        OpenMetricsBaseCheck(name, init_config, instances, default_instances=None, default_namespace=None)
+
     """
 
     DEFAULT_METRIC_LIMIT = 2000

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -52,12 +52,17 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
         self.default_namespace = default_namespace
 
         # pre-generate the scraper configurations
+
         if 'instances' in kwargs:
             instances = kwargs['instances']
         elif len(args) == 4:
+            # instances from legacy signature
             instances = args[3]
-        else:
+        elif isinstance(args[2], list):
+            # instances from new signature
             instances = args[2]
+        else:
+            instances = None
 
         if instances is not None:
             for instance in instances:

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -59,7 +59,7 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
         elif len(args) == 4:
             # instances from legacy signature
             instances = args[3]
-        elif isinstance(args[2], list):
+        elif isinstance(args[2], (tuple, list)):
             # instances from new signature
             instances = args[2]
         else:

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -60,7 +60,7 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
             # instances from agent 5 signature
             instances = args[3]
         elif isinstance(args[2], (tuple, list)):
-            # instances from new signature
+            # instances from agent 6 signature
             instances = args[2]
         else:
             instances = None

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -57,7 +57,7 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
         if 'instances' in kwargs:
             instances = kwargs['instances']
         elif len(args) == 4:
-            # instances from legacy signature
+            # instances from agent 5 signature
             instances = args[3]
         elif isinstance(args[2], (tuple, list)):
             # instances from new signature

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -189,8 +189,18 @@ def test_warning_args_errors():
             },
         ),
         (
-            'agent 6 signature: only args',
+            'agent 6 signature: only args (instances as list)',
             AgentCheck('check_name', {'init_conf1': 'init_value1'}, [{'foo': 'bar'}]),
+            {
+                'name': 'check_name',
+                'init_config': {'init_conf1': 'init_value1'},
+                'agentConfig': {},
+                'instance': {'foo': 'bar'},
+            },
+        ),
+        (
+            'agent 6 signature: only args (instances as tuple)',
+            AgentCheck('check_name', {'init_conf1': 'init_value1'}, ({'foo': 'bar'},)),
             {
                 'name': 'check_name',
                 'init_config': {'init_conf1': 'init_value1'},

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -72,6 +72,146 @@ def test_warning_args_errors():
     assert ["should not raise error: %s"] == check.warnings
 
 
+@pytest.mark.parametrize(
+    'case_name, check, expected_properties',
+    [
+        (
+            'agent 5 signature: only args',
+            AgentCheck('check_name', {'init_conf1': 'init_value1'}, {'agent_conf1': 'agent_value1'}, [{'foo': 'bar'}]),
+            {
+                'name': 'check_name',
+                'init_config': {'init_conf1': 'init_value1'},
+                'agentConfig': {'agent_conf1': 'agent_value1'},
+                'instance': {'foo': 'bar'},
+            },
+        ),
+        (
+            'agent 5 signature: instances as kwarg',
+            AgentCheck('check_name', {'init_conf1': 'init_value1'}, {'agent_conf1': 'agent_value1'}, instances=[{'foo': 'bar'}]),
+            {
+                'name': 'check_name',
+                'init_config': {'init_conf1': 'init_value1'},
+                'agentConfig': {'agent_conf1': 'agent_value1'},
+                'instance': {'foo': 'bar'},
+            },
+        ),
+        (
+            'agent 5 signature: agentConfig and instances as kwarg',
+            AgentCheck('check_name', {'init_conf1': 'init_value1'}, agentConfig={'agent_conf1': 'agent_value1'}, instances=[{'foo': 'bar'}]),
+            {
+                'name': 'check_name',
+                'init_config': {'init_conf1': 'init_value1'},
+                'agentConfig': {'agent_conf1': 'agent_value1'},
+                'instance': {'foo': 'bar'},
+            },
+        ),
+        (
+            'agent 5 signature: init_config, agentConfig and instances as kwarg',
+            AgentCheck('check_name', init_config={'init_conf1': 'init_value1'}, agentConfig={'agent_conf1': 'agent_value1'}, instances=[{'foo': 'bar'}]),
+            {
+                'name': 'check_name',
+                'init_config': {'init_conf1': 'init_value1'},
+                'agentConfig': {'agent_conf1': 'agent_value1'},
+                'instance': {'foo': 'bar'},
+            },
+        ),
+        (
+            'agent 5 signature: name, init_config, agentConfig and instances as kwarg',
+            AgentCheck(name='check_name', init_config={'init_conf1': 'init_value1'}, agentConfig={'agent_conf1': 'agent_value1'}, instances=[{'foo': 'bar'}]),
+            {
+                'name': 'check_name',
+                'init_config': {'init_conf1': 'init_value1'},
+                'agentConfig': {'agent_conf1': 'agent_value1'},
+                'instance': {'foo': 'bar'},
+            },
+        ),
+        (
+            'agent 5 signature: no instances',
+            AgentCheck('check_name', {'init_conf1': 'init_value1'}, {'agent_conf1': 'agent_value1'}),
+            {
+                'name': 'check_name',
+                'init_config': {'init_conf1': 'init_value1'},
+                'agentConfig': {'agent_conf1': 'agent_value1'},
+                'instance': None,
+            },
+        ),
+        (
+            'agent 5 signature: no instances and agentConfig as kwarg',
+            AgentCheck('check_name', {'init_conf1': 'init_value1'}, agentConfig={'agent_conf1': 'agent_value1'}),
+            {
+                'name': 'check_name',
+                'init_config': {'init_conf1': 'init_value1'},
+                'agentConfig': {'agent_conf1': 'agent_value1'},
+                'instance': None,
+            },
+        ),
+        (
+            'agent 5 signature: no instances and init_config, agentConfig as kwarg',
+            AgentCheck('check_name', init_config={'init_conf1': 'init_value1'}, agentConfig={'agent_conf1': 'agent_value1'}),
+            {
+                'name': 'check_name',
+                'init_config': {'init_conf1': 'init_value1'},
+                'agentConfig': {'agent_conf1': 'agent_value1'},
+                'instance': None,
+            },
+        ),
+        (
+            'agent 5 signature: no instances and name, init_config, agentConfig as kwarg',
+            AgentCheck(name='check_name', init_config={'init_conf1': 'init_value1'}, agentConfig={'agent_conf1': 'agent_value1'}),
+            {
+                'name': 'check_name',
+                'init_config': {'init_conf1': 'init_value1'},
+                'agentConfig': {'agent_conf1': 'agent_value1'},
+                'instance': None,
+            },
+        ),
+        (
+            'agent 6 signature: only args',
+            AgentCheck('check_name', {'init_conf1': 'init_value1'}, [{'foo': 'bar'}]),
+            {
+                'name': 'check_name',
+                'init_config': {'init_conf1': 'init_value1'},
+                'agentConfig': {},
+                'instance': {'foo': 'bar'},
+            },
+        ),
+        (
+            'agent 6 signature: instances as kwarg',
+            AgentCheck('check_name', {'init_conf1': 'init_value1'}, instances=[{'foo': 'bar'}]),
+            {
+                'name': 'check_name',
+                'init_config': {'init_conf1': 'init_value1'},
+                'agentConfig': {},
+                'instance': {'foo': 'bar'},
+            },
+        ),
+        (
+            'agent 6 signature: init_config, instances as kwarg',
+            AgentCheck('check_name', init_config={'init_conf1': 'init_value1'}, instances=[{'foo': 'bar'}]),
+            {
+                'name': 'check_name',
+                'init_config': {'init_conf1': 'init_value1'},
+                'agentConfig': {},
+                'instance': {'foo': 'bar'},
+            },
+        ),
+        (
+            'agent 6 signature: name, init_config, instances as kwarg',
+            AgentCheck(name='check_name', init_config={'init_conf1': 'init_value1'}, instances=[{'foo': 'bar'}]),
+            {
+                'name': 'check_name',
+                'init_config': {'init_conf1': 'init_value1'},
+                'agentConfig': {},
+                'instance': {'foo': 'bar'},
+            },
+        ),
+    ],
+)
+def test_agent_signature(case_name, check, expected_properties):
+    for attr, value in expected_properties.items():
+        assert getattr(check, attr) == value
+
+
 class TestMetricNormalization:
     def test_default(self):
         check = AgentCheck()

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -73,7 +73,7 @@ def test_warning_args_errors():
 
 
 @pytest.mark.parametrize(
-    'case_name, check, expected_properties',
+    'case_name, check, expected_attributes',
     [
         (
             'agent 5 signature: only args',
@@ -230,9 +230,9 @@ def test_warning_args_errors():
         ),
     ],
 )
-def test_agent_signature(case_name, check, expected_properties):
-    for attr, value in expected_properties.items():
-        assert getattr(check, attr) == value
+def test_agent_signature(case_name, check, expected_attributes):
+    actual_attributes = {attr: getattr(check, attr) for attr in expected_attributes}
+    assert expected_attributes == actual_attributes
 
 
 class TestMetricNormalization:

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -87,7 +87,9 @@ def test_warning_args_errors():
         ),
         (
             'agent 5 signature: instances as kwarg',
-            AgentCheck('check_name', {'init_conf1': 'init_value1'}, {'agent_conf1': 'agent_value1'}, instances=[{'foo': 'bar'}]),
+            AgentCheck(
+                'check_name', {'init_conf1': 'init_value1'}, {'agent_conf1': 'agent_value1'}, instances=[{'foo': 'bar'}]
+            ),
             {
                 'name': 'check_name',
                 'init_config': {'init_conf1': 'init_value1'},
@@ -97,7 +99,12 @@ def test_warning_args_errors():
         ),
         (
             'agent 5 signature: agentConfig and instances as kwarg',
-            AgentCheck('check_name', {'init_conf1': 'init_value1'}, agentConfig={'agent_conf1': 'agent_value1'}, instances=[{'foo': 'bar'}]),
+            AgentCheck(
+                'check_name',
+                {'init_conf1': 'init_value1'},
+                agentConfig={'agent_conf1': 'agent_value1'},
+                instances=[{'foo': 'bar'}],
+            ),
             {
                 'name': 'check_name',
                 'init_config': {'init_conf1': 'init_value1'},
@@ -107,7 +114,12 @@ def test_warning_args_errors():
         ),
         (
             'agent 5 signature: init_config, agentConfig and instances as kwarg',
-            AgentCheck('check_name', init_config={'init_conf1': 'init_value1'}, agentConfig={'agent_conf1': 'agent_value1'}, instances=[{'foo': 'bar'}]),
+            AgentCheck(
+                'check_name',
+                init_config={'init_conf1': 'init_value1'},
+                agentConfig={'agent_conf1': 'agent_value1'},
+                instances=[{'foo': 'bar'}],
+            ),
             {
                 'name': 'check_name',
                 'init_config': {'init_conf1': 'init_value1'},
@@ -117,7 +129,12 @@ def test_warning_args_errors():
         ),
         (
             'agent 5 signature: name, init_config, agentConfig and instances as kwarg',
-            AgentCheck(name='check_name', init_config={'init_conf1': 'init_value1'}, agentConfig={'agent_conf1': 'agent_value1'}, instances=[{'foo': 'bar'}]),
+            AgentCheck(
+                name='check_name',
+                init_config={'init_conf1': 'init_value1'},
+                agentConfig={'agent_conf1': 'agent_value1'},
+                instances=[{'foo': 'bar'}],
+            ),
             {
                 'name': 'check_name',
                 'init_config': {'init_conf1': 'init_value1'},
@@ -147,7 +164,9 @@ def test_warning_args_errors():
         ),
         (
             'agent 5 signature: no instances and init_config, agentConfig as kwarg',
-            AgentCheck('check_name', init_config={'init_conf1': 'init_value1'}, agentConfig={'agent_conf1': 'agent_value1'}),
+            AgentCheck(
+                'check_name', init_config={'init_conf1': 'init_value1'}, agentConfig={'agent_conf1': 'agent_value1'}
+            ),
             {
                 'name': 'check_name',
                 'init_config': {'init_conf1': 'init_value1'},
@@ -157,7 +176,11 @@ def test_warning_args_errors():
         ),
         (
             'agent 5 signature: no instances and name, init_config, agentConfig as kwarg',
-            AgentCheck(name='check_name', init_config={'init_conf1': 'init_value1'}, agentConfig={'agent_conf1': 'agent_value1'}),
+            AgentCheck(
+                name='check_name',
+                init_config={'init_conf1': 'init_value1'},
+                agentConfig={'agent_conf1': 'agent_value1'},
+            ),
             {
                 'name': 'check_name',
                 'init_config': {'init_conf1': 'init_value1'},

--- a/datadog_checks_base/tests/test_openmetrics_base_check.py
+++ b/datadog_checks_base/tests/test_openmetrics_base_check.py
@@ -9,47 +9,83 @@ FIXTURE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtur
 
 
 class TestSignature:
+    INIT_CONFIG = {'my_init_config': 'foo bar init config'}
+    AGENT_CONFIG = {'my_agent_config': 'foo bar agent config'}
+
     def test_default_legacy_basic(self):
-        check = OpenMetricsBaseCheck('openmetrics_check', {}, {})
+        check = OpenMetricsBaseCheck('openmetrics_check', self.INIT_CONFIG, self.AGENT_CONFIG)
 
         assert check.default_instances == {}
         assert check.default_namespace is None
+        assert check.agentConfig == {'my_agent_config': 'foo bar agent config'}
+        assert check.name == 'openmetrics_check'
+        assert check.init_config == {'my_init_config': 'foo bar init config'}
 
     def test_default_instances(self):
         instance = {'prometheus_url': 'endpoint'}
-        check = OpenMetricsBaseCheck('openmetrics_check', {}, [instance], default_namespace='openmetrics')
+        check = OpenMetricsBaseCheck('openmetrics_check', self.INIT_CONFIG, [instance], default_namespace='openmetrics')
 
         assert check.default_instances == {}
         assert check.default_namespace == 'openmetrics'
         assert 'endpoint' in check.config_map
+        assert check.instance == instance
+        assert check.agentConfig == {}
+        assert check.name == 'openmetrics_check'
+        assert check.init_config == {'my_init_config': 'foo bar init config'}
 
     def test_default_instances_legacy(self):
         instance = {'prometheus_url': 'endpoint'}
-        check = OpenMetricsBaseCheck('openmetrics_check', {}, {}, [instance], default_namespace='openmetrics')
+        check = OpenMetricsBaseCheck(
+            'openmetrics_check', self.INIT_CONFIG, self.AGENT_CONFIG, [instance], default_namespace='openmetrics'
+        )
 
         assert check.default_instances == {}
         assert check.default_namespace == 'openmetrics'
         assert 'endpoint' in check.config_map
+        assert check.instance == instance
+        assert check.agentConfig == {'my_agent_config': 'foo bar agent config'}
+        assert check.name == 'openmetrics_check'
+        assert check.init_config == {'my_init_config': 'foo bar init config'}
 
     def test_default_instances_legacy_kwarg(self):
         instance1 = {'prometheus_url': 'endpoint1'}
         instance2 = {'prometheus_url': 'endpoint2'}
         check = OpenMetricsBaseCheck(
-            'openmetrics_check', {}, {}, instances=[instance1, instance2], default_namespace='openmetrics'
+            'openmetrics_check',
+            self.INIT_CONFIG,
+            {},
+            instances=[instance1, instance2],
+            default_instances={'my_inst': {'foo': 'bar'}},
+            default_namespace='openmetrics',
         )
 
-        assert check.default_instances == {}
+        assert check.default_instances == {'my_inst': {'foo': 'bar'}}
         assert check.default_namespace == 'openmetrics'
         assert 'endpoint1' in check.config_map
         assert 'endpoint2' in check.config_map
+        assert check.instance == instance1
+        assert check.agentConfig == {}
+        assert check.name == 'openmetrics_check'
+        assert check.init_config == {'my_init_config': 'foo bar init config'}
 
     def test_args_legacy(self):
         instance = {'prometheus_url': 'endpoint'}
-        check = OpenMetricsBaseCheck('openmetrics_check', {}, {}, [instance], None, 'openmetrics')
+        check = OpenMetricsBaseCheck(
+            'openmetrics_check',
+            self.INIT_CONFIG,
+            self.AGENT_CONFIG,
+            [instance],
+            {'my_inst': {'foo': 'bar'}},
+            'openmetrics',
+        )
 
-        assert check.default_instances == {}
+        assert check.default_instances == {'my_inst': {'foo': 'bar'}}
         assert check.default_namespace == 'openmetrics'
         assert 'endpoint' in check.config_map
+        assert check.instance == instance
+        assert check.agentConfig == {'my_agent_config': 'foo bar agent config'}
+        assert check.name == 'openmetrics_check'
+        assert check.init_config == {'my_init_config': 'foo bar init config'}
 
 
 def test_rate_override():

--- a/datadog_checks_base/tests/test_openmetrics_base_check.py
+++ b/datadog_checks_base/tests/test_openmetrics_base_check.py
@@ -21,9 +21,23 @@ class TestSignature:
         assert check.name == 'openmetrics_check'
         assert check.init_config == {'my_init_config': 'foo bar init config'}
 
-    def test_default_instances(self):
+    def test_default_instances_with_list_instances(self):
         instance = {'prometheus_url': 'endpoint'}
         check = OpenMetricsBaseCheck('openmetrics_check', self.INIT_CONFIG, [instance], default_namespace='openmetrics')
+
+        assert check.default_instances == {}
+        assert check.default_namespace == 'openmetrics'
+        assert 'endpoint' in check.config_map
+        assert check.instance == instance
+        assert check.agentConfig == {}
+        assert check.name == 'openmetrics_check'
+        assert check.init_config == {'my_init_config': 'foo bar init config'}
+
+    def test_default_instances_with_tuple_instances(self):
+        instance = {'prometheus_url': 'endpoint'}
+        check = OpenMetricsBaseCheck(
+            'openmetrics_check', self.INIT_CONFIG, (instance,), default_namespace='openmetrics'
+        )
 
         assert check.default_instances == {}
         assert check.default_namespace == 'openmetrics'

--- a/datadog_checks_base/tests/test_openmetrics_base_check.py
+++ b/datadog_checks_base/tests/test_openmetrics_base_check.py
@@ -53,7 +53,7 @@ class TestSignature:
         check = OpenMetricsBaseCheck(
             'openmetrics_check',
             self.INIT_CONFIG,
-            {},
+            self.AGENT_CONFIG,
             instances=[instance1, instance2],
             default_instances={'my_inst': {'foo': 'bar'}},
             default_namespace='openmetrics',
@@ -64,7 +64,7 @@ class TestSignature:
         assert 'endpoint1' in check.config_map
         assert 'endpoint2' in check.config_map
         assert check.instance == instance1
-        assert check.agentConfig == {}
+        assert check.agentConfig == {'my_agent_config': 'foo bar agent config'}
         assert check.name == 'openmetrics_check'
         assert check.init_config == {'my_init_config': 'foo bar init config'}
 


### PR DESCRIPTION
### What does this PR do?

1) Add more tests for agent signature

2) Fix made to handle this case where instances is not passed when using agent 5 signature

```python
AgentCheck('check_name', {'init_conf1': 'init_value1'}, {'agent_conf1': 'agent_value1'})
OpenMetricsBaseCheck('openmetrics_check', self.INIT_CONFIG, self.AGENT_CONFIG)
```

### Motivation


### Additional Notes


### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
