### PR TITLE
Implement table browsing with OIDs

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -263,9 +263,9 @@ class InstanceConfig:
                         column = metric_tag['column']
                         if isinstance(column, dict):
                             column_name = column['name']
-                            column = column['OID']
-                            identity = hlapi.ObjectIdentity(column)
-                            self._resolver.register(to_oid_tuple(column), column_name)
+                            column_oid = column['OID']
+                            identity = hlapi.ObjectIdentity(column_oid)
+                            self._resolver.register(to_oid_tuple(column_oid), column_name)
                             column_tags.append((tag_key, column_name))
                         else:
                             identity = hlapi.ObjectIdentity(mib, column)
@@ -292,6 +292,11 @@ class InstanceConfig:
                                 self._resolver.register_index(
                                     symbol['name'], metric_tag['index'], metric_tag['mapping']
                                 )
+                            for tag in metric['metric_tags']:
+                                if 'column' in tag:
+                                    self._resolver.register_index(
+                                        tag['column']['name'], metric_tag['index'], metric_tag['mapping']
+                                    )
                 for symbol in metric['symbols']:
                     if isinstance(symbol, dict):
                         self._resolver.register(to_oid_tuple(symbol['OID']), symbol['name'])

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -235,6 +235,13 @@ class InstanceConfig:
         return context_engine_id, context_name
 
     def resolve_oid(self, oid):
+        """Resolve an OID to a name and its indexes.
+
+        This first tries to do manual resolution using `self._resolver`, then
+        falls back to MIB resolution if that fails.  In the first case it also
+        tries to resolve indexes to name if that applies, using
+        `self._index_resolver`.
+        """
         oid_tuple = oid.asTuple()
         prefix, resolved = self._resolver.match(oid_tuple)
         if resolved is not None:

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -19,13 +19,78 @@ from pysnmp.smi.error import MibNotFoundError
 from datadog_checks.base import ConfigurationError, is_affirmative
 
 
+def to_oid_tuple(oid_string):
+    """Return a OID tuple from a OID string."""
+    return tuple(map(int, oid_string.lstrip('.').split('.')))
+
+
+class OIDTreeNode(object):
+
+    __slots__ = ('value', 'children')
+
+    def __init__(self):
+        self.value = None
+        self.children = defaultdict(OIDTreeNode)
+
+
+class OIDTrie(object):
+    """A trie implementation to store OIDs and efficiently match prefixes.
+
+    We use it to do basic MIB-like resolution.
+    """
+
+    def __init__(self):
+        self._root = OIDTreeNode()
+
+    def set(self, oid, name):
+        node = self._root
+        for part in oid:
+            node = node.children[part]
+        node.value = name
+
+    def match(self, oid):
+        node = self._root
+        matched = []
+        value = None
+        for part in oid:
+            node = node.children.get(part)
+            if node is None:
+                break
+            matched.append(part)
+            if node.value is not None:
+                value = node.value
+        return tuple(matched), value
+
+
+class ParsedMetric(object):
+
+    __slots__ = ('name', 'metric_tags', 'forced_type', 'enforce_scalar')
+
+    def __init__(self, name, metric_tags, forced_type, enforce_scalar=True):
+        self.name = name
+        self.metric_tags = metric_tags
+        self.forced_type = forced_type
+        self.enforce_scalar = enforce_scalar
+
+
+class ParsedTableMetric(object):
+
+    __slots__ = ('name', 'index_tags', 'column_tags', 'forced_type')
+
+    def __init__(self, name, index_tags, column_tags, forced_type):
+        self.name = name
+        self.index_tags = index_tags
+        self.column_tags = column_tags
+        self.forced_type = forced_type
+
+
 class InstanceConfig:
     """Parse and hold configuration about a single instance."""
 
     DEFAULT_RETRIES = 5
     DEFAULT_TIMEOUT = 1
     DEFAULT_ALLOWED_FAILURES = 3
-    DEFAULT_BULK_THRESHOLD = 5
+    DEFAULT_BULK_THRESHOLD = 0
 
     def __init__(self, instance, warning, log, global_metrics, mibs_path, profiles, profiles_by_oid):
         self.instance = instance
@@ -39,7 +104,7 @@ class InstanceConfig:
                 raise ConfigurationError("Unknown profile '{}'".format(profile))
             self.metrics.extend(profiles[profile]['definition']['metrics'])
         self.enforce_constraints = is_affirmative(instance.get('enforce_mib_constraints', True))
-        self.snmp_engine, self.mib_view_controller = self.create_snmp_engine(mibs_path)
+        self._snmp_engine, self.mib_view_controller = self.create_snmp_engine(mibs_path)
         self.ip_address = None
         self.ip_network = None
         self.discovered_instances = {}
@@ -62,7 +127,7 @@ class InstanceConfig:
             raise ConfigurationError('Only one of IP address and network address must be specified')
 
         if ip_address:
-            self.transport = self.get_transport_target(instance, timeout, retries)
+            self._transport = self.get_transport_target(instance, timeout, retries)
 
             self.ip_address = ip_address
             self.tags.append('snmp_device:{}'.format(self.ip_address))
@@ -74,18 +139,21 @@ class InstanceConfig:
 
         if not self.metrics and not profiles_by_oid:
             raise ConfigurationError('Instance should specify at least one metric or profiles should be defined')
