### PR TITLE
Fix error on missing config

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -329,7 +329,7 @@ class KafkaCheck(AgentCheck):
         else:
             raise ConfigurationError(
                 "Cannot fetch consumer offsets because no consumer_groups are specified and "
-                "monitor_unlisted_consumer_groups is %s." % self.instance._monitor_unlisted_consumer_groups
+                "monitor_unlisted_consumer_groups is %s." % self._monitor_unlisted_consumer_groups
             )
 
         # Loop until all futures resolved.

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -5,7 +5,7 @@ import pytest
 
 from datadog_checks.kafka_consumer import KafkaCheck
 
-from .common import is_supported
+from .common import is_supported, KAFKA_CONNECT_STR
 
 pytestmark = pytest.mark.skipif(
     not is_supported('kafka'), reason='kafka consumer offsets not supported in current environment'
@@ -46,3 +46,15 @@ def assert_check_kafka(aggregator, kafka_instance):
                     aggregator.assert_metric(mname, tags=tags + ["consumer_group:{}".format(name)], at_least=1)
 
     aggregator.assert_all_metrics_covered()
+
+
+@pytest.mark.usefixtures('dd_environment')
+def test_consumer_config_error(caplog):
+    instance = {
+        'kafka_connect_str': KAFKA_CONNECT_STR,
+        'kafka_consumer_offsets': True,
+        'tags': ['optional:tag1'],
+    }
+    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [instance])
+    kafka_consumer_check.check(instance)
+    assert 'monitor_unlisted_consumer_groups is False' in caplog.text

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -5,7 +5,7 @@ import pytest
 
 from datadog_checks.kafka_consumer import KafkaCheck
 
-from .common import is_supported, KAFKA_CONNECT_STR
+from .common import KAFKA_CONNECT_STR, is_supported
 
 pytestmark = pytest.mark.skipif(
     not is_supported('kafka'), reason='kafka consumer offsets not supported in current environment'
@@ -50,11 +50,7 @@ def assert_check_kafka(aggregator, kafka_instance):
 
 @pytest.mark.usefixtures('dd_environment')
 def test_consumer_config_error(caplog):
-    instance = {
-        'kafka_connect_str': KAFKA_CONNECT_STR,
-        'kafka_consumer_offsets': True,
-        'tags': ['optional:tag1'],
-    }
+    instance = {'kafka_connect_str': KAFKA_CONNECT_STR, 'kafka_consumer_offsets': True, 'tags': ['optional:tag1']}
     kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [instance])
     kafka_consumer_check.check(instance)
     assert 'monitor_unlisted_consumer_groups is False' in caplog.text


### PR DESCRIPTION
The ConfigurationError raised when there are no consumer groups
referenced an unknown attribute.