### PR TITLE
Refactor tailers logic

### DIFF
--- a/nagios/datadog_checks/nagios/data/conf.yaml.example
+++ b/nagios/datadog_checks/nagios/data/conf.yaml.example
@@ -1,10 +1,5 @@
 init_config:
 
-  ## @param check_freq - integer - optional - default: 15
-  ## This parameter defines the check execution frequency.
-  #
-  # check_freq: 15
-
 instances:
 
     ## @param nagios_conf - string - required

--- a/nagios/datadog_checks/nagios/nagios.py
+++ b/nagios/datadog_checks/nagios/nagios.py
@@ -1,22 +1,12 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from __future__ import division
-
 import json
 import re
 from collections import namedtuple
 
-from six import PY3, next
-
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.tailfile import TailFile
-
-if not PY3:
-    from inspect import getargspec
-else:
-    from inspect import getfullargspec as getargspec
-
 
 # fields order for each event type, as named tuples
 EVENT_FIELDS = {
@@ -82,102 +72,86 @@ class NagiosCheck(AgentCheck):
         re.compile(r'^(?P<key>service_perfdata_file)\s*=\s*(?P<value>.+)$'),
     ]
 
-    def gauge(self, *args, **kwargs):
-        """
-        Compatibility wrapper for Agents that do not submit gauge metrics with custom timestamps
-        """
-        orig_gauge = super(NagiosCheck, self).gauge
-        # remove 'timestamp' arg if the base class' gauge function does not accept a 'timestamp' arg
-        if 'timestamp' in kwargs and 'timestamp' not in getargspec(orig_gauge).args:
-            del kwargs['timestamp']
-
-        orig_gauge(*args, **kwargs)
-
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+    def __init__(self, name, init_config, instances):
+        AgentCheck.__init__(self, name, init_config, instances)
         self.nagios_tails = {}
-        check_freq = init_config.get("check_freq", 15)
 
-        if instances is not None:
-            for instance in instances:
-                tailers = []
-                nagios_conf = {}
-                instance_key = None
-                custom_tag = instance.get('tags', [])
+        instance = self.instances[0]
+        tailers = []
+        nagios_conf = {}
+        instance_key = None
+        custom_tag = instance.get('tags', [])
 
-                if 'nagios_conf' in instance:  # conf.d check
-                    conf_path = instance['nagios_conf']
-                    nagios_conf = self.parse_nagios_config(conf_path)
-                    instance_key = conf_path
-                # Retrocompatibility Code
-                elif 'nagios_perf_cfg' in instance:
-                    conf_path = instance['nagios_perf_cfg']
-                    nagios_conf = self.parse_nagios_config(conf_path)
-                    instance["collect_host_performance_data"] = True
-                    instance["collect_service_performance_data"] = True
-                    instance_key = conf_path
-                if 'nagios_log' in instance:
-                    nagios_conf["log_file"] = instance['nagios_log']
-                    if instance_key is None:
-                        instance_key = instance['nagios_log']
-                # End of retrocompatibility code
-                if not nagios_conf:
-                    self.log.warning("Missing path to nagios_conf")
-                    continue
+        if 'nagios_conf' in instance:  # conf.d check
+            conf_path = instance['nagios_conf']
+            nagios_conf = self.parse_nagios_config(conf_path)
+            instance_key = conf_path
+        # Retrocompatibility Code
+        elif 'nagios_perf_cfg' in instance:
+            conf_path = instance['nagios_perf_cfg']
+            nagios_conf = self.parse_nagios_config(conf_path)
+            instance["collect_host_performance_data"] = True
+            instance["collect_service_performance_data"] = True
+            instance_key = conf_path
+        if 'nagios_log' in instance:
+            nagios_conf["log_file"] = instance['nagios_log']
+            if instance_key is None:
+                instance_key = instance['nagios_log']
+        # End of retrocompatibility code
+        if not nagios_conf:
+            self.log.warning("Missing path to nagios_conf")
+            return
 
