### PR TITLE
Add open file descriptor metric to docker and containerd metadata

### DIFF
--- a/containerd/metadata.csv
+++ b/containerd/metadata.csv
@@ -35,4 +35,4 @@ containerd.blkio.serviced_recursive,rate,,,,The blkio io serviced recursive,0,co
 containerd.blkio.wait_time_recursive,rate,,nanosecond,,The blkio io wait time recursive,0,containerd,io_wait_time_recursive
 containerd.blkio.service_time_recursive,rate,,,,The blkio io service time recursive,0,containerd,io service time recursive
 containerd.image.size,gauge,,byte,,The size of the container image,0,containerd,image size
-containerd.proc.open_fds,gauge,,,,The number of open file descriptors,0,containerd,open_fds
+containerd.proc.open_fds,gauge,,file,,The number of open file descriptors,0,containerd,open_fds

--- a/containerd/metadata.csv
+++ b/containerd/metadata.csv
@@ -33,6 +33,6 @@ containerd.blkio.service_recursive_byte,rate,,byte,,The blkio io service byte re
 containerd.blkio.time_recursive,rate,,nanosecond,,The blkio io time recursive,0,containerd,io_sectors_recursive
 containerd.blkio.serviced_recursive,rate,,,,The blkio io serviced recursive,0,containerd,io_serviced_recursive
 containerd.blkio.wait_time_recursive,rate,,nanosecond,,The blkio io wait time recursive,0,containerd,io_wait_time_recursive
-containerd.blkio.service_time_recursive,rate,,,,The blkio io service time recursive,0,containerd,io_service_time recursive
-containerd.image.size,gauge,,byte,,The size of the container image,0,containerd,image_size
+containerd.blkio.service_time_recursive,rate,,,,The blkio io service time recursive,0,containerd,io service time recursive
+containerd.image.size,gauge,,byte,,The size of the container image,0,containerd,image size
 containerd.proc.open_fds,gauge,,,,The number of open file descriptors,0,containerd,open_fds

--- a/containerd/metadata.csv
+++ b/containerd/metadata.csv
@@ -33,5 +33,6 @@ containerd.blkio.service_recursive_byte,rate,,byte,,The blkio io service byte re
 containerd.blkio.time_recursive,rate,,nanosecond,,The blkio io time recursive,0,containerd,io_sectors_recursive
 containerd.blkio.serviced_recursive,rate,,,,The blkio io serviced recursive,0,containerd,io_serviced_recursive
 containerd.blkio.wait_time_recursive,rate,,nanosecond,,The blkio io wait time recursive,0,containerd,io_wait_time_recursive
-containerd.blkio.service_time_recursive,rate,,,,The blkio io service time recursive,0,containerd,io service time recursive
-containerd.image.size,gauge,,byte,,The size of the container image,0,containerd,image size
+containerd.blkio.service_time_recursive,rate,,,,The blkio io service time recursive,0,containerd,io_service_time recursive
+containerd.image.size,gauge,,byte,,The size of the container image,0,containerd,image_size
+containerd.proc.open_fds,gauge,,,,The number of open file descriptors,0,containerd,open_fds

--- a/docker_daemon/metadata.csv
+++ b/docker_daemon/metadata.csv
@@ -33,7 +33,7 @@ docker.mem.swap.avg,gauge,,byte,,Average value of docker.mem.swap,0,docker,mem s
 docker.mem.swap.count,rate,,sample,second,The rate that the value of docker.mem.swap was sampled,0,docker,mem swap count
 docker.mem.swap.max,gauge,,byte,,Max value of docker.mem.swap,0,docker,mem swap max
 docker.mem.swap.median,gauge,,byte,,Median value of docker.mem.swap,0,docker,mem swap median
-docker.container.open_fds,gauge,,,,The number of open file descriptors,0,docker,open_fds
+docker.container.open_fds,gauge,,file,,The number of open file descriptors,0,docker,open_fds
 docker.container.size_rw,gauge,,byte,,Total size of all the files in the container which have been created or changed by processes running in the container,0,docker,changed files size
 docker.container.size_rw.95percentile,gauge,,byte,,95th percentile of docker.container.size_rw,0,docker,changed files size 95%
 docker.container.size_rw.avg,gauge,,byte,,Average value of docker.container.size_rw,0,docker,changed files size avg

--- a/docker_daemon/metadata.csv
+++ b/docker_daemon/metadata.csv
@@ -33,6 +33,7 @@ docker.mem.swap.avg,gauge,,byte,,Average value of docker.mem.swap,0,docker,mem s
 docker.mem.swap.count,rate,,sample,second,The rate that the value of docker.mem.swap was sampled,0,docker,mem swap count
 docker.mem.swap.max,gauge,,byte,,Max value of docker.mem.swap,0,docker,mem swap max
 docker.mem.swap.median,gauge,,byte,,Median value of docker.mem.swap,0,docker,mem swap median
+docker.container.open_fds,gauge,,,,The number of open file descriptors,0,docker,open_fds
 docker.container.size_rw,gauge,,byte,,Total size of all the files in the container which have been created or changed by processes running in the container,0,docker,changed files size
 docker.container.size_rw.95percentile,gauge,,byte,,95th percentile of docker.container.size_rw,0,docker,changed files size 95%
 docker.container.size_rw.avg,gauge,,byte,,Average value of docker.container.size_rw,0,docker,changed files size avg


### PR DESCRIPTION
### What does this PR do?
Add new open file descriptor metrics (https://github.com/DataDog/datadog-agent/pull/4398) to metadata for Docker and Containerd checks

### Motivation
Keep docs up to date

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
