### PR TITLE
Submit version metadata

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -569,7 +569,7 @@ class __AgentCheck(object):
         no_proxy_settings = {'http': None, 'https': None, 'no': []}
 
         # First we read the proxy configuration from datadog.conf
-        proxies = self.agentConfig.get('proxy', datadog_agent.get_config('proxy'))
+        proxies = datadog_agent.get_config('proxy')
         if proxies:
             proxies = proxies.copy()
 

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -569,7 +569,7 @@ class __AgentCheck(object):
         no_proxy_settings = {'http': None, 'https': None, 'no': []}
 
         # First we read the proxy configuration from datadog.conf
-        proxies = datadog_agent.get_config('proxy')
+        proxies = self.agentConfig.get('proxy', datadog_agent.get_config('proxy'))
         if proxies:
             proxies = proxies.copy()
 

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -649,10 +649,8 @@ class MySql(AgentCheck):
     def _submit_metadata(self):
         self.service_metadata('version', version)
         self.set_metadata('version', version)
-        self.set_metadata('version.flavor', flavor)
-        # where do I submit the flavor?
-            
-
+        self.set_metadata('flavor', flavor)
+       
     def _submit_metrics(self, variables, db_results, tags):
         for variable, metric in iteritems(variables):
             metric_name, metric_type = metric

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -636,20 +636,17 @@ class MySql(AgentCheck):
         with closing(db.cursor()) as cursor:
             cursor.execute('SELECT VERSION()')
             result = cursor.fetchone()
-
+            
             # Version might include a build or a flavor 
             # e.g. 4.1.26-log, 4.1.26-MariaDB
             # See http://dev.mysql.com/doc/refman/4.1/en/information-functions.html#function_version
             # and https://mariadb.com/kb/en/library/version/ 
-            [version, other] = result[0].split('-')
+            version, _ , other = result[0].partition('-')
             self.version = version
-            self.flavor = other if other == "MariaDB" else "Official MySQL"
+            self.set_metadata('version', version)
+            self.flavor = other if other == "MariaDB" else "MySQL"
+            self.set_metadata('flavor', flavor)
 
-    
-    def _submit_metadata(self):
-        self.service_metadata('version', version)
-        self.set_metadata('version', version)
-        self.set_metadata('flavor', flavor)
        
     def _submit_metrics(self, variables, db_results, tags):
         for variable, metric in iteritems(variables):

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -633,6 +633,7 @@ class MySql(AgentCheck):
     def _collect_metadata(self, db):
         version = self._get_version(db)
         self.service_metadata('version', ".".join(version))
+        self.set_metadata('version', ".",join(version))
 
     def _submit_metrics(self, variables, db_results, tags):
         for variable, metric in iteritems(variables):

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -690,15 +690,18 @@ class MySql(AgentCheck):
             flavor = "Official MySQL" if flavor != "MariaDB" else "MariaDB"
             version = version.split('.')
             self.mysql_version[hostkey] = {
-                "version": version
+                "version": version,
                 "flavor": flavor
             }
             return self.mysql_version[hostkey]
 
     @classmethod
     def _get_is_mariadb(cls, db):
-        hostkey = self._get_host_key()
-        return self.mysql_version[hostkey]["flavor"] == "MariaDB"
+        with closing(db.cursor()) as cursor:
+            cursor.execute('SELECT VERSION() LIKE "%MariaDB%"')
+            result = cursor.fetchone()
+
+            return result[0] == 1
 
     def _collect_all_scalars(self, key, dictionary):
         if key not in dictionary or dictionary[key] is None:

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -315,8 +315,7 @@ class MySql(AgentCheck):
             try:
                 # Metadata collection
                 self._collect_metadata(db)
-                self._submit_metadata()
-
+                
                 # Metric collection
                 self._collect_metrics(db, tags, options, queries, max_custom_queries)
                 self._collect_system_metrics(host, db, tags)
@@ -644,8 +643,12 @@ class MySql(AgentCheck):
             version, _ , other = result[0].partition('-')
             self.version = version
             self.set_metadata('version', version)
