### PR TITLE
Collect a new metric: kubelet.evictions

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -139,7 +139,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
 
         self.kubelet_scraper_config = self.get_scraper_config(kubelet_instance)
 
-        self.COUNTER_TRANSFORMERS = {k:self.send_always_counter for k in self.COUNTER_METRICS}
+        self.COUNTER_TRANSFORMERS = {k: self.send_always_counter for k in self.COUNTER_METRICS}
 
     def _create_kubelet_prometheus_instance(self, instance):
         """
@@ -233,7 +233,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
             self.process_cadvisor(instance, self.cadvisor_legacy_url, self.pod_list, self.pod_list_utils)
         elif self.cadvisor_scraper_config['prometheus_url']:  # Prometheus
             self.log.debug('processing cadvisor metrics')
-            transformers=self.CADVISOR_METRIC_TRANSFORMERS
+            transformers = self.CADVISOR_METRIC_TRANSFORMERS
             transformers.update(self.COUNTER_TRANSFORMERS)
             self.process(self.cadvisor_scraper_config, metric_transformers=transformers)
 

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -117,6 +117,8 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
 
     DEFAULT_METRIC_LIMIT = 0
 
+    COUNTER_METRICS = {'kubelet_evictions': 'kubelet.evictions'}
+
     def __init__(self, name, init_config, agentConfig, instances=None):
         self.NAMESPACE = 'kubernetes'
         if instances is not None and len(instances) > 1:
@@ -136,6 +138,8 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
         self.cadvisor_scraper_config['_text_filter_blacklist'] = ['pod_name=""', 'pod=""']
 
         self.kubelet_scraper_config = self.get_scraper_config(kubelet_instance)
+
+        self.COUNTER_TRANSFORMERS = {k:self.send_always_counter for k in self.COUNTER_METRICS}
 
     def _create_kubelet_prometheus_instance(self, instance):
         """
@@ -164,7 +168,6 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
                         'kubelet_volume_stats_inodes': 'kubelet.volume.stats.inodes',
                         'kubelet_volume_stats_inodes_free': 'kubelet.volume.stats.inodes_free',
                         'kubelet_volume_stats_inodes_used': 'kubelet.volume.stats.inodes_used',
-                        'kubelet_evictions': 'kubelet.evictions',
                     }
                 ],
                 # Defaults that were set when the Kubelet scraper was based on PrometheusScraper
@@ -230,11 +233,13 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
             self.process_cadvisor(instance, self.cadvisor_legacy_url, self.pod_list, self.pod_list_utils)
         elif self.cadvisor_scraper_config['prometheus_url']:  # Prometheus
             self.log.debug('processing cadvisor metrics')
-            self.process(self.cadvisor_scraper_config, metric_transformers=self.CADVISOR_METRIC_TRANSFORMERS)
+            transformers=self.CADVISOR_METRIC_TRANSFORMERS
+            transformers.update(self.COUNTER_TRANSFORMERS)
+            self.process(self.cadvisor_scraper_config, metric_transformers=transformers)
 
         if self.kubelet_scraper_config['prometheus_url']:  # Prometheus
             self.log.debug('processing kubelet metrics')
-            self.process(self.kubelet_scraper_config)
+            self.process(self.kubelet_scraper_config, metric_transformers=self.COUNTER_TRANSFORMERS)
 
         # Free up memory
         self.pod_list = None
@@ -553,3 +558,15 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
         if not name or phase not in ["Running", "Pending"]:
             return True
         return False
+
+    def send_always_counter(self, metric, scraper_config, hostname=None):
+        metric_name_with_namespace = '{}.{}'.format(scraper_config['namespace'], self.COUNTER_METRICS[metric.name])
+        for sample in metric.samples:
+            val = sample[self.SAMPLE_VALUE]
+            if not self._is_value_valid(val):
+                self.log.debug("Metric value is not supported for metric {}".format(sample[self.SAMPLE_NAME]))
+                continue
+            custom_hostname = self._get_hostname(hostname, sample, scraper_config)
+            # Determine the tags to send
+            tags = self._metric_tags(metric.name, val, sample, scraper_config, hostname=custom_hostname)
+            self.monotonic_count(metric_name_with_namespace, val, tags=tags, hostname=custom_hostname)

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -164,6 +164,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
                         'kubelet_volume_stats_inodes': 'kubelet.volume.stats.inodes',
                         'kubelet_volume_stats_inodes_free': 'kubelet.volume.stats.inodes_free',
                         'kubelet_volume_stats_inodes_used': 'kubelet.volume.stats.inodes_used',
+                        'kubelet_evictions': 'kubelet.evictions',
                     }
                 ],
                 # Defaults that were set when the Kubelet scraper was based on PrometheusScraper

--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -56,3 +56,4 @@ kubernetes.kubelet.volume.stats.inodes_used,gauge,,inode,,The number of used ino
 kubernetes.ephemeral_storage.limits,gauge,,byte,,Ephemeral storage limit of the container (requires kubernetes v1.8+),0,kubelet,k8s.eph_storage.limits
 kubernetes.ephemeral_storage.requests,gauge,,byte,,Ephemeral storage request of the container (requires kubernetes v1.8+),0,kubelet,k8s.eph_storage.requests
 kubernetes.ephemeral_storage.usage,gauge,,byte,,Ephemeral storage usage of the POD,0,kubelet,k8s.eph_storage.usage
