### PR TITLE
Fix warnings usage related to RequestsWrapper, Openmetrics and Prometheus

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -582,7 +582,7 @@ class OpenMetricsScraperMixin(object):
         if isinstance(scraper_config['ssl_ca_cert'], string_types):
             verify = scraper_config['ssl_ca_cert']
         elif verify is False:
-            disable_warnings(InsecureRequestWarning)  # NOTE: disables InsecureRequestWarning *globally*
+            disable_warnings(InsecureRequestWarning)
 
         # Determine the authentication settings
         username = scraper_config['username']

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -12,6 +12,7 @@ from six import PY3, iteritems, itervalues, string_types
 from urllib3.exceptions import InsecureRequestWarning
 
 from datadog_checks.base.utils.warnings_util import disable_warnings_ctx
+
 from ...config import is_affirmative
 from ...errors import CheckException
 from ...utils.common import to_string

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -582,7 +582,7 @@ class OpenMetricsScraperMixin(object):
         if isinstance(scraper_config['ssl_ca_cert'], string_types):
             verify = scraper_config['ssl_ca_cert']
         elif verify is False:
-            disable_warnings(InsecureRequestWarning)
+            disable_warnings(InsecureRequestWarning)  # NOTE: disables InsecureRequestWarning *globally*
 
         # Determine the authentication settings
         username = scraper_config['username']

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -11,11 +11,10 @@ from prometheus_client.parser import text_fd_to_metric_families
 from six import PY3, iteritems, itervalues, string_types
 from urllib3.exceptions import InsecureRequestWarning
 
-from datadog_checks.base.utils.warnings_util import disable_warnings_ctx
-
 from ...config import is_affirmative
 from ...errors import CheckException
 from ...utils.common import to_string
+from ...utils.warnings_util import disable_warnings_ctx
 from .. import AgentCheck
 
 if PY3:

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -526,7 +526,7 @@ class PrometheusScraperMixin(object):
         if isinstance(self.ssl_ca_cert, string_types):
             verify = self.ssl_ca_cert
         elif self.ssl_ca_cert is False:
