### PR TITLE
Collect version metadata for Fluentd

### DIFF
--- a/fluentd/datadog_checks/fluentd/data/conf.yaml.example
+++ b/fluentd/datadog_checks/fluentd/data/conf.yaml.example
@@ -1,6 +1,6 @@
 init_config:
     ## @param fluentd - string - optional - default: fluentd
-    ## Command or path to fluentd (e.g. `/usr/local/bin/fluentd` or `docker exec container fluentd`).
+    ## Command or path to Fluentd (e.g. `/usr/local/bin/fluentd` or `docker exec container fluentd`).
     ## Can be overwritten on an instance.
     #
     # fluentd: fluentd
@@ -40,7 +40,7 @@ instances:
   - monitor_agent_url: http://example.com:24220/api/plugins.json
 
     ## @param fluentd - string - optional - default: fluentd
-    ## Command or path to fluentd (e.g. `/usr/local/bin/fluentd` or `docker exec container fluentd`).
+    ## Command or path to Fluentd (e.g. `/usr/local/bin/fluentd` or `docker exec container fluentd`).
     #
     # fluentd: fluentd
 

--- a/fluentd/datadog_checks/fluentd/data/conf.yaml.example
+++ b/fluentd/datadog_checks/fluentd/data/conf.yaml.example
@@ -1,4 +1,10 @@
 init_config:
+    ## @param fluentd - string - optional - default: fluentd
+    ## Command or path to fluentd (e.g. `/usr/local/bin/fluentd` or `docker exec container fluentd`).
+    ## Can be overwritten on an instance.
+    #
+    # fluentd: fluentd
+
     ## @param proxy - object - optional
     ## Set HTTP or HTTPS proxies for all instances. Use the `no_proxy` list
     ## to specify hosts that must bypass proxies.
@@ -32,6 +38,11 @@ instances:
     ## Monitor Agent URL to connect to.
     #
   - monitor_agent_url: http://example.com:24220/api/plugins.json
+
+    ## @param fluentd - string - optional - default: fluentd
+    ## Command or path to fluentd (e.g. `/usr/local/bin/fluentd` or `docker exec container fluentd`).
+    #
+    # fluentd: fluentd
 
     ## @param plugin_ids - list of strings - optional
     ## Enter your Plugin IDs to monitor a specific scope of plugins.

--- a/fluentd/datadog_checks/fluentd/fluentd.py
+++ b/fluentd/datadog_checks/fluentd/fluentd.py
@@ -4,7 +4,6 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 import re
-import shlex
 
 # 3rd party
 from six.moves.urllib.parse import urlparse
@@ -34,7 +33,7 @@ class Fluentd(AgentCheck):
             )
             self.http.options['timeout'] = (timeout, timeout)
 
