### PR TITLE
update gitlab_runner metrics

### DIFF
--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -31,6 +31,7 @@ init_config:
     - go_memstats_other_sys_bytes
     - go_memstats_stack_inuse_bytes
     - go_memstats_stack_inuse_bytes
+    - go_memstats_stack_sys_bytes
     - go_memstats_sys_bytes
     - go_threads
     - http_request_duration_microseconds

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -31,7 +31,6 @@ init_config:
     - go_memstats_other_sys_bytes
     - go_memstats_stack_inuse_bytes
     - go_memstats_stack_inuse_bytes
-    - go_memstats_stack_sys_bytes
     - go_memstats_sys_bytes
     - go_threads
     - http_request_duration_microseconds

--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -12,6 +12,11 @@ init_config:
     - ci_runner_version_info
     - ci_ssh_docker_machines_provider_machine_creation_duration_seconds
     - ci_ssh_docker_machines_provider_machine_states
+    - gitlab_runner_autoscaling_machine_creation_duration_seconds
+    - gitlab_runner_autoscaling_machine_states
+    - gitlab_runner_errors_total
+    - gitlab_runner_jobs
+    - gitlab_runner_version_info
     - go_gc_duration_seconds
     - go_goroutines
     - go_memstats_alloc_bytes

--- a/gitlab_runner/metadata.csv
+++ b/gitlab_runner/metadata.csv
@@ -3,12 +3,18 @@ gitlab_runner.ci_docker_machines_provider_machine_creation_duration_seconds_buck
 gitlab_runner.ci_docker_machines_provider_machine_creation_duration_seconds_sum,gauge,,request,second,Sum of Docker machine creation time,0,gitlab_runner,sum docker machine creation time
 gitlab_runner.ci_docker_machines_provider_machine_creation_duration_seconds_count,gauge,,request,second,Count of Docker machine creation time,0,gitlab_runner,count docker machine creation time
 gitlab_runner.ci_docker_machines_provider_machine_states,gauge,,request,second,The current number of machines per state in this provider,0,gitlab_runner,total docker machines per state
+gitlab_runner.ci_runner_builds,gauge,,,,The current number of running builds.,0,gitlab_runner,current running builds
 gitlab_runner.ci_runner_errors,counter,,request,second,The number of caught errors,0,gitlab_runner,errors
 gitlab_runner.ci_runner_version_info,gauge,,request,,A metric with a constant '1' value labeled by different build stats fields,0,gitlab_runner,version info
 gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_bucket,gauge,,request,second,Histogram of SSH Docker machine creation time,0,gitlab_runner,ssh docker machine creation time
 gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_sum,gauge,,request,second,Sum of SSH Docker machine creation time,0,gitlab_runner,sum ssh docker machine creation time
 gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_count,gauge,,request,second,Count of SSH Docker machine creation time,0,gitlab_runner,count ssh docker machine creation time
 gitlab_runner.ci_ssh_docker_machines_provider_machine_states,gauge,,request,second,The current number of machines per state in this provider,0,gitlab_runner,total ssh docker machines per state
+gitlab_runner.gitlab_runner_autoscaling_machine_creation_duration_seconds,gauge,,request,second,Histogram of Docker machine creation time,0,gitlab_runner,docker machine creation time
+gitlab_runner.gitlab_runner_autoscaling_machine_states,gauge,,request,second,The current number of machines per state in this provider,0,gitlab_runner,total docker machines per state
+gitlab_runner.gitlab_runner_jobs,gauge,,,,The current number of running builds.,0,gitlab_runner,current running builds
+gitlab_runner.gitlab_runner_errors_total,counter,,request,second,The number of caught errors,0,gitlab_runner,errors
+gitlab_runner.gitlab_runner_version_info,gauge,,request,,A metric with a constant '1' value labeled by different build stats fields,0,gitlab_runner,version info
 gitlab_runner.go_gc_duration_seconds,gauge,,request,second,A summary of the GC invocation durations,0,gitlab_runner,gc duration
 gitlab_runner.go_gc_duration_seconds_sum,gauge,,request,second,Sum of the GC invocation durations,0,gitlab_runner,sum gc duration
 gitlab_runner.go_gc_duration_seconds_count,gauge,,request,second,Count of the GC invocation durations,0,gitlab_runner,count gc duration

