### PR TITLE
Handle missing partitions

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -371,7 +371,7 @@ class KafkaCheck(AgentCheck):
             # transform [("t1", [1, 2])] into [TopicPartition("t1", 1), TopicPartition("t1", 2)]
             topic_partitions = []
             for topic, partitions in topics.items():
-                if partitions is None:  # If partitions aren't specified, fetch all partitions in the topic
+                if not partitions:  # If partitions aren't specified, fetch all partitions in the topic
                     partitions = self._kafka_client._client.cluster.partitions_for_topic(topic)
                 topic_partitions.extend([TopicPartition(topic, p) for p in partitions])
         single_group_offsets_future = self._kafka_client._list_consumer_group_offsets_send_request(

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -25,18 +25,18 @@ def test_check_kafka(aggregator, kafka_instance):
     kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
     kafka_consumer_check.check(kafka_instance)
 
-    assert_check_kafka(aggregator, kafka_instance)
+    assert_check_kafka(aggregator, kafka_instance['consumer_groups'])
 
 
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, kafka_instance):
     aggregator = dd_agent_check(kafka_instance)
 
-    assert_check_kafka(aggregator, kafka_instance)
+    assert_check_kafka(aggregator, kafka_instance['consumer_groups'])
 
 
-def assert_check_kafka(aggregator, kafka_instance):
-    for name, consumer_group in kafka_instance['consumer_groups'].items():
+def assert_check_kafka(aggregator, consumer_groups):
+    for name, consumer_group in consumer_groups.items():
         for topic, partitions in consumer_group.items():
             for partition in partitions:
                 tags = ["topic:{}".format(topic), "partition:{}".format(partition)] + ['optional:tag1']
@@ -54,3 +54,21 @@ def test_consumer_config_error(caplog):
     kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [instance])
     kafka_consumer_check.check(instance)
     assert 'monitor_unlisted_consumer_groups is False' in caplog.text
+
+
+@pytest.mark.usefixtures('dd_environment')
+def test_no_topics(aggregator, kafka_instance):
+    kafka_instance['consumer_groups'] = {'my_consumer': {}}
+    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
+    kafka_consumer_check.check(kafka_instance)
+
+    assert_check_kafka(aggregator, {'my_consumer': {'marvel': [0]}})
+
+
+@pytest.mark.usefixtures('dd_environment')
+def test_no_partitions(aggregator, kafka_instance):
+    kafka_instance['consumer_groups'] = {'my_consumer': {'marvel': []}}
+    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
+    kafka_consumer_check.check(kafka_instance)
+
+    assert_check_kafka(aggregator, {'my_consumer': {'marvel': [0]}})


### PR DESCRIPTION
Both the old code and the doc worked when partition were an empty list.
This handles this case, and add tests for it and no topics.