### PR TITLE
Upgrade cryptography to 2.8

### DIFF
--- a/cisco_aci/requirements.in
+++ b/cisco_aci/requirements.in
@@ -1,1 +1,1 @@
-cryptography==2.7
+cryptography==2.8

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -4,7 +4,7 @@ beautifulsoup4==4.5.1
 binary==1.0.0
 boto==2.46.1
 contextlib2==0.5.5
-cryptography==2.7
+cryptography==2.8
 cx-oracle==7.2.0
 ddtrace==0.13.0
 dnspython==1.16.0

--- a/http_check/requirements.in
+++ b/http_check/requirements.in
@@ -1,2 +1,2 @@
-cryptography==2.7
+cryptography==2.8
 requests_ntlm==1.1.0

--- a/mysql/requirements.in
+++ b/mysql/requirements.in
@@ -1,2 +1,2 @@
-cryptography==2.7
+cryptography==2.8
 pymysql==0.9.3

--- a/tls/requirements.in
+++ b/tls/requirements.in
@@ -1,3 +1,3 @@
-cryptography==2.7
+cryptography==2.8
 ipaddress==1.0.22; python_version < '3.0'
 service_identity[idna]==18.1.0


### PR DESCRIPTION
In order to build the Agent with Python 3.8, we need a compatible cryptography and the compatibility starts with cryptography 2.8.

### What does this PR do?

Upgrade cryptography to 2.8.

### Motivation

In order to build the Agent with Python 3.8, we need a compatible cryptography and the compatibility starts with cryptography 2.8.

### Additional Notes

Issue on the cryptography repo about the Python 3.8 support https://github.com/pyca/cryptography/issues/5010

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
