### PR TITLE
Increase max VM memory for SAP HANA in CI

### DIFF
--- a/.azure-pipelines/scripts/sap_hana/linux/50_increase_docker_memory.sh
+++ b/.azure-pipelines/scripts/sap_hana/linux/50_increase_docker_memory.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+sudo sysctl -w vm.max_map_count=$(expr 6 \* 65536)
+
+set +ex

--- a/.azure-pipelines/scripts/sap_hana/linux/50_increase_docker_memory.sh
+++ b/.azure-pipelines/scripts/sap_hana/linux/50_increase_docker_memory.sh
@@ -2,6 +2,9 @@
 
 set -ex
 
-sudo sysctl -w vm.max_map_count=$(expr 6 \* 65536)
+# 6GB is proven to be enough for SAP HANA to run.
+# The default number of memory addresses is 65536, i.e. 512MB (Linux 64-bit).
+# => To get 6GB, we multiply that amount by 12.
+sudo sysctl -w vm.max_map_count=$(expr 12 \* 65536)
 
 set +ex

--- a/sap_hana/tox.ini
+++ b/sap_hana/tox.ini
@@ -22,3 +22,4 @@ setenv =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
+

--- a/sap_hana/tox.ini
+++ b/sap_hana/tox.ini
@@ -22,4 +22,3 @@ setenv =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
-


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Increase max VM RAM for SAP HANA to 6GB.

### Motivation
<!-- What inspired you to submit this pull request? -->
The SAP HANA tests are quite flaky (failed 3 times in the past 14 days on PR All). SAP HANA eats a lot of memory (#5162 recommends 6GB), and some CI tests *might* have been failing due to low available memory.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
I'll run the CI several times to see if this improves the flakiness.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
