### PR TITLE
Modify profile layout

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -37,7 +37,7 @@ class InstanceConfig:
         if profile:
             if profile not in profiles:
                 raise ConfigurationError("Unknown profile '{}'".format(profile))
-            self.metrics.extend(profiles[profile]['definition'])
+            self.metrics.extend(profiles[profile]['definition']['metrics'])
         self.enforce_constraints = is_affirmative(instance.get('enforce_mib_constraints', True))
         self.snmp_engine, self.mib_view_controller = self.create_snmp_engine(mibs_path)
         self.ip_address = None
@@ -79,7 +79,7 @@ class InstanceConfig:
         self.context_data = hlapi.ContextData(*self.get_context_data(instance))
 
     def refresh_with_profile(self, profile, warning, log):
-        self.metrics.extend(profile['definition'])
+        self.metrics.extend(profile['definition']['metrics'])
         self.table_oids, self.raw_oids, self.mibs_to_load = self.parse_metrics(self.metrics, warning, log)
 
     def call_cmd(self, cmd, *args, **kwargs):

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -96,18 +96,20 @@ init_config:
   ## @param profiles - dictionary - optional
   ## Specify profiles to be able to reference a set of metrics by name.
   ## One of definition_file or definition needs to be defined.
-  ## definition_file points to a file with the same structure as
-  ## global_metrics, whereas definition inlines it directly here.
+  ## definition_file points to a file with a prfile, whereas definition inlines
+  ## it directly here.
   ## When using a profile present on the profiles directory of the
   ## configuration, you can directly pass the filename.
-  ## sysObjectID can be set to match the devices that are going to
-  ## automatically use this profile.
   #
   # profiles:
   #   profile1:
   #   	definition_file: <PROFILE_FILE>
   #   	definition: <PROFILE>
-  #   	sysobjectid: <OID>
+  profiles:
+    f5-big-ip:
+      definition_file: f5-big-ip.yaml
+    router:
+      definition_file: generic-router.yaml
 
 instances:
   -

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -93,7 +93,7 @@ init_config:
   #     metric_tags:
   #       - TCP
 
-  ## @param profiles - dictionary - optional
+  ## @param profiles - object - optional
   ## Specify profiles to be able to reference a set of metrics by name.
   ## One of definition_file or definition needs to be defined.
   ## definition_file points to a file with a prfile, whereas definition inlines
@@ -101,10 +101,6 @@ init_config:
   ## When using a profile present on the profiles directory of the
   ## configuration, you can directly pass the filename.
   #
-  # profiles:
-  #   profile1:
-  #   	definition_file: <PROFILE_FILE>
-  #   	definition: <PROFILE>
   profiles:
     f5-big-ip:
       definition_file: f5-big-ip.yaml

--- a/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
@@ -4,101 +4,96 @@
 # automatically for you, but otherwise you can run the following command:
 # $ /opt/datadog-agent/embedded/bin/python /opt/datadog-agent/embedded/bin/mibdump.py  --destination-directory=/opt/datadog-agent/embedded/lib/python2.7/site-packages/pysnmp_mibs F5-BIGIP-SYSTEM-MIB
 #
