### PR TITLE
Include iproute2 in network e2e environment

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -161,7 +161,9 @@ def dd_agent_check(request, aggregator):
         result = run_command(check_command, capture=True)
         if AGENT_COLLECTOR_SEPARATOR not in result.stdout:
             raise ValueError(
-                '{}{}\nCould find `{}` in the output'.format(result.stdout, result.stderr, AGENT_COLLECTOR_SEPARATOR)
+                '{}{}\nCould not find `{}` in the output'.format(
+                    result.stdout, result.stderr, AGENT_COLLECTOR_SEPARATOR
+                )
             )
 
         _, _, collector_output = result.stdout.partition(AGENT_COLLECTOR_SEPARATOR)

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -181,9 +181,7 @@ def dd_agent_check(request, aggregator):
 
             else:
                 raise ValueError(
-                    '{}{}\nCould parse JSON from the output'.format(
-                        result.stdout, result.stderr, AGENT_COLLECTOR_SEPARATOR
-                    )
+                    'Could not parse JSON from the output. stdout:\n{}\nstderr{}'.format(result.stdout, result.stderr)
                 )
         collector = json.loads(collector_output)
 

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -166,9 +166,25 @@ def dd_agent_check(request, aggregator):
 
         _, _, collector_output = result.stdout.partition(AGENT_COLLECTOR_SEPARATOR)
         collector_output = collector_output.strip()
-        if not collector_output.endswith(']'):
-            # JMX needs some additional cleanup
-            collector_output = collector_output[: collector_output.rfind(']') + 1]
+        if not collector_output.endswith('} ]') or not collector_output.endswith('}\n]'):
+            # JMX and E2E parsing need some additional cleanup
+            # There can be extra text and log file output after JSON contents
+            lines = collector_output.splitlines()
+            for i, line in enumerate(lines[::-1]):
+                if line.startswith('} ]'):
+                    collector_output = '\n'.join(lines[:-i])
+                    break
+                elif line.endswith('}') and lines[-i + 1] == ']':
+                    # check for '}\n]' condition of already pretty printed json
+                    collector_output = '\n'.join(lines[:-i + 2])
+                    break
+
+            else:
+                raise ValueError(
+                    '{}{}\nCould parse JSON from the output'.format(
+                        result.stdout, result.stderr, AGENT_COLLECTOR_SEPARATOR
+                    )
+                )
         collector = json.loads(collector_output)
 
         replay_check_run(collector, aggregator)

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -168,23 +168,9 @@ def dd_agent_check(request, aggregator):
 
         _, _, collector_output = result.stdout.partition(AGENT_COLLECTOR_SEPARATOR)
         collector_output = collector_output.strip()
-        if not collector_output.endswith('} ]') or not collector_output.endswith('}\n]'):
-            # JMX and E2E parsing need some additional cleanup
-            # There can be extra text and log file output after JSON contents
-            lines = collector_output.splitlines()
-            for i, line in enumerate(lines[::-1]):
-                if line.startswith('} ]'):
-                    collector_output = '\n'.join(lines[:-i])
-                    break
-                elif line.endswith('}') and lines[-i + 1] == ']':
-                    # check for '}\n]' condition of already pretty printed json
-                    collector_output = '\n'.join(lines[: -i + 2])
-                    break
-
-            else:
-                raise ValueError(
-                    'Could not parse JSON from the output. stdout:\n{}\nstderr{}'.format(result.stdout, result.stderr)
-                )
+        if not collector_output.endswith(']'):
+            # JMX needs some additional cleanup
+            collector_output = collector_output[: collector_output.rfind(']') + 1]
         collector = json.loads(collector_output)
 
         replay_check_run(collector, aggregator)

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -176,7 +176,7 @@ def dd_agent_check(request, aggregator):
                     break
                 elif line.endswith('}') and lines[-i + 1] == ']':
                     # check for '}\n]' condition of already pretty printed json
-                    collector_output = '\n'.join(lines[:-i + 2])
+                    collector_output = '\n'.join(lines[: -i + 2])
                     break
 
             else:

--- a/network/README.md
+++ b/network/README.md
@@ -34,7 +34,8 @@ sudo modprobe nf_conntrack_ipv6
 
         ## @param collect_connection_state - boolean - required
         ## Set to true to collect connection states for your interfaces
