### PR TITLE
Update PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,15 @@
 ### What does this PR do?
-
-A brief description of the change being made with this pull request.
+<!-- A brief description of the change being made with this pull request. -->
 
 ### Motivation
-
-What inspired you to submit this pull request?
+<!-- What inspired you to submit this pull request? -->
 
 ### Additional Notes
-
-Anything else we should know when reviewing?
+<!-- Anything else we should know when reviewing? -->
 
 ### Review checklist (to be filled by reviewers)
 
+- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
 - [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
 - [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
 - [ ] PR must have `changelog/` and `integration/` labels attached
-- [ ] Feature or bugfix must have tests
-- [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
-- [ ] If PR adds a configuration option, it must be added to the configuration file.


### PR DESCRIPTION
### What does this PR do?

Use comments in PULL_REQUEST_TEMPLATE so we don't have to delete the instructions.

### Additional Details

Removed few check boxes, here are the reasons:

> - [ ] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)

Not very relevant, since we force PRs to be `squashed` before being merged to `master`.

> - [ ] If PR adds a configuration option, it must be added to the configuration file.

I'm not sure this is really needed, it's quite low level detail.

### Review checklist (to be filled by reviewers)

- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [X] PR must have `changelog/` and `integration/` labels attached
- [X] Feature or bugfix must have tests
- [X] Git history [must be clean](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#commit-messages)
- [X] If PR adds a configuration option, it must be added to the configuration file.
