### PR TITLE
Fix out-of-date agent requirements for clickhouse and external_dns

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -15,7 +15,7 @@ datadog-checks-base==10.0.2
 datadog-checks-downloader==2.0.0
 datadog-cilium==1.0.1
 datadog-cisco-aci==1.8.1
-datadog-clickhouse==0.0.1
+datadog-clickhouse==1.0.0
 datadog-cockroachdb==1.1.0
 datadog-consul==1.11.0
 datadog-coredns==1.3.0; sys_platform == 'linux2'
@@ -32,7 +32,7 @@ datadog-elastic==1.15.0
 datadog-envoy==1.11.0
 datadog-etcd==2.1.0
 datadog-exchange-server==1.6.0; sys_platform == 'win32'
-datadog-external-dns==0.0.2
+datadog-external-dns==1.0.0
 datadog-fluentd==1.5.0
 datadog-gearmand==1.3.1; sys_platform != 'win32'
 datadog-gitlab-runner==2.6.0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Cleanup for https://github.com/DataDog/integrations-core/pull/5242 x https://github.com/DataDog/integrations-core/pull/5243

### Motivation
<!-- What inspired you to submit this pull request? -->
Currently breaking CI on [Linux@master](https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=5262&view=logs&j=762a2123-1c7c-5bf0-0e62-04885c3ecd74&t=716f7aa4-f33c-5d8e-6df4-c98fb7525942&l=19) (and blocking https://github.com/DataDog/integrations-core/pull/5258).

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Reproducible locally on `master`: `ddev validate agent-reqs`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
