### PR TITLE
Refresh auth token when it expires

### DIFF
--- a/cisco_aci/datadog_checks/cisco_aci/api.py
+++ b/cisco_aci/datadog_checks/cisco_aci/api.py
@@ -12,6 +12,7 @@ from requests import Request, Session
 from six.moves.urllib.parse import unquote
 
 from datadog_checks.base import ConfigurationError
+
 from .exceptions import APIAuthException, APIConnectionException, APIParsingException
 
 

--- a/cisco_aci/datadog_checks/cisco_aci/exceptions.py
+++ b/cisco_aci/datadog_checks/cisco_aci/exceptions.py
@@ -18,6 +18,3 @@ class APIConnectionException(APIException):
 class APIParsingException(APIException):
     pass
 
-
-class ConfigurationException(Exception):
-    pass

--- a/cisco_aci/datadog_checks/cisco_aci/exceptions.py
+++ b/cisco_aci/datadog_checks/cisco_aci/exceptions.py
@@ -17,4 +17,3 @@ class APIConnectionException(APIException):
 
 class APIParsingException(APIException):
     pass
-


### PR DESCRIPTION
For long running versions of the cisco check, the auth token we use might need to be refreshed. By default it expires after 10min, let's make sure that when any request fail we re-authenticate and retry the request.