### PR TITLE
Change `wrapper` arg for environment runners to `wrappers`

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -167,11 +167,11 @@ def docker_run(
     if conditions is not None:
         docker_conditions.extend(conditions)
 
-    docker_wrappers = []
+    wrappers = list(wrappers) if wrappers is not None else []
 
     if mount_logs:
         if isinstance(mount_logs, dict):
-            docker_wrappers.append(shared_logs(mount_logs['logs']))
+            wrappers.append(shared_logs(mount_logs['logs']))
         # Easy mode, read example config
         else:
             # An extra level deep because of the context manager
@@ -179,16 +179,13 @@ def docker_run(
 
             example_log_configs = _read_example_logs_config(check_root)
             if mount_logs is True:
-                docker_wrappers.append(shared_logs(example_log_configs))
+                wrappers.append(shared_logs(example_log_configs))
             elif isinstance(mount_logs, (list, set)):
-                docker_wrappers.append(shared_logs(example_log_configs, mount_whitelist=mount_logs))
+                wrappers.append(shared_logs(example_log_configs, mount_whitelist=mount_logs))
             else:
                 raise TypeError(
                     'mount_logs: expected True, a list or a set, but got {}'.format(type(mount_logs).__name__)
                 )
-
-    if wrappers is not None:
-        docker_wrappers.extend(wrappers)
 
     with environment_run(
         up=set_up,
@@ -198,7 +195,7 @@ def docker_run(
         endpoints=endpoints,
         conditions=docker_conditions,
         env_vars=env_vars,
-        wrappers=docker_wrappers,
+        wrappers=wrappers,
     ) as result:
         yield result
 

--- a/datadog_checks_dev/datadog_checks/dev/env.py
+++ b/datadog_checks_dev/datadog_checks/dev/env.py
@@ -16,11 +16,15 @@ from ._env import (
 )
 from .conditions import CheckEndpoints
 from .structures import EnvVars
-from .utils import mock_context_manager
+
+try:
+    from contextlib import ExitStack
+except ImportError:
+    from contextlib2 import ExitStack
 
 
 @contextmanager
-def environment_run(up, down, on_error=None, sleep=None, endpoints=None, conditions=None, env_vars=None, wrapper=None):
+def environment_run(up, down, on_error=None, sleep=None, endpoints=None, conditions=None, env_vars=None, wrappers=None):
     """This utility provides a convenient way to safely set up and tear down arbitrary types of environments.
 
     :param up: A custom setup callable.
@@ -38,7 +42,7 @@ def environment_run(up, down, on_error=None, sleep=None, endpoints=None, conditi
     :type conditions: ``callable``
     :param env_vars: A dictionary to update ``os.environ`` with during execution.
     :type env_vars: ``dict``
-    :param wrapper: A context manager to use during execution.
+    :param wrappers: A list of context managers to use during execution.
     """
     if not callable(up):
         raise TypeError('The custom setup `{}` is not callable.'.format(repr(up)))
@@ -46,15 +50,17 @@ def environment_run(up, down, on_error=None, sleep=None, endpoints=None, conditi
         raise TypeError('The custom tear down `{}` is not callable.'.format(repr(down)))
 
     conditions = list(conditions) if conditions is not None else []
-
     if endpoints is not None:
         conditions.append(CheckEndpoints(endpoints))
 
-    env_vars = mock_context_manager() if env_vars is None else EnvVars(env_vars)
-    wrapper = mock_context_manager() if wrapper is None else wrapper
+    wrappers = list(wrappers) if wrappers is not None else []
+    if env_vars is not None:
+        wrappers.insert(0, EnvVars(env_vars))
 
-    result = None
-    with env_vars, wrapper:
+    with ExitStack() as stack:
+        for wrapper in wrappers:
+            stack.enter_context(wrapper)
+
         try:
             # Create an environment variable to store setup result
             key = 'environment_result_{}'.format(up.__class__.__name__.lower())

--- a/datadog_checks_dev/datadog_checks/dev/terraform.py
+++ b/datadog_checks_dev/datadog_checks/dev/terraform.py
@@ -37,7 +37,7 @@ def construct_env_vars():
 
 
 @contextmanager
-def terraform_run(directory, sleep=None, endpoints=None, conditions=None, env_vars=None, wrapper=None):
+def terraform_run(directory, sleep=None, endpoints=None, conditions=None, env_vars=None, wrappers=None):
     """This utility provides a convenient way to safely set up and tear down Terraform environments.
 
     :param directory: A path containing Terraform files.
@@ -51,7 +51,7 @@ def terraform_run(directory, sleep=None, endpoints=None, conditions=None, env_va
     :type conditions: ``callable``
     :param env_vars: A dictionary to update ``os.environ`` with during execution.
     :type env_vars: ``dict``
-    :param wrapper: A context manager to use during execution.
+    :param wrappers: A list of context managers to use during execution.
     """
     if not which('terraform'):
         pytest.skip('Terraform not available')
@@ -66,7 +66,7 @@ def terraform_run(directory, sleep=None, endpoints=None, conditions=None, env_va
         endpoints=endpoints,
         conditions=conditions,
         env_vars=env_vars,
-        wrapper=wrapper,
+        wrappers=wrappers,
     ) as result:
         yield result
 


### PR DESCRIPTION
### Motivation

Prevent overriding by simply allowing multiple context managers