-            self.flavor = other if other == "MariaDB" else "MySQL"
-            self.set_metadata('flavor', flavor)
+            if other == "MariaDB":
+                self.flavor = other
+            else:
+                self.flavor = "MySQL"
+                self.set_metadata('build', other)
+            self.set_metadata('flavor', self.flavor)
 
        
     def _submit_metrics(self, variables, db_results, tags):

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -279,9 +279,9 @@ class MySql(AgentCheck):
     SERVICE_CHECK_NAME = 'mysql.can_connect'
     SLAVE_SERVICE_CHECK_NAME = 'mysql.replication.slave_running'
     DEFAULT_MAX_CUSTOM_QUERIES = 20
-
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+    
+    def __init__(self, name, init_config, instances=None):
+        AgentCheck.__init__(self, name, init_config, instances)
         self.mysql_version = {}
         self.qcache_stats = {}
         # self.is_mariadb = False

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -682,7 +682,7 @@ class MySql(AgentCheck):
             cursor.execute('SELECT VERSION()')
             result = cursor.fetchone()
 
-            # Version might include a description e.g. 4.1.26-log.
+            # Version might include a description e.g. 4.1.26-log, -debug, -standard
             # See
             # http://dev.mysql.com/doc/refman/4.1/en/information-functions.html#function_version
             # `other` contains mysql flavor such as MariaDB

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -276,6 +276,7 @@ SYNTHETIC_VARS = {
 
 BUILDS = ('log', 'standard', 'debug', 'valgrind', 'embedded')
 
+
 class MySql(AgentCheck):
     SERVICE_CHECK_NAME = 'mysql.can_connect'
     SLAVE_SERVICE_CHECK_NAME = 'mysql.replication.slave_running'

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -282,7 +282,7 @@ class MySql(AgentCheck):
     SLAVE_SERVICE_CHECK_NAME = 'mysql.replication.slave_running'
     DEFAULT_MAX_CUSTOM_QUERIES = 20
 
-    def __init__(self, name, init_config, instances=None):
+    def __init__(self, name, init_config, instances):
         super(MySql, self).__init__(name, init_config, instances)
         self.qcache_stats = {}
         self.metadata = None

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -645,17 +645,17 @@ class MySql(AgentCheck):
             builds = ('log', 'standard', 'debug', 'valgrind', 'embedded')
             parts = result[0].split('-')
             self.version = parts[0]
-            
-            if len(parts) > 1:
-                for data in parts:
-                    if data == "MariaDB":
-                        self.flavor = "MariaDB"
-                    if data != "MariaDB" and self.flavor == '':
-                        self.flavor = "MySQL"
-                    if data in builds:
-                        self.build = data
 
-            self.set_metadata('version', self.version + '-' + self.build)
+            for data in parts:
+                if data == "MariaDB":
+                    self.flavor = "MariaDB"
+                if data != "MariaDB" and self.flavor == '':
+                    self.flavor = "MySQL"
+                if data in builds:
+                    self.build = data
+            # format version data to conform to semver
+            version_metadata = self.version + '+' + self.build if self.build != '' else self.version
+            self.set_metadata('version', version_metadata)
             self.set_metadata('flavor', self.flavor)
 
        

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -279,7 +279,7 @@ class MySql(AgentCheck):
     SERVICE_CHECK_NAME = 'mysql.can_connect'
     SLAVE_SERVICE_CHECK_NAME = 'mysql.replication.slave_running'
     DEFAULT_MAX_CUSTOM_QUERIES = 20
-    
+
     def __init__(self, name, init_config, instances=None):
         AgentCheck.__init__(self, name, init_config, instances)
         self.version = ''
@@ -316,7 +316,7 @@ class MySql(AgentCheck):
             try:
                 # Metadata collection
                 self._collect_metadata(db)
-                
+
                 # Metric collection
                 self._collect_metrics(db, tags, options, queries, max_custom_queries)
                 self._collect_system_metrics(host, db, tags)
@@ -636,8 +636,8 @@ class MySql(AgentCheck):
         with closing(db.cursor()) as cursor:
             cursor.execute('SELECT VERSION()')
             result = cursor.fetchone()
-            
-            # Version might include a build, a flavor, or both 
+
+            # Version might include a build, a flavor, or both
             # e.g. 4.1.26-log, 4.1.26-MariaDB, 10.0.1-MariaDB-mariadb1precise-log
             # See http://dev.mysql.com/doc/refman/4.1/en/information-functions.html#function_version
             # https://mariadb.com/kb/en/library/version/
@@ -658,7 +658,6 @@ class MySql(AgentCheck):
             self.set_metadata('version', version_metadata)
             self.set_metadata('flavor', self.flavor)
 
-       
     def _submit_metrics(self, variables, db_results, tags):
         for variable, metric in iteritems(variables):
             metric_name, metric_type = metric

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -284,7 +284,6 @@ class MySql(AgentCheck):
 
     def __init__(self, name, init_config, instances=None):
         super(MySql, self).__init__(name, init_config, instances)
-        self.agentConfig = {}
         self.qcache_stats = {}
         self.metadata = None
 

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -311,8 +311,7 @@ class MySql(AgentCheck):
             if build == '':
                 build = 'unspecified'
 
-            self.metadata = MySQLMetadata(version, flavor, build)
-            return self.metadata
+            return MySQLMetadata(version, flavor, build)
 
     def _send_metadata(self):
         self.set_metadata('version', self.metadata.version + '+' + self.metadata.build)
@@ -346,7 +345,7 @@ class MySql(AgentCheck):
         with self._connect(host, port, mysql_sock, user, password, defaults_file, ssl, connect_timeout, tags) as db:
             try:
                 # metadata collection
-                self._get_metadata(db)
+                self.metadata = self._get_metadata(db)
                 self._send_metadata()
 
                 # Metric collection

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -653,9 +653,11 @@ class MySql(AgentCheck):
                     self.flavor = "MySQL"
                 if data in builds:
                     self.build = data
-            # format version data to conform to semver
-            version_metadata = self.version + '+' + self.build if self.build != '' else self.version
-            self.set_metadata('version', version_metadata)
+
+            if self.build == '':
+                self.build = 'unspecified'
+            # format version data to conform to semve
+            self.set_metadata('version', self.version + '+' + self.build)
             self.set_metadata('flavor', self.flavor)
 
     def _submit_metrics(self, variables, db_results, tags):

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -88,6 +88,9 @@ def version_metadata():
         'version.raw': mock.ANY,
     }
 
