### PR TITLE
Remove redundant doc

### DIFF
--- a/snmp/README.md
+++ b/snmp/README.md
@@ -168,7 +168,7 @@ PS> & 'C:\Program Files\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\pyt
   --destination-format=pysnmp <MIB_FILE_NAME>
 ```
 
-Example using the `CISCO-TCP-MIB.my`:
+Example using the `CISCO-TCP-MIB`:
 
 ```
  # /opt/datadog-agent/embedded/bin/mibdump.py --mib-source <PATH_TO_MIB_FILE>  --mib-source http://mibs.snmplabs.com/asn1/@mib@ --destination-directory=/opt/datadog-agent/pysnmp/custom_mibpy/ --destination-format=pysnmp CISCO-TCP-MIB

--- a/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
@@ -1,8 +1,5 @@
 # Profile for F5 BIG-IP devices
 #
-# You need the MIB compiled to get the data. You can run the following command to get it:
-# $ /opt/datadog-agent/embedded/bin/python /opt/datadog-agent/embedded/bin/mibdump.py  --destination-directory=/opt/datadog-agent/embedded/lib/python2.7/site-packages/pysnmp_mibs F5-BIGIP-SYSTEM-MIB
-#
 sysobjectid: 1.3.6.1.4.1.3375.2.1.3.4.*
 # Memory stats
 metrics:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove redundant doc. The README.md already contain instructions for installing new MIBs.

Also, we were indicating`/opt/datadog-agent/embedded/lib/python2.7/site-packages/pysnmp_mibs`, a path that might not persist upon agent/snmp reinstall/upgrade.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
