### PR TITLE
Add Cisco 3850 profile

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -73,14 +73,14 @@ class InstanceConfig:
         if not self.metrics and not profiles_by_oid:
             raise ConfigurationError('Instance should specify at least one metric or profiles should be defined')
 
-        self.table_oids, self.raw_oids, self.mibs_to_load = self.parse_metrics(self.metrics, warning, log)
+        self.table_oids, self.raw_oids = self.parse_metrics(self.metrics, warning, log)
 
         self.auth_data = self.get_auth_data(instance)
         self.context_data = hlapi.ContextData(*self.get_context_data(instance))
 
     def refresh_with_profile(self, profile, warning, log):
         self.metrics.extend(profile['definition']['metrics'])
-        self.table_oids, self.raw_oids, self.mibs_to_load = self.parse_metrics(self.metrics, warning, log)
+        self.table_oids, self.raw_oids = self.parse_metrics(self.metrics, warning, log)
 
     def call_cmd(self, cmd, *args, **kwargs):
         return cmd(self.snmp_engine, self.auth_data, self.transport, self.context_data, *args, **kwargs)
@@ -171,7 +171,6 @@ class InstanceConfig:
 
         `raw_oids` is a list of SNMP numerical OIDs to query.
         `table_oids` is a dictionnary of SNMP tables to symbols to query.