-# Then you can use it this way in your SNMP configuration:
-# init_config:
-#   profiles:
-#     f5-big-ip:
-#       definition_file: f5-big-ip.yaml
-#       sysobjectid: 1.3.6.1.4.1.3375.2.1.3.4.43
-#
+sysobjectid: 1.3.6.1.4.1.3375.2.1.3.4.*
 # Memory stats
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysStatMemoryTotal
-  forced_type: gauge
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysStatMemoryUsed
-  forced_type: gauge
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysGlobalTmmStatMemoryTotal
-  forced_type: gauge
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysGlobalTmmStatMemoryUsed
-  forced_type: gauge
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysGlobalHostOtherMemoryTotal
-  forced_type: gauge
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysGlobalHostOtherMemoryUsed
-  forced_type: gauge
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysGlobalHostSwapTotal
-  forced_type: gauge
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysGlobalHostSwapUsed
-  forced_type: gauge
-# CPU stats
-- MIB: F5-BIGIP-SYSTEM-MIB
-  table: sysMultiHostCpuTable
-  symbols:
-    - sysMultiHostCpuUser
-    - sysMultiHostCpuNice
-    - sysMultiHostCpuSystem
-    - sysMultiHostCpuIdle
-    - sysMultiHostCpuIrq
-    - sysMultiHostCpuSoftirq
-    - sysMultiHostCpuIowait
-  metric_tags:
-    - tag: cpu
-      column: sysMultiHostCpuId
-# Basic interface stats
-- MIB: IF-MIB
-  table: ifTable
-  symbols:
-    - ifInOctets
-    - ifInErrors
-    - ifOutOctets
-    - ifOutErrors
-  metric_tags:
-    - tag: interface
-      column: ifDescr
-# TCP stats
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysTcpStatOpen
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysTcpStatCloseWait
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysTcpStatFinWait
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysTcpStatTimeWait
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysTcpStatAccepts
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysTcpStatAcceptfails
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysTcpStatConnects
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysTcpStatConnfails
-# UDP stats
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysUdpStatOpen
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysUdpStatAccepts
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysUdpStatAcceptfails
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysUdpStatConnects
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysUdpStatConnfails
-# SSL stats
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysClientsslStatCurConns
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysClientsslStatEncryptedBytesIn
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysClientsslStatEncryptedBytesOut
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysClientsslStatDecryptedBytesIn
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysClientsslStatDecryptedBytesOut
-- MIB: F5-BIGIP-SYSTEM-MIB
-  symbol: sysClientsslStatHandshakeFailures
+metrics:
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysStatMemoryTotal
+    forced_type: gauge
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysStatMemoryUsed
+    forced_type: gauge
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysGlobalTmmStatMemoryTotal
+    forced_type: gauge
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysGlobalTmmStatMemoryUsed
+    forced_type: gauge
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysGlobalHostOtherMemoryTotal
+    forced_type: gauge
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysGlobalHostOtherMemoryUsed
+    forced_type: gauge
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysGlobalHostSwapTotal
+    forced_type: gauge
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysGlobalHostSwapUsed
+    forced_type: gauge
+  # CPU stats
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    table: sysMultiHostCpuTable
+    symbols:
+      - sysMultiHostCpuUser
+      - sysMultiHostCpuNice
+      - sysMultiHostCpuSystem
+      - sysMultiHostCpuIdle
+      - sysMultiHostCpuIrq
+      - sysMultiHostCpuSoftirq
+      - sysMultiHostCpuIowait
+    metric_tags:
+      - tag: cpu
+        column: sysMultiHostCpuId
+  # Basic interface stats
+  - MIB: IF-MIB
+    table: ifTable
+    symbols:
+      - ifInOctets
+      - ifInErrors
+      - ifOutOctets
+      - ifOutErrors
+    metric_tags:
+      - tag: interface
+        column: ifDescr
+  # TCP stats
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysTcpStatOpen
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysTcpStatCloseWait
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysTcpStatFinWait
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysTcpStatTimeWait
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysTcpStatAccepts
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysTcpStatAcceptfails
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysTcpStatConnects
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysTcpStatConnfails
+  # UDP stats
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysUdpStatOpen
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysUdpStatAccepts
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysUdpStatAcceptfails
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysUdpStatConnects
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysUdpStatConnfails
+  # SSL stats
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysClientsslStatCurConns
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysClientsslStatEncryptedBytesIn
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysClientsslStatEncryptedBytesOut
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysClientsslStatDecryptedBytesIn
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysClientsslStatDecryptedBytesOut
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol: sysClientsslStatHandshakeFailures

--- a/snmp/datadog_checks/snmp/data/profiles/generic-router.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/generic-router.yaml
@@ -1,133 +1,126 @@
 # Generic profile for routers
 #
