### PR TITLE
Fix possible TypeError due to NoneType in parser.isoparse

### DIFF
--- a/twistlock/datadog_checks/twistlock/twistlock.py
+++ b/twistlock/datadog_checks/twistlock/twistlock.py
@@ -74,6 +74,8 @@ class TwistlockCheck(AgentCheck):
         service_check_name = "{}.license_ok".format(self.NAMESPACE)
         try:
             license = self._retrieve_json("/api/v1/settings/license")
+            if "expiration_date" not in license:
+                raise Exception("expiration_date not found.")
         except Exception as e:
             self.warning("cannot retrieve license data: {}".format(e))
             self.service_check(service_check_name, AgentCheck.CRITICAL, tags=self.config.tags)

--- a/twistlock/datadog_checks/twistlock/twistlock.py
+++ b/twistlock/datadog_checks/twistlock/twistlock.py
@@ -324,7 +324,9 @@ class TwistlockCheck(AgentCheck):
             # it's possible to get a null response from the server
             # {} is a bit easier to deal with
             if 'err' in j:
-                self.log.error("Error in response: {}".format(j.get("err")))
+                err_msg = "Error in response: {}".format(j.get("err"))
+                self.log.error(err_msg)
+                raise Exception(err_msg)
             return j or {}
         except Exception as e:
             self.log.debug("cannot get a response: {} response is: {}".format(e, response.text))

--- a/twistlock/tests/test_twistlock.py
+++ b/twistlock/tests/test_twistlock.py
@@ -101,11 +101,12 @@ def test_config_project(aggregator):
     for metric in METRICS:
         aggregator.assert_metric_has_tag(metric, project_tag)
 
+
 def test_err_response(aggregator):
 
     check = TwistlockCheck('twistlock', {}, [instance])
 
     with pytest.raises(Exception, match='^Error in response'):
-        with mock.patch('requests.get', return_value=MockResponse('{"err": "invalid credentials"}'), autospec=True) as r:
+        with mock.patch('requests.get', return_value=MockResponse('{"err": "invalid credentials"}'), autospec=True):
 
             check.check(instance)

--- a/twistlock/tests/test_twistlock.py
+++ b/twistlock/tests/test_twistlock.py
@@ -6,6 +6,7 @@ import json
 import os
 
 import mock
+import pytest
 
 from datadog_checks.dev import get_here
 from datadog_checks.twistlock import TwistlockCheck
@@ -99,3 +100,12 @@ def test_config_project(aggregator):
     # Check if metrics are tagged with the project.
     for metric in METRICS:
         aggregator.assert_metric_has_tag(metric, project_tag)
+
+def test_err_response(aggregator):
+
+    check = TwistlockCheck('twistlock', {}, [instance])
+
+    with pytest.raises(Exception, match='^Error in response'):
+        with mock.patch('requests.get', return_value=MockResponse('{"err": "invalid credentials"}'), autospec=True) as r:
+
+            check.check(instance)


### PR DESCRIPTION
### What does this PR do?
Fixes `TypeError: object of type 'NoneType' has no len()` returned by parser.isoparse if data does not contain an expiration_date due to null response or err in response.

### Motivation
Encountered in scenarios where Twistlock returns `{"err": "invalid credentials"}`
> it's possible to get a null response from the server
a null response = empty dict can trigger the error as well as if endpoint responds with a valid json but contains `err`

### Additional Notes

- Decided to raise an Exception if `err` found in response; not entirely sure if [`self.log.error(...)`](https://github.com/DataDog/integrations-core/compare/ian.bucad/isoparse_nonetype?expand=1#diff-5c498fac95289b662b07ee4b18134603R328) is still necessary.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
