### PR TITLE
Disable autoCancel for PR Changes

### DIFF
--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -1,6 +1,7 @@
 trigger: none
 
 pr:
+  autoCancel: false
   branches:
     include:
     - master


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Do you mind if we set `autoCancel: false` for `PR Changes` on Azure Pipeline, the default is true ?  It’s annoying to have build canceled automatically, intermediate results are sometimes interesting. With 100 runners, it should only have low overall impact on the load.

We can keep `autoCancel: true` for `PR All` since it ’s much costlier.

### Use cases

- Use case 1: You make some changes, push the change to a PR, that start a build and you wait for the results, but in the mean time, you see a typo, you fix it. Let’s say the build have started since 3min. The issue is that if you push that commit (no code change), it will cancel the previous build, you have to wait for a new build to get the results, so, you are losing 3min of your time.
- Use case 2: Intermediate builds help you debug, you know since which commit the build is failing.