### PR TITLE
Document slow logs config for postgres

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -103,7 +103,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 **Available for Agent >6.0**
 
-PostgreSQL default logging is to `stderr` and logs do not include detailed information. It is recommended to log into a file with additional details specified in the log line prefix.  Refer to the PostgresQL [documentation][14] on this topic for additional details.
+PostgreSQL default logging is to `stderr` and logs do not include detailed information. It is recommended to log into a file with additional details specified in the log line prefix. Refer to the PostgreSQL [documentation][14] on this topic for additional details.
 
 1. Logging is configured within the file `/etc/postgresql/<VERSION>/main/postgresql.conf`, for regular log results including statement outputs uncomment the following parameters in the log section:
 

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -103,7 +103,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 **Available for Agent >6.0**
 
-PostgreSQL default logging is to `stderr` and logs do not include detailed information. It is recommended to log into a file with additional details specified in the log line prefix.  Refer to the PostgresQL [documentation][13] on this topic for additional details.
+PostgreSQL default logging is to `stderr` and logs do not include detailed information. It is recommended to log into a file with additional details specified in the log line prefix.  Refer to the PostgresQL [documentation][14] on this topic for additional details.
 
 1. Logging is configured within the file `/etc/postgresql/<VERSION>/main/postgresql.conf`, for regular log results including statement outputs uncomment the following parameters in the log section:
 
@@ -120,7 +120,7 @@ PostgreSQL default logging is to `stderr` and logs do not include detailed infor
       #log_destination = 'eventlog'
     ```
 
-2. To gather detailed duration metrics and make them searchable in the Datadog interface, they should be configured inline with the statement themselves.  See below for the recommended configuration differences from above and note that both `log_statement` and `log_duration` options are commented out. See discussion on this topic [here][15]
+2. To gather detailed duration metrics and make them searchable in the Datadog interface, they should be configured inline with the statement themselves.  See below for the recommended configuration differences from above and note that both `log_statement` and `log_duration` options are commented out. See discussion on this topic [here][15].
    
    This config logs all statements, but to reduce the output to those which have a certain duration, set the `log_min_duration_statement` value to the desired minimum duration (in milliseconds):
 

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -103,46 +103,34 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 **Available for Agent >6.0**
 
-PostgreSQL default logging is to `stderr` and logs do not include detailed information. It is recommended to log into 
-a file with additional details specified in the log line prefix.
+PostgreSQL default logging is to `stderr` and logs do not include detailed information. It is recommended to log into a file with additional details specified in the log line prefix.  Refer to the PostgresQL [documentation][13] on this topic for additional details.
 
-1. Logging is configured within the file `/etc/postgresql/<version>/main/postgresql.conf`,
-   for regular log results including statement outputs uncomment the following parameters in the log
-   section:
+1. Logging is configured within the file `/etc/postgresql/<VERSION>/main/postgresql.conf`, for regular log results including statement outputs uncomment the following parameters in the log section:
 
     ```conf
       logging_collector = on
       log_directory = 'pg_log'  # directory where log files are written,
                                 # can be absolute or relative to PGDATA
-      log_filename = 'pg.log'   #log file name, can include pattern
-      log_statement = 'all'     #log all queries
+      log_filename = 'pg.log'   # log file name, can include pattern
+      log_statement = 'all'     # log all queries
+      #log_duration = on
       log_line_prefix= '%m [%p] %d %a %u %h %c '
       log_file_mode = 0644
       ## For Windows
       #log_destination = 'eventlog'
     ```
 
-2. To gather detailed duration metrics and make them searchable in the Datadog interface, they will need to be 
-   configured inline with the statement themselves.  See below for the recommended config, note that counterintuitively 
-   both `log_statement` and `log_duration` options are commented out.
+2. To gather detailed duration metrics and make them searchable in the Datadog interface, they should be configured inline with the statement themselves.  See below for the recommended configuration differences from above and note that both `log_statement` and `log_duration` options are commented out. See discussion on this topic [here][15]
    
-   This config will log all statements, but to optionally reduce the output to those which have a certain duration,
-   set the `log_min_duration_statement` value to the desired minimum ms:
+   This config logs all statements, but to reduce the output to those which have a certain duration, set the `log_min_duration_statement` value to the desired minimum duration (in milliseconds):
 
     ```conf
-      logging_collector = on
-      log_directory = 'pg_log'  # directory where log files are written,
-                                # can be absolute or relative to PGDATA
-      log_filename = 'pg.log'   #log file name, can include pattern
       log_min_duration_statement = 0    # -1 is disabled, 0 logs all statements
                                         # and their durations, > 0 logs only
                                         # statements running at least this number
                                         # of milliseconds
-      #log_statement = 'all'     #log all queries
-      log_line_prefix= '%m [%p] %d %a %u %h %c '
-      log_file_mode = 0644
-      ## For Windows
-      #log_destination = 'eventlog'
+      #log_statement = 'all'
+      #log_duration = on
     ```
 
 
@@ -152,15 +140,15 @@ a file with additional details specified in the log line prefix.
       logs_enabled: true
     ```
 
