### PR TITLE
Ensure the correct tls_ca_cert value is used

### DIFF
--- a/http_check/datadog_checks/http_check/config.py
+++ b/http_check/datadog_checks/http_check/config.py
@@ -52,7 +52,7 @@ def from_instance(instance, default_ca_certs=None):
         raise ConfigurationError("The url {} must start with the scheme http or https".format(url))
     include_content = is_affirmative(instance.get('include_content', False))
     ssl_expire = is_affirmative(instance.get('check_certificate_expiration', True))
-    instance_ca_certs = instance.get('ca_certs', default_ca_certs)
+    instance_ca_certs = instance.get('tls_ca_cert', instance.get('ca_certs', default_ca_certs))
     weakcipher = is_affirmative(instance.get('weakciphers', False))
     check_hostname = is_affirmative(instance.get('check_hostname', True))
     allow_redirects = is_affirmative(instance.get('allow_redirects', True))

--- a/http_check/tests/test_unit_config.py
+++ b/http_check/tests/test_unit_config.py
@@ -72,3 +72,25 @@ def test_from_instance():
     expected_headers = agent_headers({}).get('User-Agent')
     assert headers["X-Auth-Token"] == "SOME-AUTH-TOKEN", headers
     assert expected_headers == headers.get('User-Agent'), headers
+
+
+def test_instance_ca_cert():
+    """
+    `instance_ca_cert` should default to the trusted ca_cert of the system
+    if `tls_ca_cert` and `ca_certs` are unavailable.
+    """
+    # Ensure that 'tls_ca_cert' takes precedence
+    params_with_all = from_instance({'url': 'https://example2.com', 'name': 'UpService', 'tls_ca_cert': 'foobar', 'ca_certs': 'barfoo'}, 'default_ca_cert')
+    assert params_with_all[13] == 'foobar'
+
+    # Original config option for ca_certs
+    params_only_ca_certs = from_instance({'url': 'https://example2.com', 'name': 'UpService', 'ca_certs': 'ca_cert'})
+    assert params_only_ca_certs[13] == 'ca_cert'
+
+    # Default if there is no cert path is configured
+    params_no_certs = from_instance({'url': 'https://example2.com', 'name': 'UpService'}, 'default_ca_cert')
+    assert params_no_certs[13] == 'default_ca_cert'
+
+    # No default ca_cert
+    params_no_default = from_instance({'url': 'https://example2.com', 'name': 'UpService'})
+    assert params_no_default[13] is None

--- a/http_check/tests/test_unit_config.py
+++ b/http_check/tests/test_unit_config.py
@@ -80,7 +80,10 @@ def test_instance_ca_cert():
     if `tls_ca_cert` and `ca_certs` are unavailable.
     """
     # Ensure that 'tls_ca_cert' takes precedence
-    params_with_all = from_instance({'url': 'https://example2.com', 'name': 'UpService', 'tls_ca_cert': 'foobar', 'ca_certs': 'barfoo'}, 'default_ca_cert')
+    params_with_all = from_instance(
+        {'url': 'https://example2.com', 'name': 'UpService', 'tls_ca_cert': 'foobar', 'ca_certs': 'barfoo'},
+        'default_ca_cert',
+    )
     assert params_with_all[13] == 'foobar'
 
     # Original config option for ca_certs


### PR DESCRIPTION
### What does this PR do?

The value of `instance_ca_cert` used in the socket logic does not reflect the new config options for users using `tls_ca_cert`.

The issue is brought up here https://github.com/DataDog/integrations-core/issues/4812

This PR fixes the bug introduced in adding the RequestsWrapper
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
