### PR TITLE
Collect version metadata for hdfs_namenode

### DIFF
--- a/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
@@ -197,13 +197,12 @@ class HDFSNameNode(AgentCheck):
 
     def _collect_metadata(self, value):
         # only get first info block
-        data = next(iter(value))
+        data = next(iter(value), {})
 
         version = data.get('SoftwareVersion', None)
 
         if version is not None:
             self.set_metadata('version', version)
-            self.log.debug("found hadoop version %s", version)
+            self.log.debug('found hadoop version %s', version)
         else:
-            self.log.warning("could not retrieve hadoop version information")
-            self.log.warning('this was data retrieved: %s', data)
+            self.log.warning('could not retrieve hadoop version information, this was data retrieved: %s', data)

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
@@ -205,5 +205,5 @@ class HDFSNameNode(AgentCheck):
             self.set_metadata('version', version)
             self.log.debug("found hadoop version %s", version)
         else:
-            self.log.warning(u"could not retrieve hadoop version information")
-            self.log.warning('this was data retrieved: {}'.format(data))
+            self.log.warning("could not retrieve hadoop version information")
+            self.log.warning('this was data retrieved: %s', data)

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
@@ -26,6 +26,9 @@ class HDFSNameNode(AgentCheck):
     # Namesystem bean
     HDFS_NAME_SYSTEM_BEAN = 'Hadoop:service=NameNode,name=FSNamesystem'
 
+    # Namesystem info bean
+    HDFS_NAME_SYSTEM_METADATA_BEAN = 'Hadoop:service=NameNode,name=NameNodeInfo'
+
     # Metric types
     GAUGE = 'gauge'
 
@@ -71,6 +74,7 @@ class HDFSNameNode(AgentCheck):
 
         hdfs_system_state_beans = self._get_jmx_data(jmx_address, self.HDFS_NAME_SYSTEM_STATE_BEAN, tags)
         hdfs_system_beans = self._get_jmx_data(jmx_address, self.HDFS_NAME_SYSTEM_BEAN, tags)
+        hdfs_metadata_beans = self._get_jmx_data(jmx_address, self.HDFS_NAME_SYSTEM_METADATA_BEAN, tags)
 
         # Process the JMX data and send out metrics
         if hdfs_system_state_beans:
@@ -78,6 +82,9 @@ class HDFSNameNode(AgentCheck):
 
         if hdfs_system_beans:
             self._hdfs_namenode_metrics(hdfs_system_beans, self.HDFS_NAME_SYSTEM_METRICS, tags)
