### PR TITLE
Change rate flag message

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/agent.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/agent.py
@@ -26,7 +26,7 @@ MANIFEST_VERSION_PATTERN = r'agent (\d)'
 
 def get_rate_flag(agent_version):
     if agent_version >= 6:
-        return '--check-rate'
+        return '--rate'
     else:
         return 'check_rate'
 


### PR DESCRIPTION
Check prints this message
```
Check has run only once, if some metrics are missing you can try again with --check-rate to see any other metric if available.
```

but `--check-rate` is not a valid argument