### PR TITLE
Remove volume from docker compose

### DIFF
--- a/sap_hana/tests/docker/docker-compose.yaml
+++ b/sap_hana/tests/docker/docker-compose.yaml
@@ -25,8 +25,3 @@ services:
       - sh
       - -c
       - echo "{\"master_password\":\"$$PASSWORD\"}" > /tmp/hana_password.json;cat /tmp/hana_password.json;/run_hana --agree-to-sap-license --passwords-url file:///tmp/hana_password.json
-    volumes:
-       - sap-hana-data:/hana/mounts
-
-volumes:
-  sap-hana-data:


### PR DESCRIPTION
### What does this PR do?

Remove volume from docker compose.

### Motivation

The volume persist data and might cause subsequent `ddev env start` to fail. Example of error:

```
======== Starting HANA container run script ========
Started at: Tue Dec 10 18:34:01 UTC 2019
Script parameters: --agree-to-sap-license --passwords-url file:///tmp/hana_password.json
HANA version: 2.00.036.00.1547699771
Linux kernel version: 4.9
ERROR: Unknown host '41d05ff7014f'. The container must be started with one of these host names:
ERROR: 	5c81e7743d02
```

In the previous example `5c81e7743d02` is the hostname from a previous run.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
