### PR TITLE
update docs

### DIFF
--- a/ibm_mq/README.md
+++ b/ibm_mq/README.md
@@ -131,7 +131,7 @@ There are a number of options to configure IBM MQ, depending on how you're using
 - `host`: The host where IBM MQ is running
 - `port`: The port that IBM MQ has exposed
 
-If you're using a username and password setup, you can set the `username` and `password`. If no username is set, the process owner of the agent is used (e.g. `dd-agent`).
+If you are using a username and password setup, you can set the `username` and `password`. If no username is set, the Agent process owner is used (e.g. `dd-agent`).
 
 If you're using SSL Authentication, you can setup SSL Authentication.
 

--- a/ibm_mq/README.md
+++ b/ibm_mq/README.md
@@ -126,12 +126,12 @@ All valid MQSC commands were processed.
 
 There are a number of options to configure IBM MQ, depending on how you're using it.
 
-`channel`: The IBM MQ channel
-`queue_manager`: The Queue Manager named
-`host`: The host where IBM MQ is running
-`port`: The port that IBM MQ has exposed
+- `channel`: The IBM MQ channel
+- `queue_manager`: The Queue Manager named
+- `host`: The host where IBM MQ is running
+- `port`: The port that IBM MQ has exposed
 
-If you're using a username and password setup, you can set the username and password.
+If you're using a username and password setup, you can set the `username` and `password`. If no username is set, the process owner of the agent is used (e.g. `dd-agent`).
 
 If you're using SSL Authentication, you can setup SSL Authentication.
 


### PR DESCRIPTION
### What does this PR do?
Documents that if no `username` is set in the configuration file, the client(Datadog agent) will authenticate using the agent process owner/user in context e.g `dd-agent`

### Motivation
1585-agent-authentication-issues-connecting-to-ibm-mq

### Additional Notes
- also changes lines 129-132 to a list cause it looks like a one-liner in public docs (https://cl.ly/530ca4263b81) as of this writing

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