-            disable_warnings(InsecureRequestWarning)
+            disable_warnings(InsecureRequestWarning)  # NOTE: disables InsecureRequestWarning *globally*
             verify = False
         try:
             response = requests.get(

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -526,7 +526,7 @@ class PrometheusScraperMixin(object):
         if isinstance(self.ssl_ca_cert, string_types):
             verify = self.ssl_ca_cert
         elif self.ssl_ca_cert is False:
-            disable_warnings(InsecureRequestWarning)  # NOTE: disables InsecureRequestWarning *globally*
+            disable_warnings(InsecureRequestWarning)
             verify = False
         try:
             response = requests.get(

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -13,9 +13,8 @@ from prometheus_client.parser import text_fd_to_metric_families
 from six import PY3, iteritems, itervalues, string_types
 from urllib3.exceptions import InsecureRequestWarning
 
-from datadog_checks.base.utils.warnings_util import disable_warnings_ctx
-
 from ...utils.prometheus import metrics_pb2
+from ...utils.warnings_util import disable_warnings_ctx
 from .. import AgentCheck
 
 if PY3:

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -11,10 +11,10 @@ import requests
 from google.protobuf.internal.decoder import _DecodeVarint32  # pylint: disable=E0611,E0401
 from prometheus_client.parser import text_fd_to_metric_families
 from six import PY3, iteritems, itervalues, string_types
-from urllib3 import disable_warnings
 from urllib3.exceptions import InsecureRequestWarning
 
 from datadog_checks.base.utils.warnings_util import disable_warnings_ctx
+
 from ...utils.prometheus import metrics_pb2
 from .. import AgentCheck
 

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
 import os
-import warnings
 from contextlib import contextmanager
 
 import requests
@@ -11,6 +10,7 @@ from six import iteritems, string_types
 from six.moves.urllib.parse import urlparse
 from urllib3.exceptions import InsecureRequestWarning
 
+from datadog_checks.base.utils.warnings_util import simplefilter, disable_warnings_ctx
 from ..config import is_affirmative
 from ..errors import ConfigurationError
 from .headers import get_default_headers, update_headers
@@ -336,9 +336,7 @@ class RequestsWrapper(object):
 
     @contextmanager
     def handle_tls_warning(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', InsecureRequestWarning)
-
+        with disable_warnings_ctx(InsecureRequestWarning, disable=True):
             yield
 
     @property

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -10,11 +10,10 @@ from six import iteritems, string_types
 from six.moves.urllib.parse import urlparse
 from urllib3.exceptions import InsecureRequestWarning
 
-from datadog_checks.base.utils.warnings_util import disable_warnings_ctx
-
 from ..config import is_affirmative
 from ..errors import ConfigurationError
 from .headers import get_default_headers, update_headers
+from .warnings_util import disable_warnings_ctx
 
 try:
     from contextlib import ExitStack

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -271,7 +271,9 @@ class RequestsWrapper(object):
         self.log_requests = is_affirmative(config['log_requests'])
 
         # Context managers that should wrap all requests
-        self.request_hooks = [self.handle_tls_warning]
+        self.request_hooks = []
+        if self.ignore_tls_warning:
+            self.request_hooks.append(self.handle_tls_warning)
 
         if config['kerberos_keytab']:
             self.request_hooks.append(lambda: handle_kerberos_keytab(config['kerberos_keytab']))
@@ -335,8 +337,7 @@ class RequestsWrapper(object):
     @contextmanager
     def handle_tls_warning(self):
         with warnings.catch_warnings():
-            if self.ignore_tls_warning:
-                warnings.simplefilter('ignore', InsecureRequestWarning)
+            warnings.simplefilter('ignore', InsecureRequestWarning)
 
             yield
 

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -10,7 +10,8 @@ from six import iteritems, string_types
 from six.moves.urllib.parse import urlparse
 from urllib3.exceptions import InsecureRequestWarning
 
-from datadog_checks.base.utils.warnings_util import simplefilter, disable_warnings_ctx
+from datadog_checks.base.utils.warnings_util import disable_warnings_ctx
+
 from ..config import is_affirmative
 from ..errors import ConfigurationError
 from .headers import get_default_headers, update_headers

--- a/datadog_checks_base/datadog_checks/base/utils/warnings_util.py
+++ b/datadog_checks_base/datadog_checks/base/utils/warnings_util.py
@@ -8,8 +8,10 @@ from six import PY2
 
 
 def _simplefilter_py2(action, category=Warning, lineno=0, append=0):
-    """ Add remove logic for py2 to avoid warnings.filters to growth
-        indefinitely if simplefilter is called multiple times """
+    """
+    Add remove logic for py2 to avoid warnings.filters to growth
+    indefinitely if simplefilter is called multiple times
+    """
     item = (action, None, category, None, int(lineno))
     if not append:
         try:

--- a/datadog_checks_base/datadog_checks/base/utils/warnings_util.py
+++ b/datadog_checks_base/datadog_checks/base/utils/warnings_util.py
@@ -1,0 +1,36 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import warnings
+from contextlib import contextmanager
+
+from six import PY2
+
+
+def _simplefilter_py2(action, category=Warning, lineno=0, append=0):
+    """ Add remove logic for py2 to avoid warnings.filters to growth
+        indefinitely if simplefilter is called multiple times """
+    item = (action, None, category, None, int(lineno))
+    if not append:
+        try:
+            warnings.filters.remove(item)
+        except ValueError:
+            pass
+    warnings.simplefilter(action, category=category, lineno=lineno, append=append)
+
+
+if PY2:
+    simplefilter = _simplefilter_py2
+else:
+    simplefilter = warnings.simplefilter
+
+
+@contextmanager
+def disable_warnings_ctx(action, disable=True):
+    if disable:
+        simplefilter('ignore', action)
+        yield
+        simplefilter('default', action)
+    else:
+        # do nothing
+        yield

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
 import os
+import warnings
 from collections import OrderedDict
 
 import mock
@@ -12,6 +13,7 @@ import requests_kerberos
 import requests_ntlm
 from requests.exceptions import ConnectTimeout, ProxyError
 from six import iteritems
+from urllib3 import disable_warnings
 from urllib3.exceptions import InsecureRequestWarning
 
 from datadog_checks.base import AgentCheck, ConfigurationError

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -4,7 +4,6 @@
 import logging
 import os
 from collections import OrderedDict
-from contextlib import contextmanager
 
 import mock
 import pytest
@@ -595,12 +594,12 @@ class TestIgnoreTLSWarning:
     def test_ignore(self):
         instance = {'tls_ignore_warning': True}
         init_config = {}
+        http = RequestsWrapper(instance, init_config)
 
         with pytest.warns(None) as record:
-            http = RequestsWrapper(instance, init_config)
             http.get('https://www.google.com', verify=False)
 
-            assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
+        assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
 
     def test_default_no_ignore_session(self):
         instance = {'persist_connections': True}
@@ -613,32 +612,12 @@ class TestIgnoreTLSWarning:
     def test_ignore_session(self):
         instance = {'tls_ignore_warning': True, 'persist_connections': True}
         init_config = {}
+        http = RequestsWrapper(instance, init_config)
 
         with pytest.warns(None) as record:
-            http = RequestsWrapper(instance, init_config)
             http.get('https://www.google.com', verify=False)
 
-            assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
-
-    def test_warning_raised_only_once(self, caplog):
-        """ This test is here to prove that InsecureRequestWarning is only raised once """
-        instance = {}
-        init_config = {}
-
-        @contextmanager
-        def capture_warnings_as_log():
-            logging.captureWarnings(True)
-            yield
-            logging.captureWarnings(False)
-
-        with capture_warnings_as_log():
-            http = RequestsWrapper(instance, init_config)
-            http.get('https://www.example.com', verify=False)
-
-            http = RequestsWrapper(instance, init_config)
-            http.get('https://www.example.com', verify=False)
-
-        assert 1 == caplog.text.count("Unverified HTTPS request is being made.")
+        assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
 
 
 class TestSession:

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -4,6 +4,7 @@
 import logging
 import os
 from collections import OrderedDict
+from contextlib import contextmanager
 
 import mock
 import pytest
@@ -594,12 +595,12 @@ class TestIgnoreTLSWarning:
     def test_ignore(self):
         instance = {'tls_ignore_warning': True}
         init_config = {}
-        http = RequestsWrapper(instance, init_config)
 
         with pytest.warns(None) as record:
+            http = RequestsWrapper(instance, init_config)
             http.get('https://www.google.com', verify=False)
 
-        assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
+            assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
 
     def test_default_no_ignore_session(self):
         instance = {'persist_connections': True}
@@ -612,12 +613,32 @@ class TestIgnoreTLSWarning:
     def test_ignore_session(self):
         instance = {'tls_ignore_warning': True, 'persist_connections': True}
         init_config = {}
-        http = RequestsWrapper(instance, init_config)
 
         with pytest.warns(None) as record:
+            http = RequestsWrapper(instance, init_config)
             http.get('https://www.google.com', verify=False)
 
-        assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
+            assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
+
+    def test_warning_raised_only_once(self, caplog):
+        """ This test is here to prove that InsecureRequestWarning is only raised once """
+        instance = {}
+        init_config = {}
+
+        @contextmanager
+        def capture_warnings_as_log():
+            logging.captureWarnings(True)
+            yield
+            logging.captureWarnings(False)
+
+        with capture_warnings_as_log():
+            http = RequestsWrapper(instance, init_config)
+            http.get('https://www.example.com', verify=False)
+
+            http = RequestsWrapper(instance, init_config)
+            http.get('https://www.example.com', verify=False)
+
+        assert 1 == caplog.text.count("Unverified HTTPS request is being made.")
 
 
 class TestSession:

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
 import os
-import warnings
 from collections import OrderedDict
 
 import mock
@@ -13,7 +12,6 @@ import requests_kerberos
 import requests_ntlm
 from requests.exceptions import ConnectTimeout, ProxyError
 from six import iteritems
-from urllib3 import disable_warnings
 from urllib3.exceptions import InsecureRequestWarning
 
 from datadog_checks.base import AgentCheck, ConfigurationError

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -13,6 +13,7 @@ import pytest
 import requests
 from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily, HistogramMetricFamily, SummaryMetricFamily
 from six import iteritems
+from urllib3.exceptions import InsecureRequestWarning
 
 from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.dev import get_here
@@ -2109,6 +2110,8 @@ def test_ssl_verify_not_raise_warning(mocked_openmetrics_check_factory, text_dat
     check = mocked_openmetrics_check_factory(instance)
     scraper_config = check.get_scraper_config(instance)
 
-    with pytest.warns(None):
+    with pytest.warns(None) as record:
         resp = check.send_request('https://httpbin.org/get', scraper_config)
-        assert "httpbin.org" in resp.content.decode('utf-8')
+
+    assert "httpbin.org" in resp.content.decode('utf-8')
+    assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -2111,4 +2111,4 @@ def test_ssl_verify_not_raise_warning(mocked_openmetrics_check_factory, text_dat
 
     with pytest.warns(None):
         resp = check.send_request('https://httpbin.org/get', scraper_config)
-        assert "httpbin.org" in resp.content
+        assert "httpbin.org" in resp.content.decode('utf-8')

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -2095,3 +2095,20 @@ def test_metadata_transformer(mocked_openmetrics_check_factory, text_data):
         m.assert_any_call('test:123', 'version.raw', 'v1.6.0-alpha.0.680+3872cb93abf948-dirty')
         m.assert_any_call('test:123', 'version.scheme', 'semver')
         assert m.call_count == 7
+
+
+def test_ssl_verify_not_raise_warning(mocked_openmetrics_check_factory, text_data):
+    instance = dict(
+        {
+            'prometheus_url': 'https://www.example.com',
+            'metrics': [{'foo': 'bar'}],
+            'namespace': 'openmetrics',
+            'ssl_verify': False,
+        }
+    )
+    check = mocked_openmetrics_check_factory(instance)
+    scraper_config = check.get_scraper_config(instance)
+
+    with pytest.warns(None):
+        resp = check.send_request('https://httpbin.org/get', scraper_config)
+        assert "httpbin.org" in resp.content

--- a/datadog_checks_base/tests/test_prometheus.py
+++ b/datadog_checks_base/tests/test_prometheus.py
@@ -1957,3 +1957,11 @@ def test_text_filter_input():
 
     filtered = [x for x in check._text_filter_input(lines_in)]
     assert filtered == expected_out
+
+
+def test_ssl_verify_not_raise_warning(mocked_prometheus_check, text_data):
+    check = mocked_prometheus_check
+
+    with pytest.warns(None):
+        resp = check.poll('https://httpbin.org/get')
+        assert "httpbin.org" in resp.content

--- a/datadog_checks_base/tests/test_prometheus.py
+++ b/datadog_checks_base/tests/test_prometheus.py
@@ -11,6 +11,7 @@ import pytest
 import requests
 from six import iteritems, iterkeys
 from six.moves import range
+from urllib3.exceptions import InsecureRequestWarning
 
 from datadog_checks.checks.prometheus import PrometheusCheck, UnknownFormatError
 from datadog_checks.utils.prometheus import metrics_pb2, parse_metric_family
@@ -1962,13 +1963,19 @@ def test_text_filter_input():
 def test_ssl_verify_not_raise_warning(mocked_prometheus_check, text_data):
     check = mocked_prometheus_check
 
-    with pytest.warns(None):
+    with pytest.warns(None) as record:
         resp = check.poll('https://httpbin.org/get')
-        assert "httpbin.org" in resp.content.decode('utf-8')
 
+    assert "httpbin.org" in resp.content.decode('utf-8')
+    assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
+
+
+def test_ssl_verify_not_raise_warning_cert_false(mocked_prometheus_check, text_data):
     check = mocked_prometheus_check
     check.ssl_ca_cert = False
 
-    with pytest.warns(None):
+    with pytest.warns(None) as record:
         resp = check.poll('https://httpbin.org/get')
-        assert "httpbin.org" in resp.content.decode('utf-8')
+
+    assert "httpbin.org" in resp.content.decode('utf-8')
+    assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)

--- a/datadog_checks_base/tests/test_prometheus.py
+++ b/datadog_checks_base/tests/test_prometheus.py
@@ -1964,4 +1964,11 @@ def test_ssl_verify_not_raise_warning(mocked_prometheus_check, text_data):
 
     with pytest.warns(None):
         resp = check.poll('https://httpbin.org/get')
-        assert "httpbin.org" in resp.content
+        assert "httpbin.org" in resp.content.decode('utf-8')
+
+    check = mocked_prometheus_check
+    check.ssl_ca_cert = False
+
+    with pytest.warns(None):
+        resp = check.poll('https://httpbin.org/get')
+        assert "httpbin.org" in resp.content.decode('utf-8')

--- a/datadog_checks_base/tests/test_warnings_util.py
+++ b/datadog_checks_base/tests/test_warnings_util.py
@@ -1,0 +1,24 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import warnings
+
+import pytest
+from urllib3.exceptions import InsecureRequestWarning
+
+from datadog_checks.base.utils.warnings_util import simplefilter
+
+pytestmark = pytest.mark.warnings
+
+
+class TestWarnings:
+
+    def test_filters_count(self):
+        initial_count = len(warnings.filters)
+
+        for _ in range(100):
+            simplefilter('default', InsecureRequestWarning)
+
+        final_count = len(warnings.filters)
+
+        assert final_count in (initial_count, initial_count + 1)

--- a/datadog_checks_base/tests/test_warnings_util.py
+++ b/datadog_checks_base/tests/test_warnings_util.py
@@ -5,6 +5,7 @@ import warnings
 
 import pytest
 import requests
+from six import PY2
 from urllib3.exceptions import InsecureRequestWarning
 
 from datadog_checks.base import ConfigurationError
@@ -30,7 +31,10 @@ def test_filters_count_append():
 
     final_count = len(warnings.filters)
 
-    assert final_count in (initial_count + 100, initial_count + 101)
+    if PY2:
+        assert final_count in (initial_count + 100, initial_count + 101)
+    else:
+        assert final_count in (initial_count, initial_count + 1)
 
 
 def test_disable_warnings_ctx_disabled():

--- a/datadog_checks_base/tests/test_warnings_util.py
+++ b/datadog_checks_base/tests/test_warnings_util.py
@@ -4,21 +4,40 @@
 import warnings
 
 import pytest
+import requests
 from urllib3.exceptions import InsecureRequestWarning
 
-from datadog_checks.base.utils.warnings_util import simplefilter
+from datadog_checks.base.utils.warnings_util import disable_warnings_ctx, simplefilter
 
 pytestmark = pytest.mark.warnings
 
 
-class TestWarnings:
+def test_filters_count():
+    initial_count = len(warnings.filters)
 
-    def test_filters_count(self):
-        initial_count = len(warnings.filters)
+    for _ in range(100):
+        simplefilter('default', InsecureRequestWarning)
 
-        for _ in range(100):
-            simplefilter('default', InsecureRequestWarning)
+    final_count = len(warnings.filters)
 
-        final_count = len(warnings.filters)
+    assert final_count in (initial_count, initial_count + 1)
 
-        assert final_count in (initial_count, initial_count + 1)
+
+def test_disable_warnings_ctx_disabled():
+
+    with disable_warnings_ctx(InsecureRequestWarning):
+        with pytest.warns(None):
+            requests.get('https://www.example.com')
+
+    with disable_warnings_ctx(InsecureRequestWarning, disable=True):
+        with pytest.warns(None):
+            requests.get('https://www.example.com')
+
+
+def test_disable_warnings_ctx_not_disabled():
+    with pytest.warns(InsecureRequestWarning):
+        requests.get('https://www.example.com', verify=False)
+
+    with disable_warnings_ctx(InsecureRequestWarning, disable=False):
+        with pytest.warns(InsecureRequestWarning):
+            requests.get('https://www.example.com', verify=False)

--- a/datadog_checks_base/tests/test_warnings_util.py
+++ b/datadog_checks_base/tests/test_warnings_util.py
@@ -22,6 +22,17 @@ def test_filters_count():
     assert final_count in (initial_count, initial_count + 1)
 
 
+def test_filters_count_append():
+    initial_count = len(warnings.filters)
+
+    for _ in range(100):
+        simplefilter('default', InsecureRequestWarning, append=1)
+
+    final_count = len(warnings.filters)
+
+    assert final_count in (initial_count + 100, initial_count + 101)
+
+
 def test_disable_warnings_ctx_disabled():
     with pytest.warns(None) as record:
         with disable_warnings_ctx(InsecureRequestWarning):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

1. Remove `warning_lock` for RequestsWrapper. The warning lock is a bottleneck for requests calls made via `RequestsWrapper`.

2. Replace `disable_warnings` with `disable_warnings_ctx` for Openmetrics and Prometheus mixins

`disable_warnings` effect was never restored/reverted.

3. Use custom `disable_warnings_ctx` instead of `warnings.catch_warnings`. 

`warnings.catch_warnings` is not thread-safe and might leave the `warnings` global variables in a unpredictable state.

4. Fix `warnings.filters` leak issue by using a custom version called  `_simplefilter_py2`

Each call to `disable_warnings(InsecureRequestWarning)` or `warnings.simplefilter('ignore', InsecureRequestWarning)` is adding an item to `warnings.filters` for Python 2, which cause a memory leak.

Python 3 does not have that issue, because it removes items before appending: https://github.com/python/cpython/blob/1f864016950079a618a916140f3abe6480a8e22d/Lib/warnings.py#L186

Python 2 does not: https://github.com/python/cpython/blob/e6499033032d5b647e43a3b49da0c1c64b151743/Lib/warnings.py#L112

### Motivation
<!-- What inspired you to submit this pull request? -->

The warning lock is a bottleneck for requests calls made via `RequestsWrapper`. It makes some simple requests that should take `~300ms` to `20-40secs`.

**CAVEAT**: once `disable_warnings(InsecureRequestWarning)` (aka `warnings.simplefilter('ignore', InsecureRequestWarning)`) is called, it has a global effect for *all* checks.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
First 2/3 of the chart: before the change
Last 1/3 of the chart: after the change
![image](https://user-images.githubusercontent.com/49917914/69585969-77c9e600-0fe1-11ea-942f-aa4978347193.png)
