### PR TITLE
Add option to activate namespace matching logic for openmetrics tags if namespace is present

### DIFF
--- a/datadog_checks_base/tests/fixtures/prometheus/ksm.txt
+++ b/datadog_checks_base/tests/fixtures/prometheus/ksm.txt
@@ -216,10 +216,12 @@ kube_node_status_condition{condition="Ready",node="gke-foobar-test-kube-default-
 # TYPE kube_persistentvolumeclaim_info gauge
 kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="www-web-0",storageclass="standard"} 1
 kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="www-web-1",storageclass="standard"} 1
+kube_persistentvolumeclaim_info{namespace="foo",persistentvolumeclaim="www-web-1",storageclass="standard"} 1
 # HELP kube_persistentvolumeclaim_resource_requests_storage_bytes The capacity of storage requested by the persistent volume claim.
 # TYPE kube_persistentvolumeclaim_resource_requests_storage_bytes gauge
 kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="www-web-0"} 1.073741824e+09
 kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="www-web-1"} 1.073741824e+09
+kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="foo",persistentvolumeclaim="www-web-1"} 2.073741824e+09
 # HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
 # TYPE kube_persistentvolumeclaim_status_phase gauge
 kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="www-web-0",phase="Bound"} 1
@@ -228,6 +230,9 @@ kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclai
 kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="www-web-1",phase="Bound"} 1
 kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="www-web-1",phase="Lost"} 0
 kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="www-web-1",phase="Pending"} 0
+kube_persistentvolumeclaim_status_phase{namespace="foo",persistentvolumeclaim="www-web-1",phase="Bound"} 0
+kube_persistentvolumeclaim_status_phase{namespace="foo",persistentvolumeclaim="www-web-1",phase="Lost"} 1
+kube_persistentvolumeclaim_status_phase{namespace="foo",persistentvolumeclaim="www-web-1",phase="Pending"} 0
 # HELP kube_pod_container_info Information about a container in a pod.
 # TYPE kube_pod_container_info gauge
 kube_pod_container_info{container="autoscaler",container_id="docker://9e8fe714a4fd8e4f5ee417bfd7bdee10484dec917e2fd15e95a42c5673353b0f",image="eu.gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2-r2",image_id="docker-pullable://eu.gcr.io/google_containers/cluster-proportional-autoscaler-amd64@sha256:003f98d9f411ddfa6ff6d539196355e03ddd69fa4ed38c7ffb8fec6f729afe2d",namespace="kube-system",pod="kube-dns-autoscaler-97162954-mf6d3"} 1

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -335,6 +335,10 @@ class KubernetesState(OpenMetricsBaseCheck):
                         'label_to_match': 'persistentvolumeclaim',
                         'labels_to_get': ['storageclass'],
                     },
+                    'kube_persistentvolumeclaim_status_phase': {
+                        'label_to_match': 'persistentvolumeclaim',
+                        'labels_to_get': ['phase'],
+                    },
                 },
                 # Defaults that were set when kubernetes_state was based on PrometheusCheck
                 'send_monotonic_counter': ksm_instance.get('send_monotonic_counter', False),
@@ -344,6 +348,9 @@ class KubernetesState(OpenMetricsBaseCheck):
 
         ksm_instance['prometheus_url'] = endpoint
         ksm_instance['label_joins'].update(extra_labels)
+        # For KSM always use namespaced tag matching as it avoids tag collisions between namespaces
+        ksm_instance['restrict_tag_matching_label'] = 'namespace'
+        ksm_instance['unrestricted_matching_labels'] = {'node'}
         if hostname_override:
             ksm_instance['label_to_hostname'] = 'node'
             clustername = get_clustername()


### PR DESCRIPTION
### What does this PR do?
Currently we are mixing up tags coming from objects having the same name in different namespaces when data are gathered from anything running in Kubernetes.
Using it in KSM to fix this issue.

### Motivation
Issue faced internally where we are mixing up tags for PVCs in different namespaces.

### Additional Notes
Put the code in the OpenMetrics base class itself as it may be useful to all checks monitoring things running in k8s, which I expect to be the most common usage of this base class.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
