### PR TITLE
Noqa except-clause for IOError/OSError

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
@@ -29,7 +29,7 @@ def ddev(ctx, core, extras, agent, here, color, quiet):
         try:
             restore_config()
             echo_success('Success! Please see `ddev config`.')
-        except (IOError, OSError, PermissionError):
+        except (IOError, OSError, PermissionError):  # noqa: B014
             echo_warning(
                 'Unable to create config file located at `{}`. ' 'Please check your permissions.'.format(CONFIG_FILE)
             )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
@@ -29,6 +29,8 @@ def ddev(ctx, core, extras, agent, here, color, quiet):
         try:
             restore_config()
             echo_success('Success! Please see `ddev config`.')
+        # TODO: Remove IOError (and noqa: B014) when Python 2 is removed
+        # In Python 3, IOError have been merged into OSError
         except (IOError, OSError, PermissionError):  # noqa: B014
             echo_warning(
                 'Unable to create config file located at `{}`. ' 'Please check your permissions.'.format(CONFIG_FILE)

--- a/datadog_checks_dev/datadog_checks/dev/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/utils.py
@@ -169,10 +169,10 @@ def copy_dir_contents(path, d):
 def remove_path(path):
     try:
         shutil.rmtree(path, ignore_errors=False)
-    except (FileNotFoundError, OSError):
+    except (FileNotFoundError, OSError):  # noqa: B014
         try:
             os.remove(path)
-        except (FileNotFoundError, OSError, PermissionError):
+        except (FileNotFoundError, OSError, PermissionError):  # noqa: B014
             pass
 
 

--- a/datadog_checks_dev/datadog_checks/dev/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/utils.py
@@ -169,9 +169,13 @@ def copy_dir_contents(path, d):
 def remove_path(path):
     try:
         shutil.rmtree(path, ignore_errors=False)
+    # TODO: Remove FileNotFoundError (and noqa: B014) when Python 2 is removed
+    # In Python 3, IOError have been merged into OSError
     except (FileNotFoundError, OSError):  # noqa: B014
         try:
             os.remove(path)
+        # TODO: Remove FileNotFoundError (and noqa: B014) when Python 2 is removed
+        # In Python 3, IOError have been merged into OSError
         except (FileNotFoundError, OSError, PermissionError):  # noqa: B014
             pass
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This new rule have been added to bugbear (https://github.com/PyCQA/flake8-bugbear/pull/105):

```
**B014**: Redundant exception types in `except (Exception, TypeError):`.
Write `except Exception:`, which catches exactly the same exceptions.
```

And it's raising a lint error when both `IOError` and `OSError` are used in except clause.

That's because in Python 3:

> Changed in version 3.3: EnvironmentError, IOError, WindowsError, socket.error, select.error and mmap.error have been merged into OSError, and the constructor may return a subclass.

But in Python 2 `IOError` and `OSError`  are still conceptually two different error classes.

```
BaseException
 +-- Exception
      +-- StandardError
      |    +-- EnvironmentError
      |    |    +-- IOError
      |    |    +-- OSError
      |    |         +-- WindowsError (Windows)
      |    |         +-- VMSError (VMS)
```
source: https://docs.python.org/2/library/exceptions.html

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