+        self._resolver = OIDTrie()
+        self._index_resolver = defaultdict(dict)
 
-        self.table_oids, self.raw_oids = self.parse_metrics(self.metrics, warning, log)
+        self._auth_data = self.get_auth_data(instance)
 
-        self.auth_data = self.get_auth_data(instance)
-        self.context_data = hlapi.ContextData(*self.get_context_data(instance))
+        self.all_oids, self.bulk_oids, self.parsed_metrics = self.parse_metrics(self.metrics, warning, log)
+
+        self._context_data = hlapi.ContextData(*self.get_context_data(instance))
 
     def refresh_with_profile(self, profile, warning, log):
         self.metrics.extend(profile['definition']['metrics'])
-        self.table_oids, self.raw_oids = self.parse_metrics(self.metrics, warning, log)
+        self.all_oids, self.bulk_oids, self.parsed_metrics = self.parse_metrics(self.metrics, warning, log)
 
     def call_cmd(self, cmd, *args, **kwargs):
-        return cmd(self.snmp_engine, self.auth_data, self.transport, self.context_data, *args, **kwargs)
+        return cmd(self._snmp_engine, self._auth_data, self._transport, self._context_data, *args, **kwargs)
 
     @staticmethod
     def create_snmp_engine(mibs_path):
@@ -117,17 +185,15 @@ class InstanceConfig:
         """
         Generate a Security Parameters object based on the instance's
         configuration.
-        See http://pysnmp.sourceforge.net/docs/current/security-configuration.html
         """
         if 'community_string' in instance:
             # SNMP v1 - SNMP v2
-
-            # See http://pysnmp.sourceforge.net/docs/current/security-configuration.html
+            # See http://snmplabs.com/pysnmp/docs/api-reference.html#pysnmp.hlapi.CommunityData
             if int(instance.get('snmp_version', 2)) == 1:
                 return hlapi.CommunityData(instance['community_string'], mpModel=0)
             return hlapi.CommunityData(instance['community_string'], mpModel=1)
 
-        elif 'user' in instance:
+        if 'user' in instance:
             # SNMP v3
             user = instance['user']
             auth_key = None
@@ -146,8 +212,8 @@ class InstanceConfig:
             if 'privProtocol' in instance:
                 priv_protocol = getattr(hlapi, instance['privProtocol'])
             return hlapi.UsmUserData(user, auth_key, priv_key, auth_protocol, priv_protocol)
-        else:
-            raise ConfigurationError('An authentication method needs to be provided')
+
+        raise ConfigurationError('An authentication method needs to be provided')
 
     @staticmethod
     def get_context_data(instance):
@@ -168,28 +234,59 @@ class InstanceConfig:
 
         return context_engine_id, context_name
 
+    def resolve_oid(self, oid):
+        oid_tuple = oid.asTuple()
+        prefix, resolved = self._resolver.match(oid_tuple)
+        if resolved is not None:
+            index_resolver = self._index_resolver.get(resolved)
+            indexes = oid_tuple[len(prefix) :]
+            if index_resolver:
+                new_indexes = []
+                for i, index in enumerate(indexes, 1):
+                    if i in index_resolver:
+                        new_indexes.append(index_resolver[i][index])
+                    else:
+                        new_indexes.append(index)
+                indexes = tuple(new_indexes)
+            return resolved, indexes
+        result_oid = oid
+        if not self.enforce_constraints:
+            # if enforce_constraints is false, then MIB resolution has not been done yet
+            # so we need to do it manually. We have to specify the mibs that we will need
+            # to resolve the name.
+            oid_to_resolve = hlapi.ObjectIdentity(oid_tuple)
+            result_oid = oid_to_resolve.resolveWithMib(self.mib_view_controller)
+        _, metric, indexes = result_oid.getMibSymbol()
+        return metric, tuple(index.prettyPrint() for index in indexes)
+
     def parse_metrics(self, metrics, warning, log):
         """Parse configuration and returns data to be used for SNMP queries.
 
-        `raw_oids` is a list of SNMP numerical OIDs to query.
-        `table_oids` is a dictionnary of SNMP tables to symbols to query.
+        `oids` is a dictionnary of SNMP tables to symbols to query.
         """
-        raw_oids = []
         table_oids = {}
         mibs_to_load = set()
+        parsed_metrics = []
 
         def get_table_symbols(mib, table):
+            if isinstance(table, dict):
+                table = table['OID']
+                identity = hlapi.ObjectIdentity(table)
+            else:
+                identity = hlapi.ObjectIdentity(mib, table)
             key = (mib, table)
             if key in table_oids:
                 return table_oids[key][1]
 
-            table_object = hlapi.ObjectType(hlapi.ObjectIdentity(mib, table))
+            table_object = hlapi.ObjectType(identity)
             symbols = []
             table_oids[key] = (table_object, symbols)
             return symbols
 
         # Check the metrics completely defined
         for metric in metrics:
+            forced_type = metric.get('forced_type')
+            metric_tags = metric.get('metric_tags', [])
             if 'MIB' in metric:
                 if not ('table' in metric or 'symbol' in metric):
                     raise ConfigurationError('When specifying a MIB, you must specify either table or symbol')
