### PR TITLE
Updating link to point to dedicated GS

### DIFF
--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -72,5 +72,5 @@ Need help? Contact [Datadog support][4].
 [6]: https://docs.datadoghq.com/agent/prometheus
 [7]: https://docs.datadoghq.com/developers/prometheus
 [8]: https://docs.datadoghq.com/getting_started/integrations/prometheus/
-[9]: https://docs.datadoghq.com/agent/autodiscovery/integrations
+[9]: https://docs.datadoghq.com/getting_started/integrations/prometheus?tab=docker#configuration
 [10]: https://docs.datadoghq.com/integrations/openmetrics


### PR DESCRIPTION
### What does this PR do?

Updates link to point to the dedicated GS section about how to do AD with Prometheus.