### PR TITLE
Improve prompts in `ddev clean`

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/clean.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/clean.py
@@ -6,14 +6,16 @@ import os
 import click
 
 from ...utils import basepath, dir_exists, resolve_path
-from ..clean import clean_package, remove_compiled_scripts
+from ..clean import DELETE_EVERYWHERE, DELETE_IN_ROOT, clean_package, remove_compiled_scripts
 from ..constants import get_root
 from .console import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_waiting, echo_warning
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help="Remove a project's build artifacts")
 @click.argument('check', required=False)
-@click.option('--compiled-only', '-c', is_flag=True, help='Removes only .pyc files.')
+@click.option(
+    '--compiled-only', '-c', is_flag=True, help='Remove compiled files only ({}).'.format(', '.join(DELETE_EVERYWHERE)),
+)
 @click.option(
     '--all',
     '-a',
@@ -30,25 +32,16 @@ from .console import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_wait
     '-f',
     is_flag=True,
     help=(
-        'When run at the root of the project, '
-        'it will ignore most build and testing artifacts, '
-        'like .tox and build directories. '
-        'Force it to remove these.'
+        'If set and the command is run from the root directory, '
+        'allow removing build and test artifacts ({}).'.format(', '.join(DELETE_IN_ROOT))
     ),
 )
 @click.option('--verbose', '-v', is_flag=True, help='Shows removed paths.')
 @click.pass_context
 def clean(ctx, check, compiled_only, all_matches, force, verbose):
-    """Removes a project's build artifacts.
+    """Remove build and test artifacts for the given CHECK.
 
-    If `check` is not specified, the current working directory will be used.
-
-    All `*.pyc`/`*.pyd`/`*.pyo`/`*.whl` files and `__pycache__` directories will be
-    removed.
-
-    Additionally, the following patterns will be removed from the root of
-    the path: `.cache`, `.coverage`, `.eggs`, `.pytest_cache`, `.tox`, `build`,
-    `dist`, and `*.egg-info`.
+    If CHECK is not specified, the current working directory is used.
     """
     if check:
         path = resolve_path(os.path.join(get_root(), check))
@@ -75,7 +68,7 @@ def clean(ctx, check, compiled_only, all_matches, force, verbose):
                 'You are running this from the root of the integrations project.\n'
                 'By default, the following artifacts in the root directory will *not* be cleaned:'
             )
-            echo_info('.cache, .coverage, .eggs, .pytest_cache, .tox, build, dist, and *.egg-info')
+            echo_info(', '.join(DELETE_IN_ROOT))
             force_clean_root = click.confirm(
                 'Should we clean the above artifacts too? (Use --force of -f to bypass this prompt)'
             )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Don't ask for "force clean" if we're only removing compiled assets, because `force_clean_root` doesn't have any effect in that case.
- Improve wording of "force clean" prompt.
- Add hint on what actually gets cleaned.
- Use existing constants when documenting which files are cleaned.

### Motivation
<!-- What inspired you to submit this pull request? -->
- I was confused by the fact that `ddev clean -c` asked me to confirm removing root assets too, while `-c` is designed to remove compiled assets only.
- The "Should we continue?" prompt was misleading, as the command would continue regardless of the answer. What the prompt was really asking was whether root assets should be removed too — hence the change in this PR.
- The undifferentiated output ("Cleaning X...") made it unclear what was actually going to happen, even though we passed `-c` or agreed to remove root assets.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Example output:

<img width="896" alt="Screenshot 2019-11-22 at 11 39 25" src="https://user-images.githubusercontent.com/15911462/69419859-b62f7e80-0d1d-11ea-9fdd-136d9b3f6af3.png">

```console
$ ddev clean --help
Usage: ddev clean [OPTIONS] [CHECK]

  Remove build and test artifacts for the given CHECK.

  If CHECK is not specified, the current working directory is used.

Options:
  -c, --compiled-only  Remove compiled files only (__pycache__, *.pyo, *.whl,
                       *.pyd, *.pyc).
  -a, --all            Disable the detection of a project's dedicated virtual
                       env and/or editable installation. By default, these
                       will not be considered.
  -f, --force          If set and the command is run from the root directory,
                       allow removing build and test artifacts (dist,
                       .benchmarks, .pytest_cache, build, *.egg-info, .eggs,
                       .tox, .coverage, .cache).
  -v, --verbose        Shows removed paths.
  -h, --help           Show this message and exit.
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
