### PR TITLE
Report maxclients

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -28,6 +28,10 @@ class Redis(AgentCheck):
 
     SOURCE_TYPE_NAME = 'redis'
 
+    CONFIG_GAUGE_KEYS = {
+        'maxclients': 'redis.net.maxclients',
+    }
+
     GAUGE_KEYS = {
         # Active defrag metrics
         'active_defrag_running': 'redis.active_defrag.running',
@@ -183,6 +187,7 @@ class Redis(AgentCheck):
             latency_ms = round_value((time.time() - start) * 1000, 2)
             tags = sorted(tags + ["redis_role:%s" % info["role"]])
             self.gauge('redis.info.latency_ms', latency_ms, tags=tags)
+            config = conn.config_get("maxclients")
             status = AgentCheck.OK
             self.service_check('redis.can_connect', status, tags=tags)
             self._collect_metadata(info)
@@ -225,6 +230,11 @@ class Redis(AgentCheck):
                 self.gauge(self.GAUGE_KEYS[info_name], info[info_name], tags=tags)
             elif info_name in self.RATE_KEYS:
                 self.rate(self.RATE_KEYS[info_name], info[info_name], tags=tags)
+
+        for config_key, value in iteritems(config):
+            metric_name = self.CONFIG_GAUGE_KEYS.get(config_key)
+            if metric_name is not None:
+                self.gauge(metric_name, value, tags=tags)
 
         # Save the number of commands.
         self.rate('redis.net.commands', info['total_commands_processed'], tags=tags)

--- a/redisdb/metadata.csv
+++ b/redisdb/metadata.csv
@@ -35,6 +35,7 @@ redis.net.commands,gauge,,command,,The number of commands processed by the serve
 redis.net.commands.instantaneous_ops_per_sec,gauge,,command,second,The number of commands processed by the server per second.,0,redis,net commands
 redis.net.rejected,gauge,,connection,,The number of rejected connections.,-1,redis,net rejected
 redis.net.slaves,gauge,,connection,,The number of connected slaves.,0,redis,slaves
+redis.net.maxclients,gauge,,connection,,The maximum number of connected clients.,0,redis,maxclients
 redis.perf.latest_fork_usec,gauge,,microsecond,,The duration of the latest fork.,-1,redis,latest fork usec
 redis.persist,gauge,,key,,The number of keys persisted (redis.keys - redis.expires).,0,redis,persist
 redis.persist.percent,gauge,,percent,,Percentage of total keys that are persisted.,0,redis,persist pct

--- a/redisdb/tests/test_default.py
+++ b/redisdb/tests/test_default.py
@@ -50,6 +50,8 @@ def test_redis_default(aggregator, redis_auth, redis_instance):
 
     aggregator.assert_metric('redis.key.length', 3, count=1, tags=expected_db + ['key:test_list', 'key_type:list'])
 
+    aggregator.assert_metric('redis.net.maxclients')
+
     # in the old tests these was explicitly asserted, keeping it like that
     assert 'redis.net.commands' in aggregator.metric_names
     version = db.info().get('redis_version')

--- a/redisdb/tests/test_e2e.py
+++ b/redisdb/tests/test_e2e.py
@@ -30,6 +30,7 @@ def assert_common_metrics(aggregator):
     aggregator.assert_metric('redis.perf.latest_fork_usec', count=2, tags=tags)
     aggregator.assert_metric('redis.keys.evicted', count=2, tags=tags)
     aggregator.assert_metric('redis.net.slaves', count=2, tags=tags)
+    aggregator.assert_metric('redis.net.maxclients', count=2, tags=tags)
     aggregator.assert_metric('redis.clients.blocked', count=2, tags=tags)
     aggregator.assert_metric('redis.stats.keyspace_misses', count=1, tags=tags)
     aggregator.assert_metric('redis.pubsub.channels', count=2, tags=tags)


### PR DESCRIPTION
This adds support in redisdb to retrieve the maximum number of clients allowed
and store it as a metric. This is useful for displaying charts that dynamically
shows the limit of the number of connections that is available.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached