### PR TITLE
Make configuration specs an asset

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -10,8 +10,15 @@ from datadog_checks.dev.tooling.config_validator.validator_errors import SEVERIT
 from datadog_checks.dev.tooling.configuration import ConfigSpec
 from datadog_checks.dev.tooling.configuration.consumers import ExampleConsumer
 
-from ....utils import basepath, file_exists, get_parent_dir, path_join, read_file, write_file
-from ...utils import get_config_files, get_config_spec, get_valid_checks, get_version_string, load_manifest
+from ....utils import basepath, file_exists, path_join, read_file, write_file
+from ...utils import (
+    get_config_files,
+    get_config_spec,
+    get_data_directory,
+    get_valid_checks,
+    get_version_string,
+    load_manifest,
+)
 from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_waiting, echo_warning
 
 FILE_INDENT = ' ' * 8
@@ -82,7 +89,7 @@ def config(ctx, check, sync):
                     )
                 )
 
-            example_location = get_parent_dir(spec_path)
+            example_location = get_data_directory(check)
             example_consumer = ExampleConsumer(spec.data)
             for example_file, (contents, errors) in example_consumer.render().items():
                 file_counter.append(None)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -90,7 +90,19 @@ def get_config_spec(check_name):
     if check_name == 'agent':
         return os.path.join(get_root(), 'pkg', 'config', 'conf_spec.yaml')
     else:
-        return os.path.join(get_root(), check_name, 'datadog_checks', check_name, 'data', 'conf_spec.yaml')
+        path = load_manifest(check_name).get('assets', {}).get('configuration', {}).get('spec', '')
+        return os.path.join(get_root(), check_name, *path.split('/'))
+
+
+def get_default_config_spec(check_name):
+    return os.path.join(get_root(), check_name, 'assets', 'configuration', 'spec.yaml')
+
+
+def get_data_directory(check_name):
+    if check_name == 'agent':
+        return os.path.join(get_root(), 'pkg', 'config')
+    else:
+        return os.path.join(get_root(), check_name, 'datadog_checks', check_name, 'data')
 
 
 def get_config_files(check_name):


### PR DESCRIPTION
### Motivation

The Agent erroneously tries to load them and they aren't the full, rendered spec anyway