### PR TITLE
Removing AD reference

### DIFF
--- a/directory/README.md
+++ b/directory/README.md
@@ -10,15 +10,13 @@ Capture metrics from directories and files of your choosing. The Agent collects:
 
 ## Setup
 
-Follow the instructions below to install and configure this check for an Agent running on a host. For containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying these instructions.
-
 ### Installation
 
-The Directory check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your server.
+The Directory check is included in the [Datadog Agent][1] package, so you don't need to install anything else on your server.
 
 ### Configuration
 
-1. Edit the `directory.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3] to start collecting Directory performance data. See the [sample directory.d/conf.yaml][4] for all available configuration options.
+1. Edit the `directory.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2] to start collecting Directory performance data. See the [sample directory.d/conf.yaml][3] for all available configuration options.
 
     ```yaml
       init_config:
@@ -36,19 +34,19 @@ The Directory check is included in the [Datadog Agent][2] package, so you don't 
 
     **Note**: On Windows when you add your directory, use double-backslashes `C:\\path\\to\\directory` instead of single-backslashes `C:\path\to\directory` for the check to run. Otherwise, the directory check fails with traceback ending in the error: `found unknown escape character in "<string>"`.
 
-2. [Restart the Agent][5].
+2. [Restart the Agent][4].
 
 #### Metrics collection
-The Directory check can potentially emit [custom metrics][6], which may impact your [billing][7].
+The Directory check can potentially emit [custom metrics][5], which may impact your [billing][6].
 
 ### Validation
 
-[Run the Agent's status subcommand][8] and look for `directory` under the Checks section.
+[Run the Agent's status subcommand][7] and look for `directory` under the Checks section.
 
 ## Data Collected
 ### Metrics
 
-See [metadata.csv][9] for a list of metrics provided by this integration.
+See [metadata.csv][8] for a list of metrics provided by this integration.
 
 ### Events
 The Directory check does not include any events.
@@ -57,15 +55,14 @@ The Directory check does not include any events.
 The Directory check does not include any service checks.
 
 ## Troubleshooting
-Need help? Contact [Datadog support][10].
+Need help? Contact [Datadog support][9].
 
-[1]: https://docs.datadoghq.com/agent/autodiscovery/integrations
-[2]: https://app.datadoghq.com/account/settings#agent
-[3]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
-[4]: https://github.com/DataDog/integrations-core/blob/master/directory/datadog_checks/directory/data/conf.yaml.example
-[5]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[6]: https://docs.datadoghq.com/developers/metrics/custom_metrics
-[7]: https://docs.datadoghq.com/account_management/billing/custom_metrics
-[8]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[9]: https://github.com/DataDog/integrations-core/blob/master/directory/metadata.csv
-[10]: https://docs.datadoghq.com/help
+[1]: https://app.datadoghq.com/account/settings#agent
+[2]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
+[3]: https://github.com/DataDog/integrations-core/blob/master/directory/datadog_checks/directory/data/conf.yaml.example
+[4]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
+[5]: https://docs.datadoghq.com/developers/metrics/custom_metrics
+[6]: https://docs.datadoghq.com/account_management/billing/custom_metrics
+[7]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[8]: https://github.com/DataDog/integrations-core/blob/master/directory/metadata.csv
+[9]: https://docs.datadoghq.com/help

--- a/disk/README.md
+++ b/disk/README.md
@@ -6,25 +6,23 @@ Collect metrics related to disk usage and IO.
 
 ## Setup
 
-Follow the instructions below to install and configure this check for an Agent running on a host. For containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying these instructions.
-
 ### Installation
 
-The disk check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your server.
+The disk check is included in the [Datadog Agent][1] package, so you don't need to install anything else on your server.
 
 ### Configuration
 
 The disk check is enabled by default, and the Agent collects metrics on all local partitions.
-If you want to configure the check with custom options, Edit the `disk.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3]. See the [sample disk.d/conf.yaml][4] for all available configuration options.
+If you want to configure the check with custom options, Edit the `disk.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample disk.d/conf.yaml][3] for all available configuration options.
 
 ### Validation
 
-[Run the Agent's `status` subcommand][5] and look for `disk` under the Checks section.
+[Run the Agent's `status` subcommand][4] and look for `disk` under the Checks section.
 
 ## Data Collected
 ### Metrics
 
-See [metadata.csv][6] for a list of metrics provided by this integration.
+See [metadata.csv][5] for a list of metrics provided by this integration.
 
 ### Events
 The Disk check does not include any events.
@@ -34,12 +32,11 @@ The Disk check does not include any events.
 Returns `CRITICAL` if filesystem is in read-only mode.
 
 ## Troubleshooting
-Need help? Contact [Datadog support][7].
+Need help? Contact [Datadog support][6].
 
-[1]: https://docs.datadoghq.com/agent/autodiscovery/integrations
-[2]: https://app.datadoghq.com/account/settings#agent
-[3]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
-[4]: https://github.com/DataDog/integrations-core/blob/master/disk/datadog_checks/disk/data/conf.yaml.default
-[5]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[6]: https://github.com/DataDog/integrations-core/blob/master/disk/metadata.csv
-[7]: https://docs.datadoghq.com/help
+[1]: https://app.datadoghq.com/account/settings#agent
+[2]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
+[3]: https://github.com/DataDog/integrations-core/blob/master/disk/datadog_checks/disk/data/conf.yaml.default
+[4]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[5]: https://github.com/DataDog/integrations-core/blob/master/disk/metadata.csv
+[6]: https://docs.datadoghq.com/help

--- a/dns_check/README.md
+++ b/dns_check/README.md
@@ -6,18 +6,16 @@ Monitor the resolvability of and lookup times for any DNS records using nameserv
 
 ## Setup
 
-Follow the instructions below to install and configure this check for an Agent running on a host. For containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying these instructions.
-
 ### Installation
 
-The DNS check is included in the [Datadog Agent][2] package, so you don't need to install anything else on the server from which you will probe your DNS servers.
+The DNS check is included in the [Datadog Agent][1] package, so you don't need to install anything else on the server from which you will probe your DNS servers.
 
 Though many metrics-oriented checks are best run on the same host(s) as the monitored service, you may want to run this status-oriented check from hosts that do not run the monitored DNS services.
 
 ### Configuration
 
-1. Edit the `dns_check.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3] to start collecting your DNS data.
-    See the [sample dns_check.d/conf.yaml][4] for all available configuration options:
+1. Edit the `dns_check.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2] to start collecting your DNS data.
+    See the [sample dns_check.d/conf.yaml][3] for all available configuration options:
 
     ```yaml
       init_config:
@@ -33,17 +31,17 @@ Though many metrics-oriented checks are best run on the same host(s) as the moni
 
     If you omit the `nameserver` option, the check uses whichever nameserver is configured in local network settings.
 
-2. [Restart the Agent][5] to begin sending DNS service checks and response times to Datadog.
+2. [Restart the Agent][4] to begin sending DNS service checks and response times to Datadog.
 
 ### Validation
 
-[Run the Agent's `status` subcommand][6] and look for `dns_check` under the Checks section.
+[Run the Agent's `status` subcommand][5] and look for `dns_check` under the Checks section.
 
 ## Data Collected
 
 ### Metrics
 
-See [metadata.csv][7] for a list of metrics provided by this integration.
+See [metadata.csv][6] for a list of metrics provided by this integration.
 
 ### Events
 The DNS check does not include any events.
@@ -61,13 +59,12 @@ Returns CRITICAL if the Agent fails to resolve the request, otherwise returns UP
 Tagged by `hostname` and `record_type`.
 
 ## Troubleshooting
-Need help? Contact [Datadog support][8].
+Need help? Contact [Datadog support][7].
 
-[1]: https://docs.datadoghq.com/agent/autodiscovery/integrations
-[2]: https://app.datadoghq.com/account/settings#agent
-[3]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
-[4]: https://github.com/DataDog/integrations-core/blob/master/dns_check/datadog_checks/dns_check/data/conf.yaml.example
-[5]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[6]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[7]: https://github.com/DataDog/integrations-core/blob/master/dns_check/metadata.csv
-[8]: https://docs.datadoghq.com/help
+[1]: https://app.datadoghq.com/account/settings#agent
+[2]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
+[3]: https://github.com/DataDog/integrations-core/blob/master/dns_check/datadog_checks/dns_check/data/conf.yaml.example
+[4]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
+[5]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[6]: https://github.com/DataDog/integrations-core/blob/master/dns_check/metadata.csv
+[7]: https://docs.datadoghq.com/help

--- a/http_check/README.md
+++ b/http_check/README.md
@@ -6,15 +6,13 @@ Monitor the up/down status of local or remote HTTP endpoints. The HTTP check can
 
 ## Setup
 
-Follow the instructions below to install and configure this check for an Agent running on a host. For containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying these instructions.
-
 ### Installation
 
-The HTTP check is included in the [Datadog Agent][2] package, so you don't need to install anything else on the servers from which you will probe your HTTP sites. Though many metrics-oriented checks are best run on the same host(s) as the monitored service, you may want to run this status-oriented check from hosts that do not run the monitored sites.
+The HTTP check is included in the [Datadog Agent][1] package, so you don't need to install anything else on the servers from which you will probe your HTTP sites. Though many metrics-oriented checks are best run on the same host(s) as the monitored service, you may want to run this status-oriented check from hosts that do not run the monitored sites.
 
 ### Configuration
 
-Edit the `http_check.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3]. See the [sample http_check.d/conf.yaml][4] for all available configuration options:
+Edit the `http_check.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample http_check.d/conf.yaml][3] for all available configuration options:
 
 ```
 init_config:
@@ -29,9 +27,9 @@ instances:
 
 The HTTP check has more configuration options than many checks - many more than are shown above. Most options are opt-in, e.g. the Agent will not check SSL validation unless you configure the requisite options. Notably, the Agent _will_ check for soon-to-expire SSL certificates by default.
 
-This check runs on every run of the Agent collector, which defaults to every 15 seconds. To set a custom run frequency for this check, refer to the [collection interval][5] section of the custom check documentation.
+This check runs on every run of the Agent collector, which defaults to every 15 seconds. To set a custom run frequency for this check, refer to the [collection interval][4] section of the custom check documentation.
 
-See the [sample http_check.d/conf.yaml][4] for a full list and description of available options, here is a list of them:
+See the [sample http_check.d/conf.yaml][3] for a full list and description of available options, here is a list of them:
 
 | Setting                          | Description                                                                                                                                                                                                                                       |
 |----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -40,7 +38,7 @@ See the [sample http_check.d/conf.yaml][4] for a full list and description of av
 | `timeout`                        | The time in seconds to allow for a response.                                                                                                                                                                                                      |
 | `method`                         | The HTTP method to use for the check.                                                                                                                                                                                                             |
 | `data`                           | Use this parameter to specify a body for a request with a POST, PUT, DELETE, or PATCH method. SOAP requests are supported if you use the POST method and supply an XML string as the data parameter.                                              |
-| `headers`                        | This parameter allows you to send additional headers with the request. See the [example YAML file][6] for additional information and caveats.                                                                                                     |
+| `headers`                        | This parameter allows you to send additional headers with the request. See the [example YAML file][3] for additional information and caveats.                                                                                                     |
 | `content_match`                  | A string or Python regular expression. The HTTP check searches for this value in the response and reports as DOWN if the string or expression is not found.                                                                                       |
 | `reverse_content_match`          | When `true`, reverses the behavior of the `content_match` option, i.e. the HTTP check reports as DOWN if the string or expression in `content_match` IS found. (default is `false`)                                                               |
 | `username` & `password`          | If your service uses basic authentication, you can provide the username and password here.                                                                                                                                                        |
@@ -56,20 +54,20 @@ See the [sample http_check.d/conf.yaml][4] for a full list and description of av
 | `check_hostname`                 | If set to `true` the check log a warning if the checked `url` hostname is different than the SSL certificate hostname.                                                                                                                            |
 | `skip_proxy`                     | If set, the check will bypass proxy settings and attempt to reach the check url directly. This defaults to `false`.                                                                                                                               |
 | `allow_redirects`                | This setting allows the service check to follow HTTP redirects and defaults to `true`.                                                                                                                                                            |
-| `tags`                           | A list of arbitrary tags that will be associated with the check. For more information about tags, see our [Guide to tagging][7] and blog post, [The power of tagged metrics][8]                                                                   |
+| `tags`                           | A list of arbitrary tags that will be associated with the check. For more information about tags, see our [Guide to tagging][5] and blog post, [The power of tagged metrics][6]                                                                   |
 
 
-When you have finished configuring `http_check.d/conf.yaml`, [restart the Agent][9] to begin sending HTTP service checks and response times to Datadog.
+When you have finished configuring `http_check.d/conf.yaml`, [restart the Agent][7] to begin sending HTTP service checks and response times to Datadog.
 
 ### Validation
 
-[Run the Agent's `status` subcommand][10] and look for `http_check` under the Checks section.
+[Run the Agent's `status` subcommand][8] and look for `http_check` under the Checks section.
 
 ## Data Collected
 
 ### Metrics
 
-See [metadata.csv][11] for a list of metrics provided by this integration.
+See [metadata.csv][9] for a list of metrics provided by this integration.
 
 ### Events
 
@@ -77,7 +75,7 @@ The HTTP check does not include any events.
 
 ### Service Checks
 
-To create alert conditions on these service checks in Datadog, select 'Network' on the [Create Monitor][12] page, not 'Integration'.
+To create alert conditions on these service checks in Datadog, select 'Network' on the [Create Monitor][10] page, not 'Integration'.
 
 **`http.can_connect`**:
 
@@ -104,18 +102,16 @@ Otherwise, returns `UP`.
 To disable this check, set `check_certificate_expiration` to false.
 
 ## Troubleshooting
-Need help? Contact [Datadog support][13].
+Need help? Contact [Datadog support][11].
 
-[1]: https://docs.datadoghq.com/agent/autodiscovery/integrations
-[2]: https://app.datadoghq.com/account/settings#agent
-[3]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
-[4]: https://github.com/DataDog/integrations-core/blob/master/http_check/datadog_checks/http_check/data/conf.yaml.example
-[5]: https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
-[6]: https://github.com/DataDog/integrations-core/blob/master/http_check/datadog_checks/http_check/data/conf.yaml.example
-[7]: https://docs.datadoghq.com/getting_started/tagging
-[8]: https://www.datadoghq.com/blog/the-power-of-tagged-metrics
-[9]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[10]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[11]: https://github.com/DataDog/integrations-core/blob/master/http_check/metadata.csv
-[12]: https://app.datadoghq.com/monitors#/create
-[13]: https://docs.datadoghq.com/help
+[1]: https://app.datadoghq.com/account/settings#agent
+[2]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
+[3]: https://github.com/DataDog/integrations-core/blob/master/http_check/datadog_checks/http_check/data/conf.yaml.example
+[4]: https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+[5]: https://docs.datadoghq.com/getting_started/tagging
+[6]: https://www.datadoghq.com/blog/the-power-of-tagged-metrics
+[7]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
+[8]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[9]: https://github.com/DataDog/integrations-core/blob/master/http_check/metadata.csv
+[10]: https://app.datadoghq.com/monitors#/create
+[11]: https://docs.datadoghq.com/help

--- a/kyototycoon/README.md
+++ b/kyototycoon/README.md
@@ -6,45 +6,36 @@ The Agent's KyotoTycoon check tracks get, set, and delete operations, and lets y
 
 ## Setup
 
-Follow the instructions below to install and configure this check for an Agent running on a host. For containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying these instructions.
-
 ### Installation
 
-The KyotoTycoon check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your KyotoTycoon servers.
+The KyotoTycoon check is included in the [Datadog Agent][1] package, so you don't need to install anything else on your KyotoTycoon servers.
 
 ### Configuration
 
-1. Edit the `kyototycoon.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3].
-    See the [sample kyototycoon.d/conf.yaml][4] for all available configuration options:
+1. Edit the `kyototycoon.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2].
+    See the [sample kyototycoon.d/conf.yaml][3] for all available configuration options:
 
     ```yaml