+@pytest.fixture(scope='session')
+def 
+
 def init_master():
     conn = pymysql.connect(host=common.HOST, port=common.PORT, user='root')
     _add_dog_user(conn)

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -77,6 +77,16 @@ def instance_complex():
 def instance_error():
     return {'server': common.HOST, 'user': 'unknown', 'pass': common.PASS}
 
+@pytest.fixture(scope='session')
+def version_metadata():
+    major, minor = MYSQL_VERSION.split('.')[:2]
+    return {
+        'version.scheme': 'semver',
+        'version.major': major,
+        'version.minor': minor,
+        'version.patch': mock.ANY,
+        'version.raw': mock.ANY,
+    }
 
 def init_master():
     conn = pymysql.connect(host=common.HOST, port=common.PORT, user='root')
@@ -133,3 +143,4 @@ def _mysql_docker_repo():
             return 'bitnami/mysql'
     elif MYSQL_FLAVOR == 'mariadb':
         return 'bitnami/mariadb'
+

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -79,12 +79,12 @@ def instance_error():
 
 @pytest.fixture(scope='session')
 def version_metadata():
-    major, minor = MYSQL_VERSION.split('.')[:2]
+    major, minor, patch = MYSQL_VERSION.split('.')
     return {
         'version.scheme': 'semver',
         'version.major': major,
         'version.minor': minor,
-        'version.patch': mock.ANY,
+        'version.patch': patch,
         'version.raw': mock.ANY,
     }
 

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -78,18 +78,18 @@ def instance_error():
     return {'server': common.HOST, 'user': 'unknown', 'pass': common.PASS}
 
 @pytest.fixture(scope='session')
-def version_metadata():
+def collect_metadata():
     major, minor, patch = MYSQL_VERSION.split('.')
+    flavor = "MariaDB" if MYSQL_FLAVOR == "mariadb" else "MySQL"
     return {
         'version.scheme': 'semver',
         'version.major': major,
         'version.minor': minor,
         'version.patch': patch,
         'version.raw': mock.ANY,
+        'flavor': flavor
     }
 
-@pytest.fixture(scope='session')
-def 
 
 def init_master():
     conn = pymysql.connect(host=common.HOST, port=common.PORT, user='root')

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -12,9 +12,6 @@ from datadog_checks.dev.conditions import CheckDockerLogs
 
 from . import common, tags
 
