### PR TITLE
Add vertica lib log config

### DIFF
--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -150,17 +150,10 @@ instances:
 
     ## @param client_lib_log_level - string - optional
     ## Vertica library log level.
-    ## If not defined, the vertica library logging is disabled.
+    ## By default the vertica library logging is disabled.
     ## Valid values: CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG
     #
-    # client_lib_log_level: null
-
-    ## @param client_lib_log_path - string - optional
-    ## Vertica library log path.
-    ## This config has no effect if `client_lib_log_level` is not set.
-    ## Default to `/var/log/datadog/vertica_client_lib.log`
-    #
-    # client_lib_log_path: /var/log/datadog/vertica_client_lib.log
+    # client_lib_log_level: DEBUG
 
 ## Log Section (Available for Agent >=6.0)
 ##

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -148,19 +148,19 @@ instances:
     #     tags:
     #       - test:vertica
 
-    ## @param vertica_lib_log_level - string - optional
+    ## @param client_lib_log_level - string - optional
     ## Vertica library log level.
     ## If not defined, the vertica library logging is disabled.
     ## Valid values: CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG
     #
-    # vertica_lib_log_level: null
+    # client_lib_log_level: null
 
-    ## @param vertica_lib_log_path - string - optional
+    ## @param client_lib_log_path - string - optional
     ## Vertica library log path.
-    ## This config has no effect if `vertica_lib_log_level` is not set.
-    ## Default to `/var/log/datadog/vertica_lib.log`
+    ## This config has no effect if `client_lib_log_level` is not set.
+    ## Default to `/var/log/datadog/vertica_client_lib.log`
     #
-    # vertica_lib_log_path: /var/log/datadog/vertica_lib.log
+    # client_lib_log_path: /var/log/datadog/vertica_client_lib.log
 
 ## Log Section (Available for Agent >=6.0)
 ##

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -148,6 +148,20 @@ instances:
     #     tags:
     #       - test:vertica
 
+    ## @param vertica_lib_log_level - string - optional
+    ## Vertica library log level.
+    ## If not defined, the vertica library logging is disabled.
+    ## Valid values: CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG
+    #
+    # vertica_lib_log_level: null
+
+    ## @param vertica_lib_log_path - string - optional
+    ## Vertica library log path.
+    ## This config has no effect if `vertica_lib_log_level` is not set.
+    ## Default to `/var/log/datadog/vertica_lib.log`
+    #
+    # vertica_lib_log_path: /var/log/datadog/vertica_lib.log
+
 ## Log Section (Available for Agent >=6.0)
 ##
 ## type - mandatory - Type of log input source (tcp / udp / file / windows_event)

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -44,6 +44,9 @@ class VerticaCheck(AgentCheck):
         self._timeout = float(self.instance.get('timeout', 10))
         self._tags = self.instance.get('tags', [])
 
+        self._vertica_lib_log_level = self.instance.get('vertica_lib_log_level')
+        self._vertica_lib_log_path = self.instance.get('vertica_lib_log_path', '/var/log/datadog/vertica_lib.log')
+
         self._tls_verify = is_affirmative(self.instance.get('tls_verify', False))
         self._validate_hostname = is_affirmative(self.instance.get('validate_hostname', True))
 
@@ -558,6 +561,8 @@ class VerticaCheck(AgentCheck):
             'backup_server_node': self._backup_servers,
             'connection_load_balance': self._connection_load_balance,
             'connection_timeout': self._timeout,
+            'log_level': self._vertica_lib_log_level,
+            'log_path': self._vertica_lib_log_path,
         }
 
         if self._tls_verify:  # no cov

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -27,7 +27,6 @@ class VerticaCheck(AgentCheck):
     __NAMESPACE__ = 'vertica'
     SERVICE_CHECK_CONNECT = 'can_connect'
     SERVICE_CHECK_NODE_STATE = 'node_state'
