### PR TITLE
Ensure logs are lazily formatted

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -889,7 +889,7 @@ class OpenMetricsScraperMixin(object):
             for index, sample in enumerate(metric.samples):
                 val = sample[self.SAMPLE_VALUE]
                 if not self._is_value_valid(val):
-                    self.log.debug("Metric value is not supported for metric {}".format(sample[self.SAMPLE_NAME]))
+                    self.log.debug("Metric value is not supported for metric %s", sample[self.SAMPLE_NAME])
                     continue
                 if sample[self.SAMPLE_NAME].endswith("_sum"):
                     lst = list(sample)
@@ -912,7 +912,7 @@ class OpenMetricsScraperMixin(object):
             for index, sample in enumerate(metric.samples):
                 val = sample[self.SAMPLE_VALUE]
                 if not self._is_value_valid(val):
-                    self.log.debug("Metric value is not supported for metric {}".format(sample[self.SAMPLE_NAME]))
+                    self.log.debug("Metric value is not supported for metric %s", sample[self.SAMPLE_NAME])
                     continue
                 if sample[self.SAMPLE_NAME].endswith("_count"):
                     continue

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
@@ -62,11 +62,12 @@ class WinWMICheck(AgentCheck):
             )
             raise
         except TypeError:
+            wmi_property = tag_query[0]
+            wmi_class = sampler.class_name
             self.log.error(
-                u"Incorrect 'link source property' in `tag_queries` parameter:"
-                " `{wmi_property}` is not a property of `{wmi_class}`".format(
-                    wmi_property=tag_query[0], wmi_class=sampler.class_name
-                )
+                u"Incorrect 'link source property' in `tag_queries` parameter: `%s` is not a property of `%s`",
+                wmi_property,
+                wmi_class,
             )
             raise
 
@@ -84,16 +85,20 @@ class WinWMICheck(AgentCheck):
                 message = "multiple results returned (one expected)"
 
             self.log.warning(
-                u"Failed to extract a tag from `tag_queries` parameter: {reason}."
-                " wmi_object={wmi_obj} - query={tag_query}".format(reason=message, wmi_obj=wmi_obj, tag_query=tag_query)
+                u"Failed to extract a tag from `tag_queries` parameter: %s. wmi_object=%s - query=%s",
+                message,
+                wmi_obj,
+                tag_query,
             )
             raise TagQueryUniquenessFailure
 
         if sampler[0][target_property] is None:
+            wmi_property = target_property
+            wmi_class = target_class
             self.log.error(
-                u"Incorrect 'target property' in `tag_queries` parameter:"
-                " `{wmi_property}` is empty or is not a property"
-                "of `{wmi_class}`".format(wmi_property=target_property, wmi_class=target_class)
+                u"Incorrect 'target property' in `tag_queries` parameter: `%s` is empty or is not a property of `%s`",
+                wmi_property,
+                wmi_class,
             )
             raise TypeError
 
@@ -104,8 +109,9 @@ class WinWMICheck(AgentCheck):
         Returns: tag or TagQueryUniquenessFailure exception.
         """
         self.log.debug(
-            u"`tag_queries` parameter found."
-            " wmi_object={wmi_obj} - query={tag_query}".format(wmi_obj=wmi_obj, tag_query=tag_query)
+            u"`tag_queries` parameter found. wmi_object=%s - query=%s",
+            wmi_obj,
+            tag_query,
         )
 
         # Extract query information
@@ -123,7 +129,7 @@ class WinWMICheck(AgentCheck):
 
         tag = "{tag_name}:{tag_value}".format(tag_name=target_property.lower(), tag_value="_".join(link_value.split()))
 
-        self.log.debug(u"Extracted `tag_queries` tag: '{tag}'".format(tag=tag))
+        self.log.debug(u"Extracted `tag_queries` tag: '%s'", tag)
         return tag
 
     def _extract_metrics(self, wmi_sampler, tag_by, tag_queries, constant_tags):
@@ -185,13 +191,14 @@ class WinWMICheck(AgentCheck):
                     metrics.append(WMIMetric(wmi_property, float(wmi_value), tags))
                 except ValueError:
                     self.log.warning(
-                        u"When extracting metrics with WMI, found a non digit value"
-                        " for property '{0}'.".format(wmi_property)
+                        u"When extracting metrics with WMI, found a non digit value for property '%s'.",
+                        wmi_property,
                     )
                     continue
                 except TypeError:
                     self.log.warning(
-                        u"When extracting metrics with WMI, found a missing property" " '{0}'".format(wmi_property)
+                        u"When extracting metrics with WMI, found a missing property '%s'",
+                        wmi_property,
                     )
                     continue
         return metrics

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
@@ -109,9 +109,7 @@ class WinWMICheck(AgentCheck):
         Returns: tag or TagQueryUniquenessFailure exception.
         """
         self.log.debug(
-            u"`tag_queries` parameter found. wmi_object=%s - query=%s",
-            wmi_obj,
-            tag_query,
+            u"`tag_queries` parameter found. wmi_object=%s - query=%s", wmi_obj, tag_query,
         )
 
         # Extract query information