-# Youn can define it this way in your SNMP configuration:
-# init_config:
-#   profiles:
-#     router:
-#       definition_file: generic-router.yaml
-# instances:
-#   - ip_address: <IP_ADDRESS>
-#     profile: router
-#
-- MIB: IF-MIB
-  table: ifTable
-  symbols:
-    - ifInErrors
-    - ifInDiscards
-    - ifOutErrors
-    - ifOutDiscards
-  metric_tags:
-    - tag: interface
-      column: ifDescr
-- MIB: IF-MIB
-  table: ifXTable
-  symbols:
-    - ifHCInOctets
-    - ifHCInUcastPkts
-    - ifHCInMulticastPkts
-    - ifHCInBroadcastPkts
-    - ifHCOutOctets
-    - ifHCOutUcastPkts
-    - ifHCOutMulticastPkts
-    - ifHCOutBroadcastPkts
-  metric_tags:
-    - tag: interface
-      column: ifName
-- MIB: IP-MIB
-  table: ipSystemStatsTable
-  symbols:
-    - ipSystemStatsHCInReceives
-    - ipSystemStatsHCInOctets
-    - ipSystemStatsInHdrErrors
-    - ipSystemStatsInNoRoutes
-    - ipSystemStatsInAddrErrors
-    - ipSystemStatsInUnknownProtos
-    - ipSystemStatsInTruncatedPkts
-    - ipSystemStatsHCInForwDatagrams
-    - ipSystemStatsReasmReqds
-    - ipSystemStatsReasmOKs
-    - ipSystemStatsReasmFails
-    - ipSystemStatsInDiscards
-    - ipSystemStatsHCInDelivers
-    - ipSystemStatsHCOutRequests
-    - ipSystemStatsOutNoRoutes
-    - ipSystemStatsHCOutForwDatagrams
-    - ipSystemStatsOutDiscards
-    - ipSystemStatsOutFragReqds
-    - ipSystemStatsOutFragOKs
-    - ipSystemStatsOutFragFails
-    - ipSystemStatsOutFragCreates
-    - ipSystemStatsHCOutTransmits
-    - ipSystemStatsHCOutOctets
-    - ipSystemStatsHCInMcastPkts
-    - ipSystemStatsHCInMcastOctets
-    - ipSystemStatsHCOutMcastPkts
-    - ipSystemStatsHCOutMcastOctets
-    - ipSystemStatsHCInBcastPkts
-    - ipSystemStatsHCOutBcastPkts
-  metric_tags:
-    - tag: ipversion
-      index: 1
-- MIB: IP-MIB
-  table: ipIfStatsTable
-  symbols:
-    - ipIfStatsHCInOctets
-    - ipIfStatsInHdrErrors
-    - ipIfStatsInNoRoutes
-    - ipIfStatsInAddrErrors
-    - ipIfStatsInUnknownProtos
-    - ipIfStatsInTruncatedPkts
-    - ipIfStatsHCInForwDatagrams
-    - ipIfStatsReasmReqds
-    - ipIfStatsReasmOKs
-    - ipIfStatsReasmFails
-    - ipIfStatsInDiscards
-    - ipIfStatsHCInDelivers
-    - ipIfStatsHCOutRequests
-    - ipIfStatsHCOutForwDatagrams
-    - ipIfStatsOutDiscards
-    - ipIfStatsOutFragReqds
-    - ipIfStatsOutFragOKs
-    - ipIfStatsOutFragFails
-    - ipIfStatsOutFragCreates
-    - ipIfStatsHCOutTransmits
-    - ipIfStatsHCOutOctets
-    - ipIfStatsHCInMcastPkts
-    - ipIfStatsHCInMcastOctets
-    - ipIfStatsHCOutMcastPkts
-    - ipIfStatsHCOutMcastOctets
-    - ipIfStatsHCInBcastPkts
-    - ipIfStatsHCOutBcastPkts
-  metric_tags:
-    - tag: ipversion
-      index: 1
-    - tag: interface
-      index: 2
-- MIB: TCP-MIB
-  symbol: tcpActiveOpens
-- MIB: TCP-MIB
-  symbol: tcpPassiveOpens
-- MIB: TCP-MIB
-  symbol: tcpAttemptFails
-- MIB: TCP-MIB
-  symbol: tcpEstabResets
-- MIB: TCP-MIB
-  symbol: tcpCurrEstab
-- MIB: TCP-MIB
-  symbol: tcpHCInSegs
-- MIB: TCP-MIB
-  symbol: tcpHCOutSegs
-- MIB: TCP-MIB
-  symbol: tcpRetransSegs
-- MIB: TCP-MIB
-  symbol: tcpInErrs
-- MIB: TCP-MIB
-  symbol: tcpOutRsts
-- MIB: UDP-MIB
-  symbol: udpHCInDatagrams
-- MIB: UDP-MIB
-  symbol: udpNoPorts
-- MIB: UDP-MIB
-  symbol: udpInErrors
-- MIB: UDP-MIB
-  symbol: udpHCOutDatagrams
+sysobjectid: 1.3.6.1.4.*
+metrics:
+  - MIB: IF-MIB
+    table: ifTable
+    symbols:
+      - ifInErrors
+      - ifInDiscards
+      - ifOutErrors
+      - ifOutDiscards
+    metric_tags:
+      - tag: interface
+        column: ifDescr
+  - MIB: IF-MIB
+    table: ifXTable
+    symbols:
+      - ifHCInOctets
+      - ifHCInUcastPkts
+      - ifHCInMulticastPkts
+      - ifHCInBroadcastPkts
+      - ifHCOutOctets
+      - ifHCOutUcastPkts
+      - ifHCOutMulticastPkts
+      - ifHCOutBroadcastPkts
+    metric_tags:
+      - tag: interface
+        column: ifName
+  - MIB: IP-MIB
+    table: ipSystemStatsTable
+    symbols:
+      - ipSystemStatsHCInReceives
+      - ipSystemStatsHCInOctets
+      - ipSystemStatsInHdrErrors
+      - ipSystemStatsInNoRoutes
+      - ipSystemStatsInAddrErrors
+      - ipSystemStatsInUnknownProtos
+      - ipSystemStatsInTruncatedPkts
+      - ipSystemStatsHCInForwDatagrams
+      - ipSystemStatsReasmReqds
+      - ipSystemStatsReasmOKs
+      - ipSystemStatsReasmFails
+      - ipSystemStatsInDiscards
+      - ipSystemStatsHCInDelivers
+      - ipSystemStatsHCOutRequests
+      - ipSystemStatsOutNoRoutes
+      - ipSystemStatsHCOutForwDatagrams
+      - ipSystemStatsOutDiscards
+      - ipSystemStatsOutFragReqds
+      - ipSystemStatsOutFragOKs
+      - ipSystemStatsOutFragFails
+      - ipSystemStatsOutFragCreates
+      - ipSystemStatsHCOutTransmits
+      - ipSystemStatsHCOutOctets
+      - ipSystemStatsHCInMcastPkts
+      - ipSystemStatsHCInMcastOctets
+      - ipSystemStatsHCOutMcastPkts
+      - ipSystemStatsHCOutMcastOctets
+      - ipSystemStatsHCInBcastPkts
+      - ipSystemStatsHCOutBcastPkts
+    metric_tags:
+      - tag: ipversion
+        index: 1
+  - MIB: IP-MIB
+    table: ipIfStatsTable
+    symbols:
+      - ipIfStatsHCInOctets
+      - ipIfStatsInHdrErrors
+      - ipIfStatsInNoRoutes
+      - ipIfStatsInAddrErrors
+      - ipIfStatsInUnknownProtos
+      - ipIfStatsInTruncatedPkts
+      - ipIfStatsHCInForwDatagrams
+      - ipIfStatsReasmReqds
+      - ipIfStatsReasmOKs
+      - ipIfStatsReasmFails
+      - ipIfStatsInDiscards
+      - ipIfStatsHCInDelivers
+      - ipIfStatsHCOutRequests
+      - ipIfStatsHCOutForwDatagrams
+      - ipIfStatsOutDiscards
+      - ipIfStatsOutFragReqds
+      - ipIfStatsOutFragOKs
+      - ipIfStatsOutFragFails
+      - ipIfStatsOutFragCreates
+      - ipIfStatsHCOutTransmits
+      - ipIfStatsHCOutOctets
+      - ipIfStatsHCInMcastPkts
+      - ipIfStatsHCInMcastOctets
+      - ipIfStatsHCOutMcastPkts
+      - ipIfStatsHCOutMcastOctets
+      - ipIfStatsHCInBcastPkts
+      - ipIfStatsHCOutBcastPkts
+    metric_tags:
+      - tag: ipversion
+        index: 1
+      - tag: interface
+        index: 2
+  - MIB: TCP-MIB
+    symbol: tcpActiveOpens
+  - MIB: TCP-MIB
+    symbol: tcpPassiveOpens
+  - MIB: TCP-MIB
+    symbol: tcpAttemptFails
+  - MIB: TCP-MIB
+    symbol: tcpEstabResets
+  - MIB: TCP-MIB
+    symbol: tcpCurrEstab
+  - MIB: TCP-MIB
+    symbol: tcpHCInSegs
+  - MIB: TCP-MIB
+    symbol: tcpHCOutSegs
+  - MIB: TCP-MIB
+    symbol: tcpRetransSegs
+  - MIB: TCP-MIB
+    symbol: tcpInErrs
+  - MIB: TCP-MIB
+    symbol: tcpOutRsts
+  - MIB: UDP-MIB
+    symbol: udpHCInDatagrams
+  - MIB: UDP-MIB
+    symbol: udpNoPorts
+  - MIB: UDP-MIB
+    symbol: udpInErrors
+  - MIB: UDP-MIB
+    symbol: udpHCOutDatagrams

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -95,7 +95,7 @@ class SnmpCheck(AgentCheck):
             else:
                 data = profile_data['definition']
             self.profiles[profile] = {'definition': data}