+kubernetes.kubelet.evictions,count,,,,The number of PODs that have been evicted from the kubelet (ALPHA in kubernetes v1.16),0,kubelet,k8s.evict

--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -56,4 +56,4 @@ kubernetes.kubelet.volume.stats.inodes_used,gauge,,inode,,The number of used ino
 kubernetes.ephemeral_storage.limits,gauge,,byte,,Ephemeral storage limit of the container (requires kubernetes v1.8+),0,kubelet,k8s.eph_storage.limits
 kubernetes.ephemeral_storage.requests,gauge,,byte,,Ephemeral storage request of the container (requires kubernetes v1.8+),0,kubelet,k8s.eph_storage.requests
 kubernetes.ephemeral_storage.usage,gauge,,byte,,Ephemeral storage usage of the POD,0,kubelet,k8s.eph_storage.usage
-kubernetes.kubelet.evictions,count,,,,The number of PODs that have been evicted from the kubelet (ALPHA in kubernetes v1.16),0,kubelet,k8s.evict
+kubernetes.kubelet.evictions,count,,,,The number of PODs that have been evicted from the kubelet (ALPHA in kubernetes v1.16),-1,kubelet,k8s.evict

--- a/kubelet/tests/fixtures/kubelet_metrics.txt
+++ b/kubelet/tests/fixtures/kubelet_metrics.txt
@@ -976,3 +976,48 @@ storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume
 storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret",le="+Inf"} 9
 storage_operation_duration_seconds_sum{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret"} 0.331589254
 storage_operation_duration_seconds_count{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret"} 9
+# HELP kubelet_eviction_stats_age_microseconds [ALPHA] (Deprecated) Time between when stats are collected, and when pod is evicted based on those stats by eviction signal
+# TYPE kubelet_eviction_stats_age_microseconds summary
+kubelet_eviction_stats_age_microseconds{eviction_signal="allocatableMemory.available",quantile="0.5"} 1535
+kubelet_eviction_stats_age_microseconds{eviction_signal="allocatableMemory.available",quantile="0.9"} 1535
+kubelet_eviction_stats_age_microseconds{eviction_signal="allocatableMemory.available",quantile="0.99"} 1535
+kubelet_eviction_stats_age_microseconds_sum{eviction_signal="allocatableMemory.available"} 15557
+kubelet_eviction_stats_age_microseconds_count{eviction_signal="allocatableMemory.available"} 3
+kubelet_eviction_stats_age_microseconds{eviction_signal="memory.available",quantile="0.5"} 52668
+kubelet_eviction_stats_age_microseconds{eviction_signal="memory.available",quantile="0.9"} 52668
+kubelet_eviction_stats_age_microseconds{eviction_signal="memory.available",quantile="0.99"} 52668
+kubelet_eviction_stats_age_microseconds_sum{eviction_signal="memory.available"} 5.912456e+06
+kubelet_eviction_stats_age_microseconds_count{eviction_signal="memory.available"} 3
+# HELP kubelet_eviction_stats_age_seconds [ALPHA] Time between when stats are collected, and when pod is evicted based on those stats by eviction signal
+# TYPE kubelet_eviction_stats_age_seconds histogram
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="allocatableMemory.available",le="0.005"} 2
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="allocatableMemory.available",le="0.01"} 3
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="allocatableMemory.available",le="0.025"} 3
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="allocatableMemory.available",le="0.05"} 3
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="allocatableMemory.available",le="0.1"} 3
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="allocatableMemory.available",le="0.25"} 3
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="allocatableMemory.available",le="0.5"} 3
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="allocatableMemory.available",le="1"} 3
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="allocatableMemory.available",le="2.5"} 3
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="allocatableMemory.available",le="5"} 3
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="allocatableMemory.available",le="10"} 3
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="allocatableMemory.available",le="+Inf"} 3
+kubelet_eviction_stats_age_seconds_sum{eviction_signal="allocatableMemory.available"} 0.015040582
+kubelet_eviction_stats_age_seconds_count{eviction_signal="allocatableMemory.available"} 3
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.005"} 0
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.01"} 0
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.025"} 0
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.05"} 0
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.1"} 1
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.25"} 1
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.5"} 1
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="1"} 1
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="2.5"} 1
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="5"} 3
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="10"} 3
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="+Inf"} 3
+kubelet_eviction_stats_age_seconds_sum{eviction_signal="memory.available"} 5.912262458000001
+kubelet_eviction_stats_age_seconds_count{eviction_signal="memory.available"} 3
+# HELP kubelet_evictions [ALPHA] Cumulative number of pod evictions by eviction signal
+# TYPE kubelet_evictions counter
+kubelet_evictions{eviction_signal="allocatableMemory.available"} 3

