### PR TITLE
[Openstack] Adding AD instructions

### DIFF
--- a/openstack/README.md
+++ b/openstack/README.md
@@ -12,7 +12,7 @@ Get metrics from OpenStack service in real time to:
 ## Setup
 ### Installation
 
-To start capturing your OpenStack metrics, you need to [install the Agent][2] on your hosts running hypervisors.
+To capture your OpenStack metrics, [install the Agent][2] on your hosts running hypervisors.
 
 ### Configuration
 #### Prepare OpenStack
@@ -69,7 +69,7 @@ Finally, update your `policy.json` files to grant the needed permissions. `role:
 
 You may need to restart your Keystone, Neutron and Nova API services to ensure that the policy changes take.
 
-**Note**: Installing the OpenStack Integration could increase the number of VMs that Datadog monitors. For more information on how this may affect your billing, visit our Billing FAQ.
+**Note**: Installing the OpenStack integration could increase the number of VMs that Datadog monitors. For more information on how this may affect your billing, visit our Billing FAQ.
 
 #### Host
 
@@ -119,8 +119,8 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 | Parameter            | Value                                                                                                                |
 |----------------------|----------------------------------------------------------------------------------------------------------------------|
 | `<INTEGRATION_NAME>` | `openstack`                                                                                                          |
-| `<INIT_CONFIG>`      | `"keystone_server_url": "https://<KEYSTONE_SERVER_ENDPOINT>:<PORT>/"`                                                |
-| `<INSTANCE_CONFIG>`  | `"name": "<INSTANCE_NAME>", "user":{"password": "<PASSWORD>", "name": "datadog", "domain": {"id": "<DOMAINE_ID>"}}"` |
+| `<INIT_CONFIG>`      | `{"keystone_server_url": "https://<KEYSTONE_SERVER_ENDPOINT>:<PORT>/"}`                                                |
+| `<INSTANCE_CONFIG>`  | `{"name": "<INSTANCE_NAME>", "user": {"password": "<PASSWORD>", "name": "<USERNAME>", "domain": {"id": "<DOMAINE_ID>"}}}` |
 
 
 ### Validation

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -10,31 +10,23 @@ Get metrics from OpenStack service in real time to:
 * Be notified about OpenStack failovers and events.
 
 ## Setup
-
-Follow the instructions below to install and configure this check for an Agent running on a host. For containerized environments, see the [Autodiscovery Integration Templates][12] for guidance on applying these instructions.
-
 ### Installation
 
-To capture OpenStack metrics you need to [install the Agent][2] on your hosts running hypervisors.
+To start capturing your OpenStack metrics, you need to [install the Agent][2] on your hosts running hypervisors.
 
-**Note**: Installing the OpenStack Integration could increase the number of VMs that Datadog monitors. For more information on how this may affect your billing, visit our Billing FAQ.
+Then configure a Datadog role and user with your identity server:
 
-### Configuration
+```
+openstack role create datadog_monitoring
+openstack user create datadog \
+    --password my_password \
+    --project my_project_name
+openstack role add datadog_monitoring \
+    --project my_project_name \
+    --user datadog
+```
 
-1. First configure a Datadog role and user with your identity server
-
-    ```
-    openstack role create datadog_monitoring
-    openstack user create datadog \
-        --password my_password \
-        --project my_project_name
-    openstack role add datadog_monitoring \
-        --project my_project_name \
-        --user datadog
-    ```
-
-2. Update your policy.json files to grant the needed permissions.
-```role:datadog_monitoring``` requires access to the following operations:
+Finally, update your `policy.json` files to grant the needed permissions. `role:datadog_monitoring` requires access to the following operations:
 
 **Nova**
 
@@ -75,52 +67,105 @@ To capture OpenStack metrics you need to [install the Agent][2] on your hosts ru
 
 You may need to restart your Keystone, Neutron and Nova API services to ensure that the policy changes take.
 
