### PR TITLE
Fixes possible KeyError in _report_compliance_information

### DIFF
--- a/twistlock/datadog_checks/twistlock/twistlock.py
+++ b/twistlock/datadog_checks/twistlock/twistlock.py
@@ -321,6 +321,8 @@ class TwistlockCheck(AgentCheck):
             j = response.json()
             # it's possible to get a null response from the server
             # {} is a bit easier to deal with
+            if 'err' in j:
+                self.log.error("Error in response: {}".format(j.get("err")))
             return j or {}
         except Exception as e:
             self.log.debug("cannot get a response: {} response is: {}".format(e, response.text))

--- a/twistlock/datadog_checks/twistlock/twistlock.py
+++ b/twistlock/datadog_checks/twistlock/twistlock.py
@@ -288,7 +288,7 @@ class TwistlockCheck(AgentCheck):
         vulns = data.get('info', {}).get('complianceDistribution', {}) or {}
         types = ["critical", "high", "medium", "low"]
         for type in types:
-            compliance[type] += vulns[type]
+            compliance[type] += vulns.get(type, 0)
             compliance_tags = SEVERITY_TAGS.get(type, []) + tags
             self.gauge('{}.compliance.count'.format(namespace), compliance[type], compliance_tags)
 


### PR DESCRIPTION
### What does this PR do?
Fixes possible KeyError in _report_compliance_information

### Motivation
1724-twistlock-error

### Additional Notes
- added additional logging if `err` is found in response.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