-    DEFAULT_CLIENT_LIB_LOG_PATH = '/var/log/datadog/vertica_client_lib.log'
 
     def __init__(self, name, init_config, instances):
         super(VerticaCheck, self).__init__(name, init_config, instances)
@@ -46,7 +45,6 @@ class VerticaCheck(AgentCheck):
         self._tags = self.instance.get('tags', [])
 
         self._client_lib_log_level = self.instance.get('client_lib_log_level')
-        self._client_lib_log_path = self.instance.get('client_lib_log_path')
 
         self._tls_verify = is_affirmative(self.instance.get('tls_verify', False))
         self._validate_hostname = is_affirmative(self.instance.get('validate_hostname', True))
@@ -565,7 +563,7 @@ class VerticaCheck(AgentCheck):
         }
         if self._client_lib_log_level:
             connection_options['log_level'] = self._client_lib_log_level
-            connection_options['log_path'] = self._client_lib_log_path or self.DEFAULT_CLIENT_LIB_LOG_PATH
+            connection_options['log_path'] = None  # will make vertica client log to stdout
 
         if self._tls_verify:  # no cov
             # https://docs.python.org/3/library/ssl.html#ssl.SSLContext

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -27,6 +27,7 @@ class VerticaCheck(AgentCheck):
     __NAMESPACE__ = 'vertica'
     SERVICE_CHECK_CONNECT = 'can_connect'
     SERVICE_CHECK_NODE_STATE = 'node_state'
+    DEFAULT_CLIENT_LIB_LOG_PATH = '/var/log/datadog/vertica_client_lib.log'
 
     def __init__(self, name, init_config, instances):
         super(VerticaCheck, self).__init__(name, init_config, instances)
@@ -44,8 +45,8 @@ class VerticaCheck(AgentCheck):
         self._timeout = float(self.instance.get('timeout', 10))
         self._tags = self.instance.get('tags', [])
 
-        self._vertica_lib_log_level = self.instance.get('vertica_lib_log_level')
-        self._vertica_lib_log_path = self.instance.get('vertica_lib_log_path', '/var/log/datadog/vertica_lib.log')
+        self._client_lib_log_level = self.instance.get('client_lib_log_level')
+        self._client_lib_log_path = self.instance.get('client_lib_log_path')
 
         self._tls_verify = is_affirmative(self.instance.get('tls_verify', False))
         self._validate_hostname = is_affirmative(self.instance.get('validate_hostname', True))
@@ -561,9 +562,10 @@ class VerticaCheck(AgentCheck):
             'backup_server_node': self._backup_servers,
             'connection_load_balance': self._connection_load_balance,
             'connection_timeout': self._timeout,
-            'log_level': self._vertica_lib_log_level,
-            'log_path': self._vertica_lib_log_path,
         }
+        if self._client_lib_log_level:
+            connection_options['log_level'] = self._client_lib_log_level
+            connection_options['log_path'] = self._client_lib_log_path or self.DEFAULT_CLIENT_LIB_LOG_PATH
 
         if self._tls_verify:  # no cov
             # https://docs.python.org/3/library/ssl.html#ssl.SSLContext

--- a/vertica/tests/test_unit.py
+++ b/vertica/tests/test_unit.py
@@ -47,3 +47,43 @@ def test_ssl_config_ok(aggregator):
             assert check._connection is not None
 
     aggregator.assert_service_check("vertica.can_connect", status=AgentCheck.OK, tags=['db:abc', 'foo:bar'])
+
+
+def test_client_logging_enabled(aggregator, instance):
+    instance['client_lib_log_level'] = 'DEBUG'
+
+    check = VerticaCheck('vertica', {}, [instance])
+
+    with mock.patch('datadog_checks.vertica.vertica.vertica') as vertica:
+        check.check(instance)
+
+        vertica.connect.assert_called_with(
+            database=mock.ANY,
+            host=mock.ANY,
+            port=mock.ANY,
+            user=mock.ANY,
+            password=mock.ANY,
+            backup_server_node=mock.ANY,
+            connection_load_balance=mock.ANY,
+            connection_timeout=mock.ANY,
+            log_level='DEBUG',
+            log_path=None,
+        )
+
+
+def test_client_logging_disabled(aggregator, instance):
+    check = VerticaCheck('vertica', {}, [instance])
+
+    with mock.patch('datadog_checks.vertica.vertica.vertica') as vertica:
+        check.check(instance)
+
+        vertica.connect.assert_called_with(
+            database=mock.ANY,
+            host=mock.ANY,
+            port=mock.ANY,
+            user=mock.ANY,
+            password=mock.ANY,
+            backup_server_node=mock.ANY,
+            connection_load_balance=mock.ANY,
+            connection_timeout=mock.ANY,
+        )

--- a/vertica/tests/test_vertica.py
+++ b/vertica/tests/test_vertica.py
@@ -1,12 +1,9 @@
 # (C) Datadog, Inc. 2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import os
-
 import mock
 import pytest
 
-from datadog_checks.dev import TempDir
 from datadog_checks.vertica import VerticaCheck
 
 from .metrics import ALL_METRICS
@@ -33,20 +30,6 @@ def test_check(aggregator, instance):
         aggregator.assert_metric_has_tag(metric, 'foo:bar')
 
     aggregator.assert_all_metrics_covered()
-
-
-@pytest.mark.usefixtures('dd_environment')
-def test_check_client_log(aggregator, instance):
-    with TempDir() as temp_dir:
-        log_file = os.path.join(temp_dir, 'vertica_client_lib.log')
-        instance['client_lib_log_level'] = 'DEBUG'
-        instance['client_lib_log_path'] = log_file
-
-        check = VerticaCheck('vertica', {}, [instance])
-        check.check(instance)
-
-        with open(log_file) as f:
-            assert "Establishing connection to host" in f.read()
 
 
 @pytest.mark.usefixtures('dd_environment')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add vertica lib log config

Support for the log integration for Vertica client lib can be done in another PR.

### Motivation
<!-- What inspired you to submit this pull request? -->

Will help debug, support.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Example vertical log:

```
2019-11-13 17:18:37.926 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> Address list: [('localhost', 5433, False)]
2019-11-13 17:18:37.926 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> Connection prepared statements is disabled
2019-11-13 17:18:37.927 [connection] 140567003937488/133134:0x7fd856437700 <INFO> Connecting as user "dduser" to database "datadog" on host "localhost" with port 5433
2019-11-13 17:18:37.927 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> Peek at address list: [('127.0.0.1', 5433, True)]
2019-11-13 17:18:37.927 [connection] 140567003937488/133134:0x7fd856437700 <INFO> Establishing connection to host "127.0.0.1" on port 5433
2019-11-13 17:18:37.927 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> Set socket connection timeout: 10.0
2019-11-13 17:18:37.927 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> Connection load balance option is disabled
2019-11-13 17:18:37.927 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> SSL option is disabled
2019-11-13 17:18:37.928 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> => Startup
2019-11-13 17:18:37.929 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> <= Authentication: type=3
2019-11-13 17:18:37.929 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> => Password
2019-11-13 17:18:37.930 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> <= Authentication: type=0
2019-11-13 17:18:37.931 [connection] 140567003937488/133134:0x7fd856437700 <INFO> User dduser successfully authenticated
2019-11-13 17:18:37.931 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> <= ParameterStatus: client_locale = en_US@collation=binary
2019-11-13 17:18:37.931 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> <= ParameterStatus: client_label = vertica-python-0.9.4-a162b201-0639-11ea-bdbd-021a9f891360
2019-11-13 17:18:37.931 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> <= ParameterStatus: server_version = v9.2.0-7
2019-11-13 17:18:37.931 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> <= ParameterStatus: long_string_types = on
2019-11-13 17:18:37.932 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> <= ParameterStatus: protocol_version = 196613
2019-11-13 17:18:37.932 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> <= ParameterStatus: standard_conforming_strings = on
2019-11-13 17:18:37.932 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> <= BackendKeyData: pid = 35, key = 945119242
2019-11-13 17:18:37.932 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> <= ReadyForQuery: status = no_transaction
2019-11-13 17:18:37.932 [connection] 140567003937488/133134:0x7fd856437700 <INFO> Connection is ready
2019-11-13 17:18:37.932 [cursor] 140567003937488/133134:0x7fd856437700 <INFO> Execute simple query: [SELECT end_date, licensetype, node_restriction FROM v_catalog.licenses]
2019-11-13 17:18:37.932 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> => Query
2019-11-13 17:18:37.939 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> <= RowDescription: [{'attribute_number': 5, 'schema_name': u'v_catalog', 'null_ok': True, 'name': u'end_date', 'is_identity': False, 'data_type_oid': 9, 'format_code': 0, 'data_type_size': 65535, 'type_modifier': 84, 'table_name': u'licenses', 'data_type_name': 'Varchar', 'table_oid': 10256}, {'attribute_number': 6, 'schema_name': u'v_catalog', 'null_ok': True, 'name': u'licensetype', 'is_identity': False, 'data_type_oid': 9, 'format_code': 0, 'data_type_size': 65535, 'type_modifier': 21, 'table_name': u'licenses', 'data_type_name': 'Varchar', 'table_oid': 10256}, {'attribute_number': 10, 'schema_name': u'v_catalog', 'null_ok': True, 'name': u'node_restriction', 'is_identity': False, 'data_type_oid': 6, 'format_code': 0, 'data_type_size': 8, 'type_modifier': -1, 'table_name': u'licenses', 'data_type_name': 'Integer', 'table_oid': 10256}]
2019-11-13 17:18:37.939 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> <= DataRow
2019-11-13 17:18:37.940 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> <= CommandComplete: command_tag = ""
2019-11-13 17:18:37.940 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> <= ReadyForQuery: status = in_transaction
2019-11-13 17:18:37.940 [cursor] 140567003937488/133134:0x7fd856437700 <INFO> Execute simple query: [SELECT audit_start_timestamp, database_size_bytes, license_size_bytes FROM v_catalog.license_audits WHERE audited_data = 'Total' ORDER BY audit_start_timestamp DESC LIMIT 1]
2019-11-13 17:18:37.940 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> => Query
2019-11-13 17:18:37.945 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> <= RowDescription: [{'attribute_number': 4, 'schema_name': u'v_catalog', 'null_ok': True, 'name': u'audit_start_timestamp', 'is_identity': False, 'data_type_oid': 13, 'format_code': 0, 'data_type_size': 8, 'type_modifier': -1, 'table_name': u'license_audits', 'data_type_name': 'TimestampTz', 'table_oid': 10074}, {'attribute_number': 1, 'schema_name': u'v_catalog', 'null_ok': True, 'name': u'database_size_bytes', 'is_identity': False, 'data_type_oid': 6, 'format_code': 0, 'data_type_size': 8, 'type_modifier': -1, 'table_name': u'license_audits', 'data_type_name': 'Integer', 'table_oid': 10074}, {'attribute_number': 2, 'schema_name': u'v_catalog', 'null_ok': True, 'name': u'license_size_bytes', 'is_identity': False, 'data_type_oid': 9, 'format_code': 0, 'data_type_size': 65535, 'type_modifier': 24, 'table_name': u'license_audits', 'data_type_name': 'Varchar', 'table_oid': 10074}]
2019-11-13 17:18:37.946 [connection] 140567003937488/133134:0x7fd856437700 <DEBUG> <= CommandComplete: command_tag = ""
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
