### PR TITLE
Support centreon additional field in event logs

### DIFF
--- a/nagios/datadog_checks/nagios/nagios.py
+++ b/nagios/datadog_checks/nagios/nagios.py
@@ -67,7 +67,7 @@ EVENT_FIELDS = {
 
 # Regex for the Nagios event log
 RE_LINE_REG = re.compile(r'^\[(\d+)\] EXTERNAL COMMAND: (\w+);(.*)$')
-RE_LINE_EXT = re.compile(r'^\[(\d+)\] ([^:]+): (.*)$')
+RE_LINE_EXT = re.compile(r'^\[(\d+)\](?: \[\d+\])? ([^:]+): (.*)$')
 
 SOURCE_TYPE_NAME = 'Nagios'
 


### PR DESCRIPTION
This filters out the PID which prefix event logs in centreon version of
nagios logs.