### PR TITLE
Fixed name of the mongo integration in the docs

### DIFF
--- a/mongo/README.md
+++ b/mongo/README.md
@@ -117,7 +117,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 
 | Parameter            | Value                                                                                                                                                                           |
 |----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `mongodb`                                                                                                                                                                       |
+| `<INTEGRATION_NAME>` | `mongo`                                                                                                                                                                       |
 | `<INIT_CONFIG>`      | blank or `{}`                                                                                                                                                                   |
 | `<INSTANCE_CONFIG>`  | `{"server": "mongodb://datadog:<UNIQUEPASSWORD>@%%host%%:%%port%%/<DB_NAME>", "replica_check": true, "additional_metrics": ["metrics.commands","tcmalloc","top","collection"]}` |
 


### PR DESCRIPTION

### What does this PR do?
The containers section of the mongo README talks about the `mongodb` integration, where then name is `mongo`.


