### PR TITLE
Recreate connection when closed

### DIFF
--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -97,6 +97,9 @@ class VerticaCheck(AgentCheck):
 
             self._connection = connection
 
+        if self._connection.closed():
+            self._connection.reset_connection()
+
         # The order of queries is important as some results are cached for later re-use
         try:
             self.query_licenses()


### PR DESCRIPTION
Currently if the connection to the vertica database is closed, we loop
forever with a connection error. Let's retry to connect at the beginning
of check if the connection is detected as closed.