### PR TITLE
[Alternative Fix] Fix scrapper config cache issue

### DIFF
--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
@@ -62,13 +62,17 @@ class KubeAPIServerMetricsCheck(OpenMetricsBaseCheck):
 
     def check(self, instance):
         if self.kube_apiserver_config is None:
-            kube_apiserver_config = self._create_kube_apiserver_metrics_instance(instance)
-            self.kube_apiserver_config = self.get_scraper_config(kube_apiserver_config)
+            self.kube_apiserver_config = self.get_scraper_config(instance)
 
         if not self.kube_apiserver_config['metrics_mapper']:
             url = self.kube_apiserver_config['prometheus_url']
             raise CheckException("You have to collect at least one metric from the endpoint: {}".format(url))
         self.process(self.kube_apiserver_config, metric_transformers=self.metric_transformers)
+
+    def get_scraper_config(self, instance):
+        # Change config before it's cached by parent get_scraper_config
+        config = self._create_kube_apiserver_metrics_instance(instance)
+        return super(KubeAPIServerMetricsCheck, self).get_scraper_config(config)
 
     def _create_kube_apiserver_metrics_instance(self, instance):
         """

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
@@ -133,7 +133,7 @@ class TestKubeAPIServerMetrics:
 
     def test_default_config_legacy(self, aggregator, mock_read_bearer_token):
         """
-        Testing the default configuration.
+         Testing the default legacy configuration.
         """
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, {}, [minimal_instance_legacy])
         check.process = mock.MagicMock()

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
@@ -47,6 +47,14 @@ def mock_get():
         yield
 
 
+@pytest.fixture()
+def mock_read_bearer_token():
+    with mock.patch(
+        'datadog_checks.checks.openmetrics.OpenMetricsBaseCheck._get_bearer_token', return_value="XXX",
+    ):
+        yield
+
+
 class TestKubeAPIServerMetrics:
     """Basic Test for kube_apiserver integration."""
 
@@ -108,23 +116,23 @@ class TestKubeAPIServerMetrics:
         os.remove(temp_bearer_file)
         assert configured_instance["_bearer_token"] == APISERVER_INSTANCE_BEARER_TOKEN
 
-    def test_default_config(self, aggregator):
+    def test_default_config(self, aggregator, mock_read_bearer_token):
         """
         Testing the default configuration.
         """
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, {}, [minimal_instance])
-        apiserver_instance = check._create_kube_apiserver_metrics_instance(minimal_instance)
+        apiserver_instance = check.get_scraper_config(minimal_instance)
 
         assert not apiserver_instance["ssl_verify"]
         assert apiserver_instance["bearer_token_auth"]
         assert apiserver_instance["prometheus_url"] == "https://localhost:443/metrics"
 
-    def test_default_config_legacy(self, aggregator):
+    def test_default_config_legacy(self, aggregator, mock_read_bearer_token):
         """
         Testing the default configuration.
         """
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, {}, [minimal_instance_legacy])
-        apiserver_instance = check._create_kube_apiserver_metrics_instance(minimal_instance_legacy)
+        apiserver_instance = check.get_scraper_config(minimal_instance_legacy)
 
         assert not apiserver_instance["ssl_verify"]
         assert apiserver_instance["bearer_token_auth"]

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
@@ -137,7 +137,7 @@ class TestKubeAPIServerMetrics:
         """
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, {}, [minimal_instance_legacy])
         check.process = mock.MagicMock()
-        check.check(minimal_instance)
+        check.check(minimal_instance_legacy)
 
         apiserver_instance = check.kube_apiserver_config
 

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
@@ -121,7 +121,11 @@ class TestKubeAPIServerMetrics:
         Testing the default configuration.
         """
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, {}, [minimal_instance])
-        apiserver_instance = check.get_scraper_config(minimal_instance)
+
+        check.process = mock.MagicMock()
+        check.check(minimal_instance)
+
+        apiserver_instance = check.kube_apiserver_config
 
         assert not apiserver_instance["ssl_verify"]
         assert apiserver_instance["bearer_token_auth"]
@@ -132,7 +136,10 @@ class TestKubeAPIServerMetrics:
         Testing the default configuration.
         """
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, {}, [minimal_instance_legacy])
-        apiserver_instance = check.get_scraper_config(minimal_instance_legacy)
+        check.process = mock.MagicMock()
+        check.check(minimal_instance)
+
+        apiserver_instance = check.kube_apiserver_config
 
         assert not apiserver_instance["ssl_verify"]
         assert apiserver_instance["bearer_token_auth"]

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
@@ -133,7 +133,7 @@ class TestKubeAPIServerMetrics:
 
     def test_default_config_legacy(self, aggregator, mock_read_bearer_token):
         """
-         Testing the default legacy configuration.
+        Testing the default legacy configuration.
         """
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, {}, [minimal_instance_legacy])
         check.process = mock.MagicMock()


### PR DESCRIPTION
Alternative fix to: https://github.com/DataDog/integrations-core/pull/5200

### What does this PR do?

This fixes an issue when the kube_apiserver_metrics checks attempts to retrieve the scraper configuration for the current instance. Until now that check relied on a cache miss in the config map used to store scraper configurations to populate a new configuration from a slightly modified instance config, with default instance parameters specific to the check. With the endpoint parameter now accepting an actual URL, that cache miss would not happen and those custom defaults would not be set. This could cause a TLS verification failure depending on the check configuration.

### Motivation

Bug found in a release candidate of 7.16.