### PR TITLE
Update kafka_consumer envs

### DIFF
--- a/kafka_consumer/tox.ini
+++ b/kafka_consumer/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py37
 envlist =
-    py{27,37}-{0.9,0.10,0.11,1.0,1.1,2.0,2.1}-{kafka,zk}
+    py{27,37}-{0.11,1.1,2.3,latest}-{kafka,zk}
 
 [testenv]
 description =
@@ -22,10 +22,7 @@ commands =
 setenv =
     kafka: KAFKA_OFFSETS_STORAGE=kafka
     zk: KAFKA_OFFSETS_STORAGE=zookeeper
-    0.9: KAFKA_VERSION=0.9.0.1-1
-    0.10: KAFKA_VERSION=0.10.2.1
     0.11: KAFKA_VERSION=0.11.0.1
-    1.0: KAFKA_VERSION=1.0.1
     1.1: KAFKA_VERSION=1.1.0
-    2.0: KAFKA_VERSION=2.12-2.0.1
-    2.1: KAFKA_VERSION=2.12-2.1.1
+    2.3: KAFKA_VERSION=2.12-2.3.0
+    latest: KAFKA_VERSION=latest

--- a/kafka_consumer/tox.ini
+++ b/kafka_consumer/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py37
 envlist =
-    py{27,37}-{0.11,1.1,2.3,latest}-{kafka,zk}
+    py{27,37}-{0.10.2,0.11,1.1,2.3,latest}-{kafka,zk}
 
 [testenv]
 description =
@@ -22,6 +22,8 @@ commands =
 setenv =
     kafka: KAFKA_OFFSETS_STORAGE=kafka
     zk: KAFKA_OFFSETS_STORAGE=zookeeper
+    # 0.10.2 is for testing legacy implementation
+    0.10.2: KAFKA_VERSION=0.10.2.1
     0.11: KAFKA_VERSION=0.11.0.1
     1.1: KAFKA_VERSION=1.1.0
     2.3: KAFKA_VERSION=2.12-2.3.0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove low value envs and add `latest` env for  `kafka_consumer`.

Before: 28 envs
After: 20 envs

### Motivation
<!-- What inspired you to submit this pull request? -->

Kafka CI build is reaching 1h which the max for Azure Pipelines.

Beside, the value of testing some envs are not high, hence removed.

I also added `latest`, that will help spotting breaking change in new releases.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
