### PR TITLE
Gracefully handle /proc errors in network check

### DIFF
--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -336,29 +336,31 @@ class Network(AgentCheck):
         try:
             with open(proc_dev_path, 'r') as proc:
                 lines = proc.readlines()
-            # Inter-|   Receive                                                 |  Transmit
-            #  face |bytes     packets errs drop fifo frame compressed multicast|bytes       packets errs drop fifo colls carrier compressed # noqa: E501
-            #     lo:45890956   112797   0    0    0     0          0         0    45890956   112797    0    0    0     0       0          0 # noqa: E501
-            #   eth0:631947052 1042233   0   19    0   184          0      1206  1208625538  1320529    0    0    0     0       0          0 # noqa: E501
-            #   eth1:       0        0   0    0    0     0          0         0           0        0    0    0    0     0       0          0 # noqa: E501
-            for line in lines[2:]:
-                cols = line.split(':', 1)
-                x = cols[1].split()
-                # Filter inactive interfaces
-                if self._parse_value(x[0]) or self._parse_value(x[8]):
-                    iface = cols[0].strip()
-                    metrics = {
-                        'bytes_rcvd': self._parse_value(x[0]),
-                        'bytes_sent': self._parse_value(x[8]),
-                        'packets_in.count': self._parse_value(x[1]),
-                        'packets_in.error': self._parse_value(x[2]) + self._parse_value(x[3]),
-                        'packets_out.count': self._parse_value(x[9]),
-                        'packets_out.error': self._parse_value(x[10]) + self._parse_value(x[11]),
-                    }
-                    self._submit_devicemetrics(iface, metrics, custom_tags)
         except IOError:
             # On Openshift, /proc/net/snmp is only readable by root
             self.log.debug("Unable to read %s.", proc_dev_path)
+            lines = []
+
+        # Inter-|   Receive                                                 |  Transmit
+        #  face |bytes     packets errs drop fifo frame compressed multicast|bytes       packets errs drop fifo colls carrier compressed # noqa: E501
+        #     lo:45890956   112797   0    0    0     0          0         0    45890956   112797    0    0    0     0       0          0 # noqa: E501
+        #   eth0:631947052 1042233   0   19    0   184          0      1206  1208625538  1320529    0    0    0     0       0          0 # noqa: E501
+        #   eth1:       0        0   0    0    0     0          0         0           0        0    0    0    0     0       0          0 # noqa: E501
+        for line in lines[2:]:
+            cols = line.split(':', 1)
+            x = cols[1].split()
+            # Filter inactive interfaces
+            if self._parse_value(x[0]) or self._parse_value(x[8]):
+                iface = cols[0].strip()
+                metrics = {
+                    'bytes_rcvd': self._parse_value(x[0]),
+                    'bytes_sent': self._parse_value(x[8]),
+                    'packets_in.count': self._parse_value(x[1]),
+                    'packets_in.error': self._parse_value(x[2]) + self._parse_value(x[3]),
+                    'packets_out.count': self._parse_value(x[9]),
+                    'packets_out.error': self._parse_value(x[10]) + self._parse_value(x[11]),
+                }
+                self._submit_devicemetrics(iface, metrics, custom_tags)
 
         netstat_data = {}
         for f in ['netstat', 'snmp']:

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -338,4 +338,3 @@ def test_proc_permissions_error(aggregator, check, caplog):
         assert 'Unable to read /proc/net/dev.' in caplog.text
         assert 'Unable to read /proc/net/netstat.' in caplog.text
         assert 'Unable to read /proc/net/snmp.' in caplog.text
-        assert 'Unable to list the files in /proc/sys/net/netfilter.' in caplog.text

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -323,3 +323,13 @@ def test_get_net_proc_base_location(aggregator, check, proc_location, envs, expe
     with EnvVars(envs):
         actual = check._get_net_proc_base_location(proc_location)
         assert expected_net_proc_base_location == actual
+
+
+@pytest.mark.skipif(platform.system() != 'Linux', reason="Only runs on Linux systems")
+@pytest.mark.skipif(not PY3, reason="assertLogs only available on Python 3.4+")
+def test_proc_permissions_error(aggregator, check, caplog):
+    with mock.patch('builtins.open', mock.mock_open()) as mock_file:
+        mock_file.side_effect = IOError()
+        check.check(instance=None)
+        print(caplog.text)
+        assert 'Unable to read /proc/1/net/dev.' in caplog.text

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+import logging
 import os
 import platform
 import socket
@@ -325,11 +326,16 @@ def test_get_net_proc_base_location(aggregator, check, proc_location, envs, expe
         assert expected_net_proc_base_location == actual
 
 
-@pytest.mark.skipif(platform.system() != 'Linux', reason="Only runs on Linux systems")
-@pytest.mark.skipif(not PY3, reason="assertLogs only available on Python 3.4+")
+@pytest.mark.skipif(not PY3, reason="mock builtins only works on Python 3")
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=True)
 def test_proc_permissions_error(aggregator, check, caplog):
+    caplog.set_level(logging.DEBUG)
     with mock.patch('builtins.open', mock.mock_open()) as mock_file:
         mock_file.side_effect = IOError()
-        check.check(instance=None)
-        print(caplog.text)
-        assert 'Unable to read /proc/1/net/dev.' in caplog.text
+        # force linux check so it will run on macOS too
+        check._collect_cx_state = False
+        check._check_linux(instance={})
+        assert 'Unable to read /proc/net/dev.' in caplog.text
+        assert 'Unable to read /proc/net/netstat.' in caplog.text
+        assert 'Unable to read /proc/net/snmp.' in caplog.text
+        assert 'Unable to list the files in /proc/sys/net/netfilter.' in caplog.text


### PR DESCRIPTION
### What does this PR do?
Avoid Errors on OpenShift and other environments where /proc is not accessible due to permissions.

### Additional Notes
Considered using `log.warning` instead, but existing try/catch already uses `log.debug` so thought it would be more important to be consistent.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
