### PR TITLE
Document RAM requirements for testing SAP HANA

### DIFF
--- a/sap_hana/tests/README.md
+++ b/sap_hana/tests/README.md
@@ -1,0 +1,11 @@
+# Test environment for SAP HANA
+
+This integration can be tested using the Docker Compose environment.
+
+Running the environment requires a rather large amount of memory, so make sure that Docker has a comfortable amount of RAM available - 6GB should be enough. Otherwise, spinning up the Docker Compose environment may fail with the following error:
+
+```
+Entering post start phase ...
+Creating tenant database ...
+* -10807: System call 'recv' failed, rc=104:Connection reset by peer {127.0.0.1:39017}
+```


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Document that enough RAM should be made available to Docker to test the SAP HANA integration locally.

### Motivation
<!-- What inspired you to submit this pull request? -->
Came across this error while trying to run `ddev test` locally - Docker was configured to only use up to 2GB. Turns out ~6GB did the trick (thanks @ofek).

### Additional Notes
<!-- Anything else we should know when reviewing? -->
/

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
