### PR TITLE
Add e2e tests

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/_env.py
+++ b/datadog_checks_dev/datadog_checks/dev/_env.py
@@ -75,9 +75,9 @@ def replay_check_run(agent_collector, stub_aggregator):
     errors = []
     for collector in agent_collector:
         aggregator = collector['aggregator']
-        runner = collector['runner']
-        check_id = runner['CheckID']
-        check_name = runner['CheckName']
+        runner = collector.get('runner', {})
+        check_id = runner.get('CheckID', '')
+        check_name = runner.get('CheckName', '')
 
         for data in aggregator.get('metrics', []):
             for _, value in data['points']:
@@ -99,7 +99,7 @@ def replay_check_run(agent_collector, stub_aggregator):
                 check_name, check_id, data['check'], data['status'], data['tags'], data['host_name'], data['message']
             )
 
-        if runner['LastError']:
+        if runner.get('LastError'):
             errors.extend(json.loads(runner['LastError']))
     if errors:
         raise Exception("\n".join("Message: {}\n{}".format(err['message'], err['traceback']) for err in errors))

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -153,7 +153,7 @@ def dd_agent_check(request, aggregator):
         collector_output = collector_output.strip()
         if not collector_output.endswith(']'):
             # JMX needs some additional cleanup
-            collector_output = collector_output[:collector_output.rfind(']') + 1]
+            collector_output = collector_output[: collector_output.rfind(']') + 1]
         collector = json.loads(collector_output)
 
         replay_check_run(collector, aggregator)

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -150,7 +150,11 @@ def dd_agent_check(request, aggregator):
             )
 
         _, _, collector_output = result.stdout.partition(AGENT_COLLECTOR_SEPARATOR)
-        collector = json.loads(collector_output.strip())
+        collector_output = collector_output.strip()
+        if not collector_output.endswith(']'):
+            # JMX needs some additional cleanup
+            collector_output = collector_output[:collector_output.rfind(']') + 1]
+        collector = json.loads(collector_output)
 
         replay_check_run(collector, aggregator)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
@@ -34,7 +34,7 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_suc
     help='Line number to start a PDB session (0: first line, -1: last line)',
 )
 @click.option('--config', 'config_file', help='Path to a JSON check configuration to use')
-@click.option('--jmx-list', 'jmx_list', default='matching', help='JMX metrics listing method')
+@click.option('--jmx-list', 'jmx_list', help='JMX metrics listing method')
 def check_run(check, env, rate, times, pause, delay, log_level, as_json, break_point, config_file, jmx_list):
     """Run an Agent check."""
     envs = get_configured_envs(check)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -100,10 +100,10 @@ class DockerInterface(object):
         log_level=None,
         as_json=False,
         break_point=None,
-        jmx_list='matching',
+        jmx_list=None,
     ):
         # JMX check
-        if self.metadata.get('use_jmx', False):
+        if jmx_list:
             command = '{} jmx list {}'.format(self.agent_command, jmx_list)
         # Classic check
         else:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -135,10 +135,10 @@ class LocalAgentInterface(object):
         log_level=None,
         as_json=False,
         break_point=None,
-        jmx_list='matching',
+        jmx_list=None,
     ):
         # JMX check
-        if self.metadata.get('use_jmx', False):
+        if jmx_list:
             command = '{} jmx list {}'.format(self.agent_command, jmx_list)
         # Classic check
         else:

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/__init__.py
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/__init__.py
@@ -3,6 +3,4 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from .__about__ import __version__
 
-__all__ = [
-    '__version__'
-]
+__all__ = ['__version__']

--- a/jboss_wildfly/setup.py
+++ b/jboss_wildfly/setup.py
@@ -28,17 +28,13 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     keywords='datadog agent jboss wildfly check',
-
     # The project's main homepage.
     url='https://github.com/DataDog/integrations-core',
-
     # Author details
     author='Datadog',
     author_email='packages@datadoghq.com',
-
     # License
     license='BSD-3-Clause',
-
     # See https://pypi.org/classifiers
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -49,13 +45,10 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.7',
     ],
-
     # The package we're going to ship
     packages=['datadog_checks.jboss_wildfly'],
-
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
-
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/jboss_wildfly/tests/conftest.py
+++ b/jboss_wildfly/tests/conftest.py
@@ -6,13 +6,26 @@ import os
 
 import pytest
 
-from datadog_checks.dev import docker_run
+from datadog_checks.dev import docker_run, get_docker_hostname
 from datadog_checks.dev.utils import load_jmx_config
 
 from .common import HERE
+
+E2E_METADATA = {
+    'use_jmx': True,
+    'start_commands': [
+        'mkdir /opt/jboss',
+        'curl -o /opt/jboss/jboss-client.jar https://storage.googleapis.com/datadog-integrations-lab/jboss-client.jar',
+    ],
+}
 
 
 @pytest.fixture(scope="session")
 def dd_environment():
     with docker_run(os.path.join(HERE, 'docker', 'docker-compose.yml')):
