### PR TITLE
Fix formatting and typos in the MySQL documentation

### DIFF
--- a/mysql/README.md
+++ b/mysql/README.md
@@ -62,7 +62,7 @@ mysql> GRANT PROCESS ON *.* TO 'datadog'@'localhost';
 Query OK, 0 rows affected (0.00 sec)
 ```
 
-For mySQL 8.0+ set `max_user_connections` with:
+For MySQL 8.0+ set `max_user_connections` with:
 
 ```
 mysql> ALTER USER 'datadog'@'localhost' WITH MAX_USER_CONNECTIONS 5;
@@ -133,15 +133,16 @@ See our [sample mysql.yaml][9] for all available configuration options, includin
     - Edit `/etc/mysql/conf.d/mysqld_safe_syslog.cnf` and remove or comment the lines.
     - Edit `/etc/mysql/my.cnf` and add following lines to enable general, error, and slow query logs:
 
-      ```
+      ```conf
         [mysqld_safe]
-        log_error=/var/log/mysql/mysql_error.log
+        log_error = /var/log/mysql/mysql_error.log
+
         [mysqld]
         general_log = on
         general_log_file = /var/log/mysql/mysql.log
-        log_error=/var/log/mysql/mysql_error.log
+        log_error = /var/log/mysql/mysql_error.log
         slow_query_log = on
-        slow_query_log_file = /var/log/mysql/mysql-slow.log
+        slow_query_log_file = /var/log/mysql/mysql_slow.log
         long_query_time = 2
       ```
 
@@ -151,7 +152,7 @@ See our [sample mysql.yaml][9] for all available configuration options, includin
     - In `/etc/logrotate.d/mysql-server` there should be something similar to:
 
       ```
-        /var/log/mysql.log /var/log/mysql/mysql.log /var/log/mysql/mysql-slow.log {
+        /var/log/mysql.log /var/log/mysql/mysql.log /var/log/mysql/mysql_slow.log {
                 daily
                 rotate 7
                 missingok
@@ -177,7 +178,7 @@ See our [sample mysql.yaml][9] for all available configuration options, includin
             service: myapplication
 
           - type: file
-            path: /var/log/mysql/mysql-slow.log
+            path: /var/log/mysql/mysql_slow.log
             source: mysql
             sourcecategory: database
             service: myapplication

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -172,22 +172,22 @@ See our [sample mysql.yaml][9] for all available configuration options, includin
     ```yaml
       logs:
           - type: file
-            path: /var/log/mysql/mysql_error.log
+            path: "<ERROR_LOG_FILE_PATH>"
             source: mysql
             sourcecategory: database
-            service: myapplication
+            service: "<SERVICE_NAME>"
 
           - type: file
-            path: /var/log/mysql/mysql_slow.log
+            path: "<SLOW_QUERY_LOG_FILE_PATH>"
             source: mysql
             sourcecategory: database
-            service: myapplication
+            service: "<SERVICE_NAME>"
 
           - type: file
-            path: /var/log/mysql/mysql.log
+            path: "<GENERAL_LOG_FILE_PATH>"
             source: mysql
             sourcecategory: database
-            service: myapplication
+            service: "<SERVICE_NAME>"
             # For multiline logs, if they start by the date with the format yyyy-mm-dd uncomment the following processing rule
             # log_processing_rules:
             #   - type: multi_line

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -173,7 +173,7 @@ instances:
 #     service: <SERVICE_NAME>
 #
 #   - type: file
-#     path: /var/log/mysql/mysql-slow.log
+#     path: /var/log/mysql/mysql_slow.log
 #     source: mysql
 #     sourcecategory: database
 #     service: <SERVICE_NAME>

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -167,22 +167,22 @@ instances:
 #
 # logs:
 #   - type: file
-#     path: /var/log/mysql/mysql_error.log
+#     path: "<ERROR_LOG_FILE_PATH>"
 #     source: mysql
 #     sourcecategory: database
-#     service: <SERVICE_NAME>
+#     service: "<SERVICE_NAME>"
 #
 #   - type: file
-#     path: /var/log/mysql/mysql_slow.log
+#     path: "<SLOW_QUERY_LOG_FILE_PATH>"
 #     source: mysql
 #     sourcecategory: database
-#     service: <SERVICE_NAME>
+#     service: "<SERVICE_NAME>"
 #
 #   - type: file
-#     path: /var/log/mysql/mysql.log
+#     path: "<GENERAL_LOG_FILE_PATH>"
 #     source: mysql
 #     sourcecategory: database
-#     service: <SERVICE_NAME>
+#     service: "<SERVICE_NAME>"
 ## For multiline logs, if they start by the date with the format yyyy-mm-dd uncomment the following processing rule
 #     log_processing_rules:
 #       - type: multi_line


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Bunch of formatting and typo fixes for the MySQL `README` and example config.
- Also suggests using a `"<PLACEHOLDER>"` style in config file snippets and examples, in line with 5196.

### Motivation
<!-- What inspired you to submit this pull request? -->
Discovered while working on https://github.com/DataDog/integrations-core/pull/5237.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
/

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
