### PR TITLE
Correction to restart agent link in druid docs

### DIFF
--- a/druid/README.md
+++ b/druid/README.md
@@ -98,7 +98,7 @@ Use the default configuration of your `druid.d/conf.yaml` file to activate the c
 
     Change the `path` and `service` parameter values and configure them for your environment.
 
-3. [Restart the Agent][6].
+3. [Restart the Agent][4].
 
 ### Validation
 


### PR DESCRIPTION
### What does this PR do?
Adds the correct path to the restart agent link

### Motivation
Trello card request to the docs team

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
