### PR TITLE
Display Docker Compose logs when test environment fails to start

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/env.py
+++ b/datadog_checks_dev/datadog_checks/dev/env.py
@@ -11,13 +11,15 @@ from .utils import mock_context_manager
 
 
 @contextmanager
-def environment_run(up, down, sleep=None, endpoints=None, conditions=None, env_vars=None, wrapper=None):
+def environment_run(up, down, on_error=None, sleep=None, endpoints=None, conditions=None, env_vars=None, wrapper=None):
     """This utility provides a convenient way to safely set up and tear down arbitrary types of environments.
 
     :param up: A custom setup callable.
     :type up: ``callable``
     :param down: A custom tear down callable.
     :type down: ``callable``
+    :param on_error: A callable called in case of an unhandled exception.
+    :type on_error: ``callable``
     :param sleep: Number of seconds to wait before yielding.
     :type sleep: ``float``
     :param endpoints: Endpoints to verify access for before yielding. Shorthand for adding
@@ -63,6 +65,10 @@ def environment_run(up, down, sleep=None, endpoints=None, conditions=None, env_v
                 result = get_env_vars().get(key)
                 if result:
                     yield deserialize_data(result)
+        except BaseException as exc:
+            if on_error is not None:
+                on_error(exc)
+            raise
         finally:
             if tear_down_env():
                 down()

--- a/postfix/tests/conftest.py
+++ b/postfix/tests/conftest.py
@@ -54,7 +54,7 @@ class CreateQueues(LazyFunction):
 def dd_environment():
     with TempDir() as temp_dir:
         # No tear down necessary as `TempDir` will do the clean up
-        with environment_run(CreateQueues(temp_dir), lambda: None) as result:
+        with environment_run(up=CreateQueues(temp_dir), down=lambda: None) as result:
             set_env_vars({k: serialize_data(v) for k, v in result.items()})
 
             yield get_e2e_instance(), get_e2e_metadata()

--- a/postfix/tests/conftest.py
+++ b/postfix/tests/conftest.py
@@ -54,7 +54,7 @@ class CreateQueues(LazyFunction):
 def dd_environment():
     with TempDir() as temp_dir:
         # No tear down necessary as `TempDir` will do the clean up
-        with environment_run(up=CreateQueues(temp_dir), down=lambda: None) as result:
+        with environment_run(CreateQueues(temp_dir), lambda: None) as result:
             set_env_vars({k: serialize_data(v) for k, v in result.items()})
 
             yield get_e2e_instance(), get_e2e_metadata()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Display output from `docker-compose logs` when `ddev env start` fails. This includes when `ddev test` fails to start the environment.

This is done by allowing passing an `on_error` hook to `environment_run`, and providing a default one in `docker_run` that runs `docker-compose logs ...`.

### Motivation
<!-- What inspired you to submit this pull request? -->
A lot of tedious debugging done for https://github.com/DataDog/integrations-core/pull/5218 (Linux-specific error that only occurred on CI) could have been prevented if Docker Compose logs were output on CI. (Inspecting the logs in a Linux VM was how I eventually found what was wrong on that PR.)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

To try this out:

- Open `mysql/tests/compose/mysql.yaml` and change `MASTER_PORT=3306` to `MASTER_PORT=3305` in the `mysql-slave` service. (This simulates a connection error on the MySQL slave.)
- To speed up the failure, open `mysql/tests/conftest.py` and modify this line:

```diff
-    WaitFor(init_slave, wait=2),
+    WaitFor(init_slave, wait=2, attempts=10),
```

Run `ddev env start mysql py37-5.7`. The command should fail after ~20s, and `ddev` should output the Docker Compose logs -- see below. The last few lines of `mysql-slave` show the source of the error:

```console
mysql-slave     | /usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/init-slave.sh
mysql-slave     | Updating master connetion info in slave.
mysql-slave     | 2019-12-19T14:59:17.566773Z 5 [Note] 'CHANGE MASTER TO FOR CHANNEL '' executed'. Previous state master_host='', master_port= 3306, master_log_file='', master_log_pos= 4, master_bind=''. New state master_host='mysql-master', master_port= 3305, master_log_file='', master_log_pos= 4, master_bind=''.
mysql-slave     | mysqldump: [Warning] Using a password on the command line interface can be insecure.
mysql-slave     | mysqldump: Got error: 2003: Can't connect to MySQL server on 'mysql-master' (111) when trying to connect
```

<details>
<summary>
Full output (click to expand)
</summary>

```console
❯ ddev env start mysql py37-5.7
Environment variable DD_API_KEY does not exist; a well-formatted fake API key will be used instead. You can also set the API key by doing `ddev config set dd_api_key`.
Setting up environment `py37-5.7`... failed!
Stopping the environment...
py37-5.7 develop-inst-noop: /Users/florimond.manca/go/src/github.com/DataDog/integrations-core/mysql
py37-5.7 installed: attrs==19.3.0,binary==1.0.0,certifi==2019.11.28,cffi==1.13.2,chardet==3.0.4,contextlib2==0.5.5,coverage==5.0,cryptography==2.8,-e git+git@github.com:DataDog/integrations-core.git@378ab890aaae2eef10b73968bf21c632dbe1098d#egg=datadog_checks_base&subdirectory=datadog_checks_base,-e git+git@github.com:DataDog/integrations-core.git@378ab890aaae2eef10b73968bf21c632dbe1098d#egg=datadog_checks_dev&subdirectory=datadog_checks_dev,-e git+git@github.com:DataDog/integrations-core.git@378ab890aaae2eef10b73968bf21c632dbe1098d#egg=datadog_mysql&subdirectory=mysql,ddtrace==0.13.0,idna==2.8,importlib-metadata==1.3.0,mock==3.0.5,more-itertools==8.0.2,msgpack-python==0.5.6,packaging==19.2,pluggy==0.13.1,prometheus-client==0.3.0,protobuf==3.7.0,psutil==5.6.7,py==1.8.0,py-cpuinfo==5.0.0,pycparser==2.19,PyMySQL==0.9.3,pyparsing==2.4.5,pytest==5.3.2,pytest-benchmark==3.2.2,pytest-cov==2.8.1,pytest-mock==1.13.0,PyYAML==5.1,requests==2.22.0,simplejson==3.6.5,six==1.12.0,uptime==3.0.1,urllib3==1.25.7,wcwidth==0.1.7,wrapt==1.11.2,zipp==0.6.0
py37-5.7 run-test-pre: PYTHONHASHSEED='4007465885'
py37-5.7 run-test: commands[0] | pip install -r requirements.in
Requirement already satisfied: cryptography==2.8 in ./.tox/py37-5.7/lib/python3.7/site-packages (from -r requirements.in (line 1)) (2.8)
Requirement already satisfied: pymysql==0.9.3 in ./.tox/py37-5.7/lib/python3.7/site-packages (from -r requirements.in (line 2)) (0.9.3)
Requirement already satisfied: six>=1.4.1 in ./.tox/py37-5.7/lib/python3.7/site-packages (from cryptography==2.8->-r requirements.in (line 1)) (1.12.0)
Requirement already satisfied: cffi!=1.11.3,>=1.8 in ./.tox/py37-5.7/lib/python3.7/site-packages (from cryptography==2.8->-r requirements.in (line 1)) (1.13.2)
Requirement already satisfied: pycparser in ./.tox/py37-5.7/lib/python3.7/site-packages (from cffi!=1.11.3,>=1.8->cryptography==2.8->-r requirements.in (line 1)) (2.19)
py37-5.7 run-test: commands[1] | pytest -v
============================= test session starts ==============================
platform darwin -- Python 3.7.5, pytest-5.3.2, py-1.8.0, pluggy-0.13.1 -- /Users/florimond.manca/go/src/github.com/DataDog/integrations-core/mysql/.tox/py37-5.7/bin/python
cachedir: .tox/py37-5.7/.pytest_cache
benchmark: 3.2.2 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/florimond.manca/go/src/github.com/DataDog/integrations-core/mysql
plugins: mock-1.13.0, benchmark-3.2.2, cov-2.8.1, datadog-checks-dev-1.0.1
collecting ... collected 7 items

tests/test_mysql.py::test_minimal_config ERROR                           [ 14%]

==================================== ERRORS ====================================
____________________ ERROR at setup of test_minimal_config _____________________

request = <SubRequest 'dd_environment_runner' for <Function test_minimal_config>>

    @pytest.fixture(scope='session', autouse=True)
    def dd_environment_runner(request):
        testing_plugin = os.getenv(TESTING_PLUGIN) == 'true'
    
        # Do nothing if no e2e action is triggered and continue with tests
        if not testing_plugin and not e2e_active():  # no cov
            return
        # If e2e tests are being run it means the environment has
        # already been spun up so we prevent another invocation
        elif e2e_testing():  # no cov
            # Since the scope is `session` there should only ever be one definition
            fixture_def = request._fixturemanager._arg2fixturedefs[E2E_FIXTURE_NAME][0]
    
            # Make the underlying function a no-op
            fixture_def.func = lambda: None
            return
    
        try:
>           config = request.getfixturevalue(E2E_FIXTURE_NAME)

../datadog_checks_dev/datadog_checks/dev/plugin/pytest.py:78: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/conftest.py:71: in dd_environment
    populate_database,
../../../../../../.pyenv/versions/3.7.5/lib/python3.7/contextlib.py:112: in __enter__
    return next(self.gen)
../datadog_checks_dev/datadog_checks/dev/docker.py:128: in docker_run
    wrapper=wrapper,
../../../../../../.pyenv/versions/3.7.5/lib/python3.7/contextlib.py:112: in __enter__
    return next(self.gen)
../datadog_checks_dev/datadog_checks/dev/env.py:58: in environment_run
    condition()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <datadog_checks.dev.conditions.WaitFor object at 0x10de619d0>

    def __call__(self):
        last_result = None
        last_error = None
    
        for _ in range(self.attempts):
            try:
                result = self.func(*self.args, **self.kwargs)
            except Exception as e:
                last_error = str(e)
                time.sleep(self.wait)
                continue
            else:
                last_result = result
    
            if last_result is None or last_result is True:
                return True
    
            time.sleep(self.wait)
        else:
            raise RetryError(
                'Result: {}\nError: {}\nFunction: {}, Args: {}, Kwargs: {}\n'.format(
>                   repr(last_result), last_error, self.func.__name__, self.args, self.kwargs
                )
            )
E           datadog_checks.dev.errors.RetryError: Result: None
E           Error: (2003, "Can't connect to MySQL server on 'localhost' ([Errno 61] Connection refused)")
E           Function: init_slave, Args: (), Kwargs: {}

../datadog_checks_dev/datadog_checks/dev/conditions.py:50: RetryError
---------------------------- Captured stdout setup -----------------------------
Attaching to mysql-slave, compose_mysql-master_1
mysql-slave     | '/init-slave.sh' -> '/docker-entrypoint-initdb.d/init-slave.sh'
mysql-slave     | wait-for-it.sh: waiting 10 seconds for mysql-master:3305
mysql-slave     | wait-for-it.sh: timeout occurred after waiting 10 seconds for mysql-master:3305
mysql-slave     | '/init-slave.sh' -> '/docker-entrypoint-initdb.d/init-slave.sh'
mysql-slave     | Initializing database
mysql-slave     | 2019-12-19T14:59:11.593076Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
mysql-slave     | 2019-12-19T14:59:11.752795Z 0 [Warning] InnoDB: New log files created, LSN=45790
mysql-slave     | 2019-12-19T14:59:11.780860Z 0 [Warning] InnoDB: Creating foreign key constraint system tables.
mysql-slave     | 2019-12-19T14:59:11.788299Z 0 [Warning] No existing UUID has been found, so we assume that this is the first time that this server has been started. Generating a new UUID: 1dae9203-2270-11ea-9a7f-0242ac190003.
mysql-slave     | 2019-12-19T14:59:11.789186Z 0 [Warning] Gtid table is not ready to be used. Table 'mysql.gtid_executed' cannot be opened.
mysql-slave     | 2019-12-19T14:59:11.790456Z 1 [Warning] root@localhost is created with an empty password ! Please consider switching off the --initialize-insecure option.
mysql-slave     | 2019-12-19T14:59:12.195119Z 1 [Warning] 'user' entry 'root@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:12.195165Z 1 [Warning] 'user' entry 'mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:12.195179Z 1 [Warning] 'user' entry 'mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:12.195200Z 1 [Warning] 'db' entry 'performance_schema mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:12.195208Z 1 [Warning] 'db' entry 'sys mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:12.195221Z 1 [Warning] 'proxies_priv' entry '@ root@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:12.195269Z 1 [Warning] 'tables_priv' entry 'user mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:12.195316Z 1 [Warning] 'tables_priv' entry 'sys_config mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | Database initialized
mysql-slave     | Initializing certificates
mysql-slave     | Generating a 2048 bit RSA private key
mysql-slave     | ......+++
mysql-slave     | ...................................+++
mysql-slave     | unable to write 'random state'
mysql-slave     | writing new private key to 'ca-key.pem'
mysql-slave     | -----
mysql-slave     | Generating a 2048 bit RSA private key
mysql-slave     | ......................................................+++
mysql-slave     | ..................+++
mysql-slave     | unable to write 'random state'
mysql-slave     | writing new private key to 'server-key.pem'
mysql-slave     | -----
mysql-slave     | Generating a 2048 bit RSA private key
mysql-slave     | ................................................+++
mysql-slave     | ...............................................................+++
mysql-slave     | unable to write 'random state'
mysql-slave     | writing new private key to 'client-key.pem'
mysql-slave     | -----
mysql-slave     | Certificates initialized
mysql-slave     | MySQL init process in progress...
mysql-slave     | 2019-12-19T14:59:14.340475Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
mysql-slave     | 2019-12-19T14:59:14.341578Z 0 [Note] mysqld (mysqld 5.7.24-log) starting as process 132 ...
mysql-slave     | 2019-12-19T14:59:14.345497Z 0 [Note] InnoDB: PUNCH HOLE support available
mysql-slave     | 2019-12-19T14:59:14.345585Z 0 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
mysql-slave     | 2019-12-19T14:59:14.345606Z 0 [Note] InnoDB: Uses event mutexes
mysql-slave     | 2019-12-19T14:59:14.345626Z 0 [Note] InnoDB: GCC builtin __atomic_thread_fence() is used for memory barrier
mysql-slave     | 2019-12-19T14:59:14.345633Z 0 [Note] InnoDB: Compressed tables use zlib 1.2.11
mysql-slave     | 2019-12-19T14:59:14.345641Z 0 [Note] InnoDB: Using Linux native AIO
mysql-slave     | 2019-12-19T14:59:14.346499Z 0 [Note] InnoDB: Number of pools: 1
mysql-slave     | 2019-12-19T14:59:14.346659Z 0 [Note] InnoDB: Using CPU crc32 instructions
mysql-slave     | 2019-12-19T14:59:14.348249Z 0 [Note] InnoDB: Initializing buffer pool, total size = 128M, instances = 1, chunk size = 128M
mysql-slave     | 2019-12-19T14:59:14.356442Z 0 [Note] InnoDB: Completed initialization of buffer pool
mysql-slave     | 2019-12-19T14:59:14.359226Z 0 [Note] InnoDB: If the mysqld execution user is authorized, page cleaner thread priority can be changed. See the man page of setpriority().
mysql-slave     | 2019-12-19T14:59:14.370580Z 0 [Note] InnoDB: Highest supported file format is Barracuda.
mysql-slave     | 2019-12-19T14:59:14.380802Z 0 [Note] InnoDB: Creating shared tablespace for temporary tables
mysql-slave     | 2019-12-19T14:59:14.380888Z 0 [Note] InnoDB: Setting file './ibtmp1' size to 12 MB. Physically writing the file full; Please wait ...
mysql-slave     | 2019-12-19T14:59:14.405050Z 0 [Note] InnoDB: File './ibtmp1' size is now 12 MB.
mysql-slave     | 2019-12-19T14:59:14.406507Z 0 [Note] InnoDB: 96 redo rollback segment(s) found. 96 redo rollback segment(s) are active.
mysql-slave     | 2019-12-19T14:59:14.406549Z 0 [Note] InnoDB: 32 non-redo rollback segment(s) are active.
mysql-slave     | 2019-12-19T14:59:14.407664Z 0 [Note] InnoDB: 5.7.24 started; log sequence number 2591440
mysql-slave     | 2019-12-19T14:59:14.408308Z 0 [Note] InnoDB: Loading buffer pool(s) from /var/lib/mysql/ib_buffer_pool
mysql-slave     | 2019-12-19T14:59:14.408644Z 0 [Note] Plugin 'FEDERATED' is disabled.
mysql-slave     | 2019-12-19T14:59:14.409693Z 0 [Note] InnoDB: Buffer pool(s) load completed at 191219 14:59:14
mysql-slave     | 2019-12-19T14:59:14.416236Z 0 [Note] Found ca.pem, server-cert.pem and server-key.pem in data directory. Trying to enable SSL support using them.
mysql-slave     | 2019-12-19T14:59:14.416439Z 0 [Warning] CA certificate ca.pem is self signed.
mysql-slave     | 2019-12-19T14:59:14.418808Z 0 [Warning] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
mysql-slave     | 2019-12-19T14:59:14.419839Z 0 [Warning] 'user' entry 'root@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:14.419881Z 0 [Warning] 'user' entry 'mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:14.419897Z 0 [Warning] 'user' entry 'mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:14.419917Z 0 [Warning] 'db' entry 'performance_schema mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:14.419925Z 0 [Warning] 'db' entry 'sys mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:14.419938Z 0 [Warning] 'proxies_priv' entry '@ root@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:14.422328Z 0 [Warning] 'tables_priv' entry 'user mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:14.422391Z 0 [Warning] 'tables_priv' entry 'sys_config mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:14.424349Z 0 [Note] Failed to start slave threads for channel ''
mysql-slave     | 2019-12-19T14:59:14.430431Z 0 [Note] Event Scheduler: Loaded 0 events
mysql-slave     | 2019-12-19T14:59:14.430784Z 0 [Note] mysqld: ready for connections.
mysql-slave     | Version: '5.7.24-log'  socket: '/var/run/mysqld/mysqld.sock'  port: 0  MySQL Community Server (GPL)
mysql-master_1  | Initializing database
mysql-master_1  | 2019-12-19T14:59:00.681195Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
mysql-master_1  | 2019-12-19T14:59:00.855326Z 0 [Warning] InnoDB: New log files created, LSN=45790
mysql-master_1  | 2019-12-19T14:59:00.885665Z 0 [Warning] InnoDB: Creating foreign key constraint system tables.
mysql-master_1  | 2019-12-19T14:59:00.956066Z 0 [Warning] No existing UUID has been found, so we assume that this is the first time that this server has been started. Generating a new UUID: 1739b3d4-2270-11ea-8a98-0242ac190002.
mysql-master_1  | 2019-12-19T14:59:00.957077Z 0 [Warning] Gtid table is not ready to be used. Table 'mysql.gtid_executed' cannot be opened.
mysql-master_1  | 2019-12-19T14:59:00.958478Z 1 [Warning] root@localhost is created with an empty password ! Please consider switching off the --initialize-insecure option.
mysql-master_1  | 2019-12-19T14:59:02.677045Z 1 [Warning] 'user' entry 'root@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:02.677090Z 1 [Warning] 'user' entry 'mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:02.677105Z 1 [Warning] 'user' entry 'mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:02.677129Z 1 [Warning] 'db' entry 'performance_schema mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:02.677331Z 1 [Warning] 'db' entry 'sys mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:02.677365Z 1 [Warning] 'proxies_priv' entry '@ root@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:02.677417Z 1 [Warning] 'tables_priv' entry 'user mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:02.677432Z 1 [Warning] 'tables_priv' entry 'sys_config mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | Database initialized
mysql-master_1  | Initializing certificates
mysql-master_1  | Generating a 2048 bit RSA private key
mysql-master_1  | ...+++
mysql-master_1  | ................+++
mysql-master_1  | unable to write 'random state'
mysql-master_1  | writing new private key to 'ca-key.pem'
mysql-master_1  | -----
mysql-master_1  | Generating a 2048 bit RSA private key
mysql-master_1  | .............+++
mysql-master_1  | ..........................................+++
mysql-master_1  | unable to write 'random state'
mysql-master_1  | writing new private key to 'server-key.pem'
mysql-master_1  | -----
mysql-master_1  | Generating a 2048 bit RSA private key
mysql-master_1  | .....................................................................+++
mysql-master_1  | .......+++
mysql-master_1  | unable to write 'random state'
mysql-master_1  | writing new private key to 'client-key.pem'
mysql-master_1  | -----
mysql-master_1  | Certificates initialized
mysql-master_1  | MySQL init process in progress...
mysql-master_1  | 2019-12-19T14:59:05.295914Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
mysql-master_1  | 2019-12-19T14:59:05.296890Z 0 [Note] mysqld (mysqld 5.7.24-log) starting as process 93 ...
mysql-master_1  | 2019-12-19T14:59:05.302162Z 0 [Note] InnoDB: PUNCH HOLE support available
mysql-master_1  | 2019-12-19T14:59:05.302224Z 0 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
mysql-master_1  | 2019-12-19T14:59:05.302235Z 0 [Note] InnoDB: Uses event mutexes
mysql-master_1  | 2019-12-19T14:59:05.302243Z 0 [Note] InnoDB: GCC builtin __atomic_thread_fence() is used for memory barrier
mysql-master_1  | 2019-12-19T14:59:05.302254Z 0 [Note] InnoDB: Compressed tables use zlib 1.2.11
mysql-master_1  | 2019-12-19T14:59:05.302265Z 0 [Note] InnoDB: Using Linux native AIO
mysql-master_1  | 2019-12-19T14:59:05.302492Z 0 [Note] InnoDB: Number of pools: 1
mysql-master_1  | 2019-12-19T14:59:05.302594Z 0 [Note] InnoDB: Using CPU crc32 instructions
mysql-master_1  | 2019-12-19T14:59:05.304616Z 0 [Note] InnoDB: Initializing buffer pool, total size = 128M, instances = 1, chunk size = 128M
mysql-master_1  | 2019-12-19T14:59:05.314290Z 0 [Note] InnoDB: Completed initialization of buffer pool
mysql-master_1  | 2019-12-19T14:59:05.316359Z 0 [Note] InnoDB: If the mysqld execution user is authorized, page cleaner thread priority can be changed. See the man page of setpriority().
mysql-master_1  | 2019-12-19T14:59:05.329439Z 0 [Note] InnoDB: Highest supported file format is Barracuda.
mysql-master_1  | 2019-12-19T14:59:05.337928Z 0 [Note] InnoDB: Creating shared tablespace for temporary tables
mysql-master_1  | 2019-12-19T14:59:05.338000Z 0 [Note] InnoDB: Setting file './ibtmp1' size to 12 MB. Physically writing the file full; Please wait ...
mysql-master_1  | 2019-12-19T14:59:05.350962Z 0 [Note] InnoDB: File './ibtmp1' size is now 12 MB.
mysql-master_1  | 2019-12-19T14:59:05.351723Z 0 [Note] InnoDB: 96 redo rollback segment(s) found. 96 redo rollback segment(s) are active.
mysql-master_1  | 2019-12-19T14:59:05.351754Z 0 [Note] InnoDB: 32 non-redo rollback segment(s) are active.
mysql-master_1  | 2019-12-19T14:59:05.352315Z 0 [Note] InnoDB: 5.7.24 started; log sequence number 2591440
mysql-master_1  | 2019-12-19T14:59:05.352672Z 0 [Note] InnoDB: Loading buffer pool(s) from /var/lib/mysql/ib_buffer_pool
mysql-master_1  | 2019-12-19T14:59:05.352734Z 0 [Note] Plugin 'FEDERATED' is disabled.
mysql-master_1  | 2019-12-19T14:59:05.353765Z 0 [Note] InnoDB: Buffer pool(s) load completed at 191219 14:59:05
mysql-master_1  | 2019-12-19T14:59:05.365178Z 0 [Note] Found ca.pem, server-cert.pem and server-key.pem in data directory. Trying to enable SSL support using them.
mysql-master_1  | 2019-12-19T14:59:05.365368Z 0 [Warning] CA certificate ca.pem is self signed.
mysql-master_1  | 2019-12-19T14:59:05.367405Z 0 [Warning] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
mysql-master_1  | 2019-12-19T14:59:05.368213Z 0 [Warning] 'user' entry 'root@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:05.368254Z 0 [Warning] 'user' entry 'mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:05.368270Z 0 [Warning] 'user' entry 'mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:05.368288Z 0 [Warning] 'db' entry 'performance_schema mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:05.368312Z 0 [Warning] 'db' entry 'sys mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:05.368326Z 0 [Warning] 'proxies_priv' entry '@ root@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:05.369340Z 0 [Warning] 'tables_priv' entry 'user mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:05.369371Z 0 [Warning] 'tables_priv' entry 'sys_config mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:05.370474Z 0 [Note] Failed to start slave threads for channel ''
mysql-master_1  | 2019-12-19T14:59:05.375783Z 0 [Note] Event Scheduler: Loaded 0 events
mysql-master_1  | 2019-12-19T14:59:05.376111Z 0 [Note] mysqld: ready for connections.
mysql-master_1  | Version: '5.7.24-log'  socket: '/var/run/mysqld/mysqld.sock'  port: 0  MySQL Community Server (GPL)
mysql-master_1  | Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.
mysql-master_1  | Warning: Unable to load '/usr/share/zoneinfo/leap-seconds.list' as time zone. Skipping it.
mysql-master_1  | Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.
mysql-slave     | Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.
mysql-slave     | Warning: Unable to load '/usr/share/zoneinfo/leap-seconds.list' as time zone. Skipping it.
mysql-slave     | Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.
mysql-slave     | Warning: Unable to load '/usr/share/zoneinfo/zone1970.tab' as time zone. Skipping it.
mysql-slave     | 2019-12-19T14:59:17.548263Z 4 [Warning] 'user' entry 'root@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:17.548296Z 4 [Warning] 'user' entry 'mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:17.548313Z 4 [Warning] 'user' entry 'mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:17.548339Z 4 [Warning] 'db' entry 'performance_schema mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:17.548346Z 4 [Warning] 'db' entry 'sys mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:17.548362Z 4 [Warning] 'proxies_priv' entry '@ root@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:17.548417Z 4 [Warning] 'tables_priv' entry 'user mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 2019-12-19T14:59:17.548430Z 4 [Warning] 'tables_priv' entry 'sys_config mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-slave     | 
mysql-slave     | /usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/init-slave.sh
mysql-slave     | Updating master connetion info in slave.
mysql-slave     | 2019-12-19T14:59:17.566773Z 5 [Note] 'CHANGE MASTER TO FOR CHANNEL '' executed'. Previous state master_host='', master_port= 3306, master_log_file='', master_log_pos= 4, master_bind=''. New state master_host='mysql-master', master_port= 3305, master_log_file='', master_log_pos= 4, master_bind=''.
mysql-slave     | mysqldump: [Warning] Using a password on the command line interface can be insecure.
mysql-slave     | mysqldump: Got error: 2003: Can't connect to MySQL server on 'mysql-master' (111) when trying to connect
mysql-master_1  | Warning: Unable to load '/usr/share/zoneinfo/zone1970.tab' as time zone. Skipping it.
mysql-master_1  | 2019-12-19T14:59:10.587046Z 4 [Warning] 'user' entry 'root@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:10.587144Z 4 [Warning] 'user' entry 'mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:10.587185Z 4 [Warning] 'user' entry 'mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:10.587251Z 4 [Warning] 'db' entry 'performance_schema mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:10.587277Z 4 [Warning] 'db' entry 'sys mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:10.587313Z 4 [Warning] 'proxies_priv' entry '@ root@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:10.587447Z 4 [Warning] 'tables_priv' entry 'user mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:10.587527Z 4 [Warning] 'tables_priv' entry 'sys_config mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 
mysql-master_1  | /usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/init-master.sh
mysql-master_1  | Creating replication user ...
mysql-master_1  | 2019-12-19T14:59:10.598434Z 5 [Warning] 'user' entry 'root@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:10.598524Z 5 [Warning] 'user' entry 'mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:10.598618Z 5 [Warning] 'user' entry 'mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:10.598684Z 5 [Warning] 'db' entry 'performance_schema mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:10.598735Z 5 [Warning] 'db' entry 'sys mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:10.598834Z 5 [Warning] 'proxies_priv' entry '@ root@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:10.599043Z 5 [Warning] 'tables_priv' entry 'user mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:10.599119Z 5 [Warning] 'tables_priv' entry 'sys_config mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 
mysql-master_1  | 2019-12-19T14:59:10.601073Z 0 [Note] Giving 0 client threads a chance to die gracefully
mysql-master_1  | 2019-12-19T14:59:10.601107Z 0 [Note] Shutting down slave threads
mysql-master_1  | 2019-12-19T14:59:10.601118Z 0 [Note] Forcefully disconnecting 0 remaining clients
mysql-master_1  | 2019-12-19T14:59:10.601124Z 0 [Note] Event Scheduler: Purging the queue. 0 events
mysql-master_1  | 2019-12-19T14:59:10.601190Z 0 [Note] Binlog end
mysql-master_1  | 2019-12-19T14:59:10.602399Z 0 [Note] Shutting down plugin 'ngram'
mysql-master_1  | 2019-12-19T14:59:10.602429Z 0 [Note] Shutting down plugin 'partition'
mysql-master_1  | 2019-12-19T14:59:10.602439Z 0 [Note] Shutting down plugin 'BLACKHOLE'
mysql-master_1  | 2019-12-19T14:59:10.602444Z 0 [Note] Shutting down plugin 'ARCHIVE'
mysql-master_1  | 2019-12-19T14:59:10.602451Z 0 [Note] Shutting down plugin 'PERFORMANCE_SCHEMA'
mysql-master_1  | 2019-12-19T14:59:10.602472Z 0 [Note] Shutting down plugin 'MRG_MYISAM'
mysql-master_1  | 2019-12-19T14:59:10.602480Z 0 [Note] Shutting down plugin 'MyISAM'
mysql-master_1  | 2019-12-19T14:59:10.602488Z 0 [Note] Shutting down plugin 'INNODB_SYS_VIRTUAL'
mysql-master_1  | 2019-12-19T14:59:10.602493Z 0 [Note] Shutting down plugin 'INNODB_SYS_DATAFILES'
mysql-master_1  | 2019-12-19T14:59:10.602498Z 0 [Note] Shutting down plugin 'INNODB_SYS_TABLESPACES'
mysql-master_1  | 2019-12-19T14:59:10.602504Z 0 [Note] Shutting down plugin 'INNODB_SYS_FOREIGN_COLS'
mysql-master_1  | 2019-12-19T14:59:10.602509Z 0 [Note] Shutting down plugin 'INNODB_SYS_FOREIGN'
mysql-master_1  | 2019-12-19T14:59:10.602516Z 0 [Note] Shutting down plugin 'INNODB_SYS_FIELDS'
mysql-master_1  | 2019-12-19T14:59:10.602522Z 0 [Note] Shutting down plugin 'INNODB_SYS_COLUMNS'
mysql-master_1  | 2019-12-19T14:59:10.602528Z 0 [Note] Shutting down plugin 'INNODB_SYS_INDEXES'
mysql-master_1  | 2019-12-19T14:59:10.602535Z 0 [Note] Shutting down plugin 'INNODB_SYS_TABLESTATS'
mysql-master_1  | 2019-12-19T14:59:10.602544Z 0 [Note] Shutting down plugin 'INNODB_SYS_TABLES'
mysql-master_1  | 2019-12-19T14:59:10.602570Z 0 [Note] Shutting down plugin 'INNODB_FT_INDEX_TABLE'
mysql-master_1  | 2019-12-19T14:59:10.602577Z 0 [Note] Shutting down plugin 'INNODB_FT_INDEX_CACHE'
mysql-master_1  | 2019-12-19T14:59:10.602583Z 0 [Note] Shutting down plugin 'INNODB_FT_CONFIG'
mysql-master_1  | 2019-12-19T14:59:10.602589Z 0 [Note] Shutting down plugin 'INNODB_FT_BEING_DELETED'
mysql-master_1  | 2019-12-19T14:59:10.602596Z 0 [Note] Shutting down plugin 'INNODB_FT_DELETED'
mysql-master_1  | 2019-12-19T14:59:10.602601Z 0 [Note] Shutting down plugin 'INNODB_FT_DEFAULT_STOPWORD'
mysql-master_1  | 2019-12-19T14:59:10.602608Z 0 [Note] Shutting down plugin 'INNODB_METRICS'
mysql-master_1  | 2019-12-19T14:59:10.602614Z 0 [Note] Shutting down plugin 'INNODB_TEMP_TABLE_INFO'
mysql-master_1  | 2019-12-19T14:59:10.602620Z 0 [Note] Shutting down plugin 'INNODB_BUFFER_POOL_STATS'
mysql-master_1  | 2019-12-19T14:59:10.602625Z 0 [Note] Shutting down plugin 'INNODB_BUFFER_PAGE_LRU'
mysql-master_1  | 2019-12-19T14:59:10.602631Z 0 [Note] Shutting down plugin 'INNODB_BUFFER_PAGE'
mysql-master_1  | 2019-12-19T14:59:10.602638Z 0 [Note] Shutting down plugin 'INNODB_CMP_PER_INDEX_RESET'
mysql-master_1  | 2019-12-19T14:59:10.602643Z 0 [Note] Shutting down plugin 'INNODB_CMP_PER_INDEX'
mysql-master_1  | 2019-12-19T14:59:10.602648Z 0 [Note] Shutting down plugin 'INNODB_CMPMEM_RESET'
mysql-master_1  | 2019-12-19T14:59:10.602655Z 0 [Note] Shutting down plugin 'INNODB_CMPMEM'
mysql-master_1  | 2019-12-19T14:59:10.602660Z 0 [Note] Shutting down plugin 'INNODB_CMP_RESET'
mysql-master_1  | 2019-12-19T14:59:10.602667Z 0 [Note] Shutting down plugin 'INNODB_CMP'
mysql-master_1  | 2019-12-19T14:59:10.602672Z 0 [Note] Shutting down plugin 'INNODB_LOCK_WAITS'
mysql-master_1  | 2019-12-19T14:59:10.602679Z 0 [Note] Shutting down plugin 'INNODB_LOCKS'
mysql-master_1  | 2019-12-19T14:59:10.602684Z 0 [Note] Shutting down plugin 'INNODB_TRX'
mysql-master_1  | 2019-12-19T14:59:10.602692Z 0 [Note] Shutting down plugin 'InnoDB'
mysql-master_1  | 2019-12-19T14:59:10.602789Z 0 [Note] InnoDB: FTS optimize thread exiting.
mysql-master_1  | 2019-12-19T14:59:10.603280Z 0 [Note] InnoDB: Starting shutdown...
mysql-master_1  | 2019-12-19T14:59:10.704804Z 0 [Note] InnoDB: Dumping buffer pool(s) to /var/lib/mysql/ib_buffer_pool
mysql-master_1  | 2019-12-19T14:59:10.705585Z 0 [Note] InnoDB: Buffer pool(s) dump completed at 191219 14:59:10
mysql-master_1  | 2019-12-19T14:59:12.354223Z 0 [Note] InnoDB: Shutdown completed; log sequence number 12371014
mysql-master_1  | 2019-12-19T14:59:12.356473Z 0 [Note] InnoDB: Removed temporary tablespace data file: "ibtmp1"
mysql-master_1  | 2019-12-19T14:59:12.356524Z 0 [Note] Shutting down plugin 'MEMORY'
mysql-master_1  | 2019-12-19T14:59:12.356535Z 0 [Note] Shutting down plugin 'CSV'
mysql-master_1  | 2019-12-19T14:59:12.356546Z 0 [Note] Shutting down plugin 'sha256_password'
mysql-master_1  | 2019-12-19T14:59:12.356555Z 0 [Note] Shutting down plugin 'mysql_native_password'
mysql-master_1  | 2019-12-19T14:59:12.356917Z 0 [Note] Shutting down plugin 'binlog'
mysql-master_1  | 2019-12-19T14:59:12.362716Z 0 [Note] mysqld: Shutdown complete
mysql-master_1  | 
mysql-master_1  | 
mysql-master_1  | MySQL init process done. Ready for start up.
mysql-master_1  | 
mysql-master_1  | 2019-12-19T14:59:12.656027Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
mysql-master_1  | 2019-12-19T14:59:12.657052Z 0 [Note] mysqld (mysqld 5.7.24-log) starting as process 1 ...
mysql-master_1  | 2019-12-19T14:59:12.660186Z 0 [Note] InnoDB: PUNCH HOLE support available
mysql-master_1  | 2019-12-19T14:59:12.660264Z 0 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
mysql-master_1  | 2019-12-19T14:59:12.660293Z 0 [Note] InnoDB: Uses event mutexes
mysql-master_1  | 2019-12-19T14:59:12.660312Z 0 [Note] InnoDB: GCC builtin __atomic_thread_fence() is used for memory barrier
mysql-master_1  | 2019-12-19T14:59:12.660374Z 0 [Note] InnoDB: Compressed tables use zlib 1.2.11
mysql-master_1  | 2019-12-19T14:59:12.660421Z 0 [Note] InnoDB: Using Linux native AIO
mysql-master_1  | 2019-12-19T14:59:12.660757Z 0 [Note] InnoDB: Number of pools: 1
mysql-master_1  | 2019-12-19T14:59:12.660920Z 0 [Note] InnoDB: Using CPU crc32 instructions
mysql-master_1  | 2019-12-19T14:59:12.661942Z 0 [Note] InnoDB: Initializing buffer pool, total size = 128M, instances = 1, chunk size = 128M
mysql-master_1  | 2019-12-19T14:59:12.668379Z 0 [Note] InnoDB: Completed initialization of buffer pool
mysql-master_1  | 2019-12-19T14:59:12.670917Z 0 [Note] InnoDB: If the mysqld execution user is authorized, page cleaner thread priority can be changed. See the man page of setpriority().
mysql-master_1  | 2019-12-19T14:59:12.684401Z 0 [Note] InnoDB: Highest supported file format is Barracuda.
mysql-master_1  | 2019-12-19T14:59:12.693650Z 0 [Note] InnoDB: Creating shared tablespace for temporary tables
mysql-master_1  | 2019-12-19T14:59:12.693799Z 0 [Note] InnoDB: Setting file './ibtmp1' size to 12 MB. Physically writing the file full; Please wait ...
mysql-master_1  | 2019-12-19T14:59:12.708681Z 0 [Note] InnoDB: File './ibtmp1' size is now 12 MB.
mysql-master_1  | 2019-12-19T14:59:12.709693Z 0 [Note] InnoDB: 96 redo rollback segment(s) found. 96 redo rollback segment(s) are active.
mysql-master_1  | 2019-12-19T14:59:12.709782Z 0 [Note] InnoDB: 32 non-redo rollback segment(s) are active.
mysql-master_1  | 2019-12-19T14:59:12.710391Z 0 [Note] InnoDB: Waiting for purge to start
mysql-master_1  | 2019-12-19T14:59:12.760978Z 0 [Note] InnoDB: 5.7.24 started; log sequence number 12371014
mysql-master_1  | 2019-12-19T14:59:12.761698Z 0 [Note] InnoDB: Loading buffer pool(s) from /var/lib/mysql/ib_buffer_pool
mysql-master_1  | 2019-12-19T14:59:12.761877Z 0 [Note] Plugin 'FEDERATED' is disabled.
mysql-master_1  | 2019-12-19T14:59:12.764687Z 0 [Note] InnoDB: Buffer pool(s) load completed at 191219 14:59:12
mysql-master_1  | 2019-12-19T14:59:12.785741Z 0 [Note] Found ca.pem, server-cert.pem and server-key.pem in data directory. Trying to enable SSL support using them.
mysql-master_1  | 2019-12-19T14:59:12.786013Z 0 [Warning] CA certificate ca.pem is self signed.
mysql-master_1  | 2019-12-19T14:59:12.787365Z 0 [Note] Server hostname (bind-address): '*'; port: 3306
mysql-master_1  | 2019-12-19T14:59:12.787457Z 0 [Note] IPv6 is available.
mysql-master_1  | 2019-12-19T14:59:12.787497Z 0 [Note]   - '::' resolves to '::';
mysql-master_1  | 2019-12-19T14:59:12.787529Z 0 [Note] Server socket created on IP: '::'.
mysql-master_1  | 2019-12-19T14:59:12.788806Z 0 [Warning] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
mysql-master_1  | 2019-12-19T14:59:12.789716Z 0 [Warning] 'user' entry 'root@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:12.789801Z 0 [Warning] 'user' entry 'mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:12.789842Z 0 [Warning] 'user' entry 'mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:12.789922Z 0 [Warning] 'db' entry 'performance_schema mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:12.789951Z 0 [Warning] 'db' entry 'sys mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:12.790023Z 0 [Warning] 'proxies_priv' entry '@ root@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:12.791680Z 0 [Warning] 'tables_priv' entry 'user mysql.session@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:12.791757Z 0 [Warning] 'tables_priv' entry 'sys_config mysql.sys@localhost' ignored in --skip-name-resolve mode.
mysql-master_1  | 2019-12-19T14:59:12.792835Z 0 [Note] Failed to start slave threads for channel ''
mysql-master_1  | 2019-12-19T14:59:12.797989Z 0 [Note] Event Scheduler: Loaded 0 events
mysql-master_1  | 2019-12-19T14:59:12.798359Z 0 [Note] mysqld: ready for connections.
mysql-master_1  | Version: '5.7.24-log'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server (GPL)
mysql-master_1  | 2019-12-19T14:59:13.555650Z 2 [Note] Aborted connection 2 to db: 'unconnected' user: 'root' host: '172.25.0.1' (Got an error reading communication packets)
---------------------------- Captured stderr setup -----------------------------
Creating network "compose_default" with the default driver
Creating compose_mysql-master_1 ... done
Creating mysql-slave            ... done

=============================== warnings summary ===============================
tests/test_mysql.py::test_minimal_config
  (1287, "Using GRANT statement to modify existing user's properties other than privileges is deprecated and will be removed in future release. Use ALTER USER statement for this operation.")

-- Docs: https://docs.pytest.org/en/latest/warnings.html
!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
========================= 1 warning, 1 error in 35.09s =========================
ERROR: InvocationError for command /Users/florimond.manca/go/src/github.com/DataDog/integrations-core/mysql/.tox/py37-5.7/bin/pytest -v (exited with code 1)
___________________________________ summary ____________________________________
ERROR:   py37-5.7: commands failed
```
</details>

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
