### PR TITLE
Add test environment for activemq

### DIFF
--- a/.azure-pipelines/scripts/activemq/linux/50_increase_docker_memory.sh
+++ b/.azure-pipelines/scripts/activemq/linux/50_increase_docker_memory.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ex
+
+# Allocate 2GB for activemq
+# The default number of memory addresses is 65536, i.e. 512MB (Linux 64-bit).
+# => To get 2GB, we multiply that amount by 4.
+sudo sysctl -w vm.max_map_count=$(expr 4 \* 65536)
+
+set +ex

--- a/.azure-pipelines/scripts/activemq/linux/50_increase_docker_memory.sh
+++ b/.azure-pipelines/scripts/activemq/linux/50_increase_docker_memory.sh
@@ -2,9 +2,9 @@
 
 set -ex
 
-# Allocate 2GB for activemq
+# Allocate 3GB for activemq
 # The default number of memory addresses is 65536, i.e. 512MB (Linux 64-bit).
-# => To get 2GB, we multiply that amount by 4.
-sudo sysctl -w vm.max_map_count=$(expr 4 \* 65536)
+# => To get 3GB, we multiply that amount by 6.
+sudo sysctl -w vm.max_map_count=$(expr 6 \* 65536)
 
 set +ex

--- a/activemq/README.md
+++ b/activemq/README.md
@@ -24,7 +24,7 @@ The check collects metrics via JMX, so you need a JVM on each node so the Agent 
       ```yaml
       instances:
         - host: localhost
-          port: 7199
+          port: 1616
           user: username
           password: password
           name: activemq_instance

--- a/activemq/datadog_checks/activemq/data/conf.yaml.example
+++ b/activemq/datadog_checks/activemq/data/conf.yaml.example
@@ -13,7 +13,7 @@ instances:
     ## @param port - integer - required
     ## ActiveMQ port to connect to.
     #
-    port: 1099
+    port: 1616
 
     ## @param auth_type - string - optional
     ## The type of authentication to use.

--- a/activemq/requirements-dev.txt
+++ b/activemq/requirements-dev.txt
@@ -1,0 +1,1 @@
+-e ../datadog_checks_dev

--- a/activemq/setup.py
+++ b/activemq/setup.py
@@ -1,9 +1,10 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from setuptools import setup
 from codecs import open  # To use a consistent encoding
 from os import path
+
+from setuptools import setup
 
 HERE = path.dirname(path.abspath(__file__))
 
@@ -30,17 +31,13 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     keywords='datadog agent activemq check',
-
     # The project's main homepage.
     url='https://github.com/DataDog/integrations-core',
-
     # Author details
     author='Datadog',
     author_email='packages@datadoghq.com',
-
     # License
     license='BSD',
-
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -51,13 +48,10 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
     ],
-
     # The package we're going to ship
     packages=['datadog_checks.activemq'],
-
     # Run-time dependencies
     install_requires=['datadog_checks_base'],
-
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/activemq/tests/__init__.py
+++ b/activemq/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)

--- a/activemq/tests/__init__.py
+++ b/activemq/tests/__init__.py
@@ -1,3 +1,3 @@
 # (C) Datadog, Inc. 2019
 # All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/activemq/tests/common.py
+++ b/activemq/tests/common.py
@@ -1,6 +1,6 @@
 # (C) Datadog, Inc. 2019
 # All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
+# Licensed under a 3-clause BSD style license (see LICENSE)
 from datadog_checks.dev import get_docker_hostname, get_here
 
 CHECK_NAME = 'activemq'

--- a/activemq/tests/common.py
+++ b/activemq/tests/common.py
@@ -13,7 +13,7 @@ TEST_TOPICS = ('FOO_TOPIC', 'TEST_TOPIC')
 TEST_MESSAGE = {'body': 'test_message'}
 TEST_AUTH = ('admin', 'admin')
 
-BASE_URL = 'http://localhost:8161/api/message'
+BASE_URL = 'http://{}:8161/api/message'.format(HOST)
 
 ACTIVEMQ_METRICS = [
     "activemq.queue.avg_enqueue_time",

--- a/activemq/tests/common.py
+++ b/activemq/tests/common.py
@@ -15,7 +15,14 @@ TEST_AUTH = ('admin', 'admin')
 
 BASE_URL = 'http://{}:8161/api/message'.format(HOST)
 
-ACTIVEMQ_METRICS = [
+# not all metrics will be available in our E2E environment, specifically:
+# "activemq.queue.dequeue_count",
+# "activemq.queue.dispatch_count",
+# "activemq.queue.enqueue_count",
+# "activemq.queue.expired_count",
+# "activemq.queue.in_flight_count",
+
+ACTIVEMQ_E2E_METRICS = [
     "activemq.queue.avg_enqueue_time",
     "activemq.queue.consumer_count",
     "activemq.queue.producer_count",
@@ -23,11 +30,6 @@ ACTIVEMQ_METRICS = [
     "activemq.queue.min_enqueue_time",
     "activemq.queue.memory_pct",
     "activemq.queue.size",
-    "activemq.queue.dequeue_count",
-    "activemq.queue.dispatch_count",
-    "activemq.queue.enqueue_count",
-    "activemq.queue.expired_count",
-    "activemq.queue.in_flight_count",
     "activemq.broker.store_pct",
     "activemq.broker.temp_pct",
     "activemq.broker.memory_pct",

--- a/activemq/tests/common.py
+++ b/activemq/tests/common.py
@@ -13,7 +13,8 @@ TEST_TOPICS = ('FOO_TOPIC', 'TEST_TOPIC')
 TEST_MESSAGE = {'body': 'test_message'}
 TEST_AUTH = ('admin', 'admin')
 
-BASE_URL = 'http://{}:8161/api/message'.format(HOST)
+TEST_PORT = 8161
+BASE_URL = 'http://{}:{}/api/message'.format(HOST, TEST_PORT)
 
 # not all metrics will be available in our E2E environment, specifically:
 # "activemq.queue.dequeue_count",

--- a/activemq/tests/common.py
+++ b/activemq/tests/common.py
@@ -7,3 +7,28 @@ CHECK_NAME = 'activemq'
 
 HERE = get_here()
 HOST = get_docker_hostname()
+
+TEST_QUEUES = ('FOO_QUEUE', 'TEST_QUEUE')
+TEST_TOPICS = ('FOO_TOPIC', 'TEST_TOPIC')
+TEST_MESSAGE = {'body': 'test_message'}
+TEST_AUTH = ('admin', 'admin')
+
+BASE_URL = 'http://localhost:8161/api/message'
+
+ACTIVEMQ_METRICS = [
+    "activemq.queue.avg_enqueue_time",
+    "activemq.queue.consumer_count",
+    "activemq.queue.producer_count",
+    "activemq.queue.max_enqueue_time",
+    "activemq.queue.min_enqueue_time",
+    "activemq.queue.memory_pct",
+    "activemq.queue.size",
+    "activemq.queue.dequeue_count",
+    "activemq.queue.dispatch_count",
+    "activemq.queue.enqueue_count",
+    "activemq.queue.expired_count",
+    "activemq.queue.in_flight_count",
+    "activemq.broker.store_pct",
+    "activemq.broker.temp_pct",
+    "activemq.broker.memory_pct",
+]

--- a/activemq/tests/common.py
+++ b/activemq/tests/common.py
@@ -1,0 +1,9 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+from datadog_checks.dev import get_docker_hostname, get_here
+
+CHECK_NAME = 'activemq'
+
+HERE = get_here()
+HOST = get_docker_hostname()

--- a/activemq/tests/compose/docker-compose.yaml
+++ b/activemq/tests/compose/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  namenode:
+    image: rmohr/activemq:${ACTIVEMQ_VERSION}
+    container_name: dd-test-activemq-server
+    environment:
+      ACTIVEMQ_SUNJMX_START: "-Dcom.sun.management.jmxremote.port=1616 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+    ports:
+      - "61616:61616"
+      - "8161:8161"
+      - "1616:1616"

--- a/activemq/tests/conftest.py
+++ b/activemq/tests/conftest.py
@@ -10,14 +10,7 @@ import requests
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.utils import load_jmx_config
 
-from .common import HERE
-
-TEST_QUEUES = ('FOO_QUEUE', 'TEST_QUEUE')
-TEST_TOPICS = ('FOO_TOPIC', 'TEST_TOPIC')
-TEST_MESSAGE = {'body': 'test_message'}
-TEST_AUTH = ('admin', 'admin')
-
-BASE_URL = 'http://localhost:8161/api/message'
+from .common import BASE_URL, HERE, TEST_AUTH, TEST_MESSAGE, TEST_QUEUES, TEST_TOPICS
 
 
 def populate_server():
@@ -36,7 +29,7 @@ def dd_environment():
     with docker_run(
         os.path.join(HERE, 'compose', 'docker-compose.yaml'),
         log_patterns=['ActiveMQ Jolokia REST API available'],
+        conditions=[populate_server],
         sleep=2,
     ):
-        populate_server()
         yield load_jmx_config(), {'use_jmx': True}

--- a/activemq/tests/conftest.py
+++ b/activemq/tests/conftest.py
@@ -8,7 +8,7 @@ import time
 import pytest
 import requests
 
-from datadog_checks.dev import docker_run, run_command
+from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import WaitForPortListening
 from datadog_checks.dev.utils import load_jmx_config
 

--- a/activemq/tests/conftest.py
+++ b/activemq/tests/conftest.py
@@ -8,9 +8,10 @@ import pytest
 import requests
 
 from datadog_checks.dev import docker_run
+from datadog_checks.dev.conditions import WaitForPortListening
 from datadog_checks.dev.utils import load_jmx_config
 
-from .common import BASE_URL, HERE, TEST_AUTH, TEST_MESSAGE, TEST_QUEUES, TEST_TOPICS
+from .common import BASE_URL, HOST, TEST_PORT, HERE, TEST_AUTH, TEST_MESSAGE, TEST_QUEUES, TEST_TOPICS
 
 
 def populate_server():
@@ -29,7 +30,9 @@ def dd_environment():
     with docker_run(
         os.path.join(HERE, 'compose', 'docker-compose.yaml'),
         log_patterns=['ActiveMQ Jolokia REST API available'],
-        conditions=[populate_server],
-        sleep=2,
+        conditions=[
+            WaitForPortListening(HOST, TEST_PORT),
+            populate_server
+        ],
     ):
         yield load_jmx_config(), {'use_jmx': True}

--- a/activemq/tests/conftest.py
+++ b/activemq/tests/conftest.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import os
+import time
 
 import pytest
 import requests
@@ -16,9 +17,8 @@ from .common import BASE_URL, HERE, HOST, TEST_AUTH, TEST_MESSAGE, TEST_PORT, TE
 
 def populate_server():
     """Add some queues and topics to ensure more metrics are available."""
-    out = run_command('docker logs dd-test-activemq-server', capture='both')
-    print(HOST, BASE_URL)
-    print(out)
+    time.sleep(3)
+
     for queue in TEST_QUEUES:
         url = '{}/{}?type=queue'.format(BASE_URL, queue)
         requests.post(url, data=TEST_MESSAGE, auth=TEST_AUTH)

--- a/activemq/tests/conftest.py
+++ b/activemq/tests/conftest.py
@@ -7,7 +7,7 @@ import os
 import pytest
 import requests
 
-from datadog_checks.dev import docker_run
+from datadog_checks.dev import docker_run, run_command
 from datadog_checks.dev.conditions import WaitForPortListening
 from datadog_checks.dev.utils import load_jmx_config
 
@@ -16,6 +16,9 @@ from .common import BASE_URL, HERE, HOST, TEST_AUTH, TEST_MESSAGE, TEST_PORT, TE
 
 def populate_server():
     """Add some queues and topics to ensure more metrics are available."""
+    out = run_command('docker logs dd-test-activemq-server', capture='both')
+    print(HOST, BASE_URL)
+    print(out)
     for queue in TEST_QUEUES:
         url = '{}/{}?type=queue'.format(BASE_URL, queue)
         requests.post(url, data=TEST_MESSAGE, auth=TEST_AUTH)

--- a/activemq/tests/conftest.py
+++ b/activemq/tests/conftest.py
@@ -1,0 +1,42 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import os
+
+import pytest
+import requests
+
+from datadog_checks.dev import docker_run
+from datadog_checks.dev.utils import load_jmx_config
+
+from .common import HERE
+
+TEST_QUEUES = ('FOO_QUEUE', 'TEST_QUEUE')
+TEST_TOPICS = ('FOO_TOPIC', 'TEST_TOPIC')
+TEST_MESSAGE = {'body': 'test_message'}
+TEST_AUTH = ('admin', 'admin')
+
+BASE_URL = 'http://localhost:8161/api/message'
+
+
+def populate_server():
+    """Add some queues and topics to ensure more metrics are available."""
+    for queue in TEST_QUEUES:
+        url = '{}/{}?type=queue'.format(BASE_URL, queue)
+        requests.post(url, data=TEST_MESSAGE, auth=TEST_AUTH)
+
+    for topic in TEST_TOPICS:
+        url = '{}/{}?type=topic'.format(BASE_URL, topic)
+        requests.post(url, data=TEST_MESSAGE, auth=TEST_AUTH)
+
+
+@pytest.fixture(scope="session")
+def dd_environment():
+    with docker_run(
+        os.path.join(HERE, 'compose', 'docker-compose.yaml'),
+        log_patterns=['ActiveMQ Jolokia REST API available'],
+        sleep=2,
+    ):
+        populate_server()
+        yield load_jmx_config(), {'use_jmx': True}

--- a/activemq/tests/conftest.py
+++ b/activemq/tests/conftest.py
@@ -11,7 +11,7 @@ from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import WaitForPortListening
 from datadog_checks.dev.utils import load_jmx_config
 
-from .common import BASE_URL, HOST, TEST_PORT, HERE, TEST_AUTH, TEST_MESSAGE, TEST_QUEUES, TEST_TOPICS
+from .common import BASE_URL, HERE, HOST, TEST_AUTH, TEST_MESSAGE, TEST_PORT, TEST_QUEUES, TEST_TOPICS
 
 
 def populate_server():
@@ -30,9 +30,6 @@ def dd_environment():
     with docker_run(
         os.path.join(HERE, 'compose', 'docker-compose.yaml'),
         log_patterns=['ActiveMQ Jolokia REST API available'],
-        conditions=[
-            WaitForPortListening(HOST, TEST_PORT),
-            populate_server
-        ],
+        conditions=[WaitForPortListening(HOST, TEST_PORT), populate_server],
     ):
         yield load_jmx_config(), {'use_jmx': True}

--- a/activemq/tests/test_check.py
+++ b/activemq/tests/test_check.py
@@ -1,6 +1,6 @@
 # (C) Datadog, Inc. 2019
 # All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
+# Licensed under a 3-clause BSD style license (see LICENSE)
 
 import pytest
 

--- a/activemq/tests/test_check.py
+++ b/activemq/tests/test_check.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from .common import ACTIVEMQ_METRICS
+from .common import ACTIVEMQ_E2E_METRICS
 
 
 @pytest.mark.e2e
@@ -12,5 +12,5 @@ def test(dd_agent_check):
     instance = {}
     aggregator = dd_agent_check(instance)
 
-    for metric in ACTIVEMQ_METRICS:
+    for metric in ACTIVEMQ_E2E_METRICS:
         aggregator.assert_metric(metric)

--- a/activemq/tests/test_check.py
+++ b/activemq/tests/test_check.py
@@ -1,0 +1,30 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+import pytest
+
+
+@pytest.mark.e2e
+def test(dd_agent_check):
+    instance = {}
+    aggregator = dd_agent_check(instance)
+    metrics = [
+        "activemq.queue.avg_enqueue_time",
+        "activemq.queue.consumer_count",
+        "activemq.queue.producer_count",
+        "activemq.queue.max_enqueue_time",
+        "activemq.queue.min_enqueue_time",
+        "activemq.queue.memory_pct",
+        "activemq.queue.size",
+        "activemq.queue.dequeue_count",
+        "activemq.queue.dispatch_count",
+        "activemq.queue.enqueue_count",
+        "activemq.queue.expired_count",
+        "activemq.queue.in_flight_count",
+        "activemq.broker.store_pct",
+        "activemq.broker.temp_pct",
+        "activemq.broker.memory_pct",
+    ]
+    for metric in metrics:
+        aggregator.assert_metric(metric)

--- a/activemq/tests/test_check.py
+++ b/activemq/tests/test_check.py
@@ -4,27 +4,13 @@
 
 import pytest
 
+from .common import ACTIVEMQ_METRICS
+
 
 @pytest.mark.e2e
 def test(dd_agent_check):
     instance = {}
     aggregator = dd_agent_check(instance)
-    metrics = [
-        "activemq.queue.avg_enqueue_time",
-        "activemq.queue.consumer_count",
-        "activemq.queue.producer_count",
-        "activemq.queue.max_enqueue_time",
-        "activemq.queue.min_enqueue_time",
-        "activemq.queue.memory_pct",
-        "activemq.queue.size",
-        "activemq.queue.dequeue_count",
-        "activemq.queue.dispatch_count",
-        "activemq.queue.enqueue_count",
-        "activemq.queue.expired_count",
-        "activemq.queue.in_flight_count",
-        "activemq.broker.store_pct",
-        "activemq.broker.temp_pct",
-        "activemq.broker.memory_pct",
-    ]
-    for metric in metrics:
+
+    for metric in ACTIVEMQ_METRICS:
         aggregator.assert_metric(metric)

--- a/activemq/tox.ini
+++ b/activemq/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+minversion = 2.0
+skip_missing_interpreters = true
+basepython = py37
+envlist =
+    py37
+
+[testenv]
+description =
+    py37: e2e ready
+usedevelop = true
+dd_check_style = true
+platform = linux|darwin|win32
+deps =
+    -e../datadog_checks_base[deps]
+    -rrequirements-dev.txt
+passenv =
+    DOCKER*
+    COMPOSE*
+setenv = ACTIVEMQ_VERSION=5.15.9
+commands =
+    pytest -v {posargs}

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -177,9 +177,9 @@ def dd_agent_check(request, aggregator):
                     break
             else:
                 raise ValueError(
-                    '{}{}\nCould parse JSON from the output'.format(result.stdout,
-                                                                    result.stderr,
-                                                                    AGENT_COLLECTOR_SEPARATOR)
+                    '{}{}\nCould parse JSON from the output'.format(
+                        result.stdout, result.stderr, AGENT_COLLECTOR_SEPARATOR
+                    )
                 )
 
         collector = json.loads(collector_output)

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -177,7 +177,9 @@ def dd_agent_check(request, aggregator):
                     break
             else:
                 raise ValueError(
-                    '{}{}\nCould parse JSON from the output'.format(result.stdout, result.stderr, AGENT_COLLECTOR_SEPARATOR)
+                    '{}{}\nCould parse JSON from the output'.format(result.stdout,
+                                                                    result.stderr,
+                                                                    AGENT_COLLECTOR_SEPARATOR)
                 )
 
         collector = json.loads(collector_output)

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -166,22 +166,9 @@ def dd_agent_check(request, aggregator):
 
         _, _, collector_output = result.stdout.partition(AGENT_COLLECTOR_SEPARATOR)
         collector_output = collector_output.strip()
-
-        if not collector_output.endswith('} ]'):
+        if not collector_output.endswith(']'):
             # JMX needs some additional cleanup
-            # There can be extra text and log file output after JSON contents
-            lines = collector_output.splitlines()
-            for i, line in enumerate(lines[::-1]):
-                if line.startswith('} ]'):
-                    collector_output = '\n'.join(lines[:-i])
-                    break
-            else:
-                raise ValueError(
-                    '{}{}\nCould parse JSON from the output'.format(
-                        result.stdout, result.stderr, AGENT_COLLECTOR_SEPARATOR
-                    )
-                )
-
+            collector_output = collector_output[: collector_output.rfind(']') + 1]
         collector = json.loads(collector_output)
 
         replay_check_run(collector, aggregator)


### PR DESCRIPTION
### What does this PR do?
In preparation for creating a native dashboard for ActiveMQ, this PR provides a basic E2E environment where JMX metrics can be extracted.

### Additional Notes
Once the env has been started via `ddev env start activemq py37`, you can access the admin interface at the following url:  http://localhost:8161/admin/

From there, you can add new queues or topics, then run `ddev env check activemq py37` and see updated metrics in the output.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
