### PR TITLE
Fix check when vault is sealed

### DIFF
--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -32,14 +32,16 @@ class Vault(AgentCheck):
 
     # Expected HTTP Error codes for /sys/health endpoint
     # https://www.vaultproject.io/api/system/health.html
-    SYS_HEALTH_DEFAULT_CODES = {
-        200: "initialized, unsealed, and active",
-        429: "unsealed and standby",
-        472: "data recovery mode replication secondary and active",
-        473: "performance standby",
-        501: "not initialized",
-        503: "sealed",
-    }
+    SYS_HEALTH_DEFAULT_CODES = [
+        200,  # "initialized, unsealed, and active",
+        429,  # "unsealed and standby",
+        472,  # "data recovery mode replication secondary and active",
+        473,  # "performance standby",
+        501,  # "not initialized",
+        503,  # "sealed",
+    ]
+
+    SYS_LEADER_DEFAULT_CODES = [503]  # "sealed"
 
     def __init__(self, name, init_config, instances):
         super(Vault, self).__init__(name, init_config, instances)
@@ -68,9 +70,8 @@ class Vault(AgentCheck):
         self.service_check(self.SERVICE_CHECK_CONNECT, AgentCheck.OK, tags=tags)
 
     def check_leader_v1(self, config, tags):
-        path = '/sys/leader'
-        url = config['api_url']
-        leader_data = self.access_api(url, path, tags)
+        url = config['api_url'] + '/sys/leader'
+        leader_data = self.access_api(url, tags, ignore_status_codes=Vault.SYS_LEADER_DEFAULT_CODES)
 
         is_leader = is_affirmative(leader_data.get('is_self'))
         tags.append('is_leader:{}'.format('true' if is_leader else 'false'))
@@ -96,9 +97,8 @@ class Vault(AgentCheck):
             config['leader'] = current_leader
 
     def check_health_v1(self, config, tags):
-        path = '/sys/health'
-        url = config['api_url']
-        health_data = self.access_api(url, path, tags)
+        url = config['api_url'] + '/sys/health'
+        health_data = self.access_api(url, tags, ignore_status_codes=Vault.SYS_HEALTH_DEFAULT_CODES)
 
         cluster_name = health_data.get('cluster_name')
         if cluster_name:
@@ -131,8 +131,7 @@ class Vault(AgentCheck):
                 api_version = api_url[-1]
                 if api_version not in self.api_versions:
                     self.log.warning(
-                        'Unknown Vault API version `{}`, using version '
-                        '`{}`'.format(api_version, self.DEFAULT_API_VERSION)
+                        'Unknown Vault API version `%s`, using version ' '`%s`', api_version, self.DEFAULT_API_VERSION
                     )
                     api_url = api_url[:-1] + self.DEFAULT_API_VERSION
                     api_version = self.DEFAULT_API_VERSION
@@ -153,34 +152,31 @@ class Vault(AgentCheck):
 
         return config
 
-    def access_api(self, url, path, tags, params=None):
+    def access_api(self, url, tags, ignore_status_codes=None):
+        if ignore_status_codes is None:
+            ignore_status_codes = []
+
         try:
-            full_url = url + path
-            response = self.http.get(full_url, params=params)
-            json_data = response.json()
-            response.raise_for_status()
-        except requests.exceptions.HTTPError:
-            rsc = response.status_code
-            msg = 'The Vault endpoint `{}` returned {}'.format(full_url, rsc)
-            if path.endswith("/sys/health") and rsc in self.SYS_HEALTH_DEFAULT_CODES:
-                # Ignores expected HTTPError status codes for `/sys/health` endpoint.
-                self.log.debug('{} - node is {}.'.format(msg, self.SYS_HEALTH_DEFAULT_CODES[rsc]))
-            else:
+            response = self.http.get(url)
+            status_code = response.status_code
+            if status_code >= 400 and status_code not in ignore_status_codes:
+                msg = 'The Vault endpoint `{}` returned {}'.format(url, status_code)
                 self.service_check(self.SERVICE_CHECK_CONNECT, AgentCheck.CRITICAL, message=msg, tags=tags)
                 self.log.exception(msg)
                 raise ApiUnreachable
