### PR TITLE
Kubelet metrics in >= 1.14

### DIFF
--- a/kubelet/datadog_checks/kubelet/__about__.py
+++ b/kubelet/datadog_checks/kubelet/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "3.4.1"
+__version__ = "3.4.0"

--- a/kubelet/datadog_checks/kubelet/__about__.py
+++ b/kubelet/datadog_checks/kubelet/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "3.4.0"
+__version__ = "3.4.1"

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -186,7 +186,9 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
 
         self.COUNTER_TRANSFORMERS = {k: self.send_always_counter for k in self.COUNTER_METRICS}
 
-        self.histogram_transformers = {k: self._histogram_from_seconds_to_microseconds for k in TRANSFORM_VALUE_HISTOGRAMS}
+        self.histogram_transformers = {
+            k: self._histogram_from_seconds_to_microseconds for k in TRANSFORM_VALUE_HISTOGRAMS
+        }
 
     def _create_kubelet_prometheus_instance(self, instance):
         """

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -66,7 +66,7 @@ WHITELISTED_CONTAINER_STATE_REASONS = {
     'terminated': ['oomkilled', 'containercannotrun', 'error'],
 }
 
-DEFAULT_GUAGES = {
+DEFAULT_GAUGES = {
     'rest_client_requests_total': 'rest.client.requests',
     'kubelet_volume_stats_available_bytes': 'kubelet.volume.stats.available_bytes',
     'kubelet_volume_stats_capacity_bytes': 'kubelet.volume.stats.capacity_bytes',
@@ -76,12 +76,12 @@ DEFAULT_GUAGES = {
     'kubelet_volume_stats_inodes_used': 'kubelet.volume.stats.inodes_used',
 }
 
-DEPRECATED_GUAGES = {
+DEPRECATED_GAUGES = {
     'kubelet_runtime_operations': 'kubelet.runtime.operations',
     'kubelet_runtime_operations_errors': 'kubelet.runtime.errors',
 }
 
-NEW_1_14_GUAGES = {
+NEW_1_14_GAUGES = {
     'kubelet_runtime_operations_total': 'kubelet.runtime.operations',
     'kubelet_runtime_operations_errors_total': 'kubelet.runtime.errors',
 }
@@ -202,9 +202,9 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
                 # so the key is different than the cadvisor scraper.
                 'prometheus_url': instance.get('kubelet_metrics_endpoint', 'dummy_url/kubelet'),
                 'metrics': [
-                    DEFAULT_GUAGES,
-                    DEPRECATED_GUAGES,
-                    NEW_1_14_GUAGES,
+                    DEFAULT_GAUGES,
+                    DEPRECATED_GAUGES,
+                    NEW_1_14_GAUGES,
                     DEFAULT_HISTOGRAMS,
                     DEPRECATED_HISTOGRAMS,
                     NEW_1_14_HISTOGRAMS,

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -98,15 +98,13 @@ NEW_1_14_HISTOGRAMS = {
     'rest_client_request_duration_seconds': 'rest.client.latency',
 }
 
-DEFAULT_SUMMARIES = {
-}
+DEFAULT_SUMMARIES = {}
 
 DEPRECATED_SUMMARIES = {
     'kubelet_network_plugin_operations_latency_microseconds': 'kubelet.network_plugin.latency',
 }
 
-NEW_1_14_SUMMARIES = {
-}
+NEW_1_14_SUMMARIES = {}
 
 TRANSFORM_VALUE_HISTOGRAMS = {
     'kubelet_network_plugin_operations_duration_seconds': 'kubelet.network_plugin.latency',

--- a/kubelet/tests/fixtures/kubelet_metrics_1_14.txt
+++ b/kubelet/tests/fixtures/kubelet_metrics_1_14.txt
@@ -1,0 +1,1495 @@
+# HELP apiserver_audit_event_total Counter of audit events generated and sent to the audit backend.
+# TYPE apiserver_audit_event_total counter
+apiserver_audit_event_total 0
+# HELP apiserver_audit_requests_rejected_total Counter of apiserver requests rejected due to an error in audit logging backend.
+# TYPE apiserver_audit_requests_rejected_total counter
+apiserver_audit_requests_rejected_total 0
+# HELP apiserver_client_certificate_expiration_seconds Distribution of the remaining lifetime on the certificate used to authenticate a request.
+# TYPE apiserver_client_certificate_expiration_seconds histogram
+apiserver_client_certificate_expiration_seconds_bucket{le="0"} 0
+apiserver_client_certificate_expiration_seconds_bucket{le="1800"} 0
+apiserver_client_certificate_expiration_seconds_bucket{le="3600"} 0
+apiserver_client_certificate_expiration_seconds_bucket{le="7200"} 0
+apiserver_client_certificate_expiration_seconds_bucket{le="21600"} 0
+apiserver_client_certificate_expiration_seconds_bucket{le="43200"} 0
+apiserver_client_certificate_expiration_seconds_bucket{le="86400"} 0
+apiserver_client_certificate_expiration_seconds_bucket{le="172800"} 0
+apiserver_client_certificate_expiration_seconds_bucket{le="345600"} 0
+apiserver_client_certificate_expiration_seconds_bucket{le="604800"} 0
+apiserver_client_certificate_expiration_seconds_bucket{le="2.592e+06"} 0
+apiserver_client_certificate_expiration_seconds_bucket{le="7.776e+06"} 0
+apiserver_client_certificate_expiration_seconds_bucket{le="1.5552e+07"} 0
+apiserver_client_certificate_expiration_seconds_bucket{le="3.1104e+07"} 0
+apiserver_client_certificate_expiration_seconds_bucket{le="+Inf"} 6
+apiserver_client_certificate_expiration_seconds_sum 1.8861617470330057e+08
+apiserver_client_certificate_expiration_seconds_count 6
+# HELP apiserver_storage_data_key_generation_duration_seconds Latencies in seconds of data encryption key(DEK) generation operations.
+# TYPE apiserver_storage_data_key_generation_duration_seconds histogram
+apiserver_storage_data_key_generation_duration_seconds_bucket{le="5e-06"} 0
+apiserver_storage_data_key_generation_duration_seconds_bucket{le="1e-05"} 0
+apiserver_storage_data_key_generation_duration_seconds_bucket{le="2e-05"} 0
+apiserver_storage_data_key_generation_duration_seconds_bucket{le="4e-05"} 0
+apiserver_storage_data_key_generation_duration_seconds_bucket{le="8e-05"} 0
+apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.00016"} 0
+apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.00032"} 0
+apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.00064"} 0
+apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.00128"} 0
+apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.00256"} 0
+apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.00512"} 0
+apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.01024"} 0
+apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.02048"} 0
+apiserver_storage_data_key_generation_duration_seconds_bucket{le="0.04096"} 0
+apiserver_storage_data_key_generation_duration_seconds_bucket{le="+Inf"} 0
+apiserver_storage_data_key_generation_duration_seconds_sum 0
+apiserver_storage_data_key_generation_duration_seconds_count 0
+# HELP apiserver_storage_data_key_generation_failures_total Total number of failed data encryption key(DEK) generation operations.
+# TYPE apiserver_storage_data_key_generation_failures_total counter
+apiserver_storage_data_key_generation_failures_total 0
+# HELP apiserver_storage_data_key_generation_latencies_microseconds (Deprecated) Latencies in microseconds of data encryption key(DEK) generation operations.
+# TYPE apiserver_storage_data_key_generation_latencies_microseconds histogram
+apiserver_storage_data_key_generation_latencies_microseconds_bucket{le="5"} 0
+apiserver_storage_data_key_generation_latencies_microseconds_bucket{le="10"} 0
+apiserver_storage_data_key_generation_latencies_microseconds_bucket{le="20"} 0
+apiserver_storage_data_key_generation_latencies_microseconds_bucket{le="40"} 0
+apiserver_storage_data_key_generation_latencies_microseconds_bucket{le="80"} 0
+apiserver_storage_data_key_generation_latencies_microseconds_bucket{le="160"} 0
+apiserver_storage_data_key_generation_latencies_microseconds_bucket{le="320"} 0
+apiserver_storage_data_key_generation_latencies_microseconds_bucket{le="640"} 0
+apiserver_storage_data_key_generation_latencies_microseconds_bucket{le="1280"} 0
+apiserver_storage_data_key_generation_latencies_microseconds_bucket{le="2560"} 0
+apiserver_storage_data_key_generation_latencies_microseconds_bucket{le="5120"} 0
+apiserver_storage_data_key_generation_latencies_microseconds_bucket{le="10240"} 0
+apiserver_storage_data_key_generation_latencies_microseconds_bucket{le="20480"} 0
+apiserver_storage_data_key_generation_latencies_microseconds_bucket{le="40960"} 0
+apiserver_storage_data_key_generation_latencies_microseconds_bucket{le="+Inf"} 0
+apiserver_storage_data_key_generation_latencies_microseconds_sum 0
+apiserver_storage_data_key_generation_latencies_microseconds_count 0
+# HELP apiserver_storage_envelope_transformation_cache_misses_total Total number of cache misses while accessing key decryption key(KEK).
+# TYPE apiserver_storage_envelope_transformation_cache_misses_total counter
+apiserver_storage_envelope_transformation_cache_misses_total 0
+# HELP get_token_count Counter of total Token() requests to the alternate token source
+# TYPE get_token_count counter
+get_token_count 0
+# HELP get_token_fail_count Counter of failed Token() requests to the alternate token source
+# TYPE get_token_fail_count counter
+get_token_fail_count 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 2.9784e-05
+go_gc_duration_seconds{quantile="0.25"} 4.5146e-05
+go_gc_duration_seconds{quantile="0.5"} 7.4655e-05
+go_gc_duration_seconds{quantile="0.75"} 0.000120809
+go_gc_duration_seconds{quantile="1"} 0.007300404
+go_gc_duration_seconds_sum 3.075087802
+go_gc_duration_seconds_count 8619
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 312
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+go_info{version="go1.12.12"} 1
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 3.107744e+07
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 1.21129705448e+11
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 3.681735e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 9.50481593e+08
+# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
+# TYPE go_memstats_gc_cpu_fraction gauge
+go_memstats_gc_cpu_fraction 0.002992656077996334
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 2.639872e+06
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 3.107744e+07
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 2.92864e+07
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 3.4676736e+07
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 238547
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes gauge
+go_memstats_heap_released_bytes 303104
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 6.3963136e+07
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5777213959604402e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 0
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 9.5072014e+08
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 3472
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 460656
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 606208
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 3.7456336e+07
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 789297
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 3.145728e+06
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 3.145728e+06
+# HELP go_memstats_sys_bytes Number of bytes obtained from system.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 7.484236e+07
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads 20
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} 8763.954
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} 21553.757
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} 29428.649
+http_request_duration_microseconds_sum{handler="prometheus"} 2.5064447678000007e+07
+http_request_duration_microseconds_count{handler="prometheus"} 1875
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="prometheus",quantile="0.5"} 117
+http_request_size_bytes{handler="prometheus",quantile="0.9"} 117
+http_request_size_bytes{handler="prometheus",quantile="0.99"} 117
+http_request_size_bytes_sum{handler="prometheus"} 217472
+http_request_size_bytes_count{handler="prometheus"} 1875
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="prometheus",method="get"} 1875
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="prometheus",quantile="0.5"} 11666
+http_response_size_bytes{handler="prometheus",quantile="0.9"} 11686
+http_response_size_bytes{handler="prometheus",quantile="0.99"} 11689
+http_response_size_bytes_sum{handler="prometheus"} 2.3159272e+07
+http_response_size_bytes_count{handler="prometheus"} 1875
+# HELP kubelet_certificate_manager_client_expiration_seconds Gauge of the lifetime of a certificate. The value is the date the certificate will expire in seconds since January 1, 1970 UTC.
+# TYPE kubelet_certificate_manager_client_expiration_seconds gauge
+kubelet_certificate_manager_client_expiration_seconds 1.60876398e+09
+# HELP kubelet_cgroup_manager_duration_seconds Duration in seconds for cgroup manager operations. Broken down by method.
+# TYPE kubelet_cgroup_manager_duration_seconds histogram
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="create",le="0.005"} 10
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="create",le="0.01"} 14
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="create",le="0.025"} 16
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="create",le="0.05"} 17
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="create",le="0.1"} 18
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="create",le="0.25"} 18
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="create",le="0.5"} 18
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="create",le="1"} 18
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="create",le="2.5"} 18
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="create",le="5"} 18
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="create",le="10"} 18
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="create",le="+Inf"} 18
+kubelet_cgroup_manager_duration_seconds_sum{operation_type="create"} 0.22226386899999995
+kubelet_cgroup_manager_duration_seconds_count{operation_type="create"} 18
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="destroy",le="0.005"} 2
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="destroy",le="0.01"} 2
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="destroy",le="0.025"} 3
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="destroy",le="0.05"} 3
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="destroy",le="0.1"} 3
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="destroy",le="0.25"} 3
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="destroy",le="0.5"} 3
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="destroy",le="1"} 3
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="destroy",le="2.5"} 3
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="destroy",le="5"} 3
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="destroy",le="10"} 3
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="destroy",le="+Inf"} 3
+kubelet_cgroup_manager_duration_seconds_sum{operation_type="destroy"} 0.016276993
+kubelet_cgroup_manager_duration_seconds_count{operation_type="destroy"} 3
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="update",le="0.005"} 1532
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="update",le="0.01"} 1535
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="update",le="0.025"} 1541
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="update",le="0.05"} 1541
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="update",le="0.1"} 1545
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="update",le="0.25"} 1547
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="update",le="0.5"} 1550
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="update",le="1"} 1554
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="update",le="2.5"} 1556
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="update",le="5"} 1557
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="update",le="10"} 1557
+kubelet_cgroup_manager_duration_seconds_bucket{operation_type="update",le="+Inf"} 1557
+kubelet_cgroup_manager_duration_seconds_sum{operation_type="update"} 11.316291785999995
+kubelet_cgroup_manager_duration_seconds_count{operation_type="update"} 1557
+# HELP kubelet_cgroup_manager_latency_microseconds (Deprecated) Latency in microseconds for cgroup manager operations. Broken down by method.
+# TYPE kubelet_cgroup_manager_latency_microseconds summary
+kubelet_cgroup_manager_latency_microseconds{operation_type="create",quantile="0.5"} NaN
+kubelet_cgroup_manager_latency_microseconds{operation_type="create",quantile="0.9"} NaN
+kubelet_cgroup_manager_latency_microseconds{operation_type="create",quantile="0.99"} NaN
+kubelet_cgroup_manager_latency_microseconds_sum{operation_type="create"} 222337
+kubelet_cgroup_manager_latency_microseconds_count{operation_type="create"} 18
+kubelet_cgroup_manager_latency_microseconds{operation_type="destroy",quantile="0.5"} NaN
+kubelet_cgroup_manager_latency_microseconds{operation_type="destroy",quantile="0.9"} NaN
+kubelet_cgroup_manager_latency_microseconds{operation_type="destroy",quantile="0.99"} NaN
+kubelet_cgroup_manager_latency_microseconds_sum{operation_type="destroy"} 16350
+kubelet_cgroup_manager_latency_microseconds_count{operation_type="destroy"} 3
+kubelet_cgroup_manager_latency_microseconds{operation_type="update",quantile="0.5"} 156
+kubelet_cgroup_manager_latency_microseconds{operation_type="update",quantile="0.9"} 233
+kubelet_cgroup_manager_latency_microseconds{operation_type="update",quantile="0.99"} 233
+kubelet_cgroup_manager_latency_microseconds_sum{operation_type="update"} 1.1517344e+07
+kubelet_cgroup_manager_latency_microseconds_count{operation_type="update"} 1557
+# HELP kubelet_container_log_filesystem_used_bytes Bytes used by the container's logs on the filesystem.
+# TYPE kubelet_container_log_filesystem_used_bytes gauge
+kubelet_container_log_filesystem_used_bytes{container="cluster-agent",namespace="default",pod="datadog-monitoring-cluster-agent-c4fc98b6f-5xcxk"} 40960
+kubelet_container_log_filesystem_used_bytes{container="coredns",namespace="kube-system",pod="coredns-6dcc67dcbc-k74pm"} 28672
+kubelet_container_log_filesystem_used_bytes{container="coredns",namespace="kube-system",pod="coredns-6dcc67dcbc-xg7f9"} 28672
+kubelet_container_log_filesystem_used_bytes{container="datadog",namespace="default",pod="datadog-monitoring-kp46r"} 1.040384e+06
+kubelet_container_log_filesystem_used_bytes{container="etcd",namespace="kube-system",pod="etcd-minikube"} 712704
+kubelet_container_log_filesystem_used_bytes{container="kube-addon-manager",namespace="kube-system",pod="kube-addon-manager-minikube"} 7.3728e+06
+kubelet_container_log_filesystem_used_bytes{container="kube-apiserver",namespace="kube-system",pod="kube-apiserver-minikube"} 905216
+kubelet_container_log_filesystem_used_bytes{container="kube-controller-manager",namespace="kube-system",pod="kube-controller-manager-minikube"} 61440
+kubelet_container_log_filesystem_used_bytes{container="kube-proxy",namespace="kube-system",pod="kube-proxy-tfn5n"} 28672
+kubelet_container_log_filesystem_used_bytes{container="kube-scheduler",namespace="kube-system",pod="kube-scheduler-minikube"} 28672
+kubelet_container_log_filesystem_used_bytes{container="kube-state-metrics",namespace="default",pod="datadog-monitoring-kube-state-metrics-c99f4db8d-dn2x4"} 32768
+kubelet_container_log_filesystem_used_bytes{container="storage-provisioner",namespace="kube-system",pod="storage-provisioner"} 24576
+# HELP kubelet_containers_per_pod_count The number of containers per pod.
+# TYPE kubelet_containers_per_pod_count histogram
+kubelet_containers_per_pod_count_bucket{le="0.005"} 0
+kubelet_containers_per_pod_count_bucket{le="0.01"} 0
+kubelet_containers_per_pod_count_bucket{le="0.025"} 0
+kubelet_containers_per_pod_count_bucket{le="0.05"} 0
+kubelet_containers_per_pod_count_bucket{le="0.1"} 0
+kubelet_containers_per_pod_count_bucket{le="0.25"} 0
+kubelet_containers_per_pod_count_bucket{le="0.5"} 0
+kubelet_containers_per_pod_count_bucket{le="1"} 15
+kubelet_containers_per_pod_count_bucket{le="2.5"} 15
+kubelet_containers_per_pod_count_bucket{le="5"} 15
+kubelet_containers_per_pod_count_bucket{le="10"} 15
+kubelet_containers_per_pod_count_bucket{le="+Inf"} 15
+kubelet_containers_per_pod_count_sum 15
+kubelet_containers_per_pod_count_count 15
+# HELP kubelet_docker_operations (Deprecated) Cumulative number of Docker operations by operation type.
+# TYPE kubelet_docker_operations counter
+kubelet_docker_operations{operation_type="create_container"} 51
+kubelet_docker_operations{operation_type="info"} 2
+kubelet_docker_operations{operation_type="inspect_container"} 381
+kubelet_docker_operations{operation_type="inspect_image"} 414
+kubelet_docker_operations{operation_type="list_containers"} 160127
+kubelet_docker_operations{operation_type="list_images"} 7806
+kubelet_docker_operations{operation_type="pull_image"} 5
+kubelet_docker_operations{operation_type="remove_container"} 25
+kubelet_docker_operations{operation_type="start_container"} 51
+kubelet_docker_operations{operation_type="stop_container"} 15
+kubelet_docker_operations{operation_type="version"} 13113
+# HELP kubelet_docker_operations_duration_seconds Latency in seconds of Docker operations. Broken down by operation type.
+# TYPE kubelet_docker_operations_duration_seconds histogram
+kubelet_docker_operations_duration_seconds_bucket{operation_type="create_container",le="0.005"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="create_container",le="0.01"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="create_container",le="0.025"} 5
+kubelet_docker_operations_duration_seconds_bucket{operation_type="create_container",le="0.05"} 24
+kubelet_docker_operations_duration_seconds_bucket{operation_type="create_container",le="0.1"} 33
+kubelet_docker_operations_duration_seconds_bucket{operation_type="create_container",le="0.25"} 38
+kubelet_docker_operations_duration_seconds_bucket{operation_type="create_container",le="0.5"} 40
+kubelet_docker_operations_duration_seconds_bucket{operation_type="create_container",le="1"} 50
+kubelet_docker_operations_duration_seconds_bucket{operation_type="create_container",le="2.5"} 50
+kubelet_docker_operations_duration_seconds_bucket{operation_type="create_container",le="5"} 51
+kubelet_docker_operations_duration_seconds_bucket{operation_type="create_container",le="10"} 51
+kubelet_docker_operations_duration_seconds_bucket{operation_type="create_container",le="+Inf"} 51
+kubelet_docker_operations_duration_seconds_sum{operation_type="create_container"} 13.980794975000002
+kubelet_docker_operations_duration_seconds_count{operation_type="create_container"} 51
+kubelet_docker_operations_duration_seconds_bucket{operation_type="info",le="0.005"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="info",le="0.01"} 1
+kubelet_docker_operations_duration_seconds_bucket{operation_type="info",le="0.025"} 2
+kubelet_docker_operations_duration_seconds_bucket{operation_type="info",le="0.05"} 2
+kubelet_docker_operations_duration_seconds_bucket{operation_type="info",le="0.1"} 2
+kubelet_docker_operations_duration_seconds_bucket{operation_type="info",le="0.25"} 2
+kubelet_docker_operations_duration_seconds_bucket{operation_type="info",le="0.5"} 2
+kubelet_docker_operations_duration_seconds_bucket{operation_type="info",le="1"} 2
+kubelet_docker_operations_duration_seconds_bucket{operation_type="info",le="2.5"} 2
+kubelet_docker_operations_duration_seconds_bucket{operation_type="info",le="5"} 2
+kubelet_docker_operations_duration_seconds_bucket{operation_type="info",le="10"} 2
+kubelet_docker_operations_duration_seconds_bucket{operation_type="info",le="+Inf"} 2
+kubelet_docker_operations_duration_seconds_sum{operation_type="info"} 0.021787783999999998
+kubelet_docker_operations_duration_seconds_count{operation_type="info"} 2
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_container",le="0.005"} 290
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_container",le="0.01"} 334
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_container",le="0.025"} 355
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_container",le="0.05"} 365
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_container",le="0.1"} 369
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_container",le="0.25"} 374
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_container",le="0.5"} 377
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_container",le="1"} 379
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_container",le="2.5"} 380
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_container",le="5"} 381
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_container",le="10"} 381
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_container",le="+Inf"} 381
+kubelet_docker_operations_duration_seconds_sum{operation_type="inspect_container"} 9.254613304999996
+kubelet_docker_operations_duration_seconds_count{operation_type="inspect_container"} 381
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_image",le="0.005"} 354
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_image",le="0.01"} 379
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_image",le="0.025"} 396
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_image",le="0.05"} 400
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_image",le="0.1"} 401
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_image",le="0.25"} 402
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_image",le="0.5"} 402
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_image",le="1"} 406
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_image",le="2.5"} 410
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_image",le="5"} 412
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_image",le="10"} 414
+kubelet_docker_operations_duration_seconds_bucket{operation_type="inspect_image",le="+Inf"} 414
+kubelet_docker_operations_duration_seconds_sum{operation_type="inspect_image"} 30.875016726999995
+kubelet_docker_operations_duration_seconds_count{operation_type="inspect_image"} 414
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_containers",le="0.005"} 143598
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_containers",le="0.01"} 156510
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_containers",le="0.025"} 159101
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_containers",le="0.05"} 159358
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_containers",le="0.1"} 159451
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_containers",le="0.25"} 159533
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_containers",le="0.5"} 159571
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_containers",le="1"} 159637
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_containers",le="2.5"} 159852
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_containers",le="5"} 160021
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_containers",le="10"} 160113
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_containers",le="+Inf"} 160127
+kubelet_docker_operations_duration_seconds_sum{operation_type="list_containers"} 2415.2344385800448
+kubelet_docker_operations_duration_seconds_count{operation_type="list_containers"} 160127
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_images",le="0.005"} 6562
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_images",le="0.01"} 7543
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_images",le="0.025"} 7690
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_images",le="0.05"} 7705
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_images",le="0.1"} 7712
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_images",le="0.25"} 7719
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_images",le="0.5"} 7721
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_images",le="1"} 7723
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_images",le="2.5"} 7748
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_images",le="5"} 7786
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_images",le="10"} 7798
+kubelet_docker_operations_duration_seconds_bucket{operation_type="list_images",le="+Inf"} 7806
+kubelet_docker_operations_duration_seconds_sum{operation_type="list_images"} 436.48716636299775
+kubelet_docker_operations_duration_seconds_count{operation_type="list_images"} 7806
+kubelet_docker_operations_duration_seconds_bucket{operation_type="pull_image",le="0.005"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="pull_image",le="0.01"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="pull_image",le="0.025"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="pull_image",le="0.05"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="pull_image",le="0.1"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="pull_image",le="0.25"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="pull_image",le="0.5"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="pull_image",le="1"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="pull_image",le="2.5"} 1
+kubelet_docker_operations_duration_seconds_bucket{operation_type="pull_image",le="5"} 1
+kubelet_docker_operations_duration_seconds_bucket{operation_type="pull_image",le="10"} 1
+kubelet_docker_operations_duration_seconds_bucket{operation_type="pull_image",le="+Inf"} 5
+kubelet_docker_operations_duration_seconds_sum{operation_type="pull_image"} 55.337502977
+kubelet_docker_operations_duration_seconds_count{operation_type="pull_image"} 5
+kubelet_docker_operations_duration_seconds_bucket{operation_type="remove_container",le="0.005"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="remove_container",le="0.01"} 5
+kubelet_docker_operations_duration_seconds_bucket{operation_type="remove_container",le="0.025"} 14
+kubelet_docker_operations_duration_seconds_bucket{operation_type="remove_container",le="0.05"} 17
+kubelet_docker_operations_duration_seconds_bucket{operation_type="remove_container",le="0.1"} 18
+kubelet_docker_operations_duration_seconds_bucket{operation_type="remove_container",le="0.25"} 20
+kubelet_docker_operations_duration_seconds_bucket{operation_type="remove_container",le="0.5"} 21
+kubelet_docker_operations_duration_seconds_bucket{operation_type="remove_container",le="1"} 25
+kubelet_docker_operations_duration_seconds_bucket{operation_type="remove_container",le="2.5"} 25
+kubelet_docker_operations_duration_seconds_bucket{operation_type="remove_container",le="5"} 25
+kubelet_docker_operations_duration_seconds_bucket{operation_type="remove_container",le="10"} 25
+kubelet_docker_operations_duration_seconds_bucket{operation_type="remove_container",le="+Inf"} 25
+kubelet_docker_operations_duration_seconds_sum{operation_type="remove_container"} 3.951931906
+kubelet_docker_operations_duration_seconds_count{operation_type="remove_container"} 25
+kubelet_docker_operations_duration_seconds_bucket{operation_type="start_container",le="0.005"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="start_container",le="0.01"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="start_container",le="0.025"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="start_container",le="0.05"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="start_container",le="0.1"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="start_container",le="0.25"} 15
+kubelet_docker_operations_duration_seconds_bucket{operation_type="start_container",le="0.5"} 42
+kubelet_docker_operations_duration_seconds_bucket{operation_type="start_container",le="1"} 46
+kubelet_docker_operations_duration_seconds_bucket{operation_type="start_container",le="2.5"} 49
+kubelet_docker_operations_duration_seconds_bucket{operation_type="start_container",le="5"} 50
+kubelet_docker_operations_duration_seconds_bucket{operation_type="start_container",le="10"} 51
+kubelet_docker_operations_duration_seconds_bucket{operation_type="start_container",le="+Inf"} 51
+kubelet_docker_operations_duration_seconds_sum{operation_type="start_container"} 28.443232894000005
+kubelet_docker_operations_duration_seconds_count{operation_type="start_container"} 51
+kubelet_docker_operations_duration_seconds_bucket{operation_type="stop_container",le="0.005"} 7
+kubelet_docker_operations_duration_seconds_bucket{operation_type="stop_container",le="0.01"} 7
+kubelet_docker_operations_duration_seconds_bucket{operation_type="stop_container",le="0.025"} 9
+kubelet_docker_operations_duration_seconds_bucket{operation_type="stop_container",le="0.05"} 9
+kubelet_docker_operations_duration_seconds_bucket{operation_type="stop_container",le="0.1"} 9
+kubelet_docker_operations_duration_seconds_bucket{operation_type="stop_container",le="0.25"} 9
+kubelet_docker_operations_duration_seconds_bucket{operation_type="stop_container",le="0.5"} 10
+kubelet_docker_operations_duration_seconds_bucket{operation_type="stop_container",le="1"} 12
+kubelet_docker_operations_duration_seconds_bucket{operation_type="stop_container",le="2.5"} 15
+kubelet_docker_operations_duration_seconds_bucket{operation_type="stop_container",le="5"} 15
+kubelet_docker_operations_duration_seconds_bucket{operation_type="stop_container",le="10"} 15
+kubelet_docker_operations_duration_seconds_bucket{operation_type="stop_container",le="+Inf"} 15
+kubelet_docker_operations_duration_seconds_sum{operation_type="stop_container"} 6.697615975999999
+kubelet_docker_operations_duration_seconds_count{operation_type="stop_container"} 15
+kubelet_docker_operations_duration_seconds_bucket{operation_type="version",le="0.005"} 0
+kubelet_docker_operations_duration_seconds_bucket{operation_type="version",le="0.01"} 4708
+kubelet_docker_operations_duration_seconds_bucket{operation_type="version",le="0.025"} 12602
+kubelet_docker_operations_duration_seconds_bucket{operation_type="version",le="0.05"} 12900
+kubelet_docker_operations_duration_seconds_bucket{operation_type="version",le="0.1"} 12948
+kubelet_docker_operations_duration_seconds_bucket{operation_type="version",le="0.25"} 12964
+kubelet_docker_operations_duration_seconds_bucket{operation_type="version",le="0.5"} 12971
+kubelet_docker_operations_duration_seconds_bucket{operation_type="version",le="1"} 12972
+kubelet_docker_operations_duration_seconds_bucket{operation_type="version",le="2.5"} 12984
+kubelet_docker_operations_duration_seconds_bucket{operation_type="version",le="5"} 13020
+kubelet_docker_operations_duration_seconds_bucket{operation_type="version",le="10"} 13091
+kubelet_docker_operations_duration_seconds_bucket{operation_type="version",le="+Inf"} 13113
+kubelet_docker_operations_duration_seconds_sum{operation_type="version"} 1123.5475550799915
+kubelet_docker_operations_duration_seconds_count{operation_type="version"} 13113
+# HELP kubelet_docker_operations_errors (Deprecated) Cumulative number of Docker operation errors by operation type.
+# TYPE kubelet_docker_operations_errors counter
+kubelet_docker_operations_errors{operation_type="inspect_container"} 2
+kubelet_docker_operations_errors{operation_type="inspect_image"} 5
+# HELP kubelet_docker_operations_errors_total Cumulative number of Docker operation errors by operation type.
+# TYPE kubelet_docker_operations_errors_total counter
+kubelet_docker_operations_errors_total{operation_type="inspect_container"} 2
+kubelet_docker_operations_errors_total{operation_type="inspect_image"} 5
+# HELP kubelet_docker_operations_latency_microseconds (Deprecated) Latency in microseconds of Docker operations. Broken down by operation type.
+# TYPE kubelet_docker_operations_latency_microseconds summary
+kubelet_docker_operations_latency_microseconds{operation_type="create_container",quantile="0.5"} NaN
+kubelet_docker_operations_latency_microseconds{operation_type="create_container",quantile="0.9"} NaN
+kubelet_docker_operations_latency_microseconds{operation_type="create_container",quantile="0.99"} NaN
+kubelet_docker_operations_latency_microseconds_sum{operation_type="create_container"} 1.3981331e+07
+kubelet_docker_operations_latency_microseconds_count{operation_type="create_container"} 51
+kubelet_docker_operations_latency_microseconds{operation_type="info",quantile="0.5"} NaN
+kubelet_docker_operations_latency_microseconds{operation_type="info",quantile="0.9"} NaN
+kubelet_docker_operations_latency_microseconds{operation_type="info",quantile="0.99"} NaN
+kubelet_docker_operations_latency_microseconds_sum{operation_type="info"} 21799
+kubelet_docker_operations_latency_microseconds_count{operation_type="info"} 2
+kubelet_docker_operations_latency_microseconds{operation_type="inspect_container",quantile="0.5"} NaN
+kubelet_docker_operations_latency_microseconds{operation_type="inspect_container",quantile="0.9"} NaN
+kubelet_docker_operations_latency_microseconds{operation_type="inspect_container",quantile="0.99"} NaN
+kubelet_docker_operations_latency_microseconds_sum{operation_type="inspect_container"} 9.259648e+06
+kubelet_docker_operations_latency_microseconds_count{operation_type="inspect_container"} 381
+kubelet_docker_operations_latency_microseconds{operation_type="inspect_image",quantile="0.5"} 1076
+kubelet_docker_operations_latency_microseconds{operation_type="inspect_image",quantile="0.9"} 1076
+kubelet_docker_operations_latency_microseconds{operation_type="inspect_image",quantile="0.99"} 1076
+kubelet_docker_operations_latency_microseconds_sum{operation_type="inspect_image"} 3.0897669e+07
+kubelet_docker_operations_latency_microseconds_count{operation_type="inspect_image"} 414
+kubelet_docker_operations_latency_microseconds{operation_type="list_containers",quantile="0.5"} 3348
+kubelet_docker_operations_latency_microseconds{operation_type="list_containers",quantile="0.9"} 6150
+kubelet_docker_operations_latency_microseconds{operation_type="list_containers",quantile="0.99"} 13726
+kubelet_docker_operations_latency_microseconds_sum{operation_type="list_containers"} 2.421868777e+09
+kubelet_docker_operations_latency_microseconds_count{operation_type="list_containers"} 160127
+kubelet_docker_operations_latency_microseconds{operation_type="list_images",quantile="0.5"} 3514
+kubelet_docker_operations_latency_microseconds{operation_type="list_images",quantile="0.9"} 5616
+kubelet_docker_operations_latency_microseconds{operation_type="list_images",quantile="0.99"} 9986
+kubelet_docker_operations_latency_microseconds_sum{operation_type="list_images"} 4.38346598e+08
+kubelet_docker_operations_latency_microseconds_count{operation_type="list_images"} 7806
+kubelet_docker_operations_latency_microseconds{operation_type="pull_image",quantile="0.5"} NaN
+kubelet_docker_operations_latency_microseconds{operation_type="pull_image",quantile="0.9"} NaN
+kubelet_docker_operations_latency_microseconds{operation_type="pull_image",quantile="0.99"} NaN
+kubelet_docker_operations_latency_microseconds_sum{operation_type="pull_image"} 5.5337659e+07
+kubelet_docker_operations_latency_microseconds_count{operation_type="pull_image"} 5
+kubelet_docker_operations_latency_microseconds{operation_type="remove_container",quantile="0.5"} NaN
+kubelet_docker_operations_latency_microseconds{operation_type="remove_container",quantile="0.9"} NaN
+kubelet_docker_operations_latency_microseconds{operation_type="remove_container",quantile="0.99"} NaN
+kubelet_docker_operations_latency_microseconds_sum{operation_type="remove_container"} 3.952238e+06
+kubelet_docker_operations_latency_microseconds_count{operation_type="remove_container"} 25
+kubelet_docker_operations_latency_microseconds{operation_type="start_container",quantile="0.5"} NaN
+kubelet_docker_operations_latency_microseconds{operation_type="start_container",quantile="0.9"} NaN
+kubelet_docker_operations_latency_microseconds{operation_type="start_container",quantile="0.99"} NaN
+kubelet_docker_operations_latency_microseconds_sum{operation_type="start_container"} 2.8443926e+07
+kubelet_docker_operations_latency_microseconds_count{operation_type="start_container"} 51
+kubelet_docker_operations_latency_microseconds{operation_type="stop_container",quantile="0.5"} NaN
+kubelet_docker_operations_latency_microseconds{operation_type="stop_container",quantile="0.9"} NaN
+kubelet_docker_operations_latency_microseconds{operation_type="stop_container",quantile="0.99"} NaN
+kubelet_docker_operations_latency_microseconds_sum{operation_type="stop_container"} 6.697993e+06
+kubelet_docker_operations_latency_microseconds_count{operation_type="stop_container"} 15
+kubelet_docker_operations_latency_microseconds{operation_type="version",quantile="0.5"} 11876
+kubelet_docker_operations_latency_microseconds{operation_type="version",quantile="0.9"} 16081
+kubelet_docker_operations_latency_microseconds{operation_type="version",quantile="0.99"} 23373
+kubelet_docker_operations_latency_microseconds_sum{operation_type="version"} 1.123988368e+09
+kubelet_docker_operations_latency_microseconds_count{operation_type="version"} 13113
+# HELP kubelet_docker_operations_total Cumulative number of Docker operations by operation type.
+# TYPE kubelet_docker_operations_total counter
+kubelet_docker_operations_total{operation_type="create_container"} 51
+kubelet_docker_operations_total{operation_type="info"} 2
+kubelet_docker_operations_total{operation_type="inspect_container"} 381
+kubelet_docker_operations_total{operation_type="inspect_image"} 414
+kubelet_docker_operations_total{operation_type="list_containers"} 160127
+kubelet_docker_operations_total{operation_type="list_images"} 7806
+kubelet_docker_operations_total{operation_type="pull_image"} 5
+kubelet_docker_operations_total{operation_type="remove_container"} 25
+kubelet_docker_operations_total{operation_type="start_container"} 51
+kubelet_docker_operations_total{operation_type="stop_container"} 15
+kubelet_docker_operations_total{operation_type="version"} 13113
+# HELP kubelet_network_plugin_operations_duration_seconds Latency in seconds of network plugin operations. Broken down by operation type.
+# TYPE kubelet_network_plugin_operations_duration_seconds histogram
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="get_pod_network_status",le="0.005"} 25
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="get_pod_network_status",le="0.01"} 26
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="get_pod_network_status",le="0.025"} 26
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="get_pod_network_status",le="0.05"} 26
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="get_pod_network_status",le="0.1"} 26
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="get_pod_network_status",le="0.25"} 26
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="get_pod_network_status",le="0.5"} 26
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="get_pod_network_status",le="1"} 26
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="get_pod_network_status",le="2.5"} 26
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="get_pod_network_status",le="5"} 26
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="get_pod_network_status",le="10"} 26
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="get_pod_network_status",le="+Inf"} 26
+kubelet_network_plugin_operations_duration_seconds_sum{operation_type="get_pod_network_status"} 0.008526665
+kubelet_network_plugin_operations_duration_seconds_count{operation_type="get_pod_network_status"} 26
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="set_up_pod",le="0.005"} 8
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="set_up_pod",le="0.01"} 8
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="set_up_pod",le="0.025"} 8
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="set_up_pod",le="0.05"} 8
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="set_up_pod",le="0.1"} 8
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="set_up_pod",le="0.25"} 8
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="set_up_pod",le="0.5"} 8
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="set_up_pod",le="1"} 8
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="set_up_pod",le="2.5"} 8
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="set_up_pod",le="5"} 8
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="set_up_pod",le="10"} 8
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="set_up_pod",le="+Inf"} 8
+kubelet_network_plugin_operations_duration_seconds_sum{operation_type="set_up_pod"} 0.00036158
+kubelet_network_plugin_operations_duration_seconds_count{operation_type="set_up_pod"} 8
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="tear_down_pod",le="0.005"} 3
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="tear_down_pod",le="0.01"} 3
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="tear_down_pod",le="0.025"} 3
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="tear_down_pod",le="0.05"} 3
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="tear_down_pod",le="0.1"} 3
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="tear_down_pod",le="0.25"} 3
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="tear_down_pod",le="0.5"} 3
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="tear_down_pod",le="1"} 3
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="tear_down_pod",le="2.5"} 3
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="tear_down_pod",le="5"} 3
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="tear_down_pod",le="10"} 3
+kubelet_network_plugin_operations_duration_seconds_bucket{operation_type="tear_down_pod",le="+Inf"} 3
+kubelet_network_plugin_operations_duration_seconds_sum{operation_type="tear_down_pod"} 4.3269e-05
+kubelet_network_plugin_operations_duration_seconds_count{operation_type="tear_down_pod"} 3
+# HELP kubelet_network_plugin_operations_latency_microseconds (Deprecated) Latency in microseconds of network plugin operations. Broken down by operation type.
+# TYPE kubelet_network_plugin_operations_latency_microseconds summary
+kubelet_network_plugin_operations_latency_microseconds{operation_type="get_pod_network_status",quantile="0.5"} NaN
+kubelet_network_plugin_operations_latency_microseconds{operation_type="get_pod_network_status",quantile="0.9"} NaN
+kubelet_network_plugin_operations_latency_microseconds{operation_type="get_pod_network_status",quantile="0.99"} NaN
+kubelet_network_plugin_operations_latency_microseconds_sum{operation_type="get_pod_network_status"} 8893
+kubelet_network_plugin_operations_latency_microseconds_count{operation_type="get_pod_network_status"} 26
+kubelet_network_plugin_operations_latency_microseconds{operation_type="set_up_pod",quantile="0.5"} NaN
+kubelet_network_plugin_operations_latency_microseconds{operation_type="set_up_pod",quantile="0.9"} NaN
+kubelet_network_plugin_operations_latency_microseconds{operation_type="set_up_pod",quantile="0.99"} NaN
+kubelet_network_plugin_operations_latency_microseconds_sum{operation_type="set_up_pod"} 525
+kubelet_network_plugin_operations_latency_microseconds_count{operation_type="set_up_pod"} 8
+kubelet_network_plugin_operations_latency_microseconds{operation_type="tear_down_pod",quantile="0.5"} NaN
+kubelet_network_plugin_operations_latency_microseconds{operation_type="tear_down_pod",quantile="0.9"} NaN
+kubelet_network_plugin_operations_latency_microseconds{operation_type="tear_down_pod",quantile="0.99"} NaN
+kubelet_network_plugin_operations_latency_microseconds_sum{operation_type="tear_down_pod"} 104
+kubelet_network_plugin_operations_latency_microseconds_count{operation_type="tear_down_pod"} 3
+# HELP kubelet_node_config_error This metric is true (1) if the node is experiencing a configuration-related error, false (0) otherwise.
+# TYPE kubelet_node_config_error gauge
+kubelet_node_config_error 0
+# HELP kubelet_node_name The node's name. The count is always 1.
+# TYPE kubelet_node_name gauge
+kubelet_node_name{node="minikube"} 1
+# HELP kubelet_pleg_relist_duration_seconds Duration in seconds for relisting pods in PLEG.
+# TYPE kubelet_pleg_relist_duration_seconds histogram
+kubelet_pleg_relist_duration_seconds_bucket{le="0.005"} 3106
+kubelet_pleg_relist_duration_seconds_bucket{le="0.01"} 35089
+kubelet_pleg_relist_duration_seconds_bucket{le="0.025"} 42228
+kubelet_pleg_relist_duration_seconds_bucket{le="0.05"} 42583
+kubelet_pleg_relist_duration_seconds_bucket{le="0.1"} 42669
+kubelet_pleg_relist_duration_seconds_bucket{le="0.25"} 42712
+kubelet_pleg_relist_duration_seconds_bucket{le="0.5"} 42727
+kubelet_pleg_relist_duration_seconds_bucket{le="1"} 42735
+kubelet_pleg_relist_duration_seconds_bucket{le="2.5"} 42749
+kubelet_pleg_relist_duration_seconds_bucket{le="5"} 42793
+kubelet_pleg_relist_duration_seconds_bucket{le="10"} 42847
+kubelet_pleg_relist_duration_seconds_bucket{le="+Inf"} 42893
+kubelet_pleg_relist_duration_seconds_sum 1629.920016523
+kubelet_pleg_relist_duration_seconds_count 42893
+# HELP kubelet_pleg_relist_interval_microseconds (Deprecated) Interval in microseconds between relisting in PLEG.
+# TYPE kubelet_pleg_relist_interval_microseconds summary
+kubelet_pleg_relist_interval_microseconds{quantile="0.5"} 1.00921e+06
+kubelet_pleg_relist_interval_microseconds{quantile="0.9"} 1.013194e+06
+kubelet_pleg_relist_interval_microseconds{quantile="0.99"} 1.029029e+06
+kubelet_pleg_relist_interval_microseconds_sum 4.6247131304e+10
+kubelet_pleg_relist_interval_microseconds_count 42892
+# HELP kubelet_pleg_relist_interval_seconds Interval in seconds between relisting in PLEG.
+# TYPE kubelet_pleg_relist_interval_seconds histogram
+kubelet_pleg_relist_interval_seconds_bucket{le="0.005"} 0
+kubelet_pleg_relist_interval_seconds_bucket{le="0.01"} 0
+kubelet_pleg_relist_interval_seconds_bucket{le="0.025"} 0
+kubelet_pleg_relist_interval_seconds_bucket{le="0.05"} 0
+kubelet_pleg_relist_interval_seconds_bucket{le="0.1"} 0
+kubelet_pleg_relist_interval_seconds_bucket{le="0.25"} 0
+kubelet_pleg_relist_interval_seconds_bucket{le="0.5"} 0
+kubelet_pleg_relist_interval_seconds_bucket{le="1"} 0
+kubelet_pleg_relist_interval_seconds_bucket{le="2.5"} 42731
+kubelet_pleg_relist_interval_seconds_bucket{le="5"} 42769
+kubelet_pleg_relist_interval_seconds_bucket{le="10"} 42835
+kubelet_pleg_relist_interval_seconds_bucket{le="+Inf"} 42892
+kubelet_pleg_relist_interval_seconds_sum 46245.977438063026
+kubelet_pleg_relist_interval_seconds_count 42892
+# HELP kubelet_pleg_relist_latency_microseconds (Deprecated) Latency in microseconds for relisting pods in PLEG.
+# TYPE kubelet_pleg_relist_latency_microseconds summary
+kubelet_pleg_relist_latency_microseconds{quantile="0.5"} 8313
+kubelet_pleg_relist_latency_microseconds{quantile="0.9"} 12285
+kubelet_pleg_relist_latency_microseconds{quantile="0.99"} 28543
+kubelet_pleg_relist_latency_microseconds_sum 1.631155039e+09
+kubelet_pleg_relist_latency_microseconds_count 42893
+# HELP kubelet_pod_start_duration_seconds Duration in seconds for a single pod to go from pending to running.
+# TYPE kubelet_pod_start_duration_seconds histogram
+kubelet_pod_start_duration_seconds_bucket{le="0.005"} 4
+kubelet_pod_start_duration_seconds_bucket{le="0.01"} 6
+kubelet_pod_start_duration_seconds_bucket{le="0.025"} 9
+kubelet_pod_start_duration_seconds_bucket{le="0.05"} 9
+kubelet_pod_start_duration_seconds_bucket{le="0.1"} 10
+kubelet_pod_start_duration_seconds_bucket{le="0.25"} 10
+kubelet_pod_start_duration_seconds_bucket{le="0.5"} 10
+kubelet_pod_start_duration_seconds_bucket{le="1"} 11
+kubelet_pod_start_duration_seconds_bucket{le="2.5"} 14
+kubelet_pod_start_duration_seconds_bucket{le="5"} 15
+kubelet_pod_start_duration_seconds_bucket{le="10"} 26
+kubelet_pod_start_duration_seconds_bucket{le="+Inf"} 30
+kubelet_pod_start_duration_seconds_sum 146.698439544
+kubelet_pod_start_duration_seconds_count 30
+# HELP kubelet_pod_start_latency_microseconds (Deprecated) Latency in microseconds for a single pod to go from pending to running.
+# TYPE kubelet_pod_start_latency_microseconds summary
+kubelet_pod_start_latency_microseconds{quantile="0.5"} NaN
+kubelet_pod_start_latency_microseconds{quantile="0.9"} NaN
+kubelet_pod_start_latency_microseconds{quantile="0.99"} NaN
+kubelet_pod_start_latency_microseconds_sum 1.46698696e+08
+kubelet_pod_start_latency_microseconds_count 30
+# HELP kubelet_pod_worker_duration_seconds Duration in seconds to sync a single pod. Broken down by operation type: create, update, or sync
+# TYPE kubelet_pod_worker_duration_seconds histogram
+kubelet_pod_worker_duration_seconds_bucket{operation_type="sync",le="0.005"} 42
+kubelet_pod_worker_duration_seconds_bucket{operation_type="sync",le="0.01"} 49
+kubelet_pod_worker_duration_seconds_bucket{operation_type="sync",le="0.025"} 50
+kubelet_pod_worker_duration_seconds_bucket{operation_type="sync",le="0.05"} 50
+kubelet_pod_worker_duration_seconds_bucket{operation_type="sync",le="0.1"} 53
+kubelet_pod_worker_duration_seconds_bucket{operation_type="sync",le="0.25"} 58
+kubelet_pod_worker_duration_seconds_bucket{operation_type="sync",le="0.5"} 66
+kubelet_pod_worker_duration_seconds_bucket{operation_type="sync",le="1"} 67
+kubelet_pod_worker_duration_seconds_bucket{operation_type="sync",le="2.5"} 74
+kubelet_pod_worker_duration_seconds_bucket{operation_type="sync",le="5"} 76
+kubelet_pod_worker_duration_seconds_bucket{operation_type="sync",le="10"} 76
+kubelet_pod_worker_duration_seconds_bucket{operation_type="sync",le="+Inf"} 76
+kubelet_pod_worker_duration_seconds_sum{operation_type="sync"} 25.854890815999997
+kubelet_pod_worker_duration_seconds_count{operation_type="sync"} 76
+# HELP kubelet_pod_worker_latency_microseconds (Deprecated) Latency in microseconds to sync a single pod. Broken down by operation type: create, update, or sync
+# TYPE kubelet_pod_worker_latency_microseconds summary
+kubelet_pod_worker_latency_microseconds{operation_type="sync",quantile="0.5"} NaN
+kubelet_pod_worker_latency_microseconds{operation_type="sync",quantile="0.9"} NaN
+kubelet_pod_worker_latency_microseconds{operation_type="sync",quantile="0.99"} NaN
+kubelet_pod_worker_latency_microseconds_sum{operation_type="sync"} 2.6458212e+07
+kubelet_pod_worker_latency_microseconds_count{operation_type="sync"} 76
+# HELP kubelet_pod_worker_start_duration_seconds Duration in seconds from seeing a pod to starting a worker.
+# TYPE kubelet_pod_worker_start_duration_seconds histogram
+kubelet_pod_worker_start_duration_seconds_bucket{le="0.005"} 4
+kubelet_pod_worker_start_duration_seconds_bucket{le="0.01"} 7
+kubelet_pod_worker_start_duration_seconds_bucket{le="0.025"} 9
+kubelet_pod_worker_start_duration_seconds_bucket{le="0.05"} 9
+kubelet_pod_worker_start_duration_seconds_bucket{le="0.1"} 10
+kubelet_pod_worker_start_duration_seconds_bucket{le="0.25"} 10
+kubelet_pod_worker_start_duration_seconds_bucket{le="0.5"} 10
+kubelet_pod_worker_start_duration_seconds_bucket{le="1"} 10
+kubelet_pod_worker_start_duration_seconds_bucket{le="2.5"} 10
+kubelet_pod_worker_start_duration_seconds_bucket{le="5"} 10
+kubelet_pod_worker_start_duration_seconds_bucket{le="10"} 15
+kubelet_pod_worker_start_duration_seconds_bucket{le="+Inf"} 15
+kubelet_pod_worker_start_duration_seconds_sum 26.950495594
+kubelet_pod_worker_start_duration_seconds_count 15
+# HELP kubelet_pod_worker_start_latency_microseconds (Deprecated) Latency in microseconds from seeing a pod to starting a worker.
+# TYPE kubelet_pod_worker_start_latency_microseconds summary
+kubelet_pod_worker_start_latency_microseconds{quantile="0.5"} NaN
+kubelet_pod_worker_start_latency_microseconds{quantile="0.9"} NaN
+kubelet_pod_worker_start_latency_microseconds{quantile="0.99"} NaN
+kubelet_pod_worker_start_latency_microseconds_sum 2.6950588e+07
+kubelet_pod_worker_start_latency_microseconds_count 15
+# HELP kubelet_running_container_count Number of containers currently running
+# TYPE kubelet_running_container_count gauge
+kubelet_running_container_count 12
+# HELP kubelet_running_pod_count Number of pods currently running
+# TYPE kubelet_running_pod_count gauge
+kubelet_running_pod_count 12
+# HELP kubelet_runtime_operations (Deprecated) Cumulative number of runtime operations by operation type.
+# TYPE kubelet_runtime_operations counter
+kubelet_runtime_operations{operation_type="container_status"} 175
+kubelet_runtime_operations{operation_type="create_container"} 36
+kubelet_runtime_operations{operation_type="exec"} 4
+kubelet_runtime_operations{operation_type="exec_sync"} 4384
+kubelet_runtime_operations{operation_type="image_status"} 221
+kubelet_runtime_operations{operation_type="list_containers"} 80433
+kubelet_runtime_operations{operation_type="list_images"} 7806
+kubelet_runtime_operations{operation_type="list_podsandbox"} 79691
+kubelet_runtime_operations{operation_type="podsandbox_status"} 117
+kubelet_runtime_operations{operation_type="pull_image"} 5
+kubelet_runtime_operations{operation_type="remove_container"} 22
+kubelet_runtime_operations{operation_type="run_podsandbox"} 15
+kubelet_runtime_operations{operation_type="start_container"} 36
+kubelet_runtime_operations{operation_type="status"} 8719
+kubelet_runtime_operations{operation_type="stop_container"} 3
+kubelet_runtime_operations{operation_type="stop_podsandbox"} 9
+kubelet_runtime_operations{operation_type="version"} 4371
+# HELP kubelet_runtime_operations_duration_seconds Duration in seconds of runtime operations. Broken down by operation type.
+# TYPE kubelet_runtime_operations_duration_seconds histogram
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="container_status",le="0.005"} 93
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="container_status",le="0.01"} 130
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="container_status",le="0.025"} 156
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="container_status",le="0.05"} 164
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="container_status",le="0.1"} 167
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="container_status",le="0.25"} 172
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="container_status",le="0.5"} 173
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="container_status",le="1"} 174
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="container_status",le="2.5"} 175
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="container_status",le="5"} 175
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="container_status",le="10"} 175
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="container_status",le="+Inf"} 175
+kubelet_runtime_operations_duration_seconds_sum{operation_type="container_status"} 4.584615175
+kubelet_runtime_operations_duration_seconds_count{operation_type="container_status"} 175
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="create_container",le="0.005"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="create_container",le="0.01"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="create_container",le="0.025"} 1
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="create_container",le="0.05"} 9
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="create_container",le="0.1"} 16
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="create_container",le="0.25"} 23
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="create_container",le="0.5"} 24
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="create_container",le="1"} 32
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="create_container",le="2.5"} 32
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="create_container",le="5"} 34
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="create_container",le="10"} 34
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="create_container",le="+Inf"} 36
+kubelet_runtime_operations_duration_seconds_sum{operation_type="create_container"} 47.921917575
+kubelet_runtime_operations_duration_seconds_count{operation_type="create_container"} 36
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec",le="0.005"} 4
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec",le="0.01"} 4
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec",le="0.025"} 4
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec",le="0.05"} 4
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec",le="0.1"} 4
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec",le="0.25"} 4
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec",le="0.5"} 4
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec",le="1"} 4
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec",le="2.5"} 4
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec",le="5"} 4
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec",le="10"} 4
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec",le="+Inf"} 4
+kubelet_runtime_operations_duration_seconds_sum{operation_type="exec"} 0.010145043
+kubelet_runtime_operations_duration_seconds_count{operation_type="exec"} 4
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec_sync",le="0.005"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec_sync",le="0.01"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec_sync",le="0.025"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec_sync",le="0.05"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec_sync",le="0.1"} 192
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec_sync",le="0.25"} 4262
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec_sync",le="0.5"} 4323
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec_sync",le="1"} 4336
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec_sync",le="2.5"} 4346
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec_sync",le="5"} 4349
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec_sync",le="10"} 4351
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="exec_sync",le="+Inf"} 4384
+kubelet_runtime_operations_duration_seconds_sum{operation_type="exec_sync"} 1900.8313569009947
+kubelet_runtime_operations_duration_seconds_count{operation_type="exec_sync"} 4384
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="image_status",le="0.005"} 181
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="image_status",le="0.01"} 192
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="image_status",le="0.025"} 200
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="image_status",le="0.05"} 204
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="image_status",le="0.1"} 206
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="image_status",le="0.25"} 208
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="image_status",le="0.5"} 208
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="image_status",le="1"} 209
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="image_status",le="2.5"} 213
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="image_status",le="5"} 217
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="image_status",le="10"} 220
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="image_status",le="+Inf"} 221
+kubelet_runtime_operations_duration_seconds_sum{operation_type="image_status"} 63.96681223299999
+kubelet_runtime_operations_duration_seconds_count{operation_type="image_status"} 221
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_containers",le="0.005"} 71310
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_containers",le="0.01"} 78202
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_containers",le="0.025"} 79916
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_containers",le="0.05"} 80053
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_containers",le="0.1"} 80111
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_containers",le="0.25"} 80145
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_containers",le="0.5"} 80161
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_containers",le="1"} 80196
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_containers",le="2.5"} 80294
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_containers",le="5"} 80371
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_containers",le="10"} 80425
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_containers",le="+Inf"} 80433
+kubelet_runtime_operations_duration_seconds_sum{operation_type="list_containers"} 1240.3689890970297
+kubelet_runtime_operations_duration_seconds_count{operation_type="list_containers"} 80433
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_images",le="0.005"} 6003
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_images",le="0.01"} 7479
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_images",le="0.025"} 7681
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_images",le="0.05"} 7701
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_images",le="0.1"} 7710
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_images",le="0.25"} 7718
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_images",le="0.5"} 7720
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_images",le="1"} 7722
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_images",le="2.5"} 7735
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_images",le="5"} 7771
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_images",le="10"} 7796
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_images",le="+Inf"} 7806
+kubelet_runtime_operations_duration_seconds_sum{operation_type="list_images"} 543.8327454080002
+kubelet_runtime_operations_duration_seconds_count{operation_type="list_images"} 7806
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_podsandbox",le="0.005"} 59356
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_podsandbox",le="0.01"} 76831
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_podsandbox",le="0.025"} 79014
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_podsandbox",le="0.05"} 79243
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_podsandbox",le="0.1"} 79311
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_podsandbox",le="0.25"} 79360
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_podsandbox",le="0.5"} 79378
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_podsandbox",le="1"} 79392
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_podsandbox",le="2.5"} 79458
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_podsandbox",le="5"} 79586
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_podsandbox",le="10"} 79667
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="list_podsandbox",le="+Inf"} 79691
+kubelet_runtime_operations_duration_seconds_sum{operation_type="list_podsandbox"} 1874.27877241901
+kubelet_runtime_operations_duration_seconds_count{operation_type="list_podsandbox"} 79691
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="podsandbox_status",le="0.005"} 82
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="podsandbox_status",le="0.01"} 100
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="podsandbox_status",le="0.025"} 107
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="podsandbox_status",le="0.05"} 111
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="podsandbox_status",le="0.1"} 113
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="podsandbox_status",le="0.25"} 113
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="podsandbox_status",le="0.5"} 115
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="podsandbox_status",le="1"} 116
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="podsandbox_status",le="2.5"} 116
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="podsandbox_status",le="5"} 117
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="podsandbox_status",le="10"} 117
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="podsandbox_status",le="+Inf"} 117
+kubelet_runtime_operations_duration_seconds_sum{operation_type="podsandbox_status"} 5.021619159
+kubelet_runtime_operations_duration_seconds_count{operation_type="podsandbox_status"} 117
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image",le="0.005"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image",le="0.01"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image",le="0.025"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image",le="0.05"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image",le="0.1"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image",le="0.25"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image",le="0.5"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image",le="1"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image",le="2.5"} 1
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image",le="5"} 1
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image",le="10"} 1
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image",le="+Inf"} 5
+kubelet_runtime_operations_duration_seconds_sum{operation_type="pull_image"} 55.357576236
+kubelet_runtime_operations_duration_seconds_count{operation_type="pull_image"} 5
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="remove_container",le="0.005"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="remove_container",le="0.01"} 3
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="remove_container",le="0.025"} 11
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="remove_container",le="0.05"} 14
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="remove_container",le="0.1"} 15
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="remove_container",le="0.25"} 17
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="remove_container",le="0.5"} 18
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="remove_container",le="1"} 22
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="remove_container",le="2.5"} 22
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="remove_container",le="5"} 22
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="remove_container",le="10"} 22
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="remove_container",le="+Inf"} 22
+kubelet_runtime_operations_duration_seconds_sum{operation_type="remove_container"} 4.026389304
+kubelet_runtime_operations_duration_seconds_count{operation_type="remove_container"} 22
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="run_podsandbox",le="0.005"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="run_podsandbox",le="0.01"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="run_podsandbox",le="0.025"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="run_podsandbox",le="0.05"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="run_podsandbox",le="0.1"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="run_podsandbox",le="0.25"} 2
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="run_podsandbox",le="0.5"} 10
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="run_podsandbox",le="1"} 12
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="run_podsandbox",le="2.5"} 14
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="run_podsandbox",le="5"} 15
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="run_podsandbox",le="10"} 15
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="run_podsandbox",le="+Inf"} 15
+kubelet_runtime_operations_duration_seconds_sum{operation_type="run_podsandbox"} 11.840436846
+kubelet_runtime_operations_duration_seconds_count{operation_type="run_podsandbox"} 15
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="start_container",le="0.005"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="start_container",le="0.01"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="start_container",le="0.025"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="start_container",le="0.05"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="start_container",le="0.1"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="start_container",le="0.25"} 13
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="start_container",le="0.5"} 31
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="start_container",le="1"} 34
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="start_container",le="2.5"} 35
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="start_container",le="5"} 35
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="start_container",le="10"} 36
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="start_container",le="+Inf"} 36
+kubelet_runtime_operations_duration_seconds_sum{operation_type="start_container"} 18.72976257
+kubelet_runtime_operations_duration_seconds_count{operation_type="start_container"} 36
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="status",le="0.005"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="status",le="0.01"} 1905
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="status",le="0.025"} 8358
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="status",le="0.05"} 8572
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="status",le="0.1"} 8597
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="status",le="0.25"} 8610
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="status",le="0.5"} 8612
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="status",le="1"} 8614
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="status",le="2.5"} 8622
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="status",le="5"} 8636
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="status",le="10"} 8694
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="status",le="+Inf"} 8719
+kubelet_runtime_operations_duration_seconds_sum{operation_type="status"} 937.6233801129981
+kubelet_runtime_operations_duration_seconds_count{operation_type="status"} 8719
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_container",le="0.005"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_container",le="0.01"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_container",le="0.025"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_container",le="0.05"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_container",le="0.1"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_container",le="0.25"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_container",le="0.5"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_container",le="1"} 1
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_container",le="2.5"} 3
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_container",le="5"} 3
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_container",le="10"} 3
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_container",le="+Inf"} 3
+kubelet_runtime_operations_duration_seconds_sum{operation_type="stop_container"} 3.906386785
+kubelet_runtime_operations_duration_seconds_count{operation_type="stop_container"} 3
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_podsandbox",le="0.005"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_podsandbox",le="0.01"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_podsandbox",le="0.025"} 4
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_podsandbox",le="0.05"} 5
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_podsandbox",le="0.1"} 6
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_podsandbox",le="0.25"} 6
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_podsandbox",le="0.5"} 7
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_podsandbox",le="1"} 8
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_podsandbox",le="2.5"} 9
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_podsandbox",le="5"} 9
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_podsandbox",le="10"} 9
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="stop_podsandbox",le="+Inf"} 9
+kubelet_runtime_operations_duration_seconds_sum{operation_type="stop_podsandbox"} 2.975860290000001
+kubelet_runtime_operations_duration_seconds_count{operation_type="stop_podsandbox"} 9
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="version",le="0.005"} 0
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="version",le="0.01"} 1830
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="version",le="0.025"} 4202
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="version",le="0.05"} 4306
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="version",le="0.1"} 4326
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="version",le="0.25"} 4332
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="version",le="0.5"} 4335
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="version",le="1"} 4335
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="version",le="2.5"} 4336
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="version",le="5"} 4340
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="version",le="10"} 4360
+kubelet_runtime_operations_duration_seconds_bucket{operation_type="version",le="+Inf"} 4371
+kubelet_runtime_operations_duration_seconds_sum{operation_type="version"} 364.7011673999992
+kubelet_runtime_operations_duration_seconds_count{operation_type="version"} 4371
+# HELP kubelet_runtime_operations_errors (Deprecated) Cumulative number of runtime operation errors by operation type.
+# TYPE kubelet_runtime_operations_errors counter
+kubelet_runtime_operations_errors{operation_type="container_status"} 2
+kubelet_runtime_operations_errors{operation_type="exec_sync"} 2
+# HELP kubelet_runtime_operations_errors_total Cumulative number of runtime operation errors by operation type.
+# TYPE kubelet_runtime_operations_errors_total counter
+kubelet_runtime_operations_errors_total{operation_type="container_status"} 2
+kubelet_runtime_operations_errors_total{operation_type="exec_sync"} 2
+# HELP kubelet_runtime_operations_latency_microseconds (Deprecated) Latency in microseconds of runtime operations. Broken down by operation type.
+# TYPE kubelet_runtime_operations_latency_microseconds summary
+kubelet_runtime_operations_latency_microseconds{operation_type="container_status",quantile="0.5"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="container_status",quantile="0.9"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="container_status",quantile="0.99"} NaN
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="container_status"} 4.586433e+06
+kubelet_runtime_operations_latency_microseconds_count{operation_type="container_status"} 175
+kubelet_runtime_operations_latency_microseconds{operation_type="create_container",quantile="0.5"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="create_container",quantile="0.9"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="create_container",quantile="0.99"} NaN
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="create_container"} 4.7922445e+07
+kubelet_runtime_operations_latency_microseconds_count{operation_type="create_container"} 36
+kubelet_runtime_operations_latency_microseconds{operation_type="exec",quantile="0.5"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="exec",quantile="0.9"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="exec",quantile="0.99"} NaN
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="exec"} 10201
+kubelet_runtime_operations_latency_microseconds_count{operation_type="exec"} 4
+kubelet_runtime_operations_latency_microseconds{operation_type="exec_sync",quantile="0.5"} 142450
+kubelet_runtime_operations_latency_microseconds{operation_type="exec_sync",quantile="0.9"} 161868
+kubelet_runtime_operations_latency_microseconds{operation_type="exec_sync",quantile="0.99"} 172658
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="exec_sync"} 1.9008724e+09
+kubelet_runtime_operations_latency_microseconds_count{operation_type="exec_sync"} 4384
+kubelet_runtime_operations_latency_microseconds{operation_type="image_status",quantile="0.5"} 1525
+kubelet_runtime_operations_latency_microseconds{operation_type="image_status",quantile="0.9"} 1525
+kubelet_runtime_operations_latency_microseconds{operation_type="image_status",quantile="0.99"} 1525
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="image_status"} 6.4038577e+07
+kubelet_runtime_operations_latency_microseconds_count{operation_type="image_status"} 221
+kubelet_runtime_operations_latency_microseconds{operation_type="list_containers",quantile="0.5"} 3596
+kubelet_runtime_operations_latency_microseconds{operation_type="list_containers",quantile="0.9"} 6944
+kubelet_runtime_operations_latency_microseconds{operation_type="list_containers",quantile="0.99"} 15737
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="list_containers"} 1.243107396e+09
+kubelet_runtime_operations_latency_microseconds_count{operation_type="list_containers"} 80433
+kubelet_runtime_operations_latency_microseconds{operation_type="list_images",quantile="0.5"} 4104
+kubelet_runtime_operations_latency_microseconds{operation_type="list_images",quantile="0.9"} 6057
+kubelet_runtime_operations_latency_microseconds{operation_type="list_images",quantile="0.99"} 10499
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="list_images"} 5.44025046e+08
+kubelet_runtime_operations_latency_microseconds_count{operation_type="list_images"} 7806
+kubelet_runtime_operations_latency_microseconds{operation_type="list_podsandbox",quantile="0.5"} 4854
+kubelet_runtime_operations_latency_microseconds{operation_type="list_podsandbox",quantile="0.9"} 7801
+kubelet_runtime_operations_latency_microseconds{operation_type="list_podsandbox",quantile="0.99"} 18876
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="list_podsandbox"} 1.878731419e+09
+kubelet_runtime_operations_latency_microseconds_count{operation_type="list_podsandbox"} 79691
+kubelet_runtime_operations_latency_microseconds{operation_type="podsandbox_status",quantile="0.5"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="podsandbox_status",quantile="0.9"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="podsandbox_status",quantile="0.99"} NaN
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="podsandbox_status"} 5.022733e+06
+kubelet_runtime_operations_latency_microseconds_count{operation_type="podsandbox_status"} 117
+kubelet_runtime_operations_latency_microseconds{operation_type="pull_image",quantile="0.5"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="pull_image",quantile="0.9"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="pull_image",quantile="0.99"} NaN
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="pull_image"} 5.5357631e+07
+kubelet_runtime_operations_latency_microseconds_count{operation_type="pull_image"} 5
+kubelet_runtime_operations_latency_microseconds{operation_type="remove_container",quantile="0.5"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="remove_container",quantile="0.9"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="remove_container",quantile="0.99"} NaN
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="remove_container"} 4.026599e+06
+kubelet_runtime_operations_latency_microseconds_count{operation_type="remove_container"} 22
+kubelet_runtime_operations_latency_microseconds{operation_type="run_podsandbox",quantile="0.5"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="run_podsandbox",quantile="0.9"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="run_podsandbox",quantile="0.99"} NaN
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="run_podsandbox"} 1.1840512e+07
+kubelet_runtime_operations_latency_microseconds_count{operation_type="run_podsandbox"} 15
+kubelet_runtime_operations_latency_microseconds{operation_type="start_container",quantile="0.5"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="start_container",quantile="0.9"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="start_container",quantile="0.99"} NaN
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="start_container"} 1.8730115e+07
+kubelet_runtime_operations_latency_microseconds_count{operation_type="start_container"} 36
+kubelet_runtime_operations_latency_microseconds{operation_type="status",quantile="0.5"} 12791
+kubelet_runtime_operations_latency_microseconds{operation_type="status",quantile="0.9"} 16356
+kubelet_runtime_operations_latency_microseconds{operation_type="status",quantile="0.99"} 21387
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="status"} 9.38401577e+08
+kubelet_runtime_operations_latency_microseconds_count{operation_type="status"} 8719
+kubelet_runtime_operations_latency_microseconds{operation_type="stop_container",quantile="0.5"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="stop_container",quantile="0.9"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="stop_container",quantile="0.99"} NaN
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="stop_container"} 3.906448e+06
+kubelet_runtime_operations_latency_microseconds_count{operation_type="stop_container"} 3
+kubelet_runtime_operations_latency_microseconds{operation_type="stop_podsandbox",quantile="0.5"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="stop_podsandbox",quantile="0.9"} NaN
+kubelet_runtime_operations_latency_microseconds{operation_type="stop_podsandbox",quantile="0.99"} NaN
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="stop_podsandbox"} 2.975986e+06
+kubelet_runtime_operations_latency_microseconds_count{operation_type="stop_podsandbox"} 9
+kubelet_runtime_operations_latency_microseconds{operation_type="version",quantile="0.5"} 10929
+kubelet_runtime_operations_latency_microseconds{operation_type="version",quantile="0.9"} 17493
+kubelet_runtime_operations_latency_microseconds{operation_type="version",quantile="0.99"} 32229
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="version"} 3.64752989e+08
+kubelet_runtime_operations_latency_microseconds_count{operation_type="version"} 4371
+# HELP kubelet_runtime_operations_total Cumulative number of runtime operations by operation type.
+# TYPE kubelet_runtime_operations_total counter
+kubelet_runtime_operations_total{operation_type="container_status"} 175
+kubelet_runtime_operations_total{operation_type="create_container"} 36
+kubelet_runtime_operations_total{operation_type="exec"} 4
+kubelet_runtime_operations_total{operation_type="exec_sync"} 4384
+kubelet_runtime_operations_total{operation_type="image_status"} 221
+kubelet_runtime_operations_total{operation_type="list_containers"} 80433
+kubelet_runtime_operations_total{operation_type="list_images"} 7806
+kubelet_runtime_operations_total{operation_type="list_podsandbox"} 79691
+kubelet_runtime_operations_total{operation_type="podsandbox_status"} 117
+kubelet_runtime_operations_total{operation_type="pull_image"} 5
+kubelet_runtime_operations_total{operation_type="remove_container"} 22
+kubelet_runtime_operations_total{operation_type="run_podsandbox"} 15
+kubelet_runtime_operations_total{operation_type="start_container"} 36
+kubelet_runtime_operations_total{operation_type="status"} 8719
+kubelet_runtime_operations_total{operation_type="stop_container"} 3
+kubelet_runtime_operations_total{operation_type="stop_podsandbox"} 9
+kubelet_runtime_operations_total{operation_type="version"} 4371
+# HELP kubelet_volume_stats_available_bytes Number of available bytes in the volume
+# TYPE kubelet_volume_stats_available_bytes gauge
+kubelet_volume_stats_available_bytes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-2"} 9.785049088e+10
+kubelet_volume_stats_available_bytes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-3"} 9.8636845056e+10
+# HELP kubelet_volume_stats_capacity_bytes Capacity in bytes of the volume
+# TYPE kubelet_volume_stats_capacity_bytes gauge
+kubelet_volume_stats_capacity_bytes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-2"} 1.05555197952e+11
+kubelet_volume_stats_capacity_bytes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-3"} 1.05555197952e+11
+# HELP kubelet_volume_stats_inodes Maximum number of inodes in the volume
+# TYPE kubelet_volume_stats_inodes gauge
+kubelet_volume_stats_inodes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-2"} 6.5536e+06
+kubelet_volume_stats_inodes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-3"} 6.5536e+06
+# HELP kubelet_volume_stats_inodes_free Number of free inodes in the volume
+# TYPE kubelet_volume_stats_inodes_free gauge
+kubelet_volume_stats_inodes_free{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-2"} 6.538687e+06
+kubelet_volume_stats_inodes_free{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-3"} 6.535645e+06
+# HELP kubelet_volume_stats_inodes_used Number of used inodes in the volume
+# TYPE kubelet_volume_stats_inodes_used gauge
+kubelet_volume_stats_inodes_used{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-2"} 14913
+kubelet_volume_stats_inodes_used{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-3"} 17955
+# HELP kubelet_volume_stats_used_bytes Number of used bytes in the volume
+# TYPE kubelet_volume_stats_used_bytes gauge
+kubelet_volume_stats_used_bytes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-2"} 2.319220736e+09
+kubelet_volume_stats_used_bytes{namespace="unit-test",persistentvolumeclaim="ddagent-pvc-ddagent-test-3"} 1.53286656e+09
+# HELP kubernetes_build_info A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.
+# TYPE kubernetes_build_info gauge
+kubernetes_build_info{buildDate="2019-12-11T12:38:25Z",compiler="gc",gitCommit="575467a0eaf3ca1f20eb86215b3bde40a5ae617a",gitTreeState="clean",gitVersion="v1.14.10",goVersion="go1.12.12",major="1",minor="14",platform="linux/amd64"} 1
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 2239.79
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 44
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 9.8013184e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.57767514228e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 1.405288448e+09
+# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
+# TYPE process_virtual_memory_max_bytes gauge
+process_virtual_memory_max_bytes -1
+# HELP rest_client_request_duration_seconds Request latency in seconds. Broken down by verb and URL.
+# TYPE rest_client_request_duration_seconds histogram
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.001"} 0
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.002"} 0
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.004"} 0
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.008"} 0
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.016"} 0
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.032"} 1
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.064"} 1
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.128"} 2
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.256"} 3
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.512"} 3
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="+Inf"} 3
+rest_client_request_duration_seconds_sum{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE"} 0.32611697500000003
+rest_client_request_duration_seconds_count{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE"} 3
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.001"} 50
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.002"} 3129
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.004"} 8172
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.008"} 8688
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.016"} 8795
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.032"} 8845
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.064"} 8876
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.128"} 8901
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.256"} 8921
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.512"} 8931
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="+Inf"} 9063
+rest_client_request_duration_seconds_sum{url="https://localhost:8443/%7Bprefix%7D",verb="GET"} 585.2233559799982
+rest_client_request_duration_seconds_count{url="https://localhost:8443/%7Bprefix%7D",verb="GET"} 9063
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.001"} 0
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.002"} 1
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.004"} 106
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.008"} 715
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.016"} 860
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.032"} 899
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.064"} 927
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.128"} 945
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.256"} 957
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.512"} 963
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="+Inf"} 1063
+rest_client_request_duration_seconds_sum{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH"} 674.8700161060033
+rest_client_request_duration_seconds_count{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH"} 1063
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.001"} 5
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.002"} 314
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.004"} 599
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.008"} 648
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.016"} 670
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.032"} 675
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.064"} 688
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.128"} 695
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.256"} 698
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.512"} 703
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="+Inf"} 722
+rest_client_request_duration_seconds_sum{url="https://localhost:8443/%7Bprefix%7D",verb="POST"} 89.41131052000009
+rest_client_request_duration_seconds_count{url="https://localhost:8443/%7Bprefix%7D",verb="POST"} 722
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.001"} 0
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.002"} 17
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.004"} 2044
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.008"} 4081
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.016"} 4251
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.032"} 4287
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.064"} 4299
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.128"} 4307
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.256"} 4313
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.512"} 4321
+rest_client_request_duration_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="+Inf"} 4395
+rest_client_request_duration_seconds_sum{url="https://localhost:8443/%7Bprefix%7D",verb="PUT"} 370.35423456099863
+rest_client_request_duration_seconds_count{url="https://localhost:8443/%7Bprefix%7D",verb="PUT"} 4395
+# HELP rest_client_request_latency_seconds (Deprecated) Request latency in seconds. Broken down by verb and URL.
+# TYPE rest_client_request_latency_seconds histogram
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.001"} 0
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.002"} 0
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.004"} 0
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.008"} 0
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.016"} 0
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.032"} 1
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.064"} 1
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.128"} 2
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.256"} 3
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="0.512"} 3
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE",le="+Inf"} 3
+rest_client_request_latency_seconds_sum{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE"} 0.32611697500000003
+rest_client_request_latency_seconds_count{url="https://localhost:8443/%7Bprefix%7D",verb="DELETE"} 3
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.001"} 50
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.002"} 3129
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.004"} 8172
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.008"} 8688
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.016"} 8795
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.032"} 8845
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.064"} 8876
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.128"} 8901
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.256"} 8921
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="0.512"} 8931
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="GET",le="+Inf"} 9063
+rest_client_request_latency_seconds_sum{url="https://localhost:8443/%7Bprefix%7D",verb="GET"} 585.2233559799982
+rest_client_request_latency_seconds_count{url="https://localhost:8443/%7Bprefix%7D",verb="GET"} 9063
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.001"} 0
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.002"} 1
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.004"} 106
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.008"} 715
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.016"} 860
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.032"} 899
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.064"} 927
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.128"} 945
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.256"} 957
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="0.512"} 963
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH",le="+Inf"} 1063
+rest_client_request_latency_seconds_sum{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH"} 674.8700161060033
+rest_client_request_latency_seconds_count{url="https://localhost:8443/%7Bprefix%7D",verb="PATCH"} 1063
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.001"} 5
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.002"} 314
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.004"} 599
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.008"} 648
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.016"} 670
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.032"} 675
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.064"} 688
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.128"} 695
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.256"} 698
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="0.512"} 703
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="POST",le="+Inf"} 722
+rest_client_request_latency_seconds_sum{url="https://localhost:8443/%7Bprefix%7D",verb="POST"} 89.41131052000009
+rest_client_request_latency_seconds_count{url="https://localhost:8443/%7Bprefix%7D",verb="POST"} 722
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.001"} 0
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.002"} 17
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.004"} 2044
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.008"} 4081
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.016"} 4251
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.032"} 4287
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.064"} 4299
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.128"} 4307
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.256"} 4313
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="0.512"} 4321
+rest_client_request_latency_seconds_bucket{url="https://localhost:8443/%7Bprefix%7D",verb="PUT",le="+Inf"} 4395
+rest_client_request_latency_seconds_sum{url="https://localhost:8443/%7Bprefix%7D",verb="PUT"} 370.35423456099863
+rest_client_request_latency_seconds_count{url="https://localhost:8443/%7Bprefix%7D",verb="PUT"} 4395
+# HELP rest_client_requests_total Number of HTTP requests, partitioned by status code, method, and host.
+# TYPE rest_client_requests_total counter
+rest_client_requests_total{code="200",host="localhost:8443",method="DELETE"} 3
+rest_client_requests_total{code="200",host="localhost:8443",method="GET"} 10551
+rest_client_requests_total{code="200",host="localhost:8443",method="PATCH"} 1021
+rest_client_requests_total{code="200",host="localhost:8443",method="PUT"} 4370
+rest_client_requests_total{code="201",host="localhost:8443",method="POST"} 705
+rest_client_requests_total{code="403",host="localhost:8443",method="GET"} 2
+rest_client_requests_total{code="404",host="localhost:8443",method="GET"} 9
+rest_client_requests_total{code="404",host="localhost:8443",method="PATCH"} 30
+rest_client_requests_total{code="404",host="localhost:8443",method="POST"} 10
+rest_client_requests_total{code="409",host="localhost:8443",method="PUT"} 16
+rest_client_requests_total{code="504",host="localhost:8443",method="PUT"} 3
+rest_client_requests_total{code="<error>",host="localhost:8443",method="GET"} 50
+rest_client_requests_total{code="<error>",host="localhost:8443",method="PATCH"} 12
+rest_client_requests_total{code="<error>",host="localhost:8443",method="POST"} 7
+rest_client_requests_total{code="<error>",host="localhost:8443",method="PUT"} 6
+# HELP storage_operation_duration_seconds Storage operation duration
+# TYPE storage_operation_duration_seconds histogram
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/configmap",le="0.1"} 3
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/configmap",le="0.25"} 3
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/configmap",le="0.5"} 3
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/configmap",le="1"} 3
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/configmap",le="2.5"} 3
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/configmap",le="5"} 3
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/configmap",le="10"} 3
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/configmap",le="15"} 3
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/configmap",le="25"} 3
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/configmap",le="50"} 3
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/configmap",le="120"} 3
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/configmap",le="300"} 3
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/configmap",le="600"} 3
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/configmap",le="+Inf"} 3
+storage_operation_duration_seconds_sum{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/configmap"} 0.000322315
+storage_operation_duration_seconds_count{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/configmap"} 3
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/empty-dir",le="0.1"} 6
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/empty-dir",le="0.25"} 6
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/empty-dir",le="0.5"} 6
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/empty-dir",le="1"} 6
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/empty-dir",le="2.5"} 6
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/empty-dir",le="5"} 6
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/empty-dir",le="10"} 6
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/empty-dir",le="15"} 6
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/empty-dir",le="25"} 6
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/empty-dir",le="50"} 6
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/empty-dir",le="120"} 6
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/empty-dir",le="300"} 6
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/empty-dir",le="600"} 6
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/empty-dir",le="+Inf"} 6
+storage_operation_duration_seconds_sum{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/empty-dir"} 0.056190037
+storage_operation_duration_seconds_count{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/empty-dir"} 6
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/host-path",le="0.1"} 35
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/host-path",le="0.25"} 35
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/host-path",le="0.5"} 35
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/host-path",le="1"} 35
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/host-path",le="2.5"} 35
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/host-path",le="5"} 35
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/host-path",le="10"} 35
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/host-path",le="15"} 35
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/host-path",le="25"} 35
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/host-path",le="50"} 35
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/host-path",le="120"} 35
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/host-path",le="300"} 35
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/host-path",le="600"} 35
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/host-path",le="+Inf"} 35
+storage_operation_duration_seconds_sum{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/host-path"} 0.103123762
+storage_operation_duration_seconds_count{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/host-path"} 35
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/secret",le="0.1"} 10
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/secret",le="0.25"} 10
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/secret",le="0.5"} 10
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/secret",le="1"} 10
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/secret",le="2.5"} 10
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/secret",le="5"} 10
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/secret",le="10"} 10
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/secret",le="15"} 10
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/secret",le="25"} 10
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/secret",le="50"} 10
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/secret",le="120"} 10
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/secret",le="300"} 10
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/secret",le="600"} 10
+storage_operation_duration_seconds_bucket{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/secret",le="+Inf"} 10
+storage_operation_duration_seconds_sum{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/secret"} 0.023703890000000002
+storage_operation_duration_seconds_count{operation_name="verify_controller_attached_volume",volume_plugin="kubernetes.io/secret"} 10
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/configmap",le="0.1"} 1758
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/configmap",le="0.25"} 1760
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/configmap",le="0.5"} 1766
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/configmap",le="1"} 1770
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/configmap",le="2.5"} 1772
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/configmap",le="5"} 1773
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/configmap",le="10"} 1773
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/configmap",le="15"} 1773
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/configmap",le="25"} 1773
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/configmap",le="50"} 1773
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/configmap",le="120"} 1773
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/configmap",le="300"} 1773
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/configmap",le="600"} 1773
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/configmap",le="+Inf"} 1773
+storage_operation_duration_seconds_sum{operation_name="volume_mount",volume_plugin="kubernetes.io/configmap"} 12.251462870000005
+storage_operation_duration_seconds_count{operation_name="volume_mount",volume_plugin="kubernetes.io/configmap"} 1773
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/empty-dir",le="0.1"} 6
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/empty-dir",le="0.25"} 6
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/empty-dir",le="0.5"} 6
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/empty-dir",le="1"} 6
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/empty-dir",le="2.5"} 6
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/empty-dir",le="5"} 6
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/empty-dir",le="10"} 6
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/empty-dir",le="15"} 6
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/empty-dir",le="25"} 6
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/empty-dir",le="50"} 6
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/empty-dir",le="120"} 6
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/empty-dir",le="300"} 6
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/empty-dir",le="600"} 6
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/empty-dir",le="+Inf"} 6
+storage_operation_duration_seconds_sum{operation_name="volume_mount",volume_plugin="kubernetes.io/empty-dir"} 0.089531055
+storage_operation_duration_seconds_count{operation_name="volume_mount",volume_plugin="kubernetes.io/empty-dir"} 6
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/host-path",le="0.1"} 35
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/host-path",le="0.25"} 35
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/host-path",le="0.5"} 35
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/host-path",le="1"} 35
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/host-path",le="2.5"} 35
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/host-path",le="5"} 35
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/host-path",le="10"} 35
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/host-path",le="15"} 35
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/host-path",le="25"} 35
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/host-path",le="50"} 35
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/host-path",le="120"} 35
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/host-path",le="300"} 35
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/host-path",le="600"} 35
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/host-path",le="+Inf"} 35
+storage_operation_duration_seconds_sum{operation_name="volume_mount",volume_plugin="kubernetes.io/host-path"} 0.09881475599999999
+storage_operation_duration_seconds_count{operation_name="volume_mount",volume_plugin="kubernetes.io/host-path"} 35
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/secret",le="0.1"} 3520
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/secret",le="0.25"} 3527
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/secret",le="0.5"} 3534
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/secret",le="1"} 3541
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/secret",le="2.5"} 3543
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/secret",le="5"} 3544
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/secret",le="10"} 3544
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/secret",le="15"} 3544
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/secret",le="25"} 3544
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/secret",le="50"} 3544
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/secret",le="120"} 3544
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/secret",le="300"} 3544
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/secret",le="600"} 3544
+storage_operation_duration_seconds_bucket{operation_name="volume_mount",volume_plugin="kubernetes.io/secret",le="+Inf"} 3544
+storage_operation_duration_seconds_sum{operation_name="volume_mount",volume_plugin="kubernetes.io/secret"} 17.159341636999955
+storage_operation_duration_seconds_count{operation_name="volume_mount",volume_plugin="kubernetes.io/secret"} 3544
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/empty-dir",le="0.1"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/empty-dir",le="0.25"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/empty-dir",le="0.5"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/empty-dir",le="1"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/empty-dir",le="2.5"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/empty-dir",le="5"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/empty-dir",le="10"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/empty-dir",le="15"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/empty-dir",le="25"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/empty-dir",le="50"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/empty-dir",le="120"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/empty-dir",le="300"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/empty-dir",le="600"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/empty-dir",le="+Inf"} 3
+storage_operation_duration_seconds_sum{operation_name="volume_unmount",volume_plugin="kubernetes.io/empty-dir"} 0.105109472
+storage_operation_duration_seconds_count{operation_name="volume_unmount",volume_plugin="kubernetes.io/empty-dir"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/host-path",le="0.1"} 15
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/host-path",le="0.25"} 15
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/host-path",le="0.5"} 15
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/host-path",le="1"} 15
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/host-path",le="2.5"} 15
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/host-path",le="5"} 15
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/host-path",le="10"} 15
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/host-path",le="15"} 15
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/host-path",le="25"} 15
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/host-path",le="50"} 15
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/host-path",le="120"} 15
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/host-path",le="300"} 15
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/host-path",le="600"} 15
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/host-path",le="+Inf"} 15
+storage_operation_duration_seconds_sum{operation_name="volume_unmount",volume_plugin="kubernetes.io/host-path"} 0.09240096500000002
+storage_operation_duration_seconds_count{operation_name="volume_unmount",volume_plugin="kubernetes.io/host-path"} 15
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret",le="0.1"} 2
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret",le="0.25"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret",le="0.5"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret",le="1"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret",le="2.5"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret",le="5"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret",le="10"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret",le="15"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret",le="25"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret",le="50"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret",le="120"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret",le="300"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret",le="600"} 3
+storage_operation_duration_seconds_bucket{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret",le="+Inf"} 3
+storage_operation_duration_seconds_sum{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret"} 0.171444828
+storage_operation_duration_seconds_count{operation_name="volume_unmount",volume_plugin="kubernetes.io/secret"} 3
+# HELP storage_operation_status_count Storage operation return statuses count
+# TYPE storage_operation_status_count counter
+storage_operation_status_count{operation_name="verify_controller_attached_volume",status="success",volume_plugin="kubernetes.io/configmap"} 3
+storage_operation_status_count{operation_name="verify_controller_attached_volume",status="success",volume_plugin="kubernetes.io/empty-dir"} 6
+storage_operation_status_count{operation_name="verify_controller_attached_volume",status="success",volume_plugin="kubernetes.io/host-path"} 35
+storage_operation_status_count{operation_name="verify_controller_attached_volume",status="success",volume_plugin="kubernetes.io/secret"} 10
+storage_operation_status_count{operation_name="volume_mount",status="success",volume_plugin="kubernetes.io/configmap"} 1773
+storage_operation_status_count{operation_name="volume_mount",status="success",volume_plugin="kubernetes.io/empty-dir"} 6
+storage_operation_status_count{operation_name="volume_mount",status="success",volume_plugin="kubernetes.io/host-path"} 35
+storage_operation_status_count{operation_name="volume_mount",status="success",volume_plugin="kubernetes.io/secret"} 3544
+storage_operation_status_count{operation_name="volume_unmount",status="success",volume_plugin="kubernetes.io/empty-dir"} 3
+storage_operation_status_count{operation_name="volume_unmount",status="success",volume_plugin="kubernetes.io/host-path"} 15
+storage_operation_status_count{operation_name="volume_unmount",status="success",volume_plugin="kubernetes.io/secret"} 3
+# HELP volume_manager_total_volumes Number of volumes in Volume Manager
+# TYPE volume_manager_total_volumes gauge
+volume_manager_total_volumes{plugin_name="kubernetes.io/configmap",state="actual_state_of_world"} 3
+volume_manager_total_volumes{plugin_name="kubernetes.io/configmap",state="desired_state_of_world"} 3
+volume_manager_total_volumes{plugin_name="kubernetes.io/empty-dir",state="actual_state_of_world"} 3
+volume_manager_total_volumes{plugin_name="kubernetes.io/empty-dir",state="desired_state_of_world"} 3
+volume_manager_total_volumes{plugin_name="kubernetes.io/host-path",state="actual_state_of_world"} 20
+volume_manager_total_volumes{plugin_name="kubernetes.io/host-path",state="desired_state_of_world"} 20
+volume_manager_total_volumes{plugin_name="kubernetes.io/secret",state="actual_state_of_world"} 7
+volume_manager_total_volumes{plugin_name="kubernetes.io/secret",state="desired_state_of_world"} 7
+# HELP kubelet_evictions [ALPHA] Cumulative number of pod evictions by eviction signal
+# TYPE kubelet_evictions counter
+kubelet_evictions{eviction_signal="allocatableMemory.available"} 3
+kubelet_evictions{eviction_signal="memory.available"} 3

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -218,6 +218,7 @@ def mock_kubelet_check(monkeypatch, instances, kube_version=KUBE_1_14, stats_sum
 
             attrs = {'close.return_value': True, 'iter_lines.return_value': content.split('\n'), 'content': content}
             return mock.Mock(headers={'Content-Type': 'text/plain'}, **attrs)
+
         return _mocked_poll
 
     if kube_version == KUBE_POST_1_16:
@@ -226,10 +227,9 @@ def mock_kubelet_check(monkeypatch, instances, kube_version=KUBE_1_14, stats_sum
             'poll',
             mock.Mock(
                 side_effect=mocked_poll(
-                    cadvisor_response='cadvisor_metrics_post_1_16.txt',
-                    kubelet_response='kubelet_metrics_1_14.txt'
+                    cadvisor_response='cadvisor_metrics_post_1_16.txt', kubelet_response='kubelet_metrics_1_14.txt'
                 )
-            )
+            ),
         )
     elif kube_version == KUBE_1_14:
         monkeypatch.setattr(
@@ -237,10 +237,9 @@ def mock_kubelet_check(monkeypatch, instances, kube_version=KUBE_1_14, stats_sum
             'poll',
             mock.Mock(
                 side_effect=mocked_poll(
-                    cadvisor_response='cadvisor_metrics_pre_1_16.txt',
-                    kubelet_response='kubelet_metrics_1_14.txt',
+                    cadvisor_response='cadvisor_metrics_pre_1_16.txt', kubelet_response='kubelet_metrics_1_14.txt',
                 )
-            )
+            ),
         )
     elif kube_version == KUBE_PRE_1_14:
         monkeypatch.setattr(
@@ -248,10 +247,9 @@ def mock_kubelet_check(monkeypatch, instances, kube_version=KUBE_1_14, stats_sum
             'poll',
             mock.Mock(
                 side_effect=mocked_poll(
-                    cadvisor_response='cadvisor_metrics_pre_1_16.txt',
-                    kubelet_response='kubelet_metrics.txt'
+                    cadvisor_response='cadvisor_metrics_pre_1_16.txt', kubelet_response='kubelet_metrics.txt'
                 )
-            )
+            ),
         )
 
     return check
@@ -288,9 +286,7 @@ def test_kubelet_check_prometheus_instance_tags(monkeypatch, aggregator, tagger)
 
 
 def test_kubelet_check_prometheus_no_instance_tags(monkeypatch, aggregator, tagger):
-    _test_kubelet_check_prometheus(
-        monkeypatch, aggregator, tagger, kube_version=KUBE_1_14, instance_tags=None
-    )
+    _test_kubelet_check_prometheus(monkeypatch, aggregator, tagger, kube_version=KUBE_1_14, instance_tags=None)
 
 
 def test_kubelet_check_prometheus_instance_tags_pre_1_14(monkeypatch, aggregator, tagger):
@@ -300,9 +296,7 @@ def test_kubelet_check_prometheus_instance_tags_pre_1_14(monkeypatch, aggregator
 
 
 def test_kubelet_check_prometheus_no_instance_tags_pre_1_14(monkeypatch, aggregator, tagger):
-    _test_kubelet_check_prometheus(
-        monkeypatch, aggregator, tagger, kube_version=KUBE_PRE_1_14, instance_tags=None
-    )
+    _test_kubelet_check_prometheus(monkeypatch, aggregator, tagger, kube_version=KUBE_PRE_1_14, instance_tags=None)
 
 
 def _test_kubelet_check_prometheus(monkeypatch, aggregator, tagger, kube_version, instance_tags):


### PR DESCRIPTION
### What does this PR do?
Certain metrics changed (renamed or renamed/unit changed) in Kubernetes 1.14 and later. This PR addresses these discrepancies.

See: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#deprecated-metrics

### Motivation
Consistency in reported metrics.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
