### PR TITLE
Remove multi instance from code

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -67,7 +67,7 @@ class PostgreSql(AgentCheck):
         self.custom_metrics = None
 
         # Deprecate custom_metrics in favor of custom_queries
-        if any('custom_metrics' in instance for instance in instances):
+        if 'custom_metrics' in self.instance:
             self.warning(
                 "DEPRECATION NOTICE: Please use the new custom_queries option "
                 "rather than the now deprecated custom_metrics"

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -177,7 +177,7 @@ class PostgreSql(AgentCheck):
     def _is_10_or_above(self, db):
         return self._is_above(db, [10, 0, 0])
 
-    def _get_instance_metrics(self, database_size_metrics, collect_default_db):
+    def _get_instance_metrics(self, db, database_size_metrics, collect_default_db):
         """
         Add NEWER_92_METRICS to the default set of COMMON_METRICS when server
         version is 9.2 or later.
@@ -193,7 +193,7 @@ class PostgreSql(AgentCheck):
 
         if metrics is None:
             # select the right set of metrics to collect depending on postgres version
-            if self._is_9_2_or_above():
+            if self._is_9_2_or_above(db):
                 self.instance_metrics = dict(COMMON_METRICS, **NEWER_92_METRICS)
             else:
                 self.instance_metrics = dict(COMMON_METRICS)
@@ -516,7 +516,7 @@ class PostgreSql(AgentCheck):
         If custom_metrics is not an empty list, gather custom metrics defined in postgres.yaml
         """
 
-        db_instance_metrics = self._get_instance_metrics(collect_database_size_metrics, collect_default_db)
+        db_instance_metrics = self._get_instance_metrics(db, collect_database_size_metrics, collect_default_db)
         bgw_instance_metrics = self._get_bgw_metrics(db)
         archiver_instance_metrics = self._get_archiver_metrics(db)
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -51,10 +51,6 @@ ALL_SCHEMAS = object()
 SSL_MODES = {'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full'}
 
 
-class ShouldRestartException(Exception):
-    pass
-
-
 class PostgreSql(AgentCheck):
     """Collects per-database, and optionally per-relation metrics, custom metrics"""
 
@@ -68,17 +64,10 @@ class PostgreSql(AgentCheck):
     _known_servers = set()
     _known_servers_lock = threading.Lock()
 
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
-        self.dbs = {}
-        self.versions = {}
-        self.instance_metrics = {}
-        self.bgw_metrics = {}
-        self.archiver_metrics = {}
-        self.db_bgw_metrics = []
-        self.db_archiver_metrics = []
-        self.replication_metrics = {}
-        self.activity_metrics = {}
+    def __init__(self, name, init_config, instances=None):
+        AgentCheck.__init__(self, name, init_config, instances)
+        self._clean_state()
+        self.db = None
         self.custom_metrics = {}
 
         # Deprecate custom_metrics in favor of custom_queries
@@ -87,16 +76,46 @@ class PostgreSql(AgentCheck):
                 "DEPRECATION NOTICE: Please use the new custom_queries option "
                 "rather than the now deprecated custom_metrics"
             )
+        host = self.instance.get('host', '')
+        port = self.instance.get('port', '')
+        if port != '':
+            port = int(port)
+        dbname = self.instance.get('dbname', 'postgres')
+        self.relations = self.instance.get('relations', [])
+        if self.relations and not dbname:
+            raise ConfigurationError('"dbname" parameter must be set when using the "relations" parameter.')
 
-    def _clean_state(self, key):
-        self.versions.pop(key, None)
-        self.instance_metrics.pop(key, None)
-        self.bgw_metrics.pop(key, None)
-        self.archiver_metrics.pop(key, None)
+        self.key = (host, port, dbname)
+        self.tags = self._build_tags(self.instance.get('tags', []), host, port, dbname)
+
+    def _build_tags(self, custom_tags, host, port, dbname):
+        # Clean up tags in case there was a None entry in the instance
+        # e.g. if the yaml contains tags: but no actual tags
+        if custom_tags is None:
+            tags = []
+        else:
+            tags = list(set(custom_tags))
+
+        # preset tags to host
+        tags.append('server:{}'.format(host))
+        if port:
+            tags.append('port:{}'.format(port))
+        else:
+            tags.append('port:socket')
+
+        # preset tags to the database name
+        tags.extend(["db:%s" % dbname])
+        return tags
+
+    def _clean_state(self):
+        self.version = None
+        self.instance_metrics = None
+        self.bgw_metrics = None
+        self.archiver_metrics = None
         self.db_bgw_metrics = []
         self.db_archiver_metrics = []
-        self.replication_metrics.pop(key, None)
-        self.activity_metrics.pop(key, None)
+        self.replication_metrics = None
+        self.activity_metrics = None
 
     @classmethod
     def _server_known(cls, host, port):
@@ -114,15 +133,15 @@ class PostgreSql(AgentCheck):
         with PostgreSql._known_servers_lock:
             PostgreSql._known_servers.add((host, port))
 
-    def _get_replication_role(self, key, db):
+    def _get_replication_role(self, db):
         cursor = db.cursor()
         cursor.execute('SELECT pg_is_in_recovery();')
         role = cursor.fetchone()[0]
         # value fetched for role is of <type 'bool'>
         return "standby" if role else "master"
 
-    def _get_version(self, key, db):
-        if key not in self.versions:
+    def _get_version(self, db):
+        if self.version is None:
             cursor = db.cursor()
             cursor.execute('SHOW SERVER_VERSION;')
             version = cursor.fetchone()[0]
@@ -141,13 +160,13 @@ class PostgreSql(AgentCheck):
                         version_parts[1] = -1
                         version = [int(part) for part in version_parts]
 
-            self.versions[key] = version
+            self.version = version
 
-        self.service_metadata('version', self.versions[key])
-        return self.versions[key]
+        self.service_metadata('version', self.version)
+        return self.version
 
-    def _is_above(self, key, db, version_to_compare):
-        version = self._get_version(key, db)
+    def _is_above(self, db, version_to_compare):
+        version = self._get_version(db)
         if type(version) == list:
             # iterate from major down to bugfix
             for v, vc in zip_longest(version, version_to_compare, fillvalue=0):
@@ -158,28 +177,27 @@ class PostgreSql(AgentCheck):
 
             # return True if version is the same
             return True
-
         return False
 
-    def _is_8_3_or_above(self, key, db):
-        return self._is_above(key, db, [8, 3, 0])
+    def _is_8_3_or_above(self, db):
+        return self._is_above(db, [8, 3, 0])
 
