### PR TITLE
Add testing for F5 profile

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/structures.py
+++ b/datadog_checks_dev/datadog_checks/dev/structures.py
@@ -45,7 +45,7 @@ class EnvVars(dict):
 class TempDir(object):
     all_names = set()
 
-    def __init__(self, name='default'):
+    def __init__(self, name='default', base_directory=None):
         key = None
         directory = None
 
@@ -64,12 +64,12 @@ class TempDir(object):
             if key in env_vars:
                 directory = env_vars[key]
             else:
-                directory = mkdtemp()
+                directory = mkdtemp(dir=base_directory)
                 set_env_vars({key: directory})
 
         self.name = name
         self.key = key
-        self.directory = os.path.realpath(directory or mkdtemp())
+        self.directory = os.path.realpath(directory or mkdtemp(dir=base_directory))
 
     @classmethod
     def _cleanup(cls, directory):

--- a/snmp/tests/compose/docker-compose.yaml
+++ b/snmp/tests/compose/docker-compose.yaml
@@ -7,4 +7,4 @@ services:
       - "1161:1161/udp"
     command: --args-from-file=/usr/snmpsim/data/args_list.txt
     volumes:
-      - ${COMPOSE_DIR}/data/:/usr/snmpsim/data/
+      - ${DATA_DIR}:/usr/snmpsim/data/

--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -3,16 +3,29 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 import os
+import shutil
 
 import pytest
+import requests
 
-from datadog_checks.dev import docker_run
+from datadog_checks.dev import TempDir, docker_run
 
 from .common import COMPOSE_DIR, SCALAR_OBJECTS, SCALAR_OBJECTS_WITH_TAGS, TABULAR_OBJECTS, generate_instance_config
+
+FILES = ["https://ddintegrations.blob.core.windows.net/snmp/f5.snmprec"]
 
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    env = {'COMPOSE_DIR': COMPOSE_DIR}
-    with docker_run(os.path.join(COMPOSE_DIR, 'docker-compose.yaml'), env_vars=env, log_patterns="Listening at"):
-        yield generate_instance_config(SCALAR_OBJECTS + SCALAR_OBJECTS_WITH_TAGS + TABULAR_OBJECTS)
+    with TempDir('snmprec', COMPOSE_DIR) as tmp_dir:
+        data_dir = os.path.join(tmp_dir, 'data')
+        env = {'DATA_DIR': data_dir}
+        if not os.path.exists(data_dir):
+            shutil.copytree(os.path.join(COMPOSE_DIR, 'data'), data_dir)
+            for data_file in FILES:
+                response = requests.get(data_file)
+                with open(os.path.join(data_dir, data_file.rsplit('/', 1)[1]), 'wb') as output:
+                    output.write(response.content)
+
+        with docker_run(os.path.join(COMPOSE_DIR, 'docker-compose.yaml'), env_vars=env, log_patterns="Listening at"):
+            yield generate_instance_config(SCALAR_OBJECTS + SCALAR_OBJECTS_WITH_TAGS + TABULAR_OBJECTS)

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -12,6 +12,7 @@ import pysnmp_mibs
 import pytest
 import yaml
 
+from datadog_checks import snmp
 from datadog_checks.base import ConfigurationError
 from datadog_checks.dev import temp_dir
 from datadog_checks.snmp import SnmpCheck
@@ -642,3 +643,68 @@ def test_different_tables(aggregator):
 
     check.check(instance)
     aggregator.assert_metric_has_tag_prefix('snmp.ifInOctets', 'speed')
+
+
+def test_f5(aggregator):
+    instance = common.generate_instance_config([])
+    # We need the full path as we're not in installed mode
+    path = os.path.join(os.path.dirname(snmp.__file__), 'data', 'profiles', 'f5-big-ip.yaml')
+    instance['community_string'] = 'f5'
+    instance['enforce_mib_constraints'] = False
+
+    init_config = {'profiles': {'f5-big-ip': {'definition_file': path, 'sysobjectid': '1.3.6.1.4.1.3375.2.1.3.4.43'}}}
+    check = SnmpCheck('snmp', init_config, [instance])
+
+    check.check(instance)
+
+    gauges = [
+        'sysStatMemoryTotal',
+        'sysStatMemoryUsed',
+        'sysGlobalTmmStatMemoryTotal',
+        'sysGlobalTmmStatMemoryUsed',
+        'sysGlobalHostOtherMemoryTotal',
+        'sysGlobalHostOtherMemoryUsed',
+        'sysGlobalHostSwapTotal',
+        'sysGlobalHostSwapUsed',
+        'sysTcpStatOpen',
+        'sysTcpStatCloseWait',
+        'sysTcpStatFinWait',
+        'sysTcpStatTimeWait',
+        'sysTcpStatAccepts',
+        'sysTcpStatAcceptfails',
+        'sysTcpStatConnects',
+        'sysTcpStatConnfails',
+        'sysUdpStatOpen',
+        'sysUdpStatAccepts',
+        'sysUdpStatAcceptfails',
+        'sysUdpStatConnects',
+        'sysUdpStatConnfails',
+        'sysClientsslStatCurConns',
+        'sysClientsslStatEncryptedBytesIn',
+        'sysClientsslStatEncryptedBytesOut',
+        'sysClientsslStatDecryptedBytesIn',
+        'sysClientsslStatDecryptedBytesOut',
+        'sysClientsslStatHandshakeFailures',
+    ]
+    cpu_gauges = [
+        'sysMultiHostCpuUser',
+        'sysMultiHostCpuNice',
+        'sysMultiHostCpuSystem',
+        'sysMultiHostCpuIdle',
+        'sysMultiHostCpuIrq',
+        'sysMultiHostCpuSoftirq',
+        'sysMultiHostCpuIowait',
+    ]
+    if_gauges = ['ifInOctets', 'ifInErrors', 'ifOutOctets', 'ifOutErrors']
+    interfaces = ['1.0', 'mgmt', '/Common/internal', '/Common/http-tunnel', '/Common/socks-tunnel']
+    for metric in gauges:
+        aggregator.assert_metric('snmp.{}'.format(metric), tags=common.CHECK_TAGS, count=1)
+    for metric in cpu_gauges:
+        aggregator.assert_metric('snmp.{}'.format(metric), tags=['cpu:0'] + common.CHECK_TAGS, count=1)
+        aggregator.assert_metric('snmp.{}'.format(metric), tags=['cpu:1'] + common.CHECK_TAGS, count=1)
+    for metric in if_gauges:
+        for interface in interfaces:
+            aggregator.assert_metric(
+                'snmp.{}'.format(metric), tags=['interface:{}'.format(interface)] + common.CHECK_TAGS, count=1
+            )
+    aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
This adds an integration tests for F5 devices. It downloads the recorded
traffic as it's pretty big.

This relies on a dev change to be able to create temporary directories
elsewhere, as some temp directories are not docker mountable.