@@ -200,41 +297,80 @@ class InstanceConfig:
                         get_table_symbols(metric['MIB'], to_query)
                     except Exception as e:
                         warning("Can't generate MIB object for variable : %s\nException: %s", metric, e)
+                    else:
+                        if isinstance(to_query, dict):
+                            self._resolver.set(to_oid_tuple(to_query['OID']), to_query['name'])
+                            parsed_metric_name = to_query['name']
+                        else:
+                            parsed_metric_name = to_query
+                        parsed_metric = ParsedMetric(parsed_metric_name, metric_tags, forced_type)
+                        parsed_metrics.append(parsed_metric)
+                    continue
                 elif 'symbols' not in metric:
                     raise ConfigurationError('When specifying a table, you must specify a list of symbols')
-                else:
-                    symbols = get_table_symbols(metric['MIB'], metric['table'])
-                    for symbol in metric['symbols']:
+
+                symbols = get_table_symbols(metric['MIB'], metric['table'])
+                index_tags = []
+                column_tags = []
+                for metric_tag in metric_tags:
+                    if not ('tag' in metric_tag and ('index' in metric_tag or 'column' in metric_tag)):
+                        raise ConfigurationError(
+                            'When specifying metric tags, you must specify a tag, and an index or column'
+                        )
+                    tag_key = metric_tag['tag']
+                    if 'column' in metric_tag:
+                        # In case it's a column, we need to query it as well
+                        mib = metric_tag.get('MIB', metric['MIB'])
+                        column = metric_tag['column']
+                        if isinstance(column, dict):
+                            column_name = column['name']
+                            column = column['OID']
+                            identity = hlapi.ObjectIdentity(column)
+                            self._resolver.set(to_oid_tuple(column), column_name)
+                            column_tags.append((tag_key, column_name))
+                        else:
+                            identity = hlapi.ObjectIdentity(mib, column)
+                            column_tags.append((tag_key, column))
                         try:
-                            symbols.append(hlapi.ObjectType(hlapi.ObjectIdentity(metric['MIB'], symbol)))
+                            object_type = hlapi.ObjectType(identity)
                         except Exception as e:
                             warning("Can't generate MIB object for variable : %s\nException: %s", metric, e)
-                    if 'metric_tags' in metric:
-                        for metric_tag in metric['metric_tags']:
-                            if not ('tag' in metric_tag and ('index' in metric_tag or 'column' in metric_tag)):
+                        else:
+                            if 'table' in metric_tag:
+                                tag_symbols = get_table_symbols(mib, metric_tag['table'])
+                                tag_symbols.append(object_type)
+                            elif mib != metric['MIB']:
                                 raise ConfigurationError(
-                                    'When specifying metric tags, you must specify a tag, and an index or column'
+                                    'When tagging from a different MIB, the table must be specified'
                                 )
-                            if 'column' in metric_tag:
-                                # In case it's a column, we need to query it as well
-                                mib = metric_tag.get('MIB', metric['MIB'])
-                                try:
-                                    object_type = hlapi.ObjectType(hlapi.ObjectIdentity(mib, metric_tag['column']))
-                                except Exception as e:
-                                    warning("Can't generate MIB object for variable : %s\nException: %s", metric, e)
-                                else:
-                                    if 'table' in metric_tag:
-                                        tag_symbols = get_table_symbols(mib, metric_tag['table'])
-                                        tag_symbols.append(object_type)
-                                    elif mib != metric['MIB']:
-                                        raise ConfigurationError(
-                                            'When tagging from a different MIB, the table must be specified'
-                                        )
-                                    else:
-                                        symbols.append(object_type)
-
+                            else:
+                                symbols.append(object_type)
+                    elif 'index' in metric_tag:
+                        index_tags.append((tag_key, metric_tag['index']))
+                        if 'mapping' in metric_tag:
+                            # Need to do manual resolution
+                            for symbol in metric['symbols']:
+                                self._index_resolver[symbol['name']][metric_tag['index']] = metric_tag['mapping']
+                for symbol in metric['symbols']:
+                    if isinstance(symbol, dict):
+                        self._resolver.set(to_oid_tuple(symbol['OID']), symbol['name'])
+                        identity = hlapi.ObjectIdentity(symbol['OID'])
+                        parsed_metric_name = symbol['name']
+                    else:
+                        identity = hlapi.ObjectIdentity(metric['MIB'], symbol)
+                        parsed_metric_name = symbol
+                    try:
+                        symbols.append(hlapi.ObjectType(identity))
+                    except Exception as e:
+                        warning("Can't generate MIB object for variable : %s\nException: %s", metric, e)
+                    parsed_metric = ParsedTableMetric(parsed_metric_name, index_tags, column_tags, forced_type)
+                    parsed_metrics.append(parsed_metric)
             elif 'OID' in metric:
-                raw_oids.append(hlapi.ObjectType(hlapi.ObjectIdentity(metric['OID'])))
+                oid_object = hlapi.ObjectType(hlapi.ObjectIdentity(metric['OID']))
+                table_oids[metric['OID']] = (oid_object, [])
+                self._resolver.set(to_oid_tuple(metric['OID']), metric['name'])
+                parsed_metric = ParsedMetric(metric['name'], metric_tags, forced_type, enforce_scalar=False)
+                parsed_metrics.append(parsed_metric)
             else:
                 raise ConfigurationError('Unsupported metric in config file: {}'.format(metric))
 
