### PR TITLE
Fix service_checks submission

### DIFF
--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -4,11 +4,7 @@
 import socket
 import time
 
-from datadog_checks.base import AgentCheck
-
-
-class BadConfException(Exception):
-    pass
+from datadog_checks.base import AgentCheck, ConfigurationError
 
 
 class TCPCheck(AgentCheck):
@@ -30,19 +26,19 @@ class TCPCheck(AgentCheck):
         try:
             self.port = int(port)
         except Exception:
-            raise BadConfException("{} is not a correct port.".format(str(port)))
+            raise ConfigurationError("{} is not a correct port.".format(str(port)))
 
         try:
             self.url = instance.get('host', None)
             split = self.url.split(":")
         except Exception:  # Would be raised if url is not a string
-            raise BadConfException("A valid url must be specified")
+            raise ConfigurationError("A valid url must be specified")
 
         # IPv6 address format: 2001:db8:85a3:8d3:1319:8a2e:370:7348
         if len(split) == 8:  # It may then be a IP V6 address, we check that
             for block in split:
                 if len(block) != 4:
-                    raise BadConfException("{} is not a correct IPv6 address.".format(self.url))
+                    raise ConfigurationError("{} is not a correct IPv6 address.".format(self.url))
 
             self.addr = self.url
             # It's a correct IP V6 address
@@ -54,12 +50,12 @@ class TCPCheck(AgentCheck):
                 self.socket_type = socket.AF_INET
             except Exception:
                 msg = "URL: {} is not a correct IPv4, IPv6 or hostname".format(self.url)
-                raise BadConfException(msg)
+                raise ConfigurationError(msg)
 
     def check(self, instance):
         start = time.time()
         try:
-            self.log.debug("Connecting to {} {}".format(self.addr, self.port))
+            self.log.debug("Connecting to %s %d", self.addr, self.port)
             sock = socket.socket(self.socket_type)
             try:
                 sock.settimeout(self.timeout)
@@ -67,12 +63,12 @@ class TCPCheck(AgentCheck):
             finally:
                 sock.close()
 
+            self.log.debug("%s:%d is UP", self.addr, self.port)
+            self.report_as_service_check(AgentCheck.OK, 'UP')
         except socket.timeout as e:
             # The connection timed out because it took more time than the specified value in the yaml config file
             length = int((time.time() - start) * 1000)
-            self.log.info(
-                "{}:{} is DOWN ({}). Connection failed after {} ms".format(self.addr, self.port, str(e), length)
-            )
+            self.log.info("%s:%d is DOWN (%s). Connection failed after %d ms", self.addr, self.port, str(e), length)
             self.report_as_service_check(
                 AgentCheck.CRITICAL, "{}. Connection failed after {} ms".format(str(e), length)
             )
@@ -81,7 +77,7 @@ class TCPCheck(AgentCheck):
             length = int((time.time() - start) * 1000)
             if "timed out" in str(e):
 
-                # The connection timed out becase it took more time than the system tcp stack allows
+                # The connection timed out because it took more time than the system tcp stack allows
                 self.log.warning(
                     'The connection timed out because it took more time '
                     'than the system tcp stack allows. You might want to '
@@ -98,18 +94,14 @@ class TCPCheck(AgentCheck):
                 )
 
             else:
-                self.log.info(
-                    "{}:{} is DOWN ({}). Connection failed after {} ms".format(self.addr, self.port, str(e), length)
-                )
+                self.log.info("%s:%d is DOWN (%s). Connection failed after %d ms", self.addr, self.port, str(e), length)
                 self.report_as_service_check(
                     AgentCheck.CRITICAL, "{}. Connection failed after {} ms".format(str(e), length)
                 )
 
         except Exception as e:
             length = int((time.time() - start) * 1000)
-            self.log.info(
-                "{}:{} is DOWN ({}). Connection failed after {} ms".format(self.addr, self.port, str(e), length)
-            )
+            self.log.info("%s:%d is DOWN (%s). Connection failed after %d ms", self.addr, self.port, str(e), length)
             self.report_as_service_check(
                 AgentCheck.CRITICAL, "{}. Connection failed after {} ms".format(str(e), length)
             )
@@ -124,9 +116,6 @@ class TCPCheck(AgentCheck):
                 ]
                 + self.custom_tags,
             )
-
-        self.log.debug("{}:{} is UP".format(self.addr, self.port))
-        self.report_as_service_check(AgentCheck.OK, 'UP')
 
     def report_as_service_check(self, status, msg=None):
         if status == AgentCheck.OK:

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -62,9 +62,6 @@ class TCPCheck(AgentCheck):
                 sock.connect((self.addr, self.port))
             finally:
                 sock.close()
-
-            self.log.debug("%s:%d is UP", self.addr, self.port)
-            self.report_as_service_check(AgentCheck.OK, 'UP')
         except socket.timeout as e:
             # The connection timed out because it took more time than the specified value in the yaml config file
             length = int((time.time() - start) * 1000)
@@ -72,7 +69,6 @@ class TCPCheck(AgentCheck):
             self.report_as_service_check(
                 AgentCheck.CRITICAL, "{}. Connection failed after {} ms".format(str(e), length)
             )
-
         except socket.error as e:
             length = int((time.time() - start) * 1000)
             if "timed out" in str(e):
