### PR TITLE
Move unit conversion helpers to openmetrics mixin

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -893,7 +893,7 @@ class OpenMetricsScraperMixin(object):
                     continue
                 if sample[self.SAMPLE_NAME].endswith("_sum"):
                     lst = list(sample)
-                    lst[self.SAMPLE_VALUE] = converter(float(val))
+                    lst[self.SAMPLE_VALUE] = converter(val)
                     metric.samples[index] = tuple(lst)
                 elif sample[self.SAMPLE_NAME].endswith("_bucket") and "Inf" not in sample[self.SAMPLE_LABELS]["le"]:
                     sample[self.SAMPLE_LABELS]["le"] = str(converter(float(sample[self.SAMPLE_LABELS]["le"])))
@@ -918,7 +918,7 @@ class OpenMetricsScraperMixin(object):
                     continue
                 else:
                     lst = list(sample)
-                    lst[self.SAMPLE_VALUE] = converter(float(val))
+                    lst[self.SAMPLE_VALUE] = converter(val)
                     metric.samples[index] = tuple(lst)
             self.submit_openmetric(metric_name, metric, scraper_config)
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
+
 from fnmatch import fnmatchcase
 from math import isinf, isnan
 from os.path import isfile

--- a/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
@@ -132,10 +132,10 @@ class KubeSchedulerCheck(KubeLeaderElectionMixin, OpenMetricsBaseCheck):
         scraper_config = self.get_scraper_config(instance)
         # Set up metric_transformers
         transformers = {}
-        for metric in TRANSFORM_VALUE_HISTOGRAMS:
-            transformers[metric] = self._histogram_from_microseconds_to_second
-        for metric in TRANSFORM_VALUE_SUMMARIES:
-            transformers[metric] = self._summary_from_microseconds_to_second
+        for metric_from, metric_to in TRANSFORM_VALUE_HISTOGRAMS.items():
+            transformers[metric_from] = self._histogram_from_microseconds_to_seconds(metric_to)
+        for metric_from, metric_to in TRANSFORM_VALUE_SUMMARIES.items():
+            transformers[metric_from] = self._summary_from_microseconds_to_seconds(metric_to)
 
         self.process(scraper_config, metric_transformers=transformers)
         # Check the leader-election status
@@ -143,31 +143,3 @@ class KubeSchedulerCheck(KubeLeaderElectionMixin, OpenMetricsBaseCheck):
             leader_config = self.LEADER_ELECTION_CONFIG
             leader_config["tags"] = instance.get("tags", [])
             self.check_election_status(leader_config)
-
-    def _histogram_from_microseconds_to_second(self, metric, scraper_config):
-        for index, sample in enumerate(metric.samples):
-            val = sample[self.SAMPLE_VALUE]
-            if not self._is_value_valid(val):
-                self.log.debug("Metric value is not supported for metric {}".format(sample[self.SAMPLE_NAME]))
-                continue
-            if sample[self.SAMPLE_NAME].endswith("_sum"):
-                lst = list(sample)
-                lst[self.SAMPLE_VALUE] = float(val) / 1000000
-                metric.samples[index] = tuple(lst)
-            elif sample[self.SAMPLE_NAME].endswith("_bucket") and "Inf" not in sample[self.SAMPLE_LABELS]["le"]:
-                sample[self.SAMPLE_LABELS]["le"] = str(float(sample[self.SAMPLE_LABELS]["le"]) / 1000000)
-        self.submit_openmetric(TRANSFORM_VALUE_HISTOGRAMS[metric.name], metric, scraper_config)
-
-    def _summary_from_microseconds_to_second(self, metric, scraper_config):
-        for index, sample in enumerate(metric.samples):
-            val = sample[self.SAMPLE_VALUE]
-            if not self._is_value_valid(val):
-                self.log.debug("Metric value is not supported for metric {}".format(sample[self.SAMPLE_NAME]))
-                continue
-            if sample[self.SAMPLE_NAME].endswith("_count"):
-                continue
-            else:
-                lst = list(sample)
-                lst[self.SAMPLE_VALUE] = float(val) / 1000000
-                metric.samples[index] = tuple(lst)
-        self.submit_openmetric(TRANSFORM_VALUE_SUMMARIES[metric.name], metric, scraper_config)


### PR DESCRIPTION
### What does this PR do?
Move common conversion helpers from `kube_scheduler` to `OpenMetricsScraperMixin`

### Motivation
Would like to reuse these across integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
