### PR TITLE
Clarify usage of SSL in kube_apiserver_metrics and use Kube CA by default if present

### DIFF
--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -27,9 +27,16 @@ instances:
     # bearer_token_path: "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
     ## @param ssl_verify - string - optional
-    ## Used to verify self signed certificates. Default to false
+    ## Used to verify self signed certificates. Default to true
     # 
-    # ssl_verify: false    
+    # ssl_verify: true
+
+    ## @param ssl_ca_cert - string - optional
+    ## CA Cert to be used with ssl_verify = true when calling APIServer
+    ## Default to "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" is file exists.
+    ## Default to None otherwise
+    # 
+    # ssl_ca_cert: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
     ## @param tags - list of key:value element - optional
     ## List of tags to attach to every metric, event and service check emitted by this integration.

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy
+from os.path import isfile
 from re import match
 
 from six import iteritems
@@ -20,7 +21,8 @@ class KubeAPIServerMetricsCheck(OpenMetricsBaseCheck):
     # Set up metrics_transformers
     metric_transformers = {}
     DEFAULT_SCHEME = 'https'
-    DEFAULT_SSL_VERIFY = False
+    DEFAULT_SSL_VERIFY = True
+    DEFAULT_SSL_CACERT = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
     DEFAULT_BEARER_TOKEN_AUTH = True
 
     def __init__(self, name, init_config, agentConfig, instances=None):
@@ -89,6 +91,11 @@ class KubeAPIServerMetricsCheck(OpenMetricsBaseCheck):
         # Most set ups are using self signed certificates as the APIServer can be used as a CA.
         ssl_verify = instance.get('ssl_verify', self.DEFAULT_SSL_VERIFY)
         kube_apiserver_metrics_instance['ssl_verify'] = ssl_verify
+
+        ssl_ca_cert = instance.get('ssl_ca_cert', None)
+        if ssl_ca_cert is None and isfile(self.DEFAULT_SSL_CACERT):
+            ssl_ca_cert = self.DEFAULT_SSL_CACERT
+        kube_apiserver_metrics_instance['ssl_ca_cert'] = ssl_ca_cert
 
         # We should default to supporting environments using RBAC to access the APIServer.
         bearer_token_auth = instance.get('bearer_token_auth', self.DEFAULT_BEARER_TOKEN_AUTH)


### PR DESCRIPTION
### What does this PR do?
Previously this module believed that ssl_verify was false by default. Though it's not the case.
From https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L231
It's in fact true by default (for years apparently).

So changing the behavior to expect ssl_verify as true by default and use default Kube CA to target APIServer if possible.

### Motivation
Check does not work out of the box at least in Kube 1.16 setup locally with kind.

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
