### PR TITLE
Refactor QueryManager

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -40,10 +40,10 @@ class QueryManager(object):
     def compile_queries(self):
         column_transformers = COLUMN_TRANSFORMERS.copy()
 
-        for submission_method in SUBMISSION_METHODS:
+        for submission_method, transformer_name in SUBMISSION_METHODS.items():
             method = getattr(self.check, submission_method)
             # Save each method in the initializer -> callable format
-            column_transformers[submission_method] = create_submission_transformer(method)
+            column_transformers[transformer_name] = create_submission_transformer(method)
 
         for query in self.queries:
             query.compile(column_transformers, EXTRA_TRANSFORMERS.copy())
@@ -104,12 +104,12 @@ class QueryManager(object):
                     if transformer is None:
                         continue
                     elif column_type == 'tag':
-                        tags.append(transformer(value, None))
+                        tags.append(transformer(None, value))
                     else:
                         submission_queue.append((transformer, value))
 
                 for transformer, value in submission_queue:
-                    transformer(value, sources, tags=tags)
+                    transformer(sources, value, tags=tags)
 
                 for name, transformer in query_extras:
                     try:

--- a/datadog_checks_base/datadog_checks/base/utils/db/query.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/query.py
@@ -84,7 +84,7 @@ class Query(object):
             modifiers = {key: value for key, value in column.items() if key not in ('name', 'type')}
 
             try:
-                transformer = column_transformers[column_type](column_name, column_transformers, **modifiers)
+                transformer = column_transformers[column_type](column_transformers, column_name, **modifiers)
             except Exception as e:
                 error = 'error compiling type `{}` for column {} of {}: {}'.format(
                     column_type, column_name, query_name, e
@@ -153,7 +153,7 @@ class Query(object):
                 modifiers['sources'] = sources
 
             try:
-                transformer = transformer_factory(extra_name, submission_transformers, **modifiers)
+                transformer = transformer_factory(submission_transformers, extra_name, **modifiers)
             except Exception as e:
                 error = 'error compiling type `{}` for extra {} of {}: {}'.format(extra_type, extra_name, query_name, e)
 

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from itertools import chain
 
+# AgentCheck methods to transformer name e.g. set_metadata -> metadata
 SUBMISSION_METHODS = {
     'gauge': 'gauge',
     'count': 'count',


### PR DESCRIPTION
### What does this PR do?

Minor change in the internal transformer signatures to easy maintainability and support `AgentCheck` methods that don't just take a name and value e.g. `AgentCheck.event`