### PR TITLE
Add note about additional config needed in FireLens for JSON parsing

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -204,7 +204,7 @@ Configure the AWS FireLens integration built on Datadog's Fluent Bit output plug
     ```
 3. Now, whenever a Fargate task runs, Fluent Bit sends the container logs to your Datadog monitoring with information about all of the containers managed by your Fargate tasks. You can see the raw logs on the [Log Explorer page][30], [build monitors][31] for the logs, and use the [Live Container view][29].
 
-**Note** In order to parse serialized JSON logs coming from a container's `stdout`, FireLens requires an additional argument. Add the following argument directly in your FireLens configuration: 
+**Note** In order to parse serialized JSON logs coming from a container's `stdout`, add the following required argument directly in your FireLens configuration: 
 
 ```
 relensConfiguration": {

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -216,7 +216,7 @@ relensConfiguration": {
 },
 ```
 
-This will convert serialized JSON from the `log:` field into top-level fields. See the AWS sample [Parsing container stdout logs that are serialized JSON][34] for more details.
+This converts serialized JSON from the `log:` field into top-level fields. See the AWS sample [Parsing container stdout logs that are serialized JSON][34] for more details.
 
 #### AWS logDriver
 

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -204,6 +204,20 @@ Configure the AWS FireLens integration built on Datadog's Fluent Bit output plug
     ```
 3. Now, whenever a Fargate task runs, Fluent Bit sends the container logs to your Datadog monitoring with information about all of the containers managed by your Fargate tasks. You can see the raw logs on the [Log Explorer page][30], [build monitors][31] for the logs, and use the [Live Container view][29].
 
+**Note** In order to parse serialized JSON logs coming from a container's `stdout`, FireLens requires an additional argument. Add the following argument directly in your FireLens configuration: 
+
+```
+relensConfiguration": {
+    "type": "fluentbit",
+    "options": {
+        "config-file-type": "file",
+        "config-file-value": "/fluent-bit/configs/parse-json.conf"
+    }
+},
+```
+
+This will convert serialized JSON from the `log:` field into top-level fields. See the AWS sample [Parsing container stdout logs that are serialized JSON][34] for more details.
+
 #### AWS logDriver
 
 Monitor Fargate logs by using the `awslogs` log driver and a Lambda function to route logs to Datadog.
@@ -295,3 +309,4 @@ Need help? Contact [Datadog support][19].
 [31]: https://docs.datadoghq.com/monitors/monitor_types/
 [32]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html#firelens-using-fluentbit
 [33]: https://www.datadoghq.com/blog/collect-fargate-logs-with-fluentbit/ 
+[34]: https://github.com/aws-samples/amazon-ecs-firelens-examples/tree/master/examples/fluent-bit/parse-json


### PR DESCRIPTION
### What does this PR do?
Adds a note to the documentation to make users aware of an additional config that needs to be added on the FireLens side in order for JSON logs to be parsed correctly.

### Motivation
A couple of customers reached out about an issue where their logs weren't being parsed correctly. One of them found the [AWS documentation](https://github.com/aws-samples/amazon-ecs-firelens-examples/tree/master/examples/fluent-bit/parse-json) that points to the solution (I added a link to this doc in the PR).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
