### PR TITLE
adds missing metric in conf file

### DIFF
--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -31,6 +31,7 @@ init_config:
     - go_memstats_other_sys_bytes
     - go_memstats_stack_inuse_bytes
     - go_memstats_stack_inuse_bytes
+    - go_memstats_stack_sys_bytes
     - go_memstats_sys_bytes
     - go_threads
     - http_request_duration_microseconds


### PR DESCRIPTION
### What does this PR do?

adds missing but already documented metric

### Motivation

1468-missing-gitlab-gitlab-runner-metrics

### Additional Notes

- gitlab metric go_memstats_stack_sys_bytes added to conf file but is already documented in metadata.csv

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
