### PR TITLE
openmetrics: configuration parameter to replace a pattern by dots in metrics name

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -240,7 +240,7 @@ class OpenMetricsScraperMixin(object):
         )
 
         # A pattern to replace by dots in the metrics name.
-        config['pattern_to_dot'] = instance.get('pattern_to_dot', default_instance.get('pattern_to_dot', None))
+        config['_pattern_to_dot'] = instance.get('_pattern_to_dot', default_instance.get('_pattern_to_dot', None))
 
         # Authentication used when polling endpoint
         config['username'] = instance.get('username', default_instance.get('username', None))
@@ -472,8 +472,8 @@ class OpenMetricsScraperMixin(object):
         metric_name = metric.name
 
         # A configured pattern could be transformed into dot
-        if scraper_config['pattern_to_dot'] is not None:
-            metric_name = metric_name.replace(scraper_config['pattern_to_dot'], '.')
+        if scraper_config['_pattern_to_dot'] is not None:
+            metric_name = metric_name.replace(scraper_config['_pattern_to_dot'], '.')
 
         if metric_name in scraper_config['ignore_metrics']:
             self._send_telemetry_counter(

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -473,7 +473,7 @@ class OpenMetricsScraperMixin(object):
 
         # A configured pattern could be transformed into dot
         if scraper_config['pattern_to_dot'] is not None:
-            metric_name.replace(scraper_config['pattern_to_dot'], '.')
+            metric_name = metric_name.replace(scraper_config['pattern_to_dot'], '.')
 
         if metric_name in scraper_config['ignore_metrics']:
             self._send_telemetry_counter(

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -459,7 +459,7 @@ class OpenMetricsScraperMixin(object):
     def process_metric(self, metric, scraper_config, metric_transformers=None):
         """
         Handle a prometheus metric according to the following flow:
-            - apply a patterns replacer if any has been configured
+            - replace a given pattern by a dot if any pattern has been provided
             - search scraper_config['metrics_mapper'] for a prometheus.metric <--> datadog.metric mapping
             - call check method with the same name as the metric
             - log some info if none of the above worked

--- a/openmetrics/tests/conftest.py
+++ b/openmetrics/tests/conftest.py
@@ -34,6 +34,8 @@ def poll_mock():
     c1.labels(node="host2").inc(42)
     g3 = Gauge('metric3', 'memory usage', ['matched_label', 'node', 'timestamp'], registry=registry)
     g3.labels(matched_label="foobar", node="host2", timestamp="456").set(float('inf'))
+    c2 = Counter('counter2__with_pattern', 'hits', ['node'], registry=registry)
+    c2.labels(node="host2").inc(42)
 
     poll_mock_patch = mock.patch(
         'requests.get',

--- a/openmetrics/tests/test_openmetrics.py
+++ b/openmetrics/tests/test_openmetrics.py
@@ -77,7 +77,7 @@ def test_openmetrics_pattern_to_dot(aggregator):
         'prometheus_url': 'http://localhost:10249/metrics',
         'namespace': 'openmetrics',
         'metrics': ['counter*'],
-        'pattern_to_dot': '__',
+        '_pattern_to_dot': '__',
     }
     c = OpenMetricsCheck('openmetrics', None, {}, [instance_pattern])
     c.check(instance_pattern)


### PR DESCRIPTION
# What does this PR do?

Adds a configuration field in the OpenMetrics check to replace a pattern in the metrics name by a dot.
E.g. `__` -> `.`
```
observability.dogstatsd__udp_bytes -> observability.dogstatsd.udp_bytes
```

This PR exists for the upcoming Agent telemetry feature:
 - to have pretty metrics names with dots instead of underscore (`observability.forwarder_metrics_samples` produced by the Prometheus Go client is not following our documented metrics name guideline, it should be `observability.forwarder.metrics_samples`)
 - because the telemetry changes in the Agent may re-use existing dashboards with existing metrics (sent with the expvars check for the time being) and we would need this PR to properly send the data to these dotted names metrics.

### Motivation

The Prometheus Go client is generating metrics following this pattern:

```
<subsystem>_<name>
```

While using the OpenMetrics check with a namespace configured, we obtain metrics named with this pattern:

```
<namespace>.<subsystem>_<name>
```

In order to have properly named metrics in the observability metrics that we're adding in the Agent, we would prepend all metrics `<name>` with a `_`, creating a double `_` and this PR would let the OpenMetrics check replace the `__` by a `.`.

E.g.

```
metric := PromMetric{ Subsystem: "dogstatsd", Name: "_udp_bytes" } // dogstatsd__udp_bytes
```

Added for Datadog, I don't think this make a lot of sense to document this field. Let me know if you disagree.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
