### PR TITLE
Add debug option to base ddev command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
@@ -8,7 +8,7 @@ import click
 from ..compat import PermissionError
 from ..utils import dir_exists
 from .commands import ALL_COMMANDS
-from .commands.console import CONTEXT_SETTINGS, echo_success, echo_waiting, echo_warning, set_color
+from .commands.console import CONTEXT_SETTINGS, echo_success, echo_waiting, echo_warning, set_color, set_debug
 from .config import CONFIG_FILE, config_file_exists, load_config, restore_config
 from .constants import set_root
 
@@ -20,9 +20,10 @@ from .constants import set_root
 @click.option('--here', '-x', is_flag=True, help='Work on the current location.')
 @click.option('--color/--no-color', default=None, help='Whether or not to display colored output (default true).')
 @click.option('--quiet', '-q', is_flag=True)
+@click.option('--debug', '-d', is_flag=True)
 @click.version_option()
 @click.pass_context
-def ddev(ctx, core, extras, agent, here, color, quiet):
+def ddev(ctx, core, extras, agent, here, color, quiet, debug):
     if not quiet and not config_file_exists():
         echo_waiting('No config file found, creating one with default settings now...')
 
@@ -56,6 +57,9 @@ def ddev(ctx, core, extras, agent, here, color, quiet):
 
     set_root(root)
     set_color(config['color'])
+
+    if debug:
+        set_debug()
 
     if not ctx.invoked_subcommand:
         click.echo(ctx.get_help())

--- a/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
@@ -58,7 +58,7 @@ def ddev(ctx, core, extras, agent, here, color, quiet, debug):
     set_root(root)
     set_color(config['color'])
 
-    if debug:
+    if debug and not quiet:
         set_debug()
 
     if not ctx.invoked_subcommand:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/console.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/console.py
@@ -20,11 +20,17 @@ CONTEXT_SETTINGS = {'help_option_names': ['-h', '--help']}
 UNKNOWN_OPTIONS = {'help_option_names': [], 'ignore_unknown_options': True}
 DEFAULT_INDENT = '    '
 DISPLAY_COLOR = None
+DEBUG_OUTPUT = False
 
 
 def set_color(color_choice):
     global DISPLAY_COLOR
     DISPLAY_COLOR = color_choice
+
+
+def set_debug():
+    global DEBUG_OUTPUT
+    DEBUG_OUTPUT = True
 
 
 def indent_text(text, indent):
@@ -59,6 +65,16 @@ def echo_waiting(text, nl=True, err=False, indent=None):
     if indent:
         text = indent_text(text, indent)
     click.secho(text, fg='magenta', bold=True, nl=nl, err=err, color=DISPLAY_COLOR)
+
+
+def echo_debug(text, nl=True, cr=False, err=False, indent=None):
+    if DEBUG_OUTPUT:
+        text = 'DEBUG: %s' % text
+        if indent:
+            text = indent_text(text, indent)
+        if cr:
+            text = '\n%s' % text
+        click.secho(text, bold=True, nl=nl, err=err, color=DISPLAY_COLOR)
 
 
 def abort(text=None, code=1, out=False):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/console.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/console.py
@@ -68,13 +68,15 @@ def echo_waiting(text, nl=True, err=False, indent=None):
 
 
 def echo_debug(text, nl=True, cr=False, err=False, indent=None):
-    if DEBUG_OUTPUT:
-        text = 'DEBUG: %s' % text
-        if indent:
-            text = indent_text(text, indent)
-        if cr:
-            text = '\n%s' % text
-        click.secho(text, bold=True, nl=nl, err=err, color=DISPLAY_COLOR)
+    if not DEBUG_OUTPUT:
+        return
+
+    text = 'DEBUG: %s' % text
+    if indent:
+        text = indent_text(text, indent)
+    if cr:
+        text = '\n%s' % text
+    click.secho(text, bold=True, nl=nl, err=err, color=DISPLAY_COLOR)
 
 
 def abort(text=None, code=1, out=False):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
@@ -7,7 +7,7 @@ from .... import EnvVars
 from ...e2e import create_interface, get_configured_envs
 from ...e2e.agent import DEFAULT_PYTHON_VERSION
 from ...testing import get_tox_envs
-from ..console import CONTEXT_SETTINGS, echo_info, echo_warning
+from ..console import CONTEXT_SETTINGS, DEBUG_OUTPUT, echo_info, echo_warning
 from ..test import test as test_command
 from .start import start
 from .stop import stop
@@ -98,6 +98,7 @@ def test(ctx, checks, agent, python, dev, base, env_vars, new_env, profile_memor
                     ctx.invoke(
                         test_command,
                         checks=['{}:{}'.format(check, env)],
+                        debug=DEBUG_OUTPUT,
                         e2e=True,
                         passenv=' '.join(persisted_env_vars) if persisted_env_vars else None,
                         junit=junit,

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/run.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/run.py
@@ -4,8 +4,25 @@
 from ..._env import E2E_ENV_VAR_PREFIX, E2E_SET_UP, E2E_TEAR_DOWN
 from ...subprocess import run_command
 from ...utils import chdir, get_ci_env_vars, path_join
+from ..commands.console import echo_debug
 from ..constants import get_root
 from .format import parse_config_from_result
+
+
+def _execute(check, command, env_vars):
+    if E2E_TEAR_DOWN in env_vars:
+        operation = 'starting'
+    else:
+        operation = 'stopping'
+
+    with chdir(path_join(get_root(), check), env_vars=env_vars):
+        echo_debug('%s env with env_vars: %s' % (operation, env_vars), cr=True, indent=True)
+        echo_debug('%s env with command: %s' % (operation, command), indent=True)
+        result = run_command(command, capture=True)
+        echo_debug('command result stdout: %s' % result.stdout, indent=True)
+        echo_debug('command result stderr: %s' % result.stderr, indent=True)
+
+    return result
 
 
 def start_environment(check, env):
@@ -16,9 +33,7 @@ def start_environment(check, env):
         'TOX_TESTENV_PASSENV': '{} USERNAME PYTEST_ADDOPTS {}'.format(E2E_TEAR_DOWN, ' '.join(get_ci_env_vars())),
     }
 
-    with chdir(path_join(get_root(), check), env_vars=env_vars):
-        result = run_command(command, capture=True)
-
+    result = _execute(check, command, env_vars)
     return parse_config_from_result(env, result)
 
 
@@ -33,7 +48,5 @@ def stop_environment(check, env, metadata=None):
     }
     env_vars.update((metadata or {}).get('env_vars', {}))
 
-    with chdir(path_join(get_root(), check), env_vars=env_vars):
-        result = run_command(command, capture=True)
-
+    result = _execute(check, command, env_vars)
     return parse_config_from_result(env, result)


### PR DESCRIPTION
### What does this PR do?
Adds optional debug output option, and instruments the env start/stop operations to better see the specific commands and variables that are used to create the check environment.

### Motivation
When hacking on a container, it's helpful to see how it was brought up to be able to mimic it manually.

### Additional Notes
None - but open to comments/suggestions!

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
