### PR TITLE
Properly collect metadata when `postqueue` is false

### DIFF
--- a/postfix/datadog_checks/postfix/postfix.py
+++ b/postfix/datadog_checks/postfix/postfix.py
@@ -90,6 +90,8 @@ class PostfixCheck(AgentCheck):
             self.log.debug('running the check in classic mode')
             self._get_queue_count(directory, queues, tags)
 
+        self._collect_metadata()
+
     def _get_config(self, instance):
         directory = instance.get('directory', None)
         postfix_config_dir = instance.get('config_directory', None)
@@ -163,8 +165,6 @@ class PostfixCheck(AgentCheck):
             tags=tags + ['queue:deferred', 'instance:{}'.format(postfix_config_dir)],
         )
 
-        self._collect_metadata()
-
     def _get_queue_count(self, directory, queues, tags):
         for queue in queues:
             queue_path = os.path.join(directory, queue)
@@ -197,8 +197,6 @@ class PostfixCheck(AgentCheck):
             # these can be retrieved in a single graph statement
             # for example:
             #     sum:postfix.queue.size{instance:postfix-2,queue:incoming,host:hostname.domain.tld}
-
-        self._collect_metadata()
 
     def _collect_metadata(self):
         pc_output, _, _ = get_subprocess_output(['postconf', 'mail_version'], self.log, False)

--- a/postfix/datadog_checks/postfix/postfix.py
+++ b/postfix/datadog_checks/postfix/postfix.py
@@ -202,7 +202,7 @@ class PostfixCheck(AgentCheck):
         try:
             pc_output, _, _ = get_subprocess_output(['postconf', 'mail_version'], self.log, False)
         except Exception as e:
-            self.log.error('unable to call `postconf mail_version`: %s', e)
+            self.log.warning('unable to call `postconf mail_version`: %s', e)
             return
 
         self.log.debug('postconf mail_version output: %s', pc_output)

--- a/postfix/datadog_checks/postfix/postfix.py
+++ b/postfix/datadog_checks/postfix/postfix.py
@@ -199,7 +199,12 @@ class PostfixCheck(AgentCheck):
             #     sum:postfix.queue.size{instance:postfix-2,queue:incoming,host:hostname.domain.tld}
 
     def _collect_metadata(self):
-        pc_output, _, _ = get_subprocess_output(['postconf', 'mail_version'], self.log, False)
+        try:
+            pc_output, _, _ = get_subprocess_output(['postconf', 'mail_version'], self.log, False)
+        except Exception as e:
+            self.log.error('unable to call `postconf mail_version`: %s', e)
+            return
+
         self.log.debug('postconf mail_version output: %s', pc_output)
 
         postfix_version = pc_output.strip('\n').split('=')[1].strip()

--- a/postfix/datadog_checks/postfix/postfix.py
+++ b/postfix/datadog_checks/postfix/postfix.py
@@ -198,6 +198,8 @@ class PostfixCheck(AgentCheck):
             # for example:
             #     sum:postfix.queue.size{instance:postfix-2,queue:incoming,host:hostname.domain.tld}
 
+        self._collect_metadata()
+
     def _collect_metadata(self):
         pc_output, _, _ = get_subprocess_output(['postconf', 'mail_version'], self.log, False)
         self.log.debug('postconf mail_version output: %s', pc_output)

--- a/postfix/tests/test_integration.py
+++ b/postfix/tests/test_integration.py
@@ -13,6 +13,7 @@ from .common import get_instance, get_queue_counts
 def test_check(aggregator):
     instance = get_instance()
     check = PostfixCheck('postfix', {}, [instance])
+    check._collect_metadata = lambda: None
     check.check(instance)
 
     for queue, count in iteritems(get_queue_counts()):

--- a/postfix/tests/test_integration.py
+++ b/postfix/tests/test_integration.py
@@ -13,7 +13,6 @@ from .common import get_instance, get_queue_counts
 def test_check(aggregator):
     instance = get_instance()
     check = PostfixCheck('postfix', {}, [instance])
-    check._collect_metadata = lambda: None
     check.check(instance)
 
     for queue, count in iteritems(get_queue_counts()):


### PR DESCRIPTION
### Motivation

The check takes 2 code paths