### PR TITLE
Support latest envoy go-control-plane

### DIFF
--- a/envoy/tests/docker/default/controlplane.go
+++ b/envoy/tests/docker/default/controlplane.go
@@ -1,23 +1,24 @@
 package main
 
 import (
+	"context"
 	"google.golang.org/grpc"
 	"net"
-    "time"
+	"time"
 
 	api "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-    core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-    endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	xds "github.com/envoyproxy/go-control-plane/pkg/server"
 
-    "github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes"
 )
 
 func main() {
 	snapshotCache := cache.NewSnapshotCache(false, cache.IDHash{}, nil)
-	server := xds.NewServer(snapshotCache, nil)
+	server := xds.NewServer(context.Background(), snapshotCache, nil)
 	grpcServer := grpc.NewServer()
 	lis, _ := net.Listen("tcp", ":8080")
 
@@ -27,49 +28,49 @@ func main() {
 	api.RegisterRouteDiscoveryServiceServer(grpcServer, server)
 	api.RegisterListenerDiscoveryServiceServer(grpcServer, server)
 
-    go grpcServer.Serve(lis)
+	go grpcServer.Serve(lis)
 
-    dummyHost := &core.Address{
-        Address: &core.Address_SocketAddress{
-            SocketAddress: &core.SocketAddress{
-                Address: "localhost",
-                Protocol: core.SocketAddress_TCP,
-                PortSpecifier: &core.SocketAddress_PortValue{
-                    PortValue: uint32(8000),
-                },
-            },
-        },
-    }
-    dummyLbEndpoint := endpoint.LbEndpoint{
-        HostIdentifier: &endpoint.LbEndpoint_Endpoint{
-            Endpoint: &endpoint.Endpoint{
-                Address: dummyHost,
-            },
-        },
-    }
-    dummyLocalityLbEndpoint := endpoint.LocalityLbEndpoints{
-        LbEndpoints: []*endpoint.LbEndpoint{&dummyLbEndpoint},
-    }
+	dummyHost := &core.Address{
+		Address: &core.Address_SocketAddress{
+			SocketAddress: &core.SocketAddress{
+				Address:  "localhost",
+				Protocol: core.SocketAddress_TCP,
+				PortSpecifier: &core.SocketAddress_PortValue{
+					PortValue: uint32(8000),
+				},
+			},
+		},
+	}
+	dummyLbEndpoint := endpoint.LbEndpoint{
+		HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+			Endpoint: &endpoint.Endpoint{
+				Address: dummyHost,
+			},
+		},
+	}
+	dummyLocalityLbEndpoint := endpoint.LocalityLbEndpoints{
+		LbEndpoints: []*endpoint.LbEndpoint{&dummyLbEndpoint},
+	}
 
-    clusterResource := []cache.Resource{
-        &api.Cluster{
-            Name: "dummy_dynamic_cluster",
-            ConnectTimeout: ptypes.DurationProto(time.Second),
-            ClusterDiscoveryType: &api.Cluster_Type{Type: api.Cluster_LOGICAL_DNS},
-            LoadAssignment: &api.ClusterLoadAssignment{
-                ClusterName: "dummy_dynamic_cluster",
-                Endpoints: []*endpoint.LocalityLbEndpoints{&dummyLocalityLbEndpoint},
-            },
-        },
-    }
+	clusterResource := []cache.Resource{
+		&api.Cluster{
+			Name:                 "dummy_dynamic_cluster",
+			ConnectTimeout:       ptypes.DurationProto(time.Second),
+			ClusterDiscoveryType: &api.Cluster_Type{Type: api.Cluster_LOGICAL_DNS},
+			LoadAssignment: &api.ClusterLoadAssignment{
+				ClusterName: "dummy_dynamic_cluster",
+				Endpoints:   []*endpoint.LocalityLbEndpoints{&dummyLocalityLbEndpoint},
+			},
+		},
+	}
 
-    for {
-        for _, nodeId := range snapshotCache.GetStatusKeys() {
-            // snapshot := cache.NewSnapshot("1", nil, clusterResource, nil, listenerResource, nil)
-            snapshot := cache.NewSnapshot("1", nil, clusterResource, nil, nil, nil)
-            snapshotCache.SetSnapshot(nodeId, snapshot)
-        }
+	for {
+		for _, nodeId := range snapshotCache.GetStatusKeys() {
+			// snapshot := cache.NewSnapshot("1", nil, clusterResource, nil, listenerResource, nil)
+			snapshot := cache.NewSnapshot("1", nil, clusterResource, nil, nil, nil)
+			snapshotCache.SetSnapshot(nodeId, snapshot)
+		}
 
-        time.Sleep(time.Second)
-    }
+		time.Sleep(time.Second)
+	}
 }

--- a/envoy/tests/test_envoy.py
+++ b/envoy/tests/test_envoy.py
@@ -9,7 +9,7 @@ import pytest
 from datadog_checks.envoy import Envoy
 from datadog_checks.envoy.metrics import METRIC_PREFIX, METRICS
 
-from .common import INSTANCES, response
+from .common import HOST, INSTANCES, response
 
 CHECK_NAME = 'envoy'
 
@@ -119,4 +119,4 @@ def test_config(test_case, extra_config, expected_http_kwargs):
             auth=mock.ANY, cert=mock.ANY, headers=mock.ANY, proxies=mock.ANY, timeout=mock.ANY, verify=mock.ANY
         )
         http_wargs.update(expected_http_kwargs)
-        r.get.assert_called_with('http://localhost:8001/stats', **http_wargs)
+        r.get.assert_called_with('http://{}:8001/stats'.format(HOST), **http_wargs)


### PR DESCRIPTION
https://github.com/envoyproxy/go-control-plane/pull/239 changed the
signature of the server creation, we need to mirror that change. This
also fixes the tests to work with non-local docker.