### PR TITLE
Fix version metadata submitted twice

### DIFF
--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -112,6 +112,7 @@ class Apache(AgentCheck):
                 self.assumed_url[instance['apache_status_url']] = '%s?auto' % url
                 self.warning("Assuming url was not correct. Trying to add ?auto suffix to the url")
                 self.check(instance)
+                return
             else:
                 raise Exception(
                     ("No metrics were fetched for this instance. Make sure that %s is the proper url.")
@@ -133,7 +134,7 @@ class Apache(AgentCheck):
         match = self.VERSION_REGEX.match(value)
 
         if not match or not match.groups():
-            self.log.info("Cannot parse the complete Apache version from %s.".format(value))
+            self.log.info("Cannot parse the complete Apache version from %s.", value)
             return
 
         version = match.groups()[0]

--- a/apache/tests/common.py
+++ b/apache/tests/common.py
@@ -21,6 +21,8 @@ AUTO_CONFIG = {'apache_status_url': AUTO_STATUS_URL, 'tags': ['instance:second']
 
 BAD_CONFIG = {'apache_status_url': 'http://localhost:1234/server-status'}
 
+NO_METRIC_CONFIG = {'apache_status_url': BASE_URL}
+
 APACHE_GAUGES = [
     'apache.performance.idle_workers',
     'apache.performance.busy_workers',

--- a/apache/tests/test_apache.py
+++ b/apache/tests/test_apache.py
@@ -6,8 +6,17 @@ import pytest
 
 from datadog_checks.apache import Apache
 
-from .common import APACHE_GAUGES, APACHE_RATES, APACHE_VERSION, AUTO_CONFIG, BAD_CONFIG, HOST, PORT, STATUS_CONFIG, \
-    NO_METRIC_CONFIG
+from .common import (
+    APACHE_GAUGES,
+    APACHE_RATES,
+    APACHE_VERSION,
+    AUTO_CONFIG,
+    BAD_CONFIG,
+    HOST,
+    NO_METRIC_CONFIG,
+    PORT,
+    STATUS_CONFIG,
+)
 
 
 @pytest.mark.usefixtures("dd_environment")
@@ -27,8 +36,9 @@ def test_no_metrics_failure(aggregator, check):
     with pytest.raises(Exception) as excinfo:
         check.check(NO_METRIC_CONFIG)
 
-    assert str(excinfo.value) == ("No metrics were fetched for this instance. Make sure that http://localhost:18180 "
-                                  "is the proper url.")
+    assert str(excinfo.value) == (
+        "No metrics were fetched for this instance. Make sure that http://localhost:18180 " "is the proper url."
+    )
 
     sc_tags = ['host:localhost', 'port:18180']
     aggregator.assert_service_check('apache.can_connect', Apache.OK, tags=sc_tags)

--- a/apache/tests/test_apache.py
+++ b/apache/tests/test_apache.py
@@ -121,3 +121,12 @@ def test_metadata_in_header(check, datadog_agent, mock_hide_server_version):
     check.check(AUTO_CONFIG)
     datadog_agent.assert_metadata('test:123', version_metadata)
     datadog_agent.assert_metadata_count(len(version_metadata))
+
+
+def test_invalid_version(check):
+    check = check({})
+    check.log = mock.MagicMock()
+
+    check._submit_metadata("invalid_version")
+
+    check.log.info.assert_called_once_with("Cannot parse the complete Apache version from %s.", "invalid_version")


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Related: https://github.com/DataDog/integrations-core/pull/4818, https://github.com/DataDog/integrations-core/pull/5144, https://github.com/DataDog/integrations-core/pull/5252

The issues: 

1. The version metadata might be submitted twice

2. We log `Cannot parse the complete Apache version from %s.` instead of `Cannot parse the complete Apache version from <VERSION>.`

Fix version metadata submitted twice when retrying with `?auto`. We should return, when calling `self.check` recursively (note: we should avoid making recursive call if possible, it's error prone).

This PR also includes:

- Add test for no metrics case
- Add fix logging format issue for `self.log.info("Cannot parse the complete Apache version from %s.", value)`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
