### PR TITLE
add active defragmentation gauges for redis

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -29,6 +29,12 @@ class Redis(AgentCheck):
     SOURCE_TYPE_NAME = 'redis'
 
     GAUGE_KEYS = {
+        # Active defrag metrics
+        'active_defrag_running': 'redis.active_defrag.running',
+        'active_defrag_hits': 'redis.active_defrag.hits',
+        'active_defrag_misses': 'redis.active_defrag.misses',
+        'active_defrag_key_hits': 'redis.active_defrag.key_hits',
+        'active_defrag_key_misses': 'redis.active_defrag.key_misses',
         # Append-only metrics
         'aof_last_rewrite_time_sec': 'redis.aof.last_rewrite_time',
         'aof_rewrite_in_progress': 'redis.aof.rewrite',

--- a/redisdb/metadata.csv
+++ b/redisdb/metadata.csv
@@ -1,4 +1,9 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+redis.active_defrag.running,gauge,,,,Whether active defragmentation is running or not.,0,redis,active defrag running
+redis.active_defrag.hits,gauge,,operation,,Number of value reallocations performed by active the defragmentation process.,1,redis,active defrag hits
+redis.active_defrag.misses,gauge,,operation,,Number of aborted value reallocations started by the active defragmentation process.,1,redis,active defrag misses
+redis.active_defrag.key_hits,gauge,,key,,Number of keys that were actively defragmented.,1,redis,active defrag key hits
+redis.active_defrag.key_misses,gauge,,key,,Number of keys that were skipped by.,1,redis,active defrag key misses
 redis.aof.buffer_length,gauge,,byte,,Size of the AOF buffer.,0,redis,aof buf len
 redis.aof.last_rewrite_time,gauge,,second,,Duration of the last AOF rewrite.,0,redis,last aof rewrite time
 redis.aof.rewrite,gauge,,,,Flag indicating a AOF rewrite operation is on-going.,0,redis,aof rewrite

--- a/redisdb/tests/test_e2e.py
+++ b/redisdb/tests/test_e2e.py
@@ -87,6 +87,11 @@ def test_e2e_v_4_0(dd_agent_check, master_instance):
     aggregator.assert_metric('redis.mem.overhead', count=2, tags=tags)
     aggregator.assert_metric('redis.clients.longest_output_list', count=2, tags=tags)
     aggregator.assert_metric('redis.mem.startup', count=2, tags=tags)
+    aggregator.assert_metric('redis.active_defrag.running', count=2, tags=tags)
+    aggregator.assert_metric('redis.active_defrag.hits', count=2, tags=tags)
+    aggregator.assert_metric('redis.active_defrag.misses', count=2, tags=tags)
+    aggregator.assert_metric('redis.active_defrag.key_hits', count=2, tags=tags)
+    aggregator.assert_metric('redis.active_defrag.key_misses', count=2, tags=tags)
 
     aggregator.assert_all_metrics_covered()
 
@@ -100,5 +105,10 @@ def test_e2e_v_latest(dd_agent_check, master_instance):
     tags = ['redis_host:{}'.format(common.HOST), 'redis_port:6382', 'redis_role:master']
     aggregator.assert_metric('redis.mem.overhead', count=2, tags=tags)
     aggregator.assert_metric('redis.mem.startup', count=2, tags=tags)
+    aggregator.assert_metric('redis.active_defrag.running', count=2, tags=tags)
+    aggregator.assert_metric('redis.active_defrag.hits', count=2, tags=tags)
+    aggregator.assert_metric('redis.active_defrag.misses', count=2, tags=tags)
+    aggregator.assert_metric('redis.active_defrag.key_hits', count=2, tags=tags)
+    aggregator.assert_metric('redis.active_defrag.key_misses', count=2, tags=tags)
 
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
The active defrag gauges are missing from the redis integration and will be useful for monitoring the effects on CPU usage and overhead while active defrag is running

### Motivation
Investigating active defragmentation and would like to view the metrics supplied by redis in DataDog

### Additional Notes
Adds a few standard redis metrics from the INFO call

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
