### PR TITLE
Add forward metrics

### DIFF
--- a/coredns/datadog_checks/coredns/coredns.py
+++ b/coredns/datadog_checks/coredns/coredns.py
@@ -16,6 +16,12 @@ DEFAULT_METRICS = {
     'coredns_proxy_request_duration_seconds': 'proxy_request_duration.seconds',
     'coredns_cache_size': 'cache_size.count',
     'coredns_panic_count_total': 'panic_count.count',
+    'coredns_forward_request_duration_seconds': 'forward_request_duration.seconds',
+    'coredns_forward_request_count_total': 'forward_request_count',
+    'coredns_forward_response_rcode_count_total': 'forward_response_rcode_count',
+    'coredns_forward_healthcheck_failure_count_total': 'forward_healthcheck_failure_count',
+    'coredns_forward_healthcheck_broken_count_total': 'forward_healthcheck_broken_count',
+    'coredns_forward_sockets_open': 'forward_sockets_open',
 }
 
 

--- a/coredns/datadog_checks/coredns/data/auto_conf.yaml
+++ b/coredns/datadog_checks/coredns/data/auto_conf.yaml
@@ -32,7 +32,7 @@ instances:
     #  send_monotonic_counter: true
 
     ## @param metrics - list of strings - optional
-    ## Metrics from the CoreDNS plugins for 'metrics', 'proxy' and 'cache'
+    ## Metrics from the CoreDNS plugins for 'metrics', 'proxy', 'forward' and 'cache'
     ## are enabled by default, however in order to scrape metrics for optional
     ## plugins, enable the plugin in the CoreDNS corefile and then add the metric below.
     ## As an example, the 'template' plugin's metrics are below

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -29,7 +29,7 @@ instances:
     # send_monotonic_counter: true
 
     ## @param metrics - list of strings - optional
-    ## Metrics from the CoreDNS plugins for 'metrics', 'proxy' and 'cache'
+    ## Metrics from the CoreDNS plugins for 'metrics', 'proxy', 'forward' and 'cache'
     ## are enabled by default, however in order to scrape metrics for optional
     ## plugins, enable the plugin in the CoreDNS corefile and then add the metric below.
     ## As an example, the 'template' plugin's metrics are below.

--- a/coredns/metadata.csv
+++ b/coredns/metadata.csv
@@ -9,6 +9,13 @@ coredns.request_duration.seconds.sum,gauge,,second,,duration to process each que
 coredns.request_duration.seconds.count,count,,second,,duration to process each query,-1,coredns,request duration
 coredns.proxy_request_duration.seconds.sum,gauge,,second,,duration per upstream interaction,-1,coredns,proxy request duration
 coredns.proxy_request_duration.seconds.count,count,,second,,duration per upstream interaction,-1,coredns,proxy request duration
+coredns.forward_request_duration.seconds.sum,gauge,,second,,duration per upstream interaction,-1,coredns,forward request duration
+coredns.forward_request_duration.seconds.count,count,,second,,duration per upstream interaction,-1,coredns,forward request duration
+coredns.forward_request_count,count,,request,,query count per upstream,1,coredns,forward request count
+coredns.forward_response_rcode_count,count,,response,,count of RCODEs per upstream,0,coredns,forward rcodes
+coredns.forward_healthcheck_failure_count,count,,entry,,number of failed health checks per upstream,-1,coredns,forward failed healthchecks
+coredns.forward_healthcheck_broken_count,count,,entry,,counter of when all upstreams are unhealthy,-1,coredns,forward all healthchecks broken
+coredns.forward_sockets_open,gauge,,connection,,number of sockets open per upstream,-1,coredns,forward open sockets
 coredns.request_size.bytes.sum,gauge,,byte,,size of the request in bytes,0,coredns,request size
 coredns.request_size.bytes.count,count,,byte,,size of the request in bytes,0,coredns,request size
 coredns.response_size.bytes.sum,gauge,,byte,,size of the request in bytes,0,coredns,response size

--- a/coredns/tests/common.py
+++ b/coredns/tests/common.py
@@ -16,4 +16,9 @@ METRICS = [
     NAMESPACE + '.proxy_request_duration.seconds.count',
     NAMESPACE + '.request_duration.seconds.sum',
     NAMESPACE + '.request_duration.seconds.count',
+    NAMESPACE + '.forward_request_count',
+    NAMESPACE + '.forward_request_duration.seconds.sum',
+    NAMESPACE + '.forward_request_duration.seconds.count',
+    NAMESPACE + '.forward_response_rcode_count',
+    NAMESPACE + '.forward_sockets_open',
 ]

--- a/coredns/tests/conftest.py
+++ b/coredns/tests/conftest.py
@@ -15,10 +15,12 @@ from datadog_checks.utils.common import get_docker_hostname
 HERE = os.path.dirname(os.path.abspath(__file__))
 CONFIG_FOLDER = os.path.join(HERE, 'docker', 'coredns')
 HOST = get_docker_hostname()
+ATHOST = "@{}".format(HOST)
 PORT = '9153'
 URL = "http://{}:{}/metrics".format(HOST, PORT)
 
-DIG_ARGS = ["dig", "google.com", "@127.0.0.1", "-p", "54"]
+# One lookup each for the forward and proxy plugins
+DIG_ARGS = ["dig", "google.com", ATHOST, "example.com", ATHOST, "-p", "54"]
 
 
 def init_coredns():

--- a/coredns/tests/docker/coredns/Corefile
+++ b/coredns/tests/docker/coredns/Corefile
@@ -2,6 +2,8 @@
     errors
     health
     prometheus :9153
+    # forward runs before proxy, no matter the order here
+    forward example.com. /etc/resolv.conf
     proxy . /etc/resolv.conf
     cache 30
 }

--- a/coredns/tests/fixtures/metrics.txt
+++ b/coredns/tests/fixtures/metrics.txt
@@ -148,6 +148,37 @@ coredns_health_request_duration_seconds_count 1.32441e+06
 # HELP coredns_panic_count_total A metrics that counts the number of panics.
 # TYPE coredns_panic_count_total counter
 coredns_panic_count_total 0
+# HELP coredns_forward_request_count_total Counter of requests made per upstream.
+# TYPE coredns_forward_request_count_total counter
+coredns_forward_request_count_total{to="10.0.0.2:53"} 22000
+# HELP coredns_forward_request_duration_seconds Histogram of the time each request took.
+# TYPE coredns_forward_request_duration_seconds histogram
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.00025"} 6163
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.0005"} 6548
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.001"} 14705
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.002"} 20805
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.004"} 21318
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.008"} 21698
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.016"} 21874
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.032"} 21957
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.064"} 21982
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.128"} 21996
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.256"} 21999
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.512"} 21999
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="1.024"} 21999
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="2.048"} 22000
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="4.096"} 22000
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="8.192"} 22000
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="+Inf"} 22000
+coredns_forward_request_duration_seconds_sum{to="10.0.0.2:53"} 27.835685092999963
+coredns_forward_request_duration_seconds_count{to="10.0.0.2:53"} 22000
+# HELP coredns_forward_response_rcode_count_total Counter of requests made per upstream.
+# TYPE coredns_forward_response_rcode_count_total counter
+coredns_forward_response_rcode_count_total{rcode="NOERROR",to="10.0.0.2:53"} 1518
+coredns_forward_response_rcode_count_total{rcode="NXDOMAIN",to="10.0.0.2:53"} 20482
+# HELP coredns_forward_sockets_open Gauge of open sockets per upstream.
+# TYPE coredns_forward_sockets_open gauge
+coredns_forward_sockets_open{to="10.0.0.2:53"} 2
 # HELP coredns_proxy_request_count_total Counter of requests made per protocol, proxy protocol, family and upstream.
 # TYPE coredns_proxy_request_count_total counter
 coredns_proxy_request_count_total{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53"} 2031


### PR DESCRIPTION
### What does this PR do?

Add CoreDNS metrics for the forward plugin

### Motivation

The proxy plugin is deprecated and has been removed in recent versions, with users expected to replace it with the forward plugin.

### Additional Notes

I couldn't grab data for all tests: healtcheck failures are missing.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