@@ -246,7 +382,24 @@ class InstanceConfig:
                     log.debug("Couldn't found mib %s, trying to fetch it", mib)
                     self.fetch_mib(mib)
 
-        return dict(table_oids.values()), raw_oids
+        oids = []
+        all_oids = []
+        bulk_oids = []
+        # Use bulk for SNMP version > 1 and there are enough symbols
+        bulk_limit = self.bulk_threshold if self._auth_data.mpModel else 0
+        for table, symbols in table_oids.values():
+            if not symbols:
+                # No table to browse, just one symbol
+                oids.append(table)
+            elif bulk_limit and len(symbols) > bulk_limit:
+                bulk_oids.append(table)
+            else:
+                all_oids.append(symbols)
+
+        if oids:
+            all_oids.insert(0, oids)
+
+        return all_oids, bulk_oids, parsed_metrics
 
     @staticmethod
     def fetch_mib(mib):

--- a/snmp/datadog_checks/snmp/resolver.py
+++ b/snmp/datadog_checks/snmp/resolver.py
@@ -1,0 +1,93 @@
+# (C) Datadog, Inc. 2010-2019
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+from collections import defaultdict
+
+from pysnmp import hlapi
+
+
+class OIDTreeNode(object):
+
+    __slots__ = ('value', 'children')
+
+    def __init__(self):
+        self.value = None
+        self.children = defaultdict(OIDTreeNode)
+
+
+class OIDTrie(object):
+    """A trie implementation to store OIDs and efficiently match prefixes.
+
+    We use it to do basic MIB-like resolution.
+    """
+
+    def __init__(self):
+        self._root = OIDTreeNode()
+
+    def set(self, oid, name):
+        node = self._root
+        for part in oid:
+            node = node.children[part]
+        node.value = name
+
+    def match(self, oid):
+        node = self._root
+        matched = []
+        value = None
+        for part in oid:
+            node = node.children.get(part)
+            if node is None:
+                break
+            matched.append(part)
+            if node.value is not None:
+                value = node.value
+        return tuple(matched), value
+
+
+class OIDResolver(object):
+    def __init__(self, mib_view_controller, enforce_constraints):
+        self._mib_view_controller = mib_view_controller
+        self._resolver = OIDTrie()
+        self._index_resolver = defaultdict(dict)
+        self._enforce_constraints = enforce_constraints
+
+    def register(self, oid, name):
+        """Register a translation from a name to an OID."""
+        self._resolver.set(oid, name)
+
+    def register_index(self, name, index, mapping):
+        """Register a mapping for index translation."""
+        self._index_resolver[name][index] = mapping
+
+    def resolve_oid(self, oid):
+        """Resolve an OID to a name and its indexes.
+
+        This first tries to do manual resolution using `self._resolver`, then
+        falls back to MIB resolution if that fails.  In the first case it also
+        tries to resolve indexes to name if that applies, using
+        `self._index_resolver`.
+        """
+        oid_tuple = oid.asTuple()
+        prefix, resolved = self._resolver.match(oid_tuple)
+        if resolved is not None:
+            index_resolver = self._index_resolver.get(resolved)
+            indexes = oid_tuple[len(prefix) :]
+            if index_resolver:
+                new_indexes = []
+                for i, index in enumerate(indexes, 1):
+                    if i in index_resolver:
+                        new_indexes.append(index_resolver[i][index])
+                    else:
+                        new_indexes.append(index)
+                indexes = tuple(new_indexes)
+            return resolved, indexes
+        result_oid = oid
+        if not self._enforce_constraints:
+            # if enforce_constraints is false, then MIB resolution has not been done yet
+            # so we need to do it manually. We have to specify the mibs that we will need
+            # to resolve the name.
+            oid_to_resolve = hlapi.ObjectIdentity(oid_tuple)
+            result_oid = oid_to_resolve.resolveWithMib(self._mib_view_controller)
+        _, metric, indexes = result_oid.getMibSymbol()
+        return metric, tuple(index.prettyPrint() for index in indexes)

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -218,8 +218,8 @@ class SnmpCheck(AgentCheck):
                 self.warning(message)
 
         for result_oid, value in all_binds:
-            metric, index = config.resolve_oid(result_oid)
-            results[metric][index] = value
+            metric, indexes = config.resolve_oid(result_oid)
+            results[metric][indexes] = value
         self.log.debug('Raw results: %s', results)
         # Freeze the result
         results.default_factory = None

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -15,13 +15,13 @@ from pyasn1.codec.ber import decoder
 from pysnmp import hlapi
 from pysnmp.error import PySnmpError
 from pysnmp.smi import builder
-from pysnmp.smi.exval import noSuchInstance, noSuchObject
+from pysnmp.smi.exval import endOfMibView, noSuchInstance, noSuchObject
 from six import iteritems
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.errors import CheckException
 
-from .config import InstanceConfig
+from .config import InstanceConfig, ParsedTableMetric
 
 try:
     from datadog_checks.base.utils.common import total_time_to_temporal_percent
