### PR TITLE
[nomerge] debug PR to collect segfault stacktrace

### DIFF
--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -13,7 +13,7 @@ steps:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
 
 - ${{ if eq(parameters.test_e2e, 'true') }}:
-  - script: ddev env test --base --new-env --profile-memory ${{ parameters.check }}
+  - script: ddev env test --base --new-env ${{ parameters.check }}
     displayName: 'Run E2E tests'
     env:
       DD_API_KEY: $(DD_API_KEY)

--- a/datadog_checks_base/datadog_checks/base/__about__.py
+++ b/datadog_checks_base/datadog_checks/base/__about__.py
@@ -3,3 +3,4 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 __version__ = "9.4.0"
+

--- a/datadog_checks_base/datadog_checks/base/__about__.py
+++ b/datadog_checks_base/datadog_checks/base/__about__.py
@@ -3,4 +3,3 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 __version__ = "9.4.0"
-

--- a/datadog_checks_base/datadog_checks/base/utils/agent/memory.py
+++ b/datadog_checks_base/datadog_checks/base/utils/agent/memory.py
@@ -10,10 +10,8 @@ from binary import BinaryUnits, convert_units
 
 from .common import METRIC_PROFILE_NAMESPACE
 
-try:
-    import tracemalloc
-except ImportError:
-    tracemalloc = None
+import tracemalloc
+
 
 DEFAULT_FRAMES = 100
 DEFAULT_GC = False

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -147,10 +147,11 @@ def dd_agent_check(request, aggregator):
         if AGENT_COLLECTOR_SEPARATOR not in result.stdout:
             run_command('docker logs dd_{}_{}'.format(check, env))
             raise ValueError(
-                '{}{}\nCould find `{}` in the output'.format(result.stdout, result.stderr, AGENT_COLLECTOR_SEPARATOR)
+                '\n{}{}\nCould find `{}` in the output'.format(result.stdout, result.stderr, AGENT_COLLECTOR_SEPARATOR)
             )
 
         _, _, collector_output = result.stdout.partition(AGENT_COLLECTOR_SEPARATOR)
+        collector_output = '\n'.join(line for line in collector_output.splitlines() if not line.startswith('2019'))
         collector = json.loads(collector_output.strip())
 
         replay_check_run(collector, aggregator)

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -125,7 +125,7 @@ def dd_agent_check(request, aggregator):
         python_path = os.environ[E2E_PARENT_PYTHON]
         env = os.environ['TOX_ENV_NAME']
 
-        check_command = [python_path, '-m', 'datadog_checks.dev', 'env', 'check', check, env, '--json']
+        check_command = [python_path, '-m', 'datadog_checks.dev', 'env', 'check', check, env, '--json', '-l', 'debug']
 
         if config:
             config = format_config(config)

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -145,6 +145,7 @@ def dd_agent_check(request, aggregator):
 
         result = run_command(check_command, capture=True)
         if AGENT_COLLECTOR_SEPARATOR not in result.stdout:
+            run_command('docker logs dd_{}_{}'.format(check, env))
             raise ValueError(
                 '{}{}\nCould find `{}` in the output'.format(result.stdout, result.stderr, AGENT_COLLECTOR_SEPARATOR)
             )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/config.py
@@ -26,7 +26,7 @@ DEFAULT_CONFIG = OrderedDict(
         ('repo', 'core'),
         ('color', bool(int(os.environ['DDEV_COLOR'])) if 'DDEV_COLOR' in os.environ else None),
         ('dd_api_key', os.getenv('DD_API_KEY')),
-        ('agent6', OrderedDict((('docker', 'datadog/agent-dev:master'), ('local', 'latest')))),
+        ('agent6', OrderedDict((('docker', 'datadog/agent-dev:arbll-nostrip'), ('local', 'latest')))),
         ('agent5', OrderedDict((('docker', 'datadog/dev-dd-agent:master'), ('local', 'latest')))),
         ('github', OrderedDict((('user', ''), ('token', '')))),
         ('pypi', OrderedDict((('user', ''), ('pass', '')))),

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -206,6 +206,8 @@ class DockerInterface(object):
                 # Agent 6 will simply fail without an API key
                 '-e',
                 'DD_API_KEY={}'.format(self.api_key),
+                '-e',
+                'DD_C_STACKTRACE_COLLECTION: true',
                 # Run expvar on a random port
                 '-e',
                 'DD_EXPVAR_PORT=0',

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -207,7 +207,7 @@ class DockerInterface(object):
                 '-e',
                 'DD_API_KEY={}'.format(self.api_key),
                 '-e',
-                'DD_C_STACKTRACE_COLLECTION: true',
+                'DD_C_STACKTRACE_COLLECTION=true',
                 # Run expvar on a random port
                 '-e',
                 'DD_EXPVAR_PORT=0',


### PR DESCRIPTION
### What does this PR do?

unstripped image so we get a stacktrace with named symbols. The stripped build generated a stacktrace, but no names. This should help.

### Motivation

Segfault debugging.

### Additional Notes

Do *NOT* merge this.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