-# from datadog_checks.mysql import MySql
-
-
 MYSQL_FLAVOR = os.getenv('MYSQL_FLAVOR')
 MYSQL_VERSION = os.getenv('MYSQL_VERSION')
 COMPOSE_FILE = os.getenv('COMPOSE_FILE')
@@ -80,11 +77,6 @@ def instance_complex():
 @pytest.fixture(scope='session')
 def instance_error():
     return {'server': common.HOST, 'user': 'unknown', 'pass': common.PASS}
-
-
-# @pytest.fixture
-# def mysql_check():
-#     return Mysql()
 
 
 @pytest.fixture(scope='session')

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -3,15 +3,17 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 
+import mock
 import pymysql
 import pytest
-import mock
 
 from datadog_checks.dev import WaitFor, docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs
-# from datadog_checks.mysql import MySql
 
 from . import common, tags
+
+# from datadog_checks.mysql import MySql
+
 
 MYSQL_FLAVOR = os.getenv('MYSQL_FLAVOR')
 MYSQL_VERSION = os.getenv('MYSQL_VERSION')
@@ -79,9 +81,11 @@ def instance_complex():
 def instance_error():
     return {'server': common.HOST, 'user': 'unknown', 'pass': common.PASS}
 
+
 # @pytest.fixture
 # def mysql_check():
 #     return Mysql()
+
 
 @pytest.fixture(scope='session')
 def version_metadata():
@@ -92,13 +96,13 @@ def version_metadata():
     flavor = "MariaDB" if MYSQL_FLAVOR == "mariadb" else "MySQL"
 
     return {
-            'version.scheme': 'semver',
-            'version.major': major,
-            'version.minor': minor,
-            'version.patch': patch,
-            'version.raw': mock.ANY,
-            'version.build': mock.ANY,
-            'flavor': flavor,
+        'version.scheme': 'semver',
+        'version.major': major,
+        'version.minor': minor,
+        'version.patch': patch,
+        'version.raw': mock.ANY,
+        'version.build': mock.ANY,
+        'flavor': flavor,
     }
 
 
@@ -157,4 +161,3 @@ def _mysql_docker_repo():
             return 'bitnami/mysql'
     elif MYSQL_FLAVOR == 'mariadb':
         return 'bitnami/mariadb'
-

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -97,7 +97,8 @@ def version_metadata():
             'version.minor': minor,
             'version.patch': patch,
             'version.raw': mock.ANY,
-            'flavor': flavor
+            'version.build': mock.ANY,
+            'flavor': flavor,
     }
 
 

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -5,9 +5,11 @@ import os
 
 import pymysql
 import pytest
+import mock
 
 from datadog_checks.dev import WaitFor, docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs
+# from datadog_checks.mysql import MySql
 
 from . import common, tags
 
@@ -77,17 +79,25 @@ def instance_complex():
 def instance_error():
     return {'server': common.HOST, 'user': 'unknown', 'pass': common.PASS}
 
+# @pytest.fixture
+# def mysql_check():
+#     return Mysql()
+
 @pytest.fixture(scope='session')
-def collect_metadata():
-    major, minor, patch = MYSQL_VERSION.split('.')
+def version_metadata():
+    parts = MYSQL_VERSION.split('.')
+    major, minor = parts[:2]
+    patch = parts[2] if len(parts) > 2 else mock.ANY
+
     flavor = "MariaDB" if MYSQL_FLAVOR == "mariadb" else "MySQL"
+
     return {
-        'version.scheme': 'semver',
-        'version.major': major,
-        'version.minor': minor,
-        'version.patch': patch,
-        'version.raw': mock.ANY,
-        'flavor': flavor
+            'version.scheme': 'semver',
+            'version.major': major,
+            'version.minor': minor,
+            'version.patch': patch,
+            'version.raw': mock.ANY,
+            'flavor': flavor
     }
 
 

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -89,9 +89,10 @@ def instance_error():
 
 @pytest.fixture(scope='session')
 def version_metadata():