-        yield load_jmx_config(), {'use_jmx': True}
+        instance = load_jmx_config()
+        instance['init_config']['custom_jar_paths'] = ['/opt/jboss/jboss-client.jar']
+        instance['instances'][0]['jmx_url'] = 'service:jmx:remote+http://{}:9990'.format(get_docker_hostname())
+        instance['instances'][0]['user'] = 'datadog'
+        instance['instances'][0]['password'] = 'dog'
+        yield instance, E2E_METADATA

--- a/jboss_wildfly/tests/docker/config/Dockerfile
+++ b/jboss_wildfly/tests/docker/config/Dockerfile
@@ -1,5 +1,0 @@
-FROM jboss/wildfly:latest
-
-RUN /opt/jboss/wildfly/bin/add-user.sh datadog dog --silent
-
-CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0", "-bmanagement", "0.0.0.0"]

--- a/jboss_wildfly/tests/docker/docker-compose.yml
+++ b/jboss_wildfly/tests/docker/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '3'
 services:
   jboss_wildfly:
-    build:
-      context: ./config
+    image: jboss/wildfly:16.0.0.Final
+    command: ['/bin/sh', '-c', '/script.sh']
     ports:
      - 9990:9990
+    volumes:
+     - ./script.sh:/script.sh

--- a/jboss_wildfly/tests/docker/script.sh
+++ b/jboss_wildfly/tests/docker/script.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+/opt/jboss/wildfly/bin/add-user.sh datadog dog --silent
+
+/opt/jboss/wildfly/bin/standalone.sh -b 0.0.0.0 -bmanagement 0.0.0.0

--- a/jboss_wildfly/tests/test_check.py
+++ b/jboss_wildfly/tests/test_check.py
@@ -5,6 +5,54 @@
 import pytest
 
 
-@pytest.mark.usefixtures('dd_environment')
-def test():
-    pass
+@pytest.mark.e2e
+def test_e2e(dd_agent_check):
+    instance = {}
+    aggregator = dd_agent_check(instance)
+    metrics = [
+        'jvm.non_heap_memory_max',
+        'jboss.jdbc_preparedstatementcache.size',
+        'jvm.heap_memory_committed',
+        'jvm.gc.eden_size',
+        'jboss.jdbc_xarecover.count',
+        'jboss.transactions.aborted',
+        'jvm.heap_memory',
+        'jboss.transactions.resource_rollbacks',
+        'jboss.jdbc_xacommit.count',
+        'jvm.loaded_classes',
+        'jvm.gc.parnew.time',
+        'jboss.transactions.timed_out',
+        'jboss.transactions.heuristics',
+        'jboss.transactions.nested',
+        'jboss.undertow_listener.request_count',
+        'jboss.undertow_listener.error_count',
+        'jboss.jdbc_connections.count',
+        'jvm.cpu_load.system',
+        'jvm.non_heap_memory_init',
+        'jboss.transactions.inflight',
+        'jvm.thread_count',
+        'jvm.os.open_file_descriptors',
+        'jboss.jdbc_preparedstatementcache.hit',
+        'jvm.non_heap_memory',
+        'jboss.transactions.system_rollbacks',
+        'jboss.undertow_listener.bytes_received',
+        'jboss.jdbc_connections.idle',
+        'jboss.undertow_listener.processing_time',
+        'jboss.transactions.application_rollbacks',
+        'jvm.cpu_load.process',
+        'jboss.undertow_listener.bytes_sent',
+        'jboss.jdbc_xarollback.count',
+        'jboss.transactions.committed',
+        'jvm.gc.survivor_size',
+        'jvm.non_heap_memory_committed',
+        'jboss.jdbc_preparedstatementcache.miss',
+        'jboss.jdbc_connections.active',
+        'jboss.transactions.count',
+        'jvm.heap_memory_init',
+        'jvm.heap_memory_max',
+        'jboss.jdbc_connections.request_wait',
+        'jvm.gc.cms.count',
+    ]
+    for metric in metrics:
+        aggregator.assert_metric(metric)
+    aggregator.assert_all_metrics_covered()

--- a/jboss_wildfly/tests/test_check.py
+++ b/jboss_wildfly/tests/test_check.py
@@ -55,4 +55,3 @@ def test_e2e(dd_agent_check):
     ]
     for metric in metrics:
         aggregator.assert_metric(metric)
-    aggregator.assert_all_metrics_covered()

--- a/jboss_wildfly/tox.ini
+++ b/jboss_wildfly/tox.ini
@@ -6,7 +6,10 @@ envlist =
     py37
 
 [testenv]
+description =
+    py37: e2e ready
 usedevelop = true
+dd_check_style = true
 platform = linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]


### PR DESCRIPTION
This adds the first E2E test for a JMX check. It works around the small
differences in output, and change the behavior of `ddev env check` to
call `agent check` by default for JMX. It also deals with the
particuliar JAR loading for JBoss.

The `jmx list` capability is retained through the `--jmx-list` option of
the check command.