### PR TITLE
Fix TypeError in schema size check

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -1347,7 +1347,7 @@ class MySql(AgentCheck):
 
         sql_query_schema_size = """
         SELECT   table_schema,
-                 SUM(data_length+index_length)/1024/1024 AS total_mb
+                 IFNULL(SUM(data_length+index_length)/1024/1024,0) AS total_mb
                  FROM     information_schema.tables
                  GROUP BY table_schema;
         """


### PR DESCRIPTION
### What does this PR do?
This fixes a  `TypeError` exception when it returns null from a non base table such as those in the `view` or `sys` db

```
TypeError: long() argument must be a string or a number, not 'NoneType'\
\"}]"}
```

### Motivation
Getting pass the above error in checks. It now returns 0 if null instead of none.

example DBs that would return null:

```
mysql> select table_schema, data_length, index_length from information_schema.tables group by table_schema;
+--------------------+-------------+--------------+
| table_schema       | data_length | index_length |
+--------------------+-------------+--------------+
| information_schema |           0 |            0 |
| mysql              |      515970 |        53248 |
| performance_schema |           0 |            0 |
| sys                |        NULL |         NULL |
| tmp                |       16384 |        32768 |
| view               |        NULL |         NULL |
+--------------------+-------------+--------------+
9 rows in set (0.04 sec)
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