-            sys_object_oid = profile_data.get('sysobjectid')
+            sys_object_oid = data.get('sysobjectid')
             if sys_object_oid:
                 self.profiles_by_oid[sys_object_oid] = profile
 

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -496,7 +496,7 @@ def test_cast_metrics(aggregator):
 def test_profile(aggregator):
     instance = common.generate_instance_config([])
     instance['profile'] = 'profile1'
-    init_config = {'profiles': {'profile1': {'definition': common.SUPPORTED_METRIC_TYPES}}}
+    init_config = {'profiles': {'profile1': {'definition': {'metrics': common.SUPPORTED_METRIC_TYPES}}}}
     check = SnmpCheck('snmp', init_config, [instance])
     check.check(instance)
 
@@ -512,7 +512,7 @@ def test_profile_by_file(aggregator):
     with temp_dir() as tmp:
         profile_file = os.path.join(tmp, 'profile1.yaml')
         with open(profile_file, 'w') as f:
-            f.write(yaml.safe_dump(common.SUPPORTED_METRIC_TYPES))
+            f.write(yaml.safe_dump({'metrics': common.SUPPORTED_METRIC_TYPES}))
         init_config = {'profiles': {'profile1': {'definition_file': profile_file}}}
         check = SnmpCheck('snmp', init_config, [instance])
         check.check(instance)
