### PR TITLE
Add debug logging when processes are not found

### DIFF
--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -156,6 +156,13 @@ class ProcessCheck(AgentCheck):
                         matching_pids.add(proc.pid)
                         break
 
+        if not matching_pids:
+            self.log.debug(
+                "Unable to find process named '%s' from among processes:\n%s",
+                search_string,
+                ', '.join(repr(p) for p in psutil.process_iter()),
+            )
+
         self.pid_cache[name] = matching_pids
         self.last_pid_cache_ts[name] = time.time()
         if refresh_ad_cache:

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import logging
 import os
 
 import psutil
@@ -181,6 +182,15 @@ def test_check_missing_pid(aggregator):
     process = ProcessCheck(common.CHECK_NAME, {}, {})
     process.check(instance)
     aggregator.assert_service_check('process.up', count=1, status=process.CRITICAL)
+
+
+def test_check_missing_process(aggregator, caplog):
+    caplog.set_level(logging.DEBUG)
+    instance = {'name': 'foo', 'search_string': ['fooprocess', '/usr/bin/foo'], 'exact_match': False}
+    process = ProcessCheck(common.CHECK_NAME, {}, {})
+    process.check(instance)
+    aggregator.assert_service_check('process.up', count=1, status=process.CRITICAL)
+    assert "Unable to find process named '['fooprocess', '/usr/bin/foo']' from among processes" in caplog.text
 
 
 def test_check_real_process(aggregator):


### PR DESCRIPTION
### What does this PR do?
If the desired search strings are not found in the psutil output, this PR adds optional debug logging to see exactly which process lists were seen to aid in debugging.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
