### PR TITLE
Add latency and datacenter metrics for Aerospike also collect version metadata information

### DIFF
--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -125,7 +125,7 @@ class AerospikeCheck(AgentCheck):
                 set_tags.extend(namespace_tags)
                 self.collect_info('sets/{}/{}'.format(ns, s), SET_METRIC_TYPE, separator=':', tags=set_tags)
 
-            # https://www.aerospike.com/docs/reference/info/#dcs
+        # https://www.aerospike.com/docs/reference/info/#dcs
         try:
             datacenters = self.get_datacenters()
 

--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -16,9 +16,12 @@ from datadog_checks.base import AgentCheck
 SOURCE_TYPE_NAME = 'aerospike'
 SERVICE_CHECK_UP = '%s.cluster_up' % SOURCE_TYPE_NAME
 SERVICE_CHECK_CONNECT = '%s.can_connect' % SOURCE_TYPE_NAME
+DATACENTER_SERVICE_CHECK_CONNECT = '%s.datacenter.can_connect' % SOURCE_TYPE_NAME
 CLUSTER_METRIC_TYPE = SOURCE_TYPE_NAME
+DATACENTER_METRIC_TYPE = '%s.datacenter' % SOURCE_TYPE_NAME
 NAMESPACE_METRIC_TYPE = '%s.namespace' % SOURCE_TYPE_NAME
 NAMESPACE_TPS_METRIC_TYPE = '%s.namespace.tps' % SOURCE_TYPE_NAME
+NAMESPACE_LATENCY_METRIC_TYPE = '%s.namespace.latency' % SOURCE_TYPE_NAME
 SINDEX_METRIC_TYPE = '%s.sindex' % SOURCE_TYPE_NAME
 SET_METRIC_TYPE = '%s.set' % SOURCE_TYPE_NAME
 MAX_AEROSPIKE_SETS = 200
@@ -74,6 +77,8 @@ class AerospikeCheck(AgentCheck):
         self._metrics = set(self.instance.get('metrics', []))
         self._namespace_metrics = set(self.instance.get('namespace_metrics', []))
         self._required_namespaces = self.instance.get('namespaces')
+        self._datacenter_metrics = set(self.instance.get('datacenter_metrics', []))
+        self._required_datacenters = self.instance.get('datacenters')
         self._rate_metrics = set(self.init_config.get('mappings', []))
         self._tags = self.instance.get('tags', [])
 
@@ -120,10 +125,28 @@ class AerospikeCheck(AgentCheck):
                 set_tags.extend(namespace_tags)
                 self.collect_info('sets/{}/{}'.format(ns, s), SET_METRIC_TYPE, separator=':', tags=set_tags)
 
+            # https://www.aerospike.com/docs/reference/info/#dcs
+        try:
+            datacenters = self.get_datacenters()
+
+            for dc in datacenters:
+                self.collect_datacenter(dc)
+
+        except Exception as e:
+            self.log.debug("There were no datacenters found: %s" % e)
+
         # https://www.aerospike.com/docs/reference/info/#throughput
         self.collect_throughput(namespaces)
 
+        # https://www.aerospike.com/docs/reference/info/#latency
+        self.collect_latency(namespaces)
+        self.collect_version()
+
         self.service_check(SERVICE_CHECK_UP, self.OK, tags=self._tags)
+
+    def collect_version(self):
+        version = self.get_info("build")[0]
+        self.set_metadata('version', version)
 
     def collect_info(self, command, metric_type, separator=';', required_keys=None, tags=None):
         entries = self.get_info(command, separator=separator)
@@ -154,6 +177,14 @@ class AerospikeCheck(AgentCheck):
 
         return namespaces
 
+    def get_datacenters(self):
+        datacenters = self.get_info('dcs')
+
+        if self._required_datacenters:
+            return [dc for dc in datacenters if dc in self._required_datacenters]
+
+        return datacenters
+
     def get_client(self):
         try:
             client = aerospike.client({'hosts': [self._host]}).connect(self._username, self._password)
@@ -176,6 +207,78 @@ class AerospikeCheck(AgentCheck):
             return data
 
         return data.split(separator)
