### PR TITLE
Add try_sudo option for collecting conntrack metrics with containers

### DIFF
--- a/network/datadog_checks/network/data/conf.yaml.default
+++ b/network/datadog_checks/network/data/conf.yaml.default
@@ -52,10 +52,15 @@ instances:
     ## @param conntrack_path - string - optional
     ## Linux only.
     ## The location of the conntrack executable in order to get the stats from conntrack -S.
-    ## It will be run with sudo, so an entry needs to be added to the sudoers file.
+    ## It will be run with sudo by default, so an entry needs to be added to the sudoers file.
     ## By default, these metrics will not be sent.
     #
     # conntrack_path: /usr/sbin/conntrack
+
+    ## @param disable_sudo_conntrack - boolean - optional - default: false
+    ## Disable sudo when running conntrack -S (sudo isn't normally available in containers)
+    #
+    # disable_sudo_conntrack: false
 
     ## @param whitelist_conntrack_metrics - list of string - optional - default: ["max", "count"]
     ## Linux only.

--- a/network/datadog_checks/network/data/conf.yaml.default
+++ b/network/datadog_checks/network/data/conf.yaml.default
@@ -57,10 +57,11 @@ instances:
     #
     # conntrack_path: /usr/sbin/conntrack
 
-    ## @param disable_sudo_conntrack - boolean - optional - default: false
-    ## Disable sudo when running conntrack -S (sudo isn't normally available in containers)
+    ## @param try_sudo_conntrack - boolean - optional - default: true
+    ## Set to False to disable sudo when running conntrack -S 
+    ## (`sudo` isn't normally available in containers)
     #
-    # disable_sudo_conntrack: false
+    # try_sudo_conntrack: true
 
     ## @param whitelist_conntrack_metrics - list of string - optional - default: ["max", "count"]
     ## Linux only.

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -416,8 +416,9 @@ class Network(AgentCheck):
 
         # Get the conntrack -S information
         conntrack_path = instance.get('conntrack_path')
+        disable_sudo_conntrack = instance.get('disable_sudo_conntrack', False)
         if conntrack_path is not None:
-            self._add_conntrack_stats_metrics(conntrack_path, custom_tags)
+            self._add_conntrack_stats_metrics(conntrack_path, disable_sudo_conntrack, custom_tags)
 
         # Get the rest of the metric by reading the files. Metrics available since kernel 3.6
         conntrack_files_location = os.path.join(proc_location, 'sys', 'net', 'netfilter')
@@ -466,13 +467,16 @@ class Network(AgentCheck):
             net_proc_base_location = proc_location
         return net_proc_base_location
 
-    def _add_conntrack_stats_metrics(self, conntrack_path, tags):
+    def _add_conntrack_stats_metrics(self, conntrack_path, disable_sudo_conntrack, tags):
         """
         Parse the output of conntrack -S
         Add the parsed metrics
         """
         try:
-            output, _, _ = get_subprocess_output(["sudo", conntrack_path, "-S"], self.log)
+            if disable_sudo_conntrack is True:
+                output, _, _ = get_subprocess_output([conntrack_path, "-S"], self.log)
+            else:
+                output, _, _ = get_subprocess_output(["sudo", conntrack_path, "-S"], self.log)
             # conntrack -S sample:
             # cpu=0 found=27644 invalid=19060 ignore=485633411 insert=0 insert_failed=1 \
             #       drop=1 early_drop=0 error=0 search_restart=39936711

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -132,7 +132,7 @@ def test_add_conntrack_stats_metrics(aggregator, check):
     )
     with mock.patch('datadog_checks.network.network.get_subprocess_output') as subprocess:
         subprocess.return_value = mocked_conntrack_stats, None, None
-        check._add_conntrack_stats_metrics(None, ['foo:bar'])
+        check._add_conntrack_stats_metrics(None, None, ['foo:bar'])
 
         for metric, value in iteritems(CONNTRACK_STATS):
             aggregator.assert_metric(metric, value=value[0], tags=['foo:bar', 'cpu:0'])


### PR DESCRIPTION
### What does this PR do?
Adds `try_sudo_conntrack` flag to configurations to collect `conntrack` metrics without sudo for containers.

Updated contributor PR with feedback, see https://github.com/DataDog/integrations-core/pull/4746.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
