### PR TITLE
Handle total_time_to_temporal_percent missing

### DIFF
--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -20,9 +20,17 @@ from six import iteritems
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.errors import CheckException
-from datadog_checks.base.utils.common import total_time_to_temporal_percent
 
 from .config import InstanceConfig
+
+try:
+    from datadog_checks.base.utils.common import total_time_to_temporal_percent
+except ImportError:
+
+    # Provide fallback for agent < 6.16
+    def total_time_to_temporal_percent(total_time, scale=1000):
+        return total_time / scale * 100
+
 
 try:
     from datadog_agent import get_config, read_persistent_cache, write_persistent_cache


### PR DESCRIPTION
total_time_to_temporal_percent is only going to be in 6.16, let's
provide a fallback for now.