@@ -92,19 +88,20 @@ class TCPCheck(AgentCheck):
                         str(e), length
                     ),
                 )
-
             else:
                 self.log.info("%s:%d is DOWN (%s). Connection failed after %d ms", self.addr, self.port, str(e), length)
                 self.report_as_service_check(
                     AgentCheck.CRITICAL, "{}. Connection failed after {} ms".format(str(e), length)
                 )
-
         except Exception as e:
             length = int((time.time() - start) * 1000)
             self.log.info("%s:%d is DOWN (%s). Connection failed after %d ms", self.addr, self.port, str(e), length)
             self.report_as_service_check(
                 AgentCheck.CRITICAL, "{}. Connection failed after {} ms".format(str(e), length)
             )
+        else:
+            self.log.debug("%s:%d is UP", self.addr, self.port)
+            self.report_as_service_check(AgentCheck.OK, 'UP')
 
         if self.response_time:
             self.gauge(

--- a/tcp_check/tests/common.py
+++ b/tcp_check/tests/common.py
@@ -15,4 +15,4 @@ def _test_check(aggregator):
     aggregator.assert_metric('network.tcp.can_connect', value=1, tags=expected_tags)
     aggregator.assert_service_check('tcp.can_connect', status=TCPCheck.OK, tags=expected_tags)
     aggregator.assert_all_metrics_covered()
-    assert len(aggregator._service_checks['tcp.can_connect']) == 1
+    assert len(aggregator.service_checks('tcp.can_connect')) == 1

--- a/tcp_check/tests/common.py
+++ b/tcp_check/tests/common.py
@@ -14,3 +14,5 @@ def _test_check(aggregator):
     expected_tags = ['foo:bar', 'target_host:datadoghq.com', 'port:80', 'instance:UpService']
     aggregator.assert_metric('network.tcp.can_connect', value=1, tags=expected_tags)
     aggregator.assert_service_check('tcp.can_connect', status=TCPCheck.OK, tags=expected_tags)
+    aggregator.assert_all_metrics_covered()
+    assert len(aggregator._service_checks['tcp.can_connect']) == 1

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -19,7 +19,7 @@ def test_down(aggregator):
     aggregator.assert_service_check('tcp.can_connect', status=check.CRITICAL, tags=expected_tags)
     aggregator.assert_metric('network.tcp.can_connect', value=0, tags=expected_tags)
     aggregator.assert_all_metrics_covered()
-    assert len(aggregator._service_checks['tcp.can_connect']) == 1
+    assert len(aggregator.service_checks('tcp.can_connect')) == 1
 
 
 def test_up(aggregator, check):
@@ -31,7 +31,7 @@ def test_up(aggregator, check):
     aggregator.assert_service_check('tcp.can_connect', status=check.OK, tags=expected_tags)
     aggregator.assert_metric('network.tcp.can_connect', value=1, tags=expected_tags)
     aggregator.assert_all_metrics_covered()
-    assert len(aggregator._service_checks['tcp.can_connect']) == 1
+    assert len(aggregator.service_checks('tcp.can_connect')) == 1
 
 
 def test_response_time(aggregator):
@@ -53,4 +53,4 @@ def test_response_time(aggregator):
     expected_tags = ['url:datadoghq.com:80', 'instance:instance:response_time', 'foo:bar']
     aggregator.assert_metric('network.tcp.response_time', tags=expected_tags)
     aggregator.assert_all_metrics_covered()
-    assert len(aggregator._service_checks['tcp.can_connect']) == 1
+    assert len(aggregator.service_checks('tcp.can_connect')) == 1

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -18,6 +18,8 @@ def test_down(aggregator):
     expected_tags = ["instance:DownService", "target_host:127.0.0.1", "port:65530", "foo:bar"]
     aggregator.assert_service_check('tcp.can_connect', status=check.CRITICAL, tags=expected_tags)
     aggregator.assert_metric('network.tcp.can_connect', value=0, tags=expected_tags)
+    aggregator.assert_all_metrics_covered()
+    assert len(aggregator._service_checks['tcp.can_connect']) == 1
 
 
 def test_up(aggregator, check):
@@ -28,6 +30,8 @@ def test_up(aggregator, check):
     expected_tags = ["instance:UpService", "target_host:datadoghq.com", "port:80", "foo:bar"]
     aggregator.assert_service_check('tcp.can_connect', status=check.OK, tags=expected_tags)
     aggregator.assert_metric('network.tcp.can_connect', value=1, tags=expected_tags)
+    aggregator.assert_all_metrics_covered()
+    assert len(aggregator._service_checks['tcp.can_connect']) == 1
 
 
 def test_response_time(aggregator):
@@ -49,3 +53,4 @@ def test_response_time(aggregator):
     expected_tags = ['url:datadoghq.com:80', 'instance:instance:response_time', 'foo:bar']
     aggregator.assert_metric('network.tcp.response_time', tags=expected_tags)
     aggregator.assert_all_metrics_covered()
+    assert len(aggregator._service_checks['tcp.can_connect']) == 1


### PR DESCRIPTION
The TCP check was always submitting an `OK` service_check at the end of the check run, thus overriding any CRITICAL service check submitted elsewhere during the check run.

The PR fixes the behavior and also refactor the integration to use `ConfigurationError` and better logging format.