### PR TITLE
Fix CHANGELOG.md template to make it work with `ddev release changelog`

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/CHANGELOG.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/check/{check_name}/CHANGELOG.md
@@ -1,1 +1,2 @@
 # CHANGELOG - {integration_name}
+

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/CHANGELOG.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/jmx/{check_name}/CHANGELOG.md
@@ -1,1 +1,2 @@
 # CHANGELOG - {integration_name}
+


### PR DESCRIPTION
### What does this PR do?

Fix CHANGELOG.md template to make it work with `ddev release changelog`

Before `ddev release changelog` generated this:
```
# CHANGELOG - druid
## 1.0.0 / 2019-10-11

* [Added] Adhere to logging call convention. See [#4735]
```

Now `ddev release changelog` generated this:
```
# CHANGELOG - druid

## 1.0.0 / 2019-10-11

* [Added] Adhere to logging call convention. See [#4735](https://github.com/DataDog/integrations-core/pull/4735).
* [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
```

The newline at line 2 is necessary for sebsequent calls to `ddev release changelog`, it starts adding the new version to exactly the second line.