-    parts = MYSQL_VERSION.split('.')
-    major, minor = parts[:2]
-    patch = parts[2] if len(parts) > 2 else mock.ANY
+    parts = MYSQL_VERSION.split('-')
+    version = parts[0].split('.')
+    major, minor = version[:2]
+    patch = version[2] if len(version) > 2 else mock.ANY
 
     flavor = "MariaDB" if MYSQL_FLAVOR == "mariadb" else "MySQL"
 

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -247,3 +247,16 @@ def test__get_server_pid():
             # the pid should be none but without errors
             assert mysql_check._get_server_pid(None) is None
             assert mysql_check.log.exception.call_count == 0
+
+
+def test_metadata(instance_basic, version_metadata):
+    mysql_check = MySql(common.CHECK_NAME, {}, {})
+    mysql_check.check(instance_basic)
+    mysql_check.check_id = 'test:123'
+
+    with mock.patch('datadog_checks.base.stubs.datadog_agent.set_check_metadata') as m:
+        mysql_check.check(instance)
+        for name, value in version_metadata.items():
+            m.assert_any_call('test:123', name, value)
+
+        assert m.call_count == len(version_metadata)

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -251,11 +251,10 @@ def test__get_server_pid():
 
 def test_metadata(instance_basic, version_metadata):
     mysql_check = MySql(common.CHECK_NAME, {}, {})
-    mysql_check.check(instance_basic)
     mysql_check.check_id = 'test:123'
 
     with mock.patch('datadog_checks.base.stubs.datadog_agent.set_check_metadata') as m:
-        mysql_check.check(instance)
+        mysql_check.check(instance_basic)
         for name, value in version_metadata.items():
             m.assert_any_call('test:123', name, value)
 

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -251,12 +251,12 @@ def test__get_server_pid():
 
 def test_version_metadata(instance_basic, version_metadata):
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[instance_basic])
-    mysql_check.check_id = 'test:123' 
+    mysql_check.check_id = 'test:123'
 
     with mock.patch('datadog_checks.base.stubs.datadog_agent.set_check_metadata') as m:
         mysql_check.check(instance_basic)
-        import pdb; pdb.set_trace()
+
         for name, value in version_metadata.items():
             m.assert_any_call('test:123', name, value)
-            
+
         assert m.call_count == len(version_metadata)

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -250,9 +250,6 @@ def test__get_server_pid():
 
 
 def test_version_metadata(instance_basic, version_metadata):
-    # mysql_check = MySql(common.CHECK_NAME, {}, {})
-    # mysql_check.check(instance_basic)
-    # mysql_check.check_id = 'test:123'
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[instance_basic])
     mysql_check.check_id = 'test:123' 
 
@@ -261,7 +258,5 @@ def test_version_metadata(instance_basic, version_metadata):
         
         for name, value in version_metadata.items():
             m.assert_any_call('test:123', name, value)
-        
+            
         assert m.call_count == len(version_metadata)
-
-# def test_flavor_metadata(flavor_metadata):

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -254,14 +254,14 @@ def test_version_metadata(instance_basic, version_metadata):
     # mysql_check.check(instance_basic)
     # mysql_check.check_id = 'test:123'
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[instance_basic])
+    mysql_check.check_id = 'test:123' 
 
     with mock.patch('datadog_checks.base.stubs.datadog_agent.set_check_metadata') as m:
         mysql_check.check(instance_basic)
-        mysql_check.check_id = 'test:123' 
-
+        
         for name, value in version_metadata.items():
             m.assert_any_call('test:123', name, value)
-
+        
         assert m.call_count == len(version_metadata)
 
 # def test_flavor_metadata(flavor_metadata):

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -255,7 +255,7 @@ def test_version_metadata(instance_basic, version_metadata):
 
     with mock.patch('datadog_checks.base.stubs.datadog_agent.set_check_metadata') as m:
         mysql_check.check(instance_basic)
-        
+        import pdb; pdb.set_trace()
         for name, value in version_metadata.items():
             m.assert_any_call('test:123', name, value)
             

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -20,7 +20,7 @@ from .common import MYSQL_VERSION_PARSED
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_minimal_config(aggregator, instance_basic):
-    mysql_check = MySql(common.CHECK_NAME, {})
+    mysql_check = MySql(common.CHECK_NAME, {}, [instance_basic])
     mysql_check.check(instance_basic)
 
     # Test service check
@@ -135,7 +135,7 @@ def test_connection_failure(aggregator, instance_error):
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_complex_config_replica(aggregator, instance_complex):
-    mysql_check = MySql(common.CHECK_NAME, {})
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[instance_complex])
     config = copy.deepcopy(instance_complex)
     config['port'] = common.SLAVE_PORT
     mysql_check.check(config)
