### PR TITLE
Fix bean name of directsql_errors metric

### DIFF
--- a/hive/datadog_checks/hive/data/conf.yaml.example
+++ b/hive/datadog_checks/hive/data/conf.yaml.example
@@ -621,7 +621,7 @@ init_config:
             metric_type: gauge
 
     - include:
-        bean: metrics:name=directsql_error
+        bean: metrics:name=directsql_errors
         attribute:
           Count:
             alias: hive.metastore.directsql_errors

--- a/hive/datadog_checks/hive/data/metrics.yaml
+++ b/hive/datadog_checks/hive/data/metrics.yaml
@@ -29,7 +29,7 @@ jmx_metrics:
         Value:
           alias: hive.server.session.open
           metric_type: gauge
-  
+
   - include:
       bean: metrics:name=hs2_avg_open_session_time
       attribute:
@@ -108,7 +108,7 @@ jmx_metrics:
         Count:
           alias: hive.server.api.queries.executing.active_call
           metric_type: gauge
-  
+
   - include:
       bean: metrics:name=hs2_executing_queries
       attribute:
@@ -210,7 +210,7 @@ jmx_metrics:
         MeanRate:
           alias: hive.server.api.sql_operation.running.meanrate
           metric_type: rate
-  
+
   # Completed
   - include:
       bean: metrics:name=hs2_completed_sql_operation_CLOSED
@@ -456,7 +456,7 @@ jmx_metrics:
         Count:
           alias: hive.metastore.db.deleted
           metric_type: monotonic_count
-    
+
   - include:
       bean: metrics:name=init_total_count_dbs
       attribute:
@@ -477,7 +477,7 @@ jmx_metrics:
         Count:
           alias: hive.metastore.table.deleted
           metric_type: monotonic_count
-  
+
   - include:
       bean: metrics:name=init_total_count_tables
       attribute:
@@ -498,7 +498,7 @@ jmx_metrics:
         Count:
           alias: hive.metastore.partition.deleted
           metric_type: monotonic_count
-  
+
   - include:
       bean: metrics:name=init_total_count_partitions
       attribute:
@@ -507,7 +507,7 @@ jmx_metrics:
           metric_type: gauge
 
   - include:
-      bean: metrics:name=directsql_error
+      bean: metrics:name=directsql_errors
       attribute:
         Count:
           alias: hive.metastore.directsql_errors


### PR DESCRIPTION
Fix for a typo introduced in https://github.com/DataDog/integrations-core/pull/5074. ([Official Hive docs](https://cwiki.apache.org/confluence/display/Hive/Hive+Metrics) do list `directsql_errors` as the bean name, instead of `directsql_error`.)