-    def _is_9_1_or_above(self, key, db):
-        return self._is_above(key, db, [9, 1, 0])
+    def _is_9_1_or_above(self, db):
+        return self._is_above(db, [9, 1, 0])
 
-    def _is_9_2_or_above(self, key, db):
-        return self._is_above(key, db, [9, 2, 0])
+    def _is_9_2_or_above(self, db):
+        return self._is_above(db, [9, 2, 0])
 
-    def _is_9_4_or_above(self, key, db):
-        return self._is_above(key, db, [9, 4, 0])
+    def _is_9_4_or_above(self, db):
+        return self._is_above(db, [9, 4, 0])
 
-    def _is_9_6_or_above(self, key, db):
-        return self._is_above(key, db, [9, 6, 0])
+    def _is_9_6_or_above(self, db):
+        return self._is_above(db, [9, 6, 0])
 
-    def _is_10_or_above(self, key, db):
-        return self._is_above(key, db, [10, 0, 0])
+    def _is_10_or_above(self, db):
+        return self._is_above(db, [10, 0, 0])
 
-    def _get_instance_metrics(self, key, db, database_size_metrics, collect_default_db):
+    def _get_instance_metrics(self, database_size_metrics, collect_default_db):
         """
         Add NEWER_92_METRICS to the default set of COMMON_METRICS when server
         version is 9.2 or later.
@@ -191,34 +209,34 @@ class PostgreSql(AgentCheck):
         monitoring different databases, we want to collect server metrics
         only once. See https://github.com/DataDog/dd-agent/issues/1211
         """
-        metrics = self.instance_metrics.get(key)
+        metrics = self.instance_metrics
 
         if metrics is None:
-            host, port, dbname = key
+            host, port, dbname = self.key
             # check whether we already collected server-wide metrics for this
             # postgres instance
             if self._server_known(host, port):
                 # explicitly set instance metrics for this key to an empty list
                 # so we don't get here more than once
-                self.instance_metrics[key] = []
+                self.instance_metrics = []
                 self.log.debug(
                     "Not collecting instance metrics for key: {} as "
-                    "they are already collected by another instance".format(key)
+                    "they are already collected by another instance".format(self.key)
                 )
                 return None
             self._set_server_known(host, port)
 
             # select the right set of metrics to collect depending on postgres version
-            if self._is_9_2_or_above(key, db):
-                self.instance_metrics[key] = dict(COMMON_METRICS, **NEWER_92_METRICS)
+            if self._is_9_2_or_above():
+                self.instance_metrics = dict(COMMON_METRICS, **NEWER_92_METRICS)
             else:
-                self.instance_metrics[key] = dict(COMMON_METRICS)
+                self.instance_metrics = dict(COMMON_METRICS)
 
             # add size metrics if needed
             if database_size_metrics:
-                self.instance_metrics[key].update(DATABASE_SIZE_METRICS)
+                self.instance_metrics.update(DATABASE_SIZE_METRICS)
 
-            metrics = self.instance_metrics.get(key)
+            metrics = self.instance_metrics
 
         # this will happen when the current key contains a postgres server that
         # we already know, let's avoid to collect duplicates
@@ -242,36 +260,36 @@ class PostgreSql(AgentCheck):
 
         return res
 
-    def _get_bgw_metrics(self, key, db):
+    def _get_bgw_metrics(self, db):
         """Use either COMMON_BGW_METRICS or COMMON_BGW_METRICS + NEWER_92_BGW_METRICS
         depending on the postgres version.
         Uses a dictionary to save the result for each instance
         """
         # Extended 9.2+ metrics if needed
-        metrics = self.bgw_metrics.get(key)
+        metrics = self.bgw_metrics
 
         if metrics is None:
             # Hack to make sure that if we have multiple instances that connect to
             # the same host, port, we don't collect metrics twice
             # as it will result in https://github.com/DataDog/dd-agent/issues/1211
-            sub_key = key[:2]
+            sub_key = self.key[:2]
             if sub_key in self.db_bgw_metrics:
-                self.bgw_metrics[key] = None
+                self.bgw_metrics = None
                 self.log.debug(
                     "Not collecting bgw metrics for key: {0} as "
-                    "they are already collected by another instance".format(key)
+                    "they are already collected by another instance".format(self.key)
                 )
                 return None
 
             self.db_bgw_metrics.append(sub_key)
 
-            self.bgw_metrics[key] = dict(COMMON_BGW_METRICS)
-            if self._is_9_1_or_above(key, db):
-                self.bgw_metrics[key].update(NEWER_91_BGW_METRICS)
-            if self._is_9_2_or_above(key, db):
-                self.bgw_metrics[key].update(NEWER_92_BGW_METRICS)
+            self.bgw_metrics = dict(COMMON_BGW_METRICS)
+            if self._is_9_1_or_abovedb():
+                self.bgw_metrics.update(NEWER_91_BGW_METRICS)
+            if self._is_9_2_or_above(db):
+                self.bgw_metrics.update(NEWER_92_BGW_METRICS)
 
-            metrics = self.bgw_metrics.get(key)
+            metrics = self.bgw_metrics
 
         if not metrics:
             return None
@@ -290,30 +308,30 @@ class PostgreSql(AgentCheck):
         )
         return metrics
 
-    def _get_archiver_metrics(self, key, db):
+    def _get_archiver_metrics(self, db):
         """Use COMMON_ARCHIVER_METRICS to read from pg_stat_archiver as
         defined in 9.4 (first version to have this table).
         Uses a dictionary to save the result for each instance
         """
         # While there's only one set for now, prepare for future additions to
         # the table, mirroring _get_bgw_metrics()
-        metrics = self.archiver_metrics.get(key)
+        metrics = self.archiver_metrics.get()
 
-        if self._is_9_4_or_above(key, db) and metrics is None:
+        if self._is_9_4_or_above(db) and metrics is None:
             # Collect from only one instance. See _get_bgw_metrics() for details on why.
-            sub_key = key[:2]
+            sub_key = self.key[:2]
             if sub_key in self.db_archiver_metrics:
-                self.archiver_metrics[key] = None
+                self.archiver_metrics = None
                 self.log.debug(
                     "Not collecting archiver metrics for key: {0} as "
-                    "they are already collected by another instance".format(key)
+                    "they are already collected by another instance".format(self.key)
                 )
                 return None
 
             self.db_archiver_metrics.append(sub_key)
 