@@ -220,7 +220,7 @@ def test__get_server_pid():
     """
     Test the logic looping through the processes searching for `mysqld`
     """
-    mysql_check = MySql(common.CHECK_NAME, {})
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[{}])
     mysql_check._get_pid_file_variable = mock.MagicMock(return_value=None)
     mysql_check.log = mock.MagicMock()
     dummy_proc = subprocess.Popen(["python"])

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -257,7 +257,6 @@ def test_version_metadata(instance_basic, version_metadata):
         mysql_check.check(instance_basic)
 
         for name, value in version_metadata.items():
-            import pdb; pdb.set_trace()
             m.assert_any_call('test:123', name, value)
 
         assert m.call_count == len(version_metadata)

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -249,13 +249,19 @@ def test__get_server_pid():
             assert mysql_check.log.exception.call_count == 0
 
 
-def test_metadata(instance_basic, version_metadata):
-    mysql_check = MySql(common.CHECK_NAME, {}, {})
-    mysql_check.check_id = 'test:123'
+def test_version_metadata(instance_basic, version_metadata):
+    # mysql_check = MySql(common.CHECK_NAME, {}, {})
+    # mysql_check.check(instance_basic)
+    # mysql_check.check_id = 'test:123'
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[instance_basic])
 
     with mock.patch('datadog_checks.base.stubs.datadog_agent.set_check_metadata') as m:
         mysql_check.check(instance_basic)
+        mysql_check.check_id = 'test:123' 
+
         for name, value in version_metadata.items():
             m.assert_any_call('test:123', name, value)
 
         assert m.call_count == len(version_metadata)
+
+# def test_flavor_metadata(flavor_metadata):

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -257,6 +257,7 @@ def test_version_metadata(instance_basic, version_metadata):
         mysql_check.check(instance_basic)
 
         for name, value in version_metadata.items():
+            import pdb; pdb.set_trace()
             m.assert_any_call('test:123', name, value)
 
         assert m.call_count == len(version_metadata)

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -20,7 +20,7 @@ from .common import MYSQL_VERSION_PARSED
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_minimal_config(aggregator, instance_basic):
-    mysql_check = MySql(common.CHECK_NAME, {}, {})
+    mysql_check = MySql(common.CHECK_NAME, {})
     mysql_check.check(instance_basic)
 
     # Test service check
@@ -43,7 +43,7 @@ def test_minimal_config(aggregator, instance_basic):
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_complex_config(aggregator, instance_complex):
-    mysql_check = MySql(common.CHECK_NAME, {}, {}, instances=[instance_complex])
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[instance_complex])
     mysql_check.check(instance_complex)
 
     _assert_complex_config(aggregator)
@@ -122,7 +122,7 @@ def test_connection_failure(aggregator, instance_error):
     """
     Service check reports connection failure
     """
-    mysql_check = MySql(common.CHECK_NAME, {}, {}, instances=[instance_error])
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[instance_error])
 
     with pytest.raises(Exception):
         mysql_check.check(instance_error)
@@ -135,7 +135,7 @@ def test_connection_failure(aggregator, instance_error):
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_complex_config_replica(aggregator, instance_complex):
-    mysql_check = MySql(common.CHECK_NAME, {}, {})
+    mysql_check = MySql(common.CHECK_NAME, {})
     config = copy.deepcopy(instance_complex)
     config['port'] = common.SLAVE_PORT
     mysql_check.check(config)
@@ -220,7 +220,7 @@ def test__get_server_pid():
     """
     Test the logic looping through the processes searching for `mysqld`
     """
-    mysql_check = MySql(common.CHECK_NAME, {}, {})
+    mysql_check = MySql(common.CHECK_NAME, {})
     mysql_check._get_pid_file_variable = mock.MagicMock(return_value=None)
     mysql_check.log = mock.MagicMock()
     dummy_proc = subprocess.Popen(["python"])


### PR DESCRIPTION
### What does this PR do?

- Add ability to retrieve mysql version, flavor, and build to set as metadata for inventories.
- Adjusted mysql init function signature to get rid of unused argument `AgentConfig`
- Modified existing mysql tests to reflect new function signature
- Added new tests for version metadata

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
