### PR TITLE
Add more global utilities the pytest plugin

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -202,13 +202,19 @@ def dd_run_check():
 
 
 @pytest.fixture
-def dd_get_state(key):
-    return deserialize_data(get_env_vars().get(key.lower()))
+def dd_get_state():
+    def get_state(key):
+        return deserialize_data(get_env_vars().get(key.lower()))
+
+    return get_state
 
 
 @pytest.fixture
-def dd_save_state(key, value):
-    set_env_vars({key.lower(): serialize_data(value)})
+def dd_save_state():
+    def save_state(key, value):
+        set_env_vars({key.lower(): serialize_data(value)})
+
+    return save_state
 
 
 def pytest_configure(config):


### PR DESCRIPTION
### What does this PR do?

Takes from https://github.com/DataDog/integrations-core/blob/master/vault/tests/utils.py

- `dd_run_check` - Emulates the behavior of the `check` method, but calls `run` so any `check_initializations` can execute
- `dd_get_state`/`dd_save_state` - The way to persist state between `env start` & `env stop` e.g. for  `env test`