### PR TITLE
Handle scheme in prometheus_url instead of separate option

### DIFF
--- a/kube_apiserver_metrics/README.md
+++ b/kube_apiserver_metrics/README.md
@@ -21,7 +21,7 @@ Annotations:       ad.datadoghq.com/endpoint.check_names: ["kube_apiserver_metri
                    ad.datadoghq.com/endpoint.instances:
                      [
                        {
-                         "prometheus_url": "%%host%%:%%port%%/metrics",
+                         "prometheus_url": "https://%%host%%:%%port%%/metrics",
                          "bearer_token_auth": "true"
                        }
                      ]

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/auto_conf.yaml
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/auto_conf.yaml
@@ -7,12 +7,7 @@ instances:
     ## @param prometheus_url - string - required
     ## The URL where your application metrics are exposed by Prometheus.
     #
-  - prometheus_url: "%%host%%:6443/metrics"
-
-    ## @param scheme - string - optional
-    ## Used to specify the scheme to reach the APIServer endpoints. Default to https.
-    #
-    # scheme: "https"
+  - prometheus_url: "https://%%host%%:6443/metrics"
 
     ## @param bearer_token_auth - string - optional
     ## Used if you are using RBACs and need the Agent to authenticate

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -7,6 +7,13 @@ instances:
     #
   - prometheus_url: https://localhost:443/metrics
     
+    ## @param scheme - string - optional - deprecated
+    ## Used to specify the scheme to reach the APIServer endpoints. Default to https.
+    ## This option is deprecated, declare the scheme in the prometheus_url
+    ## parameter instead.
+    #
+    # scheme: "https"
+
     ## @param bearer_token_auth - string - optional
     ## Used if you are using RBACs and need the agent to authenticate
     ## against the APIServer to retrieve metrics. Default to true.

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -5,13 +5,8 @@ instances:
     ## @param prometheus_url - string - required
     ## The URL where your application metrics are exposed by Prometheus.
     #
-  - prometheus_url: localhost:443/metrics
+  - prometheus_url: https://localhost:443/metrics
     
-    ## @param scheme - string - optional
-    ## Used to specify the scheme to reach the APIServer endpoints. Default to https.
-    #
-    # scheme: "https"
-
     ## @param bearer_token_auth - string - optional
     ## Used if you are using RBACs and need the agent to authenticate
     ## against the APIServer to retrieve metrics. Default to true.

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -6,8 +6,8 @@ instances:
     ## The URL where your application metrics are exposed by Prometheus.
     #
   - prometheus_url: https://localhost:443/metrics
-    
-    ## @param scheme - string - optional - deprecated
+
+    ## @param scheme - string - optional
     ## Used to specify the scheme to reach the APIServer endpoints. Default to https.
     ## This option is deprecated, declare the scheme in the prometheus_url
     ## parameter instead.

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
@@ -77,7 +77,8 @@ class KubeAPIServerMetricsCheck(OpenMetricsBaseCheck):
         endpoint = instance.get('prometheus_url')
         prometheus_url = endpoint
 
-        # Allow using a proper URL without introducing a breaking change.
+        # Allow using a proper URL without introducing a breaking change since
+        # the scheme option is deprecated.
         if not match('^https?://.*$', endpoint):
             scheme = instance.get('scheme', self.DEFAULT_SCHEME)
             prometheus_url = "{0}://{1}".format(scheme, endpoint)

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy
 from re import match
+
 from six import iteritems
 
 from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
@@ -15,18 +15,17 @@ from .common import APISERVER_INSTANCE_BEARER_TOKEN
 
 customtag = "custom:tag"
 
-minimal_instance = {'prometheus_url': 'localhost:443/metrics'}
+minimal_instance = {'prometheus_url': 'https://localhost:443/metrics'}
+minimal_instance_legacy = {'prometheus_url': 'localhost:443/metrics'}
 
 instance = {
-    'prometheus_url': 'localhost:443/metrics',
+    'prometheus_url': 'https://localhost:443/metrics',
     'bearer_token_auth': 'false',
-    'scheme': 'https',
     'tags': [customtag],
 }
 
 instanceSecure = {
-    'prometheus_url': 'localhost:443/metrics',
-    'scheme': 'https',
+    'prometheus_url': 'https://localhost:443/metrics',
     'bearer_token_auth': 'true',
     'tags': [customtag],
 }
@@ -115,6 +114,17 @@ class TestKubeAPIServerMetrics:
         """
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, {}, [minimal_instance])
         apiserver_instance = check._create_kube_apiserver_metrics_instance(minimal_instance)
+
+        assert not apiserver_instance["ssl_verify"]
+        assert apiserver_instance["bearer_token_auth"]
+        assert apiserver_instance["prometheus_url"] == "https://localhost:443/metrics"
+
+    def test_default_config_legacy(self, aggregator):
+        """
+        Testing the default configuration.
+        """
+        check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, {}, [minimal_instance_legacy])
+        apiserver_instance = check._create_kube_apiserver_metrics_instance(minimal_instance_legacy)
 
         assert not apiserver_instance["ssl_verify"]
         assert apiserver_instance["bearer_token_auth"]

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_15.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_15.py
@@ -13,9 +13,8 @@ from datadog_checks.kube_apiserver_metrics import KubeAPIServerMetricsCheck
 customtag = "custom:tag"
 
 instance = {
-    'prometheus_url': 'localhost:443/metrics',
+    'prometheus_url': 'https://localhost:443/metrics',
     'bearer_token_auth': 'false',
-    'scheme': 'https',
     'tags': [customtag],
 }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Changes the way we handle `prometheus_url` in that integration so that it's consistent with the format used in other integrations.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
