### PR TITLE
Fix for rabbit 3.1 queue_totals introduced in #4668

### DIFF
--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -531,12 +531,15 @@ class RabbitMQ(AgentCheck):
             # Walk down through the data path, e.g. foo/bar => d['foo']['bar']
             root = data
             keys = attribute.split('/')
-            for path in keys[:-1]:
-                root = root.get(path, {})
+            value = None
+            try:  # In RabbitMQ 3.1.x queue_totals is a list instead of a dict
+                for path in keys[:-1]:
+                    root = root.get(path, {})
+                value = root.get(keys[-1], None)
+            except AttributeError as e:
+                if isinstance(root, dict):
+                    raise e
 
-            value = (
-                root.get(keys[-1], None) if isinstance(root, dict) else None
-            )  # In RabbitMQ 3.1.x queue_totals is a list instead of a dict
             if value is not None:
                 try:
                     self.gauge(

--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -531,14 +531,13 @@ class RabbitMQ(AgentCheck):
             # Walk down through the data path, e.g. foo/bar => d['foo']['bar']
             root = data
             keys = attribute.split('/')
-            value = None
-            try:  # In RabbitMQ 3.1.x queue_totals is a list instead of a dict
-                for path in keys[:-1]:
-                    root = root.get(path, {})
-                value = root.get(keys[-1], None)
-            except AttributeError as e:
-                if isinstance(root, dict):
-                    raise e
+
+            # In RabbitMQ 3.1.x queue_totals is an empty list instead of a dict when initialising
+            for path in keys[:-1]:
+                if not isinstance(root, dict):
+                    break
+                root = root.get(path, {})
+            value = root.get(keys[-1], None) if isinstance(root, dict) else None
 
             if value is not None:
                 try:

--- a/rabbitmq/tests/test_unit.py
+++ b/rabbitmq/tests/test_unit.py
@@ -9,7 +9,7 @@ from tests.common import EXCHANGE_MESSAGE_STATS
 
 import datadog_checks
 from datadog_checks.rabbitmq import RabbitMQ
-from datadog_checks.rabbitmq.rabbitmq import EXCHANGE_TYPE, NODE_TYPE, RabbitMQException
+from datadog_checks.rabbitmq.rabbitmq import EXCHANGE_TYPE, NODE_TYPE, OVERVIEW_TYPE, RabbitMQException
 
 from . import common
 
@@ -92,6 +92,14 @@ def test__get_metrics(check, aggregator):
 
     assert check._get_metrics(data, NODE_TYPE, []) == 3
     assert check._get_metrics({}, NODE_TYPE, []) == 0
+
+
+@pytest.mark.unit
+def test__get_metrics_3_1(check, aggregator):
+    data = {'queue_totals': []}
+
+    metrics = check._get_metrics(data, OVERVIEW_TYPE, [])
+    assert metrics == 0
 
 
 @pytest.mark.unit


### PR DESCRIPTION
if queue_totals is a list and not a dict the fix in #4668 works for queue_totals/messages but fails when trying to get queue_totals/messages_details/rate