-                if 'log_file' in nagios_conf and instance.get('collect_events', True):
-                    self.log.debug("Starting to tail the event log")
-                    tailers.append(
-                        NagiosEventLogTailer(
-                            log_path=nagios_conf['log_file'],
-                            file_template=None,
-                            logger=self.log,
-                            hostname=self.hostname,
-                            tags=custom_tag,
-                            event_func=self.event,
-                            gauge_func=self.gauge,
-                            freq=check_freq,
-                            passive_checks=instance.get('passive_checks_events', False),
-                        )
-                    )
-                if (
-                    'host_perfdata_file' in nagios_conf
-                    and 'host_perfdata_file_template' in nagios_conf
-                    and instance.get('collect_host_performance_data', False)
-                ):
-                    self.log.debug("Starting to tail the host_perfdata file")
-                    tailers.append(
-                        NagiosHostPerfDataTailer(
-                            log_path=nagios_conf['host_perfdata_file'],
-                            file_template=nagios_conf['host_perfdata_file_template'],
-                            logger=self.log,
-                            hostname=self.hostname,
-                            event_func=self.event,
-                            gauge_func=self.gauge,
-                            freq=check_freq,
-                            tags=custom_tag,
-                        )
-                    )
-                if (
-                    'service_perfdata_file' in nagios_conf
-                    and 'service_perfdata_file_template' in nagios_conf
-                    and instance.get('collect_service_performance_data', False)
-                ):
-                    self.log.debug("Starting to tail the service_perfdata file")
-                    tailers.append(
-                        NagiosServicePerfDataTailer(
-                            log_path=nagios_conf['service_perfdata_file'],
-                            file_template=nagios_conf['service_perfdata_file_template'],
-                            logger=self.log,
-                            hostname=self.hostname,
-                            event_func=self.event,
-                            gauge_func=self.gauge,
-                            freq=check_freq,
-                            tags=custom_tag,
-                        )
-                    )
+        if 'log_file' in nagios_conf and instance.get('collect_events', True):
+            self.log.debug("Starting to tail the event log")
+            tailers.append(
+                NagiosEventLogTailer(
+                    log_path=nagios_conf['log_file'],
+                    logger=self.log,
+                    hostname=self.hostname,
+                    event_func=self.event,
+                    tags=custom_tag,
+                    passive_checks=instance.get('passive_checks_events', False),
+                )
+            )
+        if (
+            'host_perfdata_file' in nagios_conf
+            and 'host_perfdata_file_template' in nagios_conf
+            and instance.get('collect_host_performance_data', False)
+        ):
+            self.log.debug("Starting to tail the host_perfdata file")
+            tailers.append(
+                NagiosPerfDataTailer(
+                    log_path=nagios_conf['host_perfdata_file'],
+                    file_template=nagios_conf['host_perfdata_file_template'],
+                    logger=self.log,
+                    hostname=self.hostname,
+                    gauge_func=self.gauge,
+                    tags=custom_tag,
+                    perfdata_field='HOSTPERFDATA',
+                    metric_prefix=_get_host_metric_prefix,
+                )
+            )
+        if (
+            'service_perfdata_file' in nagios_conf
+            and 'service_perfdata_file_template' in nagios_conf
+            and instance.get('collect_service_performance_data', False)
+        ):
+            self.log.debug("Starting to tail the service_perfdata file")
+            tailers.append(
+                NagiosPerfDataTailer(
+                    log_path=nagios_conf['service_perfdata_file'],
+                    file_template=nagios_conf['service_perfdata_file_template'],
+                    logger=self.log,
+                    hostname=self.hostname,
+                    gauge_func=self.gauge,
+                    tags=custom_tag,
+                    perfdata_field='SERVICEPERFDATA',
+                    metric_prefix=_get_service_metric_prefix,
+                )
+            )
 
-                self.nagios_tails[instance_key] = tailers
+        self.nagios_tails[instance_key] = tailers
 
     def parse_nagios_config(self, filename):
         output = {}
@@ -212,7 +186,7 @@ class NagiosCheck(AgentCheck):
         Special case: Compatibility with the old conf when no conf file is specified
         but the path to the event_log is given
         """
-        instance_key = instance.get('nagios_conf', instance.get('nagios_perf_cfg', instance.get('nagios_log', None)))
+        instance_key = instance.get('nagios_conf', instance.get('nagios_perf_cfg', instance.get('nagios_log')))
 
         # Bad configuration: This instance does not contain any necessary configuration
         if not instance_key or instance_key not in self.nagios_tails:
@@ -222,78 +196,46 @@ class NagiosCheck(AgentCheck):
 
 
 class NagiosTailer(object):
-    def __init__(self, log_path, file_template, logger, hostname, event_func, gauge_func, freq, tags=None):
+    def __init__(self, log_path, logger, parse_line):
         """
         :param log_path: string, path to the file to parse
-        :param file_template: string, format of the perfdata file
         :param logger: Logger object