@@ -191,14 +189,12 @@ class WinWMICheck(AgentCheck):
                     metrics.append(WMIMetric(wmi_property, float(wmi_value), tags))
                 except ValueError:
                     self.log.warning(
-                        u"When extracting metrics with WMI, found a non digit value for property '%s'.",
-                        wmi_property,
+                        u"When extracting metrics with WMI, found a non digit value for property '%s'.", wmi_property,
                     )
                     continue
                 except TypeError:
                     self.log.warning(
-                        u"When extracting metrics with WMI, found a missing property '%s'",
-                        wmi_property,
+                        u"When extracting metrics with WMI, found a missing property '%s'", wmi_property,
                     )
                     continue
         return metrics

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
@@ -93,12 +93,10 @@ class WinWMICheck(AgentCheck):
             raise TagQueryUniquenessFailure
 
         if sampler[0][target_property] is None:
-            wmi_property = target_property
-            wmi_class = target_class
             self.log.error(
                 u"Incorrect 'target property' in `tag_queries` parameter: `%s` is empty or is not a property of `%s`",
-                wmi_property,
-                wmi_class,
+                target_property,
+                target_class,
             )
             raise TypeError
 

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -154,7 +154,7 @@ class WMISampler(object):
         try:
             pythoncom.CoInitialize()
         except Exception as e:
-            self.logger.info("exception in CoInitialize {}".format(e))
+            self.logger.info("exception in CoInitialize: %s", e)
             raise
 
         while True:
@@ -298,8 +298,7 @@ class WMISampler(object):
             calculator = get_calculator(counter_type)
         except UndefinedCalculator:
             self.logger.warning(
-                u"Undefined WMI calculator for counter_type {counter_type}."
-                " Values are reported as RAW.".format(counter_type=counter_type)
+                u"Undefined WMI calculator for counter_type %s. Values are reported as RAW.", counter_type,
             )
 
         return calculator
@@ -329,10 +328,11 @@ class WMISampler(object):
         Create a new WMI connection
         """
         self.logger.debug(
-            u"Connecting to WMI server "
-            u"(host={host}, namespace={namespace}, provider={provider}, username={username}).".format(
-                host=self.host, namespace=self.namespace, provider=self.provider, username=self.username
-            )
+            u"Connecting to WMI server (host=%s, namespace=%s, provider=%s, username=%s).",
+            self.host,
+            self.namespace,
+            self.provider,
+            self.username,
         )
 
         # Initialize COM for the current thread
@@ -444,7 +444,7 @@ class WMISampler(object):
         wql = "Select {property_names} from {class_name}{filters}".format(
             property_names=formated_property_names, class_name=self.class_name, filters=self.formatted_filters
         )
-        self.logger.debug(u"Querying WMI: {0}".format(wql))
+        self.logger.debug(u"Querying WMI: %s", wql)
 
         try:
             # From: https://msdn.microsoft.com/en-us/library/aa393866(v=vs.85).aspx
@@ -519,16 +519,14 @@ class WMISampler(object):
                         self._property_counter_types[wmi_property.Name] = counter_type
 
                         self.logger.debug(
-                            u"Caching property qualifier CounterType: "
-                            "{class_name}.{property_names} = {counter_type}".format(
-                                class_name=self.class_name, property_names=wmi_property.Name, counter_type=counter_type
-                            )
+                            u"Caching property qualifier CounterType: %s.%s = %s",
+                            self.class_name,
+                            wmi_property.Name,
+                            counter_type,
                         )
                     else:
                         self.logger.debug(
-                            u"CounterType qualifier not found for {class_name}.{property_names}".format(
-                                class_name=self.class_name, property_names=wmi_property.Name
-                            )
+                            u"CounterType qualifier not found for %s.%s", self.class_name, wmi_property.Name,
                         )
 
                 try:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Review `datadog_checks_base` to switch eager `.format()`-style formatting of log messages to lazy `%s`-style formatting.

### Motivation
<!-- What inspired you to submit this pull request? -->
Ongoing effort across all integrations, + exercise working on `datadog_checks_base`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Entries to fix were found by searching for the following terms:

- `log.`
- `logger.`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
