### PR TITLE
[NTP] Refactoring documentation

### DIFF
--- a/ntp/README.md
+++ b/ntp/README.md
@@ -17,37 +17,15 @@ Default NTP servers reached:
 
 ## Setup
 
-Follow the instructions below to install and configure this check for an Agent running on a host. For containerized environments, see the [Autodiscovery Integration Templates][8] for guidance on applying these instructions.
-
 ### Installation
 
 The NTP check is included in the [Datadog Agent][1] package, so you don't need to install anything else on your servers.
 
 ### Configuration
 
-The Agent enables the NTP check by default, but if you want to configure the check yourself, edit the file `ntp.d/conf.yaml` in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample ntp.d/conf.yaml][3] for all available configuration options:
+The Agent enables the NTP check by default, but if you want to configure the check yourself, edit the file `ntp.d/conf.yaml` in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample ntp.d/conf.yaml][3] for all available configuration options.
 
-```
-init_config:
-
-instances:
-  - offset_threshold: 60 # seconds difference between local clock and NTP server when ntp.in_sync service check becomes CRITICAL; default is 60
-#   host: pool.ntp.org # set to use an NTP server of your choosing
-#   port: 1234         # set along with host
-#   version: 3         # to use a specific NTP version
-#   timeout: 5         # seconds to wait for a response from the NTP server; default is 1
-#   use_local_defined_servers: false # Use the NTP servers defined in the localhost; default is false
-```
-
-Configuration Options:
-
-* `host` (Optional) - Host name of alternate ntp server, for example `pool.ntp.org`
-* `port` (Optional) - What port to use
-* `version` (Optional) - ntp version
-* `timeout` (Optional) - Response timeout
-* `use_local_defined_servers` (Optional) - True to use NTP servers defined in the localhost. For Unix system, the servers defined in /etc/ntp.conf and etc/xntp.conf are used. For Windows system, the servers defined in registry key HKLM\SYSTEM\CurrentControlSet\Services\W32Time\Parameters\NtpServer are used. **Caveat**: Enabling this option will make the NTP check unable to detect issues if the clock of the target NTP server of the system is skewed
-
-[Restart the Agent][4] to effect any configuration changes.
+**Note**: If you edit the Datadog-NTP check configuration file, [restart the Agent][4] to effect any configuration changes.
 
 ### Validation
 


### PR DESCRIPTION
### What does this PR do?
Refactors documentation:

* Removes references to AD since it doesn't make sense for the NTP check.
* Removes configuration examples snippet since all parameters are optional and the check is enabled by default since it's a core check.
* Removes parameter description list since they are now documented directly in the configuration file.

### Motivation
Better doc.