-        :param hostname: string, name of the host this agent is running on
-        :param event_func: function to create event, should accept dict
-        :param gauge_func: function to report a gauge
-        :param freq: int, size of bucket to aggregate perfdata metrics
-        :param tags: list, list of custom tags
         """
-
         self.log_path = log_path
         self.log = logger
-        self.gen = None
-        self.tail = None
-        self.hostname = hostname
-        self._event = event_func
-        self._gauge = gauge_func
-        self._line_parsed = 0
-        self._freq = freq
-        self._tags = [] if tags is None else tags
 
-        if file_template is not None:
-            self.compile_file_template(file_template)
-
-        self.tail = TailFile(self.log, self.log_path, self._parse_line)
-        self.gen = self.tail.tail(line_by_line=False, move_end=True)
+        tail = TailFile(self.log, self.log_path, parse_line)
+        self.gen = tail.tail(line_by_line=False, move_end=True)
         next(self.gen)
 
     def check(self):
         self._line_parsed = 0
         # read until the end of file
         try:
-            self.log.debug("Start nagios check for file %s" % self.log_path)
+            self.log.debug("Start nagios check for file %s", self.log_path)
             next(self.gen)
-            self.log.debug("Done nagios check for file %s (parsed %s line(s))" % (self.log_path, self._line_parsed))
+            self._line_parsed += 1
+            self.log.debug("Done nagios check for file %s (parsed %s line(s))", self.log_path, self._line_parsed)
         except StopIteration as e:
             self.log.exception(e)
-            self.log.warning("Can't tail %s file" % self.log_path)
-
-    def compile_file_template(self, file_template):
-        try:
-            # Escape characters that will be interpreted as regex bits
-            # e.g. [ and ] in "[SERVICEPERFDATA]"
-            regex = re.sub(r'[\[\]*]', r'.', file_template)
-            regex = re.sub(r'\$([^\$]*)\$', r'(?P<\1>[^\$]*)', regex)
-            self.line_pattern = re.compile(regex)
-        except Exception as e:
-            raise InvalidDataTemplate("%s (%s)" % (file_template, e))
+            self.log.warning("Can't tail %s file", self.log_path)
 
 
-class NagiosEventLogTailer(NagiosTailer):
-    def __init__(
-        self, log_path, file_template, logger, hostname, tags, event_func, gauge_func, freq, passive_checks=False
-    ):
+class NagiosEventLogTailer(object):
+    def __init__(self, log_path, logger, hostname, event_func, tags, passive_checks):
         """
         :param log_path: string, path to the file to parse
-        :param file_template: string, format of the perfdata file
         :param logger: Logger object
         :param hostname: string, name of the host this agent is running on
         :param event_func: function to create event, should accept dict
-        :param gauge_func: function to report a gauge
-        :param freq: int, size of bucket to aggregate perfdata metrics
         :param passive_checks: bool, enable or not passive checks events
         """
-
-        self.passive_checks = passive_checks
-        self.tags = tags
-        super(NagiosEventLogTailer, self).__init__(
-            log_path, file_template, logger, hostname, event_func, gauge_func, freq
-        )
+        self.log = logger
+        self.hostname = hostname
+        self._event = event_func
+        self._tags = tags
+        self._passive_checks = passive_checks
+        self.check = NagiosTailer(log_path, logger, self._parse_line).check
 
     def _parse_line(self, line):
         """