-    init_config:
+        init_config:
 
-    instances:
-        #  Each instance needs a report URL.
-        #  name, and optionally tags keys. The report URL should
-        #  be a URL to the Kyoto Tycoon "report" RPC endpoint.
-        #
-        #  Complete example:
-        #
-        - report_url: http://localhost:1978/rpc/report
-        #   name: my_kyoto_instance
-        #   tags:
-        #     foo: bar
-        #     baz: bat
+        instances:
+
+            ## @param report_url - string - required
+            ## The report URL should be a URL to the Kyoto Tycoon "report" RPC endpoint.
+            #
+          - report_url: http://localhost:1978/rpc/report
     ```
 
-2. [Restart the Agent][5] to begin sending Kong metrics to Datadog.
-
+2. [Restart the Agent][4].
 
 ### Validation
 
-[Run the Agent's `status` subcommand][6] and look for `kyototycoon` under the Checks section.
+[Run the Agent's `status` subcommand][5] and look for `kyototycoon` under the Checks section.
 
 ## Data Collected
 ### Metrics
 
-See [metadata.csv][7] for a list of metrics provided by this check.
+See [metadata.csv][6] for a list of metrics provided by this check.
 
 ### Events
 The KyotoTycoon check does not include any events.
@@ -56,13 +47,12 @@ The KyotoTycoon check does not include any events.
 Returns CRITICAL if the Agent cannot connect to KyotoTycoon to collect metrics, otherwise OK.
 
 ## Troubleshooting
-Need help? Contact [Datadog support][8].
+Need help? Contact [Datadog support][7].
 
-[1]: https://docs.datadoghq.com/agent/autodiscovery/integrations
-[2]: https://app.datadoghq.com/account/settings#agent
-[3]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
-[4]: https://github.com/DataDog/integrations-core/blob/master/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
-[5]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[6]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[7]: https://github.com/DataDog/integrations-core/blob/master/kyototycoon/metadata.csv
-[8]: https://docs.datadoghq.com/help
+[1]: https://app.datadoghq.com/account/settings#agent
+[2]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
+[3]: https://github.com/DataDog/integrations-core/blob/master/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
+[4]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
+[5]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[6]: https://github.com/DataDog/integrations-core/blob/master/kyototycoon/metadata.csv
+[7]: https://docs.datadoghq.com/help

--- a/linux_proc_extras/README.md
+++ b/linux_proc_extras/README.md
@@ -8,8 +8,6 @@ Get metrics from linux_proc_extras service in real time to:
 
 ## Setup
 
-Follow the instructions below to install and configure this check for an Agent running on a host. For containerized environments, see the [Autodiscovery Integration Templates][8] for guidance on applying these instructions.
-
 ### Installation
 
 The Linux_proc_extras check is included in the [Datadog Agent][1] package, so you don't need to install anything else on your servers.
@@ -46,4 +44,3 @@ Need help? Contact [Datadog support][7].
 [5]: https://docs.datadoghq.com/account_management/billing/custom_metrics
 [6]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [7]: https://docs.datadoghq.com/help
-[8]: https://docs.datadoghq.com/agent/autodiscovery/integrations


### PR DESCRIPTION
### What does this PR do?

Removes AD references for integrations: `directory`, `disk`, `dns_check`, `kyototycoon`, `linux_proc_extras` as it doesn't make sense.

It also update all link as reference.