+
+    def collect_datacenter(self, datacenter):
+        # returned information from dc/<DATACENTER> endpoint includes a service check:
+        # dc_state=CLUSTER_UP
+
+        datacenter_tags = ['datacenter:{}'.format(datacenter)]
+        datacenter_tags.extend(self._tags)
+
+        # https://www.aerospike.com/docs/reference/info/#dc/DC_NAME
+        data = self.get_info('dc/{}'.format(datacenter))
+
+        for item in data:
+            metric = item.split("=")
+            key = metric[0]
+            value = metric[1]
+            if key == 'dc_state':
+                if value == 'CLUSTER_UP':
+                    self.service_check(DATACENTER_SERVICE_CHECK_CONNECT, self.OK, tags=self._tags)
+                    continue
+                else:
+                    self.service_check(DATACENTER_SERVICE_CHECK_CONNECT, self.CRITICAL, tags=self._tags)
+                    continue
+            self.send(DATACENTER_METRIC_TYPE, key, value, datacenter_tags)
+
+    def collect_latency(self, namespaces):
+        data = self.get_info('latency:')
+
+        ns = None
+
+        metric_names = []
+
+        metric_values = []
+
+        while data:
+            line = data.pop(0)
+
+            if line.startswith("error-"):
+                continue
+
+            if not data:
+                break
+
+            timestamp = re.match(r'(\d+:\d+:\d+)', line)
+            if timestamp:
+                metric_values += line.split(",")[1:]
+                continue
+
+            # match only works at the beginning
+            ns_metric_name_match = re.match(r'{(\w+)}-(\w+):', line)
+            if ns_metric_name_match:
+                ns = ns_metric_name_match.groups()[0]
+                metric_name = ns_metric_name_match.groups()[1]
+
+            # need search because this isn't at the beginning
+            ops_per_sec = re.search(r'(\w+\/\w+)', line)
+            if ops_per_sec:
+                ops_per_sec_name = ops_per_sec.groups()[0].replace("/", "_")
+                metric_names.append(metric_name + "_" + ops_per_sec_name)
+
+            # findall will grab everything instead of first match
+            latencies = re.findall(r'>(\d+ms)', line)
+            if latencies:
+                for latency in latencies:
+                    latency = metric_name + '_over_' + latency
+                    metric_names.append(latency)
+
+            namespace_tags = ['namespace:{}'.format(ns)]
+            namespace_tags.extend(self._tags)
+
+        if len(metric_names) == len(metric_values):
+            for i in range(len(metric_names)):
+                self.send(NAMESPACE_LATENCY_METRIC_TYPE, metric_names[i], metric_values[i], namespace_tags)
 
     def collect_throughput(self, namespaces):
         data = self.get_info('throughput:')

--- a/aerospike/datadog_checks/aerospike/data/conf.yaml.example
+++ b/aerospike/datadog_checks/aerospike/data/conf.yaml.example
@@ -49,6 +49,22 @@ instances:
     #   - migrate_rx_objs
     #   - migrate_tx_objs
 
+    ## @param namespaces - list of strings - optional
+    ## all namespaces are collected  by default. If you want to collect specific namespaces
+    ## specify them here.
+    #
+    # namespaces:
+    #   - example_namespace
+    #   - another_example_namespace
+
+    ## @param datacenters - list of strings - optional
+    ## all datacenters are collected  by default. If you want to collect specific datacenters
+    ## specify them here.
+    #
+    # datacenters:
+    #   - example_datacenter
+    #   - another_example_datacenter
+
     ## @param namespace_metrics - list of strings - optional
     ## All Namespace metrics collected by default. You probably don't want to do this,
     ## so list the ones you do want here. Check with:
@@ -64,6 +80,16 @@ instances:
     #   - migrate-rx-partitions-remaining
     #   - migrate-tx-partitions-initial
     #   - migrate-tx-partitions-remaining
+
+    ## @param datacenter_metrics - list of strings - optional
+    ## All datacenter metrics collected by default specify which
+    ## metrics you want here. List datacenters using this command:
+    ##  asinfo -v dcs -l.
+    #
+    # datacenter_metrics:
+    #   - dc_rec_ship_attempts        # renamed dc_ship_attempt
+    #   - dc_remote_ship_ok
+    #   - dc_delete_ship_attempts    # renamed dc_ship_delete_success
 
 init_config:
 

