### PR TITLE
[Docs] Fix fluentbit configuration property names

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -192,8 +192,8 @@ Configure the AWS FireLens integration built on Datadog's Fluent Bit output plug
     "logConfiguration": {
 	    "logDriver": "awsfirelens",
 	    "options": {
-		    "name": "datadog",
-		    "apiKey": "<DATADOG_API_KEY>",
+		    "Name": "datadog",
+		    "apikey": "<DATADOG_API_KEY>",
             "dd_service": "firelens-test",
             "dd_source": "redis",
             "dd_tags": "project:fluentbit",


### PR DESCRIPTION
### What does this PR do?

Fixing wrong property names of fluent bit configuration for ECS Fargate integrations.

### Motivation

Making the doc more accurate, and saving your time.
If you follow the configuration, you'll see errors like below:

> missing output key Name which is required for firelens configuration of type fluentbit

Here is Datadog configuration options on Fluent Bit

> Datadog - Fluent Bit: Official Manual
> https://docs.fluentbit.io/manual/output/datadog

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] Feature or bugfix must have tests
- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] If PR adds a configuration option, it must be added to the configuration file.
