### PR TITLE
Use origin/master instead of master

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release.py
@@ -284,7 +284,7 @@ def testable(ctx, start_id, agent_version, milestone, dry_run):
         echo_success(current_agent_version)
 
     current_release_branch = '{}.x'.format(current_agent_version)
-    diff_target_branch = 'master'
+    diff_target_branch = 'origin/master'
     echo_info('Branch `{}` will be compared to `{}`.'.format(current_release_branch, diff_target_branch))
 
     echo_waiting('Getting diff... ', nl=False)
@@ -382,7 +382,7 @@ def testable(ctx, start_id, agent_version, milestone, dry_run):
                 elif api_response.status_code == 403:
                     echo_failure(
                         'Error getting info for #{}. Please set a GitHub HTTPS '
-                        'token to avoid rate limits.'.format(commit_id)
+                        'token to avoid rate limits.'.format(commit_hash)
                     )
                     continue
 


### PR DESCRIPTION
### What does this PR do?

Use `origin/master` instead of `master` when computing the diff to create trello cards.

### Motivation


### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
