### PR TITLE
Tweak MySQL logs setup

### DIFF
--- a/mysql/tests/compose/mariadb.conf
+++ b/mysql/tests/compose/mariadb.conf
@@ -1,8 +1,11 @@
 [mysqld]
+# Activate all logs (general and slow query logs aren't enabled by default),
+# and locate them all under the same folder so we can easily share them
+# with the Agent container.
+general_log = on
+general_log_file = /opt/bitnami/mariadb/logs/mysql.log
+log_error = /opt/bitnami/mariadb/logs/mysql_error.log
+slow_query_log = on
+slow_query_log_file = /opt/bitnami/mariadb/logs/mysql_slow.log
+long_query_time = 0.1  # Facilitates local slow query log testing.
 # log_short_format=ON  # Uncomment to simulate short log format.
-
-# Slow logs aren't enabled by default, so we enable and configure them here
-# to save us some manual configuration when developing.
-slow_query_log = 1
-slow_query_log_file = /opt/bitnami/mariadb/logs/slow.log
-long_query_time = 0.1

--- a/mysql/tests/compose/mariadb.yaml
+++ b/mysql/tests/compose/mariadb.yaml
@@ -14,7 +14,7 @@ services:
     ports:
       - "${MYSQL_PORT}:3306"
     volumes:
-      - ${MYSQL_CONF_PATH}:/bitnami/mariadb/conf/my_custom.cnf:ro
+      - ${MYSQL_CONF_PATH}:/opt/bitnami/mariadb/conf/my_custom.cnf:ro
 
   mysql-slave:
     container_name: mysql-slave

--- a/mysql/tests/compose/mysql.conf
+++ b/mysql/tests/compose/mysql.conf
@@ -1,13 +1,16 @@
 [mysqld]
+# Activate all logs (general and slow query logs aren't enabled by default),
+# and locate them all under a shared folder so we can easily share them
+# with the Agent container.
+general_log = on
+general_log_file = /var/log/mysql/mysql.log
+log_error = /var/log/mysql/mysql_error.log
+slow_query_log = on
+slow_query_log_file = /var/log/mysql/mysql_slow.log
+long_query_time = 0.1  # Facilitates local slow query log testing.
 # log_short_format=ON  # Uncomment to simulate short log format.
 
-# Slow logs aren't enabled by default, so we enable and configure them here
-# to save us some manual configuration when developing.
-slow_query_log = on
-long_query_time = 0.1
-
-[mysqld-5]
-slow_query_log_file = /var/log/mysql/slow.log
-
 [mysqld-8.0]
-slow_query_log_file = /opt/bitnami/mysql/logs/slow.log
+general_log_file = /opt/bitnami/mysql/logs/mysql.log
+log_error = /opt/bitnami/mysql/logs/mysql_error.log
+slow_query_log_file = /opt/bitnami/mysql/logs/mysql_slow.log

--- a/mysql/tests/compose/mysql.conf
+++ b/mysql/tests/compose/mysql.conf
@@ -3,6 +3,11 @@
 
 # Slow logs aren't enabled by default, so we enable and configure them here
 # to save us some manual configuration when developing.
-slow_query_log = 1
-slow_query_log_file = /var/log/mysql/slow.log
+slow_query_log = on
 long_query_time = 0.1
+
+[mysqld-5]
+slow_query_log_file = /var/log/mysql/slow.log
+
+[mysqld-8.0]
+slow_query_log_file = /opt/bitnami/mysql/logs/slow.log

--- a/mysql/tests/compose/mysql8.yaml
+++ b/mysql/tests/compose/mysql8.yaml
@@ -13,6 +13,8 @@ services:
       - MYSQL_DATABASE=my_database
     ports:
       - "${MYSQL_PORT}:3306"
+    volumes:
+      - ${MYSQL_CONF_PATH}:/opt/bitnami/mysql/conf/my_custom.cnf:ro
 
   mysql-slave:
     container_name: mysql-slave


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Add missing config file for MySQL 8.0
- Explicit set log file paths for all tested MySQL versions/flavors.

### Motivation
<!-- What inspired you to submit this pull request? -->
Cleanup for #5186, pre-requisite for #5218.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
/

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
