### PR TITLE
Make changes and changelog command work with other repos

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/console.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/console.py
@@ -1,9 +1,12 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import os
 import sys
 
 import click
+
+from ...tooling.constants import INTEGRATION_REPOS, set_root
 
 try:
     from textwrap import indent as __indent_text
@@ -62,3 +65,14 @@ def abort(text=None, code=1, out=False):
     if text is not None:
         click.secho(text, fg='red', bold=True, err=not out, color=DISPLAY_COLOR)
     sys.exit(code)
+
+
+def validate_check_arg(ctx, param, value):
+    # Treat '.' as a special value, meaning run the command against a repository, not an individual check
+    if value == '.':
+        if os.getcwd() in INTEGRATION_REPOS:
+            raise click.BadParameter('Needs to be the name of a real check or `.` for other repositories')
+        else:
+            set_root(os.getcwd())
+            return
+    return value

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -14,8 +14,8 @@ from ...constants import CHANGELOG_TYPE_NONE, get_root
 from ...git import get_commits_since
 from ...github import from_contributor, get_changelog_types, get_pr, parse_pr_numbers
 from ...release import get_release_tag_string
-from ...utils import get_valid_checks, get_version_string, validate_check_arg
-from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info
+from ...utils import get_valid_checks, get_version_string
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, validate_check_arg
 
 ChangelogEntry = namedtuple('ChangelogEntry', 'number, title, url, author, author_url, from_contributor')
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -33,8 +33,6 @@ def changelog(ctx, check, version, old_version, initial, quiet, dry_run):
 
     This method is supposed to be used by other tasks and not directly.
     """
-    check = None if check == '.' else check
-
     if check and check not in get_valid_checks():
         abort('Check `{}` is not an Agent-based Integration'.format(check))
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
@@ -11,7 +11,7 @@ from ...console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_su
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Show all the pending PRs for a given check.')
-@click.argument('check', callback=validate_check_arg, required=False)
+@click.argument('check', callback=validate_check_arg)
 @click.option('--dry-run', '-n', is_flag=True)
 @click.pass_context
 def changes(ctx, check, dry_run):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
@@ -6,17 +6,17 @@ import click
 from ....git import get_commits_since
 from ....github import get_changelog_types, get_pr, parse_pr_numbers
 from ....release import get_release_tag_string
-from ....utils import get_valid_checks, get_version_string
+from ....utils import get_valid_checks, get_version_string, validate_check_arg
 from ...console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_warning
 
 
-@click.command(context_settings=CONTEXT_SETTINGS, short_help='Show all the pending PRs for a given check')
-@click.argument('check')
+@click.command(context_settings=CONTEXT_SETTINGS, short_help='Show all the pending PRs for a given check.')
+@click.argument('check', callback=validate_check_arg, required=False)
 @click.option('--dry-run', '-n', is_flag=True)
 @click.pass_context
 def changes(ctx, check, dry_run):
     """Show all the pending PRs for a given check."""
-    if not dry_run and check not in get_valid_checks():
+    if not dry_run and check and check not in get_valid_checks():
         abort('Check `{}` is not an Agent-based Integration'.format(check))
 
     # get the name of the current release tag

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
@@ -6,8 +6,8 @@ import click
 from ....git import get_commits_since
 from ....github import get_changelog_types, get_pr, parse_pr_numbers
 from ....release import get_release_tag_string
-from ....utils import get_valid_checks, get_version_string, validate_check_arg
-from ...console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_warning
+from ....utils import get_valid_checks, get_version_string
+from ...console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_warning, validate_check_arg
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Show all the pending PRs for a given check.')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -8,6 +8,11 @@ import semver
 
 CHANGELOG_LABEL_PREFIX = 'changelog/'
 CHANGELOG_TYPE_NONE = 'no-changelog'
+INTEGRATION_REPOS = [
+    'integrations-core',
+    'integrations-internal',
+    'integrations-extras',
+]
 VERSION_BUMP = OrderedDict(
     [
         ('Added', semver.bump_minor),

--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -10,8 +10,8 @@ CHANGELOG_LABEL_PREFIX = 'changelog/'
 CHANGELOG_TYPE_NONE = 'no-changelog'
 INTEGRATION_REPOS = [
     'integrations-core',
-    'integrations-internal',
     'integrations-extras',
+    'integrations-internal',
 ]
 VERSION_BUMP = OrderedDict(
     [

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -4,6 +4,8 @@
 import os
 import re
 
+from semver import parse_version_info
+
 from ..subprocess import run_command
 from ..utils import chdir
 from .constants import get_root
@@ -36,7 +38,10 @@ def get_commits_since(check_name, target_tag=None):
     Get the list of commits from `target_tag` to `HEAD` for the given check
     """
     root = get_root()
-    target_path = os.path.join(root, check_name)
+    if check_name:
+        target_path = os.path.join(root, check_name)
+    else:
+        target_path = root
     command = 'git log --pretty=%s {}{}'.format('' if target_tag is None else '{}... '.format(target_tag), target_path)
 
     with chdir(root):
@@ -100,6 +105,18 @@ def git_tag_list(pattern=None):
 
     regex = re.compile(pattern)
     return list(filter(regex.search, result))
+
+
+def get_latest_tag(pattern=None):
+    """
+    Return the highest numbered tag (most recent)
+    Filters on pattern first, otherwise based off all tags
+    Removes prefixed `v` if applicable
+    """
+    all_tags = sorted((parse_version_info(t.lstrip('v')), t) for t in git_tag_list(r'^v?\d+\.\d+\.\d+$'))
+
+    # reverse so we have descendant order
+    return list(reversed(all_tags))[0][1]
 
 
 def tracked_by_git(filename):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/github.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/github.py
