### PR TITLE
Merge CI tests results

### DIFF
--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -28,4 +28,3 @@ steps:
     testResultsFiles: '**/test-*.xml'
     testRunTitle: '${{ parameters.test_run }}'
     mergeTestResults: true
-    failTaskOnFailedTests: true

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -27,3 +27,5 @@ steps:
   inputs:
     testResultsFiles: '**/test-*.xml'
     testRunTitle: '${{ parameters.test_run }}'
+    mergeTestResults: true
+    failTaskOnFailedTests: true


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

1) Merge test results
> When this option is selected, test results from all the files will be reported against a single test run. If this option is not selected, a separate test run will be created for each test result file.Note: Use merge test results to combine files from same test framework to ensure results mapping and duration are calculated correctly.

To avoid having multiple test sections:

![image](https://user-images.githubusercontent.com/49917914/67589137-100d4a80-f758-11e9-9dae-70bbf7e66262.png)

2) Fail if there are test failures
> When selected, the task will fail if any of the tests in the results file is marked as failed. The default is false, which will simply publish the results from the results file.

^ Seems to make sense to turn on.


### Motivation
<!-- What inspired you to submit this pull request? -->

Better CI analytics

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