-        `mibs_to_load` contains the relevant MIBs used for querying.
         """
         raw_oids = []
         table_oids = {}
@@ -244,7 +243,7 @@ class InstanceConfig:
                 log.debug("Couldn't found mib %s, trying to fetch it", mib)
                 self.fetch_mib(mib)
 
-        return dict(table_oids.values()), raw_oids, mibs_to_load
+        return dict(table_oids.values()), raw_oids
 
     @staticmethod
     def fetch_mib(mib):

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -106,6 +106,8 @@ init_config:
       definition_file: f5-big-ip.yaml
     router:
       definition_file: generic-router.yaml
+    cisco-3850:
+      definition_file: cisco-3850.yaml
 
 instances:
   -

--- a/snmp/datadog_checks/snmp/data/profiles/cisco-3850.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/cisco-3850.yaml
@@ -1,0 +1,129 @@
+# Profile for Cisco 3850 devices
+#
+sysobjectid: 1.3.6.1.4.1.9.1.1745
+metrics:
+  - MIB: CISCO-ENTITY-SENSOR-MIB
+    table: entSensorValueTable
+    symbols:
+      - entSensorValue
+    metric_tags:
+      - tag: sensor_type
+        column: entSensorType
+      - tag: sensor_id
+        index: 1
+  - MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+    table: cefcFRUPowerStatusTable
+    symbols:
+      - cefcFRUPowerAdminStatus
+      - cefcFRUPowerOperStatus
+      - cefcFRUCurrent
+    metric_tags:
+      - tag: fru
+        index: 1
+  - MIB: CISCO-PROCESS-MIB
+    table: cpmCPUTotalTable
+    symbols:
+      - cpmCPUTotalMonIntervalValue
+      - cpmCPUMemoryUsed
+      - cpmCPUMemoryFree
+    metric_tags:
+      - tag: cpu
+        index: 1
+  - MIB: CISCO-IF-EXTENSION-MIB
+    table: cieIfPacketStatsTable
+    forced_type: gauge
+    symbols:
+      - cieIfLastInTime
+      - cieIfLastOutTime
+      - cieIfInputQueueDrops
+      - cieIfOutputQueueDrops
+    metric_tags:
+      - tag: interface
+        column: ifName
+        MIB: IF-MIB
+        table: ifXTable
+  - MIB: CISCO-IF-EXTENSION-MIB
+    table: cieIfInterfaceTable
+    forced_type: monotonic_count
+    symbols:
+      - cieIfResetCount
+    metric_tags:
+      - tag: interface
+        column: ifName
+        MIB: IF-MIB
+        table: ifXTable
+  - MIB: IF-MIB
+    table: ifTable
+    forced_type: monotonic_count
+    symbols:
+      - ifInErrors
+      - ifInDiscards
+      - ifOutErrors
+      - ifOutDiscards
+    metric_tags:
+      - tag: interface
+        column: ifDescr
+  - MIB: IF-MIB
+    table: ifTable
+    symbols:
+      - ifAdminStatus
+      - ifOperStatus
+    metric_tags:
+      - tag: interface
+        column: ifDescr
+  - MIB: IF-MIB
+    table: ifXTable
+    forced_type: monotonic_count
+    symbols:
+      - ifHCInOctets
+      - ifHCInUcastPkts
+      - ifHCInMulticastPkts
+      - ifHCInBroadcastPkts
+      - ifHCOutOctets
+      - ifHCOutUcastPkts
+      - ifHCOutMulticastPkts
+      - ifHCOutBroadcastPkts
+    metric_tags:
+      - tag: interface
+        column: ifName
+  - MIB: TCP-MIB
+    symbol: tcpActiveOpens
+    forced_type: monotonic_count
+  - MIB: TCP-MIB
+    symbol: tcpPassiveOpens
+    forced_type: monotonic_count
+  - MIB: TCP-MIB
+    symbol: tcpAttemptFails
+    forced_type: monotonic_count
+  - MIB: TCP-MIB
+    symbol: tcpEstabResets
+    forced_type: monotonic_count
+  - MIB: TCP-MIB
+    symbol: tcpCurrEstab
+  - MIB: TCP-MIB
+    symbol: tcpHCInSegs
+    forced_type: monotonic_count
+  - MIB: TCP-MIB
+    symbol: tcpHCOutSegs
+    forced_type: monotonic_count
+  - MIB: TCP-MIB
+    symbol: tcpRetransSegs
+    forced_type: monotonic_count
+  - MIB: TCP-MIB
+    symbol: tcpInErrs
+    forced_type: monotonic_count
+  - MIB: TCP-MIB
+    symbol: tcpOutRsts
+    forced_type: monotonic_count
+  - MIB: UDP-MIB
+    symbol: udpHCInDatagrams
+    forced_type: monotonic_count
+  - MIB: UDP-MIB
+    symbol: udpNoPorts
+    forced_type: monotonic_count
+  - MIB: UDP-MIB
+    symbol: udpInErrors
+    forced_type: monotonic_count
+  - MIB: UDP-MIB
+    symbol: udpHCOutDatagrams
+    forced_type: monotonic_count

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -228,7 +228,7 @@ class SnmpCheck(AgentCheck):
                 # if enforce_constraints is false, then MIB resolution has not been done yet
                 # so we need to do it manually. We have to specify the mibs that we will need
                 # to resolve the name.
-                oid_to_resolve = hlapi.ObjectIdentity(result_oid.asTuple()).loadMibs(*config.mibs_to_load)
+                oid_to_resolve = hlapi.ObjectIdentity(result_oid.asTuple())
                 result_oid = oid_to_resolve.resolveWithMib(config.mib_view_controller)
             _, metric, indexes = result_oid.getMibSymbol()
             results[metric][indexes] = value

--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -12,7 +12,10 @@ from datadog_checks.dev import TempDir, docker_run
 
 from .common import COMPOSE_DIR, SCALAR_OBJECTS, SCALAR_OBJECTS_WITH_TAGS, TABULAR_OBJECTS, generate_instance_config
 
-FILES = ["https://ddintegrations.blob.core.windows.net/snmp/f5.snmprec"]
+FILES = [
+    "https://ddintegrations.blob.core.windows.net/snmp/f5.snmprec",
+    "https://ddintegrations.blob.core.windows.net/snmp/3850.snmprec",
+]
 
 
 @pytest.fixture(scope='session')

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -39,9 +39,8 @@ def test_parse_metrics(hlapi_mock):
 
     # Simple OID
     metrics = [{"OID": "1.2.3"}]
-    table, raw, mibs = config.parse_metrics(metrics, check.warning, check.log)
+    table, raw = config.parse_metrics(metrics, check.warning, check.log)
     assert table == {}
-    assert mibs == set()
     assert len(raw) == 1
     hlapi_mock.ObjectIdentity.assert_called_once_with("1.2.3")
     hlapi_mock.reset_mock()
@@ -53,9 +52,8 @@ def test_parse_metrics(hlapi_mock):
 
     # MIB with symbol
     metrics = [{"MIB": "foo_mib", "symbol": "foo"}]
-    table, raw, mibs = config.parse_metrics(metrics, check.warning, check.log)
+    table, raw = config.parse_metrics(metrics, check.warning, check.log)
     assert raw == []
-    assert mibs == {"foo_mib"}
     assert len(table) == 1
     hlapi_mock.ObjectIdentity.assert_called_once_with("foo_mib", "foo")
     hlapi_mock.reset_mock()
@@ -67,9 +65,8 @@ def test_parse_metrics(hlapi_mock):
 
     # MIB with table and symbols
     metrics = [{"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"]}]
-    table, raw, mibs = config.parse_metrics(metrics, check.warning, check.log)
+    table, raw = config.parse_metrics(metrics, check.warning, check.log)
     assert raw == []
-    assert mibs == {"foo_mib"}
     assert len(table) == 1
     assert len(list(table.values())[0]) == 2
     hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "foo")
@@ -90,9 +87,8 @@ def test_parse_metrics(hlapi_mock):
     metrics = [
         {"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{"tag": "foo", "index": "1"}]}
     ]
-    table, raw, mibs = config.parse_metrics(metrics, check.warning, check.log)
+    table, raw = config.parse_metrics(metrics, check.warning, check.log)
     assert raw == []
-    assert mibs == {"foo_mib"}
     assert len(table) == 1
     assert len(list(table.values())[0]) == 2
     hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "foo")
@@ -103,9 +99,8 @@ def test_parse_metrics(hlapi_mock):
     metrics = [
         {"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{"tag": "foo", "column": "baz"}]}
     ]
-    table, raw, mibs = config.parse_metrics(metrics, check.warning, check.log)
+    table, raw = config.parse_metrics(metrics, check.warning, check.log)
     assert raw == []
-    assert mibs == {"foo_mib"}
     assert len(table) == 1
     assert len(list(table.values())[0]) == 3
     hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "foo")


### PR DESCRIPTION
This adds a new profile for Cisco 3850. It also tweaks result building
to remove MIBs loading at each value, instead relying on the builder to
be configured beforehand.