### PR TITLE
Update requirements when updating check

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -7,7 +7,7 @@ import click
 from six import itervalues
 
 from ...utils import write_file_lines
-from ..constants import get_agent_requirements, get_root
+from ..constants import REQUIREMENTS_IN, get_agent_requirements, get_root
 from ..requirements import Package, make_catalog, read_packages, resolve_requirements
 from .console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_waiting, echo_warning
 
@@ -66,7 +66,7 @@ def resolve(checks, lazy, quiet):
         checks = os.listdir(root)
 
     for check_name in sorted(checks):
-        pinned_reqs_file = os.path.join(root, check_name, 'requirements.in')
+        pinned_reqs_file = os.path.join(root, check_name, REQUIREMENTS_IN)
         resolved_reqs_file = os.path.join(root, check_name, 'requirements.txt')
 
         if os.path.isfile(pinned_reqs_file):
@@ -107,7 +107,7 @@ def pin(package, version, checks, marker, resolving, lazy, quiet):
     version = version.lower()
 
     for check_name in sorted(os.listdir(root)):
-        pinned_reqs_file = os.path.join(root, check_name, 'requirements.in')
+        pinned_reqs_file = os.path.join(root, check_name, REQUIREMENTS_IN)
         resolved_reqs_file = os.path.join(root, check_name, 'requirements.txt')
 
         if os.path.isfile(pinned_reqs_file):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -62,6 +62,7 @@ NOT_TILES = [
 TESTABLE_FILE_EXTENSIONS = ('.py', '.ini', '.in', '.txt', '.yml', '.yaml')
 NON_TESTABLE_FILES = ('auto_conf.yaml', 'metrics.yaml')
 
+REQUIREMENTS_IN = 'requirements.in'
 
 ROOT = ''
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -5,7 +5,7 @@ import re
 from contextlib import contextmanager
 
 from ...subprocess import run_command
-from ...utils import path_join
+from ...utils import file_exists, path_join
 from ..constants import get_root
 from .agent import (
     DEFAULT_AGENT_VERSION,
@@ -178,12 +178,15 @@ class DockerInterface(object):
         command = ['docker', 'exec', self.container_name]
         command.extend(get_pip_exe(self.python_version))
         command.extend(('install', '-e', self.check_mount_dir))
+        if file_exists(path_join(get_root(), self.check, 'requirements.in')):
+            command.extend(('-r', path_join(self.check_mount_dir, 'requirements.in')))
         run_command(command, capture=True, check=True)
 
     def update_base_package(self):
         command = ['docker', 'exec', self.container_name]
         command.extend(get_pip_exe(self.python_version))
         command.extend(('install', '-e', self.base_mount_dir))
+        command.extend(('-r', path_join(self.base_mount_dir, 'requirements.in')))
         run_command(command, capture=True, check=True)
 
     def update_agent(self):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 
 from ...subprocess import run_command
 from ...utils import file_exists, path_join
-from ..constants import get_root
+from ..constants import REQUIREMENTS_IN, get_root
 from .agent import (
     DEFAULT_AGENT_VERSION,
     DEFAULT_PYTHON_VERSION,
@@ -178,15 +178,15 @@ class DockerInterface(object):
         command = ['docker', 'exec', self.container_name]
         command.extend(get_pip_exe(self.python_version))
         command.extend(('install', '-e', self.check_mount_dir))
-        if file_exists(path_join(get_root(), self.check, 'requirements.in')):
-            command.extend(('-r', path_join(self.check_mount_dir, 'requirements.in')))
+        if file_exists(path_join(get_root(), self.check, REQUIREMENTS_IN)):
+            command.extend(('-r', path_join(self.check_mount_dir, REQUIREMENTS_IN)))
         run_command(command, capture=True, check=True)
 
     def update_base_package(self):
         command = ['docker', 'exec', self.container_name]
         command.extend(get_pip_exe(self.python_version))
         command.extend(('install', '-e', self.base_mount_dir))
-        command.extend(('-r', path_join(self.base_mount_dir, 'requirements.in')))
+        command.extend(('-r', path_join(self.base_mount_dir, REQUIREMENTS_IN)))
         run_command(command, capture=True, check=True)
 
     def update_agent(self):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -9,7 +9,7 @@ from shutil import copyfile, move
 from ...structures import EnvVars
 from ...subprocess import run_command
 from ...utils import ON_LINUX, ON_MACOS, ON_WINDOWS, file_exists, path_join
-from ..constants import get_root
+from ..constants import REQUIREMENTS_IN, get_root
 from .agent import (
     DEFAULT_AGENT_VERSION,
     DEFAULT_PYTHON_VERSION,
@@ -172,14 +172,14 @@ class LocalAgentInterface(object):
         command = get_pip_exe(self.python_version, self.platform)
         path = path_join(get_root(), self.check)
         command.extend(('install', '-e', path))
-        if file_exists(path_join(path, 'requirements.in')):
-            command.extend(('-r', path_join(path, 'requirements.in')))
+        if file_exists(path_join(path, REQUIREMENTS_IN)):
+            command.extend(('-r', path_join(path, REQUIREMENTS_IN)))
         return run_command(command, capture=True, check=True)
 
     def update_base_package(self):
         command = get_pip_exe(self.python_version, self.platform)
         command.extend(('install', '-e', self.base_package))
-        command.extend(('-r', path_join(self.base_package, 'requirements.in')))
+        command.extend(('-r', path_join(self.base_package, REQUIREMENTS_IN)))
         return run_command(command, capture=True, check=True)
 
     def update_agent(self):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -170,12 +170,16 @@ class LocalAgentInterface(object):
 
     def update_check(self):
         command = get_pip_exe(self.python_version, self.platform)
-        command.extend(('install', '-e', path_join(get_root(), self.check)))
+        path = path_join(get_root(), self.check)
+        command.extend(('install', '-e', path))
+        if file_exists(path_join(path, 'requirements.in')):
+            command.extend(('-r', path_join(path, 'requirements.in')))
         return run_command(command, capture=True, check=True)
 
     def update_base_package(self):
         command = get_pip_exe(self.python_version, self.platform)
         command.extend(('install', '-e', self.base_package))
+        command.extend(('-r', path_join(self.base_package, 'requirements.in')))
         return run_command(command, capture=True, check=True)
 
     def update_agent(self):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/requirements.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/requirements.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 from ..subprocess import run_command
 from ..utils import chdir, resolve_path, stream_file_lines, write_file_lines
-from .constants import get_root
+from .constants import REQUIREMENTS_IN, get_root
 
 DEP_PATTERN = re.compile(r'([^=]+)(?:==([^;\s]+)(?:; *(.*))?)?')
 
@@ -181,7 +181,7 @@ def make_catalog(verify=False, checks=None):
     checks = checks if checks else os.listdir(root)
 
     for check_name in sorted(checks):
-        for package in read_packages(os.path.join(root, check_name, 'requirements.in')):
+        for package in read_packages(os.path.join(root, check_name, REQUIREMENTS_IN)):
             if not package.version:
                 errors.append('Unpinned dependency `{}` in the `{}` check'.format(package.name, check_name))
             catalog.add_package(check_name, package)


### PR DESCRIPTION
We need to pass the requirements explicitly when updating a check to
its development version.