### PR TITLE
Fix version collection

### DIFF
--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -85,6 +85,7 @@ class Apache(AgentCheck):
                 if metric == 'ServerVersion':
                     self._submit_metadata(value)
                     version_submitted = True
+                    continue
                 try:
                     value = float(value)
                 except ValueError:
@@ -127,8 +128,9 @@ class Apache(AgentCheck):
     def _submit_metadata(self, value):
         """Possible formats:
             Apache | Apache/X | Apache/X.Y | Apache/X.Y.Z | Apache/X.Y.Z (<OS>)
+            Incomplete versions are ignored.
         """
-        match = re.match(self.VERSION_REGEX, value)
+        match = self.VERSION_REGEX.match(value)
 
         if not match or not match.groups():
             self.log.info("Cannot parse the complete Apache version from %s.".format(value))

--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2010-2017
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import re
+
 from six.moves.urllib.parse import urlparse
 
 from datadog_checks.base import AgentCheck
@@ -35,6 +37,8 @@ class Apache(AgentCheck):
         'connect_timeout': {'name': 'connect_timeout', 'default': 5},
     }
 
+    VERSION_REGEX = re.compile(r'^Apache/([0-9]+\.[0-9]+\.[0-9]+)( \(.*\))?$')
+
     def __init__(self, name, init_config, instances):
         super(Apache, self).__init__(name, init_config, instances)
         self.assumed_url = {}
@@ -68,16 +72,19 @@ class Apache(AgentCheck):
             raise
         else:
             self.service_check(service_check_name, AgentCheck.OK, tags=service_check_tags)
-        server = r.headers.get("Server")
-        if server:
-            self._collect_metadata(server)
+
         self.log.debug("apache check succeeded")
         metric_count = 0
+        version_submitted = False
         # Loop through and extract the numerical values
         for line in r.iter_lines(decode_unicode=True):
             values = line.split(': ')
             if len(values) == 2:  # match
                 metric, value = values
+                # Special case: fetch and submit the version
+                if metric == 'ServerVersion':
+                    self._submit_metadata(value)
+                    version_submitted = True
                 try:
                     value = float(value)
                 except ValueError:
@@ -110,8 +117,23 @@ class Apache(AgentCheck):
                     % instance['apache_status_url']
                 )
 
-    def _collect_metadata(self, value):
-        raw_version = value.split(' ')[0]
-        version = raw_version.split('/')[1]
+        if not version_submitted:
+            # Can't get it from the mod_status output, try to get it from the server header even though
+            # it may not be exposed with some configurations.
+            server_version = r.headers.get("Server")
+            if server_version:
+                self._submit_metadata(server_version)
+
+    def _submit_metadata(self, value):
+        """Possible formats:
+            Apache | Apache/X | Apache/X.Y | Apache/X.Y.Z | Apache/X.Y.Z (<OS>)
+        """
+        match = re.match(self.VERSION_REGEX, value)
+
+        if not match or not match.groups():
+            self.log.info("Cannot parse the complete Apache version from %s.".format(value))
+            return
+
+        version = match.groups()[0]
         self.set_metadata('version', version)
         self.log.debug("found apache version %s", version)

--- a/apache/tests/test_apache.py
+++ b/apache/tests/test_apache.py
@@ -65,7 +65,27 @@ def test_e2e(dd_agent_check):
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_metadata(check, datadog_agent):
+def test_metadata_in_content(check, datadog_agent):
+    check = check(AUTO_CONFIG)
+    check.check_id = 'test:123'
+    major, minor, patch = APACHE_VERSION.split('.')
+    version_metadata = {
+        'version.scheme': 'semver',
+        'version.major': major,
+        'version.minor': minor,
+        'version.patch': patch,
+        'version.raw': APACHE_VERSION,
+    }
+
+    check.check(AUTO_CONFIG)
+    datadog_agent.assert_metadata('test:123', version_metadata)
+    datadog_agent.assert_metadata_count(len(version_metadata))
+
+
+@pytest.mark.usefixtures("dd_environment")
+def test_metadata_in_header(check, datadog_agent, mock_hide_server_version):
+    """For older Apache versions, the version is not in the output. This test asserts that
+    the check can fallback to the headers."""
     check = check(AUTO_CONFIG)
     check.check_id = 'test:123'
     major, minor, patch = APACHE_VERSION.split('.')

--- a/apache/tox.ini
+++ b/apache/tox.ini
@@ -13,7 +13,7 @@ platform = linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
-setenv = APACHE_VERSION=2.4.12
+setenv = APACHE_VERSION=2.4.27
 passenv =
     DOCKER*
     COMPOSE*


### PR DESCRIPTION
Apache version can be collected from three places:
- from the mod_status html output
- from the mod_status machine-readable output
- or from the 'Status' header in any request to Apache.

A few notes:
- The check does not expect an html output.
- The machine-readable output only contains the version since version 2.4.20
- The status header does not always contain the full version (it can be hidden using server configuration parameters).

This PR first fixes the behavior of the `_collect_metadata` method to prevent failing.
It also tries to extract the version from the machine-readable output before falling back to the 'Status' header