### PR TITLE
Activate slow query log in MySQL test setup

### DIFF
--- a/mysql/tests/compose/mariadb.conf
+++ b/mysql/tests/compose/mariadb.conf
@@ -1,0 +1,5 @@
+[mysqld]
+# log_short_format=ON  # Uncomment to simulate short log format.
+slow_query_log = 1
+slow_query_log_file = /opt/bitnami/mariadb/logs/slow.log
+long_query_time = 0.1

--- a/mysql/tests/compose/mariadb.conf
+++ b/mysql/tests/compose/mariadb.conf
@@ -1,5 +1,8 @@
 [mysqld]
 # log_short_format=ON  # Uncomment to simulate short log format.
+
+# Slow logs aren't enabled by default, so we enable and configure them here
+# to save us some manual configuration when developing.
 slow_query_log = 1
 slow_query_log_file = /opt/bitnami/mariadb/logs/slow.log
 long_query_time = 0.1

--- a/mysql/tests/compose/mariadb.yaml
+++ b/mysql/tests/compose/mariadb.yaml
@@ -13,6 +13,8 @@ services:
       - MARIADB_DATABASE=my_database
     ports:
       - "${MYSQL_PORT}:3306"
+    volumes:
+      - ${MYSQL_CONF_PATH}:/bitnami/mariadb/conf/my_custom.cnf:ro
 
   mysql-slave:
     container_name: mysql-slave

--- a/mysql/tests/compose/mysql.conf
+++ b/mysql/tests/compose/mysql.conf
@@ -1,5 +1,8 @@
 [mysqld]
 # log_short_format=ON  # Uncomment to simulate short log format.
+
+# Slow logs aren't enabled by default, so we enable and configure them here
+# to save us some manual configuration when developing.
 slow_query_log = 1
 slow_query_log_file = /var/log/mysql/slow.log
 long_query_time = 0.1

--- a/mysql/tests/compose/mysql.conf
+++ b/mysql/tests/compose/mysql.conf
@@ -1,0 +1,5 @@
+[mysqld]
+# log_short_format=ON  # Uncomment to simulate short log format.
+slow_query_log = 1
+slow_query_log_file = /var/log/mysql/slow.log
+long_query_time = 0.1

--- a/mysql/tests/compose/mysql.yaml
+++ b/mysql/tests/compose/mysql.yaml
@@ -7,6 +7,9 @@ services:
       - MYSQL_ALLOW_EMPTY_PASSWORD=1
     ports:
       - "${MYSQL_PORT}:3306"
+    volumes:
+      # This is a supported conf location that isn't used by the image.
+      - ${MYSQL_CONF_PATH}:/etc/my.cnf
 
   mysql-slave:
     container_name: mysql-slave

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -145,10 +145,12 @@ def _wait_for_it_script():
 
 
 def _mysql_conf_path():
-    filename = {
-        'mysql': 'mysql.conf',
-        'mariadb': 'mariadb.conf',
-    }[MYSQL_FLAVOR]
+    if MYSQL_FLAVOR == 'mysql':
+        filename = 'mysql.conf'
+    else:
+        assert MYSQL_FLAVOR == 'mariadb'
+        filename = 'mariadb.conf'
+
     conf = os.path.join(common.HERE, 'compose', filename)
     return os.path.abspath(conf)
 

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -25,6 +25,7 @@ def dd_environment(instance_basic):
             'MYSQL_DOCKER_REPO': _mysql_docker_repo(),
             'MYSQL_PORT': str(common.PORT),
             'MYSQL_SLAVE_PORT': str(common.SLAVE_PORT),
+            'MYSQL_CONF_PATH': _mysql_conf_path(),
             'WAIT_FOR_IT_SCRIPT_PATH': _wait_for_it_script(),
         },
         conditions=[
@@ -141,6 +142,15 @@ def _wait_for_it_script():
     """
     script = os.path.join(common.TESTS_HELPER_DIR, 'scripts', 'wait-for-it.sh')
     return os.path.abspath(script)
+
+
+def _mysql_conf_path():
+    filename = {
+        'mysql': 'mysql.conf',
+        'mariadb': 'mariadb.conf',
+    }[MYSQL_FLAVOR]
+    conf = os.path.join(common.HERE, 'compose', filename)
+    return os.path.abspath(conf)
 
 
 def _mysql_docker_repo():

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -147,9 +147,10 @@ def _wait_for_it_script():
 def _mysql_conf_path():
     if MYSQL_FLAVOR == 'mysql':
         filename = 'mysql.conf'
-    else:
-        assert MYSQL_FLAVOR == 'mariadb'
+    elif MYSQL_FLAVOR == 'mariadb':
         filename = 'mariadb.conf'
+    else:
+        raise ValueError('Unsupported MySQL flavor: {}'.format(MYSQL_FLAVOR))
 
     conf = os.path.join(common.HERE, 'compose', filename)
     return os.path.abspath(conf)
@@ -166,3 +167,5 @@ def _mysql_docker_repo():
             return 'bitnami/mysql'
     elif MYSQL_FLAVOR == 'mariadb':
         return 'bitnami/mariadb'
+    else:
+        raise ValueError('Unsupported MySQL flavor: {}'.format(MYSQL_FLAVOR))

--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -28,4 +28,4 @@ setenv =
     8.0: MYSQL_VERSION=8.0
     maria: COMPOSE_FILE=mariadb.yaml
     maria: MYSQL_FLAVOR=mariadb
-    maria: MYSQL_VERSION=10.1.30-r1
+    maria: MYSQL_VERSION=10.1.43


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Activate and configure slow query logs for the MySQL Docker Compose setup (for both MySQL and MariaDB flavors).

### Motivation
<!-- What inspired you to submit this pull request? -->
This makes it much easier to test slow query logs locally. I essentially got tired of having to do the setup manually. :-)

### Additional Notes
<!-- Anything else we should know when reviewing? -->
/

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
