### PR TITLE
Set Azure fetchDepth to 10

### DIFF
--- a/.azure-pipelines/templates/checkout-code.yml
+++ b/.azure-pipelines/templates/checkout-code.yml
@@ -1,7 +1,7 @@
 steps:
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema#checkout
 - checkout: self
-  fetchDepth: 3
+  fetchDepth: 10
 
 # Azure checks out the code from the PR but leaves us in a detached state.
 # Because ddev cannot work in that state, we create a branch.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Set Azure fetchDepth to 10

### Motivation
<!-- What inspired you to submit this pull request? -->

If more than 3 PR are merged at the same time on `master`, build might fail because the depth is only 3.

Setting the depth to 10 will reduce the chance of this happening.

No visible performance difference:

```
$ python -m timeit -s 'import os, uuid' 'os.system("git clone git@github.com:DataDog/integrations-core.git --depth 3 /tmp/integrations-core-depth3-" + uuid.uuid4().hex)'

1 loop, best of 5: 3.6 sec per loop

$ python -m timeit -s 'import os, uuid' 'os.system("git clone git@github.com:DataDog/integrations-core.git --depth 10 /tmp/integrations-core-depth10-" + uuid.uuid4().hex)'

1 loop, best of 5: 3.56 sec per loop
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
