### PR TITLE
Fix version collection

### DIFF
--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -68,6 +68,9 @@ class Apache(AgentCheck):
             raise
         else:
             self.service_check(service_check_name, AgentCheck.OK, tags=service_check_tags)
+        server = r.headers.get("Server")
+        if server:
+            self._collect_metadata(server)
         self.log.debug("apache check succeeded")
         metric_count = 0
         # Loop through and extract the numerical values
@@ -75,8 +78,6 @@ class Apache(AgentCheck):
             values = line.split(': ')
             if len(values) == 2:  # match
                 metric, value = values
-                if metric == '<dl><dt>Server Version':
-                    self._collect_metadata(value)
                 try:
                     value = float(value)
                 except ValueError:
@@ -99,7 +100,7 @@ class Apache(AgentCheck):
                     self.rate(metric_name, value, tags=tags)
 
         if metric_count == 0:
-            if self.assumed_url.get(instance['apache_status_url'], None) is None and url[-5:] != '?auto':
+            if self.assumed_url.get(instance['apache_status_url']) is None and url[-5:] != '?auto':
                 self.assumed_url[instance['apache_status_url']] = '%s?auto' % url
                 self.warning("Assuming url was not correct. Trying to add ?auto suffix to the url")
                 self.check(instance)

--- a/apache/tests/test_apache.py
+++ b/apache/tests/test_apache.py
@@ -66,7 +66,7 @@ def test_e2e(dd_agent_check):
 
 @pytest.mark.usefixtures("dd_environment")
 def test_metadata(check, datadog_agent):
-    check = check(STATUS_CONFIG)
+    check = check(AUTO_CONFIG)
     check.check_id = 'test:123'
     major, minor, patch = APACHE_VERSION.split('.')
     version_metadata = {
@@ -77,6 +77,6 @@ def test_metadata(check, datadog_agent):
         'version.raw': APACHE_VERSION,
     }
 
-    check.check(STATUS_CONFIG)
+    check.check(AUTO_CONFIG)
     datadog_agent.assert_metadata('test:123', version_metadata)
     datadog_agent.assert_metadata_count(len(version_metadata))


### PR DESCRIPTION
The current implementation parses the HTML output, but we usually
discourage that, and parse the text output instead, which doesn't
contain the version. Let's use the Server header instead.