### PR TITLE
document requirements for conntrack metrics in k8s

### DIFF
--- a/network/README.md
+++ b/network/README.md
@@ -40,11 +40,17 @@ sudo modprobe nf_conntrack_ipv6
 
 2. [Restart the Agent][5] to effect any configuration changes.
 
-**Note**: Some conntrack metrics require running conntrack with privileged access to be retrieved. Configure the following sudoers rule for this to work:
+**Note**: 
+
+Some conntrack metrics require running conntrack with privileged access to be retrieved. 
+
+Linux: Configure the following sudoers rule for this to work:
 
 ```
 dd-agent ALL=NOPASSWD: /usr/sbin/conntrack -S
 ```
+
+Kubernetes: Conntrack metrics are available by default in Kubernetes <= v1.11 or when using the `host` networking mode in Kubernetes v1.11+. 
 
 ### Validation
 

--- a/network/README.md
+++ b/network/README.md
@@ -50,7 +50,7 @@ Linux: Configure the following sudoers rule for this to work:
 dd-agent ALL=NOPASSWD: /usr/sbin/conntrack -S
 ```
 
-Kubernetes: Conntrack metrics are available by default in Kubernetes <= v1.11 or when using the `host` networking mode in Kubernetes v1.11+. 
+Kubernetes: Conntrack metrics are available by default in Kubernetes < v1.11 or when using the `host` networking mode in Kubernetes v1.11+. 
 
 ### Validation
 


### PR DESCRIPTION
### What does this PR do?

Documents requirement of Kubernetes < 1.11 or running on `host` network to collect conntrack metrics in Kubernetes. 

IPVS became GA in Kubernetes 1.11, resulting in conntrack metrics requiring root/admin permissions:

`conntrack v1.4.5 (conntrack-tools): Operation failed: sorry, you must be root or get CAP_NET_ADMIN capability to do this`

Issue is resolved when running on the `host` network.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