--- a/gitlab_runner/metadata.csv
+++ b/gitlab_runner/metadata.csv
@@ -1,20 +1,20 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-gitlab_runner.ci_docker_machines_provider_machine_creation_duration_seconds_bucket,gauge,,request,second,Histogram of Docker machine creation time,0,gitlab_runner,docker machine creation time
-gitlab_runner.ci_docker_machines_provider_machine_creation_duration_seconds_sum,gauge,,request,second,Sum of Docker machine creation time,0,gitlab_runner,sum docker machine creation time
-gitlab_runner.ci_docker_machines_provider_machine_creation_duration_seconds_count,gauge,,request,second,Count of Docker machine creation time,0,gitlab_runner,count docker machine creation time
-gitlab_runner.ci_docker_machines_provider_machine_states,gauge,,request,second,The current number of machines per state in this provider,0,gitlab_runner,total docker machines per state
-gitlab_runner.ci_runner_builds,gauge,,,,The current number of running builds.,0,gitlab_runner,current running builds
-gitlab_runner.ci_runner_errors,counter,,request,second,The number of caught errors,0,gitlab_runner,errors
-gitlab_runner.ci_runner_version_info,gauge,,request,,A metric with a constant '1' value labeled by different build stats fields,0,gitlab_runner,version info
-gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_bucket,gauge,,request,second,Histogram of SSH Docker machine creation time,0,gitlab_runner,ssh docker machine creation time
-gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_sum,gauge,,request,second,Sum of SSH Docker machine creation time,0,gitlab_runner,sum ssh docker machine creation time
-gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_count,gauge,,request,second,Count of SSH Docker machine creation time,0,gitlab_runner,count ssh docker machine creation time
-gitlab_runner.ci_ssh_docker_machines_provider_machine_states,gauge,,request,second,The current number of machines per state in this provider,0,gitlab_runner,total ssh docker machines per state
-gitlab_runner.gitlab_runner_autoscaling_machine_creation_duration_seconds,gauge,,request,second,Histogram of Docker machine creation time,0,gitlab_runner,docker machine creation time
-gitlab_runner.gitlab_runner_autoscaling_machine_states,gauge,,request,second,The current number of machines per state in this provider,0,gitlab_runner,total docker machines per state
-gitlab_runner.gitlab_runner_jobs,gauge,,,,The current number of running builds.,0,gitlab_runner,current running builds
-gitlab_runner.gitlab_runner_errors_total,counter,,request,second,The number of caught errors,0,gitlab_runner,errors
-gitlab_runner.gitlab_runner_version_info,gauge,,request,,A metric with a constant '1' value labeled by different build stats fields,0,gitlab_runner,version info
+gitlab_runner.ci_docker_machines_provider_machine_creation_duration_seconds_bucket,gauge,,request,second,Histogram of Docker machine creation time. Applies to GitLab Runner < 1.11.0,0,gitlab_runner,docker machine creation time
+gitlab_runner.ci_docker_machines_provider_machine_creation_duration_seconds_sum,gauge,,request,second,Sum of Docker machine creation time. Applies to GitLab Runner < 1.11.0,0,gitlab_runner,sum docker machine creation time
+gitlab_runner.ci_docker_machines_provider_machine_creation_duration_seconds_count,gauge,,request,second,Count of Docker machine creation time. Applies to GitLab Runner < 1.11.0,0,gitlab_runner,count docker machine creation time
+gitlab_runner.ci_docker_machines_provider_machine_states,gauge,,request,second,The current number of machines per state in this provider. Applies to GitLab Runner < 1.11.0,0,gitlab_runner,total docker machines per state
+gitlab_runner.ci_runner_builds,gauge,,,,The current number of running builds. Applies to GitLab Runner < 1.11.0,0,gitlab_runner,current running builds
+gitlab_runner.ci_runner_errors,counter,,request,second,The number of caught errors. Applies to GitLab Runner < 1.11.0,0,gitlab_runner,errors
+gitlab_runner.ci_runner_version_info,gauge,,request,,A metric with a constant '1' value labeled by different build stats fields. Applies to GitLab Runner < 1.11.0,0,gitlab_runner,version info
+gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_bucket,gauge,,request,second,Histogram of SSH Docker machine creation time. Applies to GitLab Runner < 1.11.0,0,gitlab_runner,ssh docker machine creation time
+gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_sum,gauge,,request,second,Sum of SSH Docker machine creation time. Applies to GitLab Runner < 1.11.0,0,gitlab_runner,sum ssh docker machine creation time
+gitlab_runner.ci_ssh_docker_machines_provider_machine_creation_duration_seconds_count,gauge,,request,second,Count of SSH Docker machine creation time. Applies to GitLab Runner < 1.11.0,0,gitlab_runner,count ssh docker machine creation time
+gitlab_runner.ci_ssh_docker_machines_provider_machine_states,gauge,,request,second,The current number of machines per state in this provider. Applies to GitLab Runner < 1.11.0,0,gitlab_runner,total ssh docker machines per state
+gitlab_runner.gitlab_runner_autoscaling_machine_creation_duration_seconds,gauge,,request,second,Histogram of Docker machine creation time. Applies to GitLab Runner 1.11.0+,0,gitlab_runner,docker machine creation time
+gitlab_runner.gitlab_runner_autoscaling_machine_states,gauge,,request,second,The current number of machines per state in this provider. Applies to GitLab Runner 1.11.0+,0,gitlab_runner,total docker machines per state
+gitlab_runner.gitlab_runner_jobs,gauge,,,,The current number of running builds. Applies to GitLab Runner 1.11.0+,0,gitlab_runner,current running builds
+gitlab_runner.gitlab_runner_errors_total,counter,,request,second,The number of caught errors. Applies to GitLab Runner 1.11.0+,0,gitlab_runner,errors
+gitlab_runner.gitlab_runner_version_info,gauge,,request,,A metric with a constant '1' value labeled by different build stats fields. Applies to GitLab Runner 1.11.0+,0,gitlab_runner,version info
 gitlab_runner.go_gc_duration_seconds,gauge,,request,second,A summary of the GC invocation durations,0,gitlab_runner,gc duration
 gitlab_runner.go_gc_duration_seconds_sum,gauge,,request,second,Sum of the GC invocation durations,0,gitlab_runner,sum gc duration
 gitlab_runner.go_gc_duration_seconds_count,gauge,,request,second,Count of the GC invocation durations,0,gitlab_runner,count gc duration


### PR DESCRIPTION
### What does this PR do?

Updates the list of metrics collected. Some have been renamed starting gitlab runner 11.1.0.

- the following metrics ...
  - `ci_docker_machines_provider_machine_creation_duration_seconds`
  - `ci_ssh_docker_machines_provider_machine_creation_duration_seconds`
  ... have been replaced with the same metric name `gitlab_runner_autoscaling_machine_creation_duration_seconds`  but labeled accordingly; `executor="docker+machine"` and `executor="docker-ssh+machine"` respectively

- the following metrics ...
  - `ci_docker_machines_provider_machine_states`
  - `ci_ssh_docker_machines_provider_machine_states`
  ... have been replaced with the same metric name `gitlab_runner_autoscaling_machine_states`  but labeled accordingly; `executor="docker+machine"` and `executor="docker-ssh+machine"` respectively

### Motivation

1468-missing-gitlab-gitlab-runner-metrics

### Additional Notes

~-  gitlab metric `go_memstats_stack_sys_bytes` added to conf file but is already documented in metadata.csv~
- `gitlab_runner.ci_runner_builds` added to metadata.csv but already in conf file
- Reference: https://gitlab.com/gitlab-org/gitlab-runner/issues/3114#note_74251482

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
