### PR TITLE
[Solr] Update the Solr integration README

### DIFF
--- a/solr/README.md
+++ b/solr/README.md
@@ -234,17 +234,17 @@ Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from
 The `datadog-agent jmx` command was added in version 4.1.0.
 
   * List attributes that match at least one of your instances configuration:
-`sudo /etc/init.d/datadog-agent jmx list_matching_attributes`
+`sudo datadog-agent jmx list matching`
   * List attributes that do match one of your instances configuration but that are not being collected because it would exceed the number of metrics that can be collected:
-`sudo /etc/init.d/datadog-agent jmx list_limited_attributes`
+`sudo datadog-agent jmx list limited`
   * List attributes that will actually be collected by your current instances configuration:
-`sudo /etc/init.d/datadog-agent jmx list_collected_attributes`
+`sudo datadog-agent jmx list collected`
   * List attributes that don't match any of your instances configuration:
-`sudo /etc/init.d/datadog-agent jmx list_not_matching_attributes`
+`sudo datadog-agent jmx list not-matching`
   * List every attributes available that has a type supported by JMXFetch:
-`sudo /etc/init.d/datadog-agent jmx list_everything`
+`sudo datadog-agent jmx list everything`
   * Start the collection of metrics based on your current configuration and display them in the console:
-`sudo /etc/init.d/datadog-agent jmx collect`
+`sudo datadog-agent jmx collect`
 
 ## Further Reading
 ### Parsing a string value into a number


### PR DESCRIPTION
Update the Solr integration README to reflect changes in the datadog-agent commandline interface

### What does this PR do?
The current documentation of the Solr integration seems to reference the commandline arguments of an older version of the datadog-agent. This PR updates it with the current parameters of version 6.x

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