@@ -68,7 +68,7 @@ DEFAULT_OID_BATCH_SIZE = 10
 
 
 def reply_invalid(oid):
-    return noSuchInstance.isSameTypeWith(oid) or noSuchObject.isSameTypeWith(oid)
+    return noSuchInstance.isSameTypeWith(oid) or noSuchObject.isSameTypeWith(oid) or endOfMibView.isSameTypeWith(oid)
 
 
 class SnmpCheck(AgentCheck):
@@ -176,7 +176,7 @@ class SnmpCheck(AgentCheck):
             message = '{} for instance {}'.format(error_indication, ip_address)
             raise CheckException(message)
 
-    def check_table(self, config, table_oids):
+    def fetch_results(self, config, all_oids, bulk_oids):
         """
         Perform a snmpwalk on the domain specified by the oids, on the device
         configured in instance.
@@ -187,30 +187,13 @@ class SnmpCheck(AgentCheck):
         """
         results = defaultdict(dict)
         enforce_constraints = config.enforce_constraints
-        oids = []
-        all_oids = []
-        bulk_oids = []
-        # Use bulk for SNMP version > 1 and there are enough symbols
-        bulk_limit = config.bulk_threshold if config.auth_data.mpModel else 0
-        for table, symbols in table_oids.items():
-            if not symbols:
-                # No table to browse, just one symbol
-                oids.append(table)
-            elif len(symbols) < bulk_limit:
-                all_oids.append(symbols)
-            else:
-                bulk_oids.append(table)
-
-        if oids:
-            all_oids.insert(0, oids)
 
         all_binds = []
         error = None
         for to_fetch in all_oids:
             binds, current_error = self.fetch_oids(config, to_fetch, enforce_constraints=enforce_constraints)
             all_binds.extend(binds)
-            if not error:
-                error = current_error
+            error = current_error if not error else error
 
         for oid in bulk_oids:
             try:
@@ -226,8 +209,7 @@ class SnmpCheck(AgentCheck):
                 )
                 binds, current_error = self._consume_binds_iterator(binds_iterator, config)
                 all_binds.extend(binds)
-                if not error:
-                    error = current_error
+                error = current_error if not error else error
 
             except PySnmpError as e:
                 message = 'Failed to collect some metrics: {}'.format(e)
@@ -236,36 +218,11 @@ class SnmpCheck(AgentCheck):
                 self.warning(message)
 
         for result_oid, value in all_binds:
-            if not enforce_constraints:
-                # if enforce_constraints is false, then MIB resolution has not been done yet
-                # so we need to do it manually. We have to specify the mibs that we will need
-                # to resolve the name.
-                oid_to_resolve = hlapi.ObjectIdentity(result_oid.asTuple())
-                result_oid = oid_to_resolve.resolveWithMib(config.mib_view_controller)
-            _, metric, indexes = result_oid.getMibSymbol()
-            results[metric][indexes] = value
+            metric, index = config.resolve_oid(result_oid)
+            results[metric][index] = value
         self.log.debug('Raw results: %s', results)
         # Freeze the result
         results.default_factory = None
-        return results, error
-
-    def check_raw(self, config, oids):
-        """
-        Perform a snmpwalk on the domain specified by the oids, on the device
-        configured in instance.
-
-        Returns a dictionary:
-        dict[oid/metric_name] = value
-        In case of scalar objects, the row index is just 0
-        """
-        all_binds, error = self.fetch_oids(config, oids, enforce_constraints=False)
-        results = {}
-
-        for result_oid, value in all_binds:
-            oid = result_oid.asTuple()
-            matching = '.'.join(str(i) for i in oid)
-            results[matching] = value
-        self.log.debug('Raw results: %s', results)
         return results, error
 
     def fetch_oids(self, config, oids, enforce_constraints):
@@ -389,12 +346,8 @@ class SnmpCheck(AgentCheck):
         self._thread.start()
 
     def check(self, instance):
-        """
-        Perform two series of SNMP requests, one for all that have MIB associated
-        and should be looked up and one for those specified by oids.
-        """
         config = self._config
-        if self._config.ip_network:
+        if config.ip_network:
             if self._thread is None:
                 self._start_discovery()
             for host, discovered in list(config.discovered_instances.items()):
@@ -408,7 +361,7 @@ class SnmpCheck(AgentCheck):
                 else:
                     # Reset the counter if not's failing
                     config.failing_instances.pop(host, None)
-            tags = ['network:{}'.format(self._config.ip_network)]
+            tags = ['network:{}'.format(config.ip_network)]
             tags.extend(config.tags)
             self.gauge('snmp.discovered_devices_count', len(config.discovered_instances), tags=tags)
         else:
@@ -417,22 +370,17 @@ class SnmpCheck(AgentCheck):
     def _check_with_config(self, config):
         # Reset errors
         instance = config.instance
-        error = table_results = raw_results = None
+        error = results = None
         try:
-            if not (config.table_oids or config.raw_oids):
+            if not (config.all_oids or config.bulk_oids):
                 sys_object_oid = self.fetch_sysobject_oid(config)
                 profile = self._profile_for_sysobject_oid(sys_object_oid)
                 config.refresh_with_profile(self.profiles[profile], self.warning, self.log)
 