-            self.archiver_metrics[key] = dict(COMMON_ARCHIVER_METRICS)
-            metrics = self.archiver_metrics.get(key)
+            self.archiver_metrics = dict(COMMON_ARCHIVER_METRICS)
+            metrics = self.archiver_metrics
 
         if not metrics:
             return None
@@ -325,37 +343,37 @@ class PostgreSql(AgentCheck):
             'relation': False,
         }
 
-    def _get_replication_metrics(self, key, db):
+    def _get_replication_metrics(self, db):
         """ Use either REPLICATION_METRICS_10, REPLICATION_METRICS_9_1, or
         REPLICATION_METRICS_9_1 + REPLICATION_METRICS_9_2, depending on the
         postgres version.
         Uses a dictionnary to save the result for each instance
         """
-        metrics = self.replication_metrics.get(key)
-        if self._is_10_or_above(key, db) and metrics is None:
-            self.replication_metrics[key] = dict(REPLICATION_METRICS_10)
-            metrics = self.replication_metrics.get(key)
-        elif self._is_9_1_or_above(key, db) and metrics is None:
-            self.replication_metrics[key] = dict(REPLICATION_METRICS_9_1)
-            if self._is_9_2_or_above(key, db):
-                self.replication_metrics[key].update(REPLICATION_METRICS_9_2)
-            metrics = self.replication_metrics.get(key)
+        metrics = self.replication_metrics
+        if self._is_10_or_above(db) and metrics is None:
+            self.replication_metrics = dict(REPLICATION_METRICS_10)
+            metrics = self.replication_metrics
+        elif self._is_9_1_or_above(db) and metrics is None:
+            self.replication_metrics = dict(REPLICATION_METRICS_9_1)
+            if self._is_9_2_or_above(db):
+                self.replication_metrics.update(REPLICATION_METRICS_9_2)
+            metrics = self.replication_metrics
         return metrics
 
-    def _get_activity_metrics(self, key, db, user):
+    def _get_activity_metrics(self, db, user):
         """ Use ACTIVITY_METRICS_LT_8_3 or ACTIVITY_METRICS_8_3 or ACTIVITY_METRICS_9_2
         depending on the postgres version in conjunction with ACTIVITY_QUERY_10 or ACTIVITY_QUERY_LT_10.
         Uses a dictionnary to save the result for each instance
         """
-        metrics_data = self.activity_metrics.get(key)
+        metrics_data = self.activity_metrics
 
         if metrics_data is None:
-            query = ACTIVITY_QUERY_10 if self._is_10_or_above(key, db) else ACTIVITY_QUERY_LT_10
-            if self._is_9_6_or_above(key, db):
+            query = ACTIVITY_QUERY_10 if self._is_10_or_above( db) else ACTIVITY_QUERY_LT_10
+            if self._is_9_6_or_above(db):
                 metrics_query = ACTIVITY_METRICS_9_6
-            elif self._is_9_2_or_above(key, db):
+            elif self._is_9_2_or_above(db):
                 metrics_query = ACTIVITY_METRICS_9_2
-            elif self._is_8_3_or_above(key, db):
+            elif self._is_8_3_or_above(db):
                 metrics_query = ACTIVITY_METRICS_8_3
             else:
                 metrics_query = ACTIVITY_METRICS_LT_8_3
@@ -365,7 +383,7 @@ class PostgreSql(AgentCheck):
                     metrics_query[i] = q.format(dd__user=user)
 
             metrics = {k: v for k, v in zip(metrics_query, ACTIVITY_DD_METRICS)}
-            self.activity_metrics[key] = (metrics, query)
+            self.activity_metrics = (metrics, query)
         else:
             metrics, query = metrics_data
 
@@ -403,11 +421,11 @@ class PostgreSql(AgentCheck):
                 self.log.warning('Unhandled relations config type: {}'.format(element))
         return config
 
-    def _query_scope(self, cursor, scope, key, db, instance_tags, is_custom_metrics, relations_config):
+    def _query_scope(self, cursor, scope, db, instance_tags, is_custom_metrics, relations_config):
         if scope is None:
             return None
 
-        if scope == REPLICATION_METRICS or not self._is_above(key, db, [9, 0, 0]):
+        if scope == REPLICATION_METRICS or not self._is_above(db, [9, 0, 0]):
             log_func = self.log.debug
         else:
             log_func = self.log.warning
@@ -435,9 +453,9 @@ class PostgreSql(AgentCheck):
             log_func(e)
             log_func(
                 "It seems the PG version has been incorrectly identified as %s. "
-                "A reattempt to identify the right version will happen on next agent run." % self.versions[key]
+                "A reattempt to identify the right version will happen on next agent run." % self.version
             )
-            self._clean_state(key)
+            self._clean_state()
             db.rollback()
         except (psycopg2.ProgrammingError, psycopg2.errors.QueryCanceled) as e:
             log_func("Not all metrics may be available: %s" % str(e))
