### PR TITLE
Fix deprecated exception

### DIFF
--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -116,7 +116,7 @@ class Oracle(AgentCheck):
                             jpype.java.lang.ClassLoader.getSystemClassLoader()
                         )
                     con = jdb.connect(self.ORACLE_DRIVER_CLASS, connect_string, [user, password], jdbc_driver)
-                except jpype.JException(jpype.java.lang.RuntimeException) as e:
+                except Exception as e:
                     if "Class {} not found".format(self.ORACLE_DRIVER_CLASS) in str(e):
                         msg = """Cannot run the Oracle check until either the Oracle instant client or the JDBC Driver
                         is available.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove deprecated exception.

We check for `if "Class {} not found".format(self.ORACLE_DRIVER_CLASS) in str(e):` so it should be ok to catch `Exception`.

### Motivation
<!-- What inspired you to submit this pull request? -->

```
tests/test_oracle.py::test__get_connection_failure
  integrations-core/oracle/datadog_checks/oracle/oracle.py:119: DeprecationWarning: Using JException to construct an exception type is deprecated.
    except jpype.JException(jpype.java.lang.RuntimeException) as e:
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
