### PR TITLE
Update SNMP requirements

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -34,15 +34,15 @@ protobuf==3.7.0
 psutil==5.6.7
 psycopg2-binary==2.8.4
 pyasn1==0.4.6
-pycryptodomex==3.8.2
+pycryptodomex==3.9.4
 pyhdb==0.3.4
 pymongo==3.8.0
 pymqi==1.8.0; sys_platform != 'win32' and sys_platform != 'darwin'
 pymysql==0.9.3
 pyodbc==4.0.26; sys_platform != 'darwin'
 pyro4==4.73; sys_platform == 'win32'
-pysmi==0.2.2
-pysnmp==4.4.3
+pysmi==0.3.4
+pysnmp==4.4.9
 pysnmp-mibs==0.1.6
 pysocks==1.7.0
 python-binary-memcached==0.26.1; sys_platform != 'win32'

--- a/snmp/requirements.in
+++ b/snmp/requirements.in
@@ -1,7 +1,9 @@
 ipaddress==1.0.22; python_version < '3.0'
 ply==3.10
+# Can't upgrade until https://github.com/etingof/pyasn1/issues/178 is fixed
 pyasn1==0.4.6
 pycryptodomex==3.9.4
 pysmi==0.3.4
+# Can't upgrade until https://github.com/etingof/pysnmp/issues/329 is fixed
 pysnmp==4.4.9
 pysnmp-mibs==0.1.6

--- a/snmp/requirements.in
+++ b/snmp/requirements.in
@@ -1,7 +1,7 @@
 ipaddress==1.0.22; python_version < '3.0'
 ply==3.10
 pyasn1==0.4.6
-pycryptodomex==3.8.2
-pysmi==0.2.2
-pysnmp==4.4.3
+pycryptodomex==3.9.4
+pysmi==0.3.4
+pysnmp==4.4.9
 pysnmp-mibs==0.1.6


### PR DESCRIPTION
This updates pysnmp and its dependencies. We can't update pyasn1 for now
because of https://github.com/etingof/pyasn1/issues/178. And we can't
update pysnmp to 4.4.10+ because of https://github.com/etingof/pysnmp/issues/329.