### PR TITLE
Use a stub class for metadata testing

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/__init__.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from .aggregator import aggregator
+from .datadog_agent import datadog_agent
 from .tagging import tagger
 
 __all__ = ['aggregator', 'datadog_agent', 'tagger']

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -3,41 +3,41 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 
-def get_hostname():
-    return 'stubbed.hostname'
+class DatadogAgentStub(object):
+    def __init__(self):
+        self._metadata = {}
+
+    def reset(self):
+        self._metadata = {}
+
+    def assert_metadata(self, check_id, data):
+        for name, value in data.items():
+            assert self._metadata[(check_id, name)] == value
+
+    def assert_metadata_count(self, count):
+        assert len(self._metadata) == count
+
+    def get_hostname(self):
+        return 'stubbed.hostname'
+
+    def get_config(self, *args, **kwargs):
+        return ''
+
+    def get_version(self):
+        return '0.0.0'
+
+    def log(*args, **kwargs):
+        pass
+
+    def set_check_metadata(self, check_id, name, value):
+        self._metadata[(check_id, name)] = value
+
+    def set_external_tags(self, *args, **kwargs):
+        pass
+
+    def tracemalloc_enabled(self, *args, **kwargs):
+        return False
 
 
-def log(*args, **kwargs):
-    pass
-
-
-def get_config(*args, **kwargs):
-    return ''
-
-
-def get_version():
-    return '0.0.0'
-
-
-def warning(msg, *args, **kwargs):
-    pass
-
-
-def error(msg, *args, **kwargs):
-    pass
-
-
-def debug(msg, *args, **kwargs):
-    pass
-
-
-def set_check_metadata(*args, **kwargs):
-    pass
-
-
-def set_external_tags(*args, **kwargs):
-    pass
-
-
-def tracemalloc_enabled(*args, **kwargs):
-    return False
+# Use the stub as a singleton
+datadog_agent = DatadogAgentStub()

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -26,7 +26,7 @@ class DatadogAgentStub(object):
     def get_version(self):
         return '0.0.0'
 
-    def log(*args, **kwargs):
+    def log(self, *args, **kwargs):
         pass
 
     def set_check_metadata(self, check_id, name, value):

--- a/datadog_checks_base/tests/test_winpdh.py
+++ b/datadog_checks_base/tests/test_winpdh.py
@@ -3,10 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from collections import defaultdict
+import logging
 
 import pytest
-
-import datadog_checks.stubs.datadog_agent as logger
 
 from .utils import requires_windows
 
@@ -22,6 +21,8 @@ except ImportError:
 
     if platform.system() != 'Windows':
         pass
+
+logger = logging.getLogger(__file__)
 
 
 '''

--- a/datadog_checks_base/tests/test_winpdh.py
+++ b/datadog_checks_base/tests/test_winpdh.py
@@ -2,8 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from collections import defaultdict
 import logging
+from collections import defaultdict
 
 import pytest
 

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -23,6 +23,7 @@ from .._env import (
 )
 
 __aggregator = None
+__datadog_agent = None
 
 
 @pytest.fixture
@@ -40,6 +41,20 @@ def aggregator():
 
     __aggregator.reset()
     return __aggregator
+
+
+@pytest.fixture
+def datadog_agent():
+    global __datadog_agent
+
+    if __datadog_agent is None:
+        try:
+            from datadog_checks.base.stubs import datadog_agent as __datadog_agent
+        except ImportError:
+            raise ImportError('datadog-checks-base is not installed!')
+
+    __datadog_agent.reset()
+    return __datadog_agent
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/redisdb/tests/conftest.py
+++ b/redisdb/tests/conftest.py
@@ -10,7 +10,7 @@ import redis
 from datadog_checks.dev import LazyFunction, RetryError, docker_run
 from datadog_checks.redisdb import Redis
 
-from .common import HOST, MASTER_PORT, PASSWORD, PORT, REDIS_VERSION, REPLICA_PORT
+from .common import HOST, MASTER_PORT, PASSWORD, PORT, REPLICA_PORT
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
@@ -94,9 +94,3 @@ def master_instance():
 @pytest.fixture
 def check():
     return Redis('redisdb', {}, {}, None)
-
-
-@pytest.fixture(scope='session')
-def version_metadata():
-    major, minor = REDIS_VERSION.split('.')
-    return {'version.scheme': 'semver', 'version.major': major, 'version.minor': minor}


### PR DESCRIPTION
This introduces a new class for metadata testing, similar to what we do
for aggregator, so that we can test `set_metadata` calls more easily.