### PR TITLE
Fix http url for collect version

### DIFF
--- a/haproxy/datadog_checks/haproxy/haproxy.py
+++ b/haproxy/datadog_checks/haproxy/haproxy.py
@@ -107,8 +107,9 @@ class HAProxy(AgentCheck):
             info, data = self._fetch_socket_data(parsed_url)
             self._collect_version_from_socket(info)
         else:
-            self._collect_version_from_http(url)
-            data = self._fetch_url_data(url)
+            http_url = "%s%s" % (url, STATS_URL)
+            self._collect_version_from_http(http_url)
+            data = self._fetch_url_data(http_url)
 
         collect_aggregates_only = instance.get('collect_aggregates_only', True)
         collect_status_metrics = is_affirmative(instance.get('collect_status_metrics', False))
@@ -157,7 +158,6 @@ class HAProxy(AgentCheck):
     def _fetch_url_data(self, url):
         ''' Hit a given http url and return the stats lines '''
         # Try to fetch data from the stats URL
-        url = "%s%s" % (url, STATS_URL)
 
         self.log.debug("Fetching haproxy stats from url: %s" % url)
 


### PR DESCRIPTION
### What does this PR do?
Use the same url (with the `;csv;norefresh` parameter) for fetching version and stats for haproxy.

### Motivation
When scraping haproxy http stats, the agent will append `/;csv;norefresh` to the url.
However, https://github.com/DataDog/integrations-core/pull/4851 introduced a second call to the stats page without the `/;csv;norefresh`. 
This will break scrapping when haproxy's ACL are configured to match the url with the appended parameters (like `acl haproxy_stats url_end -i /stats/;csv;norefresh `)
Additionally, it creates an additional call to the stats page which can be non negligible on infrastructure with 500+ servers.  

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
