### PR TITLE
Collect version metadata for hdfs_datanode

### DIFF
--- a/hdfs_datanode/datadog_checks/hdfs_datanode/hdfs_datanode.py
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/hdfs_datanode.py
@@ -63,6 +63,13 @@ class HDFSDataNode(AgentCheck):
         if hdfs_datanode_beans:
             self._hdfs_datanode_metrics(hdfs_datanode_beans, tags)
 
+        self.service_check(
+            self.JMX_SERVICE_CHECK,
+            AgentCheck.OK,
+            tags=tags,
+            message="Connection to {} was successful".format(jmx_address),
+        )
+
     def _get_jmx_data(self, jmx_address, bean_name, tags):
         """
         Get datanode beans data from JMX endpoint
@@ -140,10 +147,6 @@ class HDFSDataNode(AgentCheck):
             raise
 
         else:
-            self.service_check(
-                self.JMX_SERVICE_CHECK, AgentCheck.OK, tags=tags, message="Connection to {} was successful".format(url)
-            )
-
             return response_json
 
     @classmethod
@@ -160,13 +163,12 @@ class HDFSDataNode(AgentCheck):
 
     def _collect_metadata(self, value):
         # only get first info block
-        data = next(iter(value))
+        data = next(iter(value), {})
 
         version = data.get('Version', None)
 
         if version is not None:
             self.set_metadata('version', version)
-            self.log.debug("found hadoop version %s", version)
+            self.log.debug('found hadoop version %s', version)
         else:
-            self.log.warning("could not retrieve hadoop version information")
-            self.log.warning('this was data retrieved: %s', data)
+            self.log.warning('could not retrieve hadoop version information, this was data retrieved: %s', data)

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/hdfs_datanode.py
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/hdfs_datanode.py
@@ -168,5 +168,5 @@ class HDFSDataNode(AgentCheck):
             self.set_metadata('version', version)
             self.log.debug("found hadoop version %s", version)
         else:
-            self.log.warning(u"could not retrieve hadoop version information")
-            self.log.warning('this was data retreived: {}'.format(data))
+            self.log.warning("could not retrieve hadoop version information")
+            self.log.warning('this was data retrieved: %s', data)

--- a/hdfs_datanode/tests/common.py
+++ b/hdfs_datanode/tests/common.py
@@ -42,6 +42,8 @@ HDFS_DATANODE_AUTH_CONFIG = {
     ]
 }
 
+HDFS_DATANODE_RAW_VERSION = '2.7.1'
+
 HDFS_DATANODE_METRICS_VALUES = {
     'hdfs.datanode.dfs_remaining': 27914526720,
     'hdfs.datanode.dfs_capacity': 41167421440,

--- a/hdfs_datanode/tests/common.py
+++ b/hdfs_datanode/tests/common.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import os
+
 from datadog_checks.dev import get_docker_hostname, get_here
 
 HERE = get_here()
@@ -15,6 +17,9 @@ TEST_USERNAME = 'AzureDiamond'
 TEST_PASSWORD = 'hunter2'
 
 INSTANCE_INTEGRATION = {"hdfs_datanode_jmx_uri": "http://{}:50075".format(HOST)}
+
+HDFS_RAW_VERSION = os.environ.get('HDFS_RAW_VERSION')
+HDFS_IMAGE_TAG = os.environ.get('HDFS_IMAGE_TAG')
 
 EXPECTED_METRICS = [
     'hdfs.datanode.dfs_remaining',
@@ -42,7 +47,6 @@ HDFS_DATANODE_AUTH_CONFIG = {
     ]
 }
 
-HDFS_DATANODE_RAW_VERSION = '2.7.1'
 
 HDFS_DATANODE_METRICS_VALUES = {
     'hdfs.datanode.dfs_remaining': 27914526720,

--- a/hdfs_datanode/tests/compose/docker-compose.yaml
+++ b/hdfs_datanode/tests/compose/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3'
 # https://github.com/big-data-europe/docker-hadoop
 services:
   namenode:
-    image: bde2020/hadoop-namenode:1.1.0-hadoop2.7.1-java8
+    image: bde2020/hadoop-namenode:${HDFS_IMAGE_TAG}
     container_name: namenode
     volumes:
       - hadoop_namenode:/hadoop/dfs/name
@@ -15,7 +15,7 @@ services:
       - "50070:50070"
 
   datanode:
-    image: bde2020/hadoop-datanode:1.1.0-hadoop2.7.1-java8
+    image: bde2020/hadoop-datanode:${HDFS_IMAGE_TAG}
     container_name: datanode
     depends_on:
       - namenode

--- a/hdfs_datanode/tests/conftest.py
+++ b/hdfs_datanode/tests/conftest.py
@@ -41,12 +41,18 @@ def mocked_request():
 
 
 @pytest.fixture
+def mocked_metadata_request():
+    with patch('requests.get', new=requests_metadata_mock):
+        yield
+
+
+@pytest.fixture
 def mocked_auth_request():
     with patch('requests.get', new=requests_auth_mock):
         yield
 
 
-def requests_get_mock(*args, **kwargs):
+def _requests_mock(fixture, *args, **kwargs):
     class MockResponse:
         def __init__(self, json_data, status_code):
             self.json_data = json_data
@@ -58,10 +64,19 @@ def requests_get_mock(*args, **kwargs):
         def raise_for_status(self):
             return True
 
-    datanode_beans_file_path = os.path.join(HERE, 'fixtures', 'hdfs_datanode_jmx')
-    with open(datanode_beans_file_path, 'r') as f:
+    with open(fixture, 'r') as f:
         body = f.read()
         return MockResponse(body, 200)
+
+
+def requests_get_mock(*args, **kwargs):
+    fixture = os.path.join(HERE, 'fixtures', 'hdfs_datanode_jmx')
+    return _requests_mock(fixture, *args, **kwargs)
+
+
+def requests_metadata_mock(*args, **kwargs):
+    fixture = os.path.join(HERE, 'fixtures', 'hdfs_datanode_info_jmx')
+    return _requests_mock(fixture, *args, **kwargs)
 
 
 def requests_auth_mock(*args, **kwargs):

--- a/hdfs_datanode/tests/fixtures/hdfs_datanode_info_jmx
+++ b/hdfs_datanode/tests/fixtures/hdfs_datanode_info_jmx
@@ -1,0 +1,14 @@
+{
+  "beans" : [ {
+    "name" : "Hadoop:service=DataNode,name=DataNodeInfo",
+    "modelerType" : "org.apache.hadoop.hdfs.server.datanode.DataNode",
+    "XceiverCount" : 1,
+    "DatanodeNetworkCounts" : [ ],
+    "Version" : "2.7.1",
+    "RpcPort" : "50020",
+    "HttpPort" : null,
+    "NamenodeAddresses" : "{\"namenode\":\"BP-2057692275-172.27.0.2-1574696115415\"}",
+    "VolumeInfo" : "{\"/hadoop/dfs/data/current\":{\"usedSpace\":28672,\"freeSpace\":56364617728,\"reservedSpace\":0}}",
+    "ClusterId" : "CID-29d7943f-2e09-4737-953d-695ccc1e9340"
+  } ]
+}

--- a/hdfs_datanode/tests/test_hdfs_datanode.py
+++ b/hdfs_datanode/tests/test_hdfs_datanode.py
@@ -17,6 +17,8 @@ from .common import (
 
 pytestmark = pytest.mark.unit
 
+CHECK_ID = 'test:123'
+
 
 def test_check(aggregator, mocked_request):
     """
