### PR TITLE
Fix character casing logic for custom_queries_units_gauge option

### DIFF
--- a/ibm_was/datadog_checks/ibm_was/data/conf.yaml.example
+++ b/ibm_was/datadog_checks/ibm_was/data/conf.yaml.example
@@ -136,7 +136,10 @@ instances:
     ##
     ## would be submitted as a count, but will be as a gauge if `unit.kbyte` is present in `custom_queries_units_gauge`.
     #
-    # custom_queries_units_gauge: [kilobyte, second, unit.kbyte]
+    # custom_queries_units_gauge:
+    #   - unit.kbyte
+    #   - kilobyte
+    #   - second
 
     ## @param tags - list of key:value elements - optional
     ## List of tags to attach to every metric, event and service check emitted by this integration.

--- a/ibm_was/datadog_checks/ibm_was/ibm_was.py
+++ b/ibm_was/datadog_checks/ibm_was/ibm_was.py
@@ -105,7 +105,7 @@ class IbmWasCheck(AgentCheck):
 
         tag = child.tag
         if (
-            child.get('unit', '').lower() in self.custom_queries_units_gauge
+            child.get('unit') in self.custom_queries_units_gauge
             and prefix in self.custom_stats
             and tag == 'CountStatistic'
         ):

--- a/ibm_was/tests/fixtures/server.xml
+++ b/ibm_was/tests/fixtures/server.xml
@@ -8875,7 +8875,7 @@
 				<DoubleStatistic ID="1" double="0.29668912581386736" lastSampleTime="1568667667254" name="overallCPUUtilization" startTime="1568393052570" unit="Process.unit.none"/>
 				<DoubleStatistic ID="2" double="0.33291678784837747" lastSampleTime="1568667667254" name="recentCPUUtilization" startTime="1568393052572" unit="Process.unit.none"/>
 				<CountStatistic ID="3" count="261552" lastSampleTime="1568667667254" name="residentMemory" startTime="1568393052573" unit="unit.kbyte"/>
-				<CountStatistic ID="4" count="9317244" lastSampleTime="1568667667254" name="totalMemory" startTime="1568393052574" unit="unit.kbyte"/>
+				<CountStatistic ID="4" count="9317244" lastSampleTime="1568667667254" name="totalMemory" startTime="1568393052574" unit="unit.KByte"/>
 			</Stat>
 		</Server>
 	</Node>

--- a/ibm_was/tests/test_unit.py
+++ b/ibm_was/tests/test_unit.py
@@ -67,6 +67,16 @@ def test_custom_query_unit(aggregator, instance, check):
     aggregator.assert_metric('ibm_was.xdpm.resident_memory', metric_type=aggregator.GAUGE)
 
 
+def test_custom_query_unit_casing(aggregator, instance, check):
+    instance['custom_queries'] = [{"stat": "xdProcessModule", "metric_prefix": "xdpm"}]
+    instance['custom_queries_units_gauge'] = ['unit.KByte']
+    with mock.patch('datadog_checks.ibm_was.IbmWasCheck.make_request', return_value=mock_data('server.xml')):
+        check = check(instance)
+        check.check(instance)
+
+    aggregator.assert_metric('ibm_was.xdpm.total_memory', metric_type=aggregator.GAUGE)
+
+
 def test_config_validation(check):
     with mock.patch('datadog_checks.ibm_was.IbmWasCheck.make_request', return_value=mock_data('server.xml')):
         with pytest.raises(ConfigurationError) as e:


### PR DESCRIPTION
### Motivation

We were normalizing the unit names but not the defined names in config, leading to mismatches