### PR TITLE
Upgrade vertica to stop logging to /dev/null

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -68,5 +68,5 @@ six==1.12.0
 supervisor==4.0.1
 tuf==0.12.1
 uptime==3.0.1
-vertica-python==0.9.4
+vertica-python==0.10.1
 win-inet-pton==1.1.0; sys_platform == 'win32' and python_version < '3.0'

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -565,8 +565,9 @@ class VerticaCheck(AgentCheck):
         if self._client_lib_log_level:
             connection_options['log_level'] = self._client_lib_log_level
             # log_path is required by vertica client for using logging
-            # we still get vertica client logs in the agent log even if `log_path` is set to os.devnull
-            connection_options['log_path'] = os.devnull
+            # when log_path is set to '', vertica won't log to a file
+            # but we still get logs via parent root logger
+            connection_options['log_path'] = ''
 
         if self._tls_verify:  # no cov
             # https://docs.python.org/3/library/ssl.html#ssl.SSLContext

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
-import os
 import ssl
 from collections import defaultdict
 from datetime import datetime

--- a/vertica/requirements.in
+++ b/vertica/requirements.in
@@ -1,1 +1,1 @@
-vertica-python==0.9.4
+vertica-python==0.10.1

--- a/vertica/tests/common.py
+++ b/vertica/tests/common.py
@@ -20,4 +20,5 @@ CONFIG = {
     'password': 'monitor',
     'timeout': 10,
     'tags': ['foo:bar'],
+    'client_lib_log_level': 'DEBUG',
 }

--- a/vertica/tests/test_unit.py
+++ b/vertica/tests/test_unit.py
@@ -67,11 +67,12 @@ def test_client_logging_enabled(aggregator, instance):
             connection_load_balance=mock.ANY,
             connection_timeout=mock.ANY,
             log_level='DEBUG',
-            log_path=os.devnull,
+            log_path='',
         )
 
 
 def test_client_logging_disabled(aggregator, instance):
+    instance['client_lib_log_level'] = None
     check = VerticaCheck('vertica', {}, [instance])
 
     with mock.patch('datadog_checks.vertica.vertica.vertica') as vertica:

--- a/vertica/tests/test_vertica.py
+++ b/vertica/tests/test_vertica.py
@@ -39,7 +39,7 @@ def test_check(aggregator, instance):
 def test_vertica_log_file_not_created(aggregator, instance):
     instance['client_lib_log_level'] = 'DEBUG'
 
-    vertica_default_log = os.path.abspath(os.path.join(common.HERE, os.pardir, 'vertica_python.log'))
+    vertica_default_log = os.path.join(os.path.dirname(common.HERE), 'vertica_python.log')
     if os.path.exists(vertica_default_log):
         os.remove(vertica_default_log)
 

--- a/vertica/tests/test_vertica.py
+++ b/vertica/tests/test_vertica.py
@@ -1,11 +1,14 @@
 # (C) Datadog, Inc. 2019
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+
 import mock
 import pytest
 
 from datadog_checks.vertica import VerticaCheck
 
+from . import common
 from .metrics import ALL_METRICS
 
 
@@ -30,6 +33,19 @@ def test_check(aggregator, instance):
         aggregator.assert_metric_has_tag(metric, 'foo:bar')
 
     aggregator.assert_all_metrics_covered()
+
+
+@pytest.mark.usefixtures('dd_environment')
+def test_vertica_log_file_not_created(aggregator, instance):
+    instance['client_lib_log_level'] = 'DEBUG'
+
+    vertica_default_log = os.path.abspath(os.path.join(common.HERE, os.pardir, 'vertica_python.log'))
+    os.remove(vertica_default_log)
+
+    check = VerticaCheck('vertica', {}, [instance])
+    check.check(instance)
+
+    assert not os.path.exists(vertica_default_log)
 
 
 @pytest.mark.usefixtures('dd_environment')

--- a/vertica/tests/test_vertica.py
+++ b/vertica/tests/test_vertica.py
@@ -40,7 +40,8 @@ def test_vertica_log_file_not_created(aggregator, instance):
     instance['client_lib_log_level'] = 'DEBUG'
 
     vertica_default_log = os.path.abspath(os.path.join(common.HERE, os.pardir, 'vertica_python.log'))
-    os.remove(vertica_default_log)
+    if os.path.exists(vertica_default_log):
+        os.remove(vertica_default_log)
 
     check = VerticaCheck('vertica', {}, [instance])
     check.check(instance)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Upgrade vertica to stop logging to /dev/null

Related upstream PR: https://github.com/vertica/vertica-python/pull/352

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