@@ -49,6 +51,7 @@ def test_metadata(aggregator, mocked_request, mocked_metadata_request, datadog_a
     hdfs_datanode = HDFSDataNode('hdfs_datanode', {}, [instance])
 
     # Run the check once
+    hdfs_datanode.check_id = CHECK_ID
     hdfs_datanode.check(instance)
 
     # Make sure the service is up
@@ -66,7 +69,7 @@ def test_metadata(aggregator, mocked_request, mocked_metadata_request, datadog_a
         'version.patch': patch,
     }
 
-    datadog_agent.assert_metadata('', version_metadata)
+    datadog_agent.assert_metadata(CHECK_ID, version_metadata)
     datadog_agent.assert_metadata_count(5)
 
 

--- a/hdfs_datanode/tests/test_hdfs_datanode.py
+++ b/hdfs_datanode/tests/test_hdfs_datanode.py
@@ -9,10 +9,10 @@ from datadog_checks.hdfs_datanode import HDFSDataNode
 from .common import (
     CUSTOM_TAGS,
     HDFS_DATANODE_AUTH_CONFIG,
-    HDFS_DATANODE_RAW_VERSION,
     HDFS_DATANODE_CONFIG,
     HDFS_DATANODE_METRIC_TAGS,
     HDFS_DATANODE_METRICS_VALUES,
+    HDFS_RAW_VERSION,
 )
 
 pytestmark = pytest.mark.unit
@@ -56,10 +56,10 @@ def test_metadata(aggregator, mocked_request, mocked_metadata_request, datadog_a
         HDFSDataNode.JMX_SERVICE_CHECK, status=HDFSDataNode.OK, tags=HDFS_DATANODE_METRIC_TAGS + CUSTOM_TAGS, count=2
     )
 
-    major, minor, patch = HDFS_DATANODE_RAW_VERSION.split('.')
+    major, minor, patch = HDFS_RAW_VERSION.split('.')
 
     version_metadata = {
-        'version.raw': HDFS_DATANODE_RAW_VERSION,
+        'version.raw': HDFS_RAW_VERSION,
         'version.scheme': 'semver',
         'version.major': major,
         'version.minor': minor,

--- a/hdfs_datanode/tests/test_hdfs_datanode.py
+++ b/hdfs_datanode/tests/test_hdfs_datanode.py
@@ -33,7 +33,7 @@ def test_check(aggregator, mocked_request):
 
     # Make sure the service is up
     aggregator.assert_service_check(
-        HDFSDataNode.JMX_SERVICE_CHECK, status=HDFSDataNode.OK, tags=HDFS_DATANODE_METRIC_TAGS + CUSTOM_TAGS, count=2
+        HDFSDataNode.JMX_SERVICE_CHECK, status=HDFSDataNode.OK, tags=HDFS_DATANODE_METRIC_TAGS + CUSTOM_TAGS, count=1
     )
 
     for metric, value in iteritems(HDFS_DATANODE_METRICS_VALUES):
@@ -56,7 +56,7 @@ def test_metadata(aggregator, mocked_request, mocked_metadata_request, datadog_a
 
     # Make sure the service is up
     aggregator.assert_service_check(
-        HDFSDataNode.JMX_SERVICE_CHECK, status=HDFSDataNode.OK, tags=HDFS_DATANODE_METRIC_TAGS + CUSTOM_TAGS, count=2
+        HDFSDataNode.JMX_SERVICE_CHECK, status=HDFSDataNode.OK, tags=HDFS_DATANODE_METRIC_TAGS + CUSTOM_TAGS, count=1
     )
 
     major, minor, patch = HDFS_RAW_VERSION.split('.')
@@ -85,5 +85,5 @@ def test_auth(aggregator, mocked_auth_request):
 
     # Make sure the service is up
     aggregator.assert_service_check(
-        HDFSDataNode.JMX_SERVICE_CHECK, status=HDFSDataNode.OK, tags=HDFS_DATANODE_METRIC_TAGS + CUSTOM_TAGS, count=2
+        HDFSDataNode.JMX_SERVICE_CHECK, status=HDFSDataNode.OK, tags=HDFS_DATANODE_METRIC_TAGS + CUSTOM_TAGS, count=1
     )

--- a/hdfs_datanode/tests/test_integration.py
+++ b/hdfs_datanode/tests/test_integration.py
@@ -8,6 +8,8 @@ from . import common
 
 pytestmark = pytest.mark.integration
 
+CHECK_ID = 'test:123'
+
 
 @pytest.mark.usefixtures("dd_environment")
 def test_check(aggregator, check, instance):
@@ -16,3 +18,23 @@ def test_check(aggregator, check, instance):
 
     for metric in common.EXPECTED_METRICS:
         aggregator.assert_metric(metric)
+
+
+@pytest.mark.usefixtures("dd_environment")
+def test_metadata(aggregator, check, instance, datadog_agent):
+    check = check(instance)
+    check.check_id = CHECK_ID
+    check.check(instance)
+
+    major, minor, patch = common.HDFS_DATANODE_RAW_VERSION.split('.')
+
+    version_metadata = {
+        'version.raw': common.HDFS_DATANODE_RAW_VERSION,
+        'version.scheme': 'semver',
+        'version.major': major,
+        'version.minor': minor,
+        'version.patch': patch,
+    }
+
+    datadog_agent.assert_metadata(CHECK_ID, version_metadata)
+    datadog_agent.assert_metadata_count(5)

--- a/hdfs_datanode/tests/test_integration.py
+++ b/hdfs_datanode/tests/test_integration.py
@@ -26,10 +26,10 @@ def test_metadata(aggregator, check, instance, datadog_agent):
     check.check_id = CHECK_ID
     check.check(instance)
 
-    major, minor, patch = common.HDFS_DATANODE_RAW_VERSION.split('.')
+    major, minor, patch = common.HDFS_RAW_VERSION.split('.')
 
     version_metadata = {
-        'version.raw': common.HDFS_DATANODE_RAW_VERSION,
+        'version.raw': common.HDFS_RAW_VERSION,
         'version.scheme': 'semver',
         'version.major': major,
         'version.minor': minor,

--- a/hdfs_datanode/tox.ini
+++ b/hdfs_datanode/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py37
 envlist =
-    py{27,37}
+    py{27,37}-2.7.1
 
 [testenv]
 description =
@@ -16,6 +16,9 @@ deps =
 passenv =
     DOCKER*
     COMPOSE*
+setenv =
+    2.7.1: HDFS_RAW_VERSION=2.7.1
+    2.7.1: HDFS_IMAGE_TAG=1.1.0-hadoop2.7.1-java8
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?

- Collects version metadata for both HDFS integrations: HDFS DataNode and HDFS NameNode. 

### Motivation
 - Ongoing effort for metadata integrations

### Additional Notes

- None

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
