### PR TITLE
Updating links to point to correct GS

### DIFF
--- a/openmetrics/README.md
+++ b/openmetrics/README.md
@@ -55,7 +55,7 @@ Need help? Contact [Datadog support][7].
 * [Writing a custom OpenMetrics Check][9]
 
 [2]: https://docs.datadoghq.com/agent/autodiscovery/integrations
-[3]: https://app.datadoghq.com/account/settings#agent
+[3]: https://docs.datadoghq.com/getting_started/integrations/prometheus/?tab=docker#configuration
 [4]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6#agent-configuration-directory
 [5]: https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
 [6]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-status-and-information

--- a/openmetrics/manifest.json
+++ b/openmetrics/manifest.json
@@ -1,6 +1,7 @@
 {
   "categories": [
-    "monitoring"
+    "monitoring",
+    "autodiscovery"
   ],
   "creates_events": false,
   "display_name": "OpenMetrics",


### PR DESCRIPTION
### What does this PR do?

Updates the link in the openmetrics doc to point to the correct GS.

### Motivation

Better support of AD instructions across integrations.