### PR TITLE
Document how to check against Cisco sandbox using ddev

### DIFF
--- a/cisco_aci/tests/README.md
+++ b/cisco_aci/tests/README.md
@@ -16,8 +16,9 @@ Cisco has created VM images for a simulator that is said to behave exactly like 
 https://devnetsandbox.cisco.com/
 
 Even if the simulator cannot be installed on a VM, cisco offers a publicly available sandbox which is running a specific version
-of the simulator. This AlwaysOn simulator is very convenient to use as it doesn't require a VPN and you can just configure the Agent
-to point at the sandbox with the following configuration:
+of the simulator. This AlwaysOn simulator is very convenient to use as it doesn't require a VPN.
+
+To use it, configure a locally-running Agent to point at the sandbox with the following configuration:
 
 ```yaml
 instances:
@@ -25,6 +26,30 @@ instances:
     username: admin
     pwd: ciscopsdt
 ```
+
+Alternatively, add a temporary `conftest.py` with the following contents:
+
+```python
+import pytest
+
+SANDBOX_CONFIG = {
+    'instances': [
+        {
+            'aci_url': 'https://sandboxapicdc.cisco.com',
+            'username': 'admin',
+            'pwd': 'ciscopsdt',
+            'tls_verify': False,  # As of 2019-12-03, the sandbox endpoint doesn't have a valid TLS certificate.
+        }
+    ]
+}
+
+
+@pytest.fixture(scope="session")
+def dd_environment():
+    return SANDBOX_CONFIG
+```
+
+and use `ddev` to run the check. (Be sure not to commit this `conftest.py`, as we should only use the sandbox for manual testing.)
 
 The main downsides of this are that:
 - Anyone can modify the environment and thus tests cannot be reproducible.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Document how to manually run the `cisco_aci` check against the Cisco sandbox (real system).

### Motivation
<!-- What inspired you to submit this pull request? -->
I needed to test `cisco_aci` integration against a live system, but the existing docs on testing against the Cisco sandbox require a locally-running agent. Using `ddev` is more handy: we can select which agent to use, and use the same workflow than for other integrations.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Any extra suggestions on making sure the config isn't accidentally committed to the repo?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