--- a/aerospike/tests/common.py
+++ b/aerospike/tests/common.py
@@ -26,5 +26,23 @@ INSTANCE = {
         'memory_data_bytes',
     ],
     'namespaces': ['test'],
+    'datacenters': ['test'],
     'tags': ['tag:value'],
 }
+
+DATACENTER_METRICS = [
+    'dc_state=CLUSTER_UP',
+    'dc_timelag=0',
+    'dc_rec_ship_attempts=58374',
+    'dc_delete_ship_attempts=0',
+    'dc_remote_ship_ok=58121',
+    'dc_err_ship_client=38',
+    'dc_err_ship_server=0',
+    'dc_esmt_bytes_shipped=5662278',
+    'dc_esmt_ship_avg_comp_pct=0.00',
+    'dc_latency_avg_ship=0',
+    'dc_remote_ship_avg_sleep=0.000',
+    'dc_open_conn=192',
+    'dc_recs_inflight=216',
+    'dc_size=3',
+]

--- a/aerospike/tests/conftest.py
+++ b/aerospike/tests/conftest.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 import aerospike
 import pytest
 
-from datadog_checks.dev import run_command
 from datadog_checks.dev.conditions import WaitFor
 from datadog_checks.dev.docker import CheckDockerLogs, docker_run
 

--- a/aerospike/tests/conftest.py
+++ b/aerospike/tests/conftest.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 import aerospike
 import pytest
 
+from datadog_checks.dev import run_command
 from datadog_checks.dev.conditions import WaitFor
 from datadog_checks.dev.docker import CheckDockerLogs, docker_run
 
@@ -32,6 +33,10 @@ def init_db():
         'quote_cnt': 47,
     }
     client.put(key, bins)
+
+    for _ in range(10):
+        client.get(key)
+
     client.close()
 
 

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -1,0 +1,48 @@
+import mock
+import pytest
+
+from datadog_checks import aerospike
+
+from . import common
+
+pytestmark = pytest.mark.unit
+
+METRICS = [
+    'aerospike.datacenter.dc_timelag',
+    'aerospike.datacenter.dc_rec_ship_attempts',
+    'aerospike.datacenter.dc_delete_ship_attempts',
+    'aerospike.datacenter.dc_remote_ship_ok',
+    'aerospike.datacenter.dc_err_ship_client',
+    'aerospike.datacenter.dc_err_ship_server',
+    'aerospike.datacenter.dc_esmt_bytes_shipped',
+    'aerospike.datacenter.dc_esmt_ship_avg_comp_pct',
+    'aerospike.datacenter.dc_latency_avg_ship',
+    'aerospike.datacenter.dc_remote_ship_avg_sleep',
+    'aerospike.datacenter.dc_open_conn',
+    'aerospike.datacenter.dc_recs_inflight',
+    'aerospike.datacenter.dc_size',
+]
+
+
+def test_datacenter_metrics(aggregator):
+    check = aerospike.AerospikeCheck('aerospike', {}, [common.INSTANCE])
+    original_get_info = check.get_info
+
+    def mock_get_info(command, separator=";"):
+        if command == 'dcs':
+            return ['test']
+        elif command.startswith("dc/"):
+            return common.DATACENTER_METRICS
+
+        return original_get_info(command, separator)
+
+    check.get_info = mock_get_info
+    check._client = mock.MagicMock()
+    check.get_namespaces = mock.MagicMock()
+    check.collect_info = mock.MagicMock()
+    check.collect_throughput = mock.MagicMock()
+    check.collect_latency = mock.MagicMock()
+    check.collect_version = mock.MagicMock()
+    check.check(common.INSTANCE)
+    for metric in METRICS:
+        aggregator.assert_metric(metric)


### PR DESCRIPTION
### What does this PR do?
Adds latency and datacenter metrics as well as tests.
Collects version metadata.

### Motivation
https://trello.com/c/OXHpIVdU/1444-collect-additional-latency-metrics-for-aerospike

### Additional Notes
E2E tests only pass when the env is spun up manually. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
