### PR TITLE
Add warning log on historical metrics collection failure

### DIFF
--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -893,8 +893,8 @@ class VSphereCheck(AgentCheck):
                     max_historical_metrics = int(vcenter_settings[0].value)
                 if max_historical_metrics < 0:
                     max_historical_metrics = float('inf')
-            except Exception:
-                pass
+            except Exception as e:
+                self.log.warning("Error collecting historical metrics: %s", e)
 
         # TODO: Remove me once the fix for `max_query_metrics` is here by default
         mors_batch_method = (

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -894,7 +894,7 @@ class VSphereCheck(AgentCheck):
                 if max_historical_metrics < 0:
                     max_historical_metrics = float('inf')
             except Exception as e:
-                self.log.warning("Error collecting historical metrics: %s", e)
+                self.log.warning("Error getting maxQueryMetrics setting: %s", e)
 
         # TODO: Remove me once the fix for `max_query_metrics` is here by default
         mors_batch_method = (

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -894,7 +894,13 @@ class VSphereCheck(AgentCheck):
                 if max_historical_metrics < 0:
                     max_historical_metrics = float('inf')
             except Exception as e:
-                self.log.warning("Error getting maxQueryMetrics setting: %s", e)
+                self.log.debug(
+                    "Error getting maxQueryMetrics setting "
+                    "(max_historical_metrics=%s, DEFAULT_MAX_HIST_METRICS=%s): %s",
+                    max_historical_metrics,
+                    DEFAULT_MAX_HIST_METRICS,
+                    e,
+                )
 
         # TODO: Remove me once the fix for `max_query_metrics` is here by default
         mors_batch_method = (


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add warning log on historical metrics collection failure

### Motivation
<!-- What inspired you to submit this pull request? -->

Helpful debug info.

Already suggested here https://github.com/DataDog/integrations-core/pull/4337#discussion_r313852136

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
