### PR TITLE
Only ship `contextlib2` on Python 2

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -8,7 +8,7 @@ boto3==1.10.27
 botocore==1.13.42
 clickhouse-cityhash==1.0.2.3
 clickhouse-driver==0.1.2
-contextlib2==0.5.5
+contextlib2==0.5.5; python_version < '3.0'
 cryptography==2.8
 cx-oracle==7.2.0
 ddtrace==0.13.0

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -1,7 +1,7 @@
 aws-requests-auth==0.4.2
 binary==1.0.0
 botocore==1.13.42
-contextlib2==0.5.5
+contextlib2==0.5.5; python_version < '3.0'
 ddtrace==0.13.0
 ipaddress==1.0.22; python_version < '3.0'
 kubernetes==8.0.1


### PR DESCRIPTION
It's in stdlib now