### PR TITLE
Add integration test for `spark_driver_mode`

### DIFF
--- a/spark/tests/common.py
+++ b/spark/tests/common.py
@@ -57,3 +57,17 @@ EXPECTED_E2E_METRICS = [
     'spark.job.num_skipped_stages',
     'spark.job.num_failed_tasks',
 ]
+
+
+INSTANCE_STANDALONE = {
+    'spark_url': 'http://{}:8080'.format(HOST),
+    'cluster_name': 'SparkCluster',
+    'spark_cluster_mode': 'spark_standalone_mode',
+}
+
+
+INSTANCE_DRIVER = {
+    'spark_url': 'http://{}:4040'.format(HOST),
+    'cluster_name': 'SparkDriver',
+    'spark_cluster_mode': 'spark_driver_mode',
+}

--- a/spark/tests/conftest.py
+++ b/spark/tests/conftest.py
@@ -7,24 +7,15 @@ import pytest
 
 from datadog_checks.dev import docker_run
 
-from .common import HERE, HOST
+from .common import HERE, HOST, INSTANCE_STANDALONE
 
 
 @pytest.fixture(scope='session')
-def dd_environment(instance_standalone):
+def dd_environment():
     with docker_run(
         compose_file=os.path.join(HERE, 'docker', 'docker-compose.yaml'),
         build=True,
         endpoints='http://{}:4040/api/v1/applications'.format(HOST),
         sleep=5,
     ):
-        yield instance_standalone
-
-
-@pytest.fixture(scope='session')
-def instance_standalone():
-    return {
-        'spark_url': 'http://{}:8080'.format(HOST),
-        'cluster_name': 'SparkCluster',
-        'spark_cluster_mode': 'spark_standalone_mode',
-    }
+        yield INSTANCE_STANDALONE

--- a/spark/tests/test_e2e.py
+++ b/spark/tests/test_e2e.py
@@ -9,8 +9,8 @@ from . import common
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, instance_standalone):
-    aggregator = dd_agent_check(instance_standalone, rate=True)
+def test_e2e(dd_agent_check):
+    aggregator = dd_agent_check(common.INSTANCE_STANDALONE, rate=True)
 
     for metric in common.EXPECTED_E2E_METRICS:
         aggregator.assert_metric(metric)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add an integration test for the Spark integration using `spark_driver_mode` (as opposed to `spark_standalone_mode`, which was already tested).

### Motivation
<!-- What inspired you to submit this pull request? -->
While QA'ing #4631, I realised that both the integration test and the e2e test were using `spark_standalone_mode`, which means `spark_driver_mode` was only unit-tested.

Currently it is not possible to have multiple e2e tests (at least from what I've seen in our `ddev` pytest plugin?), but it *is* possible to expand our integration test setup to also test the `spark_driver_mode` against a live Spark driver (i.e. the one spun up by Compose), hence this PR.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
The implementation makes use of `pytest.mark.parametrize` because both modes emit the same metrics, and only differ in the service check (which is now tested as part of the integration test). I reckon the `parametrize` syntax isn't the most readable one, but I decided to use it instead of duplicating the test code. Let me know if that's reasonable!

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
