### PR TITLE
Remove Agent 5 conditional imports

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/__init__.py
@@ -3,6 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from .base import AgentCheck
-from .network import NetworkCheck, Status, EventType
+from .network import EventType, NetworkCheck, Status
 
 __all__ = ['AgentCheck', 'NetworkCheck', 'Status', 'EventType']

--- a/datadog_checks_base/datadog_checks/base/checks/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/__init__.py
@@ -2,12 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-try:
-    # Agent5 compatibility layer
-    from checks import AgentCheck
-    from checks.network_checks import NetworkCheck, Status, EventType
-except ImportError:
-    from .base import AgentCheck
-    from .network import NetworkCheck, Status, EventType
+from .base import AgentCheck
+from .network import NetworkCheck, Status, EventType
 
 __all__ = ['AgentCheck', 'NetworkCheck', 'Status', 'EventType']

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -112,11 +112,6 @@ class __AgentCheck(object):
         the Agent might create several different Check instances and the method would be
         called as many times.
 
-        Agent 5 signature:
-
-            AgentCheck(name, init_config, agentConfig, instances=None)
-            AgentCheck.check(instance)
-
         Agent 6,7 signature:
 
             AgentCheck(name, init_config, instances)    # instances contain only 1 instance

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/__init__.py
@@ -2,14 +2,9 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-try:
-    # Agent5 compatibility layer
-    from checks import UnknownFormatError, PrometheusFormat, PrometheusCheck
-except ImportError:
-    from .mixins import PrometheusFormat, UnknownFormatError
-    from .prometheus_base import PrometheusCheck
-    from .base_check import GenericPrometheusCheck
+from .mixins import PrometheusFormat, UnknownFormatError
+from .prometheus_base import PrometheusCheck
+from .base_check import GenericPrometheusCheck, PrometheusScraper
 
-from .base_check import PrometheusScraper
 
 __all__ = ['PrometheusFormat', 'UnknownFormatError', 'PrometheusCheck', 'GenericPrometheusCheck', 'PrometheusScraper']

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/__init__.py
@@ -2,9 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from .base_check import GenericPrometheusCheck, PrometheusScraper
 from .mixins import PrometheusFormat, UnknownFormatError
 from .prometheus_base import PrometheusCheck
-from .base_check import GenericPrometheusCheck, PrometheusScraper
-
 
 __all__ = ['PrometheusFormat', 'UnknownFormatError', 'PrometheusCheck', 'GenericPrometheusCheck', 'PrometheusScraper']

--- a/datadog_checks_base/datadog_checks/base/checks/win/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/__init__.py
@@ -2,13 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-try:
-    # Agent5 compatibility layer
-    from checks.libs.win.pdhbasecheck import PDHBaseCheck
-    from checks.libs.win.winpdh import WinPDHCounter
-except ImportError:
-    from .winpdh_base import PDHBaseCheck
-    from .winpdh import WinPDHCounter
+from .winpdh_base import PDHBaseCheck
+from .winpdh import WinPDHCounter
 
 
 __all__ = ['PDHBaseCheck', 'WinPDHCounter']

--- a/datadog_checks_base/datadog_checks/base/checks/win/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/__init__.py
@@ -2,8 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from .winpdh_base import PDHBaseCheck
 from .winpdh import WinPDHCounter
-
+from .winpdh_base import PDHBaseCheck
 
 __all__ = ['PDHBaseCheck', 'WinPDHCounter']

--- a/datadog_checks_base/datadog_checks/base/config.py
+++ b/datadog_checks_base/datadog_checks/base/config.py
@@ -14,7 +14,3 @@ def is_affirmative(value):
     # use object's implementation of `__bool__`, it's faster than cast.
     # None -> False, 0 -> False, 1 -> True, etc.
     return not not value
-
-
-# Compatibility layer for Agent5
-_is_affirmative = is_affirmative

--- a/datadog_checks_base/datadog_checks/base/config.py
+++ b/datadog_checks_base/datadog_checks/base/config.py
@@ -14,3 +14,7 @@ def is_affirmative(value):
     # use object's implementation of `__bool__`, it's faster than cast.
     # None -> False, 0 -> False, 1 -> True, etc.
     return not not value
+
+
+# Deprecated compatibility layer for Agent 5, will be removed in Agent 8
+_is_affirmative = is_affirmative

--- a/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
+++ b/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
@@ -8,18 +8,12 @@ from six import string_types
 from .. import ensure_unicode
 
 try:
-    # Agent6
     from _util import get_subprocess_output as subprocess_output
     from _util import SubprocessOutputEmptyError  # noqa
 except ImportError:
-    try:
-        # Agent5 (these paths may also exist in Agent6, so import them only if Agent6-specific ones aren't found)
-        from utils.subprocess_output import subprocess_output
-        from utils.subprocess_output import SubprocessOutputEmptyError  # noqa
-    except ImportError:
-        # No agent
-        from ..stubs._util import subprocess_output
-        from ..stubs._util import SubprocessOutputEmptyError  # noqa
+    # No agent
+    from ..stubs._util import subprocess_output
+    from ..stubs._util import SubprocessOutputEmptyError  # noqa
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
### What does this PR do?
Reduce try/except blocks which were guarding against Agent 5 usage.  Since Agent 5 is currently on a separate branch, these guards are no longer necessary.

### Motivation
Code cleanup.

### Additional Notes
There are some #TODOs in `datadog_checks/base/checks/base.py` which also look ripe for removal, but its not clear how much of the stanzas are specific to Agent 5.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
