### PR TITLE
add `"TLS": "on"` parameter to config to match our recommendation

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -198,7 +198,7 @@ Configure the AWS FireLens integration built on Datadog's Fluent Bit output plug
             "dd_source": "redis",
             "dd_tags": "project:fluentbit",
             "TLS": "on",
-		    "provider": "ecs"
+            "provider": "ecs"
 	    }
     }
 

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -197,6 +197,7 @@ Configure the AWS FireLens integration built on Datadog's Fluent Bit output plug
             "dd_service": "firelens-test",
             "dd_source": "redis",
             "dd_tags": "project:fluentbit",
+            "TLS": "on",
 		    "provider": "ecs"
 	    }
     }


### PR DESCRIPTION
### What does this PR do?

Adds `"TLS": "on"` parameter to fluent-bit configuration.  It defaults to "off" and we recommend having it "on". 

### Motivation

Support escalation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
