### PR TITLE
Fix `kafka_client_api_version`

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -69,6 +69,9 @@ class KafkaCheck(AgentCheck):
         )
         self._consumer_groups = self.instance.get('consumer_groups', {})
         self._kafka_client = self._create_kafka_admin_client()
+        self._kafka_version = self.instance.get('kafka_client_api_version')
+        if isinstance(self._kafka_version, str):
+            self._kafka_version = tuple(map(int, self._kafka_version.split(".")))
 
     def check(self, instance):
         """The main entrypoint of the check."""
@@ -123,7 +126,9 @@ class KafkaCheck(AgentCheck):
             bootstrap_servers=kafka_connect_str,
             client_id='dd-agent',
             request_timeout_ms=self.init_config.get('kafka_timeout', DEFAULT_KAFKA_TIMEOUT) * 1000,
-            api_version=self.instance.get('kafka_client_api_version'),
+            # There is a bug with kafka-python where pinning api_version for KafkaAdminClient raises an IncompatibleBrokerVersion. Change to api_version=self._kafka_version once fixed.
+            # api_version=self._kafka_version,
+            api_version=None,
             # While we check for SASL/SSL params, if not present they will default to the kafka-python values for
             # plaintext connections
             security_protocol=self.instance.get('security_protocol', 'PLAINTEXT'),
@@ -139,6 +144,7 @@ class KafkaCheck(AgentCheck):
             ssl_crlfile=self.instance.get('ssl_crlfile'),
             ssl_password=self.instance.get('ssl_password'),
         )
+        self.log.debug("KafkaAdminClient api_version: {}".format(kafka_admin_client.config['api_version']))
         # Force initial population of the local cluster metadata cache
         kafka_admin_client._client.poll(future=kafka_admin_client._client.cluster.request_update())
         if kafka_admin_client._client.cluster.topics(exclude_internal_topics=False) is None:
@@ -431,7 +437,9 @@ class KafkaCheck(AgentCheck):
     @classmethod
     def _determine_kafka_version(cls, init_config, instance):
         """Return the Kafka cluster version as a tuple."""
-        kafka_version = instance.get('kafka_client_api_version')
+        kafka_client_api_version = instance.get('kafka_client_api_version')
+        if isinstance(kafka_client_api_version, str):
+            kafka_version = tuple(map(int, kafka_client_api_version.split(".")))
         if kafka_version is None:  # if unspecified by the user, we have to probe the cluster
             kafka_connect_str = instance.get('kafka_connect_str')  # TODO call validation method
             kafka_client = KafkaClient(
@@ -441,7 +449,7 @@ class KafkaCheck(AgentCheck):
                 # if `kafka_client_api_version` is not set, then kafka-python automatically probes the cluster for
                 # broker version during the bootstrapping process. Note that this returns the first version found, so in
                 # a mixed-version cluster this will be a non-deterministic result.
-                api_version=instance.get('kafka_client_api_version'),
+                api_version=kafka_version,
                 # While we check for SASL/SSL params, if not present they will default to the kafka-python values for
                 # plaintext connections
                 security_protocol=instance.get('security_protocol', 'PLAINTEXT'),

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -68,14 +68,13 @@ class KafkaCheck(AgentCheck):
             self.instance.get('monitor_all_broker_highwatermarks', False)
         )
         self._consumer_groups = self.instance.get('consumer_groups', {})
+        self._kafka_client = self._create_kafka_admin_client()
         self._kafka_version = self.instance.get('kafka_client_api_version')
         if isinstance(self._kafka_version, str):
             self._kafka_version = tuple(map(int, self._kafka_version.split(".")))
 
     def check(self, instance):
         """The main entrypoint of the check."""
-
-        self._kafka_client = self._create_kafka_admin_client()
         self._consumer_offsets = {}  # Expected format: {(consumer_group, topic, partition): offset}
         self._highwater_offsets = {}  # Expected format: {(topic, partition): offset}
 
@@ -113,8 +112,6 @@ class KafkaCheck(AgentCheck):
         # Report the metics
         self._report_highwater_offsets()
         self._report_consumer_offsets_and_lag()
-
-        self._kafka_client.close()
 
     def _create_kafka_admin_client(self):
         """Return a KafkaAdminClient."""

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -129,8 +129,8 @@ class KafkaCheck(AgentCheck):
             bootstrap_servers=kafka_connect_str,
             client_id='dd-agent',
             request_timeout_ms=self.init_config.get('kafka_timeout', DEFAULT_KAFKA_TIMEOUT) * 1000,
-            # There is a bug with kafka-python where pinning api_version for KafkaAdminClient raises an IncompatibleBrokerVersion. Change to api_version=self._kafka_version once fixed.
-            # api_version=self._kafka_version,
+            # There is a bug with kafka-python where pinning api_version for KafkaAdminClient raises an
+            # `IncompatibleBrokerVersion`. Change to `api_version=self._kafka_version` once fixed upstream.
             api_version=None,
             # While we check for SASL/SSL params, if not present they will default to the kafka-python values for
             # plaintext connections

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -440,9 +440,9 @@ class KafkaCheck(AgentCheck):
     @classmethod
     def _determine_kafka_version(cls, init_config, instance):
         """Return the Kafka cluster version as a tuple."""