-            if config.table_oids:
-                self.log.debug('Querying device %s for %s oids', config.ip_address, len(config.table_oids))
-                table_results, error = self.check_table(config, config.table_oids)
-                self.report_table_metrics(config.metrics, table_results, config.tags)
-
-            if config.raw_oids:
-                self.log.debug('Querying device %s for %s oids', config.ip_address, len(config.raw_oids))
-                raw_results, error = self.check_raw(config, config.raw_oids)
-                self.report_raw_metrics(config.metrics, raw_results, config.tags)
+            if config.all_oids or config.bulk_oids:
+                self.log.debug('Querying device %s', config.ip_address)
+                results, error = self.fetch_results(config, config.all_oids, config.bulk_oids)
+                self.report_metrics(config.parsed_metrics, results, config.tags)
         except CheckException as e:
             error = str(e)
             self.warning(error)
@@ -447,84 +395,37 @@ class SnmpCheck(AgentCheck):
             status = self.OK
             if error:
                 status = self.CRITICAL
-                if raw_results or table_results:
+                if results:
                     status = self.WARNING
             self.service_check(self.SC_STATUS, status, tags=sc_tags, message=error)
         return error
 
-    def report_raw_metrics(self, metrics, results, tags):
+    def report_metrics(self, metrics, results, tags):
         """
-        For all the metrics that are specified as oid,
-        the conf oid is going to exactly match or be a prefix of the oid sent back by the device
-        Use the instance configuration to find the name to give to the metric
+        For each of the metrics specified gather the tags requested in the
+        instance conf for each row.
 
         Submit the results to the aggregator.
         """
         for metric in metrics:
-            if 'OID' in metric:
-                forced_type = metric.get('forced_type')
-                queried_oid = metric['OID'].lstrip('.')
-                if queried_oid in results:
-                    value = results[queried_oid]
-                else:
-                    for oid in results:
-                        if oid.startswith(queried_oid):
-                            value = results[oid]
-                            break
-                    else:
-                        self.log.warning('No matching results found for oid %s', queried_oid)
-                        continue
-                name = metric.get('name', 'unnamed_metric')
-                metric_tags = tags
-                if metric.get('metric_tags'):
-                    metric_tags = metric_tags + metric.get('metric_tags')
-                self.submit_metric(name, value, forced_type, metric_tags)
-
-    def report_table_metrics(self, metrics, results, tags):
-        """
-        For each of the metrics specified as needing to be resolved with mib,
-        gather the tags requested in the instance conf for each row.
-
-        Submit the results to the aggregator.
-        """
-        for metric in metrics:
-            forced_type = metric.get('forced_type')
-            if 'table' in metric:
-                index_based_tags = []
-                column_based_tags = []
-                for metric_tag in metric.get('metric_tags', []):
-                    tag_key = metric_tag['tag']
-                    if 'index' in metric_tag:
-                        index_based_tags.append((tag_key, metric_tag.get('index')))
-                    elif 'column' in metric_tag:
-                        column_based_tags.append((tag_key, metric_tag.get('column')))
-                    else:
-                        self.log.warning('No indication on what value to use for this tag')
-
-                for value_to_collect in metric.get('symbols', []):
-                    if value_to_collect not in results:
-                        self.log.debug('Ignoring metric %s from table %s', value_to_collect, metric['table'])
-                        continue
-                    for index, val in iteritems(results[value_to_collect]):
-                        metric_tags = tags + self.get_index_tags(index, results, index_based_tags, column_based_tags)
-                        self.submit_metric(value_to_collect, val, forced_type, metric_tags)
-
-            elif 'symbol' in metric:
-                name = metric['symbol']
-                if name not in results:
-                    self.log.debug('Ignoring metric %s', name)
-                    continue
+            name = metric.name
+            if name not in results:
+                self.log.debug('Ignoring metric %s', name)
+                continue
+            if isinstance(metric, ParsedTableMetric):
+                for index, val in iteritems(results[name]):
+                    metric_tags = tags + self.get_index_tags(index, results, metric.index_tags, metric.column_tags)
+                    self.submit_metric(name, val, metric.forced_type, metric_tags)
+            else:
                 result = list(results[name].items())
                 if len(result) > 1:
                     self.log.warning('Several rows corresponding while the metric is supposed to be a scalar')
-                    continue
+                    if metric.enforce_scalar:
+                        # For backward compatibility reason, we publish the first value for OID.
+                        continue
                 val = result[0][1]