@@ -527,7 +527,9 @@ def test_profile_sys_object(aggregator):
     instance = common.generate_instance_config([])
     init_config = {
         'profiles': {
-            'profile1': {'definition': common.SUPPORTED_METRIC_TYPES, 'sysobjectid': '1.3.6.1.4.1.8072.3.2.10'}
+            'profile1': {
+                'definition': {'metrics': common.SUPPORTED_METRIC_TYPES, 'sysobjectid': '1.3.6.1.4.1.8072.3.2.10'}
+            }
         }
     }
     check = SnmpCheck('snmp', init_config, [instance])
@@ -543,8 +545,10 @@ def test_profile_sys_object_prefix(aggregator):
     instance = common.generate_instance_config([])
     init_config = {
         'profiles': {
-            'profile1': {'definition': common.SUPPORTED_METRIC_TYPES, 'sysobjectid': '1.3.6.1.4.1.8072.3.2.10'},
-            'profile2': {'definition': common.CAST_METRICS, 'sysobjectid': '1.3.6.1.4.*'},
+            'profile1': {
+                'definition': {'metrics': common.SUPPORTED_METRIC_TYPES, 'sysobjectid': '1.3.6.1.4.1.8072.3.2.10'}
+            },
+            'profile2': {'definition': {'metrics': common.CAST_METRICS, 'sysobjectid': '1.3.6.1.4.*'}},
         }
     }
     check = SnmpCheck('snmp', init_config, [instance])
@@ -559,7 +563,9 @@ def test_profile_sys_object_prefix(aggregator):
 def test_profile_sys_object_unknown(aggregator):
     """If the fetched sysObjectID is not referenced by any profiles, check fails."""
     instance = common.generate_instance_config([])
-    init_config = {'profiles': {'profile1': {'definition': common.SUPPORTED_METRIC_TYPES, 'sysobjectid': '1.2.3.4.5'}}}
+    init_config = {
+        'profiles': {'profile1': {'definition': {'metrics': common.SUPPORTED_METRIC_TYPES, 'sysobjectid': '1.2.3.4.5'}}}
+    }
     check = SnmpCheck('snmp', init_config, [instance])
     check.check(instance)
 
@@ -587,7 +593,9 @@ def test_discovery(aggregator):
         'community_string': 'public',
     }
     init_config = {
-        'profiles': {'profile1': {'definition': common.SUPPORTED_METRIC_TYPES, 'sysobjectid': '1.3.6.1.4.1.8072.*'}}
+        'profiles': {
+            'profile1': {'definition': {'metrics': common.SUPPORTED_METRIC_TYPES, 'sysobjectid': '1.3.6.1.4.1.8072.*'}}
+        }
     }
     check = SnmpCheck('snmp', init_config, [instance])
     try:
@@ -674,7 +682,7 @@ def test_f5(aggregator):
     instance['community_string'] = 'f5'
     instance['enforce_mib_constraints'] = False
 
-    init_config = {'profiles': {'f5-big-ip': {'definition_file': path, 'sysobjectid': '1.3.6.1.4.1.3375.2.1.3.4.43'}}}
+    init_config = {'profiles': {'f5-big-ip': {'definition_file': path}}}
     check = SnmpCheck('snmp', init_config, [instance])
 
     check.check(instance)


### PR DESCRIPTION
This moves sysobjectid definition in the profile itself, instead of
being in the integration config. It allows us to store the most common config in the check, as
sysoid don't change.

It changes and breaks compatibility
with profile format. Hopefully it is new enough that it won't be an
issue.