### PR TITLE
Use default port for kube apiserver metrics auto conf

### DIFF
--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/auto_conf.yaml
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/auto_conf.yaml
@@ -7,8 +7,8 @@ instances:
     ## @param prometheus_url - string - required
     ## The URL where your application metrics are exposed by Prometheus.
     #
-  - prometheus_url: "%%host%%:%%port%%/metrics"
-    
+  - prometheus_url: "%%host%%:6443/metrics"
+
     ## @param scheme - string - optional
     ## Used to specify the scheme to reach the APIServer endpoints. Default to https.
     #
@@ -28,8 +28,8 @@ instances:
 
     ## @param ssl_verify - string - optional
     ## Used to verify self signed certificates. Default to false.
-    # 
-    # ssl_verify: false   
+    #
+    # ssl_verify: false
 
     ## @param tags - list of key:value element - optional
     ## List of tags to attach to every metric, event and service check emitted by this integration.


### PR DESCRIPTION
### What does this PR do?

Use the default value for the API server secure port `6443`

### Motivation

Easier autodiscovery

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] Feature or bugfix must have tests
- [x] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [x] If PR adds a configuration option, it must be added to the configuration file.
