### PR TITLE
Upgrade pywin32 to 227

### DIFF
--- a/active_directory/requirements.in
+++ b/active_directory/requirements.in
@@ -1,1 +1,1 @@
-pywin32==225; sys_platform == 'win32'
+pywin32==227; sys_platform == 'win32'

--- a/aspdotnet/requirements.in
+++ b/aspdotnet/requirements.in
@@ -1,1 +1,1 @@
-pywin32==225; sys_platform == 'win32'
+pywin32==227; sys_platform == 'win32'

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -45,7 +45,7 @@ python-binary-memcached==0.26.1; sys_platform != 'win32'
 python-dateutil==2.8.0
 python3-gearman==0.1.0; sys_platform != 'win32' and python_version > '3.0'
 pyvmomi==v6.5.0.2017.5-1
-pywin32==225; sys_platform == 'win32'
+pywin32==227; sys_platform == 'win32'
 pyyaml==5.1
 redis==2.10.5
 requests==2.22.0

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -5,7 +5,7 @@ kubernetes==8.0.1
 prometheus-client==0.3.0
 protobuf==3.7.0
 pysocks==1.7.0
-pywin32==225; sys_platform == 'win32'
+pywin32==227; sys_platform == 'win32'
 pyyaml==5.1
 requests==2.22.0
 requests-kerberos==0.12.0

--- a/dotnetclr/requirements.in
+++ b/dotnetclr/requirements.in
@@ -1,1 +1,1 @@
-pywin32==225; sys_platform == 'win32'
+pywin32==227; sys_platform == 'win32'

--- a/exchange_server/requirements.in
+++ b/exchange_server/requirements.in
@@ -1,1 +1,1 @@
-pywin32==225; sys_platform == 'win32'
+pywin32==227; sys_platform == 'win32'

--- a/iis/requirements.in
+++ b/iis/requirements.in
@@ -1,1 +1,1 @@
-pywin32==225; sys_platform == 'win32'
+pywin32==227; sys_platform == 'win32'

--- a/pdh_check/requirements.in
+++ b/pdh_check/requirements.in
@@ -1,1 +1,1 @@
-pywin32==225; sys_platform == 'win32'
+pywin32==227; sys_platform == 'win32'

--- a/sqlserver/requirements.in
+++ b/sqlserver/requirements.in
@@ -1,6 +1,6 @@
 adodbapi==2.6.0.7; sys_platform == 'win32'
 pyodbc==4.0.26; sys_platform != 'darwin'
 pyro4==4.73; sys_platform == 'win32'
-pywin32==225; sys_platform == 'win32'
+pywin32==227; sys_platform == 'win32'
 selectors34==1.2.0; sys_platform == 'win32' and python_version < '3.4'
 serpent==1.27; sys_platform == 'win32'

--- a/win32_event_log/requirements.in
+++ b/win32_event_log/requirements.in
@@ -1,2 +1,2 @@
-pywin32==225; sys_platform == 'win32'
+pywin32==227; sys_platform == 'win32'
 uptime==3.0.1

--- a/windows_service/requirements.in
+++ b/windows_service/requirements.in
@@ -1,1 +1,1 @@
-pywin32==225; sys_platform == 'win32'
+pywin32==227; sys_platform == 'win32'

--- a/wmi_check/requirements.in
+++ b/wmi_check/requirements.in
@@ -1,1 +1,1 @@
-pywin32==225; sys_platform == 'win32'
+pywin32==227; sys_platform == 'win32'


### PR DESCRIPTION
In order to build the Agent with Python 3.8, we need a compatible pywin32.

### What does this PR do?
Upgrade pywin32 to 227.

### Motivation
In order to build the Agent with Python 3.8, we need a compatible pywin32.

### Additional Notes
See https://github.com/mhammond/pywin32/issues/1327 mentioning that support is in starting from 226.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