+            json_data = response.json()
         except JSONDecodeError:
-            msg = 'The Vault endpoint `{}` returned invalid json data.'.format(full_url)
+            msg = 'The Vault endpoint `{}` returned invalid json data.'.format(url)
             self.service_check(self.SERVICE_CHECK_CONNECT, AgentCheck.CRITICAL, message=msg, tags=tags)
             self.log.exception(msg)
             raise ApiUnreachable
         except requests.exceptions.Timeout:
-            msg = 'Vault endpoint `{}` timed out after {} seconds'.format(full_url, self.http.options['timeout'])
+            msg = 'Vault endpoint `{}` timed out after {} seconds'.format(url, self.http.options['timeout'])
             self.service_check(self.SERVICE_CHECK_CONNECT, AgentCheck.CRITICAL, message=msg, tags=tags)
             self.log.exception(msg)
             raise ApiUnreachable
         except (requests.exceptions.RequestException, requests.exceptions.ConnectionError):
-            msg = 'Error accessing Vault endpoint `{}`'.format(full_url)
+            msg = 'Error accessing Vault endpoint `{}`'.format(url)
             self.service_check(self.SERVICE_CHECK_CONNECT, AgentCheck.CRITICAL, message=msg, tags=tags)
             self.log.exception(msg)
             raise ApiUnreachable

--- a/vault/tests/test_vault.py
+++ b/vault/tests/test_vault.py
@@ -335,7 +335,8 @@ class TestVault:
 
         aggregator.assert_metric('vault.is_leader', 0)
 
-    def test_ha_is_standby(self, aggregator):
+    @pytest.mark.parametrize('status_code', [200, 429, 472, 473, 501, 503])
+    def test_sys_health_non_standard_status_codes(self, aggregator, status_code):
         instance = INSTANCES['main']
         c = Vault(Vault.CHECK_NAME, {}, [instance])
 
@@ -359,7 +360,7 @@ class TestVault:
                         'performance_standby': False,
                         'version': '0.10.2',
                     },
-                    status_code=429,
+                    status_code=status_code,
                 )
             return requests_get(url, *args, **kwargs)
 
@@ -368,7 +369,7 @@ class TestVault:
         aggregator.assert_metric('vault.is_leader', 1)
         aggregator.assert_all_metrics_covered()
 
-    def test_ha_is_perf_standby(self, aggregator):
+    def test_sys_leader_non_standard_status_codes(self, aggregator):
         instance = INSTANCES['main']
         c = Vault(Vault.CHECK_NAME, {}, [instance])
 
@@ -378,7 +379,7 @@ class TestVault:
         requests_get = requests.get
 
         def mock_requests_get(url, *args, **kwargs):
-            if url == config['api_url'] + '/sys/health':
+            if url == config['api_url'] + '/sys/leader':
                 return MockResponse(
                     {
                         'cluster_id': '9e25ccdb-09ea-8bd8-0521-34cf3ef7a4cc',
@@ -388,11 +389,11 @@ class TestVault:
                         'replication_performance_mode': 'disabled',
                         'sealed': False,
                         'server_time_utc': 1529357080,
-                        'standby': False,
-                        'performance_standby': True,
+                        'standby': True,
+                        'performance_standby': False,
                         'version': '0.10.2',
                     },
-                    status_code=473,
+                    status_code=503,
                 )
             return requests_get(url, *args, **kwargs)
 


### PR DESCRIPTION
Extension to https://github.com/DataDog/integrations-core/pull/4745 which was not completely fixing the issue.
The `/sys/leader` endpoint can also return 503 when the vault is sealed. This had to be taken into account.