### PR TITLE
raise exception when openmetrics process fails so check reports it

### DIFF
--- a/linkerd/datadog_checks/linkerd/linkerd.py
+++ b/linkerd/datadog_checks/linkerd/linkerd.py
@@ -32,5 +32,6 @@ class LinkerdCheck(OpenMetricsBaseCheck):
             super(LinkerdCheck, self).process(scraper_config, metric_transformers=metric_transformers)
         except Exception:
             self.gauge(self.HEALTH_METRIC, 1, tags=tags)
+            raise
         else:
             self.gauge(self.HEALTH_METRIC, 0, tags=tags)

--- a/linkerd/tests/test_linkerd.py
+++ b/linkerd/tests/test_linkerd.py
@@ -55,6 +55,13 @@ def test_linkerd_v2(aggregator):
     )
 
 
+def test_openmetrics_error(monkeypatch):
+    check = LinkerdCheck('linkerd', None, {}, [MOCK_INSTANCE])
+    with requests_mock.Mocker() as metric_request:
+        metric_request.get('http://fake.tld/prometheus', exc="Exception")
+        with pytest.raises(Exception):
+            check.check(MOCK_INSTANCE)
+
 @pytest.mark.e2e
 def test_e2e(dd_agent_check):
     aggregator = dd_agent_check(rate=True)

--- a/linkerd/tests/test_linkerd.py
+++ b/linkerd/tests/test_linkerd.py
@@ -62,6 +62,7 @@ def test_openmetrics_error(monkeypatch):
         with pytest.raises(Exception):
             check.check(MOCK_INSTANCE)
 
+
 @pytest.mark.e2e
 def test_e2e(dd_agent_check):
     aggregator = dd_agent_check(rate=True)


### PR DESCRIPTION
### What does this PR do?
Raise exception when openmetrics process method throws an exception, so the check reports it in the status of the agent.

### Motivation
The integration reports OK even though there is a connection issue.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
