### PR TITLE
Don't report response time when connection fails

### DIFF
--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -19,7 +19,7 @@ class TCPCheck(AgentCheck):
         self.instance_name = self.normalize_tag(instance['name'])
         port = instance.get('port', None)
         self.timeout = float(instance.get('timeout', 10))
-        self.response_time = instance.get('collect_response_time', False)
+        self.collect_response_time = instance.get('collect_response_time', False)
         self.custom_tags = instance.get('tags', [])
         self.socket_type = None
 
@@ -105,7 +105,7 @@ class TCPCheck(AgentCheck):
             self.log.debug("%s:%d is UP", self.addr, self.port)
             self.report_as_service_check(AgentCheck.OK, 'UP')
 
-        if self.response_time and response_time is not None:
+        if self.collect_response_time and response_time is not None:
             self.gauge(
                 'network.tcp.response_time',
                 response_time,

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -19,6 +19,7 @@ def test_down(aggregator):
     expected_tags = ["instance:DownService", "target_host:127.0.0.1", "port:65530", "foo:bar"]
     aggregator.assert_service_check('tcp.can_connect', status=check.CRITICAL, tags=expected_tags)
     aggregator.assert_metric('network.tcp.can_connect', value=0, tags=expected_tags)
+    aggregator.assert_metric('network.tcp.response_time', count=0)  # should not submit response time metric on failure
     aggregator.assert_all_metrics_covered()
     assert len(aggregator.service_checks('tcp.can_connect')) == 1
 

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -13,6 +13,7 @@ def test_down(aggregator):
     Service expected to be down
     """
     instance = deepcopy(common.INSTANCE_KO)
+    instance['collect_response_time'] = True
     check = TCPCheck(common.CHECK_NAME, {}, [instance])
     check.check(instance)
     expected_tags = ["instance:DownService", "target_host:127.0.0.1", "port:65530", "foo:bar"]


### PR DESCRIPTION
This doesn't make sense to report response time when we fail to connect
to the host. Let's also try to calculate closer to the connect
operation.