### PR TITLE
Add ability to exclude specific host tags from host metadata

### DIFF
--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -135,6 +135,12 @@ instances:
     #
     # use_guest_hostname: false
 
+    ## @param excluded_host_tags - list of strings - optional - default: []
+    ## List of host tags keys to exclude from host metadata collection.
+    ## Overrides the same parameter specified in init_config.
+    #
+    # excluded_host_tags: []
+
     ## @param event_config - dictionary - optional
     ## Event config is a dictionary
     ## For now the only switch you can flip is collect_vcenter_alarms

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -37,6 +37,11 @@ init_config:
   #
   # refresh_metrics_metadata_interval: 600
 
+  ## @param excluded_host_tags - list of strings - optional - default: []
+  ## List of host tags keys to exclude from host metadata collection
+  #
+  # excluded_host_tags: []
+
 ## Define your list of instances here each item is a
 ## vCenter instance you want to connect to and fetch metrics from
 

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -119,6 +119,9 @@ class VSphereCheck(AgentCheck):
         # Event configuration
         self.event_config = {}
 
+        # Host tags exclusion
+        self.excluded_host_tags = instances[0].get("excluded_host_tags", init_config.get("excluded_host_tags", []))
+
         # Caching configuration
         self.cache_config = CacheConfig()
 
@@ -365,7 +368,16 @@ class VSphereCheck(AgentCheck):
                 # Note: some mors have a None hostname
                 hostname = mor.get('hostname')
                 if hostname:
-                    external_host_tags.append((hostname, {SOURCE_TYPE: mor.get('tags')}))
+                    external_host_tags.append(
+                        (
+                            hostname,
+                            {
+                                SOURCE_TYPE: [
+                                    t for t in mor.get('tags') if t.split(":", 1)[0] not in self.excluded_host_tags
+                                ]
+                            },
+                        )
+                    )
 
         return external_host_tags
 

--- a/vsphere/tests/test_vsphere.py
+++ b/vsphere/tests/test_vsphere.py
@@ -52,6 +52,51 @@ def test__init__(instance):
     assert not check.latest_event_query
     assert check.batch_collector_size == 0
     assert check.batch_morlist_size == 50
+    assert check.excluded_host_tags == []
+
+
+def test_excluded_host_tags(vsphere, instance, aggregator):
+    # Check default value and precedence of instance config over init config
+    check = VSphereCheck('vsphere', {}, {}, [instance])
+    assert check.excluded_host_tags == []
+    check = VSphereCheck('vsphere', {"excluded_host_tags": ["vsphere_host"]}, {}, [instance])
+    assert check.excluded_host_tags == ["vsphere_host"]
+    instance["excluded_host_tags"] = []
+    check = VSphereCheck('vsphere', {"excluded_host_tags": ["vsphere_host"]}, {}, [instance])
+    assert check.excluded_host_tags == []
+
+    # Test host tags are excluded from external host metadata, but still stored in the cache for metrics
+    vsphere.excluded_host_tags = ["vsphere_host"]
+    mocked_vm = MockedMOR(spec="VirtualMachine")
+    mocked_host = MockedMOR(spec="HostSystem")
+    mocked_mors_attrs = {
+        mocked_vm: {
+            "name": "mocked_vm",
+            "parent": mocked_host,
+            "runtime.powerState": vim.VirtualMachinePowerState.poweredOn,
+        },
+        mocked_host: {"name": "mocked_host", "parent": None},
+    }
+
+    with mock.patch("datadog_checks.vsphere.VSphereCheck._collect_mors_and_attributes", return_value=mocked_mors_attrs):
+        vsphere.check(instance)
+        ext_host_tags = vsphere.get_external_host_tags()
+
+        # vsphere_host tag not in external metadata
+        for host, source_tags in ext_host_tags:
+            if host == u"mocked_vm":
+                tags = source_tags["vsphere"]
+                for tag in tags:
+                    assert "vsphere_host:" not in tag
+                break
+
+        # vsphere_host tag still in cache for sending with metrics
+        cached_vm = vsphere.mor_cache.get_mor("vsphere_mock", str(mocked_vm))
+        for tag in cached_vm["tags"]:
+            if "vsphere_host:" in tag:
+                break
+        else:
+            raise AssertionError("tag vsphere_host not found in " + str(cached_vm["tags"]))
 
 
 def test__is_excluded():


### PR DESCRIPTION
### What does this PR do?

Add an option to disable sending some host tags in the external hosts metadata payload.

### Motivation

Some tags can trigger context churns on non vsphere metrics (in case of vm migrations for instance with the host tag `vsphere_host` changing) which can have unwanted impact such as short spikes in dashboards graphs while the old context is still alive.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
