### PR TITLE
Check that GET on kubelet on `stats/summary` is successful

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -314,8 +314,11 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
             if stats_response.status_code >= 200 and stats_response.status_code < 300:
                 return stats_response.json()
             else:
-                self.log.warning('GET on kubelet s `/stats/summary` returned a non-OK status code: {}'.format(
-                                 stats_response.status_code))
+                self.log.warning(
+                    'GET on kubelet s `/stats/summary` returned a non-OK status code: {}'.format(
+                        stats_response.status_code
+                    )
+                )
                 return {}
         except Exception as e:
             self.log.warning('GET on kubelet s `/stats/summary` failed: {}'.format(str(e)))

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -311,15 +311,8 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
         """
         try:
             stats_response = self.perform_kubelet_query(self.stats_url)
-            if stats_response.status_code >= 200 and stats_response.status_code < 300:
-                return stats_response.json()
-            else:
-                self.log.warning(
-                    'GET on kubelet s `/stats/summary` returned a non-OK status code: {}'.format(
-                        stats_response.status_code
-                    )
-                )
-                return {}
+            stats_response.raise_for_status()
+            return stats_response.json()
         except Exception as e:
             self.log.warning('GET on kubelet s `/stats/summary` failed: {}'.format(str(e)))
             return {}

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -190,9 +190,7 @@ def mock_kubelet_check(monkeypatch, instances, kube_version=KUBE_PRE_1_16, stats
     monkeypatch.setattr(check, 'retrieve_pod_list', mock.Mock(return_value=json.loads(mock_from_file('pods.json'))))
     monkeypatch.setattr(check, '_retrieve_node_spec', mock.Mock(return_value=NODE_SPEC))
     if stats_summary_fail:
-        monkeypatch.setattr(
-            check, '_retrieve_stats', mock.Mock(return_value={})
-        )
+        monkeypatch.setattr(check, '_retrieve_stats', mock.Mock(return_value={}))
     else:
         monkeypatch.setattr(
             check, '_retrieve_stats', mock.Mock(return_value=json.loads(mock_from_file('stats_summary.json')))


### PR DESCRIPTION
### What does this PR do?

Check that GET on kubelet on `stats/summary` is successful
before attempting to interpret the result as JSON.

### Motivation

Goal is to avoid having the following the following error:
```
  File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/base.py", line 671, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/kubelet/kubelet.py", line 225, in check
          self._report_ephemeral_storage_usage(self.pod_list, self.instance_tags)
        File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/kubelet/kubelet.py", line 500, in _report_ephemeral_storage_usage
          stats = self._retrieve_stats()
        File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/kubelet/kubelet.py", line 306, in _retrieve_stats
          return self.perform_kubelet_query(self.stats_url).json()
        File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/requests/models.py", line 897, in json
          return complexjson.loads(self.text, **kwargs)
        File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/simplejson/__init__.py", line 505, in loads
          return _default_decoder.decode(s)
        File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/simplejson/decoder.py", line 370, in decode
          obj, end = self.raw_decode(s)
        File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/simplejson/decoder.py", line 400, in raw_decode
          return self.scan_once(s, idx=_w(s, idx).end())
      simplejson.scanner.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

when the GET on `nodes/stats` hasn’t been granted in the `datadog` clusterrole.


<!-- A brief description of the change being made with this pull request. -->


<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