-        self._fluentd_command = shlex.split(self.instance.get('fluentd', init_config.get('fluentd', 'fluentd')))
+        self._fluentd_command = self.instance.get('fluentd', init_config.get('fluentd', 'fluentd'))
 
     """Tracks basic fluentd metrics via the monitor_agent plugin
     * number of retry_count
@@ -104,10 +103,10 @@ class Fluentd(AgentCheck):
             self.set_metadata('version', raw_version)
 
     def _get_raw_version(self):
-        command = self._fluentd_command + ['--version']
+        version_command = '{} --version'.format(self._fluentd_command)
 
         try:
-            out, _, _ = get_subprocess_output(command, self.log, False)
+            out, _, _ = get_subprocess_output(version_command, self.log, raise_on_empty_output=False)
         except OSError as exc:
             self.log.warning("Error collecting fluentd version: %s", exc)
             return None

--- a/fluentd/datadog_checks/fluentd/fluentd.py
+++ b/fluentd/datadog_checks/fluentd/fluentd.py
@@ -19,7 +19,7 @@ class Fluentd(AgentCheck):
     SERVICE_CHECK_NAME = 'fluentd.is_ok'
     GAUGES = ['retry_count', 'buffer_total_queued_size', 'buffer_queue_length']
     _AVAILABLE_TAGS = frozenset(['plugin_id', 'type'])
-    VERSION_PATTERN = r'.* (?P<version>[0-9\.]+)$'
+    VERSION_PATTERN = r'.* (?P<version>[0-9\.]+)'
 
     def __init__(self, name, init_config, instances):
         super(Fluentd, self).__init__(name, init_config, instances)

--- a/fluentd/datadog_checks/fluentd/fluentd.py
+++ b/fluentd/datadog_checks/fluentd/fluentd.py
@@ -3,10 +3,14 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+import re
+import shlex
+
 # 3rd party
 from six.moves.urllib.parse import urlparse
 
 # project
+from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 from datadog_checks.checks import AgentCheck
 
 
@@ -15,6 +19,7 @@ class Fluentd(AgentCheck):
     SERVICE_CHECK_NAME = 'fluentd.is_ok'
     GAUGES = ['retry_count', 'buffer_total_queued_size', 'buffer_queue_length']
     _AVAILABLE_TAGS = frozenset(['plugin_id', 'type'])
+    VERSION_PATTERN = r'.* (?P<version>[0-9\.]+)$'
 
     def __init__(self, name, init_config, instances):
         super(Fluentd, self).__init__(name, init_config, instances)
@@ -28,6 +33,8 @@ class Fluentd(AgentCheck):
                 or self.DEFAULT_TIMEOUT
             )
             self.http.options['timeout'] = (timeout, timeout)
+
+        self._fluentd_command = shlex.split(self.instance.get('fluentd', init_config.get('fluentd', 'fluentd')))
 
     """Tracks basic fluentd metrics via the monitor_agent plugin
     * number of retry_count
@@ -81,9 +88,34 @@ class Fluentd(AgentCheck):
                     # Filter unspecified plugins to keep backward compatibility.
                     if len(plugin_ids) == 0 or p.get('plugin_id') in plugin_ids:
                         self.gauge('fluentd.%s' % (m), metric, [tag] + custom_tags)
+
+            self._collect_metadata()
         except Exception as e:
             msg = "No stats could be retrieved from %s : %s" % (url, str(e))
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=service_check_tags, message=msg)
             raise
         else:
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK, tags=service_check_tags)
+
+    def _collect_metadata(self):
+        raw_version = self._get_raw_version()
+
+        if raw_version:
+            self.set_metadata('version', raw_version)
+
+    def _get_raw_version(self):
+        command = self._fluentd_command + ['--version']
+
+        try:
+            out, _, _ = get_subprocess_output(command, self.log, False)
+        except OSError as exc:
+            self.log.warning("Error collecting fluentd version: %s", exc)
+            return None
+
+        match = re.match(self.VERSION_PATTERN, out)
+
+        if match is None:
+            self.log.warning("fluentd version not found in stdout: `%s`", out)
+            return None
+
+        return match.group('version')

--- a/fluentd/tests/common.py
+++ b/fluentd/tests/common.py
@@ -10,6 +10,8 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(os.path.dirname(HERE))
 
 FLUENTD_VERSION = os.environ.get('FLUENTD_VERSION')
+FLUENTD_IMAGE_TAG = os.environ.get('FLUENTD_IMAGE_TAG')
+FLUENTD_CONTAINER_NAME = 'dd-test-fluentd'
 
 HOST = get_docker_hostname()
 PORT = 24220

--- a/fluentd/tests/common.py
+++ b/fluentd/tests/common.py
@@ -9,6 +9,8 @@ from datadog_checks.utils.common import get_docker_hostname
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(os.path.dirname(HERE))
 
+FLUENTD_VERSION = os.environ.get('FLUENTD_VERSION')
+
 HOST = get_docker_hostname()
 PORT = 24220
 BAD_PORT = 24222

