### PR TITLE
Handle formatting edge cases for `meta changes`

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/changes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/changes.py
@@ -88,7 +88,6 @@ def changes(since, out_file, eager):
 
             for patch in patches:
                 integration = patch[0].split('/')[-2].strip()
-                history_data[integration]['releasers'].add(author_name)
 
                 additions = deque()
                 for line in reversed(patch):
@@ -106,13 +105,15 @@ def changes(since, out_file, eager):
                     additions.pop()
 
                 # Get rid of blank lines to ensure consistency
-                while not additions[0].strip():
+                while additions and not additions[0].strip():
                     additions.popleft()
-                while not additions[-1].strip():
+                while additions and not additions[-1].strip():
                     additions.pop()
 
-                history_data[integration]['lines'].appendleft('')
-                history_data[integration]['lines'].extendleft(additions)
+                if additions:
+                    history_data[integration]['releasers'].add(author_name)
+                    history_data[integration]['lines'].appendleft('')
+                    history_data[integration]['lines'].extendleft(additions)
 
     output_lines = ['# Changes since {}'.format(since), '']
 


### PR DESCRIPTION
### Motivation

```
ofek@ozone ~\Desktop\code\architecture ofek/clickhouse $ ddev meta changes 2019-10-01
Traceback (most recent call last):
  File "C:\Users\ofek\AppData\Local\Programs\Python\Python37\Scripts\ddev-script.py", line 11, in <module>
    load_entry_point('datadog-checks-dev', 'console_scripts', 'ddev')()
  File "c:\users\ofek\appdata\local\programs\python\python37\lib\site-packages\click\core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "c:\users\ofek\appdata\local\programs\python\python37\lib\site-packages\click\core.py", line 717, in main
    rv = self.invoke(ctx)
  File "c:\users\ofek\appdata\local\programs\python\python37\lib\site-packages\click\core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\users\ofek\appdata\local\programs\python\python37\lib\site-packages\click\core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\users\ofek\appdata\local\programs\python\python37\lib\site-packages\click\core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\users\ofek\appdata\local\programs\python\python37\lib\site-packages\click\core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "c:\users\ofek\desktop\code\integrations-core\datadog_checks_dev\datadog_checks\dev\tooling\commands\meta\changes.py", line 109, in changes
    while not additions[0].strip():
IndexError: deque index out of range
```