### PR TITLE
Don't provide a CLI entry point

### DIFF
--- a/datadog_checks_downloader/README.md
+++ b/datadog_checks_downloader/README.md
@@ -35,13 +35,13 @@ To download a new or updated integration, you may specify a precise
 [version][7]:
 
 ```shell
-datadog-checks-downloader -vvvv datadog-$INTEGRATION --version X.Y.Z
+python -m datadog_checks.downloader -vvvv datadog-$INTEGRATION --version X.Y.Z
 ```
 
 Or you may leave the version unspecified to download the latest version:
 
 ```shell
-datadog-checks-downloader -vvvv datadog-$INTEGRATION
+python -m datadog_checks.downloader -vvvv datadog-$INTEGRATION
 ```
 
 To run the tests, [install tox][8] and just run:

--- a/datadog_checks_downloader/setup.py
+++ b/datadog_checks_downloader/setup.py
@@ -58,5 +58,4 @@ setup(
         ]
     },
     include_package_data=True,
-    entry_points={'console_scripts': ['datadog-checks-downloader=datadog_checks.downloader.cli:download']},
 )

--- a/datadog_checks_downloader/tests/test_downloader.py
+++ b/datadog_checks_downloader/tests/test_downloader.py
@@ -55,7 +55,7 @@ def download(package):
     # -vvv:   WARNING
     # -vvvv:  INFO
     # -vvvvv: DEBUG
-    cmd = ['datadog-checks-downloader', '-vvvv', package]
+    cmd = ['python', '-m', 'datadog_checks.downloader', '-vvvv', package]
     out = subprocess.check_output(cmd)
     log.debug(' '.join(cmd))
     log.debug(out)


### PR DESCRIPTION
### Motivation

We don't use it:

https://github.com/DataDog/integrations-core/pull/3108
https://github.com/DataDog/datadog-agent/blob/168d24d33cc77fe60270da374adb66e4bc46f046/cmd/agent/app/integrations.go#L448-L458