### PR TITLE
Change doc to not mention autofetch

### DIFF
--- a/snmp/README.md
+++ b/snmp/README.md
@@ -117,9 +117,6 @@ There are a few ways to specify the metrics to collect. See the [sample snmp.d/c
 
 ##### Use your own MIB
 
-Since Agent v6.15, MIBs hosted at http://mibs.snmplabs.com/asn1 will be fetched automatically the first
-time the check finds a reference in the configuration.
-
 To use your own MIB with the Datadog Agent, convert it to the [PySNMP][5] format. This can be done using the `mibdump.py` script that ships with PySNMP. `mibdump.py` replaces `build-pysnmp-mib` which was made obsolete in [PySNMP 4.3+][6].
 
 Since Datadog Agent v5.14, the Agent's PySNMP dependency has been upgraded from version 4.25 to 4.3.5 (refer to the [changelog][7]). This means that the `build-pysnmp-mib` which shipped with the Agent from version 5.13.x and earlier has also been replaced with `mibdump.py`.

--- a/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
@@ -1,7 +1,6 @@
 # Profile for F5 BIG-IP devices
 #
-# You need the MIB compiled to get the data. The check will fetch it
-# automatically for you, but otherwise you can run the following command:
+# You need the MIB compiled to get the data. You can run the following command to get it:
 # $ /opt/datadog-agent/embedded/bin/python /opt/datadog-agent/embedded/bin/mibdump.py  --destination-directory=/opt/datadog-agent/embedded/lib/python2.7/site-packages/pysnmp_mibs F5-BIGIP-SYSTEM-MIB
 #
 sysobjectid: 1.3.6.1.4.1.3375.2.1.3.4.*


### PR DESCRIPTION
We hide the code behind a feature flag, but it was still mentioned in
the doc. Let's get rid of it for now.