### PR TITLE
Handle connection closed

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -512,6 +512,10 @@ class PostgreSql(AgentCheck):
 
     def _connect(self, host, port, user, password, dbname, ssl, tags):
         """Get and memoize connections to instances"""
+        if self.db and self.db.closed:
+            # Reset the connection object to retry to connect
+            self.db = None
+
         if self.db:
             if self.db.status != psycopg2.extensions.STATUS_READY:
                 # Some transaction went wrong and the connection is in an unhealthy state. Let's fix that


### PR DESCRIPTION
Reset the connection object to give the opportunity to the check to
retry to connect, for example when the database is restarted.