### PR TITLE
change metadata logger level to debug

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/metadata/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/metadata/core.py
@@ -42,9 +42,9 @@ class MetadataManager(object):
                 transformed = transformer(value, options)
             except Exception as e:
                 if is_primitive(value):
-                    self.logger.error('Unable to transform `%s` metadata value `%s`: %s', name, value, e)
+                    self.logger.debug('Unable to transform `%s` metadata value `%s`: %s', name, value, e)
                 else:
-                    self.logger.error('Unable to transform `%s` metadata: %s', name, e)
+                    self.logger.debug('Unable to transform `%s` metadata: %s', name, e)
 
                 return
 


### PR DESCRIPTION
### What does this PR do?
Change logger level when metadata could not be retrieved from ERROR to DEBUG.

### Motivation
Customers who have intentionally hidden version information is being spammed with error logs. Changing logging level to debug will prevent this from happening.