### PR TITLE
Always pass USERNAME to tox

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -95,6 +95,8 @@ def test(
         'TOX_TESTENV_PASSENV': (
             # Used in .coveragerc for whether or not to show missing line numbers for coverage
             'DDEV_COV_MISSING '
+            # Necessary for getting the user on Windows https://docs.python.org/3/library/getpass.html#getpass.getuser
+            'USERNAME '
             # Space-separated list of pytest options
             'PYTEST_ADDOPTS '
             # https://docs.docker.com/compose/reference/envvars/

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/run.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/run.py
@@ -13,7 +13,7 @@ def start_environment(check, env):
     env_vars = {
         E2E_TEAR_DOWN: 'false',
         'PYTEST_ADDOPTS': '--benchmark-skip --exitfirst',
-        'TOX_TESTENV_PASSENV': '{} PYTEST_ADDOPTS {}'.format(E2E_TEAR_DOWN, ' '.join(get_ci_env_vars())),
+        'TOX_TESTENV_PASSENV': '{} USERNAME PYTEST_ADDOPTS {}'.format(E2E_TEAR_DOWN, ' '.join(get_ci_env_vars())),
     }
 
     with chdir(path_join(get_root(), check), env_vars=env_vars):
@@ -27,7 +27,7 @@ def stop_environment(check, env, metadata=None):
     env_vars = {
         E2E_SET_UP: 'false',
         'PYTEST_ADDOPTS': '--benchmark-skip --exitfirst',
-        'TOX_TESTENV_PASSENV': '{}* {} PYTEST_ADDOPTS {}'.format(
+        'TOX_TESTENV_PASSENV': '{}* {} USERNAME PYTEST_ADDOPTS {}'.format(
             E2E_ENV_VAR_PREFIX, E2E_SET_UP, ' '.join(get_ci_env_vars())
         ),
     }


### PR DESCRIPTION
### Motivation

Avoid hard coding (or forgetting to) in `tox.ini`, particularly for Terraform e2e since it always calls `getpass.getuser()` https://github.com/DataDog/integrations-core/blob/f04c7c143c1af234ef57cf568f9204fe3035546d/linkerd/tox.ini#L17