### PR TITLE
Document DB slow log support?

### DIFF
--- a/mongo/README.md
+++ b/mongo/README.md
@@ -109,6 +109,8 @@ db.createUser({
 
 3. [Restart the Agent][5].
 
+This check supports slow query logs: you can identify slow queries by filtering logs by duration.
+
 #### Containerized
 
 For containerized environments, see the [Autodiscovery Integration Templates][6] for guidance on applying the parameters below.


### PR DESCRIPTION
I'm mostly opening this PR to discuss how to document support for slow query logs in DB integrations, which we plan to ensure for 8 DB integrations. (For background, see [Slow logs support](https://trello.com/c/v4mp0YEY).)

Ideally we'd want users to be aware that they can use logs to identify slow queries, but I'm unsure whether this kind of information should land in an integration's README, or elsewhere. (It may even already be documented in a general how-to guide that I'm not aware of.)

I started with MongoDB, but it's a bit special. There isn't any extra config necessary, since Mongo always outputs the query duration as part of logs. This means users can simply filter Mongo logs by `duration` in the logs UI. OTOH, some databases may have a separate log file for slow queries, which may require extra configuration that will need to be documented.

So, my current idea (in line with this PR) is:

- Add a note about slow logs in the "Logs collection" section for *all* DB integrations.
  - If slow logs require special setup, document it there.
  - Otherwise, simply mention that slow logs are supported.
  - In all cases, hint at how to identify slow queries.

Alternatives I can think of:

- Document this somewhere else (where?).
- Don't provide special documentation for slow query logs -- expect users to find out about the `duration` facet in the Search UI. (Quite a power user move, IMO.)

What does the docs team think about this? :-)