### PR TITLE
Add Envoy dashboard

### DIFF
--- a/envoy/assets/dashboards/envoy_overview.json
+++ b/envoy/assets/dashboards/envoy_overview.json
@@ -1,399 +1,583 @@
 {
-    "title": "Envoy - Overview",
+    "board_title": "Envoy - Overview",
+    "read_only": false,
+    "author_info": {
+        "author_name": "Datadog"
+    },
     "description": "## Envoy\n\nThis dashboard provides a high-level overview of your Envoy cluster so you can monitor its performance and resource usage.\n\nFor further reading on monitoring Envoy, see:\n\n- [Official Envoy integration docs](https://docs.datadoghq.com/integrations/envoy/#data-collected)\n- [Monitoring AWS App Mesh and Envoy with Datadog](https://www.datadoghq.com/blog/envoy-app-mesh-monitoring/)\n\nClone this template to make changes and add your own graphs and widgets.",
+    "board_bgtype": "board_graph",
+    "created": "2019-11-26T10:01:27.045918+00:00",
+    "created_by": {
+        "disabled": false,
+        "handle": "support@datadoghq.com",
+        "name": "Datadog",
+        "is_admin": false,
+        "role": null,
+        "access_role": "st",
+        "verified": true,
+        "email": "support@datadoghq.com"
+    },
+    "new_id": "ccb-44a-8gh",
+    "modified": "2019-11-26T14:00:43.907183+00:00",
+    "originalHeight": 80,
+    "template_variables": [
+        {
+            "default": "*",
+            "prefix": null,
+            "name": "scope"
+        }
+    ],
+    "isIntegration": false,
+    "disableEditing": false,
+    "originalWidth": "calc(100% - 32px)",
     "widgets": [
         {
-            "id": 0,
-            "definition": {
-                "type": "timeseries",
+            "title_size": 16,
+            "time": {},
+            "title": true,
+            "type": "timeseries",
+            "title_align": "left",
+            "title_text": "Requests (req/s)",
+            "height": 15,
+            "tile_def": {
+                "viz": "timeseries",
                 "requests": [
                     {
                         "q": "sum:envoy.http.downstream_rq_total{$scope}.as_rate()",
-                        "display_type": "area",
+                        "aggregator": "avg",
                         "style": {
+                            "width": "normal",
                             "palette": "dog_classic",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        }
+                            "type": "solid"
+                        },
+                        "type": "area",
+                        "conditional_formats": []
                     }
                 ],
-                "title": "Requests (req/s)",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": false,
-                "legend_size": "0"
+                "autoscale": true
             },
-            "layout": {
-                "x": 1,
-                "y": 17,
-                "width": 43,
-                "height": 17
-            }
+            "width": 43,
+            "legend": false,
+            "sharedGlobalTime": {
+                "live_span": "1h"
+            },
+            "error": null,
+            "y": 17,
+            "x": 1,
+            "legend_size": "0",
+            "isShared": false,
+            "scaleFactor": 1,
+            "id": 0,
+            "add_timeframe": true
         },
         {
-            "id": 1,
-            "definition": {
-                "type": "timeseries",
+            "title_size": 16,
+            "time": {},
+            "title": true,
+            "type": "timeseries",
+            "title_align": "left",
+            "title_text": "Total cluster membership update successes",
+            "height": 15,
+            "tile_def": {
+                "viz": "timeseries",
                 "requests": [
                     {
                         "q": "avg:envoy.cluster.update_success{*} by {cluster_name}.as_count()",
-                        "display_type": "bars",
+                        "aggregator": "avg",
                         "style": {
+                            "width": "normal",
                             "palette": "dog_classic",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        }
+                            "type": "solid"
+                        },
+                        "type": "bars",
+                        "conditional_formats": []
                     }
                 ],
-                "title": "Total cluster membership update successes",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": false,
-                "legend_size": "0"
+                "autoscale": true
             },
-            "layout": {
-                "x": 48,
-                "y": 53,
-                "width": 43,
-                "height": 17
-            }
+            "width": 43,
+            "legend": false,
+            "sharedGlobalTime": {
+                "live_span": "1h"
+            },
+            "error": null,
+            "y": 53,
+            "x": 48,
+            "legend_size": "0",
+            "isShared": false,
+            "scaleFactor": 1,
+            "id": 2,
+            "add_timeframe": true
         },
         {
-            "id": 2,
-            "definition": {
-                "type": "timeseries",
+            "title_size": 16,
+            "time": {},
+            "title": true,
+            "type": "timeseries",
+            "title_align": "left",
+            "title_text": "Bytes received and sent (B/s)",
+            "height": 15,
+            "tile_def": {
+                "viz": "timeseries",
                 "requests": [
                     {
                         "q": "avg:envoy.http.downstream_cx_rx_bytes_total{$scope}.as_rate()",
-                        "display_type": "line",
+                        "aggregator": "avg",
                         "style": {
+                            "width": "normal",
                             "palette": "dog_classic",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        }
+                            "type": "solid"
+                        },
+                        "type": "line",
+                        "conditional_formats": []
                     },
                     {
                         "q": "avg:envoy.http.downstream_cx_tx_bytes_total{$scope}.as_rate()",
-                        "display_type": "line",
                         "style": {
+                            "width": "normal",
                             "palette": "dog_classic",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        }
+                            "type": "solid"
+                        },
+                        "type": "line"
                     }
                 ],
-                "title": "Bytes received and sent (B/s)",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": false,
-                "legend_size": "0"
+                "autoscale": true
             },
-            "layout": {
-                "x": 1,
-                "y": 35,
-                "width": 43,
-                "height": 17
-            }
+            "width": 43,
+            "legend": false,
+            "sharedGlobalTime": {
+                "live_span": "1h"
+            },
+            "error": null,
+            "y": 35,
+            "x": 1,
+            "legend_size": "0",
+            "isShared": false,
+            "scaleFactor": 1,
+            "id": 3,
+            "add_timeframe": true
         },
         {
-            "id": 3,
-            "definition": {
-                "type": "query_value",
+            "x": 48,
+            "autoscale": true,
+            "time": {},
+            "title": true,
+            "type": "query_value",
+            "id": 4,
+            "title_align": "left",
+            "title_text": "Total active clusters",
+            "height": 5,
+            "tile_def": {
+                "viz": "query_value",
                 "requests": [
                     {
                         "q": "avg:envoy.cluster_manager.active_clusters{*}",
-                        "aggregator": "last"
+                        "aggregator": "last",
+                        "style": {
+                            "width": "normal",
+                            "palette": "dog_classic",
+                            "type": "solid"
+                        },
+                        "type": null,
+                        "conditional_formats": []
                     }
                 ],
-                "title": "Total active clusters",
-                "title_size": "16",
-                "title_align": "left",
                 "autoscale": true,
-                "precision": 2
+                "precision": "2"
             },
-            "layout": {
-                "x": 48,
-                "y": 45,
-                "width": 21,
-                "height": 7
-            }
+            "width": 21,
+            "sharedGlobalTime": {
+                "live_span": "1h"
+            },
+            "error": null,
+            "y": 45,
+            "title_size": 16,
+            "legend_size": "0",
+            "isShared": false,
+            "scaleFactor": 1,
+            "legend": false,
+            "add_timeframe": true
         },
         {
-            "id": 4,
-            "definition": {
-                "type": "query_value",
+            "x": 70,
+            "autoscale": true,
+            "time": {},
+            "title": true,
+            "type": "query_value",
+            "id": 5,
+            "title_align": "left",
+            "title_text": "Total warming clusters",
+            "height": 5,
+            "tile_def": {
+                "viz": "query_value",
                 "requests": [
                     {
                         "q": "avg:envoy.cluster_manager.warming_clusters{*}",
-                        "aggregator": "last"
+                        "aggregator": "last",
+                        "style": {
+                            "width": "normal",
+                            "palette": "dog_classic",
+                            "type": "solid"
+                        },
+                        "type": null,
+                        "conditional_formats": []
                     }
                 ],
-                "title": "Total warming clusters",
-                "title_size": "16",
-                "title_align": "left",
                 "autoscale": true,
-                "precision": 2
+                "precision": "2"
             },
-            "layout": {
-                "x": 70,
-                "y": 45,
-                "width": 21,
-                "height": 7
-            }
+            "width": 21,
+            "sharedGlobalTime": {
+                "live_span": "1h"
+            },
+            "error": null,
+            "y": 45,
+            "title_size": 16,
+            "legend_size": "0",
+            "isShared": false,
+            "scaleFactor": 1,
+            "legend": false,
+            "add_timeframe": true
         },
         {
-            "id": 5,
-            "definition": {
-                "type": "timeseries",
+            "title_size": "16",
+            "time": {},
+            "title": true,
+            "title_align": "left",
+            "title_text": "Total pending requests per cluster",
+            "height": 15,
+            "tile_def": {
+                "viz": "timeseries",
                 "requests": [
                     {
                         "q": "avg:envoy.cluster.upstream_rq_pending_total{*} by {cluster_name}.as_count()",
-                        "display_type": "bars",
                         "style": {
+                            "width": "normal",
                             "palette": "dog_classic",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        }
+                            "type": "solid"
+                        },
+                        "type": "bars"
                     }
-                ],
-                "title": "Total pending requests per cluster",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": false,
-                "legend_size": "0"
+                ]
             },
-            "layout": {
-                "x": 1,
-                "y": 53,
-                "width": 43,
-                "height": 17
-            }
-        },
-        {
+            "width": 43,
+            "legend": false,
+            "sharedGlobalTime": {
+                "live_span": "1h"
+            },
+            "error": null,
+            "y": 53,
+            "x": 1,
+            "legend_size": "0",
+            "isShared": false,
+            "type": "timeseries",
             "id": 6,
-            "definition": {
-                "type": "image",
-                "url": "/static/images/saas_logos/bot/envoy.png",
-                "sizing": "zoom"
-            },
-            "layout": {
-                "x": 1,
-                "y": 1,
-                "width": 19,
-                "height": 7
-            }
+            "add_timeframe": true
         },
         {
-            "id": 7,
-            "definition": {
-                "type": "query_value",
+            "sizing": "zoom",
+            "title": false,
+            "url": "/static/images/saas_logos/bot/envoy.png",
+            "type": "image",
+            "height": 7,
+            "width": 19,
+            "y": 1,
+            "x": 1,
+            "isShared": false,
+            "margin": "",
+            "id": 9,
+            "add_timeframe": true
+        },
+        {
+            "x": 74,
+            "autoscale": true,
+            "time": {},
+            "title": true,
+            "type": "query_value",
+            "id": 10,
+            "title_align": "left",
+            "title_text": "Allocated memory",
+            "height": 5,
+            "tile_def": {
+                "viz": "query_value",
                 "requests": [
                     {
                         "q": "avg:envoy.server.memory_allocated{*}",
-                        "aggregator": "avg"
+                        "aggregator": "avg",
+                        "style": {
+                            "width": "normal",
+                            "palette": "dog_classic",
+                            "type": "solid"
+                        },
+                        "type": null,
+                        "conditional_formats": []
                     }
                 ],
-                "title": "Allocated memory",
-                "title_size": "16",
-                "title_align": "left",
                 "autoscale": true,
                 "custom_unit": "B",
-                "precision": 2
+                "precision": "2"
             },
-            "layout": {
-                "x": 74,
-                "y": 1,
-                "width": 17,
-                "height": 7
-            }
+            "width": 17,
+            "sharedGlobalTime": {
+                "live_span": "1h"
+            },
+            "error": null,
+            "y": 1,
+            "title_size": 16,
+            "legend_size": "0",
+            "isShared": false,
+            "scaleFactor": 1,
+            "legend": false,
+            "add_timeframe": true
         },
         {
-            "id": 8,
-            "definition": {
-                "type": "note",
-                "content": "Requests",
-                "background_color": "yellow",
-                "font_size": "14",
-                "text_align": "center",
-                "show_tick": true,
-                "tick_pos": "50%",
-                "tick_edge": "bottom"
-            },
-            "layout": {
-                "x": 1,
-                "y": 10,
-                "width": 43,
-                "height": 5
-            }
+            "height": 5,
+            "viz": "note",
+            "background_color": "yellow",
+            "title": false,
+            "tick_pos": "50%",
+            "text_align": "center",
+            "content": "\n\n\n\n\n\n\nConnections",
+            "bgcolor": "yellow",
+            "html": "Requests",
+            "legend_size": "0",
+            "type": "note",
+            "isShared": false,
+            "refresh_every": 30000,
+            "auto_refresh": false,
+            "tick": true,
+            "scaleFactor": 1,
+            "legend": false,
+            "add_timeframe": true,
+            "font_size": "14",
+            "tick_edge": "bottom",
+            "y": 10,
+            "x": 1,
+            "width": 43
         },
         {
-            "id": 9,
-            "definition": {
-                "type": "timeseries",
+            "title_size": 16,
+            "time": {},
+            "title": true,
+            "type": "timeseries",
+            "title_align": "left",
+            "title_text": "Total connections per cluster",
+            "height": 15,
+            "tile_def": {
+                "title_size": "16",
+                "title_align": "left",
+                "custom_unit": "B",
+                "precision": "2",
+                "viz": "timeseries",
+                "autoscale": true,
                 "requests": [
                     {
                         "q": "sum:envoy.http.downstream_cx_total{$scope} by {cluster_name}.as_count()",
-                        "display_type": "bars",
+                        "aggregator": "avg",
                         "style": {
+                            "width": "normal",
                             "palette": "dog_classic",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        }
+                            "type": "solid"
+                        },
+                        "type": "bars",
+                        "conditional_formats": []
                     }
-                ],
-                "title": "Total connections per cluster",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": false,
-                "legend_size": "0"
+                ]
             },
-            "layout": {
-                "x": 48,
-                "y": 17,
-                "width": 43,
-                "height": 17
-            }
+            "width": 43,
+            "sharedGlobalTime": {
+                "live_span": "1h"
+            },
+            "error": null,
+            "y": 17,
+            "x": 48,
+            "legend_size": "0",
+            "add_timeframe": true,
+            "scaleFactor": 1,
+            "legend": false,
+            "isShared": false
         },
         {
-            "id": 10,
-            "definition": {
-                "type": "note",
-                "content": "Connections",
-                "background_color": "yellow",
-                "font_size": "14",
-                "text_align": "center",
-                "show_tick": true,
-                "tick_pos": "50%",
-                "tick_edge": "bottom"
-            },
-            "layout": {
-                "x": 48,
-                "y": 10,
-                "width": 43,
-                "height": 5
-            }
+            "height": 5,
+            "viz": "note",
+            "background_color": "yellow",
+            "title": false,
+            "tick_pos": "50%",
+            "text_align": "center",
+            "content": "\n\n\n\n\n\n\nRequests",
+            "bgcolor": "yellow",
+            "html": "Connections",
+            "legend_size": "0",
+            "type": "note",
+            "isShared": false,
+            "refresh_every": 30000,
+            "auto_refresh": false,
+            "tick": true,
+            "scaleFactor": 1,
+            "legend": false,
+            "add_timeframe": true,
+            "font_size": "14",
+            "tick_edge": "bottom",
+            "y": 10,
+            "x": 48,
+            "width": 43
         },
         {
-            "id": 11,
-            "definition": {
-                "type": "note",
-                "content": "Clusters",
-                "background_color": "yellow",
-                "font_size": "14",
-                "text_align": "center",
-                "show_tick": true,
-                "tick_pos": "50%",
-                "tick_edge": "bottom"
-            },
-            "layout": {
-                "x": 48,
-                "y": 38,
-                "width": 43,
-                "height": 5
-            }
+            "height": 5,
+            "viz": "note",
+            "tick_pos": "50%",
+            "title": false,
+            "background_color": "yellow",
+            "text_align": "center",
+            "content": "\n\n\n\n\n\n\nConnections",
+            "bgcolor": "yellow",
+            "html": "Clusters",
+            "legend_size": "0",
+            "type": "note",
+            "refresh_every": 30000,
+            "auto_refresh": false,
+            "tick": true,
+            "scaleFactor": 1,
+            "legend": false,
+            "add_timeframe": true,
+            "font_size": "14",
+            "tick_edge": "bottom",
+            "y": 38,
+            "x": 48,
+            "width": 43
         },
         {
-            "id": 14,
-            "definition": {
-                "type": "query_value",
+            "title_size": 16,
+            "title": true,
+            "type": "query_value",
+            "title_align": "left",
+            "title_text": "Uptime",
+            "height": 5,
+            "tile_def": {
+                "viz": "query_value",
                 "requests": [
                     {
                         "q": "avg:envoy.server.uptime{*}/3600/24",
-                        "aggregator": "last"
+                        "aggregator": "last",
+                        "style": {
+                            "width": "normal",
+                            "palette": "dog_classic",
+                            "type": "solid"
+                        },
+                        "type": null,
+                        "conditional_formats": []
                     }
                 ],
-                "title": "Uptime",
-                "title_size": "16",
-                "title_align": "left",
                 "autoscale": true,
                 "custom_unit": "days",
-                "precision": 1
+                "precision": "1"
             },
-            "layout": {
-                "x": 56,
-                "y": 1,
-                "width": 17,
-                "height": 7
-            }
+            "width": 17,
+            "time": {},
+            "error": null,
+            "y": 1,
+            "x": 56,
+            "legend_size": "0",
+            "scaleFactor": 1,
+            "legend": false,
+            "add_timeframe": true
         },
         {
-            "id": 15,
-            "definition": {
-                "type": "query_value",
+            "title_size": 16,
+            "title": true,
+            "type": "query_value",
+            "title_align": "left",
+            "title_text": "Live",
+            "height": 5,
+            "tile_def": {
+                "title_size": "16",
+                "title_align": "left",
+                "custom_unit": null,
+                "precision": "2",
+                "viz": "query_value",
+                "autoscale": true,
                 "requests": [
                     {
                         "q": "avg:envoy.server.live{*}",
                         "aggregator": "last",
+                        "style": {
+                            "width": "normal",
+                            "palette": "dog_classic",
+                            "type": "solid"
+                        },
+                        "type": null,
                         "conditional_formats": [
                             {
+                                "palette": "white_on_green",
                                 "comparator": ">",
-                                "value": 0,
-                                "palette": "white_on_green"
+                                "value": "0"
                             },
                             {
+                                "palette": "white_on_yellow",
                                 "comparator": "<",
-                                "value": 1,
-                                "palette": "white_on_yellow"
+                                "value": "1"
                             }
                         ]
                     }
-                ],
-                "title": "Live",
-                "title_size": "16",
-                "title_align": "left",
-                "autoscale": true,
-                "precision": 2
+                ]
             },
-            "layout": {
-                "x": 38,
-                "y": 1,
-                "width": 17,
-                "height": 7
-            }
+            "width": 17,
+            "time": {},
+            "error": null,
+            "y": 1,
+            "x": 38,
+            "legend_size": "0",
+            "scaleFactor": 1,
+            "legend": false,
+            "add_timeframe": true
         },
         {
-            "id": 30,
-            "definition": {
-                "type": "query_value",
+            "title_size": 16,
+            "title": true,
+            "type": "query_value",
+            "title_align": "left",
+            "title_text": "Cluster membership update failures",
+            "height": 5,
+            "tile_def": {
+                "title_size": "13",
+                "title_align": "left",
+                "precision": "2",
+                "viz": "query_value",
+                "autoscale": true,
                 "requests": [
                     {
                         "q": "avg:envoy.cluster.update_failure{*}.as_count()",
                         "aggregator": "last",
+                        "style": {
+                            "width": "normal",
+                            "palette": "dog_classic",
+                            "type": "solid"
+                        },
+                        "type": null,
                         "conditional_formats": [
                             {
+                                "palette": "red_on_white",
                                 "comparator": ">",
-                                "value": 0,
-                                "palette": "red_on_white"
+                                "value": "0"
                             }
                         ]
                     }
-                ],
-                "title": "Cluster membership update failures",
-                "title_size": "13",
-                "title_align": "left",
-                "time": {
-                    "live_span": "30m"
-                },
-                "autoscale": true,
-                "precision": 2
+                ]
             },
-            "layout": {
-                "x": 48,
-                "y": 71,
-                "width": 43,
-                "height": 7
-            }
+            "width": 43,
+            "time": {
+                "live_span": "30m"
+            },
+            "error": null,
+            "y": 71,
+            "x": 48,
+            "legend_size": "0",
+            "scaleFactor": 1,
+            "legend": false,
+            "add_timeframe": true
         }
     ],
-    "template_variables": [
-        {
-            "name": "scope",
-            "default": "*",
-            "prefix": null
-        }
-    ],
-    "layout_type": "free",
-    "is_read_only": false,
-    "notify_list": [],
-    "dashboard_id": "ccb-44a-8gh"
+    "disableCog": false,
+    "id": 907169,
+    "isShared": false
 }

--- a/envoy/assets/dashboards/envoy_overview.json
+++ b/envoy/assets/dashboards/envoy_overview.json
@@ -1,0 +1,399 @@
+{
+    "title": "Envoy - Overview",
+    "description": "## Envoy\n\nThis dashboard provides a high-level overview of your Envoy cluster so you can monitor its performance and resource usage.\n\nFor further reading on monitoring Envoy, see:\n\n- [Official Envoy integration docs](https://docs.datadoghq.com/integrations/envoy/#data-collected)\n- [Monitoring AWS App Mesh and Envoy with Datadog](https://www.datadoghq.com/blog/envoy-app-mesh-monitoring/)\n\nClone this template to make changes and add your own graphs and widgets.",
+    "widgets": [
+        {
+            "id": 0,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:envoy.http.downstream_rq_total{$scope}.as_rate()",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "title": "Requests (req/s)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 1,
+                "y": 17,
+                "width": 43,
+                "height": 17
+            }
+        },
+        {
+            "id": 1,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:envoy.cluster.update_success{*} by {cluster_name}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "title": "Total cluster membership update successes",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 48,
+                "y": 53,
+                "width": 43,
+                "height": 17
+            }
+        },
+        {
+            "id": 2,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:envoy.http.downstream_cx_rx_bytes_total{$scope}.as_rate()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:envoy.http.downstream_cx_tx_bytes_total{$scope}.as_rate()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "title": "Bytes received and sent (B/s)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 1,
+                "y": 35,
+                "width": 43,
+                "height": 17
+            }
+        },
+        {
+            "id": 3,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:envoy.cluster_manager.active_clusters{*}",
+                        "aggregator": "last"
+                    }
+                ],
+                "title": "Total active clusters",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 48,
+                "y": 45,
+                "width": 21,
+                "height": 7
+            }
+        },
+        {
+            "id": 4,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:envoy.cluster_manager.warming_clusters{*}",
+                        "aggregator": "last"
+                    }
+                ],
+                "title": "Total warming clusters",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 70,
+                "y": 45,
+                "width": 21,
+                "height": 7
+            }
+        },
+        {
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:envoy.cluster.upstream_rq_pending_total{*} by {cluster_name}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "title": "Total pending requests per cluster",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 1,
+                "y": 53,
+                "width": 43,
+                "height": 17
+            }
+        },
+        {
+            "id": 6,
+            "definition": {
+                "type": "image",
+                "url": "/static/images/saas_logos/bot/envoy.png",
+                "sizing": "zoom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 1,
+                "width": 19,
+                "height": 7
+            }
+        },
+        {
+            "id": 7,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:envoy.server.memory_allocated{*}",
+                        "aggregator": "avg"
+                    }
+                ],
+                "title": "Allocated memory",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "custom_unit": "B",
+                "precision": 2
+            },
+            "layout": {
+                "x": 74,
+                "y": 1,
+                "width": 17,
+                "height": 7
+            }
+        },
+        {
+            "id": 8,
+            "definition": {
+                "type": "note",
+                "content": "Requests",
+                "background_color": "yellow",
+                "font_size": "14",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 10,
+                "width": 43,
+                "height": 5
+            }
+        },
+        {
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:envoy.http.downstream_cx_total{$scope} by {cluster_name}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "title": "Total connections per cluster",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 48,
+                "y": 17,
+                "width": 43,
+                "height": 17
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "note",
+                "content": "Connections",
+                "background_color": "yellow",
+                "font_size": "14",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 48,
+                "y": 10,
+                "width": 43,
+                "height": 5
+            }
+        },
+        {
+            "id": 11,
+            "definition": {
+                "type": "note",
+                "content": "Clusters",
+                "background_color": "yellow",
+                "font_size": "14",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 48,
+                "y": 38,
+                "width": 43,
+                "height": 5
+            }
+        },
+        {
+            "id": 14,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:envoy.server.uptime{*}/3600/24",
+                        "aggregator": "last"
+                    }
+                ],
+                "title": "Uptime",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "custom_unit": "days",
+                "precision": 1
+            },
+            "layout": {
+                "x": 56,
+                "y": 1,
+                "width": 17,
+                "height": 7
+            }
+        },
+        {
+            "id": 15,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:envoy.server.live{*}",
+                        "aggregator": "last",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 0,
+                                "palette": "white_on_green"
+                            },
+                            {
+                                "comparator": "<",
+                                "value": 1,
+                                "palette": "white_on_yellow"
+                            }
+                        ]
+                    }
+                ],
+                "title": "Live",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 38,
+                "y": 1,
+                "width": 17,
+                "height": 7
+            }
+        },
+        {
+            "id": 30,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:envoy.cluster.update_failure{*}.as_count()",
+                        "aggregator": "last",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 0,
+                                "palette": "red_on_white"
+                            }
+                        ]
+                    }
+                ],
+                "title": "Cluster membership update failures",
+                "title_size": "13",
+                "title_align": "left",
+                "time": {
+                    "live_span": "30m"
+                },
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 48,
+                "y": 71,
+                "width": 43,
+                "height": 7
+            }
+        }
+    ],
+    "template_variables": [
+        {
+            "name": "scope",
+            "default": "*",
+            "prefix": null
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": false,
+    "notify_list": [],
+    "dashboard_id": "ccb-44a-8gh"
+}

--- a/envoy/manifest.json
+++ b/envoy/manifest.json
@@ -25,7 +25,9 @@
   "integration_id": "envoy",
   "assets": {
     "monitors": {},
-    "dashboards": {},
+    "dashboards": {
+      "Envoy - Overview": "assets/dashboards/envoy_overview.json"
+    },
     "service_checks": "assets/service_checks.json"
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add an out-of-the-box dashboard for Envoy (edge and service proxy).

Dashboard used to generate the JSON config file is available [here](https://dddev.datadoghq.com/dashboard/ccb-44a-8gh/envoy---overview?from_ts=1574172291100&live=true&to_ts=1574777091100).

Preview:

![Screenshot 2019-11-26 at 15 00 51](https://user-images.githubusercontent.com/15911462/69640236-51965b80-105e-11ea-9da1-3c960dd410a5.png)

### Motivation
<!-- What inspired you to submit this pull request? -->
Ongoing effort to provide all integrations with an out-of-the-box dashboard.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
I initially generated the JSON by clicking "Copy dashboard to JSON" on the UI, but this exports to a new format that isn't yet supported here. Instead, I used the [Screenboard API](https://docs.datadoghq.com/graphing/guide/screenboard-api-doc/?tab=python#get-a-screenboard) as hinted at by `$ ddev validate dashboards`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