+
+        if hdfs_metadata_beans:
+            self._collect_metadata(hdfs_metadata_beans)
 
         # Send an OK service check
         self.service_check(
@@ -187,3 +194,16 @@ class HDFSNameNode(AgentCheck):
             url = urljoin(url, path.lstrip('/'))
 
         return url
+
+    def _collect_metadata(self, value):
+        # only get first info block
+        data = next(iter(value))
+
+        version = data.get('SoftwareVersion', None)
+
+        if version is not None:
+            self.set_metadata('version', version)
+            self.log.debug("found hadoop version %s", version)
+        else:
+            self.log.warning(u"could not retrieve hadoop version information")
+            self.log.warning('this was data retrieved: {}'.format(data))

--- a/hdfs_namenode/tests/common.py
+++ b/hdfs_namenode/tests/common.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import os
+
 from datadog_checks.dev import get_here
 from datadog_checks.dev.docker import get_docker_hostname
 
@@ -30,9 +32,10 @@ TEST_PASSWORD = 'NCC-1701'
 
 HDFS_NAMENODE_CONFIG = {'instances': [{'hdfs_namenode_jmx_uri': NAMENODE_URI, 'tags': list(CUSTOM_TAGS)}]}
 
-HDFS_NAMENODE_RAW_VERSION = '2.7.1'
-
 INSTANCE_INTEGRATION = {'hdfs_namenode_jmx_uri': NAMENODE_URI}
+
+HDFS_RAW_VERSION = os.environ.get('HDFS_RAW_VERSION')
+HDFS_IMAGE_TAG = os.environ.get('HDFS_IMAGE_TAG')
 
 EXPECTED_METRICS = [
     'hdfs.namenode.capacity_total',

--- a/hdfs_namenode/tests/common.py
+++ b/hdfs_namenode/tests/common.py
@@ -19,6 +19,9 @@ NAME_SYSTEM_STATE_URL = NAMENODE_JMX_URI + '?qry=Hadoop:service=NameNode,name=FS
 # Namesystem url
 NAME_SYSTEM_URL = NAMENODE_JMX_URI + '?qry=Hadoop:service=NameNode,name=FSNamesystem'
 
+# Namesystem metadata url
+NAME_SYSTEM_METADATA_URL = NAMENODE_JMX_URI + '?qry=Hadoop:service=NameNode,name=NameNodeInfo'
+
 CUSTOM_TAGS = ["cluster_name:hdfs_dev", "instance:level_tags"]
 
 # Authentication Parameters
@@ -26,6 +29,8 @@ TEST_USERNAME = 'Picard'
 TEST_PASSWORD = 'NCC-1701'
 
 HDFS_NAMENODE_CONFIG = {'instances': [{'hdfs_namenode_jmx_uri': NAMENODE_URI, 'tags': list(CUSTOM_TAGS)}]}
+
+HDFS_NAMENODE_RAW_VERSION = '2.7.1'
 
 INSTANCE_INTEGRATION = {'hdfs_namenode_jmx_uri': NAMENODE_URI}
 

--- a/hdfs_namenode/tests/compose/docker-compose.yaml
+++ b/hdfs_namenode/tests/compose/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3'
 # https://github.com/big-data-europe/docker-hadoop
 services:
   namenode:
-    image: bde2020/hadoop-namenode:1.1.0-hadoop2.7.1-java8
+    image: bde2020/hadoop-namenode:${HDFS_IMAGE_TAG}
     container_name: namenode
     volumes:
       - hadoop_namenode:/hadoop/dfs/name
@@ -15,7 +15,7 @@ services:
       - "50070:50070"
 
   datanode:
-    image: bde2020/hadoop-datanode:1.1.0-hadoop2.7.1-java8
+    image: bde2020/hadoop-datanode:${HDFS_IMAGE_TAG}
     container_name: datanode
     depends_on:
       - namenode

--- a/hdfs_namenode/tests/conftest.py
+++ b/hdfs_namenode/tests/conftest.py
@@ -10,7 +10,15 @@ from mock import patch
 from datadog_checks.dev import docker_run
 from datadog_checks.hdfs_namenode import HDFSNameNode
 
-from .common import HERE, INSTANCE_INTEGRATION, NAME_SYSTEM_STATE_URL, NAME_SYSTEM_URL, TEST_PASSWORD, TEST_USERNAME
+from .common import (
+    HERE,
+    INSTANCE_INTEGRATION,
+    NAME_SYSTEM_METADATA_URL,
+    NAME_SYSTEM_STATE_URL,
+    NAME_SYSTEM_URL,
+    TEST_PASSWORD,
+    TEST_USERNAME,
+)
 
 
 @pytest.fixture(scope="session")
@@ -64,6 +72,12 @@ def requests_get_mock(*args, **kwargs):
 
     elif args[0] == NAME_SYSTEM_URL:
         system_file_path = os.path.join(HERE, 'fixtures', 'hdfs_namesystem')
+        with open(system_file_path, 'r') as f:
+            body = f.read()
+            return MockResponse(body, 200)
+
+    elif args[0] == NAME_SYSTEM_METADATA_URL:
+        system_file_path = os.path.join(HERE, 'fixtures', 'hdfs_namesystem_info')
         with open(system_file_path, 'r') as f:
             body = f.read()
             return MockResponse(body, 200)

--- a/hdfs_namenode/tests/conftest.py
+++ b/hdfs_namenode/tests/conftest.py
@@ -52,7 +52,7 @@ def mocked_auth_request():
         yield
 
 
-def requests_get_mock(*args, **kwargs):
+def requests_get_mock(url, *args, **kwargs):
     class MockResponse:
         def __init__(self, json_data, status_code):
             self.json_data = json_data
@@ -64,19 +64,19 @@ def requests_get_mock(*args, **kwargs):
         def raise_for_status(self):
             return True
 
-    if args[0] == NAME_SYSTEM_STATE_URL:
+    if url == NAME_SYSTEM_STATE_URL:
         system_state_file_path = os.path.join(HERE, 'fixtures', 'hdfs_namesystem_state')
         with open(system_state_file_path, 'r') as f:
             body = f.read()
             return MockResponse(body, 200)
 
-    elif args[0] == NAME_SYSTEM_URL:
+    elif url == NAME_SYSTEM_URL:
         system_file_path = os.path.join(HERE, 'fixtures', 'hdfs_namesystem')
         with open(system_file_path, 'r') as f:
             body = f.read()
             return MockResponse(body, 200)
 
-    elif args[0] == NAME_SYSTEM_METADATA_URL:
+    elif url == NAME_SYSTEM_METADATA_URL:
         system_file_path = os.path.join(HERE, 'fixtures', 'hdfs_namesystem_info')
         with open(system_file_path, 'r') as f:
             body = f.read()

--- a/hdfs_namenode/tests/fixtures/hdfs_namesystem_info
+++ b/hdfs_namenode/tests/fixtures/hdfs_namesystem_info
@@ -1,0 +1,43 @@
+{
+  "beans" : [ {
+    "name" : "Hadoop:service=NameNode,name=NameNodeInfo",
+    "modelerType" : "org.apache.hadoop.hdfs.server.namenode.FSNamesystem",
+    "Total" : 62725623808,
+    "UpgradeFinalized" : true,
+    "ClusterId" : "CID-44e20313-500c-4587-ad7d-4bf751a4a652",
+    "Version" : "2.7.1, r15ecc87ccf4a0228f35af08fc56de536e6ce657a",
+    "Used" : 24576,
+    "Free" : 55830482944,
+    "Safemode" : "",
+    "NonDfsUsedSpace" : 6895116288,
+    "PercentUsed" : 3.918016E-5,
+    "BlockPoolUsedSpace" : 24576,
+    "PercentBlockPoolUsed" : 3.918016E-5,
+    "PercentRemaining" : 89.00746,
+    "CacheCapacity" : 0,
+    "CacheUsed" : 0,
+    "TotalBlocks" : 0,
+    "TotalFiles" : 1,
+    "NumberOfMissingBlocks" : 0,
+    "NumberOfMissingBlocksWithReplicationFactorOne" : 0,
+    "LiveNodes" : "{\"c68ae3949d7f:50010\":{\"infoAddr\":\"172.24.0.3:50075\",\"infoSecureAddr\":\"172.24.0.3:0\",\"xferaddr\":\"172.24.0.3:50010\",\"lastContact\":2,\"usedSpace\":24576,\"adminState\":\"In Service\",\"nonDfsUsedSpace\":6895116288,\"capacity\":62725623808,\"numBlocks\":0,\"version\":\"2.7.1\",\"used\":24576,\"remaining\":55830482944,\"blockScheduled\":0,\"blockPoolUsed\":24576,\"blockPoolUsedPercent\":3.918016E-5,\"volfails\":0}}",
+    "DeadNodes" : "{}",
+    "DecomNodes" : "{}",
+    "BlockPoolId" : "BP-526874547-172.24.0.2-1574784379919",
+    "NameDirStatuses" : "{\"active\":{\"/hadoop/dfs/name\":\"IMAGE_AND_EDITS\"},\"failed\":{}}",
+    "NodeUsage" : "{\"nodeUsage\":{\"min\":\"0.00%\",\"median\":\"0.00%\",\"max\":\"0.00%\",\"stdDev\":\"0.00%\"}}",
+    "NameJournalStatus" : "[{\"manager\":\"FileJournalManager(root=/hadoop/dfs/name)\",\"stream\":\"EditLogFileOutputStream(/hadoop/dfs/name/current/edits_inprogress_0000000000000000001)\",\"disabled\":\"false\",\"required\":\"false\"}]",
+    "JournalTransactionInfo" : "{\"MostRecentCheckpointTxId\":\"0\",\"LastAppliedOrWrittenTxId\":\"1\"}",
+    "NNStarted" : "Tue Nov 26 16:06:22 UTC 2019",
+    "CompileInfo" : "2015-06-29T06:04Z by jenkins from (detached from 15ecc87)",
+    "CorruptFiles" : "[]",
+    "DistinctVersionCount" : 1,
+    "DistinctVersions" : [ {
+      "key" : "2.7.1",
+      "value" : 1
+    } ],
+    "SoftwareVersion" : "2.7.1",
+    "RollingUpgradeStatus" : null,
+    "Threads" : 33
+  } ]
+}

--- a/hdfs_namenode/tests/test_hdfs_namenode.py
+++ b/hdfs_namenode/tests/test_hdfs_namenode.py
@@ -10,14 +10,16 @@ from .common import (
     CUSTOM_TAGS,
     HDFS_NAMENODE_AUTH_CONFIG,
     HDFS_NAMENODE_CONFIG,
-    HDFS_NAMENODE_RAW_VERSION,
     HDFS_NAMESYSTEM_METRIC_TAGS,
     HDFS_NAMESYSTEM_METRICS_VALUES,
     HDFS_NAMESYSTEM_MUTUAL_METRICS_VALUES,
     HDFS_NAMESYSTEM_STATE_METRICS_VALUES,
+    HDFS_RAW_VERSION,
 )
 
 pytestmark = pytest.mark.unit
+
+CHECK_ID = 'test:123'
 
 
 def test_check(aggregator, mocked_request):
@@ -48,23 +50,24 @@ def test_metadata(aggregator, mocked_request, datadog_agent):
     hdfs_namenode = HDFSNameNode('hdfs_namenode', {}, [instance])
 
     # Run the check once
+    hdfs_namenode.check_id = CHECK_ID
     hdfs_namenode.check(instance)
 
     aggregator.assert_service_check(
         HDFSNameNode.JMX_SERVICE_CHECK, HDFSNameNode.OK, tags=HDFS_NAMESYSTEM_METRIC_TAGS + CUSTOM_TAGS, count=1
     )
 
-    major, minor, patch = HDFS_NAMENODE_RAW_VERSION.split('.')
+    major, minor, patch = HDFS_RAW_VERSION.split('.')
 
     version_metadata = {
-        'version.raw': HDFS_NAMENODE_RAW_VERSION,
+        'version.raw': HDFS_RAW_VERSION,
         'version.scheme': 'semver',
         'version.major': major,
         'version.minor': minor,
         'version.patch': patch,
     }
 
-    datadog_agent.assert_metadata('', version_metadata)
+    datadog_agent.assert_metadata(CHECK_ID, version_metadata)
     datadog_agent.assert_metadata_count(5)
 
 

--- a/hdfs_namenode/tests/test_hdfs_namenode.py
+++ b/hdfs_namenode/tests/test_hdfs_namenode.py
@@ -10,6 +10,7 @@ from .common import (
     CUSTOM_TAGS,
     HDFS_NAMENODE_AUTH_CONFIG,
     HDFS_NAMENODE_CONFIG,
+    HDFS_NAMENODE_RAW_VERSION,
     HDFS_NAMESYSTEM_METRIC_TAGS,
     HDFS_NAMESYSTEM_METRICS_VALUES,
     HDFS_NAMESYSTEM_MUTUAL_METRICS_VALUES,
@@ -40,6 +41,31 @@ def test_check(aggregator, mocked_request):
         aggregator.assert_metric(metric, value=value, tags=HDFS_NAMESYSTEM_METRIC_TAGS + CUSTOM_TAGS, count=2)
 
     aggregator.assert_all_metrics_covered()
+
+
+def test_metadata(aggregator, mocked_request, datadog_agent):
+    instance = HDFS_NAMENODE_CONFIG['instances'][0]
+    hdfs_namenode = HDFSNameNode('hdfs_namenode', {}, [instance])
+
+    # Run the check once
+    hdfs_namenode.check(instance)
+
+    aggregator.assert_service_check(
+        HDFSNameNode.JMX_SERVICE_CHECK, HDFSNameNode.OK, tags=HDFS_NAMESYSTEM_METRIC_TAGS + CUSTOM_TAGS, count=1
+    )
+
+    major, minor, patch = HDFS_NAMENODE_RAW_VERSION.split('.')
+
+    version_metadata = {
+        'version.raw': HDFS_NAMENODE_RAW_VERSION,
+        'version.scheme': 'semver',
+        'version.major': major,
+        'version.minor': minor,
+        'version.patch': patch,
+    }
+
+    datadog_agent.assert_metadata('', version_metadata)
+    datadog_agent.assert_metadata_count(5)
 
 
 def test_auth(aggregator, mocked_auth_request):

--- a/hdfs_namenode/tests/test_integration.py
+++ b/hdfs_namenode/tests/test_integration.py
@@ -8,6 +8,8 @@ from . import common
 
 pytestmark = pytest.mark.integration
 
+CHECK_ID = 'test:123'
+
 
 @pytest.mark.usefixtures("dd_environment")
 def test_check(aggregator, check, instance):
@@ -18,3 +20,23 @@ def test_check(aggregator, check, instance):
         aggregator.assert_metric(metric)
 
     aggregator.assert_all_metrics_covered()
+
+
+@pytest.mark.usefixtures("dd_environment")
+def test_metadata(aggregator, check, instance, datadog_agent):
+    check = check(instance)
+    check.check_id = CHECK_ID
+    check.check(instance)
+
+    major, minor, patch = common.HDFS_NAMENODE_RAW_VERSION.split('.')
+
+    version_metadata = {
+        'version.raw': common.HDFS_NAMENODE_RAW_VERSION,
+        'version.scheme': 'semver',
+        'version.major': major,
+        'version.minor': minor,
+        'version.patch': patch,
+    }
+
+    datadog_agent.assert_metadata(CHECK_ID, version_metadata)
+    datadog_agent.assert_metadata_count(5)

--- a/hdfs_namenode/tests/test_integration.py
+++ b/hdfs_namenode/tests/test_integration.py
@@ -28,10 +28,10 @@ def test_metadata(aggregator, check, instance, datadog_agent):
     check.check_id = CHECK_ID
     check.check(instance)
 
-    major, minor, patch = common.HDFS_NAMENODE_RAW_VERSION.split('.')
+    major, minor, patch = common.HDFS_RAW_VERSION.split('.')
 
     version_metadata = {
-        'version.raw': common.HDFS_NAMENODE_RAW_VERSION,
+        'version.raw': common.HDFS_RAW_VERSION,
         'version.scheme': 'semver',
         'version.major': major,
         'version.minor': minor,

--- a/hdfs_namenode/tox.ini
+++ b/hdfs_namenode/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py37
 envlist =
-    py{27,37}
+    py{27,37}-2.7.1
 
 [testenv]
 description =
@@ -16,6 +16,9 @@ deps =
 passenv =
     DOCKER*
     COMPOSE*
+setenv =
+    2.7.1: HDFS_RAW_VERSION=2.7.1
+    2.7.1: HDFS_IMAGE_TAG=1.1.0-hadoop2.7.1-java8
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?

- Collects version metadata for both HDFS integrations: HDFS DataNode and HDFS NameNode.

### Motivation

- Ongoing effort for metadata integrations

### Additional Notes

- Formally part of #5088, now separated into its own review.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