-        ## Note: this will require the command `ss` from system package `iproute2` to be installed
+        ## Note: this will require either the command `ss` from system package `iproute2` or
+        ## the command `netstat` from the system package `net-tools` to be installed
         #
         - collect_connection_state: false
     ```

--- a/network/README.md
+++ b/network/README.md
@@ -34,6 +34,7 @@ sudo modprobe nf_conntrack_ipv6
 
         ## @param collect_connection_state - boolean - required
         ## Set to true to collect connection states for your interfaces
+        ## Note: this will require the command `ss` from system package `iproute2` to be installed
         #
         - collect_connection_state: false
     ```

--- a/network/datadog_checks/network/data/conf.yaml.default
+++ b/network/datadog_checks/network/data/conf.yaml.default
@@ -10,7 +10,8 @@ instances:
 
     ## @param collect_connection_state - boolean - required
     ## Set to true to collect connection states for your interfaces
-    ## Note: this will require the command `ss` from system package `iproute2` to be installed
+    ## Note: this will require either the command `ss` from system package `iproute2` or
+    ## the command `netstat` from the system package `net-tools` to be installed
     #
   - collect_connection_state: false
 

--- a/network/datadog_checks/network/data/conf.yaml.default
+++ b/network/datadog_checks/network/data/conf.yaml.default
@@ -10,6 +10,7 @@ instances:
 
     ## @param collect_connection_state - boolean - required
     ## Set to true to collect connection states for your interfaces
+    ## Note: this will require the command `ss` from system package `iproute2` to be installed
     #
   - collect_connection_state: false
 

--- a/network/tests/common.py
+++ b/network/tests/common.py
@@ -12,7 +12,7 @@ INSTANCE_BLACKLIST = {"collect_connection_state": True, "blacklist_conntrack_met
 
 
 # In order to collect connection state we need `ss` command included in `iproute2` package
-E2E_METADATA = {'start_commands': ['apt-get update', 'apt-get install iproute2 -y',]}
+E2E_METADATA = {'start_commands': ['apt-get update', 'apt-get install iproute2 -y']}
 
 EXPECTED_METRICS = [
     'system.net.bytes_rcvd',

--- a/network/tests/common.py
+++ b/network/tests/common.py
@@ -10,6 +10,10 @@ INSTANCE = {"collect_connection_state": True}
 
 INSTANCE_BLACKLIST = {"collect_connection_state": True, "blacklist_conntrack_metrics": ["count"]}
 
+
+# In order to collect connection state we need `ss` command included in `iproute2` package
+E2E_METADATA = {'start_commands': ['apt-get update', 'apt-get install iproute2 -y',]}
+
 EXPECTED_METRICS = [
     'system.net.bytes_rcvd',
     'system.net.bytes_sent',

--- a/network/tests/common.py
+++ b/network/tests/common.py
@@ -23,6 +23,21 @@ EXPECTED_METRICS = [
     'system.net.packets_out.error',
 ]
 
+E2E_EXPECTED_METRICS = EXPECTED_METRICS + [
+    "system.net.tcp4.closing",
+    "system.net.tcp4.established",
+    "system.net.tcp4.listening",
+    "system.net.tcp4.opening",
+    "system.net.tcp4.time_wait",
+    "system.net.tcp6.closing",
+    "system.net.tcp6.established",
+    "system.net.tcp6.listening",
+    "system.net.tcp6.opening",
+    "system.net.tcp6.time_wait",
+    "system.net.udp4.connections",
+    "system.net.udp6.connections",
+]
+
 CONNTRACK_METRICS = [
     'system.net.conntrack.acct',
     'system.net.conntrack.buckets',

--- a/network/tests/conftest.py
+++ b/network/tests/conftest.py
@@ -12,7 +12,7 @@ from . import common
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    yield common.INSTANCE
+    yield common.INSTANCE, common.E2E_METADATA
 
 
 @pytest.fixture

--- a/network/tests/test_e2e.py
+++ b/network/tests/test_e2e.py
@@ -7,5 +7,5 @@ from . import common
 def test_check_e2e(dd_agent_check, instance):
     aggregator = dd_agent_check(instance, rate=True)
 
-    for metric in common.EXPECTED_METRICS:
+    for metric in common.E2E_EXPECTED_METRICS:
         aggregator.assert_metric(metric)


### PR DESCRIPTION
### What does this PR do?
Tests will fail in the e2e environment because the `ss` package isn't installed when we ask to `collect_connection_state`.

This PR includes it in our setup, plus adds a comment to the default YAML and README that the package will be required if that config option is set.

### Additional Notes
There seems to be a separate issue with the check not appropriately catching the `SubprocessOutputEmptyError` - but that gets avoided by having the package installed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
