### PR TITLE
Upgrade to jaydebeapi 1.1.2

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -14,7 +14,7 @@ gearman==2.0.2; sys_platform != 'win32' and python_version < '3.0'
 httplib2==0.10.3
 in-toto==0.3.0
 ipaddress==1.0.22; python_version < '3.0'
-jaydebeapi==1.1.1
+-e git+https://github.com/baztian/jaydebeapi.git#egg=jaydebeapi==1.1.2
 jpype1==0.7.0
 kafka-python==1.4.7; sys_platform != 'win32'
 kazoo==2.6.1; sys_platform != 'win32'

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -14,7 +14,7 @@ gearman==2.0.2; sys_platform != 'win32' and python_version < '3.0'
 httplib2==0.10.3
 in-toto==0.3.0
 ipaddress==1.0.22; python_version < '3.0'
--e git+https://github.com/baztian/jaydebeapi.git#egg=jaydebeapi==1.1.2
+git+https://github.com/baztian/jaydebeapi.git@a1b87626abc863edcedba365599fd385ef00cf57#egg=jaydebeapi
 jpype1==0.7.0
 kafka-python==1.4.7; sys_platform != 'win32'
 kazoo==2.6.1; sys_platform != 'win32'

--- a/oracle/requirements.in
+++ b/oracle/requirements.in
@@ -1,3 +1,3 @@
 cx-oracle==7.2.0
--e git+https://github.com/baztian/jaydebeapi.git#egg=jaydebeapi==1.1.2
+git+https://github.com/baztian/jaydebeapi.git@a1b87626abc863edcedba365599fd385ef00cf57#egg=jaydebeapi
 jpype1==0.7.0

--- a/oracle/requirements.in
+++ b/oracle/requirements.in
@@ -1,3 +1,3 @@
 cx-oracle==7.2.0
-jaydebeapi==1.1.1
+-e git+https://github.com/baztian/jaydebeapi.git#egg=jaydebeapi==1.1.2
 jpype1==0.7.0


### PR DESCRIPTION
### What does this PR do?
Sets the oracle requirements.in and base agent_requirements.in to use jaydebeapi 1.1.2 from source code. 

### Motivation
The maintainer of JayDeBeApi has committed version 1.1.2 which fixes compatibility with JPype 0.7.0, however [they are unable to publish to PyPi at this time](https://github.com/baztian/jaydebeapi/issues/117).  

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
