### PR TITLE
Remove reference to Kubernetes in the service check message for `spark_driver_mode`

### DIFF
--- a/spark/datadog_checks/spark/spark.py
+++ b/spark/datadog_checks/spark/spark.py
@@ -283,12 +283,11 @@ class SparkCheck(AgentCheck):
             app_name = app_json.get('name')
             running_apps[app_id] = (app_name, spark_driver_address)
 
-        # Report success after gathering metrics from k8s spark driver
         self.service_check(
             SPARK_DRIVER_SERVICE_CHECK,
             AgentCheck.OK,
             tags=['url:%s' % spark_driver_address] + tags,
-            message='Connection to k8s spark driver "%s" was successful' % spark_driver_address,
+            message='Connection to Spark driver "%s" was successful' % spark_driver_address,
         )
         self.log.info("Returning running apps %s" % running_apps)
         return running_apps


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Remove a reference to Kubernetes in the Spark driver mode service check message.

### Motivation
<!-- What inspired you to submit this pull request? -->
In PR #4631, OP and @AlexandreYang agreed that the `spark_driver_mode` was not specific to Kubernetes (checking Spark drivers running on k8s only happened to be the author's target use case).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
