### PR TITLE
[Consul] Adding AD instructions

### DIFF
--- a/consul/README.md
+++ b/consul/README.md
@@ -29,9 +29,9 @@ The Datadog Agent's Consul check is included in the [Datadog Agent][2] package, 
 
 ### Configuration
 
-Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
-
 #### Host
+
+Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
 ##### Metric Collection
 

--- a/consul/README.md
+++ b/consul/README.md
@@ -29,19 +29,7 @@ The Datadog Agent's Consul check is included in the [Datadog Agent][2] package, 
 
 ### Configuration
 
-1. Connect Consul Agent to [DogStatsD][3]. In the main Consul configuration file, add your `dogstatsd_addr` nested under the top-level `telemetry` key:
-
-    ```conf
-    {
-      ...
-      "telemetry": {
-        "dogstatsd_addr": "127.0.0.1:8125"
-      },
-      ...
-    }
-    ```
-
-2. Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
+Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
 #### Host
 
@@ -112,6 +100,20 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 | Parameter      | Value                                               |
 |----------------|-----------------------------------------------------|
 | `<LOG_CONFIG>` | `{"source": "consul", "service": "<SERVICE_NAME>"}` |
+
+#### DogStatsD
+
+Alternatively, you can configure consul to send its data to the Agent through [DogStatsD][3] instead of relying on the Agent to pull the data from consul. To achieve this, add your `dogstatsd_addr` nested under the top-level `telemetry` key in the main Consul configuration file:
+
+```conf
+{
+  ...
+  "telemetry": {
+    "dogstatsd_addr": "127.0.0.1:8125"
+  },
+  ...
+}
+```
 
 ### Validation
 

--- a/consul/README.md
+++ b/consul/README.md
@@ -103,7 +103,7 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 #### DogStatsD
 
-Alternatively, you can configure consul to send its data to the Agent through [DogStatsD][3] instead of relying on the Agent to pull the data from consul. To achieve this, add your `dogstatsd_addr` nested under the top-level `telemetry` key in the main Consul configuration file:
+Alternatively, you can configure Consul to send data to the Agent through [DogStatsD][3] instead of relying on the Agent to pull the data from Consul. To achieve this, add your `dogstatsd_addr` nested under the top-level `telemetry` key in the main Consul configuration file:
 
 ```conf
 {
@@ -147,7 +147,7 @@ See [metadata.csv][10] for a list of metrics provided by this integration.
 
 See [Consul's Telemetry doc][11] for a description of metrics the Consul Agent sends to DogStatsD.
 
-See [Consul's Network Coordinates doc][12] if you're curious about how the network latency metrics are calculated.
+See [Consul's Network Coordinates doc][12] for details on how the network latency metrics are calculated.
 
 ### Events
 

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -4,7 +4,8 @@
     "orchestration",
     "configuration & deployment",
     "notification",
-    "log collection"
+    "log collection",
+    "autodiscovery"
   ],
   "creates_events": true,
   "display_name": "Consul",


### PR DESCRIPTION
### What does this PR do?

* Adds AD instructions. 
* Refactor the instructions a bit to make it clear that DogStatsD is an alternative configuration option