--- a/fluentd/tests/compose/docker-compose.yaml
+++ b/fluentd/tests/compose/docker-compose.yaml
@@ -2,7 +2,8 @@ version: '3'
 services:
 
   fluentd:
-    image: fluent/fluentd:${FLUENTD_VERSION}
+    image: fluent/fluentd:${FLUENTD_IMAGE_TAG}
+    container_name: ${FLUENTD_CONTAINER_NAME}
     ports:
       - 24220:24220
     volumes:

--- a/fluentd/tests/conftest.py
+++ b/fluentd/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 
 from datadog_checks.dev import docker_run
 
-from .common import DEFAULT_INSTANCE, FLUENTD_VERSION, HERE, URL
+from .common import DEFAULT_INSTANCE, FLUENTD_CONTAINER_NAME, FLUENTD_IMAGE_TAG, HERE, URL
 
 
 @pytest.fixture(scope="session")
@@ -19,12 +19,13 @@ def dd_environment():
     If there's any problem executing docker-compose, let the exception bubble
     up.
     """
-    if not FLUENTD_VERSION:
-        pytest.skip(reason='FLUENTD_VERSION is required')
+    if not FLUENTD_IMAGE_TAG:
+        pytest.skip('FLUENTD_IMAGE_TAG is required')
 
     env = {
         'TD_AGENT_CONF_PATH': os.path.join(HERE, 'compose', 'td-agent.conf'),
-        'FLUENTD_VERSION': FLUENTD_VERSION,
+        'FLUENTD_IMAGE_TAG': FLUENTD_IMAGE_TAG,
+        'FLUENTD_CONTAINER_NAME': FLUENTD_CONTAINER_NAME,
     }
 
     with docker_run(

--- a/fluentd/tests/conftest.py
+++ b/fluentd/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 
 from datadog_checks.dev import docker_run
 
-from .common import DEFAULT_INSTANCE, HERE, URL
+from .common import DEFAULT_INSTANCE, FLUENTD_VERSION, HERE, URL
 
 
 @pytest.fixture(scope="session")
@@ -19,10 +19,12 @@ def dd_environment():
     If there's any problem executing docker-compose, let the exception bubble
     up.
     """
