### PR TITLE
Fix ksm job metrics

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -125,7 +125,6 @@ class KubernetesState(OpenMetricsBaseCheck):
         for job_tags, job_count in iteritems(self.job_failed_count):
             self.monotonic_count(scraper_config['namespace'] + '.job.failed', job_count, list(job_tags))
 
-
     def _filter_metric(self, metric, scraper_config):
         if scraper_config['telemetry']:
             # name is like "kube_pod_execution_duration"
@@ -576,8 +575,10 @@ class KubernetesState(OpenMetricsBaseCheck):
                     tags.append(self._format_tag(label_name, trimmed_job, scraper_config))
                 else:
                     tags.append(self._format_tag(label_name, label_value, scraper_config))
-            if job_ts != None: # if there is a timestamp, this is a Cron Job
-                self.failed_cron_job_counts[frozenset(tags)].update_current_ts_and_add_count(job_ts, sample[self.SAMPLE_VALUE])
+            if job_ts is not None:  # if there is a timestamp, this is a Cron Job
+                self.failed_cron_job_counts[frozenset(tags)].update_current_ts_and_add_count(
+                    job_ts, sample[self.SAMPLE_VALUE]
+                )
             else:
                 self.job_failed_count[frozenset(tags)] += sample[self.SAMPLE_VALUE]
 
@@ -592,7 +593,7 @@ class KubernetesState(OpenMetricsBaseCheck):
                     tags.append(self._format_tag(label_name, trimmed_job, scraper_config))
                 else:
                     tags.append(self._format_tag(label_name, label_value, scraper_config))
-            if job_ts != None: # if there is a timestamp, this is a Cron Job
+            if job_ts is not None:  # if there is a timestamp, this is a Cron Job
                 self.succeeded_cron_job_counts[frozenset(tags)].update_current_ts_and_add_count(
                     job_ts, sample[self.SAMPLE_VALUE]
                 )

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -567,7 +567,7 @@ class KubernetesState(OpenMetricsBaseCheck):
 
     def kube_job_status_failed(self, metric, scraper_config):
         for sample in metric.samples:
-            job_ts = 0
+            job_ts = None
             tags = [] + scraper_config['custom_tags']
             for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
                 if label_name == 'job' or label_name == 'job_name':
@@ -583,7 +583,7 @@ class KubernetesState(OpenMetricsBaseCheck):
 
     def kube_job_status_succeeded(self, metric, scraper_config):
         for sample in metric.samples:
-            job_ts = 0
+            job_ts = None
             tags = [] + scraper_config['custom_tags']
             for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
                 if label_name == 'job' or label_name == 'job_name':

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -100,12 +100,12 @@ class KubernetesState(OpenMetricsBaseCheck):
         self.failed_cron_job_counts = defaultdict(KubernetesState.CronJobCount)
         self.succeeded_cron_job_counts = defaultdict(KubernetesState.CronJobCount)
 
-    def check(self, instance):
-        endpoint = instance.get('kube_state_url')
-
         # Logic for Jobs
         self.job_succeeded_count = defaultdict(int)
         self.job_failed_count = defaultdict(int)
+
+    def check(self, instance):
+        endpoint = instance.get('kube_state_url')
 
         scraper_config = self.config_map[endpoint]
         self.process(scraper_config, metric_transformers=self.METRIC_TRANSFORMERS)

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -47,7 +47,7 @@ class KubernetesState(OpenMetricsBaseCheck):
                 self.current_run_max_ts = 0
 
         def update_current_ts_and_add_count(self, job_ts, count):
-            if job_ts != 0 and job_ts > self.previous_run_max_ts:
+            if job_ts != 0 and job_ts > self.previous_run_max_ts and count > 0:
                 self.count += count
                 self.current_run_max_ts = max(self.current_run_max_ts, job_ts)
 

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -185,6 +185,7 @@ kube_job_status_failed{job="hello-1509998460",namespace="default"} 0
 kube_job_status_failed{job_name="hello2-1509998340",namespace="default"} 0
 kube_job_status_failed{job_name="hello2-1509998400",namespace="default"} 0
 kube_job_status_failed{job_name="hello2-1509998460",namespace="default"} 0
+kube_job_status_failed{job_name="test",namespace="default"} 0
 # HELP kube_job_status_start_time StartTime represents time when the job was acknowledged by the Job Manager.
 # TYPE kube_job_status_start_time counter
 kube_job_status_start_time{job="hello-1509998340",namespace="default"} 1.509998347e+09
@@ -198,6 +199,7 @@ kube_job_status_succeeded{job="hello-1509998460",namespace="default"} 1
 kube_job_status_succeeded{job_name="hello2-1509998340",namespace="default"} 1
 kube_job_status_succeeded{job_name="hello2-1509998400",namespace="default"} 1
 kube_job_status_succeeded{job_name="hello2-1509998460",namespace="default"} 1
+kube_job_status_succeeded{job_name="test",namespace="default"} 1
 # HELP kube_namespace_created Unix creation timestamp
 # TYPE kube_namespace_created gauge
 kube_namespace_created{namespace="default"} 1.508406437e+09

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -453,6 +453,27 @@ def test_job_counts(aggregator, instance):
         NAMESPACE + '.job.succeeded', tags=['namespace:default', 'job:hello', 'optional:tag1'], value=4
     )
 
