### PR TITLE
Fix RequestsWrapper session `timeout`

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -314,7 +314,7 @@ class RequestsWrapper(object):
                 stack.enter_context(hook())
 
             if persist:
-                return getattr(self.session, method)(url, **options)
+                return getattr(self.session, method)(url, **self.populate_options(options))
             else:
                 return getattr(requests, method)(url, **self.populate_options(options))
 

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -21,6 +21,15 @@ from datadog_checks.dev.utils import running_on_windows_ci
 
 pytestmark = pytest.mark.http
 
+DEFAULT_OPTIONS = {
+    'auth': None,
+    'cert': None,
+    'headers': OrderedDict([('User-Agent', 'Datadog Agent/0.0.0')]),
+    'proxies': None,
+    'timeout': (10.0, 10.0),
+    'verify': True,
+}
+
 
 class TestAttribute:
     def test_default(self):
@@ -744,7 +753,7 @@ class TestAPI:
 
         with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
             http.get('https://www.google.com')
-            http.session.get.assert_called_once_with('https://www.google.com')
+            http.session.get.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
 
     def test_get_option_override(self):
         http = RequestsWrapper({}, {})
@@ -757,7 +766,8 @@ class TestAPI:
 
     def test_get_session_option_override(self):
         http = RequestsWrapper({}, {})
-        options = {'auth': ('user', 'pass')}
+        options = DEFAULT_OPTIONS.copy()
+        options.update({'auth': ('user', 'pass')})
 
         with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
             http.get('https://www.google.com', persist=True, auth=options['auth'])
@@ -775,7 +785,7 @@ class TestAPI:
 
         with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
             http.post('https://www.google.com')
-            http.session.post.assert_called_once_with('https://www.google.com')
+            http.session.post.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
 
     def test_post_option_override(self):
         http = RequestsWrapper({}, {})
@@ -788,7 +798,8 @@ class TestAPI:
 
     def test_post_session_option_override(self):
         http = RequestsWrapper({}, {})
-        options = {'auth': ('user', 'pass')}
+        options = DEFAULT_OPTIONS.copy()
+        options.update({'auth': ('user', 'pass')})
 
         with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
             http.post('https://www.google.com', persist=True, auth=options['auth'])
@@ -806,7 +817,7 @@ class TestAPI:
 
         with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
             http.head('https://www.google.com')
-            http.session.head.assert_called_once_with('https://www.google.com')
+            http.session.head.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
 
     def test_head_option_override(self):
         http = RequestsWrapper({}, {})
@@ -819,7 +830,8 @@ class TestAPI:
 
     def test_head_session_option_override(self):
         http = RequestsWrapper({}, {})
-        options = {'auth': ('user', 'pass')}
+        options = DEFAULT_OPTIONS.copy()
+        options.update({'auth': ('user', 'pass')})
 
         with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
             http.head('https://www.google.com', persist=True, auth=options['auth'])
@@ -837,7 +849,7 @@ class TestAPI:
 
         with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
             http.put('https://www.google.com')
-            http.session.put.assert_called_once_with('https://www.google.com')
+            http.session.put.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
 
     def test_put_option_override(self):
         http = RequestsWrapper({}, {})
@@ -850,7 +862,8 @@ class TestAPI:
 
     def test_put_session_option_override(self):
         http = RequestsWrapper({}, {})
-        options = {'auth': ('user', 'pass')}
+        options = DEFAULT_OPTIONS.copy()
+        options.update({'auth': ('user', 'pass')})
 
         with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
             http.put('https://www.google.com', persist=True, auth=options['auth'])
@@ -868,7 +881,7 @@ class TestAPI:
 
         with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
             http.patch('https://www.google.com')
-            http.session.patch.assert_called_once_with('https://www.google.com')
+            http.session.patch.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
 
     def test_patch_option_override(self):
         http = RequestsWrapper({}, {})
@@ -881,7 +894,8 @@ class TestAPI:
 
     def test_patch_session_option_override(self):
         http = RequestsWrapper({}, {})
-        options = {'auth': ('user', 'pass')}
+        options = DEFAULT_OPTIONS.copy()
+        options.update({'auth': ('user', 'pass')})
 
         with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
             http.patch('https://www.google.com', persist=True, auth=options['auth'])
@@ -899,7 +913,7 @@ class TestAPI:
 
         with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
             http.delete('https://www.google.com')
-            http.session.delete.assert_called_once_with('https://www.google.com')
+            http.session.delete.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
 
     def test_delete_option_override(self):
         http = RequestsWrapper({}, {})
@@ -912,8 +926,16 @@ class TestAPI:
 
     def test_delete_session_option_override(self):
         http = RequestsWrapper({}, {})
-        options = {'auth': ('user', 'pass')}
+        options = DEFAULT_OPTIONS.copy()
+        options.update({'auth': ('user', 'pass')})
 
         with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
             http.delete('https://www.google.com', persist=True, auth=options['auth'])
             http.session.delete.assert_called_once_with('https://www.google.com', **options)
+
+
+class TestIntegration:
+    def test_session_timeout(self):
+        http = RequestsWrapper({'persist_connections': True}, {'timeout': 0.300})
+        with pytest.raises(requests.exceptions.Timeout):
+            http.get('https://httpstat.us/200?sleep=500')


### PR DESCRIPTION
### What does this PR do?

Fix RequestsWrapper session not valid timeout attribute

`timeout` is not a valid session attribute, it need to be passed when http (get/post/put/etc) call is made the call is made.

### Motivation

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