--- a/kubelet/tests/fixtures/kubelet_metrics.txt
+++ b/kubelet/tests/fixtures/kubelet_metrics.txt
@@ -978,16 +978,16 @@ storage_operation_duration_seconds_sum{operation_name="volume_unmount",volume_pl
 storage_operation_duration_seconds_count{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret"} 9
 # HELP kubelet_eviction_stats_age_microseconds [ALPHA] (Deprecated) Time between when stats are collected, and when pod is evicted based on those stats by eviction signal
 # TYPE kubelet_eviction_stats_age_microseconds summary
-kubelet_eviction_stats_age_microseconds{eviction_signal="allocatableMemory.available",quantile="0.5"} 1535
-kubelet_eviction_stats_age_microseconds{eviction_signal="allocatableMemory.available",quantile="0.9"} 1535
-kubelet_eviction_stats_age_microseconds{eviction_signal="allocatableMemory.available",quantile="0.99"} 1535
+kubelet_eviction_stats_age_microseconds{eviction_signal="allocatableMemory.available",quantile="0.5"} NaN
+kubelet_eviction_stats_age_microseconds{eviction_signal="allocatableMemory.available",quantile="0.9"} NaN
+kubelet_eviction_stats_age_microseconds{eviction_signal="allocatableMemory.available",quantile="0.99"} NaN
 kubelet_eviction_stats_age_microseconds_sum{eviction_signal="allocatableMemory.available"} 15557
 kubelet_eviction_stats_age_microseconds_count{eviction_signal="allocatableMemory.available"} 3
-kubelet_eviction_stats_age_microseconds{eviction_signal="memory.available",quantile="0.5"} 52668
-kubelet_eviction_stats_age_microseconds{eviction_signal="memory.available",quantile="0.9"} 52668
-kubelet_eviction_stats_age_microseconds{eviction_signal="memory.available",quantile="0.99"} 52668
-kubelet_eviction_stats_age_microseconds_sum{eviction_signal="memory.available"} 5.912456e+06
-kubelet_eviction_stats_age_microseconds_count{eviction_signal="memory.available"} 3
+kubelet_eviction_stats_age_microseconds{eviction_signal="memory.available",quantile="0.5"} NaN
+kubelet_eviction_stats_age_microseconds{eviction_signal="memory.available",quantile="0.9"} NaN
+kubelet_eviction_stats_age_microseconds{eviction_signal="memory.available",quantile="0.99"} NaN
+kubelet_eviction_stats_age_microseconds_sum{eviction_signal="memory.available"} 6.074921e+06
+kubelet_eviction_stats_age_microseconds_count{eviction_signal="memory.available"} 6
 # HELP kubelet_eviction_stats_age_seconds [ALPHA] Time between when stats are collected, and when pod is evicted based on those stats by eviction signal
 # TYPE kubelet_eviction_stats_age_seconds histogram
 kubelet_eviction_stats_age_seconds_bucket{eviction_signal="allocatableMemory.available",le="0.005"} 2
@@ -1007,17 +1007,18 @@ kubelet_eviction_stats_age_seconds_count{eviction_signal="allocatableMemory.avai
 kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.005"} 0
 kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.01"} 0
 kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.025"} 0
-kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.05"} 0
-kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.1"} 1
-kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.25"} 1
-kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.5"} 1
-kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="1"} 1
-kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="2.5"} 1
-kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="5"} 3
-kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="10"} 3
-kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="+Inf"} 3
-kubelet_eviction_stats_age_seconds_sum{eviction_signal="memory.available"} 5.912262458000001
-kubelet_eviction_stats_age_seconds_count{eviction_signal="memory.available"} 3
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.05"} 1
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.1"} 4
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.25"} 4
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="0.5"} 4
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="1"} 4
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="2.5"} 4
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="5"} 6
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="10"} 6
+kubelet_eviction_stats_age_seconds_bucket{eviction_signal="memory.available",le="+Inf"} 6
+kubelet_eviction_stats_age_seconds_sum{eviction_signal="memory.available"} 6.074719042
+kubelet_eviction_stats_age_seconds_count{eviction_signal="memory.available"} 6
 # HELP kubelet_evictions [ALPHA] Cumulative number of pod evictions by eviction signal
 # TYPE kubelet_evictions counter
 kubelet_evictions{eviction_signal="allocatableMemory.available"} 3
+kubelet_evictions{eviction_signal="memory.available"} 3

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -91,6 +91,7 @@ EXPECTED_METRICS_PROMETHEUS = [
     'kubernetes.kubelet.volume.stats.inodes',
     'kubernetes.kubelet.volume.stats.inodes_free',
     'kubernetes.kubelet.volume.stats.inodes_used',
+    'kubernetes.kubelet.evictions',
 ]
 
 COMMON_TAGS = {


### PR DESCRIPTION
### What does this PR do?

Collect a new metric: `kubelet.evictions` 

This metric provides the number of PODs that have been evicted from a node and by eviction signal.

This metric has been introduced in Kubernetes 1.16 by kubernetes/kubernetes#81377

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