-3. Configure the Datadog Agent to connect to your Keystone server, and specify individual projects to monitor. Edit the `openstack.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][3]. See the [sample openstack.d/conf.yaml][4] for all available configuration options.
+**Note**: Installing the OpenStack Integration could increase the number of VMs that Datadog monitors. For more information on how this may affect your billing, visit our Billing FAQ.
 
-4. [Restart the Agent][5]
+### Configuration
+#### Host
+
+Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
+
+1. Configure the Datadog Agent to connect to your Keystone server, and specify individual projects to monitor. Edit the `openstack.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][3] with the configuration below. See the [sample openstack.d/conf.yaml][4] for all available configuration options:
+
+    ```yaml
+        init_config:
+
+            ## @param keystone_server_url - string - required
+            ## Where your identity server lives.
+            ## Note that the server must support Identity API v3
+            #
+            keystone_server_url: "https://<KEYSTONE_SERVER_ENDPOINT>:<PORT>/"
+
+        instances:
+
+            ## @param name - string - required
+            ## Unique identifier for this instance.
+            #
+          - name: "<INSTANCE_NAME>"
+
+            ## @param user - object - required
+            ## User credentials
+            ## Password authentication is the only auth method supported.
+            ## `user` object expects the parameter `username`, `password`,
+            ## and `user.domain.id`.
+            ##
+            ## `user` should resolve to a structure like:
+            ##
+            ##  {'password': '<PASSWORD>', 'name': '<USERNAME>', 'domain': {'id': '<DOMAINE_ID>'}}
+            #
+            user:
+              password: "<PASSWORD>"
+              name: datadog
+              domain:
+                id: "<DOMAINE_ID>"
+    ```
+
+2. [Restart the Agent][5].
+
+#### Containerized
+
+For containerized environments, see the [Autodiscovery Integration Templates][6] for guidance on applying the parameters below.
+
+| Parameter            | Value                                                                                                                |
+|----------------------|----------------------------------------------------------------------------------------------------------------------|
+| `<INTEGRATION_NAME>` | `openstack`                                                                                                          |
+| `<INIT_CONFIG>`      | `"keystone_server_url": "https://<KEYSTONE_SERVER_ENDPOINT>:<PORT>/"`                                                |
+| `<INSTANCE_CONFIG>`  | `"name": "<INSTANCE_NAME>", "user":{"password": "<PASSWORD>", "name": "datadog", "domain": {"id": "<DOMAINE_ID>"}}"` |
+
 
 ### Validation
 
