### PR TITLE
Fix examples in conf.yaml.default  

### DIFF
--- a/network/datadog_checks/network/data/conf.yaml.default
+++ b/network/datadog_checks/network/data/conf.yaml.default
@@ -67,7 +67,7 @@ instances:
     #
     # whitelist_conntrack_metrics:
     #   - <METRIC_NAME>
-    #   - <METRIC_PREFIX>*
+    #   - <METRIC_PREFIX>.*
 
     ## @param blacklist_conntrack_metrics - list of strings - optional - default: []
     ## Linux only.
@@ -79,7 +79,7 @@ instances:
     #
     # blacklist_conntrack_metrics:
     #   - <METRIC_NAME>
-    #   - <METRIC_PREFIX>*
+    #   - <METRIC_PREFIX>.*
 
     ## @param tags - list of key:value elements - optional
     ## List of tags to attach to every metric, event and service check emitted by this integration.


### PR DESCRIPTION
### What does this PR do?
The examples for whitelist_conntrack_metrics and blacklist_conntrack_metrics, as found in
https://github.com/DataDog/integrations-core/blob/master/network/datadog_checks/network/data/conf.yaml.default#L68-L70,
suggest a glob-like pattern while the documentation mentions regex expressions.

### Motivation
I was running into this when I had:
```
whitelist_conntrack_metrics:
  - *
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
