### PR TITLE
Fix job metrics for job with no timestamp and added a test

### DIFF
--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -172,6 +172,7 @@ kube_job_spec_parallelism{job="hello-1509998460",namespace="default"} 1
 kube_job_status_active{job="hello-1509998340",namespace="default"} 0
 kube_job_status_active{job="hello-1509998400",namespace="default"} 0
 kube_job_status_active{job="hello-1509998460",namespace="default"} 0
+kube_job_status_active{job_name="bangkok",namespace="default"} 1
 # HELP kube_job_status_completion_time CompletionTime represents time when the job was completed.
 # TYPE kube_job_status_completion_time counter
 kube_job_status_completion_time{job="hello-1509998340",namespace="default"} 1.509998351e+09
@@ -198,6 +199,7 @@ kube_job_status_succeeded{job="hello-1509998460",namespace="default"} 1
 kube_job_status_succeeded{job_name="hello2-1509998340",namespace="default"} 1
 kube_job_status_succeeded{job_name="hello2-1509998400",namespace="default"} 1
 kube_job_status_succeeded{job_name="hello2-1509998460",namespace="default"} 1
+kube_job_status_succeeded{job_name="bangkok",namespace="default"} 1
 # HELP kube_namespace_created Unix creation timestamp
 # TYPE kube_namespace_created gauge
 kube_namespace_created{namespace="default"} 1.508406437e+09


### PR DESCRIPTION
### What does this PR do?

The last code fix did not include job with no timestamps, meaning regular jobs and not cron jobs.
This PR adds another level on the logic to use job with no timestamps.
This PR also adds a test for this use case.

### Motivation

Few customers reached out about their jobs not being counted in the metric job.succeeded and job.failed.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
