### PR TITLE
Refactor auth handling of RequestsWrapper

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from ipaddress import ip_address, ip_network
 
 import requests
+from requests import auth as requests_auth
 from six import iteritems, string_types
 from six.moves.urllib.parse import urlparse
 from urllib3.exceptions import InsecureRequestWarning
@@ -40,7 +41,7 @@ LOGGER = logging.getLogger(__file__)
 DEFAULT_TIMEOUT = 10
 
 STANDARD_FIELDS = {
-    'auth_type': '',
+    'auth_type': 'basic',
     'aws_host': '',
     'aws_region': '',
     'aws_service': '',
@@ -169,59 +170,26 @@ class RequestsWrapper(object):
             update_headers(headers, config['extra_headers'])
 
         # http://docs.python-requests.org/en/master/user/authentication/
-        auth = None
-        if config['password']:
-            if config['username']:
-                auth_type = config.get('auth_type', 'basic').lower()
-                if auth_type == 'digest':
-                    auth = requests.auth.HTTPDigestAuth(config['username'], config['password'])
-                else:
-                    if auth_type != 'basic':
-                        self.logger.debug('auth_type %s is not supported, defaulting to basic', auth_type)
-                    auth = (config['username'], config['password'])
+        auth_type = config['auth_type'].lower()
+        if auth_type not in AUTH_TYPES:
+            self.logger.warning('auth_type %s is not supported, defaulting to basic', auth_type)
+            auth_type = 'basic'
 
-            elif config['ntlm_domain']:
-                ensure_ntlm()
-
-                auth = requests_ntlm.HttpNtlmAuth(config['ntlm_domain'], config['password'])
-
-        if auth is None:
+        if auth_type == 'basic':
             if config['kerberos_auth']:
-                ensure_kerberos()
-
-                # For convenience
-                if is_affirmative(config['kerberos_auth']):
-                    config['kerberos_auth'] = 'required'
-
-                if config['kerberos_auth'] not in KERBEROS_STRATEGIES:
-                    raise ConfigurationError(
-                        'Invalid Kerberos strategy `{}`, must be one of: {}'.format(
-                            config['kerberos_auth'], ' | '.join(KERBEROS_STRATEGIES)
-                        )
-                    )
-
-                auth = requests_kerberos.HTTPKerberosAuth(
-                    mutual_authentication=KERBEROS_STRATEGIES[config['kerberos_auth']],
-                    delegate=is_affirmative(config['kerberos_delegate']),
-                    force_preemptive=is_affirmative(config['kerberos_force_initiate']),
-                    hostname_override=config['kerberos_hostname'],
-                    principal=config['kerberos_principal'],
+                self.logger.warning(
+                    'The ability to use Kerberos auth without explicitly setting auth_type to '
+                    '`kerberos` is deprecated and will be removed in Agent 7.20.0'
                 )
-            elif config['auth_type'].lower() == 'aws':
-                ensure_aws()
-
-                if not config['aws_host']:
-                    raise ConfigurationError('AWS auth requires the setting `aws_host`')
-
-                if not config['aws_region']:
-                    raise ConfigurationError('AWS auth requires the setting `aws_region`')
-
-                if not config['aws_service']:
-                    raise ConfigurationError('AWS auth requires the setting `aws_service`')
-
-                auth = requests_aws.BotoAWSRequestsAuth(
-                    aws_host=config['aws_host'], aws_region=config['aws_region'], aws_service=config['aws_service']
+                auth_type = 'kerberos'
+            elif config['ntlm_domain']:
+                self.logger.warning(
+                    'The ability to use NTLM auth without explicitly setting auth_type to '
+                    '`ntlm` is deprecated and will be removed in Agent 7.20.0'
                 )
+                auth_type = 'ntlm'
+
+        auth = AUTH_TYPES[auth_type](config)
 
         # http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
         verify = True
@@ -411,28 +379,6 @@ def handle_kerberos_cache(cache_file_path):
         os.environ['KRB5CCNAME'] = old_cache_path
 
 
-def ensure_kerberos():
-    global requests_kerberos
-    if requests_kerberos is None:
-        import requests_kerberos
-
-        KERBEROS_STRATEGIES['required'] = requests_kerberos.REQUIRED
-        KERBEROS_STRATEGIES['optional'] = requests_kerberos.OPTIONAL
-        KERBEROS_STRATEGIES['disabled'] = requests_kerberos.DISABLED
-
-
-def ensure_ntlm():
-    global requests_ntlm
-    if requests_ntlm is None:
-        import requests_ntlm
-
-
-def ensure_aws():
-    global requests_aws
-    if requests_aws is None:
-        from aws_requests_auth import boto_utils as requests_aws
-
-
 def should_bypass_proxy(url, no_proxy_uris):
     # Accepts a URL and a list of no_proxy URIs
     # Returns True if URL should bypass the proxy.
@@ -456,3 +402,73 @@ def should_bypass_proxy(url, no_proxy_uris):
             if no_proxy_uri == parsed_uri or parsed_uri.endswith(dot_no_proxy_uri):
                 return True
     return False
+
+
+def create_basic_auth(config):
+    # Since this is the default case, only activate when all fields are explicitly set
+    if config['username'] and config['password']:
+        return (config['username'], config['password'])
+
+
+def create_digest_auth(config):
+    return requests_auth.HTTPDigestAuth(config['username'], config['password'])
+
+
+def create_ntlm_auth(config):
+    global requests_ntlm
+    if requests_ntlm is None:
+        import requests_ntlm
+
+    return requests_ntlm.HttpNtlmAuth(config['ntlm_domain'], config['password'])
+
+
+def create_kerberos_auth(config):
+    global requests_kerberos
+    if requests_kerberos is None:
+        import requests_kerberos
+
+        KERBEROS_STRATEGIES['required'] = requests_kerberos.REQUIRED
+        KERBEROS_STRATEGIES['optional'] = requests_kerberos.OPTIONAL
+        KERBEROS_STRATEGIES['disabled'] = requests_kerberos.DISABLED
+
+    # For convenience
+    if is_affirmative(config['kerberos_auth']):
+        config['kerberos_auth'] = 'required'
+
+    if config['kerberos_auth'] not in KERBEROS_STRATEGIES:
+        raise ConfigurationError(
+            'Invalid Kerberos strategy `{}`, must be one of: {}'.format(
+                config['kerberos_auth'], ' | '.join(KERBEROS_STRATEGIES)
+            )
+        )
+
+    return requests_kerberos.HTTPKerberosAuth(
+        mutual_authentication=KERBEROS_STRATEGIES[config['kerberos_auth']],
+        delegate=is_affirmative(config['kerberos_delegate']),
+        force_preemptive=is_affirmative(config['kerberos_force_initiate']),
+        hostname_override=config['kerberos_hostname'],
+        principal=config['kerberos_principal'],
+    )
+
+
+def create_aws_auth(config):
+    global requests_aws
+    if requests_aws is None:
+        from aws_requests_auth import boto_utils as requests_aws
+
+    for setting in ('aws_host', 'aws_region', 'aws_service'):
+        if not config[setting]:
+            raise ConfigurationError('AWS auth requires the setting `{}`'.format(setting))
+
+    return requests_aws.BotoAWSRequestsAuth(
+        aws_host=config['aws_host'], aws_region=config['aws_region'], aws_service=config['aws_service']
+    )
+
+
+AUTH_TYPES = {
+    'basic': create_basic_auth,
+    'digest': create_digest_auth,
+    'ntlm': create_ntlm_auth,
+    'kerberos': create_kerberos_auth,
+    'aws': create_aws_auth,
+}

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -179,13 +179,13 @@ class RequestsWrapper(object):
             if config['kerberos_auth']:
                 self.logger.warning(
                     'The ability to use Kerberos auth without explicitly setting auth_type to '
-                    '`kerberos` is deprecated and will be removed in Agent 7.20.0'
+                    '`kerberos` is deprecated and will be removed in Agent 8'
                 )
                 auth_type = 'kerberos'
             elif config['ntlm_domain']:
                 self.logger.warning(
                     'The ability to use NTLM auth without explicitly setting auth_type to '
-                    '`ntlm` is deprecated and will be removed in Agent 7.20.0'
+                    '`ntlm` is deprecated and will be removed in Agent 8'
                 )
                 auth_type = 'ntlm'
 
@@ -432,7 +432,7 @@ def create_kerberos_auth(config):
         KERBEROS_STRATEGIES['disabled'] = requests_kerberos.DISABLED
 
     # For convenience
-    if is_affirmative(config['kerberos_auth']):
+    if config['kerberos_auth'] is None or is_affirmative(config['kerberos_auth']):
         config['kerberos_auth'] = 'required'
 
     if config['kerberos_auth'] not in KERBEROS_STRATEGIES:

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -220,7 +220,7 @@ class TestAuth:
 
         assert http.options['auth'] is None
 
-    def test_config_kerberos(self):
+    def test_config_kerberos_legacy(self):
         instance = {'kerberos_auth': 'required'}
         init_config = {}
 
@@ -239,8 +239,27 @@ class TestAuth:
                 principal=None,
             )
 
+    def test_config_kerberos(self):
+        instance = {'auth_type': 'kerberos', 'kerberos_auth': 'required'}
+        init_config = {}
+
+        # Trigger lazy import
+        http = RequestsWrapper(instance, init_config)
+        assert isinstance(http.options['auth'], requests_kerberos.HTTPKerberosAuth)
+
         with mock.patch('datadog_checks.base.utils.http.requests_kerberos.HTTPKerberosAuth') as m:
-            RequestsWrapper({'kerberos_auth': 'optional'}, init_config)
+            RequestsWrapper(instance, init_config)
+
+            m.assert_called_once_with(
+                mutual_authentication=requests_kerberos.REQUIRED,
+                delegate=False,
+                force_preemptive=False,
+                hostname_override=None,
+                principal=None,
+            )
+
+        with mock.patch('datadog_checks.base.utils.http.requests_kerberos.HTTPKerberosAuth') as m:
+            RequestsWrapper({'auth_type': 'kerberos', 'kerberos_auth': 'optional'}, init_config)
 
             m.assert_called_once_with(
                 mutual_authentication=requests_kerberos.OPTIONAL,
@@ -251,7 +270,7 @@ class TestAuth:
             )
 
         with mock.patch('datadog_checks.base.utils.http.requests_kerberos.HTTPKerberosAuth') as m:
-            RequestsWrapper({'kerberos_auth': 'disabled'}, init_config)
+            RequestsWrapper({'auth_type': 'kerberos', 'kerberos_auth': 'disabled'}, init_config)
 
             m.assert_called_once_with(
                 mutual_authentication=requests_kerberos.DISABLED,
@@ -262,7 +281,7 @@ class TestAuth:
             )
 
     def test_config_kerberos_shortcut(self):
-        instance = {'kerberos_auth': True}
+        instance = {'auth_type': 'kerberos', 'kerberos_auth': True}
         init_config = {}
 
         # Trigger lazy import
@@ -281,14 +300,14 @@ class TestAuth:
             )
 
     def test_config_kerberos_unknown(self):
-        instance = {'kerberos_auth': 'unknown'}
+        instance = {'auth_type': 'kerberos', 'kerberos_auth': 'unknown'}
         init_config = {}
 
         with pytest.raises(ConfigurationError):
             RequestsWrapper(instance, init_config)
 
     def test_config_kerberos_keytab_file(self):
-        instance = {'kerberos_keytab': '/test/file'}
+        instance = {'auth_type': 'kerberos', 'kerberos_keytab': '/test/file'}
         init_config = {}
 
         http = RequestsWrapper(instance, init_config)
@@ -301,7 +320,7 @@ class TestAuth:
         assert os.environ.get('KRB5_CLIENT_KTNAME') is None
 
     def test_config_kerberos_cache(self):
-        instance = {'kerberos_cache': '/test/file'}
+        instance = {'auth_type': 'kerberos', 'kerberos_cache': '/test/file'}
         init_config = {}
 
         http = RequestsWrapper(instance, init_config)
@@ -314,7 +333,7 @@ class TestAuth:
         assert os.environ.get('KRB5CCNAME') is None
 
     def test_config_kerberos_cache_restores_rollback(self):
-        instance = {'kerberos_cache': '/test/file'}
+        instance = {'auth_type': 'kerberos', 'kerberos_cache': '/test/file'}
         init_config = {}
 
         http = RequestsWrapper(instance, init_config)
@@ -326,7 +345,7 @@ class TestAuth:
             assert os.environ.get('KRB5CCNAME') == 'old'
 
     def test_config_kerberos_keytab_file_rollback(self):
-        instance = {'kerberos_keytab': '/test/file'}
+        instance = {'auth_type': 'kerberos', 'kerberos_keytab': '/test/file'}
         init_config = {}
 
         http = RequestsWrapper(instance, init_config)
@@ -340,7 +359,7 @@ class TestAuth:
             assert os.environ.get('KRB5_CLIENT_KTNAME') == 'old'
 
     def test_config_kerberos_legacy_remap(self):
-        instance = {'kerberos': True}
+        instance = {'auth_type': 'kerberos', 'kerberos': True}
         init_config = {}
 
         # Trigger lazy import
@@ -371,6 +390,7 @@ class TestAuth:
     def test_kerberos_auth_principal_inexistent(self, kerberos):
         instance = {
             'url': kerberos["url"],
+            'auth_type': 'kerberos',
             'kerberos_auth': 'required',
             'kerberos_hostname': kerberos["hostname"],
             'kerberos_cache': "DIR:{}".format(kerberos["cache"]),
@@ -387,6 +407,7 @@ class TestAuth:
     def test_kerberos_auth_principal_incache_nokeytab(self, kerberos):
         instance = {
             'url': kerberos["url"],
+            'auth_type': 'kerberos',
             'kerberos_auth': 'required',
             'kerberos_cache': "DIR:{}".format(kerberos["cache"]),
             'kerberos_hostname': kerberos["hostname"],
@@ -402,6 +423,7 @@ class TestAuth:
     def test_kerberos_auth_principal_inkeytab_nocache(self, kerberos):
         instance = {
             'url': kerberos["url"],
+            'auth_type': 'kerberos',
             'kerberos_auth': 'required',
             'kerberos_hostname': kerberos["hostname"],
             'kerberos_cache': "DIR:{}".format(kerberos["tmp_dir"]),
@@ -415,6 +437,19 @@ class TestAuth:
         assert response.status_code == 200
 
     def test_config_ntlm(self):
+        instance = {'auth_type': 'ntlm', 'ntlm_domain': 'domain\\user', 'password': 'pass'}
+        init_config = {}
+
+        # Trigger lazy import
+        http = RequestsWrapper(instance, init_config)
+        assert isinstance(http.options['auth'], requests_ntlm.HttpNtlmAuth)
+
+        with mock.patch('datadog_checks.base.utils.http.requests_ntlm.HttpNtlmAuth') as m:
+            RequestsWrapper(instance, init_config)
+
+            m.assert_called_once_with('domain\\user', 'pass')
+
+    def test_config_ntlm_legacy(self, caplog):
         instance = {'ntlm_domain': 'domain\\user', 'password': 'pass'}
         init_config = {}
 
@@ -426,6 +461,11 @@ class TestAuth:
             RequestsWrapper(instance, init_config)
 
             m.assert_called_once_with('domain\\user', 'pass')
+
+        assert (
+            'The ability to use NTLM auth without explicitly setting auth_type to '
+            '`ntlm` is deprecated and will be removed in Agent 8'
+        ) in caplog.text
 
     def test_config_aws(self):
         instance = {'auth_type': 'aws', 'aws_host': 'uri', 'aws_region': 'earth', 'aws_service': 'saas'}

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -11,6 +11,7 @@ import requests
 import requests_kerberos
 import requests_ntlm
 from aws_requests_auth import boto_utils as requests_aws
+from requests import auth as requests_auth
 from requests.exceptions import ConnectTimeout, ProxyError
 from six import iteritems
 from urllib3.exceptions import InsecureRequestWarning
@@ -198,8 +199,12 @@ class TestAuth:
         instance = {'username': 'user', 'password': 'pass', 'auth_type': 'digest'}
         init_config = {}
         http = RequestsWrapper(instance, init_config)
+        assert isinstance(http.options['auth'], requests_auth.HTTPDigestAuth)
 
-        assert isinstance(http.options['auth'], requests.auth.HTTPDigestAuth)
+        with mock.patch('datadog_checks.base.utils.http.requests_auth.HTTPDigestAuth') as m:
+            RequestsWrapper(instance, init_config)
+
+            m.assert_called_once_with('user', 'pass')
 
     def test_config_basic_only_username(self):
         instance = {'username': 'user'}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
@@ -45,17 +45,33 @@
     example: basic
     type: string
   description: |
-    The type of authentication to use. The available types are:
+    The type of authentication to use. The available types (and related options) are:
 
       - basic
+        |__ username
+        |__ password
       - digest
+        |__ username
+        |__ password
       - ntlm
+        |__ ntlm_domain
+        |__ password
       - kerberos
+        |__ kerberos_auth
+        |__ kerberos_cache
+        |__ kerberos_delegate
+        |__ kerberos_force_initiate
+        |__ kerberos_hostname
+        |__ kerberos_keytab
+        |__ kerberos_principal
       - aws
+        |__ aws_region
+        |__ aws_host
+        |__ aws_service
 - name: username
   value:
     type: string
-  description: The username to use if services are behind basic auth.
+  description: The username to use if services are behind basic or digest auth.
 - name: password
   secret: true
   value:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
@@ -40,6 +40,18 @@
 
     If set to `true`, this makes the check bypass any proxy
     settings enabled and attempt to reach services directly.
+- name: auth_type
+  value:
+    example: basic
+    type: string
+  description: |
+    The type of authentication to use. The available types are:
+
+      - basic
+      - digest
+      - ntlm
+      - kerberos
+      - aws
 - name: username
   value:
     type: string

--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -2670,6 +2670,7 @@ def test_template_array():
         'foo',
         'proxy',
         'skip_proxy',
+        'auth_type',
         'username',
         'password',
         'ntlm_domain',


### PR DESCRIPTION
### Motivation

All auth should be behind the field `auth_type` so we don't determine the type arbitrarily