-                metric_tags = tags + metric.get('metric_tags', [])
-                self.submit_metric(name, val, forced_type, metric_tags)
-            elif 'OID' in metric:
-                pass  # This one is already handled by the other batch of requests
-            else:
-                raise ConfigurationError('Unsupported metric in config file: {}'.format(metric))
+                metric_tags = tags + metric.metric_tags
+                self.submit_metric(name, val, metric.forced_type, metric_tags)
 
     def get_index_tags(self, index, results, index_tags, column_tags):
         """
@@ -542,7 +443,7 @@ class SnmpCheck(AgentCheck):
         for idx_tag in index_tags:
             tag_group = idx_tag[0]
             try:
-                tag_value = index[idx_tag[1] - 1].prettyPrint()
+                tag_value = index[idx_tag[1] - 1]
             except IndexError:
                 self.log.warning('Not enough indexes, skipping this tag')
                 continue
@@ -561,12 +462,11 @@ class SnmpCheck(AgentCheck):
             tags.append('{}:{}'.format(tag_group, tag_value))
         return tags
 
-    def submit_metric(self, name, snmp_value, forced_type, tags=None):
+    def submit_metric(self, name, snmp_value, forced_type, tags):
         """
         Convert the values reported as pysnmp-Managed Objects to values and
         report them to the aggregator.
         """
-        tags = [] if tags is None else tags
         if reply_invalid(snmp_value):
             # Metrics not present in the queried object
             self.log.warning('No such Mib available: %s', name)
@@ -575,16 +475,17 @@ class SnmpCheck(AgentCheck):
         metric_name = self.normalize(name, prefix='snmp')
 
         if forced_type:
-            if forced_type.lower() == 'gauge':
+            forced_type = forced_type.lower()
+            if forced_type == 'gauge':
                 value = int(snmp_value)
                 self.gauge(metric_name, value, tags)
-            elif forced_type.lower() == 'percent':
+            elif forced_type == 'percent':
                 value = total_time_to_temporal_percent(int(snmp_value), scale=1)
                 self.rate(metric_name, value, tags)
-            elif forced_type.lower() == 'counter':
+            elif forced_type == 'counter':
                 value = int(snmp_value)
                 self.rate(metric_name, value, tags)
-            elif forced_type.lower() == 'monotonic_count':
+            elif forced_type == 'monotonic_count':
                 value = int(snmp_value)
                 self.monotonic_count(metric_name, value, tags)
             else:

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -153,6 +153,21 @@ PLAY_WITH_GET_NEXT_METRICS = [
     {"OID": "1.3.6.1.2.1.4.31.3.1.3.2.1", "name": "noFallbackAndSameResult"},
 ]
 
+RESOLVED_TABULAR_OBJECTS = [
+    {
+        "MIB": "IF-MIB",
+        "table": "ifTable",
+        "symbols": [
+            {"name": "ifInOctets", "OID": "1.3.6.1.2.1.2.2.1.10"},
+            {"name": "ifOutOctets", "OID": "1.3.6.1.2.1.2.2.1.16"},
+        ],
+        "metric_tags": [
+            {"tag": "interface", "column": {"name": "ifDescr", "OID": "1.3.6.1.2.1.2.2.1.2"}},
+            {"tag": "dumbindex", "index": 1, "mapping": {1: "one", 2: "two", 3: "three", 90: "other"}},
+        ],
+    }
+]
+
 
 def generate_instance_config(metrics, template=None):
     template = template if template else SNMP_CONF

--- a/snmp/tests/test_bench.py
+++ b/snmp/tests/test_bench.py
@@ -26,6 +26,7 @@ def test_tabular_no_enforce(benchmark):
 
 def test_tabular_bulk(benchmark):
     instance = generate_instance_config(BULK_TABULAR_OBJECTS)
+    instance['bulk_threshold'] = 5
     check = create_check(instance)
 
     benchmark(check.check, instance)

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -217,6 +217,26 @@ def test_table(aggregator):
     aggregator.all_metrics_asserted()
 
 
+def test_resolved_table(aggregator):
+    instance = common.generate_instance_config(common.RESOLVED_TABULAR_OBJECTS)
+    check = common.create_check(instance)
+
+    check.check(instance)
+
+    for symbol in common.TABULAR_OBJECTS[0]['symbols']:
+        metric_name = "snmp." + symbol
+        aggregator.assert_metric(metric_name, at_least=1)
+        aggregator.assert_metric_has_tag(metric_name, common.CHECK_TAGS[0], at_least=1)
+
+        for mtag in common.TABULAR_OBJECTS[0]['metric_tags']:
+            tag = mtag['tag']
+            aggregator.assert_metric_has_tag_prefix(metric_name, tag, at_least=1)
+
+    aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
+
+    aggregator.all_metrics_asserted()
+
+
 def test_table_v3_MD5_DES(aggregator):
     """
     Support SNMP V3 priv modes: MD5 + DES

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -11,7 +11,8 @@ import pytest
 from datadog_checks.base import ConfigurationError
 from datadog_checks.dev import temp_dir
 from datadog_checks.snmp import SnmpCheck
-from datadog_checks.snmp.config import InstanceConfig, OIDTrie
+from datadog_checks.snmp.config import InstanceConfig
+from datadog_checks.snmp.resolver import OIDTrie
 
 from . import common
 

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -11,7 +11,7 @@ import pytest
 from datadog_checks.base import ConfigurationError
 from datadog_checks.dev import temp_dir
 from datadog_checks.snmp import SnmpCheck
-from datadog_checks.snmp.config import InstanceConfig
+from datadog_checks.snmp.config import InstanceConfig, OIDTrie
 
 from . import common
 