+    # Edit the payload to mimick a job running and rerun the check
+    payload = payload.replace(
+        b'kube_job_status_succeeded{job="hello-1509998500",namespace="default"} 1',
+        b'kube_job_status_succeeded{job="hello-1509998600",namespace="default"} 0',
+    )
+
+    check.poll = mock.MagicMock(return_value=MockResponse(payload, 'text/plain'))
+    check.check(instance)
+
+
+    # Edit the payload to mimick a job that stopped running and rerun the check
+    payload = payload.replace(
+        b'kube_job_status_succeeded{job="hello-1509998600",namespace="default"} 0',
+        b'kube_job_status_succeeded{job="hello-1509998600",namespace="default"} 1',
+    )
+
+    check.poll = mock.MagicMock(return_value=MockResponse(payload, 'text/plain'))
+    check.check(instance)
+    aggregator.assert_metric(
+        NAMESPACE + '.job.succeeded', tags=['namespace:default', 'job:hello', 'optional:tag1'], value=5
+    )
 
 def test_telemetry(aggregator, instance):
     instance['telemetry'] = True

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -408,7 +408,7 @@ def test_extract_timestamp(check):
     result = check._extract_job_timestamp(job_name2)
     assert result == 1509998340
     result = check._extract_job_timestamp(job_name3)
-    assert result == 0
+    assert result == None
 
 
 def test_job_counts(aggregator, instance):
@@ -418,6 +418,8 @@ def test_job_counts(aggregator, instance):
 
     for _ in range(2):
         check.check(instance)
+
+    # Test cron jobs
     aggregator.assert_metric(
         NAMESPACE + '.job.failed', tags=['namespace:default', 'job:hello', 'optional:tag1'], value=0
     )
@@ -425,13 +427,31 @@ def test_job_counts(aggregator, instance):
         NAMESPACE + '.job.succeeded', tags=['namespace:default', 'job:hello', 'optional:tag1'], value=3
     )
 
+    # Test jobs
+    aggregator.assert_metric(
+        NAMESPACE + '.job.failed', tags=['namespace:default', 'job_name:test', 'optional:tag1'], value=0
+    )
+    aggregator.assert_metric(
+        NAMESPACE + '.job.succeeded', tags=['namespace:default', 'job_name:test', 'optional:tag1'], value=1
+    )
+
     # Re-run check to make sure we don't count the same jobs
     check.check(instance)
+
+    # Test cron jobs
     aggregator.assert_metric(
         NAMESPACE + '.job.failed', tags=['namespace:default', 'job:hello', 'optional:tag1'], value=0
     )
     aggregator.assert_metric(
         NAMESPACE + '.job.succeeded', tags=['namespace:default', 'job:hello', 'optional:tag1'], value=3
+    )
+
+     # Test jobs
+    aggregator.assert_metric(
+        NAMESPACE + '.job.failed', tags=['namespace:default', 'job_name:test', 'optional:tag1'], value=0
+    )
+    aggregator.assert_metric(
+        NAMESPACE + '.job.succeeded', tags=['namespace:default', 'job_name:test', 'optional:tag1'], value=1
     )
 
     # Edit the payload and rerun the check
@@ -487,9 +507,9 @@ def test_telemetry(aggregator, instance):
 
     for _ in range(2):
         check.check(instance)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=90270.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=908.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1282.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=90397.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=912.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1286.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.blacklist.count', tags=['optional:tag1'], value=24.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.ignored.count', tags=['optional:tag1'], value=374.0)
     aggregator.assert_metric(

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -408,7 +408,7 @@ def test_extract_timestamp(check):
     result = check._extract_job_timestamp(job_name2)
     assert result == 1509998340
     result = check._extract_job_timestamp(job_name3)
-    assert result == None
+    assert result is None
 
 
 def test_job_counts(aggregator, instance):
@@ -446,7 +446,7 @@ def test_job_counts(aggregator, instance):
         NAMESPACE + '.job.succeeded', tags=['namespace:default', 'job:hello', 'optional:tag1'], value=3
     )
 
-     # Test jobs
+    # Test jobs
     aggregator.assert_metric(
         NAMESPACE + '.job.failed', tags=['namespace:default', 'job_name:test', 'optional:tag1'], value=0
     )
@@ -482,7 +482,6 @@ def test_job_counts(aggregator, instance):
     check.poll = mock.MagicMock(return_value=MockResponse(payload, 'text/plain'))
     check.check(instance)
 
-
     # Edit the payload to mimick a job that stopped running and rerun the check
     payload = payload.replace(
         b'kube_job_status_succeeded{job="hello-1509998600",namespace="default"} 0',
@@ -494,6 +493,7 @@ def test_job_counts(aggregator, instance):
     aggregator.assert_metric(
         NAMESPACE + '.job.succeeded', tags=['namespace:default', 'job:hello', 'optional:tag1'], value=5
     )
+
 
 def test_telemetry(aggregator, instance):
     instance['telemetry'] = True


### PR DESCRIPTION
### What does this PR do?
The last change did not include a code path for jobs, only for cron jobs.
Also, there was an issue when the value of the succeeded/failed metric was set to 0, before being set to 1.

### Motivation
Several customers reported missing values

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
