### PR TITLE
Fix normalize for invalid chars and underscore

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -97,8 +97,9 @@ class __AgentCheck(object):
 
     FIRST_CAP_RE = re.compile(br'(.)([A-Z][a-z]+)')
     ALL_CAP_RE = re.compile(br'([a-z0-9])([A-Z])')
-    METRIC_REPLACEMENT = re.compile(br'([^a-zA-Z0-9_.]+)|(^[^a-zA-Z]+)|__+')
-    TAG_REPLACEMENT = re.compile(br'[,\+\*\-/()\[\]{}\s]|__+')
+    METRIC_REPLACEMENT = re.compile(br'([^a-zA-Z0-9_.]+)|(^[^a-zA-Z]+)')
+    TAG_REPLACEMENT = re.compile(br'[,\+\*\-/()\[\]{}\s]')
+    MULTIPLE_UNDERSCORE_CLEANUP = re.compile(br'__+')
     DOT_UNDERSCORE_CLEANUP = re.compile(br'_*\._*')
     DEFAULT_METRIC_LIMIT = 0
 
@@ -621,6 +622,8 @@ class __AgentCheck(object):
             name = self.METRIC_REPLACEMENT.sub(br'_', metric)
             name = self.DOT_UNDERSCORE_CLEANUP.sub(br'.', name).strip(b'_')
 
+        name = self.MULTIPLE_UNDERSCORE_CLEANUP.sub(br'_', name)
+
         if prefix is not None:
             name = ensure_bytes(prefix) + b"." + name
 
@@ -635,6 +638,7 @@ class __AgentCheck(object):
         if isinstance(tag, text_type):
             tag = tag.encode('utf-8', 'ignore')
         tag = self.TAG_REPLACEMENT.sub(br'_', tag)
+        tag = self.MULTIPLE_UNDERSCORE_CLEANUP.sub(br'_', tag)
         tag = self.DOT_UNDERSCORE_CLEANUP.sub(br'.', tag).strip(b'_')
         return to_string(tag)
 

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -263,8 +263,8 @@ class TestMetricNormalization:
     def test_prefix(self):
         check = AgentCheck()
         metric_name = u'metric'
-        prefix = u'some'
-        normalized_metric_name = 'some.metric'
+        prefix = u'somePrefix'
+        normalized_metric_name = 'somePrefix.metric'
 
         assert check.normalize(metric_name, prefix=prefix) == normalized_metric_name
 
@@ -283,6 +283,14 @@ class TestMetricNormalization:
         normalized_metric_name = 'some.metric'
 
         assert check.normalize(metric_name, prefix=prefix) == normalized_metric_name
+
+    def test_prefix_fix_case(self):
+        check = AgentCheck()
+        metric_name = b'metric'
+        prefix = u'somePrefix'
+        normalized_metric_name = 'some_prefix.metric'
+
+        assert check.normalize(metric_name, fix_case=True, prefix=prefix) == normalized_metric_name
 
     def test_underscores_redundant(self):
         check = AgentCheck()
@@ -304,6 +312,29 @@ class TestMetricNormalization:
         normalized_metric_name = 'some.dots.and.underscores'
 
         assert check.normalize(metric_name) == normalized_metric_name
+
+    def test_invalid_chars_and_underscore(self):
+        check = AgentCheck()
+        metric_name = u'metric.hello++aaa$$_bbb'
+        normalized_metric_name = 'metric.hello_aaa_bbb'
+
+        assert check.normalize(metric_name) == normalized_metric_name
+
+
+@pytest.mark.parametrize(
+    'case, tag, expected_tag',
+    [
+        ('nothing to normalize', 'abc:123', 'abc:123'),
+        ('unicode', u'Klüft inför på fédéral', 'Klüft_inför_på_fédéral'),
+        ('invalid chars', 'foo,+*-/()[]{}  \t\nbar:123', 'foo_bar:123'),
+        ('leading and trailing underscores', '__abc:123__', 'abc:123'),
+        ('redundant underscore', 'foo_____bar', 'foo_bar'),
+        ('invalid chars and underscore', 'foo++__bar', 'foo_bar'),
+    ],
+)
+def test_normalize_tag(case, tag, expected_tag):
+    check = AgentCheck()
+    assert check.normalize_tag(tag) == expected_tag, 'Failed case: {}'.format(case)
 
 
 class TestMetrics:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix normalize for invalid chars and underscore

This case was not handled, the result was `metric.hello_aaa__bbb` instead of `metric.hello_aaa_bbb`:

```
    def test_invalid_chars_and_underscore(self):
        check = AgentCheck()
        metric_name = u'metric.hello++aaa$$_bbb'
        normalized_metric_name = 'metric.hello_aaa_bbb'

        assert check.normalize(metric_name) == normalized_metric_name
```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