@@ -302,28 +244,26 @@ class NagiosEventLogTailer(NagiosTailer):
         """
         # first isolate the timestamp and the event type
         try:
-            self._line_parsed = self._line_parsed + 1
-
             m = RE_LINE_REG.match(line)
             if m is None:
                 m = RE_LINE_EXT.match(line)
             if m is None:
                 return False
-            self.log.debug("Matching line found %s" % line)
-            (tstamp, event_type, remainder) = m.groups()
+            self.log.debug("Matching line found %s", line)
+            tstamp, event_type, remainder = m.groups()
             tstamp = int(tstamp)
 
             # skip passive checks reports by default for spamminess
-            if event_type == 'PASSIVE SERVICE CHECK' and not self.passive_checks:
+            if event_type == 'PASSIVE SERVICE CHECK' and not self._passive_checks:
                 return False
             # then retrieve the event format for each specific event type
-            fields = EVENT_FIELDS.get(event_type, None)
+            fields = EVENT_FIELDS.get(event_type)
             if fields is None:
-                self.log.warning("Ignoring unknown nagios event for line: %s" % (line[:-1]))
+                self.log.warning("Ignoring unknown nagios event for line: %s", (line[:-1]))
                 return False
-            elif fields is False:
+            elif not fields:
                 # Ignore and skip
-                self.log.debug("Ignoring Nagios event for line: %s" % (line[:-1]))
+                self.log.debug("Ignoring Nagios event for line: %s", (line[:-1]))
                 return False
 
             # and parse the rest of the line
@@ -331,14 +271,14 @@ class NagiosEventLogTailer(NagiosTailer):
             # Chop parts we don't recognize
             parts = parts[: len(fields._fields)]
 
-            event = self.create_event(tstamp, event_type, self.hostname, fields._make(parts), tags=self.tags)
+            event = self.create_event(tstamp, event_type, self.hostname, fields._make(parts), tags=self._tags)
 
             self._event(event)
-            self.log.debug("Nagios event: %s" % (event))
+            self.log.debug("Nagios event: %s", event)
 
             return True
         except Exception:
-            self.log.exception("Unable to create a nagios event from line: [%s]" % line)
+            self.log.exception("Unable to create a nagios event from line: [%s]", line)
             return False
 
     def create_event(self, timestamp, event_type, hostname, fields, tags=None):
@@ -360,7 +300,7 @@ class NagiosEventLogTailer(NagiosTailer):
         }
 
         msg_text = json.dumps(msg_text)
-        self.log.info("Nagios Event pack: {}".format(msg_text))
+        self.log.info("Nagios Event pack: {}", msg_text)
 
         event_payload.update(
             {
@@ -373,14 +313,13 @@ class NagiosEventLogTailer(NagiosTailer):
         )
 
         # if host is localhost, turn that into the internal host name
-        host = event_payload.get('host', None)
+        host = event_payload.get('host')
         if host == "localhost":
             event_payload["host"] = hostname
         return event_payload
 
 
-class NagiosPerfDataTailer(NagiosTailer):
-    perfdata_field = ''  # Should be overriden by subclasses
+class NagiosPerfDataTailer(object):
     metric_prefix = 'nagios'
     pair_pattern = re.compile(
         r"".join(
@@ -396,31 +335,45 @@ class NagiosPerfDataTailer(NagiosTailer):
         )
     )
 
-    @staticmethod
-    def underscorize(s):
-        return s.replace(' ', '_').lower()
+    def __init__(self, log_path, file_template, logger, hostname, gauge_func, tags, perfdata_field, metric_prefix):
+        self.log = logger
+        self.compile_file_template(file_template)
+        self.hostname = hostname
+        self._gauge = gauge_func
+        self._tags = tags
+        self._get_metric_prefix = metric_prefix
+        self._perfdata_field = perfdata_field
+        self.check = NagiosTailer(log_path, logger, self._parse_line).check
 
-    def _get_metric_prefix(self, data):
-        raise NotImplementedError()
+    def compile_file_template(self, file_template):
+        try:
+            # Escape characters that will be interpreted as regex bits
+            # e.g. [ and ] in "[SERVICEPERFDATA]"
+            regex = re.sub(r'[\[\]*]', r'.', file_template)
+            regex = re.sub(r'\|', r'\|', regex)
+            regex = re.sub(r'\$([^\$]*)\$', r'(?P<\1>[^\$]*)', regex)
+            self.line_pattern = re.compile(regex)
+        except Exception as e:
+            raise InvalidDataTemplate("%s (%s)" % (file_template, e))
 
     def _parse_line(self, line):
         matched = self.line_pattern.match(line)
         if not matched:
-            self.log.debug("Non matching line found %s" % line)
+            self.log.debug("Non matching line found %s", line)
         else:
-            self.log.debug("Matching line found %s" % line)
+            self.log.debug("Matching line found %s", line)
             data = matched.groupdict()
-            metric_prefix = self._get_metric_prefix(data)
+            metric_prefix = self._get_metric_prefix(self.metric_prefix, data)
 
             # Parse the prefdata values, which are a space-delimited list of:
             #   'label'=value[UOM];[warn];[crit];[min];[max]
-            perf_data = data.get(self.perfdata_field, '')
+            perf_data = data.get(self._perfdata_field)
             if not perf_data:
                 self.log.warning(
-                    'Could not find field {} in {}, check your perfdata_format'.format(self.perfdata_field, line)
+                    'Could not find field {} in {}, check your perfdata_format', self._perfdata_field, line
                 )
                 return
-            for pair in perf_data.split(' '):
+            for pair in perf_data.split():
                 pair_match = self.pair_pattern.match(pair)
                 if not pair_match:
                     continue
@@ -428,9 +381,6 @@ class NagiosPerfDataTailer(NagiosTailer):
                     pair_data = pair_match.groupdict()
 
                 label = pair_data['label']
-                timestamp = data.get('TIMET', None)
-                if timestamp is not None:
-                    timestamp = (int(float(timestamp)) / self._freq) * self._freq
                 value = float(pair_data['value'])
                 device_name = None
 
@@ -451,36 +401,23 @@ class NagiosPerfDataTailer(NagiosTailer):
                 optional_keys = ['unit', 'warn', 'crit', 'min', 'max']
                 tags = []
                 for key in optional_keys:
-                    attr_val = pair_data.get(key, None)
+                    attr_val = pair_data.get(key)
                     if attr_val is not None and attr_val != '':
-                        tags.append("{0}:{1}".format(key, attr_val))
+                        tags.append("{}:{}".format(key, attr_val))
 
-                self._gauge(
-                    metric,
-                    value,
-                    tags=tags + self._tags,
-                    hostname=host_name,
-                    device_name=device_name,
-                    timestamp=timestamp,
-                )
+                self._gauge(metric, value, tags=tags + self._tags, hostname=host_name, device_name=device_name)
 
 
-class NagiosHostPerfDataTailer(NagiosPerfDataTailer):
-    perfdata_field = 'HOSTPERFDATA'
-
-    def _get_metric_prefix(self, line_data):
-        return [self.metric_prefix, 'host']
+def _get_host_metric_prefix(prefix, line_data):
+    return [prefix, 'host']
 
 
-class NagiosServicePerfDataTailer(NagiosPerfDataTailer):
-    perfdata_field = 'SERVICEPERFDATA'
-
-    def _get_metric_prefix(self, line_data):
-        metric = [self.metric_prefix]
-        middle_name = line_data.get('SERVICEDESC', None)
-        if middle_name:
-            metric.append(middle_name.replace(' ', '_').lower())
-        return metric
+def _get_service_metric_prefix(prefix, line_data):
+    prefix = [prefix]
+    middle_name = line_data.get('SERVICEDESC')
+    if middle_name:
+        prefix.append(middle_name.replace(' ', '_').lower())
+    return prefix
 
 
 class InvalidDataTemplate(Exception):

--- a/nagios/tests/test_e2e.py
+++ b/nagios/tests/test_e2e.py
@@ -1,11 +1,7 @@
 # (C) Datadog, Inc. 2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import logging
-
 import pytest
-
-LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.e2e

--- a/nagios/tests/test_nagios.py
+++ b/nagios/tests/test_nagios.py
@@ -33,7 +33,7 @@ class TestEventLogTailer:
         )
 
         # Set up the check
-        nagios = NagiosCheck(CHECK_NAME, {}, {}, config['instances'])
+        nagios = NagiosCheck(CHECK_NAME, {}, config['instances'])
 
         # Run the check once
         nagios.check(config['instances'][0])
@@ -104,7 +104,7 @@ class TestEventLogTailer:
         config, nagios_cfg = get_config("log_file={}\n".format(log_file.name), events=True)
 
         # Set up the check
-        nagios = NagiosCheck(CHECK_NAME, {}, {}, config['instances'])
+        nagios = NagiosCheck(CHECK_NAME, {}, config['instances'])
 
         for _ in range(ITERATIONS):
             log_file.write(test_data)
@@ -190,7 +190,7 @@ class TestPerfDataTailer:
         )
 
         # Set up the check
-        nagios = NagiosCheck(CHECK_NAME, {}, {}, config['instances'])
+        nagios = NagiosCheck(CHECK_NAME, {}, config['instances'])
 
         # Run the check once
         nagios.check(config['instances'][0])
@@ -230,7 +230,7 @@ class TestPerfDataTailer:
         )
 
         # Set up the check
-        nagios = NagiosCheck(CHECK_NAME, {}, {}, config['instances'])
+        nagios = NagiosCheck(CHECK_NAME, {}, config['instances'])
 
         # Run the check once
         nagios.check(config['instances'][0])
@@ -270,7 +270,7 @@ class TestPerfDataTailer:
         )
 
         # Set up the check
-        nagios = NagiosCheck(CHECK_NAME, {}, {}, config['instances'])
+        nagios = NagiosCheck(CHECK_NAME, {}, config['instances'])
 
         # Run the check once
         nagios.check(config['instances'][0])
@@ -314,7 +314,7 @@ class TestPerfDataTailer:
         )
 
         # Set up the check
-        nagios = NagiosCheck(CHECK_NAME, {}, {}, config['instances'])
+        nagios = NagiosCheck(CHECK_NAME, {}, config['instances'])
 
         # Run the check once
         nagios.check(config['instances'][0])
@@ -379,7 +379,7 @@ class TestPerfDataTailer:
         )
 
         # Set up the check
-        nagios = NagiosCheck(CHECK_NAME, {}, {}, config['instances'])
+        nagios = NagiosCheck(CHECK_NAME, {}, config['instances'])
 
         # Run the check once
         nagios.check(config['instances'][0])

--- a/nagios/tests/test_unit.py
+++ b/nagios/tests/test_unit.py
@@ -2,63 +2,11 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from mock import MagicMock, patch
+from mock import MagicMock
 
-from datadog_checks.nagios import NagiosCheck
 from datadog_checks.nagios.nagios import NagiosEventLogTailer
 
-from .common import CHECK_NAME, CUSTOM_TAGS, NAGIOS_TEST_LOG
-
-# Random test values
-METRIC_NAME = 'nagios.metric_name'
-METRIC_VALUE = 42
-METRIC_TAGS = CUSTOM_TAGS
-METRIC_TIMESTAMP = 1337404007
-
-
-class TestGaugeWrapper:
-    def test_gauge_without_timestamp(self):
-        """
-        Test the 'gauge' wrapper to see if it strips the 'timestamp' arg for gauge functions that do not accept it
-        """
-
-        def gauge_v6(self, name, value, tags=None, hostname=None, device_name=None):
-            """
-            A gauge function that does not accept the 'timestamp' argument
-            """
-            # Make sure we get the original arguments back and timestamp is not being received
-            assert name == METRIC_NAME
-            assert value == METRIC_VALUE
-            assert tags == METRIC_TAGS
-            assert hostname is None
-            assert device_name is None
-
-        # This should call 'gauge_v6' with all the same arguments that we passed in, except for the 'timestamp' argument
-        with patch('datadog_checks.checks.AgentCheck.gauge', new=gauge_v6):
-            nagios = NagiosCheck(CHECK_NAME, {}, {})
-            nagios.gauge(METRIC_NAME, METRIC_VALUE, tags=METRIC_TAGS, timestamp=METRIC_TIMESTAMP)
-
-    def test_gauge_with_timestamp(self):
-        """
-        Test the 'gauge' wrapper to see if it doesn't strip anything for gauge functions that accept timestamps
-        """
-
-        def gauge_v5(self, metric, value, tags=None, hostname=None, device_name=None, timestamp=None):
-            """
-            A gauge function that should accept the 'timestamp' argument
-            """
-            # Make sure we get the original arguments back
-            assert metric == METRIC_NAME
-            assert value == METRIC_VALUE
-            assert tags == METRIC_TAGS
-            assert hostname is None
-            assert device_name is None
-            assert timestamp == METRIC_TIMESTAMP
-
-        # This should call 'gauge_v5' with all the same arguments that we passed in
-        with patch('datadog_checks.checks.AgentCheck.gauge', new=gauge_v5):
-            nagios = NagiosCheck(CHECK_NAME, {}, {})
-            nagios.gauge(METRIC_NAME, METRIC_VALUE, tags=METRIC_TAGS, timestamp=METRIC_TIMESTAMP)
+from .common import NAGIOS_TEST_LOG
 
 
 def test_centreon_event_logs():
@@ -68,7 +16,7 @@ def test_centreon_event_logs():
     )
     events = []
     mock_log = MagicMock()
-    tailer = NagiosEventLogTailer(NAGIOS_TEST_LOG, None, mock_log, "host", [], events.append, None, 5)
+    tailer = NagiosEventLogTailer(NAGIOS_TEST_LOG, mock_log, "host", events.append, None, False)
     tailer._parse_line(log)
     assert len(events) == 1
     assert events[0]['event_type'] == 'SERVICE ALERT'


### PR DESCRIPTION
This refactors the tailers logic a bit, minimizing the number of classes. It
also removes Agent 5 compatibility code, and fixes a bug when | is present in a
perfdata format (like our e2e).