### PR TITLE
win32_process.commandline only works for admins

### DIFF
--- a/wmi_check/README.md
+++ b/wmi_check/README.md
@@ -100,9 +100,9 @@ See [MSDN][8] for more information.
   It translates to a WMI query:
   `SELECT '<TARGET_PROPERTY>' FROM '<TARGET_CLASS>' WHERE '<LINK_TARGET_CLASS_PROPERTY>' = '<LINK_SOURCE_PROPERTY>'`
 
-<div class="alert alert-info">
-Setting this causes any instance number to be removed from tag_by values i.e. name:process#1 => name:process
-</div>
+  ##### Example
+  The setting `[IDProcess, Win32_Process, Handle, CommandLine]` tags each process with its command line. Any instance number will be removed from tag_by values i.e. name:process#1 => name:process. NB: The agent must be running under an **Administrator** account for this to work as the `CommandLine` property is not accessible to non-admins.
+
 
 #### Metrics collection
 The WMI check can potentially emit [custom metrics][9], which may impact your [billing][10].


### PR DESCRIPTION
### What does this PR do?
Update WMI readme to mention that agent needs to run as admin for Win32_Process to get CommandLine property

### Motivation

Upgrade was failing because new service account is not admin by default.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
