### PR TITLE
Add ssl config options necessary for Openmetrics base

### DIFF
--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -36,26 +36,34 @@ instances:
     ## @param ssl_cert - string - optional
     ## The certificate to use when connecting to the `prometheus_url`.
     ## It may also contain an unencrypted private key to use.
+    ##
     ## NOTE: Use only if `use_preview` is set to `true`.
+    ##       This option is used in place of `tls_cert`
     #
     # ssl_cert: <CERT_PATH>
 
     ## @param ssl_private_key - string - optional
     ## The unencrypted private key to use when connecting to the `prometheus_url`.
     ## This is required if `ssl_cert` is set and it does not already contain a private key.
+    ##
     ## NOTE: Use only if `use_preview` is set to `true`.
+    ##       This option is used in place of `tls_private_key`.
     #
     # ssl_private_key: <PRIVATE_KEY_PATH>
 
     ## @param ssl_ca_cert - string - optional
     ## The path to a CA_BUNDLE file or a directory with certificates of trusted CAs.
+    ##
     ## NOTE: Use only if `use_preview` is set to `true`.
+    ##       This option is used in place of `tls_ca_cert`.
     #
     # ssl_ca_cert: <CA_CERT_PATH>
 
     ## @param ssl_verify - boolean - optional - default: true
     ## Instruct the check to validate SSL certificates when connecting to `prometheus_url` and GPRC gateway.
+    ##
     ## NOTE: Use only if `use_preview` is set to `true`.
+    ##       This option is used in place of `tls_verify`.
     #
     # ssl_verify: true
 

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -33,6 +33,32 @@ instances:
     #
     # prometheus_url: http://localhost:2379/metrics
 
+    ## @param ssl_cert - string - optional
+    ## The certificate to use when connecting to the `prometheus_url`.
+    ## It may also contain an unencrypted private key to use.
+    ## NOTE: Use only if `use_preview` is set to `true`.
+    #
+    # ssl_cert: <CERT_PATH>
+
+    ## @param ssl_private_key - string - optional
+    ## The unencrypted private key to use when connecting to the `prometheus_url`.
+    ## This is required if `ssl_cert` is set and it does not already contain a private key.
+    ## NOTE: Use only if `use_preview` is set to `true`.
+    #
+    # ssl_private_key: <PRIVATE_KEY_PATH>
+
+    ## @param ssl_ca_cert - string - optional
+    ## The path to a CA_BUNDLE file or a directory with certificates of trusted CAs.
+    ## NOTE: Use only if `use_preview` is set to `true`.
+    #
+    # ssl_ca_cert: <CA_CERT_PATH>
+
+    ## @param ssl_verify - boolean - optional - default: true
+    ## Instruct the check to validate SSL certificates when connecting to `prometheus_url` and GPRC gateway.
+    ## NOTE: Use only if `use_preview` is set to `true`.
+    #
+    # ssl_verify: true
+
     ## @param leader_tag - boolean - optional - default: true
     ## Whether or not to tag with `is_leader:true` or `is_leader:false`.
     #


### PR DESCRIPTION
### What does this PR do?
The ssl config options were removed from `conf.yaml` when standardizing our config options and adding the RequestsWrapper. The `use_preview` version of the etcd check uses Prometheus/Openmetrics options which has not been updated with the RequestsWrapper.

This PR adds back those options with a note so that the ssl options can still be configured when using the integration with `use_preview`.

### Motivation
https://github.com/DataDog/integrations-core/issues/4945 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
