### PR TITLE
Improve normalize

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -625,6 +625,16 @@ class __AgentCheck(object):
 
         return to_string(name)
 
+    def normalize_tag(self, tag):
+        """Normalize tag values.
+
+        It doesn't entirely duplicate backend logic, as the cleanup will happen
+        here. It just removes leading underscores for consistency, and replaces
+        spaces for testing.
+        """
+        tag = tag.replace(' ', '_').strip('_')
+        return to_string(tag)
+
     def check(self, instance):
         raise NotImplementedError
 

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -97,7 +97,7 @@ class __AgentCheck(object):
 
     FIRST_CAP_RE = re.compile(br'(.)([A-Z][a-z]+)')
     ALL_CAP_RE = re.compile(br'([a-z0-9])([A-Z])')
-    METRIC_REPLACEMENT = re.compile(br'([^a-zA-Z0-9_.]+)|(^[^a-zA-Z]+)')
+    METRIC_REPLACEMENT = re.compile(br'([^a-zA-Z0-9_.]+)|(^[^a-zA-Z]+)|__+')
     DOT_UNDERSCORE_CLEANUP = re.compile(br'_*\._*')
     DEFAULT_METRIC_LIMIT = 0
 
@@ -617,15 +617,8 @@ class __AgentCheck(object):
             if prefix is not None:
                 prefix = self.convert_to_underscore_separated(prefix)
         else:
-            name = re.sub(br"[,\+\*\-/()\[\]{}\s]", b"_", metric)
-        # Eliminate multiple _
-        name = re.sub(br"__+", b"_", name)
-        # Don't start/end with _
-        name = re.sub(br"^_", b"", name)
-        name = re.sub(br"_$", b"", name)
-        # Drop ._ and _.
-        name = re.sub(br"\._", b".", name)
-        name = re.sub(br"_\.", b".", name)
+            name = self.METRIC_REPLACEMENT.sub(br'_', metric)
+            name = self.DOT_UNDERSCORE_CLEANUP.sub(br'.', name).strip(b'_')
 
         if prefix is not None:
             name = ensure_bytes(prefix) + b"." + name

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -96,7 +96,7 @@ class HTTPCheck(AgentCheck):
         # Store tags in a temporary list so that we don't modify the global tags data structure
         tags_list = list(tags)
         tags_list.append('url:{}'.format(addr))
-        instance_name = self.normalize(instance['name'])
+        instance_name = self.normalize_tag(instance['name'])
         tags_list.append("instance:{}".format(instance_name))
         service_checks = []
         service_checks_tags = self._get_service_checks_tags(instance)
@@ -243,7 +243,7 @@ class HTTPCheck(AgentCheck):
             self.report_as_service_check(sc_name, status, service_checks_tags, msg)
 
     def _get_service_checks_tags(self, instance):
-        instance_name = self.normalize(instance['name'])
+        instance_name = self.normalize_tag(instance['name'])
         url = instance.get('url', None)
         if url is not None:
             url = ensure_unicode(url)

--- a/http_check/tests/test_integration.py
+++ b/http_check/tests/test_integration.py
@@ -170,7 +170,6 @@ def test_mock_case(aggregator, http_check):
 def test_service_check_instance_name_normalization(aggregator, http_check):
     """
     Service check `instance` tag value is normalized.
-
     Note: necessary to avoid mismatch and backward incompatibility.
     """
 
@@ -178,7 +177,7 @@ def test_service_check_instance_name_normalization(aggregator, http_check):
     http_check.check(CONFIG_UNORMALIZED_INSTANCE_NAME['instances'][0])
 
     # Assess instance name normalization
-    normalized_tags = ['url:https://github.com', 'instance:need_to_be_normalized']
+    normalized_tags = ['url:https://github.com', 'instance:need-to__be_normalized-']
     aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=normalized_tags, count=1)
     aggregator.assert_service_check(HTTPCheck.SC_SSL_CERT, status=HTTPCheck.OK, tags=normalized_tags, count=1)
 

--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -52,7 +52,7 @@ class IIS(PDHBaseCheck):
             iis_host = self.hostname
         else:
             iis_host = inst_host
-        return "iis_host:{}".format(self.normalize(iis_host))
+        return "iis_host:{}".format(self.normalize_tag(iis_host))
 
     def check(self, instance):
         # Duplicate refresh_counters from PDHBaseCheck
@@ -113,7 +113,7 @@ class IIS(PDHBaseCheck):
             if instance_hash in self._tags:
                 tags = list(self._tags[instance_hash])
             tags.append(self.get_iishost(instance))
-            normalized_site = self.normalize(site)
+            normalized_site = self.normalize_tag(site)
             tags.append("site:{}".format(normalized_site))
             self.log.warning("Check didn't get any data for expected site: %r", site)
             self.service_check(self.SERVICE_CHECK, self.CRITICAL, tags)
@@ -126,7 +126,7 @@ class IIS(PDHBaseCheck):
 
         try:
             if not is_single_instance:
-                tags.append("site:{}".format(self.normalize(site_name)))
+                tags.append("site:{}".format(self.normalize_tag(site_name)))
         except Exception as e:
             self.log.error("Caught exception %r setting tags", e)
 

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -20,7 +20,7 @@ class TCPCheck(AgentCheck):
         super(TCPCheck, self).__init__(name, init_config, instances)
         instance = self.instances[0]
 
-        self.instance_name = self.normalize(instance['name'])
+        self.instance_name = self.normalize_tag(instance['name'])
         port = instance.get('port', None)
         self.timeout = float(instance.get('timeout', 10))
         self.response_time = instance.get('collect_response_time', False)


### PR DESCRIPTION
We have pre-compiled regular expressions for string cleanups, use that
instead of dynamic re.sub calls.

This also removes usage of normalize on tags. normalize is meant to be used on metrics, which has different rule. It somewhat reverts https://github.com/DataDog/integrations-core/pull/3218 in the process. I'm not sure what was the point of that PR exactly, but we normalize tags types already, so I think it's unnecessary. It adds new `normalize_tag` method, which does one thing that the backend doesn't do, which is remove leading underscores from tag value.