+    if not FLUENTD_VERSION:
+        pytest.skip(reason='FLUENTD_VERSION is required')
 
     env = {
         'TD_AGENT_CONF_PATH': os.path.join(HERE, 'compose', 'td-agent.conf'),
-        'FLUENTD_VERSION': os.environ.get('FLUENTD_VERSION') or 'v0.12.23',
+        'FLUENTD_VERSION': FLUENTD_VERSION,
     }
 
     with docker_run(

--- a/fluentd/tests/mock/fluentd_version.py
+++ b/fluentd/tests/mock/fluentd_version.py
@@ -1,0 +1,5 @@
+import sys
+
+if __name__ == "__main__":
+    mock_output = sys.argv[1]
+    print('fluentd {}'.format(mock_output))

--- a/fluentd/tests/test_metadata.py
+++ b/fluentd/tests/test_metadata.py
@@ -1,0 +1,19 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+from datadog_checks.fluentd import Fluentd
+
+from .common import CHECK_NAME
+
+CHECK_ID = 'test:123'
+
+
+def test_collect_metadata_invalid_binary(datadog_agent, instance):
+    instance['fluentd'] = '/bin/does_not_exist'
+
+    check = Fluentd(CHECK_NAME, {}, [instance])
+    check.check_id = CHECK_ID
+    check.check(instance)
+
+    datadog_agent.assert_metadata(CHECK_ID, {})
+    datadog_agent.assert_metadata_count(0)

--- a/fluentd/tests/test_metadata.py
+++ b/fluentd/tests/test_metadata.py
@@ -13,7 +13,6 @@ CHECK_ID = 'test:123'
 VERSION_MOCK_SCRIPT = os.path.join(HERE, 'mock', 'fluentd_version.py')
 
 
-@pytest.mark.skipif(not FLUENTD_VERSION, reason="FLUENTD_VERSION is required")
 @pytest.mark.usefixtures("dd_environment")
 def test_collect_metadata_instance(aggregator, datadog_agent, instance):
     instance['fluentd'] = 'docker exec {} fluentd'.format(FLUENTD_CONTAINER_NAME)

--- a/fluentd/tests/test_metadata.py
+++ b/fluentd/tests/test_metadata.py
@@ -1,13 +1,53 @@
 # (C) Datadog, Inc. 2019
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import os
+
+import pytest
+
 from datadog_checks.fluentd import Fluentd
 
-from .common import CHECK_NAME
+from .common import CHECK_NAME, FLUENTD_CONTAINER_NAME, FLUENTD_VERSION, HERE
 
 CHECK_ID = 'test:123'
+VERSION_MOCK_SCRIPT = os.path.join(HERE, 'mock', 'fluentd_version.py')
 
 
+@pytest.mark.skipif(not FLUENTD_VERSION, reason="FLUENTD_VERSION is required")
+@pytest.mark.usefixtures("dd_environment")
+def test_collect_metadata_instance(aggregator, datadog_agent, instance):
+    instance['fluentd'] = 'docker exec {} fluentd'.format(FLUENTD_CONTAINER_NAME)
+
+    check = Fluentd(CHECK_NAME, {}, [instance])
+    check.check_id = CHECK_ID
+    check.check(instance)
+
+    major, minor, patch = FLUENTD_VERSION.split('.')
+    version_metadata = {
+        'version.raw': FLUENTD_VERSION,
+        'version.scheme': 'semver',
+        'version.major': major,
+        'version.minor': minor,
+        'version.patch': patch,
+    }
+
+    datadog_agent.assert_metadata(CHECK_ID, version_metadata)
+    datadog_agent.assert_metadata_count(5)
+
+
+@pytest.mark.usefixtures("dd_environment")
+def test_collect_metadata_missing_version(aggregator, datadog_agent, instance):
+    instance["fluentd"] = "python {} 'fluentd not.a.version'".format(VERSION_MOCK_SCRIPT)
+
+    check = Fluentd(CHECK_NAME, {}, [instance])
+    check.check_id = CHECK_ID
+    check.check(instance)
+
+    datadog_agent.assert_metadata(CHECK_ID, {})
+    datadog_agent.assert_metadata_count(0)
+
+
+@pytest.mark.usefixtures("dd_environment")
 def test_collect_metadata_invalid_binary(datadog_agent, instance):
     instance['fluentd'] = '/bin/does_not_exist'
 

--- a/fluentd/tox.ini
+++ b/fluentd/tox.ini
@@ -17,8 +17,10 @@ passenv =
     COMPOSE*
     DOCKER*
 setenv =
-    0.12.23: FLUENTD_VERSION=v0.12.23
-    1.4: FLUENTD_VERSION=v1.4
+    0.12.23: FLUENTD_VERSION=0.12.23
+    0.12.23: FLUENTD_IMAGE_TAG=v0.12.23
+    1.4: FLUENTD_VERSION=1.4.2
+    1.4: FLUENTD_IMAGE_TAG=v1.4-2
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Collect version metadata for the Fluentd integration.

### Motivation
<!-- What inspired you to submit this pull request? -->
- Ongoing effort to collect version metadata for Inventories across all integrations.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
- Implementation inspired by #4968 (esp. the `fluentd` command override trick).
- Some changes to `tox.ini` and the Compose setup as Fluentd doesn't *always* use the `vX.Y.Z` scheme for their Docker image tags.
- **CAVEAT**: will only find the version if the configured `fluentd` command is available in the Agent. See https://github.com/DataDog/integrations-core/pull/5057#discussion_r349640709

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
