### PR TITLE
[WIP] Collect version metadata

### DIFF
--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -1,4 +1,9 @@
 init_config:
+    ## @param istioctl - string - optional - default: istioctl
+    ## Command or path to istioctl (e.g. `/usr/local/bin/istioctl` or `docker exec <container> istioctl`).
+    ## Can be overwritten on an instance.
+    #
+    # istioctl: istioctl
 
 instances:
 
@@ -41,6 +46,11 @@ instances:
     ## Only available for Istio >= v1.1.
     #
     # citadel_endpoint: http://istio-citadel.istio-system:15014/metrics
+
+    ## @param istioctl - string - optional - default: istioctl
+    ## Command or path to istioctl (e.g. `/usr/local/bin/istioctl` or `docker exec <container> istioctl`).
+    #
+    # istioctl: istioctl
 
     ## @param tags - list of key:value elements - optional
     ## List of tags to attach to every metric, event and service check emitted by this integration.

--- a/istio/tests/common.py
+++ b/istio/tests/common.py
@@ -1,7 +1,11 @@
 # (C) Datadog, Inc. 2019
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import os
 
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+ISTIO_VERSION = '1.2.3'
 
 MESH_METRICS = [
     'istio.mesh.request.count',

--- a/istio/tests/conftest.py
+++ b/istio/tests/conftest.py
@@ -11,6 +11,8 @@ from datadog_checks.dev.kube_port_forward import port_forward
 from datadog_checks.dev.terraform import terraform_run
 from datadog_checks.dev.utils import get_here
 
+from .common import ISTIO_VERSION
+
 try:
     from contextlib import ExitStack
 except ImportError:
@@ -28,7 +30,10 @@ DEPLOYMENTS = [
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    with terraform_run(os.path.join(get_here(), 'terraform')) as outputs:
+    directory = os.path.join(get_here(), 'terraform')
+    env_vars = {'TF_VAR_istio_version': ISTIO_VERSION}
+
+    with terraform_run(directory, env_vars=env_vars) as outputs:
         kubeconfig = outputs['kubeconfig']['value']
         with ExitStack() as stack:
             ip_ports = [

--- a/istio/tests/mock/istioctl_version.py
+++ b/istio/tests/mock/istioctl_version.py
@@ -1,0 +1,7 @@
+import sys
+
+if __name__ == "__main__":
+    assert '--short' in sys.argv
+    assert '--remote=false' in sys.argv
+    version = sys.argv[1]
+    print(version)

--- a/istio/tests/terraform/main.tf
+++ b/istio/tests/terraform/main.tf
@@ -6,6 +6,10 @@ variable "user" {
   type = string
 }
 
+variable "istio_version" {
+  type = string
+}
+
 resource "random_id" "password" {
   byte_length = 16
 }
@@ -82,7 +86,7 @@ resource "null_resource" "startup" {
     command = "python ./script.py"
     environment = {
       KUBECONFIG = "${local_file.kubeconfig.filename}"
-      ISTIO_VERSION = "1.2.3"
+      ISTIO_VERSION = "${var.istio_version}"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Collect version metadata for `istio`.

### Motivation
<!-- What inspired you to submit this pull request? -->
Ongoing effort to collect version metadata about integrations.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Relevant documentation: [`istioctl version`](https://istio.io/docs/reference/commands/istioctl).

Still need to figure out whether we can expect `istioctl` to be available in our users' environments. Eg. [this page](https://istio.io/docs/ops/diagnostic-tools/istioctl/) seems to indicate that `istioctl` must be installed separately.

QUESTION: e2e tests do not seem to have run — is there any extra step to get Terraform-based e2e tests to run? => See #5176 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
