### PR TITLE
Upgrade jaydebeapi from 1.1.1 to 1.1.2 in Oracle integration

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -16,7 +16,7 @@ gearman==2.0.2; sys_platform != 'win32' and python_version < '3.0'
 httplib2==0.10.3
 in-toto==0.3.0
 ipaddress==1.0.22; python_version < '3.0'
-jaydebeapi==1.1.1
+jaydebeapi==1.1.2
 jpype1==0.7.0
 kafka-python==1.4.7; sys_platform != 'win32'
 kazoo==2.6.1; sys_platform != 'win32'

--- a/oracle/requirements.in
+++ b/oracle/requirements.in
@@ -1,3 +1,3 @@
 cx-oracle==7.2.0
-jaydebeapi==1.1.1
+jaydebeapi==1.1.2
 jpype1==0.7.0


### PR DESCRIPTION
Oracle integration uses jaydebeapi==1.1.1 and jpype1==0.7.0 python packages that are uncompatible.
jaydebeapi==1.1.2 release address this issue.
- https://github.com/baztian/jaydebeapi/issues/99
- https://github.com/baztian/jaydebeapi#changelog

### What does this PR do?
Upgrade jaydebeapi from 1.1.1 to 1.1.2 in Oracle integration.

### Motivation
The current python modules required for the Oracle integrations are `jydebeapi==1.1.1` and `jpype1==0.7.0`. Nonetheless, using those, I get the following error:

```
2019-11-25 12:35:57 UTC | CORE | ERROR | (pkg/collector/runner/runner.go:292 in work) | Error running check oracle: [{"message": "'_jpype.PyJPField' object has no attribute 'getStaticAttrib
ute'", "traceback": "Traceback (most recent call last):\n  File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/base.py\", line 652, in run\n    self.ch
eck(instance)\n  File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/oracle/oracle.py\", line 75, in check\n    with closing(self._get_connection(server, user, pas
sword, service, jdbc_driver, service_check_tags)) as con:\n  File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/oracle/oracle.py\", line 118, in _get_connection\n
    con = jdb.connect(self.ORACLE_DRIVER_CLASS, connect_string, [user, password], jdbc_driver)\n  File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/jaydebeapi/__init__.py\", li
ne 381, in connect\n    jconn = _jdbc_connect(jclassname, url, driver_args, jars, libs)\n  File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/jaydebeapi/__init__.py\", line 183,
 in _jdbc_connect_jpype\n    types_map[i.getName()] = i.getStaticAttribute()\nAttributeError: '_jpype.PyJPField' object has no attribute 'getStaticAttribute'\n"}]
```

Looking at the changelog of jaydebeapi, a new release is available (1.1.2) addressing this specific incompatibility (https://github.com/baztian/jaydebeapi#changelog).

### Additional Notes
None.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
