### PR TITLE
Update http check response_time metric source

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -156,9 +156,7 @@ class HTTPCheck(AgentCheck):
 
             # Only report this metric if the site is not down
             if response_time and not service_checks:
-                # Stop the timer as early as possible
-                running_time = time.time() - start
-                self.gauge('network.http.response_time', running_time, tags=tags_list)
+                self.gauge('network.http.response_time', r.elapsed.total_seconds(), tags=tags_list)
 
             content = r.text
 

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -214,6 +214,7 @@ class HTTPCheck(AgentCheck):
             if r is not None:
                 r.close()
             # resets the wrapper Session object
+            self.http._session.close()
             self.http._session = None
 
         # Report status metrics as well


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Using the elapsed time collected by the requests lib should be more precise/reliable than our own measurement. That will avoid accounting in the response time, the time spend on other things than the request call itself.

The different between the two methods is especially visible when:
- the agent is starting
- the endpoint payload is large
- using 6.15

For some endpoints, the difference is quite substantial (but not for others, see 2nd image)
![image](https://user-images.githubusercontent.com/49917914/68954218-db733880-07c3-11ea-8323-bd3ef7b201ab.png)

But some other endpoints are less impacted:

![image](https://user-images.githubusercontent.com/49917914/68954390-33aa3a80-07c4-11ea-9f87-9c1d82261dd3.png)

### Motivation
<!-- What inspired you to submit this pull request? -->

Some users have seen increase/variation of the `network.http.response_time` when upgrading form 6.13 to to 6.14/6.15.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