@@ -519,7 +537,6 @@ class PostgreSql(AgentCheck):
 
     def _collect_stats(
         self,
-        key,
         db,
         user,
         instance_tags,
@@ -538,9 +555,9 @@ class PostgreSql(AgentCheck):
         If custom_metrics is not an empty list, gather custom metrics defined in postgres.yaml
         """
 
-        db_instance_metrics = self._get_instance_metrics(key, db, collect_database_size_metrics, collect_default_db)
-        bgw_instance_metrics = self._get_bgw_metrics(key, db)
-        archiver_instance_metrics = self._get_archiver_metrics(key, db)
+        db_instance_metrics = self._get_instance_metrics(collect_database_size_metrics, collect_default_db)
+        bgw_instance_metrics = self._get_bgw_metrics(db)
+        archiver_instance_metrics = self._get_archiver_metrics(db)
 
         metric_scope = [CONNECTION_METRICS, LOCK_METRICS]
 
@@ -555,49 +572,44 @@ class PostgreSql(AgentCheck):
             metric_scope += [REL_METRICS, IDX_METRICS, SIZE_METRICS, STATIO_METRICS]
             relations_config = self._build_relations_config(relations)
 
-        replication_metrics = self._get_replication_metrics(key, db)
+        replication_metrics = self._get_replication_metrics(db)
         if replication_metrics is not None:
             # FIXME: constants shouldn't be modified
             REPLICATION_METRICS['metrics'] = replication_metrics
             metric_scope.append(REPLICATION_METRICS)
 
-        try:
-            cursor = db.cursor()
-            results_len = self._query_scope(
-                cursor, db_instance_metrics, key, db, instance_tags, False, relations_config
+        cursor = db.cursor()
+        results_len = self._query_scope(
+            cursor, db_instance_metrics, db, instance_tags, False, relations_config
+        )
+        if results_len is not None:
+            self.gauge(
+                "postgresql.db.count", results_len, tags=[t for t in instance_tags if not t.startswith("db:")]
             )
-            if results_len is not None:
-                self.gauge(
-                    "postgresql.db.count", results_len, tags=[t for t in instance_tags if not t.startswith("db:")]
-                )
 
-            self._query_scope(cursor, bgw_instance_metrics, key, db, instance_tags, False, relations_config)
-            self._query_scope(cursor, archiver_instance_metrics, key, db, instance_tags, False, relations_config)
+        self._query_scope(cursor, bgw_instance_metrics, db, instance_tags, False, relations_config)
+        self._query_scope(cursor, archiver_instance_metrics, db, instance_tags, False, relations_config)
 
-            if collect_activity_metrics:
-                activity_metrics = self._get_activity_metrics(key, db, user)
-                self._query_scope(cursor, activity_metrics, key, db, instance_tags, False, relations_config)
+        if collect_activity_metrics:
+            activity_metrics = self._get_activity_metrics(db, user)
+            self._query_scope(cursor, activity_metrics, db, instance_tags, False, relations_config)
 
-            for scope in list(metric_scope) + custom_metrics:
-                self._query_scope(cursor, scope, key, db, instance_tags, scope in custom_metrics, relations_config)
+        for scope in list(metric_scope) + custom_metrics:
+            self._query_scope(cursor, scope, db, instance_tags, scope in custom_metrics, relations_config)
 
-            cursor.close()
-
-        except (psycopg2.InterfaceError, socket.error) as e:
-            self.log.error("Connection error: %s" % str(e))
-            raise ShouldRestartException
+        cursor.close()
 
     @classmethod
-    def _get_service_check_tags(cls, host, port, tags):
+    def _get_service_check_tags(cls, host, tags):
         service_check_tags = ["host:%s" % host]
         service_check_tags.extend(tags)
         service_check_tags = list(set(service_check_tags))
         return service_check_tags
 
-    def get_connection(self, key, host, port, user, password, dbname, ssl, tags, use_cached=True):
+    def get_connection(self, host, port, user, password, dbname, ssl, tags, use_cached=True):
         """Get and memoize connections to instances"""
-        if key in self.dbs and use_cached:
-            conn = self.dbs[key]
+        if self.db and use_cached:
+            conn = self.db
             if conn.status != psycopg2.extensions.STATUS_READY:
                 # Some transaction went wrong and the connection is in an unhealthy state. Let's fix that
                 conn.rollback()
@@ -628,11 +640,11 @@ class PostgreSql(AgentCheck):
                         sslmode=ssl,
                         application_name="datadog-agent",
                     )
-                self.dbs[key] = connection
+                self.db = connection
                 return connection
             except Exception as e:
                 message = u'Error establishing postgres connection: %s' % (str(e))
-                service_check_tags = self._get_service_check_tags(host, port, tags)
+                service_check_tags = self._get_service_check_tags(host, tags)
                 self.service_check(
                     self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=service_check_tags, message=message
                 )
@@ -737,10 +749,10 @@ class PostgreSql(AgentCheck):
                             metric, value, method = info
                             getattr(self, method)(metric, value, tags=query_tags)
 
-    def _get_custom_metrics(self, custom_metrics, key):
+    def _get_custom_metrics(self, custom_metrics):
         # Pre-processed cached custom_metrics
-        if key in self.custom_metrics:
-            return self.custom_metrics[key]
+        if self.custom_metrics is not None:
+            return self.custom_metrics
 
         # Otherwise pre-process custom metrics and verify definition
         required_parameters = ("descriptors", "metrics", "query", "relation")
@@ -774,75 +786,49 @@ class PostgreSql(AgentCheck):
             except Exception as e:
                 raise Exception('Error processing custom metric `{}`: {}'.format(m, e))
 
-        self.custom_metrics[key] = custom_metrics
+        self.custom_metrics = custom_metrics
         return custom_metrics
 
     def check(self, instance):
-        host = instance.get('host', '')
-        port = instance.get('port', '')
-        if port != '':
-            port = int(port)
-        user = instance.get('username', '')
-        password = instance.get('password', '')
-        tags = instance.get('tags', [])
-        dbname = instance.get('dbname', None)
-        relations = instance.get('relations', [])
-        ssl = instance.get('ssl', False)
+        ssl = self.instance.get('ssl', False)
         if ssl not in SSL_MODES:
             ssl = 'require' if is_affirmative(ssl) else 'disable'
-        table_count_limit = instance.get('table_count_limit', TABLE_COUNT_LIMIT)
-        collect_function_metrics = is_affirmative(instance.get('collect_function_metrics', False))
+
+        user = self.instance.get('username', '')
+        password = self.instance.get('password', '')
+
+        table_count_limit = self.instance.get('table_count_limit', TABLE_COUNT_LIMIT)
+        collect_function_metrics = is_affirmative(self.instance.get('collect_function_metrics', False))
         # Default value for `count_metrics` is True for backward compatibility
-        collect_count_metrics = is_affirmative(instance.get('collect_count_metrics', True))
-        collect_activity_metrics = is_affirmative(instance.get('collect_activity_metrics', False))
-        collect_database_size_metrics = is_affirmative(instance.get('collect_database_size_metrics', True))
-        collect_default_db = is_affirmative(instance.get('collect_default_database', False))
-        tag_replication_role = is_affirmative(instance.get('tag_replication_role', False))
+        collect_count_metrics = is_affirmative(self.instance.get('collect_count_metrics', True))
+        collect_activity_metrics = is_affirmative(self.instance.get('collect_activity_metrics', False))
+        collect_database_size_metrics = is_affirmative(self.instance.get('collect_database_size_metrics', True))
+        collect_default_db = is_affirmative(self.instance.get('collect_default_database', False))
 
-        if relations and not dbname:
-            self.warning('"dbname" parameter must be set when using the "relations" parameter.')
-
-        if dbname is None:
-            dbname = 'postgres'
-
-        key = (host, port, dbname)
-
-        custom_metrics = self._get_custom_metrics(instance.get('custom_metrics', []), key)
+        custom_metrics = self._get_custom_metrics(instance.get('custom_metrics', []))
         custom_queries = instance.get('custom_queries', [])
 
-        # Clean up tags in case there was a None entry in the instance
-        # e.g. if the yaml contains tags: but no actual tags
-        if tags is None:
-            tags = []
-        else:
-            tags = list(set(tags))
-
-        # preset tags to host
-        tags.append('server:{}'.format(host))
-        if port:
-            tags.append('port:{}'.format(port))
-        else:
-            tags.append('port:socket')
-
-        # preset tags to the database name
-        tags.extend(["db:%s" % dbname])
+        (host, port, dbname) = self.key
 
         self.log.debug("Custom metrics: %s" % custom_metrics)
 
+        tag_replication_role = is_affirmative(self.instance.get('tag_replication_role', False))
+        tags = self.tags
+
         # Collect metrics
+        db = None
         try:
             # Check version
-            db = self.get_connection(key, host, port, user, password, dbname, ssl, tags)
-            version = self._get_version(key, db)
-            self.log.debug("Running check against version %s" % version)
+            db = self.get_connection(host, port, user, password, dbname, ssl, tags)
             if tag_replication_role:
-                tags.extend(["replication_role:{}".format(self._get_replication_role(key, db))])
+                tags.extend(["replication_role:{}".format(self._get_replication_role(db))])
+            version = self._get_version(db)
+            self.log.debug("Running check against version %s" % version)
             self._collect_stats(
-                key,
                 db,
                 user,
                 tags,
-                relations,
+                self.relations,
                 custom_metrics,
                 table_count_limit,
                 collect_function_metrics,
@@ -852,31 +838,16 @@ class PostgreSql(AgentCheck):
                 collect_default_db,
             )
             self._get_custom_queries(db, tags, custom_queries)
-        except ShouldRestartException:
-            self.log.info("Resetting the connection")
-            self._clean_state(key)
-            db = self.get_connection(key, host, port, user, password, dbname, ssl, tags, use_cached=False)
-            self._collect_stats(
-                key,
-                db,
-                user,
-                tags,
-                relations,
-                custom_metrics,
-                table_count_limit,
-                collect_function_metrics,
-                collect_count_metrics,
-                collect_activity_metrics,
-                collect_database_size_metrics,
-                collect_default_db,
-            )
-            self._get_custom_queries(db, tags, custom_queries)
+        except (psycopg2.InterfaceError, socket.error) as e:
+            self.log.info("Connection error, will retry on next agent run")
+            self._clean_state()
 
-        service_check_tags = self._get_service_check_tags(host, port, tags)
-        message = u'Established connection to postgres://%s:%s/%s' % (host, port, dbname)
-        self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK, tags=service_check_tags, message=message)
-        try:
-            # commit to close the current query transaction
-            db.commit()
-        except Exception as e:
-            self.log.warning("Unable to commit: {0}".format(e))
+        if db is not None:
+            service_check_tags = self._get_service_check_tags(host, tags)
+            message = u'Established connection to postgres://%s:%s/%s' % (host, port, dbname)
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK, tags=service_check_tags, message=message)
+            try:
+                # commit to close the current query transaction
+                db.commit()
+            except Exception as e:
+                self.log.warning("Unable to commit: {0}".format(e))

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -30,7 +30,7 @@ def dd_environment(e2e_instance):
 
 @pytest.fixture
 def check():
-    c = PostgreSql('postgres', {}, {})
+    c = PostgreSql('postgres', {}, [{'dbname': 'dbname', 'host':'localhost', 'port': '5432'}])
     c._is_9_2_or_above = mock.MagicMock()
     PostgreSql._known_servers = set()  # reset the global state
     return c

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -42,6 +42,7 @@ def integration_check():
         c = PostgreSql('postgres', {}, [instance])
         c._is_9_2_or_above = mock.MagicMock()
         return c
+
     return _check
 
 

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -35,12 +35,14 @@ def check():
     PostgreSql._known_servers = set()  # reset the global state
     return c
 
+
 @pytest.fixture
 def integration_check():
-    c = PostgreSql('postgres', {}, [{'host': HOST, 'port': PORT, 'username': USER, 'password': PASSWORD, 'dbname': DB_NAME, 'tags': ['foo:bar']}])
-    c._is_9_2_or_above = mock.MagicMock()
-    PostgreSql._known_servers = set()  # reset the global state
-    return c
+    def _check(instance):
+        c = PostgreSql('postgres', {}, [instance])
+        c._is_9_2_or_above = mock.MagicMock()
+        return c
+    return _check
 
 
 @pytest.fixture

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -32,7 +32,6 @@ def dd_environment(e2e_instance):
 def check():
     c = PostgreSql('postgres', {}, [{'dbname': 'dbname', 'host': 'localhost', 'port': '5432'}])
     c._is_9_2_or_above = mock.MagicMock()
-    PostgreSql._known_servers = set()  # reset the global state
     return c
 
 

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -30,7 +30,14 @@ def dd_environment(e2e_instance):
 
 @pytest.fixture
 def check():
-    c = PostgreSql('postgres', {}, [{'dbname': 'dbname', 'host':'localhost', 'port': '5432'}])
+    c = PostgreSql('postgres', {}, [{'dbname': 'dbname', 'host': 'localhost', 'port': '5432'}])
+    c._is_9_2_or_above = mock.MagicMock()
+    PostgreSql._known_servers = set()  # reset the global state
+    return c
+
+@pytest.fixture
+def integration_check():
+    c = PostgreSql('postgres', {}, [{'host': HOST, 'port': PORT, 'username': USER, 'password': PASSWORD, 'dbname': DB_NAME, 'tags': ['foo:bar']}])
     c._is_9_2_or_above = mock.MagicMock()
     PostgreSql._known_servers = set()  # reset the global state
     return c

--- a/postgres/tests/test_custom_metrics.py
+++ b/postgres/tests/test_custom_metrics.py
@@ -24,7 +24,7 @@ def test_custom_metrics(aggregator, pg_instance):
             ],
         }
     )
-    postgres_check = PostgreSql('postgres', {}, [])
+    postgres_check = PostgreSql('postgres', {}, [pg_instance])
     postgres_check.check(pg_instance)
 
     tags = ['customdb:a', 'server:{}'.format(pg_instance['host']), 'port:{}'.format(pg_instance['port'])]
@@ -54,7 +54,7 @@ def test_custom_queries(aggregator, pg_instance):
             ]
         }
     )
-    postgres_check = PostgreSql('postgres', {}, [])
+    postgres_check = PostgreSql('postgres', {}, [pg_instance])
     postgres_check.check(pg_instance)
     tags = [
         'db:{}'.format(pg_instance['dbname']),

--- a/postgres/tests/test_custom_metrics.py
+++ b/postgres/tests/test_custom_metrics.py
@@ -24,7 +24,7 @@ def test_custom_metrics(aggregator, pg_instance):
             ],
         }
     )
-    postgres_check = PostgreSql('postgres', {}, {})
+    postgres_check = PostgreSql('postgres', {}, [])
     postgres_check.check(pg_instance)
 
     tags = ['customdb:a', 'server:{}'.format(pg_instance['host']), 'port:{}'.format(pg_instance['port'])]
@@ -54,7 +54,7 @@ def test_custom_queries(aggregator, pg_instance):
             ]
         }
     )
-    postgres_check = PostgreSql('postgres', {}, {})
+    postgres_check = PostgreSql('postgres', {}, [])
     postgres_check.check(pg_instance)
     tags = [
         'db:{}'.format(pg_instance['dbname']),

--- a/postgres/tests/test_integration.py
+++ b/postgres/tests/test_integration.py
@@ -1,10 +1,11 @@
 # (C) Datadog, Inc. 2010-2018
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import socket
+
 import mock
 import psycopg2
 import pytest
-import socket
 
 from datadog_checks.postgres import PostgreSql
 

--- a/postgres/tests/test_integration.py
+++ b/postgres/tests/test_integration.py
@@ -4,9 +4,9 @@
 import mock
 import psycopg2
 import pytest
+import socket
 
 from datadog_checks.postgres import PostgreSql
-from datadog_checks.postgres.postgres import ShouldRestartException
 
 from .common import DB_NAME, HOST, PORT, POSTGRES_VERSION, check_bgw_metrics, check_common_metrics
 from .utils import requires_over_10
@@ -141,7 +141,7 @@ def test_state_clears_on_connection_error(check, pg_instance):
         if throw_exception_first_time.counter > 1:
             pass  # avoid throwing exception again
         else:
-            raise ShouldRestartException
+            raise socket.error
 
     throw_exception_first_time.counter = 0
 

--- a/postgres/tests/test_integration.py
+++ b/postgres/tests/test_integration.py
@@ -24,7 +24,8 @@ ACTIVITY_METRICS = [
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_common_metrics(aggregator, integration_check, pg_instance):
-    integration_check.check(pg_instance)
+    check = integration_check(pg_instance)
+    check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + ['server:{}'.format(HOST), 'port:{}'.format(PORT)]
     check_bgw_metrics(aggregator, expected_tags)
@@ -37,20 +38,22 @@ def test_common_metrics(aggregator, integration_check, pg_instance):
 @pytest.mark.usefixtures('dd_environment')
 def test_common_metrics_without_size(aggregator, integration_check, pg_instance):
     pg_instance['collect_database_size_metrics'] = False
-    integration_check.check(pg_instance)
+    check = integration_check(pg_instance)
+    check.check(pg_instance)
     assert 'postgresql.database_size' not in aggregator.metric_names
 
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_can_connect_service_check(aggregator, integration_check, pg_instance):
+    check = integration_check(pg_instance)
     expected_tags = pg_instance['tags'] + [
         'host:{}'.format(HOST),
         'server:{}'.format(HOST),
         'port:{}'.format(PORT),
         'db:{}'.format(DB_NAME),
     ]
-    integration_check.check(pg_instance)
+    check.check(pg_instance)
     aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.OK, tags=expected_tags)
 
 
@@ -58,7 +61,8 @@ def test_can_connect_service_check(aggregator, integration_check, pg_instance):
 @pytest.mark.usefixtures('dd_environment')
 def test_schema_metrics(aggregator, integration_check, pg_instance):
     pg_instance['table_count_limit'] = 1
-    integration_check.check(pg_instance)
+    check = integration_check(pg_instance)
+    check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + [
         'db:{}'.format(DB_NAME),
@@ -73,7 +77,8 @@ def test_schema_metrics(aggregator, integration_check, pg_instance):
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_connections_metrics(aggregator, integration_check, pg_instance):
-    integration_check.check(pg_instance)
+    check = integration_check(pg_instance)
+    check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + ['server:{}'.format(HOST), 'port:{}'.format(PORT)]
     for name in CONNECTION_METRICS:
@@ -85,10 +90,11 @@ def test_connections_metrics(aggregator, integration_check, pg_instance):
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_locks_metrics(aggregator, integration_check, pg_instance):
+    check = integration_check(pg_instance)
     with psycopg2.connect(host=HOST, dbname=DB_NAME, user="postgres") as conn:
         with conn.cursor() as cur:
             cur.execute('LOCK persons')
-            integration_check.check(pg_instance)
+            check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + [
         'server:{}'.format(HOST),
@@ -105,7 +111,8 @@ def test_locks_metrics(aggregator, integration_check, pg_instance):
 @pytest.mark.usefixtures('dd_environment')
 def test_activity_metrics(aggregator, integration_check, pg_instance):
     pg_instance['collect_activity_metrics'] = True
-    integration_check.check(pg_instance)
+    check = integration_check(pg_instance)
+    check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + ['server:{}'.format(HOST), 'port:{}'.format(PORT), 'db:datadog_test']
     for name in ACTIVITY_METRICS:
@@ -116,25 +123,24 @@ def test_activity_metrics(aggregator, integration_check, pg_instance):
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_wrong_version(aggregator, integration_check, pg_instance):
+    check = integration_check(pg_instance)
     # Enforce to cache wrong version
-    db_key = ('localhost', 5432, 'datadog_test')
-    integration_check.version = [9, 6, 0]
+    check.version = [9, 6, 0]
 
-    integration_check.check(pg_instance)
-    assert_state_clean(integration_check)
+    check.check(pg_instance)
+    assert_state_clean(check)
 
-    integration_check.check(pg_instance)
-    assert integration_check.version[0] == int(POSTGRES_VERSION)
-    assert_state_set(integration_check)
+    check.check(pg_instance)
+    assert check.version[0] == int(POSTGRES_VERSION)
+    assert_state_set(check)
 
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_state_clears_on_connection_error(integration_check, pg_instance):
-    db_key = ('localhost', 5432, 'datadog_test')
-
-    integration_check.check(pg_instance)
-    assert_state_set(integration_check, db_key)
+    check = integration_check(pg_instance)
+    check.check(pg_instance)
+    assert_state_set(check)
 
     def throw_exception_first_time(*args, **kwargs):
         throw_exception_first_time.counter += 1
@@ -146,8 +152,8 @@ def test_state_clears_on_connection_error(integration_check, pg_instance):
     throw_exception_first_time.counter = 0
 
     with mock.patch('datadog_checks.postgres.PostgreSql._collect_stats', side_effect=throw_exception_first_time):
-        integration_check.check(pg_instance)
-    assert_state_clean(integration_check, db_key)
+        check.check(pg_instance)
+    assert_state_clean(check)
 
 
 def assert_state_clean(check):
@@ -162,7 +168,7 @@ def assert_state_clean(check):
 
 
 def assert_state_set(check,):
-    assert check.versions
+    assert check.version
     assert check.instance_metrics
     assert check.bgw_metrics
     if POSTGRES_VERSION != '9.3':

--- a/postgres/tests/test_integration.py
+++ b/postgres/tests/test_integration.py
@@ -23,8 +23,8 @@ ACTIVITY_METRICS = [
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_common_metrics(aggregator, check, pg_instance):
-    check.check(pg_instance)
+def test_common_metrics(aggregator, integration_check, pg_instance):
+    integration_check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + ['server:{}'.format(HOST), 'port:{}'.format(PORT)]
     check_bgw_metrics(aggregator, expected_tags)
@@ -35,30 +35,30 @@ def test_common_metrics(aggregator, check, pg_instance):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_common_metrics_without_size(aggregator, check, pg_instance):
+def test_common_metrics_without_size(aggregator, integration_check, pg_instance):
     pg_instance['collect_database_size_metrics'] = False
-    check.check(pg_instance)
+    integration_check.check(pg_instance)
     assert 'postgresql.database_size' not in aggregator.metric_names
 
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_can_connect_service_check(aggregator, check, pg_instance):
+def test_can_connect_service_check(aggregator, integration_check, pg_instance):
     expected_tags = pg_instance['tags'] + [
         'host:{}'.format(HOST),
         'server:{}'.format(HOST),
         'port:{}'.format(PORT),
         'db:{}'.format(DB_NAME),
     ]
-    check.check(pg_instance)
+    integration_check.check(pg_instance)
     aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.OK, tags=expected_tags)
 
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_schema_metrics(aggregator, check, pg_instance):
+def test_schema_metrics(aggregator, integration_check, pg_instance):
     pg_instance['table_count_limit'] = 1
-    check.check(pg_instance)
+    integration_check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + [
         'db:{}'.format(DB_NAME),
@@ -72,8 +72,8 @@ def test_schema_metrics(aggregator, check, pg_instance):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_connections_metrics(aggregator, check, pg_instance):
-    check.check(pg_instance)
+def test_connections_metrics(aggregator, integration_check, pg_instance):
+    integration_check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + ['server:{}'.format(HOST), 'port:{}'.format(PORT)]
     for name in CONNECTION_METRICS:
@@ -84,11 +84,11 @@ def test_connections_metrics(aggregator, check, pg_instance):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_locks_metrics(aggregator, check, pg_instance):
+def test_locks_metrics(aggregator, integration_check, pg_instance):
     with psycopg2.connect(host=HOST, dbname=DB_NAME, user="postgres") as conn:
         with conn.cursor() as cur:
             cur.execute('LOCK persons')
-            check.check(pg_instance)
+            integration_check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + [
         'server:{}'.format(HOST),
@@ -103,9 +103,9 @@ def test_locks_metrics(aggregator, check, pg_instance):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_activity_metrics(aggregator, check, pg_instance):
+def test_activity_metrics(aggregator, integration_check, pg_instance):
     pg_instance['collect_activity_metrics'] = True
-    check.check(pg_instance)
+    integration_check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + ['server:{}'.format(HOST), 'port:{}'.format(PORT), 'db:datadog_test']
     for name in ACTIVITY_METRICS:
@@ -115,26 +115,26 @@ def test_activity_metrics(aggregator, check, pg_instance):
 @requires_over_10
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_wrong_version(aggregator, check, pg_instance):
+def test_wrong_version(aggregator, integration_check, pg_instance):
     # Enforce to cache wrong version
     db_key = ('localhost', 5432, 'datadog_test')
-    check.versions[db_key] = [9, 6, 0]
+    integration_check.version = [9, 6, 0]
 
-    check.check(pg_instance)
-    assert_state_clean(check, db_key)
+    integration_check.check(pg_instance)
+    assert_state_clean(integration_check)
 
-    check.check(pg_instance)
-    assert check.versions[db_key][0] == int(POSTGRES_VERSION)
-    assert_state_set(check, db_key)
+    integration_check.check(pg_instance)
+    assert integration_check.version[0] == int(POSTGRES_VERSION)
+    assert_state_set(integration_check)
 
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_state_clears_on_connection_error(check, pg_instance):
+def test_state_clears_on_connection_error(integration_check, pg_instance):
     db_key = ('localhost', 5432, 'datadog_test')
 
-    check.check(pg_instance)
-    assert_state_set(check, db_key)
+    integration_check.check(pg_instance)
+    assert_state_set(integration_check, db_key)
 
     def throw_exception_first_time(*args, **kwargs):
         throw_exception_first_time.counter += 1
@@ -146,27 +146,27 @@ def test_state_clears_on_connection_error(check, pg_instance):
     throw_exception_first_time.counter = 0
 
     with mock.patch('datadog_checks.postgres.PostgreSql._collect_stats', side_effect=throw_exception_first_time):
-        check.check(pg_instance)
-    assert_state_clean(check, db_key)
+        integration_check.check(pg_instance)
+    assert_state_clean(integration_check, db_key)
 
 
-def assert_state_clean(check, db_key):
-    assert db_key not in check.versions
-    assert db_key not in check.instance_metrics
-    assert db_key not in check.bgw_metrics
-    assert db_key not in check.archiver_metrics
+def assert_state_clean(check):
+    assert check.version is None
+    assert check.instance_metrics is None
+    assert check.bgw_metrics is None
+    assert check.archiver_metrics is None
     assert check.db_bgw_metrics == []
     assert check.db_archiver_metrics == []
-    assert db_key not in check.replication_metrics
-    assert db_key not in check.activity_metrics
+    assert check.replication_metrics is None
+    assert check.activity_metrics is None
 
 
-def assert_state_set(check, db_key):
-    assert db_key in check.versions
-    assert db_key in check.instance_metrics
-    assert db_key in check.bgw_metrics
+def assert_state_set(check,):
+    assert check.versions
+    assert check.instance_metrics
+    assert check.bgw_metrics
     if POSTGRES_VERSION != '9.3':
-        assert db_key in check.archiver_metrics
+        assert check.archiver_metrics
         assert check.db_archiver_metrics != []
     assert check.db_bgw_metrics != []
-    assert db_key in check.replication_metrics
+    assert check.replication_metrics

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -3,8 +3,6 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import pytest
 
-from datadog_checks.postgres import PostgreSql
-
 RELATION_METRICS = [
     'postgresql.seq_scans',
     'postgresql.seq_rows_read',

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -37,10 +37,10 @@ IDX_METRICS = ['postgresql.index_scans', 'postgresql.index_rows_read', 'postgres
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_relations_metrics(aggregator, pg_instance):
+def test_relations_metrics(aggregator, integration_check, pg_instance):
     pg_instance['relations'] = ['persons']
 
-    posgres_check = PostgreSql('postgres', {}, [pg_instance])
+    posgres_check = integration_check(pg_instance)
     posgres_check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + [
@@ -72,14 +72,14 @@ def test_relations_metrics(aggregator, pg_instance):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_relations_metrics2(aggregator, pg_instance):
+def test_relations_metrics2(aggregator, integration_check, pg_instance):
     pg_instance['relations'] = [
         {'relation_regex': '.*', 'schemas': ['hello', 'hello2']},
         # Empty schemas means all schemas, even though the first relation matches first.
         {'relation_regex': r'[pP]ersons[-_]?(dup\d)?'},
     ]
     relations = ['persons', 'personsdup1', 'Personsdup2']
-    posgres_check = PostgreSql('postgres', {}, [pg_instance])
+    posgres_check = integration_check(pg_instance)
     posgres_check.check(pg_instance)
 
     expected_tags = {}
@@ -114,11 +114,11 @@ def test_relations_metrics2(aggregator, pg_instance):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_index_metrics(aggregator, pg_instance):
+def test_index_metrics(aggregator, integration_check, pg_instance):
     pg_instance['relations'] = ['breed']
     pg_instance['dbname'] = 'dogs'
 
-    posgres_check = PostgreSql('postgres', {}, [pg_instance])
+    posgres_check = integration_check(pg_instance)
     posgres_check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + [

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -40,7 +40,7 @@ IDX_METRICS = ['postgresql.index_scans', 'postgresql.index_rows_read', 'postgres
 def test_relations_metrics(aggregator, pg_instance):
     pg_instance['relations'] = ['persons']
 
-    posgres_check = PostgreSql('postgres', {}, {})
+    posgres_check = PostgreSql('postgres', {}, [pg_instance])
     posgres_check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + [
@@ -79,7 +79,7 @@ def test_relations_metrics2(aggregator, pg_instance):
         {'relation_regex': r'[pP]ersons[-_]?(dup\d)?'},
     ]
     relations = ['persons', 'personsdup1', 'Personsdup2']
-    posgres_check = PostgreSql('postgres', {}, {})
+    posgres_check = PostgreSql('postgres', {}, [pg_instance])
     posgres_check.check(pg_instance)
 
     expected_tags = {}
@@ -118,7 +118,7 @@ def test_index_metrics(aggregator, pg_instance):
     pg_instance['relations'] = ['breed']
     pg_instance['dbname'] = 'dogs'
 
-    posgres_check = PostgreSql('postgres', {}, {})
+    posgres_check = PostgreSql('postgres', {}, [pg_instance])
     posgres_check.check(pg_instance)
 
     expected_tags = pg_instance['tags'] + [

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -16,7 +16,7 @@ def test_get_instance_metrics_lt_92(check):
     check output when 9.2+
     """
     check._is_9_2_or_above.return_value = False
-    res = check._get_instance_metrics(False, False)
+    res = check._get_instance_metrics('dbname', False, False)
     assert res['metrics'] == util.COMMON_METRICS
 
 
@@ -25,7 +25,7 @@ def test_get_instance_metrics_92(check):
     check output when <9.2
     """
     check._is_9_2_or_above.return_value = True
-    res = check._get_instance_metrics(False, False)
+    res = check._get_instance_metrics('dbname', False, False)
     assert res['metrics'] == dict(util.COMMON_METRICS, **util.NEWER_92_METRICS)
 
 
@@ -33,10 +33,10 @@ def test_get_instance_metrics_state(check):
     """
     Ensure data is consistent when the function is called more than once
     """
-    res = check._get_instance_metrics(False, False)
+    res = check._get_instance_metrics('dbname', False, False)
     assert res['metrics'] == dict(util.COMMON_METRICS, **util.NEWER_92_METRICS)
     check._is_9_2_or_above.side_effect = Exception  # metrics were cached so this shouldn't be called
-    res = check._get_instance_metrics([], False)
+    res = check._get_instance_metrics('dbname', [], False)
     assert res['metrics'] == dict(util.COMMON_METRICS, **util.NEWER_92_METRICS)
 
 
@@ -47,7 +47,7 @@ def test_get_instance_metrics_database_size_metrics(check):
     expected = util.COMMON_METRICS
     expected.update(util.NEWER_92_METRICS)
     expected.update(util.DATABASE_SIZE_METRICS)
-    res = check._get_instance_metrics(True, False)
+    res = check._get_instance_metrics('dbname', True, False)
     assert res['metrics'] == expected
 
 
@@ -56,11 +56,11 @@ def test_get_instance_with_default(check):
     Test the contents of the query string with different `collect_default_db` values
     """
     collect_default_db = False
-    res = check._get_instance_metrics(False, collect_default_db)
+    res = check._get_instance_metrics('dbname', False, collect_default_db)
     assert "  AND psd.datname not ilike 'postgres'" in res['query']
 
     collect_default_db = True
-    res = check._get_instance_metrics(False, collect_default_db)
+    res = check._get_instance_metrics('dbname', False, collect_default_db)
     assert "  AND psd.datname not ilike 'postgres'" not in res['query']
 
 
@@ -122,7 +122,6 @@ def test_is_above(check):
 
     # Test beta version above
     db.cursor().fetchone.return_value = ['11beta4']
-    check._clean_state()
     check._clean_state()
     assert check._is_above(db, [11, -1, 3])
 

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -39,11 +39,6 @@ def test_get_instance_metrics_state(check):
     res = check._get_instance_metrics([], False)
     assert res['metrics'] == dict(util.COMMON_METRICS, **util.NEWER_92_METRICS)
 
-    # also check what happens when `metrics` is not valid
-    check.instance_metrics = []
-    res = check._get_instance_metrics(False, False)
-    assert res is None
-
 
 def test_get_instance_metrics_database_size_metrics(check):
     """


### PR DESCRIPTION
Remove multi instance support from postgres check as it makes the code unnecessarily complicated and is not needed in agent 6
It also removes retry within check, it will instead retry on next agent run