### PR TITLE
 Updating hyperlinks in the README.md for the Dotnetclr Integration

### DIFF
--- a/dotnetclr/README.md
+++ b/dotnetclr/README.md
@@ -21,13 +21,14 @@ The Dotnetclr check is included in the [Datadog Agent][2] package, so you don't 
 
 ## Validation
 
-[Run the Agent's `status` subcommand][4] and look for `dotnetclr` under the Checks section.
+[Run the Agent's `status` subcommand][6] and look for `dotnetclr` under the Checks section.
 
 ## Troubleshooting
-Need help? Contact [Datadog support][6].
+Need help? Contact [Datadog support][7].
 
 [2]: https://app.datadoghq.com/account/settings#agent
 [3]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
-[4]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[4]: https://github.com/DataDog/integrations-core/blob/master/dotnetclr/datadog_checks/dotnetclr/data/conf.yaml.example
 [5]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[6]: https://docs.datadoghq.com/help
+[6]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[7]: https://docs.datadoghq.com/help


### PR DESCRIPTION
### What does this PR do?
This pull request updates the hyperlinks within the Dotnetclr integration.

### Motivation
Currently the link within the readme points to the incorrect location.
instead of pointing to the sample configuration file within Github, the link directs you to the agent restart command in the documentation.


### Additional Notes
The agent status command also pointed to the agent restart command, So a new link to the correct location has also been added.

Links updated are 4 with the addition of number 6 also ( original 6 has been changed to 7 to preserve ordering)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
