### PR TITLE
Add lock_type tag to Lock metric

### DIFF
--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -72,10 +72,17 @@ COMMON_ARCHIVER_METRICS = {
 }
 
 LOCK_METRICS = {
-    'descriptors': [('mode', 'lock_mode'), ('nspname', 'schema'), ('datname', 'db'), ('relname', 'table')],
+    'descriptors': [
+        ('mode', 'lock_mode'),
+        ('locktype', 'lock_type'),
+        ('nspname', 'schema'),
+        ('datname', 'db'),
+        ('relname', 'table'),
+    ],
     'metrics': {'lock_count': ('postgresql.locks', AgentCheck.gauge)},
     'query': """
 SELECT mode,
+       locktype,
        pn.nspname,
        pd.datname,
        pc.relname,
@@ -86,7 +93,7 @@ SELECT mode,
   LEFT JOIN pg_namespace pn ON (pn.oid = pc.relnamespace)
  WHERE l.mode IS NOT NULL
    AND pc.relname NOT LIKE 'pg_%%'
- GROUP BY pd.datname, pc.relname, pn.nspname, mode""",
+ GROUP BY pd.datname, pc.relname, pn.nspname, locktype, mode""",
     'relation': False,
 }
 

--- a/postgres/tests/test_integration.py
+++ b/postgres/tests/test_integration.py
@@ -103,6 +103,7 @@ def test_locks_metrics(aggregator, integration_check, pg_instance):
         'port:{}'.format(PORT),
         'db:datadog_test',
         'lock_mode:AccessExclusiveLock',
+        'lock_type:relation',
         'table:persons',
         'schema:public',
     ]


### PR DESCRIPTION
### What does this PR do?

Adds a `lock_type` tag to the `postgres.locks` gauge metric reported for Postgresql.

### Motivation

The `locktype` column from the `pg_locks` table provides the type of object locked. This is a useful attribute to be able to separate metrics on.

An `ExclusiveLock` mode on a `relation` (table) type may be problematic while the same lock mode on a page or tuple for the same table may be uninteresting.

### Additional Notes

Pretty small change but this would remove the guesswork from some analysis we were trying to perform.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