-        kafka_client_api_version = instance.get('kafka_client_api_version')
-        if isinstance(kafka_client_api_version, str):
-            kafka_version = tuple(map(int, kafka_client_api_version.split(".")))
+        kafka_version = instance.get('kafka_client_api_version')
+        if isinstance(kafka_version, str):
+            kafka_version = tuple(map(int, kafka_version.split(".")))
         if kafka_version is None:  # if unspecified by the user, we have to probe the cluster
             kafka_connect_str = instance.get('kafka_connect_str')  # TODO call validation method
             kafka_client = KafkaClient(

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -68,13 +68,14 @@ class KafkaCheck(AgentCheck):
             self.instance.get('monitor_all_broker_highwatermarks', False)
         )
         self._consumer_groups = self.instance.get('consumer_groups', {})
-        self._kafka_client = self._create_kafka_admin_client()
         self._kafka_version = self.instance.get('kafka_client_api_version')
         if isinstance(self._kafka_version, str):
             self._kafka_version = tuple(map(int, self._kafka_version.split(".")))
 
     def check(self, instance):
         """The main entrypoint of the check."""
+
+        self._kafka_client = self._create_kafka_admin_client()
         self._consumer_offsets = {}  # Expected format: {(consumer_group, topic, partition): offset}
         self._highwater_offsets = {}  # Expected format: {(topic, partition): offset}
 
@@ -112,6 +113,8 @@ class KafkaCheck(AgentCheck):
         # Report the metics
         self._report_highwater_offsets()
         self._report_consumer_offsets_and_lag()
+
+        self._kafka_client.close()
 
     def _create_kafka_admin_client(self):
         """Return a KafkaAdminClient."""

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -131,6 +131,7 @@ class KafkaCheck(AgentCheck):
             request_timeout_ms=self.init_config.get('kafka_timeout', DEFAULT_KAFKA_TIMEOUT) * 1000,
             # There is a bug with kafka-python where pinning api_version for KafkaAdminClient raises an
             # `IncompatibleBrokerVersion`. Change to `api_version=self._kafka_version` once fixed upstream.
+            # See linked issues in PR: https://github.com/dpkp/kafka-python/pull/1953
             api_version=None,
             # While we check for SASL/SSL params, if not present they will default to the kafka-python values for
             # plaintext connections

--- a/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
@@ -65,7 +65,7 @@ class LegacyKafkaCheck_0_10_2(AgentCheck):
 
     def check(self, instance):
         """The main entrypoint of the check."""
-        self.log.debug("Found `zk_connect_str`. Running legacy Kafka Consumer check.")
+        self.log.debug("Running legacy Kafka Consumer check.")
         self._zk_consumer_offsets = {}  # Expected format: {(consumer_group, topic, partition): offset}
         self._kafka_consumer_offsets = {}  # Expected format: {(consumer_group, topic, partition): offset}
         self._highwater_offsets = {}  # Expected format: {(topic, partition): offset}

--- a/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
@@ -65,6 +65,7 @@ class LegacyKafkaCheck_0_10_2(AgentCheck):
 
     def check(self, instance):
         """The main entrypoint of the check."""
+        self.log.debug("Found `zk_connect_str`. Running legacy Kafka Consumer check.")
         self._zk_consumer_offsets = {}  # Expected format: {(consumer_group, topic, partition): offset}
         self._kafka_consumer_offsets = {}  # Expected format: {(consumer_group, topic, partition): offset}
         self._highwater_offsets = {}  # Expected format: {(topic, partition): offset}
@@ -126,6 +127,9 @@ class LegacyKafkaCheck_0_10_2(AgentCheck):
         kafka_conn_str = self.instance.get('kafka_connect_str')
         if not isinstance(kafka_conn_str, (string_types, list)):
             raise ConfigurationError('kafka_connect_str should be string or list of strings')
+        kafka_version = self.instance.get('kafka_client_api_version')
+        if isinstance(kafka_version, str):
+            kafka_version = tuple(map(int, kafka_version.split(".")))
         kafka_client = KafkaClient(
             bootstrap_servers=kafka_conn_str,
             client_id='dd-agent',
@@ -133,7 +137,7 @@ class LegacyKafkaCheck_0_10_2(AgentCheck):
             # if `kafka_client_api_version` is not set, then kafka-python automatically probes the cluster for broker
             # version during the bootstrapping process. Note that probing randomly picks a broker to probe, so in a
             # mixed-version cluster probing returns a non-deterministic result.
-            api_version=self.instance.get('kafka_client_api_version'),
+            api_version=kafka_version,
             # While we check for SSL params, if not present they will default to the kafka-python values for plaintext
             # connections
             security_protocol=self.instance.get('security_protocol', 'PLAINTEXT'),


### PR DESCRIPTION
### What does this PR do?
fixes an issue when pinning the `api_version`.

2 issues:

- `api_version` expects a tuple but `kafka_client_api_version` is a string
- there is a bug with `KafkaAdminClient` where pinning any `api_version` will raise an `IncompatibleBrokerVersion`. Setting `api_version=None` would be a temporary fix. 

### Motivation
found bug while investigating something.

### Additional Notes
- Created a PR over at kafka-python to fix pinning api_version for KafkaAdminClient.
  -  https://github.com/dpkp/kafka-python/pull/1953
- Related: https://github.com/dpkp/kafka-python/issues/1675

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
