### PR TITLE
Add mechanism to cross-mount temporary log files between containers

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/_env.py
+++ b/datadog_checks_dev/datadog_checks/dev/_env.py
@@ -52,6 +52,18 @@ def get_env_vars(raw=False):
         return env_vars
 
 
+def get_state(key, default=None):
+    value = get_env_vars().get(key.lower())
+    if value is None:
+        return default
+
+    return deserialize_data(value)
+
+
+def save_state(key, value):
+    set_env_vars({key.lower(): serialize_data(value)})
+
+
 def set_up_env():
     return os.getenv(E2E_SET_UP, 'true') != 'false'
 

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -1,16 +1,24 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
 import os
 from contextlib import contextmanager
 
+import yaml
 from six import string_types
 from six.moves.urllib.parse import urlparse
 
 from .conditions import CheckDockerLogs
-from .env import environment_run
-from .structures import LazyFunction
+from .env import environment_run, get_state, save_state
+from .structures import EnvVars, LazyFunction, TempDir
 from .subprocess import run_command
+from .utils import create_file, file_exists, find_check_root, read_file
+
+try:
+    from contextlib import ExitStack
+except ImportError:
+    from contextlib2 import ExitStack
 
 
 def get_docker_hostname():
@@ -42,6 +50,45 @@ def compose_file_active(compose_file):
 
 
 @contextmanager