@@ -25,7 +25,7 @@ def test_parse_metrics(hlapi_mock):
     # Unsupported metric
     metrics = [{"foo": "bar"}]
     config = InstanceConfig(
-        {"ip_address": "127.0.0.1", "community_string": "public", "metrics": [{"OID": "1.2.3"}]},
+        {"ip_address": "127.0.0.1", "community_string": "public", "metrics": [{"OID": "1.2.3", "name": "foo"}]},
         check.warning,
         check.log,
         [],
@@ -38,10 +38,9 @@ def test_parse_metrics(hlapi_mock):
         config.parse_metrics(metrics, check.warning, check.log)
 
     # Simple OID
-    metrics = [{"OID": "1.2.3"}]
-    table, raw = config.parse_metrics(metrics, check.warning, check.log)
-    assert table == {}
-    assert len(raw) == 1
+    metrics = [{"OID": "1.2.3", "name": "foo"}]
+    table, _, _ = config.parse_metrics(metrics, check.warning, check.log)
+    assert len(table) == 1
     hlapi_mock.ObjectIdentity.assert_called_once_with("1.2.3")
     hlapi_mock.reset_mock()
 
@@ -52,8 +51,7 @@ def test_parse_metrics(hlapi_mock):
 
     # MIB with symbol
     metrics = [{"MIB": "foo_mib", "symbol": "foo"}]
-    table, raw = config.parse_metrics(metrics, check.warning, check.log)
-    assert raw == []
+    table, _, _ = config.parse_metrics(metrics, check.warning, check.log)
     assert len(table) == 1
     hlapi_mock.ObjectIdentity.assert_called_once_with("foo_mib", "foo")
     hlapi_mock.reset_mock()
@@ -65,10 +63,9 @@ def test_parse_metrics(hlapi_mock):
 
     # MIB with table and symbols
     metrics = [{"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"]}]
-    table, raw = config.parse_metrics(metrics, check.warning, check.log)
-    assert raw == []
+    table, _, _ = config.parse_metrics(metrics, check.warning, check.log)
     assert len(table) == 1
-    assert len(list(table.values())[0]) == 2
+    assert len(table[0]) == 2
     hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "foo")
     hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "bar")
     hlapi_mock.reset_mock()
@@ -83,14 +80,21 @@ def test_parse_metrics(hlapi_mock):
     with pytest.raises(Exception):
         config.parse_metrics(metrics, check.warning, check.log)
 
+    # Table with manual OID
+    metrics = [{"MIB": "foo_mib", "table": "foo", "symbols": [{"OID": "1.2.3", "name": "foo"}]}]
+    table, _, _ = config.parse_metrics(metrics, check.warning, check.log)
+    assert len(table) == 1
+    assert len(table[0]) == 1
+    hlapi_mock.ObjectIdentity.assert_any_call("1.2.3")
+    hlapi_mock.reset_mock()
+
     # MIB with table, symbols, metrics_tags index
     metrics = [
         {"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{"tag": "foo", "index": "1"}]}
     ]
-    table, raw = config.parse_metrics(metrics, check.warning, check.log)
-    assert raw == []
+    table, _, _ = config.parse_metrics(metrics, check.warning, check.log)
     assert len(table) == 1
-    assert len(list(table.values())[0]) == 2
+    assert len(table[0]) == 2
     hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "foo")
     hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "bar")
     hlapi_mock.reset_mock()
@@ -99,13 +103,29 @@ def test_parse_metrics(hlapi_mock):
     metrics = [
         {"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{"tag": "foo", "column": "baz"}]}
     ]
-    table, raw = config.parse_metrics(metrics, check.warning, check.log)
-    assert raw == []
+    table, _, _ = config.parse_metrics(metrics, check.warning, check.log)
     assert len(table) == 1
-    assert len(list(table.values())[0]) == 3
+    assert len(table[0]) == 3
     hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "foo")
     hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "bar")
     hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "baz")
+    hlapi_mock.reset_mock()
+
+    # MIB with table, symbols, metrics_tags column with OID
+    metrics = [
+        {
+            "MIB": "foo_mib",
+            "table": "foo",
+            "symbols": ["foo", "bar"],
+            "metric_tags": [{"tag": "foo", "column": {"name": "baz", "OID": "1.5.6"}}],
+        }
+    ]
+    table, _, _ = config.parse_metrics(metrics, check.warning, check.log)
+    assert len(table) == 1
+    assert len(table[0]) == 3
+    hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "foo")
+    hlapi_mock.ObjectIdentity.assert_any_call("foo_mib", "bar")
+    hlapi_mock.ObjectIdentity.assert_any_call("1.5.6")
     hlapi_mock.reset_mock()
 
 
@@ -228,3 +248,14 @@ def test_cache_building(write_mock, read_mock):
         check._running = False
 
     write_mock.assert_called_once_with('', '["192.168.0.1"]')
+
+
+def test_trie():
+    trie = OIDTrie()
+    trie.set((1, 2), 'bar')
+    trie.set((1, 2, 3), 'foo')
+    assert trie.match((1,)) == ((1,), None)
+    assert trie.match((1, 2)) == ((1, 2), 'bar')
+    assert trie.match((1, 2, 3)) == ((1, 2, 3), 'foo')
+    assert trie.match((1, 2, 3, 4)) == ((1, 2, 3), 'foo')
+    assert trie.match((2, 3, 4)) == ((), None)


### PR DESCRIPTION
This adds support for browsing and tagging table with just OIDs. This
allow creating profiles with just numerical values, not requiring to
parse MIBs.

It also disables bulk by default, as we're not seeing the expected
performance gains.