### PR TITLE
[Fix] Update Kube_apiserver_metrics annotations documentation

### DIFF
--- a/kube_apiserver_metrics/README.md
+++ b/kube_apiserver_metrics/README.md
@@ -28,8 +28,6 @@ Annotations:       ad.datadoghq.com/endpoints.check_names: ["kube_apiserver_metr
 ```
 Then the Datadog Cluster Agent schedules the check(s) for each endpoint onto Datadog Agent(s).
 
-Disclaimer: Your apiserver(s) need to run as pods, other methods (e.g. systemd unit) are not supported at the moment.
-
 You can also run the check by configuring the endpoints directly in the `kube_apiserver_metrics.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent’s configuration directory][4].
 See the [sample kube_apiserver_metrics.d/conf.yaml][2] for all available configuration options.
 

--- a/kube_apiserver_metrics/README.md
+++ b/kube_apiserver_metrics/README.md
@@ -16,18 +16,15 @@ The main use case to run the kube_apiserver_metrics check is as a Cluster Level 
 Refer to the dedicated documentation for [Cluster Level Checks][3].
 You can annotate the service of your apiserver with the following:
 ```
-Annotations:       ad.datadoghq.com/endpoint.check_names: ["kube_apiserver_metrics"]
-                   ad.datadoghq.com/endpoint.init_configs: [{}]
-                   ad.datadoghq.com/endpoint.instances:
+Annotations:       ad.datadoghq.com/endpoints.check_names: ["kube_apiserver_metrics"]
+                   ad.datadoghq.com/endpoints.init_configs: [{}]
+                   ad.datadoghq.com/endpoints.instances:
                      [
                        {
                          "prometheus_url": "https://%%host%%:%%port%%/metrics",
                          "bearer_token_auth": "true"
                        }
                      ]
-                   ad.datadoghq.com/service.check_names: [""]
-                   ad.datadoghq.com/service.init_configs: [{}]
-                   ad.datadoghq.com/service.instances: [{}]
 ```
 Then the Datadog Cluster Agent schedules the check(s) for each endpoint onto Datadog Agent(s).
 


### PR DESCRIPTION
# What does this PR do?

* fix typo in autodiscovery annotation: endpoint -> endpoints
* remove useless service autodiscovery annotations with cluster-agent >= 1.4.0

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
