### PR TITLE
Account for no query tags

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/query.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/query.py
@@ -37,7 +37,7 @@ class Query(object):
         elif not isinstance(columns, list):
             raise ValueError('field `columns` for {} must be a list'.format(query_name))
 
-        tags = self.query_data.get('tags')
+        tags = self.query_data.get('tags', [])
         if tags is not None and not isinstance(tags, list):
             raise ValueError('field `tags` for {} must be a list'.format(query_name))
 

--- a/datadog_checks_base/tests/test_db.py
+++ b/datadog_checks_base/tests/test_db.py
@@ -486,6 +486,23 @@ class TestSubmission:
         aggregator.assert_metric('test.foo', 7, metric_type=aggregator.COUNT, tags=['test:foo', 'test:bar', 'tag:tag2'])
         aggregator.assert_all_metrics_covered()
 
+    def test_no_query_tags(self, aggregator):
+        query_manager = create_query_manager(
+            {
+                'name': 'test query',
+                'query': 'foo',
+                'columns': [{'name': 'test.foo', 'type': 'count'}, {'name': 'tag', 'type': 'tag'}],
+            },
+            executor=mock_executor([[3, 'tag1'], [7, 'tag2'], [5, 'tag1']]),
+            tags=['test:foo'],
+        )
+        query_manager.compile_queries()
+        query_manager.execute()
+
+        aggregator.assert_metric('test.foo', 8, metric_type=aggregator.COUNT, tags=['test:foo', 'tag:tag1'])
+        aggregator.assert_metric('test.foo', 7, metric_type=aggregator.COUNT, tags=['test:foo', 'tag:tag2'])
+        aggregator.assert_all_metrics_covered()
+
     def test_kwarg_passing(self, aggregator):
         class MyCheck(AgentCheck):
             __NAMESPACE__ = 'test_check'


### PR DESCRIPTION
### Motivation

```
clickhouse (0.0.1)
------------------
  Instance ID: clickhouse:bd2de4abf3114cb4 [ERROR]
  Configuration Source: file:/etc/datadog-agent/conf.d/clickhouse.d/clickhouse.yaml
  Total Runs: 1
  Metric Samples: Last Run: 0, Total: 0
  Events: Last Run: 0, Total: 0
  Service Checks: Last Run: 1, Total: 1
  Average Execution Time : 58ms
  Error: 'NoneType' object is not iterable
  Traceback (most recent call last):
    File "/home/datadog_checks_base/datadog_checks/base/checks/base.py", line 668, in run
      self.check(instance)
    File "/home/clickhouse/datadog_checks/clickhouse/clickhouse.py", line 60, in check
      self._query_manager.execute()
    File "/home/datadog_checks_base/datadog_checks/base/utils/db/core.py", line 90, in execute
      tags.extend(query_tags)
  TypeError: 'NoneType' object is not iterable
```