### PR TITLE
Decrease default verbosity of tracebacks in pytest

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -174,6 +174,9 @@ def construct_pytest_options(
     # Prevent no verbosity
     pytest_options = '--verbosity={}'.format(verbose or 1)
 
+    if not verbose:
+        pytest_options += ' --tb=short'
+
     if color is not None:
         pytest_options += ' --color=yes' if color else ' --color=no'
 


### PR DESCRIPTION
### Motivation

The root causes of errors are unreasonably difficult to grok in almost all cases