### PR TITLE
Add extra metrics to db utility

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/common.py
+++ b/datadog_checks_base/datadog_checks/base/utils/common.py
@@ -28,6 +28,13 @@ def ensure_unicode(s):
 to_string = ensure_unicode if PY3 else ensure_bytes
 
 
+def compute_percent(part, total):
+    if total:
+        return part / total * 100
+
+    return 0
+
+
 def total_time_to_temporal_percent(total_time, scale=MILLISECOND):
     # This is really confusing, sorry.
     #

--- a/datadog_checks_base/datadog_checks/base/utils/db/query.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/query.py
@@ -5,6 +5,8 @@ from copy import deepcopy
 
 from six import raise_from
 
+from .utils import create_extra_transformer
+
 
 class Query(object):
     def __init__(self, query_data):
@@ -12,9 +14,10 @@ class Query(object):
         self.name = None
         self.query = None
         self.columns = None
+        self.extras = None
         self.tags = None
 
-    def compile(self, transformers):
+    def compile(self, column_transformers, extra_transformers):
         # Check for previous compilation
         if self.name is not None:
             return
@@ -41,6 +44,9 @@ class Query(object):
         if tags is not None and not isinstance(tags, list):
             raise ValueError('field `tags` for {} must be a list'.format(query_name))
 
+        # Keep track of all defined names
+        sources = {}
+
         column_data = []
         for i, column in enumerate(columns, 1):
             # Columns can be ignored via configuration.
@@ -55,6 +61,14 @@ class Query(object):
                 raise ValueError('field `name` for column #{} of {} is required'.format(i, query_name))
             elif not isinstance(column_name, str):
                 raise ValueError('field `name` for column #{} of {} must be a string'.format(i, query_name))
+            elif column_name in sources:
+                raise ValueError(
+                    'the name {} of {} was already defined in {} #{}'.format(
+                        column_name, query_name, sources[column_name]['type'], sources[column_name]['index']
+                    )
+                )
+
+            sources[column_name] = {'type': 'column', 'index': i}
 
             column_type = column.get('type')
             if not column_type:
@@ -64,13 +78,13 @@ class Query(object):
             elif column_type == 'source':
                 column_data.append((column_name, (None, None)))
                 continue
-            elif column_type not in transformers:
+            elif column_type not in column_transformers:
                 raise ValueError('unknown type `{}` for column {} of {}'.format(column_type, column_name, query_name))
 
             modifiers = {key: value for key, value in column.items() if key not in ('name', 'type')}
 
             try:
-                transformer = transformers[column_type](column_name, transformers, **modifiers)
+                transformer = column_transformers[column_type](column_name, column_transformers, **modifiers)
             except Exception as e:
                 error = 'error compiling type `{}` for column {} of {}: {}'.format(
                     column_type, column_name, query_name, e
@@ -89,8 +103,70 @@ class Query(object):
                     # a reference to None since if we use e.g. `value` it would never be checked anyway.
                     column_data.append((column_name, (None, transformer)))
 
+        submission_transformers = column_transformers.copy()
+        submission_transformers.pop('tag')
+
+        extras = self.query_data.get('extras', [])
+        if not isinstance(extras, list):
+            raise ValueError('field `extras` for {} must be a list'.format(query_name))
+
+        extra_data = []
+        for i, extra in enumerate(extras, 1):
+            if not isinstance(extra, dict):
+                raise ValueError('extra #{} of {} is not a mapping'.format(i, query_name))
+
+            extra_name = extra.get('name')
+            if not extra_name:
+                raise ValueError('field `name` for extra #{} of {} is required'.format(i, query_name))
+            elif not isinstance(extra_name, str):
+                raise ValueError('field `name` for extra #{} of {} must be a string'.format(i, query_name))
+            elif extra_name in sources:
+                raise ValueError(
+                    'the name {} of {} was already defined in {} #{}'.format(
+                        extra_name, query_name, sources[extra_name]['type'], sources[extra_name]['index']
+                    )
+                )
+
+            sources[extra_name] = {'type': 'extra', 'index': i}
+
+            extra_type = extra.get('type')
+            if not extra_type:
+                if 'expression' in extra:
+                    extra_type = 'expression'
+                else:
+                    raise ValueError('field `type` for extra {} of {} is required'.format(extra_name, query_name))
+            elif not isinstance(extra_type, str):
+                raise ValueError('field `type` for extra {} of {} must be a string'.format(extra_name, query_name))
+            elif extra_type not in extra_transformers and extra_type not in submission_transformers:
+                raise ValueError('unknown type `{}` for extra {} of {}'.format(extra_type, extra_name, query_name))
+
+            transformer_factory = extra_transformers.get(extra_type, submission_transformers.get(extra_type))
+
+            extra_source = extra.get('source')
+            if extra_type in submission_transformers:
+                if not extra_source:
+                    raise ValueError('field `source` for extra {} of {} is required'.format(extra_name, query_name))
+
+                modifiers = {key: value for key, value in extra.items() if key not in ('name', 'type', 'source')}
+            else:
+                modifiers = {key: value for key, value in extra.items() if key not in ('name', 'type')}
+                modifiers['sources'] = sources
+
+            try:
+                transformer = transformer_factory(extra_name, submission_transformers, **modifiers)
+            except Exception as e:
+                error = 'error compiling type `{}` for extra {} of {}: {}'.format(extra_type, extra_name, query_name, e)
+
+                raise_from(type(e)(error), None)
+            else:
+                if extra_type in submission_transformers:
+                    transformer = create_extra_transformer(transformer, extra_source)
+
+                extra_data.append((extra_name, transformer))
+
         self.name = query_name
         self.query = query
         self.columns = tuple(column_data)
+        self.extras = tuple(extra_data)
         self.tags = tags
         del self.query_data

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -13,3 +13,21 @@ def create_submission_transformer(submit_method):
         return transformer
 
     return get_transformer
+
+
+def create_extra_transformer(column_transformer, source=None):
+    # Every column transformer expects a value to be given but in the post-processing
+    # phase the values are determined by references, so to avoid redefining every
+    # transformer we just map the proper source to the value.
+    if source:
+
+        def call_transformer(sources, **kwargs):
+            return column_transformer(sources[source], sources, **kwargs)
+
+    # Extra transformers that call regular transformers will want to pass values directly.
+    else:
+
+        def call_transformer(sources, value, **kwargs):
+            return column_transformer(value, sources, **kwargs)
+
+    return call_transformer


### PR DESCRIPTION
## What does this PR do?

This allows users to define additional metrics to be sent via an `extras` attribute.

Every column transformer (except `tag`) is supported at this level, the only difference being one must set the `source` to retrieve the desired value.

So for example here:

```yaml
columns:
  - name: foo.bar
    type: rate
extras:
  - name: foo.current
    type: gauge
    source: foo.bar
```

the metric `foo.current` will be sent as a gauge will the value of `foo.bar`.

There also exists 2 new transformers at this level:

### percent

will be submitted as a gauge

```yaml
columns:
  - name: disk.total
    type: gauge
  - name: disk.used
    type: gauge
extras:
  - name: disk.utilized
    type: percent
    part: disk.used
    total: disk.total
```

### expression

This allows the evaluation of a limited subset of Python syntax and built-in functions

```yaml
columns:
  - name: disk.total
    type: gauge
  - name: disk.used
    type: gauge
extras:
  - name: disk.free
    expression: disk.total - disk.used
    submit_type: gauge
```

For brevity, if the `expression` attribute exists and `type` does not then it is assumed the type is expression. The `submit_type` can be any transformer and any extra options are passed down to it.

The result of every expression is stored, so in lieu of a `submit_type` the above example could also be written as:

```yaml
columns:
  - name: disk.total
    type: gauge
  - name: disk.used
    type: gauge
extras:
  - name: free
    expression: disk.total - disk.used
  - name: disk.free
    type: gauge
    source: free
```

The order matters though, so for example the following will fail:

```yaml
columns:
  - name: disk.total
    type: gauge
  - name: disk.used
    type: gauge
extras:
  - name: disk.free
    type: gauge
    source: free
  - name: free
    expression: disk.total - disk.used
```

since the source `free` does not yet exist.

## Motivation

Follow up to https://github.com/DataDog/integrations-core/pull/5045

## Additional Notes

- I also added a compile-time check for duplicate source names
- In the next PR I'll implement metadata submission