### PR TITLE
Change the label map from `team/platform` to `team/agent-platform`.

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
@@ -22,11 +22,11 @@ class TrelloClient:
         self.label_team_map = {
             'team/agent-apm': 'Trace',
             'team/agent-core': 'Core',
+            'team/agent-platform': 'Platform',
             'team/burrito': 'Process',
             'team/containers': 'Containers',
             'team/integrations': 'Integrations',
             'team/logs': 'Logs',
-            'team/platform': 'Platform',
         }
 
     def create_card(self, team, name, body):


### PR DESCRIPTION
Disambiguates other platform teams, and matches label used in other
environs (slack, etc.)


### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