-[Run the Agent's `status` subcommand][6] and look for `openstack` under the Checks section.
+[Run the Agent's `status` subcommand][7] and look for `openstack` under the Checks section.
 
 ## Data Collected
 ### Metrics
-See [metadata.csv][7] for a list of metrics provided by this integration.
+See [metadata.csv][8] for a list of metrics provided by this integration.
 
 ### Events
 The OpenStack check does not include any events.
 
 ### Service Checks
-**openstack.neutron.api.up**
+**openstack.neutron.api.up**:
 
 Returns `CRITICAL` if the Agent is unable to query the Neutron API, `UNKNOWN` if there is an issue with the Keystone API. Returns `OK` otherwise.
 
-**openstack.nova.api.up**
+**openstack.nova.api.up**:
 
 Returns `CRITICAL` if the Agent is unable to query the Nova API, `UNKNOWN` if there is an issue with the Keystone API. Returns `OK` otherwise.
 
-**openstack.keystone.api.up**
+**openstack.keystone.api.up**:
 
 Returns `CRITICAL` if the Agent is unable to query the Keystone API. Returns `OK` otherwise.
 
-**openstack.nova.hypervisor.up**
+**openstack.nova.hypervisor.up**:
 
 Returns `UNKNOWN` if the Agent is unable to get the Hypervisor state, `CRITICAL` if the Hypervisor is down. Returns `OK` otherwise.
 
-**openstack.neutron.network.up**
+**openstack.neutron.network.up**:
 
 Returns `UNKNOWN` if the Agent is unable to get the Network state, `CRITICAL` if the Network is down. Returns `OK` otherwise.
 
 ## Troubleshooting
-Need help? Contact [Datadog support][8].
+
+Need help? Contact [Datadog support][9].
 
 ## Further Reading
-To get a better idea of how (or why) to integrate your Nova OpenStack compute module with Datadog, check out our [series of blog posts][9] about it.
+
+To get a better idea of how (or why) to integrate your Nova OpenStack compute module with Datadog, check out our [series of blog posts][10] about it.
 
 See also our blog posts:
 
-* [Install OpenStack in two commands for dev and test][10]
-* [OpenStack: host aggregates, flavors, and availability zones][11]
+* [Install OpenStack in two commands for dev and test][11]
+* [OpenStack: host aggregates, flavors, and availability zones][12]
 
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/openstack/images/openstack_dashboard.png
@@ -128,10 +173,10 @@ See also our blog posts:
 [3]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6#agent-configuration-directory
 [4]: https://github.com/DataDog/integrations-core/blob/master/openstack/datadog_checks/openstack/data/conf.yaml.example
 [5]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#start-stop-and-restart-the-agent
-[6]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
-[7]: https://github.com/DataDog/integrations-core/blob/master/openstack/metadata.csv
-[8]: https://docs.datadoghq.com/help
-[9]: https://www.datadoghq.com/blog/openstack-monitoring-nova
-[10]: https://www.datadoghq.com/blog/install-openstack-in-two-commands
-[11]: https://www.datadoghq.com/blog/openstack-host-aggregates-flavors-availability-zones
-[12]: https://docs.datadoghq.com/agent/autodiscovery/integrations
+[6]: https://docs.datadoghq.com/agent/autodiscovery/integrations/
+[7]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
+[8]: https://github.com/DataDog/integrations-core/blob/master/openstack/metadata.csv
+[9]: https://docs.datadoghq.com/help
+[10]: https://www.datadoghq.com/blog/openstack-monitoring-nova
+[11]: https://www.datadoghq.com/blog/install-openstack-in-two-commands
+[12]: https://www.datadoghq.com/blog/openstack-host-aggregates-flavors-availability-zones

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -18,7 +18,7 @@ To capture your OpenStack metrics, [install the Agent][2] on your hosts running 
 #### Prepare OpenStack
 Then configure a Datadog role and user with your identity server:
 
-```
+```console
 openstack role create datadog_monitoring
 openstack user create datadog \
     --password my_password \

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -14,6 +14,8 @@ Get metrics from OpenStack service in real time to:
 
 To start capturing your OpenStack metrics, you need to [install the Agent][2] on your hosts running hypervisors.
 
+### Configuration
+#### Prepare OpenStack
 Then configure a Datadog role and user with your identity server:
 
 ```
@@ -69,8 +71,8 @@ You may need to restart your Keystone, Neutron and Nova API services to ensure t
 
 **Note**: Installing the OpenStack Integration could increase the number of VMs that Datadog monitors. For more information on how this may affect your billing, visit our Billing FAQ.
 
-### Configuration
-#### Host
+#### Metric collection
+##### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
@@ -111,7 +113,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 2. [Restart the Agent][5].
 
-#### Containerized
+##### Containerized
 
 For containerized environments, see the [Autodiscovery Integration Templates][6] for guidance on applying the parameters below.
 

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -71,9 +71,7 @@ You may need to restart your Keystone, Neutron and Nova API services to ensure t
 
 **Note**: Installing the OpenStack integration could increase the number of VMs that Datadog monitors. For more information on how this may affect your billing, visit our Billing FAQ.
 
-#### Host
-
-Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
+#### Agent Configuration
 
 1. Configure the Datadog Agent to connect to your Keystone server, and specify individual projects to monitor. Edit the `openstack.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][3] with the configuration below. See the [sample openstack.d/conf.yaml][4] for all available configuration options:
 
@@ -112,24 +110,13 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 2. [Restart the Agent][5].
 
-#### Containerized
-
-For containerized environments, see the [Autodiscovery Integration Templates][6] for guidance on applying the parameters below.
-
-| Parameter            | Value                                                                                                                |
-|----------------------|----------------------------------------------------------------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `openstack`                                                                                                          |
-| `<INIT_CONFIG>`      | `{"keystone_server_url": "https://<KEYSTONE_SERVER_ENDPOINT>:<PORT>/"}`                                                |
-| `<INSTANCE_CONFIG>`  | `{"name": "<INSTANCE_NAME>", "user": {"password": "<PASSWORD>", "name": "<USERNAME>", "domain": {"id": "<DOMAINE_ID>"}}}` |
-
-
 ### Validation
 
-[Run the Agent's `status` subcommand][7] and look for `openstack` under the Checks section.
+[Run the Agent's `status` subcommand][6] and look for `openstack` under the Checks section.
 
 ## Data Collected
 ### Metrics
-See [metadata.csv][8] for a list of metrics provided by this integration.
+See [metadata.csv][7] for a list of metrics provided by this integration.
 
 ### Events
 The OpenStack check does not include any events.
@@ -157,16 +144,16 @@ Returns `UNKNOWN` if the Agent is unable to get the Network state, `CRITICAL` if
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][9].
+Need help? Contact [Datadog support][8].
 
 ## Further Reading
 
-To get a better idea of how (or why) to integrate your Nova OpenStack compute module with Datadog, check out our [series of blog posts][10] about it.
+To get a better idea of how (or why) to integrate your Nova OpenStack compute module with Datadog, check out our [series of blog posts][9] about it.
 
 See also our blog posts:
 
-* [Install OpenStack in two commands for dev and test][11]
-* [OpenStack: host aggregates, flavors, and availability zones][12]
+* [Install OpenStack in two commands for dev and test][10]
+* [OpenStack: host aggregates, flavors, and availability zones][11]
 
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/openstack/images/openstack_dashboard.png
@@ -174,10 +161,9 @@ See also our blog posts:
 [3]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6#agent-configuration-directory
 [4]: https://github.com/DataDog/integrations-core/blob/master/openstack/datadog_checks/openstack/data/conf.yaml.example
 [5]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#start-stop-and-restart-the-agent
-[6]: https://docs.datadoghq.com/agent/autodiscovery/integrations/
-[7]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
-[8]: https://github.com/DataDog/integrations-core/blob/master/openstack/metadata.csv
-[9]: https://docs.datadoghq.com/help
-[10]: https://www.datadoghq.com/blog/openstack-monitoring-nova
-[11]: https://www.datadoghq.com/blog/install-openstack-in-two-commands
-[12]: https://www.datadoghq.com/blog/openstack-host-aggregates-flavors-availability-zones
+[6]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
+[7]: https://github.com/DataDog/integrations-core/blob/master/openstack/metadata.csv
+[8]: https://docs.datadoghq.com/help
+[9]: https://www.datadoghq.com/blog/openstack-monitoring-nova
+[10]: https://www.datadoghq.com/blog/install-openstack-in-two-commands
+[11]: https://www.datadoghq.com/blog/openstack-host-aggregates-flavors-availability-zones

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -71,8 +71,7 @@ You may need to restart your Keystone, Neutron and Nova API services to ensure t
 
 **Note**: Installing the OpenStack Integration could increase the number of VMs that Datadog monitors. For more information on how this may affect your billing, visit our Billing FAQ.
 
-#### Metric collection
-##### Host
+#### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
@@ -113,7 +112,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 2. [Restart the Agent][5].
 
-##### Containerized
+#### Containerized
 
 For containerized environments, see the [Autodiscovery Integration Templates][6] for guidance on applying the parameters below.
 

--- a/openstack/manifest.json
+++ b/openstack/manifest.json
@@ -1,6 +1,7 @@
 {
   "categories": [
-    "cloud"
+    "cloud",
+    "autodiscovery"
   ],
   "creates_events": false,
   "display_name": "OpenStack",

--- a/openstack/manifest.json
+++ b/openstack/manifest.json
@@ -1,7 +1,6 @@
 {
   "categories": [
-    "cloud",
-    "autodiscovery"
+    "cloud"
   ],
   "creates_events": false,
   "display_name": "OpenStack",


### PR DESCRIPTION
### What does this PR do?

* Adds AD instructions to the openstack integration doc
* Fixes the broken list design
* Adds the minimum required host configuration snippet
* Update all links as reference.

### Motivation
Document AD for all Agent integrations.
