### PR TITLE
Instance configuration retrieval bugfix

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -92,12 +92,20 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
             return self.config_map[endpoint]
 
         # Otherwise, we create the scraper configuration
-        config = self.create_scraper_configuration(instance)
+        mutated_instance = self.set_instance_defaults(instance)
+        config = self.create_scraper_configuration(mutated_instance)
 
         # Add this configuration to the config_map
         self.config_map[endpoint] = config
 
         return config
+
+    def set_instance_defaults(self, instance):
+        """
+        This method allows a child class to set default instance parameters
+        before the scraper configuration is created.
+        """
+        return instance
 
     def _finalize_tags_to_submit(self, _tags, metric_name, val, metric, custom_tags=None, hostname=None):
         """

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
@@ -47,6 +47,15 @@ def mock_get():
         yield
 
 
+@pytest.fixture()
+def mock_read_bearer_token():
+    with mock.patch(
+        'datadog_checks.checks.openmetrics.OpenMetricsBaseCheck._get_bearer_token',
+        return_value="XXX",
+    ):
+        yield
+
+
 class TestKubeAPIServerMetrics:
     """Basic Test for kube_apiserver integration."""
 
@@ -102,29 +111,28 @@ class TestKubeAPIServerMetrics:
         instanceSecure["bearer_token_path"] = temp_bearer_file
 
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, {}, [instanceSecure])
-        apiserver_instance = check._create_kube_apiserver_metrics_instance(instanceSecure)
-        configured_instance = check.get_scraper_config(apiserver_instance)
+        configured_instance = check.get_scraper_config(instanceSecure)
 
         os.remove(temp_bearer_file)
         assert configured_instance["_bearer_token"] == APISERVER_INSTANCE_BEARER_TOKEN
 
-    def test_default_config(self, aggregator):
+    def test_default_config(self, aggregator, mock_read_bearer_token):
         """
         Testing the default configuration.
         """
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, {}, [minimal_instance])
-        apiserver_instance = check._create_kube_apiserver_metrics_instance(minimal_instance)
+        apiserver_instance = check.get_scraper_config(minimal_instance)
 
         assert not apiserver_instance["ssl_verify"]
         assert apiserver_instance["bearer_token_auth"]
         assert apiserver_instance["prometheus_url"] == "https://localhost:443/metrics"
 
-    def test_default_config_legacy(self, aggregator):
+    def test_default_config_legacy(self, aggregator, mock_read_bearer_token):
         """
         Testing the default configuration.
         """
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, {}, [minimal_instance_legacy])
-        apiserver_instance = check._create_kube_apiserver_metrics_instance(minimal_instance_legacy)
+        apiserver_instance = check.get_scraper_config(minimal_instance_legacy)
 
         assert not apiserver_instance["ssl_verify"]
         assert apiserver_instance["bearer_token_auth"]

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
@@ -50,8 +50,7 @@ def mock_get():
 @pytest.fixture()
 def mock_read_bearer_token():
     with mock.patch(
-        'datadog_checks.checks.openmetrics.OpenMetricsBaseCheck._get_bearer_token',
-        return_value="XXX",
+        'datadog_checks.checks.openmetrics.OpenMetricsBaseCheck._get_bearer_token', return_value="XXX",
     ):
         yield
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This fixes an issue when the kube_apiserver_metrics checks attempts to retrieve the scraper configuration for the current instance. Until now that check relied on a cache miss in the config map used to store scraper configurations to populate a new configuration from a slightly modified instance config, with default instance parameters specific to the check. With the endpoint parameter now accepting an actual URL, that cache miss would not happen and those custom defaults would not be set. This could cause a TLS verification failure depending on the check configuration.

### Motivation
<!-- What inspired you to submit this pull request? -->
Bug found in a release candidate of 7.16.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