@@ -6,11 +6,10 @@ import re
 
 import requests
 
-from .constants import CHANGELOG_LABEL_PREFIX
+from .constants import CHANGELOG_LABEL_PREFIX, get_root
 
 API_URL = 'https://api.github.com'
 PR_ENDPOINT = API_URL + '/repos/DataDog/{}/pulls/{}'
-DEFAULT_REPO = 'integrations-core'
 PR_PATTERN = re.compile(r'\(#(\d+)\)')  # match something like `(#1234)` and return `1234` in a group
 
 
@@ -52,11 +51,11 @@ def get_changelog_types(pr_payload):
     return changelog_labels
 
 
-def get_pr(pr_num, config=None, repo=None, raw=False):
+def get_pr(pr_num, config=None, raw=False):
     """
     Get the payload for the given PR number. Let exceptions bubble up.
     """
-    repo = os.path.basename(os.getcwd()) if repo is None else repo
+    repo = os.path.basename(os.path.normpath(get_root()))
     response = requests.get(PR_ENDPOINT.format(repo, pr_num), auth=get_auth_info(config))
 
     if raw:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/github.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/github.py
@@ -6,8 +6,8 @@ import re
 
 import requests
 
-from .constants import CHANGELOG_LABEL_PREFIX, get_root
 from ..utils import basepath
+from .constants import CHANGELOG_LABEL_PREFIX, get_root
 
 API_URL = 'https://api.github.com'
 PR_ENDPOINT = API_URL + '/repos/DataDog/{}/pulls/{}'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/github.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/github.py
@@ -7,6 +7,7 @@ import re
 import requests
 
 from .constants import CHANGELOG_LABEL_PREFIX, get_root
+from ..utils import basepath
 
 API_URL = 'https://api.github.com'
 PR_ENDPOINT = API_URL + '/repos/DataDog/{}/pulls/{}'
@@ -55,7 +56,7 @@ def get_pr(pr_num, config=None, raw=False):
     """
     Get the payload for the given PR number. Let exceptions bubble up.
     """
-    repo = os.path.basename(os.path.normpath(get_root()))
+    repo = basepath(get_root())
     response = requests.get(PR_ENDPOINT.format(repo, pr_num), auth=get_auth_info(config))
 
     if raw:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/github.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/github.py
@@ -52,10 +52,11 @@ def get_changelog_types(pr_payload):
     return changelog_labels
 
 
-def get_pr(pr_num, config=None, repo=DEFAULT_REPO, raw=False):
+def get_pr(pr_num, config=None, repo=None, raw=False):
     """
     Get the payload for the given PR number. Let exceptions bubble up.
     """
+    repo = os.path.basename(os.getcwd()) if repo is None else repo
     response = requests.get(PR_ENDPOINT.format(repo, pr_num), auth=get_auth_info(config))
 
     if raw:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/release.py
@@ -19,7 +19,10 @@ def get_release_tag_string(check_name, version_string):
     """
     Compose a string to use for release tags
     """
-    return '{}-{}'.format(check_name, version_string)
+    if check_name:
+        return '{}-{}'.format(check_name, version_string)
+    else:
+        return version_string
 
 
 def update_version_module(check_name, old_ver, new_ver):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -208,10 +208,11 @@ def parse_version_parts(version):
 
 
 def validate_check_arg(ctx, param, value):
-    if not value or value == '.':
+    # Treat '.' as a special value, meaning run the command against a repository, not an individual check
+    if value == '.':
         if os.getcwd() in INTEGRATION_REPOS:
             raise click.BadParameter('Needs to be the name of a real check or `.` for other repositories')
         else:
             set_root(os.getcwd())
-            return None
+            return
     return value

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -210,6 +210,9 @@ def parse_version_parts(version):
 def validate_check_arg(ctx, param, value):
     if not value or value == '.':
         if os.getcwd() in INTEGRATION_REPOS:
-            raise click.BadParameter('Needs to be real check name')
+            raise click.BadParameter('Needs to be the name of a real check or `.` for other repositories')
         else:
             set_root(os.getcwd())
+            return None
+    return value
+

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -7,13 +7,12 @@ import re
 from ast import literal_eval
 from collections import OrderedDict
 
-import click
 import requests
 import semver
 from six import string_types
 
 from ..utils import file_exists, read_file
-from .constants import INTEGRATION_REPOS, NOT_CHECKS, VERSION_BUMP, get_root, set_root
+from .constants import NOT_CHECKS, VERSION_BUMP, get_root
 from .git import get_latest_tag
 
 # match integration's version within the __about__.py module
@@ -205,14 +204,3 @@ def parse_version_parts(version):
     if not isinstance(version, string_types):
         return []
     return [int(v) for v in version.split('.') if v.isdigit()]
-
-
-def validate_check_arg(ctx, param, value):
-    # Treat '.' as a special value, meaning run the command against a repository, not an individual check
-    if value == '.':
-        if os.getcwd() in INTEGRATION_REPOS:
-            raise click.BadParameter('Needs to be the name of a real check or `.` for other repositories')
-        else:
-            set_root(os.getcwd())
-            return
-    return value

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -215,4 +215,3 @@ def validate_check_arg(ctx, param, value):
             set_root(os.getcwd())
             return None
     return value
-


### PR DESCRIPTION
### What does this PR do?
Updates the changes and changelog ddev command to allow it to work with other open-source repositories

### Motivation
Gain the ability to use the same autogeneration changelog workflow in other projects 😄 

### Additional Notes
The command invocation wouldn't change for existing integrations, but for other projects would now let you:

`ddev release show changes .` (Note the lack of a check name at the end, instead is `.` which would now default to the current working directory)

and

`ddev release changelog . <VERSION>` (Note the special `.` character to denote we're not doing a check but the current directory. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