+def shared_logs(example_log_configs, mount_whitelist=None):
+    log_source = example_log_configs[0].get('source', 'check')
+
+    if mount_whitelist is None:
+        # Default to all
+        mount_whitelist = range(1, len(example_log_configs) + 1)
+
+    env_vars = {}
+    docker_volumes = get_state('docker_volumes', [])
+
+    with ExitStack() as stack:
+        for i, example_log_config in enumerate(example_log_configs, 1):
+            if i not in mount_whitelist:
+                continue
+
+            log_name = 'dd_log_{}'.format(i)
+            d = stack.enter_context(TempDir(log_name))
+
+            # Create the file that will ultimately be shared by containers
+            shared_log_file = os.path.join(d, '{}_{}.txt'.format(log_source, log_name))
+            if not file_exists(shared_log_file):
+                create_file(shared_log_file)
+
+            # Set config to the path in the Agent
+            agent_mount_path = '/var/log/{}/{}'.format(log_source, log_name)
+            example_log_config['path'] = agent_mount_path
+            docker_volumes.append('{}:{}'.format(shared_log_file, agent_mount_path))
+
+            # Make it available to reference for Docker volumes
+            env_vars[log_name.upper()] = shared_log_file
+
+        save_state('logs_config', example_log_configs)
+        save_state('docker_volumes', docker_volumes)
+
+        with EnvVars(env_vars):
+            yield
+
+
+@contextmanager
 def docker_run(
     compose_file=None,
     build=False,
@@ -52,6 +99,7 @@ def docker_run(
     sleep=None,
     endpoints=None,
     log_patterns=None,
+    mount_logs=False,
     conditions=None,
     env_vars=None,
     wrapper=None,
@@ -80,6 +128,8 @@ def docker_run(
                          when ``compose_file`` is provided. Shorthand for adding
                          ``conditions.CheckDockerLogs(compose_file, log_patterns)`` to the ``conditions`` argument.
     :type log_patterns: ``list`` of (``str`` or ``re.Pattern``)
+    :param mount_logs: Whether or not to mount log files in Agent containers based on example logs configuration.
+    :type mount_logs: ``bool`` or ``list`` of ``int`` or ``dict``
     :param conditions: A list of callable objects that will be executed before yielding to check for errors.
     :type conditions: ``callable``
     :param env_vars: A dictionary to update ``os.environ`` with during execution.
@@ -116,6 +166,19 @@ def docker_run(
 
     if conditions is not None:
         docker_conditions.extend(conditions)
+
+    if mount_logs:
+        if isinstance(mount_logs, dict):
+            wrapper = shared_logs(mount_logs['logs'])
+        # Easy mode, read example config
+        else:
+            # An extra level deep because of the context manager
+            check_root = find_check_root(depth=2)
+            example_log_configs = _read_example_logs_config(check_root)
+            if mount_logs is True:
+                wrapper = shared_logs(example_log_configs)
+            elif isinstance(mount_logs, (list, set)):
+                wrapper = shared_logs(example_log_configs, mount_whitelist=mount_logs)
 
     with environment_run(
         up=set_up,
@@ -165,3 +228,28 @@ class ComposeFileDown(LazyFunction):
 
     def __call__(self):
         return run_command(self.command, check=self.check)
+
+
+def _read_example_logs_config(check_root):
+    spec_path = _get_spec_path(check_root)
+    spec = yaml.safe_load(read_file(spec_path))
+
+    for f in spec['files']:
+        for option in f['options']:
+            if option.get('template') == 'logs':
+                return option['example']
+
+    raise ValueError('No logs example found')
+
+
+def _get_spec_path(check_root):
+    manifest = json.loads(read_file(os.path.join(check_root, 'manifest.json')))
+    relative_spec_path = manifest.get('assets', {}).get('configuration', {}).get('spec', '')
+    if not relative_spec_path:
+        raise OSError('No config spec defined')
+
+    spec_path = os.path.join(check_root, *relative_spec_path.split('/'))
+    if not file_exists(spec_path):
+        raise OSError('No config spec found')
+
+    return spec_path

--- a/datadog_checks_dev/datadog_checks/dev/env.py
+++ b/datadog_checks_dev/datadog_checks/dev/env.py
@@ -4,7 +4,16 @@
 import time
 from contextlib import contextmanager
 
-from ._env import deserialize_data, get_env_vars, serialize_data, set_env_vars, set_up_env, tear_down_env
+from ._env import (
+    deserialize_data,
+    get_env_vars,
+    get_state,
+    save_state,
+    serialize_data,
+    set_env_vars,
+    set_up_env,
+    tear_down_env,
+)
 from .conditions import CheckEndpoints
 from .structures import EnvVars
 from .utils import mock_context_manager
@@ -74,4 +83,12 @@ def environment_run(up, down, on_error=None, sleep=None, endpoints=None, conditi
                 down()
 
 
-__all__ = ['environment_run', 'deserialize_data', 'get_env_vars', 'serialize_data', 'set_env_vars']
+__all__ = [
+    'environment_run',
+    'deserialize_data',
+    'get_env_vars',
+    'get_state',
+    'save_state',
+    'serialize_data',
+    'set_env_vars',
+]

--- a/datadog_checks_dev/datadog_checks/dev/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/spec.py
@@ -1,0 +1,26 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+
+import yaml
+
+from .utils import file_exists, path_join, read_file
+
+
+def load_spec(check_root):
+    spec_path = get_spec_path(check_root)
+    return yaml.safe_load(read_file(spec_path))
+
+
+def get_spec_path(check_root):
+    manifest = json.loads(read_file(path_join(check_root, 'manifest.json')))
+    relative_spec_path = manifest.get('assets', {}).get('configuration', {}).get('spec', '')
+    if not relative_spec_path:
+        raise ValueError('No config spec defined')
+
+    spec_path = path_join(check_root, *relative_spec_path.split('/'))
+    if not file_exists(spec_path):
+        raise ValueError('No config spec found')
+
+    return spec_path

--- a/datadog_checks_dev/datadog_checks/dev/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/utils.py
@@ -197,7 +197,24 @@ def get_here():
 
 
 def load_jmx_config():
-    root = get_parent_dir(inspect.currentframe().f_back.f_code.co_filename)
+    # Only called in tests of a check, so just go back one frame
+    root = find_check_root(depth=1)
+
+    check = basepath(root)
+    jmx_config = path_join(root, 'datadog_checks', check, 'data', 'conf.yaml.example')
+
+    return yaml.safe_load(read_file(jmx_config))
+
+
+def find_check_root(depth=0):
+    # Account for this call
+    depth += 1
+
+    frame = inspect.currentframe()
+    for _ in range(depth):
+        frame = frame.f_back
+
+    root = get_parent_dir(frame.f_code.co_filename)
     while True:
         if file_exists(path_join(root, 'setup.py')):
             break
@@ -208,10 +225,7 @@ def load_jmx_config():
 
         root = new_root
 
-    check = basepath(root)
-    jmx_config = path_join(root, 'datadog_checks', check, 'data', 'conf.yaml.example')
-
-    return yaml.safe_load(read_file(jmx_config))
+    return root
 
 
 @contextmanager

--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -22,6 +22,7 @@ with open(path.join(HERE, 'README.md'), 'r', encoding='utf-8') as f:
 
 
 REQUIRES = [
+    "contextlib2; python_version < '3.0'",
     'coverage==4.5.4',  # pinned due to https://github.com/nedbat/coveragepy/issues/883
     'mock',
     'psutil',


### PR DESCRIPTION
### Motivation

Make it as easy as technically possible to test our log product on arbitrary integrations

### What does this PR do?

This adds a new `mount_logs` option to `docker_run` which will automatically create/clean-up temporary log files that may be shared between the product and Agent containers for E2E. The default, user-friendly mode requires a config spec like https://github.com/DataDog/integrations-core/blob/5959f3281dee04b81c10922e7488711f8d8dee49/apache/assets/configuration/spec.yaml#L19-L30

If `mount_logs` is `True`, all example log configurations will be used. If `mount_logs` is a sequence of `int`, only the selected indices (starting at 1) will be used. So, using the Apache example above, to only monitor the error log you would set it to `[2]`.

In lieu of a config spec, for whatever reason, you may set `mount_logs` to a `dict` containing the standard `logs` key.

The subsequent log files are available to reference as environment variables for any Docker calls as `DD_LOG_<LOG_CONFIG_INDEX>` where the indices start at 1.

Here's a complete example https://github.com/DataDog/integrations-core/pull/5347

```
==========
Logs Agent
==========
    Sending uncompressed logs in SSL encrypted TCP to agent-intake.logs.datadoghq.com on port 10516
    BytesSent: 11176
    EncodedBytesSent: 11176
    LogsProcessed: 52
    LogsSent: 52

  apache
  ------
    Type: file
    Path: /var/log/apache/dd_log_1
    Status: OK
    Inputs: /var/log/apache/dd_log_1
    Type: file
    Path: /var/log/apache/dd_log_2
    Status: OK
    Inputs: /var/log/apache/dd_log_2
```