-3.  Add this configuration block to your `postgres.d/conf.yaml` file to start collecting your PostgreSQL logs:
+3.  Add and edit this configuration block to your `postgres.d/conf.yaml` file to start collecting your PostgreSQL logs:
 
     ```yaml
       logs:
           - type: file
-            path: </path/to/logfile>
+            path: <LOG_FILE_PATH>
             source: postgresql
             sourcecategory: database
-            service: <myapp>
+            service: <SERVICE_NAME>
             #To handle multi line that starts with yyyy-mm-dd use the following pattern
             #log_processing_rules:
             #  - type: multi_line
@@ -231,13 +219,15 @@ Additional helpful documentation, links, and articles:
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/postgres/images/postgresql_dashboard.png
 [2]: https://app.datadoghq.com/account/settings#agent
 [3]: https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/data/conf.yaml.example
-[4]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#start-stop-and-restart-the-agent
+[4]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [5]: https://docs.datadoghq.com/agent/autodiscovery/integrations/
 [6]: https://docs.datadoghq.com/agent/docker/log/
-[7]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
+[7]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [8]: https://github.com/DataDog/integrations-core/blob/master/postgres/metadata.csv
 [9]: https://docs.datadoghq.com/integrations/faq/postgres-custom-metric-collection-explained
 [10]: https://www.datadoghq.com/blog/100x-faster-postgres-performance-by-changing-1-line
 [11]: https://www.datadoghq.com/blog/postgresql-monitoring
 [12]: https://www.datadoghq.com/blog/postgresql-monitoring-tools
 [13]: https://www.datadoghq.com/blog/collect-postgresql-data-with-datadog
+[14]: https://www.postgresql.org/docs/11/runtime-config-logging.html
+[15]: https://www.postgresql.org/message-id/20100210180532.GA20138@depesz.com

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -103,9 +103,12 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 **Available for Agent >6.0**
 
-PostgreSQL default logging is to `stderr` and logs do not include detailed information. It is recommended to log into a file with additional details specified in the log line prefix.
+PostgreSQL default logging is to `stderr` and logs do not include detailed information. It is recommended to log into 
+a file with additional details specified in the log line prefix.
 
-1. Edit your PostgreSQL configuration file `/etc/postgresql/<version>/main/postgresql.conf` and uncomment the following parameter in the log section:
+1. Logging is configured within the file `/etc/postgresql/<version>/main/postgresql.conf`,
+   for regular log results including statement outputs uncomment the following parameters in the log
+   section:
 
     ```conf
       logging_collector = on
@@ -119,6 +122,30 @@ PostgreSQL default logging is to `stderr` and logs do not include detailed infor
       #log_destination = 'eventlog'
     ```
 
+2. To gather detailed duration metrics and make them searchable in the Datadog interface, they will need to be 
+   configured inline with the statement themselves.  See below for the recommended config, note that counterintuitively 
+   both `log_statement` and `log_duration` options are commented out.
+   
+   This config will log all statements, but to optionally reduce the output to those which have a certain duration,
+   set the `log_min_duration_statement` value to the desired minimum ms:
+
+    ```conf
+      logging_collector = on
+      log_directory = 'pg_log'  # directory where log files are written,
+                                # can be absolute or relative to PGDATA
+      log_filename = 'pg.log'   #log file name, can include pattern
+      log_min_duration_statement = 0    # -1 is disabled, 0 logs all statements
+                                        # and their durations, > 0 logs only
+                                        # statements running at least this number
+                                        # of milliseconds
+      #log_statement = 'all'     #log all queries
+      log_line_prefix= '%m [%p] %d %a %u %h %c '
+      log_file_mode = 0644
+      ## For Windows
+      #log_destination = 'eventlog'
+    ```
+
+
 2. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
     ```yaml
@@ -130,10 +157,10 @@ PostgreSQL default logging is to `stderr` and logs do not include detailed infor
     ```yaml
       logs:
           - type: file
-            path: /var/log/pg_log/pg.log
+            path: </path/to/logfile>
             source: postgresql
             sourcecategory: database
-            service: myapp
+            service: <myapp>
             #To handle multi line that starts with yyyy-mm-dd use the following pattern
             #log_processing_rules:
             #  - type: multi_line
@@ -204,10 +231,10 @@ Additional helpful documentation, links, and articles:
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/postgres/images/postgresql_dashboard.png
 [2]: https://app.datadoghq.com/account/settings#agent
 [3]: https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/data/conf.yaml.example
-[4]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
+[4]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#start-stop-and-restart-the-agent
 [5]: https://docs.datadoghq.com/agent/autodiscovery/integrations/
 [6]: https://docs.datadoghq.com/agent/docker/log/
-[7]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[7]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
 [8]: https://github.com/DataDog/integrations-core/blob/master/postgres/metadata.csv
 [9]: https://docs.datadoghq.com/integrations/faq/postgres-custom-metric-collection-explained
 [10]: https://www.datadoghq.com/blog/100x-faster-postgres-performance-by-changing-1-line


### PR DESCRIPTION
### What does this PR do?
Updates the postgres README to document how to log duration values for each query operation or how to only log slow performing query operations.

### Motivation
Assist users in identifying slow performing database operations.

### Additional Notes
This PR is documentation only, setting up output of logs currently requires manual configuration.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
