### PR TITLE
Add log filesystem container metric

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -84,6 +84,7 @@ DEPRECATED_GAUGES = {
 NEW_1_14_GAUGES = {
     'kubelet_runtime_operations_total': 'kubelet.runtime.operations',
     'kubelet_runtime_operations_errors_total': 'kubelet.runtime.errors',
+    'kubelet_container_log_filesystem_used_bytes': 'kubelet.container.log_filesystem.used_bytes',
 }
 
 DEFAULT_HISTOGRAMS = {

--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -61,3 +61,4 @@ kubernetes.kubelet.cpu.usage,gauge,,nanocore,,The number of cores used by kubele
 kubernetes.kubelet.memory.rss,gauge,,byte,,Size of kubelet RSS in bytes,-1,kubelet,k8s.kubelet.mem.rss
 kubernetes.runtime.cpu.usage,gauge,,nanocore,,The number of cores used by the runtime,-1,kubelet,k8s.runtime.cpu
 kubernetes.runtime.memory.rss,gauge,,byte,,Size of runtime RSS in bytes,-1,kubelet,k8s.runtime.mem.rss
+kubernetes.kubelet.container.log_filesystem.used_bytes,gauge,,byte,,Bytes used by the container's logs on the filesystem (requires kubernetes 1.14+),0,kubelet,k8s.kubelet.container.log_filesystem

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -98,6 +98,10 @@ EXPECTED_METRICS_PROMETHEUS = [
     'kubernetes.kubelet.evictions',
 ]
 
+EXPECTED_METRICS_PROMETHEUS_1_14 = EXPECTED_METRICS_PROMETHEUS + [
+    'kubernetes.kubelet.container.log_filesystem.used_bytes'
+]
+
 EXPECTED_METRICS_PROMETHEUS_PRE_1_14 = EXPECTED_METRICS_PROMETHEUS + [
     'kubernetes.kubelet.network_plugin.latency.quantile'
 ]
@@ -327,9 +331,11 @@ def _test_kubelet_check_prometheus(monkeypatch, aggregator, tagger, kube_version
             for tag in instance_tags:
                 aggregator.assert_metric_has_tag(metric, tag)
 
-    prom_metrics = EXPECTED_METRICS_PROMETHEUS
     if kube_version == KUBE_PRE_1_14:
         prom_metrics = EXPECTED_METRICS_PROMETHEUS_PRE_1_14
+
+    if kube_version == KUBE_1_14:
+        prom_metrics = EXPECTED_METRICS_PROMETHEUS_1_14
 
     for metric in prom_metrics:
         aggregator.assert_metric(metric)


### PR DESCRIPTION
### What does this PR do?

collect `kubernetes.kubelet.container.log_filesystem.used_bytes` available in k8s 1.14+

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
