### PR TITLE
Update KE version

### DIFF
--- a/istio/tests/terraform/main.tf
+++ b/istio/tests/terraform/main.tf
@@ -37,7 +37,7 @@ resource "local_file" "kubeconfig" {
 resource "google_container_cluster" "gke_cluster" {
   name = replace("istio-cluster-${var.user}-${random_string.suffix.result}", ".", "-")
   location = random_shuffle.az.result[0]
-  min_master_version = "1.13.7-gke.24"
+  min_master_version = "1.13.11-gke.14"
 
   lifecycle {
     ignore_changes = ["node_pool"]

--- a/linkerd/tests/terraform/main.tf
+++ b/linkerd/tests/terraform/main.tf
@@ -94,7 +94,7 @@ resource "null_resource" "linkerd-init" {
 resource "google_container_cluster" "gke_cluster" {
   name = replace("linkerd-cluster-${var.user}-${random_string.suffix.result}", ".", "-")
   location = random_shuffle.az.result[0]
-  min_master_version = "1.13.7-gke.24"
+  min_master_version = "1.13.11-gke.14"
 
   lifecycle {
     ignore_changes = ["node_pool"]


### PR DESCRIPTION
See prior PR #4762 

The version seems out of date again, as of November 18, 2019.  https://cloud.google.com/kubernetes-engine/docs/release-notes#november_18_2019

The same error message from previous PR was seen when trying to bring up a terraform instance:

```
---------------------------- Captured stderr setup -----------------------------

Error: googleapi: Error 400: Master version "1.13.7-gke.24" is unsupported., badRequest

  on main.tf line 37, in resource "google_container_cluster" "gke_cluster":
  37: resource "google_container_cluster" "gke_cluster" {


!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
