### PR TITLE
add version info to mongo readme

### DIFF
--- a/mongo/README.md
+++ b/mongo/README.md
@@ -11,6 +11,8 @@ Connect MongoDB to Datadog in order to:
 
 You can also create your own metrics using custom `find`, `count` and `aggregate` queries.
 
+**Note**: MongoDB v2.6+ is required for this integration.
+
 ## Setup
 ### Installation
 


### PR DESCRIPTION
### What does this PR do?

Adds a note to the mongo integration that calls out how you need to be using mongodb 2.6+

### Motivation

pymongo version got bumped to 3.8 which requires mongodb 2.6+

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
