### PR TITLE
Use lazy logging format

### DIFF
--- a/couch/datadog_checks/couch/couch.py
+++ b/couch/datadog_checks/couch/couch.py
@@ -237,9 +237,7 @@ class CouchDB2:
                         if 'count' in val:
                             self.gauge("{0}.{1}.size".format(prefix, key), val['count'], queue_tags)
                         else:
-                            self.agent_check.log.debug(
-                                "Queue %s does not have a key 'count'. It will be ignored." % queue
-                            )
+                            self.agent_check.log.debug("Queue %s does not have a key 'count'. It will be ignored.", queue)
                     else:
                         self.gauge("{0}.{1}.size".format(prefix, key), val, queue_tags)
             elif key == "distribution":

--- a/couch/datadog_checks/couch/couch.py
+++ b/couch/datadog_checks/couch/couch.py
@@ -237,7 +237,9 @@ class CouchDB2:
                         if 'count' in val:
                             self.gauge("{0}.{1}.size".format(prefix, key), val['count'], queue_tags)
                         else:
-                            self.agent_check.log.debug("Queue %s does not have a key 'count'. It will be ignored.", queue)
+                            self.agent_check.log.debug(
+                                "Queue %s does not have a key 'count'. It will be ignored.", queue
+                            )
                     else:
                         self.gauge("{0}.{1}.size".format(prefix, key), val, queue_tags)
             elif key == "distribution":

--- a/datadog_checks_base/datadog_checks/__init__.py
+++ b/datadog_checks_base/datadog_checks/__init__.py
@@ -1,5 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-#
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -63,7 +63,9 @@ def add_style_checker(config, sections, make_envconfig, reader):
                 'flake8 --config=../.flake8 .',
                 'black --check --diff .',
                 'isort --check-only --diff --recursive .',
-                'flake8 --config=../.flake8 --enable-extensions=G --select=G .',  # lint `flake8-logging-format`
+                'python -c "print(\'\\n[WARNING] Complying with following lint rules is recommended, '
+                'but not mandatory, yet.\')"',
+                '- flake8 --config=../.flake8 --enable-extensions=G --select=G .',  # lint `flake8-logging-format`
             ]
         ),
     }

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -63,9 +63,7 @@ def add_style_checker(config, sections, make_envconfig, reader):
                 'flake8 --config=../.flake8 .',
                 'black --check --diff .',
                 'isort --check-only --diff --recursive .',
-                'python -c "print(\'\\n[WARNING] Complying with following lint rules is recommended, '
-                'but not mandatory, yet.\')"',
-                '- flake8 --config=../.flake8 --enable-extensions=G --select=G .',  # lint `flake8-logging-format`
+                'flake8 --config=../.flake8 --enable-extensions=G --select=G .',  # lint `flake8-logging-format`
             ]
         ),
     }

--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -104,7 +104,7 @@ class TUFDownloader:
 
         # Either the target has not been updated...
         if not len(updated_targets):
-            logger.debug('{} has not been updated'.format(target_relpath))
+            logger.debug('%s has not been updated', target_relpath)
         # or, it has been updated, in which case...
         else:
             # First, we use TUF to download and verify the target.
@@ -113,7 +113,7 @@ class TUFDownloader:
             assert updated_target == target
             self.__updater.download_target(updated_target, self.__targets_dir)
 
-        logger.info('TUF verified {}'.format(target_relpath))
+        logger.info('TUF verified %s', target_relpath)
 
         target_abspath = os.path.join(self.__targets_dir, target_relpath)
         return target_abspath, target
@@ -185,7 +185,7 @@ class TUFDownloader:
         return root_layout, root_layout_pubkeys, root_layout_params
 
     def __handle_in_toto_verification_exception(self, target_relpath, e):
-        logger.exception('in-toto failed to verify {}'.format(target_relpath))
+        logger.exception('in-toto failed to verify %s', target_relpath)
 
         if isinstance(e, LinkNotFoundError) and str(e) == RevokedDeveloper.MSG:
             raise RevokedDeveloper(target_relpath, IN_TOTO_ROOT_LAYOUT)
@@ -211,7 +211,7 @@ class TUFDownloader:
         except Exception as e:
             self.__handle_in_toto_verification_exception(target_relpath, e)
         else:
-            logger.info('in-toto verified {}'.format(target_relpath))
+            logger.info('in-toto verified %s', target_relpath)
         finally:
             # Switch back to a parent directory we control, so that we can
             # safely delete temp dir.

--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -133,7 +133,7 @@ class DirectoryCheck(AgentCheck):
                     file_stat = file_entry.stat()
 
                 except OSError as ose:
-                    self.warning('DirectoryCheck: could not stat file {} - {}'.format(join(root, file_entry.name), ose))
+                    self.warning('DirectoryCheck: could not stat file %s - %s', join(root, file_entry.name), ose)
                 else:
                     # file specific metrics
                     directory_bytes += file_stat.st_size

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -263,25 +263,25 @@ class Disk(AgentCheck):
         device_blacklist_extras = []
         mount_point_blacklist_extras = []
 
-        deprecation_message = '`{old}` is deprecated and will be removed in 6.9. Please use `{new}` instead.'
+        deprecation_message = '`%s` is deprecated and will be removed in 6.9. Please use `%s` instead.'
 
         if 'excluded_filesystems' in instance:
             file_system_blacklist_extras.extend(
                 '{}$'.format(pattern) for pattern in instance['excluded_filesystems'] if pattern
             )
-            self.warning(deprecation_message.format(old='excluded_filesystems', new='file_system_blacklist'))
+            self.warning(deprecation_message, 'excluded_filesystems', 'file_system_blacklist')
 
         if 'excluded_disks' in instance:
             device_blacklist_extras.extend('{}$'.format(pattern) for pattern in instance['excluded_disks'] if pattern)
-            self.warning(deprecation_message.format(old='excluded_disks', new='device_blacklist'))
+            self.warning(deprecation_message, 'excluded_disks', 'device_blacklist')
 
         if 'excluded_disk_re' in instance:
             device_blacklist_extras.append(instance['excluded_disk_re'])
-            self.warning(deprecation_message.format(old='excluded_disk_re', new='device_blacklist'))
+            self.warning(deprecation_message, 'excluded_disk_re', 'device_blacklist')
 
         if 'excluded_mountpoint_re' in instance:
             mount_point_blacklist_extras.append(instance['excluded_mountpoint_re'])
-            self.warning(deprecation_message.format(old='excluded_mountpoint_re', new='mount_point_blacklist'))
+            self.warning(deprecation_message, 'excluded_mountpoint_re', 'mount_point_blacklist')
 
         # Any without valid patterns will become None
         self._file_system_whitelist = self._compile_valid_patterns(self._file_system_whitelist, casing=re.I)

--- a/docker_daemon/test/test_docker_daemon.py
+++ b/docker_daemon/test/test_docker_daemon.py
@@ -82,7 +82,7 @@ class TestCheckDockerDaemonNoSetUp(AgentCheckTest):
             "nginx:latest", detach=True, name='event-tags-test', entrypoint='/bin/false')
         log.debug('start nginx:latest with entrypoint /bin/false')
         DockerUtil().client.start(container_fail)
-        log.debug('container exited with %s' % DockerUtil().client.wait(container_fail, 1))
+        log.debug('container exited with %s', DockerUtil().client.wait(container_fail, 1))
         # Wait 1 second after exit so the event will be picked up
         from time import sleep
         sleep(1)
@@ -278,12 +278,12 @@ class TestCheckDockerDaemon(AgentCheckTest):
                 self.docker_client.connect_container_to_network(cont['Id'], self.second_network)
 
         for c in self.containers:
-            log.info("Starting container: {0}".format(c))
+            log.info("Starting container: %s", c)
             self.docker_client.start(c)
 
     def tearDown(self):
         for c in self.containers:
-            log.info("Stopping container: {0}".format(c))
+            log.info("Stopping container: %s", c)
             self.docker_client.remove_container(c, force=True)
         self.docker_client.remove_network(self.second_network)
 
@@ -829,8 +829,8 @@ class TestCheckDockerDaemon(AgentCheckTest):
         log.debug('start nginx:latest with entrypoint /bin/false')
         self.docker_client.start(container_ok)
         self.docker_client.start(container_fail)
-        log.debug('container exited with %s' % self.docker_client.wait(container_ok, 1))
-        log.debug('container exited with %s' % self.docker_client.wait(container_fail, 1))
+        log.debug('container exited with %s', self.docker_client.wait(container_ok, 1))
+        log.debug('container exited with %s', self.docker_client.wait(container_fail, 1))
         # After the container exits, we need to wait a second so the event isn't too recent
         # when the check runs, otherwise the event is not picked up
         from time import sleep

--- a/gitlab/datadog_checks/gitlab/gitlab.py
+++ b/gitlab/datadog_checks/gitlab/gitlab.py
@@ -110,7 +110,7 @@ class GitlabCheck(OpenMetricsBaseCheck):
 
         if url is None:
             # Simply ignore this service check if not configured
-            self.log.debug("gitlab_url not configured, service check {} skipped".format(check_type))
+            self.log.debug("gitlab_url not configured, service check %s skipped", check_type)
             return
 
         service_check_tags = self._service_check_tags(url)
@@ -121,7 +121,7 @@ class GitlabCheck(OpenMetricsBaseCheck):
         check_url = '{}/-/{}'.format(url, check_type)
 
         try:
-            self.log.debug("checking {} against {}".format(check_type, check_url))
+            self.log.debug("checking %s against %s", check_type, check_url)
             r = self.http.get(check_url)
             if r.status_code != 200:
                 self.service_check(
@@ -153,4 +153,4 @@ class GitlabCheck(OpenMetricsBaseCheck):
             raise
         else:
             self.service_check(service_check_name, OpenMetricsBaseCheck.OK, tags=service_check_tags)
-        self.log.debug("gitlab check {} succeeded".format(check_type))
+        self.log.debug("gitlab check %s succeeded", check_type)

--- a/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
@@ -108,7 +108,7 @@ class GitlabRunnerCheck(OpenMetricsBaseCheck):
         service_check_tags.extend(tags)
 
         try:
-            self.log.debug("checking connectivity against {}".format(url))
+            self.log.debug("checking connectivity against %s", url)
             r = self.http.get(url)
             if r.status_code != 200:
                 self.service_check(

--- a/haproxy/datadog_checks/haproxy/haproxy.py
+++ b/haproxy/datadog_checks/haproxy/haproxy.py
@@ -200,7 +200,7 @@ class HAProxy(AgentCheck):
             self.log.debug("unable to find HAProxy version info")
         else:
             version = re.search(r"HAProxy version ([^,]+)", raw_version).group(1)
-            self.log.debug(u"HAProxy version is {}".format(version))
+            self.log.debug("HAProxy version is %s", version)
             self.set_metadata('version', version)
 
     def _fetch_socket_data(self, parsed_url):
@@ -577,14 +577,13 @@ class HAProxy(AgentCheck):
             try:
                 service, _, hostname, status = host_status
             except Exception:
+                service, _, status = host_status
                 if collect_status_metrics_by_host:
                     self.warning(
-                        '`collect_status_metrics_by_host` is enabled but no host info\
-                                 could be extracted from HAProxy stats endpoint for {0}'.format(
-                            service
-                        )
+                        '`collect_status_metrics_by_host` is enabled but no host info could be extracted from HAProxy '
+                        'stats endpoint for %s',
+                        service,
                     )
-                service, _, status = host_status
 
             if self._is_service_excl_filtered(service, services_incl_filter, services_excl_filter):
                 continue

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -480,7 +480,7 @@ class IbmDb2Check(AgentCheck):
                     column_type = column.get('type')
                     if not column_type:  # no cov
                         self.log.error(
-                            'Column field `type` is required for column `%s` ' 'of metric_prefix `%s`',
+                            'Column field `type` is required for column `%s` of metric_prefix `%s`',
                             name,
                             metric_prefix,
                         )
@@ -491,7 +491,7 @@ class IbmDb2Check(AgentCheck):
                     else:
                         if not hasattr(self, column_type):
                             self.log.error(
-                                'Invalid submission method `%s` for metric column `%s` of ' 'metric_prefix `%s`',
+                                'Invalid submission method `%s` for metric column `%s` of metric_prefix `%s`',
                                 column_type,
                                 name,
                                 metric_prefix,
@@ -501,7 +501,7 @@ class IbmDb2Check(AgentCheck):
                             metric_info.append(('{}.{}'.format(metric_prefix, name), float(value), column_type))
                         except (ValueError, TypeError):  # no cov
                             self.log.error(
-                                'Non-numeric value `%s` for metric column `%s` of ' 'metric_prefix `%s`',
+                                'Non-numeric value `%s` for metric column `%s` of metric_prefix `%s`',
                                 value,
                                 name,
                                 metric_prefix,

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -480,8 +480,9 @@ class IbmDb2Check(AgentCheck):
                     column_type = column.get('type')
                     if not column_type:  # no cov
                         self.log.error(
-                            'Column field `type` is required for column `{}` '
-                            'of metric_prefix `{}`'.format(name, metric_prefix)
+                            'Column field `type` is required for column `%s` ' 'of metric_prefix `%s`',
+                            name,
+                            metric_prefix,
                         )
                         break
 
@@ -490,16 +491,20 @@ class IbmDb2Check(AgentCheck):
                     else:
                         if not hasattr(self, column_type):
                             self.log.error(
-                                'Invalid submission method `{}` for metric column `{}` of '
-                                'metric_prefix `{}`'.format(column_type, name, metric_prefix)
+                                'Invalid submission method `%s` for metric column `%s` of ' 'metric_prefix `%s`',
+                                column_type,
+                                name,
+                                metric_prefix,
                             )
                             break
                         try:
                             metric_info.append(('{}.{}'.format(metric_prefix, name), float(value), column_type))
                         except (ValueError, TypeError):  # no cov
                             self.log.error(
-                                'Non-numeric value `{}` for metric column `{}` of '
-                                'metric_prefix `{}`'.format(value, name, metric_prefix)
+                                'Non-numeric value `%s` for metric column `%s` of ' 'metric_prefix `%s`',
+                                value,
+                                name,
+                                metric_prefix,
                             )
                             break
 

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -117,7 +117,7 @@ class IBMMQConfig:
             try:
                 queue_tag_list.append([re.compile(regex_str), [t.strip() for t in tags.split(',')]])
             except TypeError:
-                log.warning('{} is not a valid regular expression and will be ignored'.format(regex_str))
+                log.warning('%s is not a valid regular expression and will be ignored', regex_str)
         return queue_tag_list
 
     @property

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -59,7 +59,7 @@ class IbmMqCheck(AgentCheck):
         config.check_properly_configured()
 
         if not pymqi:
-            log.error("You need to install pymqi: {}".format(pymqiException))
+            log.error("You need to install pymqi: %s", pymqiException)
             raise errors.PymqiException("You need to install pymqi: {}".format(pymqiException))
 
         try:

--- a/ibm_mq/tests/conftest.py
+++ b/ibm_mq/tests/conftest.py
@@ -71,10 +71,10 @@ def publish():
     for i in range(10):
         try:
             message = 'Hello from Python! Message {}'.format(i)
-            log.info("sending message: {}".format(message))
+            log.info("sending message: %s", message)
             queue.put(message.encode())
         except Exception as e:
-            log.info("exception publishing: {}".format(e))
+            log.info("exception publishing: %s", e)
             queue.close()
             qmgr.disconnect()
             return

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -102,11 +102,11 @@ class KafkaCheck(AgentCheck):
         total_contexts = len(self._consumer_offsets) + len(self._highwater_offsets)
         if total_contexts > self._context_limit:
             self.warning(
-                """Discovered {} metric contexts - this exceeds the maximum number of {} contexts permitted by the
+                """Discovered %s metric contexts - this exceeds the maximum number of %s contexts permitted by the
                 check. Please narrow your target by specifying in your kafka_consumer.yaml the consumer groups, topics
-                and partitions you wish to monitor.""".format(
-                    total_contexts, self._context_limit
-                )
+                and partitions you wish to monitor.""",
+                total_contexts,
+                self._context_limit,
             )
 
         # Report the metics
@@ -145,7 +145,7 @@ class KafkaCheck(AgentCheck):
             ssl_crlfile=self.instance.get('ssl_crlfile'),
             ssl_password=self.instance.get('ssl_password'),
         )
-        self.log.debug("KafkaAdminClient api_version: {}".format(kafka_admin_client.config['api_version']))
+        self.log.debug("KafkaAdminClient api_version: %s", kafka_admin_client.config['api_version'])
         # Force initial population of the local cluster metadata cache
         kafka_admin_client._client.poll(future=kafka_admin_client._client.cluster.request_update())
         if kafka_admin_client._client.cluster.topics(exclude_internal_topics=False) is None:

--- a/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
@@ -109,11 +109,11 @@ class LegacyKafkaCheck_0_10_2(AgentCheck):
         )
         if total_contexts > self._context_limit:
             self.warning(
-                """Discovered {} metric contexts - this exceeds the maximum number of {} contexts permitted by the
+                """Discovered %s metric contexts - this exceeds the maximum number of %s contexts permitted by the
                 check. Please narrow your target by specifying in your kafka_consumer.yaml the consumer groups, topics
-                and partitions you wish to monitor.""".format(
-                    total_contexts, self._context_limit
-                )
+                and partitions you wish to monitor.""",
+                total_contexts,
+                self._context_limit,
             )
 
         # Report the metics

--- a/kong/datadog_checks/kong/kong.py
+++ b/kong/datadog_checks/kong/kong.py
@@ -38,9 +38,9 @@ class Kong(AgentCheck):
         service_check_tags = ['kong_host:%s' % host, 'kong_port:%s' % port] + tags
 
         try:
-            self.log.debug(u"Querying URL: {0}".format(url))
+            self.log.debug("Querying URL: %s", url)
             response = requests.get(url, headers=headers(self.agentConfig), verify=ssl_validation)
-            self.log.debug(u"Kong status `response`: {0}".format(response))
+            self.log.debug("Kong status `response`: %s", response)
             response.raise_for_status()
         except Exception:
             self.service_check(service_check_name, Kong.CRITICAL, tags=service_check_tags)

--- a/kubelet/datadog_checks/kubelet/cadvisor.py
+++ b/kubelet/datadog_checks/kubelet/cadvisor.py
@@ -107,7 +107,7 @@ class CadvisorScraper(object):
             try:
                 self._update_container_metrics(instance, subcontainer, pod_list, pod_list_utils)
             except Exception as e:
-                self.log.error("Unable to collect metrics for container: {0} ({1})".format(c_id, e))
+                self.log.error("Unable to collect metrics for container: %s (%s)", c_id, e)
 
     def _publish_raw_metrics(self, metric, dat, tags, is_pod, depth=0):
         """
@@ -180,7 +180,7 @@ class CadvisorScraper(object):
                 )
             )
             if pod_list_utils.is_excluded(cid):
-                self.log.debug("Filtering out " + cid)
+                self.log.debug("Filtering out %s", cid)
                 return
             tags = tagger.tag(replace_container_rt_prefix(cid), tagger.HIGH) or []
 

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -439,7 +439,7 @@ class CadvisorPrometheusScraperMixin(object):
                     self.gauge(pct_m_name, float(usage / float(limit)), tags)
                 else:
                     self.log.debug(
-                        "No corresponding usage found for metric %s and container %s, skipping usage_pct " "for now.",
+                        "No corresponding usage found for metric %s and container %s, skipping usage_pct for now.",
                         pct_m_name,
                         c_name,
                     )

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -439,8 +439,9 @@ class CadvisorPrometheusScraperMixin(object):
                     self.gauge(pct_m_name, float(usage / float(limit)), tags)
                 else:
                     self.log.debug(
-                        "No corresponding usage found for metric %s and "
-                        "container %s, skipping usage_pct for now." % (pct_m_name, c_name)
+                        "No corresponding usage found for metric %s and container %s, skipping usage_pct " "for now.",
+                        pct_m_name,
+                        c_name,
                     )
 
     def container_cpu_usage_seconds_total(self, metric, scraper_config):

--- a/mapreduce/datadog_checks/mapreduce/mapreduce.py
+++ b/mapreduce/datadog_checks/mapreduce/mapreduce.py
@@ -130,8 +130,8 @@ class MapReduceCheck(AgentCheck):
         cluster_name = instance.get('cluster_name')
         if cluster_name is None:
             self.warning(
-                "The cluster_name must be specified in the instance configuration, "
-                "defaulting to '{}'".format(self.DEFAULT_CLUSTER_NAME)
+                "The cluster_name must be specified in the instance configuration, defaulting to '%s'",
+                self.DEFAULT_CLUSTER_NAME,
             )
             cluster_name = self.DEFAULT_CLUSTER_NAME
 

--- a/mesos_master/datadog_checks/mesos_master/mesos_master.py
+++ b/mesos_master/datadog_checks/mesos_master/mesos_master.py
@@ -178,7 +178,7 @@ class MesosMaster(AgentCheck):
             msg = str(e)
             status = AgentCheck.CRITICAL
         finally:
-            self.log.debug('Request to url : {0}, timeout: {1}, message: {2}'.format(url, timeout, msg))
+            self.log.debug('Request to url : %s, timeout: %s, message: %s', url, timeout, msg)
             self._send_service_check(url, status, failure_expected=failure_expected, tags=tags, message=msg)
 
         if response.encoding is None:
@@ -210,9 +210,7 @@ class MesosMaster(AgentCheck):
             # Mesos version < 0.25
             old_endpoint = endpoint + '.json'
             self.log.info(
-                'Unable to fetch state from {0}. Retrying with the deprecated endpoint: {1}.'.format(
-                    endpoint, old_endpoint
-                )
+                'Unable to fetch state from %s. Retrying with the deprecated endpoint: %s.', endpoint, old_endpoint
             )
             master_state = self._get_json(old_endpoint, tags=tags)
         return master_state

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -954,7 +954,7 @@ class MySql(AgentCheck):
                 cursor.execute("SHOW /*!50000 ENGINE*/ INNODB STATUS")
         except (pymysql.err.InternalError, pymysql.err.OperationalError, pymysql.err.NotSupportedError) as e:
             self.warning(
-                "Privilege error or engine unavailable accessing the INNODB status tables " "(must grant PROCESS): %s",
+                "Privilege error or engine unavailable accessing the INNODB status tables (must grant PROCESS): %s",
                 e,
             )
             return {}

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -953,11 +953,8 @@ class MySql(AgentCheck):
             with closing(db.cursor()) as cursor:
                 cursor.execute("SHOW /*!50000 ENGINE*/ INNODB STATUS")
         except (pymysql.err.InternalError, pymysql.err.OperationalError, pymysql.err.NotSupportedError) as e:
-            self.warning(
-                "Privilege error or engine unavailable accessing the INNODB status \
-                         tables (must grant PROCESS): %s"
-                % str(e)
-            )
+            self.warning("Privilege error or engine unavailable accessing the INNODB status tables "
+                         "(must grant PROCESS): %s", e)
             return {}
 
         if cursor.rowcount < 1:

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -954,8 +954,7 @@ class MySql(AgentCheck):
                 cursor.execute("SHOW /*!50000 ENGINE*/ INNODB STATUS")
         except (pymysql.err.InternalError, pymysql.err.OperationalError, pymysql.err.NotSupportedError) as e:
             self.warning(
-                "Privilege error or engine unavailable accessing the INNODB status tables (must grant PROCESS): %s",
-                e,
+                "Privilege error or engine unavailable accessing the INNODB status tables (must grant PROCESS): %s", e,
             )
             return {}
 

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -953,8 +953,10 @@ class MySql(AgentCheck):
             with closing(db.cursor()) as cursor:
                 cursor.execute("SHOW /*!50000 ENGINE*/ INNODB STATUS")
         except (pymysql.err.InternalError, pymysql.err.OperationalError, pymysql.err.NotSupportedError) as e:
-            self.warning("Privilege error or engine unavailable accessing the INNODB status tables "
-                         "(must grant PROCESS): %s", e)
+            self.warning(
+                "Privilege error or engine unavailable accessing the INNODB status tables " "(must grant PROCESS): %s",
+                e,
+            )
             return {}
 
         if cursor.rowcount < 1:

--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -85,8 +85,8 @@ class Nginx(AgentCheck):
             # for unpaid versions
             self._set_version_metadata(version)
 
-            self.log.debug(u"Nginx status `response`: {}".format(response))
-            self.log.debug(u"Nginx status `content_type`: {}".format(content_type))
+            self.log.debug("Nginx status `response`: %s", response)
+            self.log.debug("Nginx status `content_type`: %s", content_type)
 
             if content_type.startswith('application/json'):
                 metrics = self.parse_json(response, tags)
@@ -100,7 +100,7 @@ class Nginx(AgentCheck):
             # since we can't get everything in one place anymore.
             for endpoint, nest in chain(iteritems(PLUS_API_ENDPOINTS), iteritems(PLUS_API_STREAM_ENDPOINTS)):
                 response = self._get_plus_api_data(url, plus_api_version, endpoint, nest)
-                self.log.debug(u"Nginx Plus API version {} `response`: {}".format(plus_api_version, response))
+                self.log.debug("Nginx Plus API version %s `response`: %s", plus_api_version, response)
                 metrics.extend(self.parse_json(response, tags))
 
         funcs = {'gauge': self.gauge, 'rate': self.rate, 'count': self.monotonic_count}
@@ -141,7 +141,7 @@ class Nginx(AgentCheck):
                     self._set_version_metadata(value)
 
             except Exception as e:
-                self.log.error(u'Could not submit metric: %s: %s' % (repr(row), str(e)))
+                self.log.error('Could not submit metric: %s: %s', repr(row), e)
 
     @classmethod
     def _get_instance_params(cls, instance):
@@ -176,7 +176,7 @@ class Nginx(AgentCheck):
         service_check_name = 'nginx.can_connect'
         service_check_tags = ['host:%s' % nginx_host, 'port:%s' % nginx_port] + custom_tags
         try:
-            self.log.debug(u"Querying URL: {}".format(url))
+            self.log.debug("Querying URL: %s", url)
             r = self._perform_request(url)
         except Exception:
             self.service_check(service_check_name, AgentCheck.CRITICAL, tags=service_check_tags)
@@ -201,7 +201,7 @@ class Nginx(AgentCheck):
         url = "/".join([api_url, plus_api_version, endpoint])
         payload = {}
         try:
-            self.log.debug(u"Querying URL: {}".format(url))
+            self.log.debug("Querying URL: %s", url)
             r = self._perform_request(url)
             payload = self._nest_payload(nest, r.json())
         except Exception as e:
@@ -220,7 +220,7 @@ class Nginx(AgentCheck):
                 version = version.split('/')[1]
             self.set_metadata('version', version)
 
-            self.log.debug(u"Nginx version `server`: {}".format(version))
+            self.log.debug("Nginx version `server`: %s", version)
         else:
             self.log.warning(u"could not retrieve nginx version info")
 

--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -698,7 +698,7 @@ class OpenStackCheck(AgentCheck):
         if not network_ids:
             self.warning(
                 "Your check is not configured to monitor any networks.\n"
-                + "Please list `network_ids` under your init_config"
+                "Please list `network_ids` under your init_config"
             )
 
         for nid in network_ids:
@@ -779,7 +779,7 @@ class OpenStackCheck(AgentCheck):
             if not self.init_config.get("hypervisor_ids"):
                 self.warning(
                     "Nova API v2 requires admin privileges to index hypervisors. "
-                    + "Please specify the hypervisor you wish to monitor under the `hypervisor_ids` section"
+                    "Please specify the hypervisor you wish to monitor under the `hypervisor_ids` section"
                 )
                 return []
             return self.init_config.get("hypervisor_ids")
@@ -832,7 +832,7 @@ class OpenStackCheck(AgentCheck):
         try:
             uptime = self.get_uptime_for_single_hypervisor(hyp['id'])
         except Exception as e:
-            self.warning('Unable to get uptime for hypervisor {0}: {1}'.format(hyp['id'], str(e)))
+            self.warning('Unable to get uptime for hypervisor %s: %s', hyp['id'], e)
             uptime = {}
 
         hyp_state = hyp.get('state', None)
@@ -1008,7 +1008,7 @@ class OpenStackCheck(AgentCheck):
 
         project_name = project.get('name')
 
-        self.log.debug("Collecting metrics for project. name: {0} id: {1}".format(project_name, project['id']))
+        self.log.debug("Collecting metrics for project. name: %s id: %s", project_name, project['id'])
 
         url = '{0}/limits'.format(self.get_nova_endpoint())
         headers = {'X-Auth-Token': self.get_auth_token()}
@@ -1124,9 +1124,9 @@ class OpenStackCheck(AgentCheck):
                 )
             except KeystoneUnreachable as e:
                 self.warning(
-                    "The agent could not contact the specified identity server at %s . \
-                    Are you sure it is up at that address?"
-                    % self.init_config.get("keystone_server_url")
+                    "The agent could not contact the specified identity server at %s . "
+                    "Are you sure it is up at that address?",
+                    self.init_config.get("keystone_server_url"),
                 )
                 self.log.debug("Problem grabbing auth token: %s", e)
                 self.service_check(
@@ -1250,8 +1250,8 @@ class OpenStackCheck(AgentCheck):
                     self.get_stats_for_single_hypervisor(hyp, instance, host_tags=host_tags, custom_tags=custom_tags)
                 else:
                     self.warning(
-                        "Couldn't get hypervisor to monitor for host: %s"
-                        % self.get_my_hostname(split_hostname_on_first_period=split_hostname_on_first_period)
+                        "Couldn't get hypervisor to monitor for host: %s",
+                        self.get_my_hostname(split_hostname_on_first_period=split_hostname_on_first_period),
                     )
 
             if projects:
@@ -1276,9 +1276,9 @@ class OpenStackCheck(AgentCheck):
             elif isinstance(e, IncompleteIdentity):
                 self.warning(
                     "Please specify the user via the `user` variable in your init_config.\n"
-                    + "This is the user you would use to authenticate with Keystone v3 via password auth.\n"
-                    + "The user should look like:"
-                    + "{'password': 'my_password', 'name': 'my_name', 'domain': {'id': 'my_domain_id'}}"
+                    "This is the user you would use to authenticate with Keystone v3 via password auth.\n"
+                    "The user should look like: "
+                    "{'password': 'my_password', 'name': 'my_name', 'domain': {'id': 'my_domain_id'}}"
                 )
             else:
                 self.warning("Configuration Incomplete! Check your openstack.yaml file")

--- a/openstack_controller/datadog_checks/openstack_controller/api.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api.py
@@ -378,9 +378,11 @@ class SimpleApi(AbstractApi):
                     # Only catch HTTPErrors to enable the retry mechanism.
                     # Other exceptions raised by _make_request (e.g. AuthenticationNeeded) should be caught downstream
                     self.logger.debug(
-                        "Error making paginated request to {}, lowering limit from {} to {}: {}".format(
-                            url, query_params['limit'], query_params['limit'] // 2, e
-                        )
+                        "Error making paginated request to %s, lowering limit from %s to %s: %s",
+                        url,
+                        query_params['limit'],
+                        query_params['limit'] // 2,
+                        e,
                     )
                     query_params['limit'] //= 2
                     retry += 1

--- a/openstack_controller/datadog_checks/openstack_controller/api.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api.py
@@ -300,7 +300,7 @@ class SimpleApi(AbstractApi):
             else:
                 raise e
         except Exception:
-            self.logger.exception("Unexpected error contacting openstack endpoint {}".format(url))
+            self.logger.exception("Unexpected error contacting openstack endpoint %s", url)
             raise
         jresp = resp.json()
         self.logger.debug("url: %s || response: %s", url, jresp)
@@ -405,7 +405,7 @@ class SimpleApi(AbstractApi):
             networks = self._make_request(url)
             return networks.get('networks')
         except Exception as e:
-            self.logger.warning('Unable to get the list of all network ids: {}'.format(e))
+            self.logger.warning('Unable to get the list of all network ids: %s', e)
             raise e
 
     def get_projects(self):
@@ -418,7 +418,7 @@ class SimpleApi(AbstractApi):
             return r.get('projects', [])
 
         except Exception as e:
-            self.logger.warning('Unable to get projects: {}'.format(e))
+            self.logger.warning('Unable to get projects: %s', e)
             raise e
 
 

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -289,7 +289,7 @@ class OpenStackControllerCheck(AgentCheck):
             try:
                 load_averages = self.get_loads_for_single_hypervisor(hyp['id'])
             except Exception as e:
-                self.warning('Unable to get loads averages for hypervisor {}: {}'.format(hyp['id'], e))
+                self.warning('Unable to get loads averages for hypervisor %s: %s', hyp['id'], e)
                 load_averages = []
             if load_averages and len(load_averages) == 3:
                 for i, avg in enumerate([1, 5, 15]):
@@ -466,7 +466,7 @@ class OpenStackControllerCheck(AgentCheck):
         project_name = project.get('name')
         project_id = project.get('id')
 
-        self.log.debug("Collecting metrics for project. name: {} id: {}".format(project_name, project['id']))
+        self.log.debug("Collecting metrics for project. name: %s id: %s", project_name, project['id'])
         server_stats = self.get_project_limits(project['id'])
         server_tags.append('tenant_id:{}'.format(project_id))
 
@@ -479,7 +479,7 @@ class OpenStackControllerCheck(AgentCheck):
                     metric_key = PROJECT_METRICS[st]
                     self.gauge("openstack.nova.limits.{}".format(metric_key), server_stats[st], tags=server_tags)
         except KeyError:
-            self.warning("Unexpected response, not submitting limits metrics for project id {}".format(project['id']))
+            self.warning("Unexpected response, not submitting limits metrics for project id %s", project['id'])
 
     def get_flavors(self):
         query_params = {}
@@ -612,8 +612,9 @@ class OpenStackControllerCheck(AgentCheck):
                 )
             except KeystoneUnreachable as e:
                 self.warning(
-                    "The agent could not contact the specified identity server at {} . "
-                    "Are you sure it is up at that address?".format(keystone_server_url)
+                    "The agent could not contact the specified identity server at `%s`. "
+                    "Are you sure it is up at that address?",
+                    keystone_server_url,
                 )
                 self.log.debug("Problem grabbing auth token: %s", e)
                 self.service_check(
@@ -748,9 +749,9 @@ class OpenStackControllerCheck(AgentCheck):
             if isinstance(e, IncompleteIdentity):
                 self.warning(
                     "Please specify the user via the `user` variable in your init_config.\n"
-                    + "This is the user you would use to authenticate with Keystone v3 via password auth.\n"
-                    + "The user should look like:"
-                    + "{'password': 'my_password', 'name': 'my_name', 'domain': {'id': 'my_domain_id'}}"
+                    "This is the user you would use to authenticate with Keystone v3 via password auth.\n"
+                    "The user should look like: "
+                    "{'password': 'my_password', 'name': 'my_name', 'domain': {'id': 'my_domain_id'}}"
                 )
             else:
                 self.warning("Configuration Incomplete: %s! Check your openstack.yaml file", e)

--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -186,7 +186,7 @@ class Oracle(AgentCheck):
                             column_type = column.get('type')
                             if not column_type:
                                 self.log.error(
-                                    'column field `type` is required for column `%s` ' 'of metric_prefix `%s`',
+                                    'column field `type` is required for column `%s` of metric_prefix `%s`',
                                     name,
                                     metric_prefix,
                                 )
@@ -197,7 +197,7 @@ class Oracle(AgentCheck):
                             else:
                                 if not hasattr(self, column_type):
                                     self.log.error(
-                                        'invalid submission method `%s` for column `%s` "' '"of metric_prefix `%s`',
+                                        'invalid submission method `%s` for column `%s` of metric_prefix `%s`',
                                         column_type,
                                         name,
                                         metric_prefix,
@@ -207,7 +207,7 @@ class Oracle(AgentCheck):
                                     metric_info.append(('{}.{}'.format(metric_prefix, name), float(value), column_type))
                                 except (ValueError, TypeError):
                                     self.log.error(
-                                        'non-numeric value `%s` for metric column `%s` ' 'of metric_prefix `%s`',
+                                        'non-numeric value `%s` for metric column `%s` of metric_prefix `%s`',
                                         value,
                                         name,
                                         metric_prefix,

--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -186,8 +186,9 @@ class Oracle(AgentCheck):
                             column_type = column.get('type')
                             if not column_type:
                                 self.log.error(
-                                    'column field `type` is required for column `{}` '
-                                    'of metric_prefix `{}`'.format(name, metric_prefix)
+                                    'column field `type` is required for column `%s` ' 'of metric_prefix `%s`',
+                                    name,
+                                    metric_prefix,
                                 )
                                 break
 
@@ -196,16 +197,20 @@ class Oracle(AgentCheck):
                             else:
                                 if not hasattr(self, column_type):
                                     self.log.error(
-                                        'invalid submission method `{}` for column `{}` of '
-                                        'metric_prefix `{}`'.format(column_type, name, metric_prefix)
+                                        'invalid submission method `%s` for column `%s` "' '"of metric_prefix `%s`',
+                                        column_type,
+                                        name,
+                                        metric_prefix,
                                     )
                                     break
                                 try:
                                     metric_info.append(('{}.{}'.format(metric_prefix, name), float(value), column_type))
                                 except (ValueError, TypeError):
                                     self.log.error(
-                                        'non-numeric value `{}` for metric column `{}` of '
-                                        'metric_prefix `{}`'.format(value, name, metric_prefix)
+                                        'non-numeric value `%s` for metric column `%s` ' 'of metric_prefix `%s`',
+                                        value,
+                                        name,
+                                        metric_prefix,
                                     )
                                     break
 

--- a/oracle/tests/test_metrics.py
+++ b/oracle/tests/test_metrics.py
@@ -142,21 +142,27 @@ def test__get_custom_metrics_misconfigured(check):
 
     # No type in column
     check._get_custom_metrics(con, custom_queries, [])
-    log.error.assert_called_once_with('column field `type` is required for column `foo` of metric_prefix `foo`')
+    log.error.assert_called_once_with(
+        'column field `type` is required for column `%s` of metric_prefix `%s`', 'foo', 'foo'
+    )
     log.reset_mock()
 
     col2["type"] = "invalid"
 
     # Invalid type column
     check._get_custom_metrics(con, custom_queries, [])
-    log.error.assert_called_once_with('invalid submission method `invalid` for column `foo` of metric_prefix `foo`')
+    log.error.assert_called_once_with(
+        'invalid submission method `%s` for column `%s` of metric_prefix `%s`', 'invalid', 'foo', 'foo'
+    )
     log.reset_mock()
 
     col2["type"] = "gauge"
 
     # Non numeric value
     check._get_custom_metrics(con, custom_queries, [])
-    log.error.assert_called_once_with('non-numeric value `bar` for metric column `foo` of metric_prefix `foo`')
+    log.error.assert_called_once_with(
+        'non-numeric value `%s` for metric column `%s` of metric_prefix `%s`', 'bar', 'foo', 'foo'
+    )
 
     # No metric sent if errors
     gauge.assert_not_called()

--- a/postfix/datadog_checks/postfix/postfix.py
+++ b/postfix/datadog_checks/postfix/postfix.py
@@ -100,7 +100,7 @@ class PostfixCheck(AgentCheck):
 
         if not self.init_config.get('postqueue', False):
             self.log.debug('postqueue : get_config')
-            self.log.debug('postqueue: {}'.format(self.init_config.get('postqueue', False)))
+            self.log.debug('postqueue: %s', self.init_config.get('postqueue', False))
             if not queues or not directory:
                 raise Exception('using sudo: missing required yaml config entry')
         else:

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -361,7 +361,8 @@ class ProcessCheck(AgentCheck):
             self.warning(
                 'The `procfs_path` defined in `process.yaml is different from the one defined in '
                 '`datadog.conf` This is currently not supported by the Agent. Defaulting to the '
-                'value defined in `datadog.conf`:{}'.format(psutil.PROCFS_PATH)
+                'value defined in `datadog.conf`: %s',
+                psutil.PROCFS_PATH,
             )
         elif self._deprecated_init_procfs:
             self.warning(

--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -210,9 +210,9 @@ class RabbitMQ(AgentCheck):
         version = str(overview_response['rabbitmq_version'])
         if version:
             self.set_metadata('version', version)
-            self.log.debug(u"found rabbitmq version {}".format(version))
+            self.log.debug("found rabbitmq version %s", version)
         else:
-            self.log.warning(u"could not retrieve rabbitmq version information")
+            self.log.warning("could not retrieve rabbitmq version information")
 
     def _get_vhosts(self, instance, base_url):
         vhosts = instance.get('vhosts')

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -411,7 +411,7 @@ class Redis(AgentCheck):
                 max_slow_entries = int(conn.config_get(MAX_SLOW_ENTRIES_KEY)[MAX_SLOW_ENTRIES_KEY])
                 if max_slow_entries > DEFAULT_MAX_SLOW_ENTRIES:
                     self.warning(
-                        "Redis {0} is higher than {1}. Defaulting to {1}. "
+                        "Redis {0} is higher than {1}. Defaulting to {1}. "  # noqa: G001
                         "If you need a higher value, please set {0} in your check config".format(
                             MAX_SLOW_ENTRIES_KEY, DEFAULT_MAX_SLOW_ENTRIES
                         )

--- a/riak/datadog_checks/riak/riak.py
+++ b/riak/datadog_checks/riak/riak.py
@@ -274,14 +274,12 @@ class Riak(AgentCheck):
             self.gauge(name, float(value), tags=tags)
             return
         except ValueError:
-            self.log.debug("metric name {0} cannot be converted to a float: {1}".format(name, value))
+            self.log.debug("metric name %s cannot be converted to a float: %s", name, value)
             pass
 
         try:
             self.gauge(name, unicodedata.numeric(value), tags=tags)
             return
         except (TypeError, ValueError):
-            self.log.debug(
-                "metric name {0} cannot be converted to a float even using unicode tools: {1}".format(name, value)
-            )
+            self.log.debug("metric name %s cannot be converted to a float even using unicode tools: %s", name, value)
             pass

--- a/riakcs/datadog_checks/riakcs/riakcs.py
+++ b/riakcs/datadog_checks/riakcs/riakcs.py
@@ -94,7 +94,7 @@ class RiakCs(AgentCheck):
         try:
             s3 = S3Connection(**s3_settings)
         except Exception as e:
-            self.log.error("Error connecting to {0}: {1}".format(aggregation_key, e))
+            self.log.error("Error connecting to %s: %s", aggregation_key, e)
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=tags, message=str(e))
             raise
 
@@ -110,7 +110,7 @@ class RiakCs(AgentCheck):
             stats = self.load_json(stats_str)
 
         except Exception as e:
-            self.log.error("Error retrieving stats from {0}: {1}".format(aggregation_key, e))
+            self.log.error("Error retrieving stats from %s: %s", aggregation_key, e)
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=tags, message=str(e))
             raise
 

--- a/spark/datadog_checks/spark/spark.py
+++ b/spark/datadog_checks/spark/spark.py
@@ -245,8 +245,8 @@ class SparkCheck(AgentCheck):
         cluster_mode = instance.get(SPARK_CLUSTER_MODE)
         if cluster_mode is None:
             self.log.warning(
-                'The value for `spark_cluster_mode` was not set in the configuration. '
-                'Defaulting to "%s"' % SPARK_YARN_MODE
+                'The value for `spark_cluster_mode` was not set in the configuration. Defaulting to "%s"',
+                SPARK_YARN_MODE,
             )
             cluster_mode = SPARK_YARN_MODE
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -219,26 +219,26 @@ class SQLServer(AgentCheck):
             except SQLConnectionError:
                 raise
             except Exception:
-                self.log.warning("Can't load the metric {}, ignoring".format(name), exc_info=True)
+                self.log.warning("Can't load the metric %s, ignoring", name, exc_info=True)
                 continue
 
         # Load any custom metrics from conf.d/sqlserver.yaml
         for row in custom_metrics:
             db_table = row.get('table', DEFAULT_PERFORMANCE_TABLE)
             if db_table not in self.valid_tables:
-                self.log.error('{} has an invalid table name: {}'.format(row['name'], db_table))
+                self.log.error('%s has an invalid table name: %s', row['name'], db_table)
                 continue
 
             if db_table == DEFAULT_PERFORMANCE_TABLE:
                 user_type = row.get('type')
                 if user_type is not None and user_type not in VALID_METRIC_TYPES:
-                    self.log.error('{} has an invalid metric type: {}'.format(row['name'], user_type))
+                    self.log.error('%s has an invalid metric type: %s', row['name'], user_type)
                 sql_type = None
                 try:
                     if user_type is None:
                         sql_type, base_name = self.get_sql_type(instance, row['counter_name'])
                 except Exception:
-                    self.log.warning("Can't load the metric {}, ignoring".format(row['name']), exc_info=True)
+                    self.log.warning("Can't load the metric %s, ignoring", row['name'], exc_info=True)
                     continue
 
                 metrics_to_collect.append(
@@ -258,7 +258,7 @@ class SQLServer(AgentCheck):
         wait_stat_metrics = []
         vfs_metrics = []
         clerk_metrics = []
-        self.log.debug("metrics to collect %s", str(metrics_to_collect))
+        self.log.debug("metrics to collect %s", metrics_to_collect)
         for m in metrics_to_collect:
             if type(m) is SqlSimpleMetric:
                 self.log.debug("Adding simple metric %s", m.sql_name)
@@ -323,7 +323,7 @@ class SQLServer(AgentCheck):
                 self.log.warning("Invalid database connector %s using default %s", connector, self.connector)
                 connector = self.connector
             else:
-                self.log.debug("Overriding default connector for {} with {}".format(instance['host'], connector))
+                self.log.debug("Overriding default connector for %s with %s", instance['host'], connector)
         return connector
 
     def _get_adoprovider(self, instance):

--- a/teamcity/datadog_checks/teamcity/teamcity.py
+++ b/teamcity/datadog_checks/teamcity/teamcity.py
@@ -63,7 +63,7 @@ class TeamCityCheck(AgentCheck):
         self.last_build_ids[instance_name] = last_build_id
 
     def _build_and_send_event(self, new_build, instance_name, is_deployment, host, tags):
-        self.log.debug("Found new build with id {}, saving and alerting.".format(new_build["id"]))
+        self.log.debug("Found new build with id %s, saving and alerting.", new_build["id"])
         self.last_build_ids[instance_name] = new_build["id"]
 
         event_dict = {"timestamp": int(time.time()), "source_type_name": "teamcity", "host": host, "tags": []}

--- a/tls/datadog_checks/tls/tls.py
+++ b/tls/datadog_checks/tls/tls.py
@@ -292,11 +292,11 @@ class TLSCheck(AgentCheck):
             if err is not None:
                 raise err
             else:
-                raise socket.error('No valid addresses found, try checking your IPv6 connectivity')
+                raise socket.error('No valid addresses found, try checking your IPv6 connectivity')  # noqa: G
         except socket.gaierror as e:
             err_code, message = e.args
             if err_code == socket.EAI_NODATA or err_code == socket.EAI_NONAME:
-                raise socket.error('Unable to resolve host, check your DNS: {}'.format(message))
+                raise socket.error('Unable to resolve host, check your DNS: {}'.format(message))  # noqa: G
 
             raise
 

--- a/twemproxy/datadog_checks/twemproxy/twemproxy.py
+++ b/twemproxy/datadog_checks/twemproxy/twemproxy.py
@@ -84,10 +84,10 @@ class Twemproxy(AgentCheck):
         tags = instance.get('tags', [])
 
         response = self._get_data(instance)
-        self.log.debug(u"Twemproxy `response`: {0}".format(response))
+        self.log.debug("Twemproxy `response`: %s", response)
 
         if not response:
-            self.log.warning(u"No response received from twemproxy.")
+            self.log.warning("No response received from twemproxy.")
             return
 
         metrics = Twemproxy.parse_json(response, tags)
@@ -99,7 +99,7 @@ class Twemproxy(AgentCheck):
                 else:
                     self.rate(name, value, tags)
             except Exception as e:
-                self.log.error(u'Could not submit metric: %s: %s', repr(row), str(e))
+                self.log.error('Could not submit metric: %s: %s', repr(row), e)
 
     def _get_data(self, instance):
         host = instance.get('host')
@@ -114,7 +114,7 @@ class Twemproxy(AgentCheck):
         try:
             addrs = socket.getaddrinfo(host, port, 0, 0, socket.IPPROTO_TCP)
         except socket.gaierror as e:
-            self.log.warning("unable to retrieve address info for %s:%s - %s", host, port, e)
+            self.log.warning("Unable to retrieve address info for %s:%s - %s", host, port, e)
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=service_check_tags)
             return None
 
@@ -125,7 +125,7 @@ class Twemproxy(AgentCheck):
                     client = socket.socket(*addr[0:3])
                     client.connect(addr[-1])
 
-                    self.log.debug(u"Querying: {0}:{1}".format(host, port))
+                    self.log.debug("Querying: %s:%s", host, port)
                     while 1:
                         data = ensure_unicode(client.recv(1024))
                         if not data:
@@ -135,7 +135,7 @@ class Twemproxy(AgentCheck):
                 client.close()
                 break
             except socket.error as e:
-                self.log.warning("unable to connect to %s - %s", addr[-1], e)
+                self.log.warning("Unable to connect to %s - %s", addr[-1], e)
 
         status = AgentCheck.OK if response else AgentCheck.CRITICAL
         self.service_check(self.SERVICE_CHECK_NAME, status, tags=service_check_tags)

--- a/win32_event_log/datadog_checks/win32_event_log/win32_event_log.py
+++ b/win32_event_log/datadog_checks/win32_event_log/win32_event_log.py
@@ -132,11 +132,11 @@ class Win32EventLogWMI(WinWMICheck):
             wmi_sampler.sample()
         except TimeoutException:
             self.log.warning(
-                u"[Win32EventLog] WMI query timed out."
-                u" class={wmi_class} - properties={wmi_properties} -"
-                u" filters={filters} - tags={tags}".format(
-                    wmi_class=self.EVENT_CLASS, wmi_properties=event_properties, filters=filters, tags=instance_tags
-                )
+                "[Win32EventLog] WMI query timed out. class=%s - properties=%s - filters=%s - tags=%s",
+                self.EVENT_CLASS,
+                event_properties,
+                filters,
+                instance_tags,
             )
         else:
             for ev in wmi_sampler:

--- a/wmi_check/datadog_checks/wmi_check/wmi_check.py
+++ b/wmi_check/datadog_checks/wmi_check/wmi_check.py
@@ -71,11 +71,11 @@ class WMICheck(WinWMICheck):
             metrics = self._extract_metrics(wmi_sampler, tag_by, tag_queries, constant_tags)
         except TimeoutException:
             self.log.warning(
-                u"WMI query timed out."
-                u" class={wmi_class} - properties={wmi_properties} -"
-                u" filters={filters} - tag_queries={tag_queries}".format(
-                    wmi_class=wmi_class, wmi_properties=properties, filters=filters, tag_queries=tag_queries
-                )
+                "WMI query timed out. class=%s - properties=%s - filters=%s - tag_queries=%s",
+                wmi_class,
+                properties,
+                filters,
+                tag_queries,
             )
         else:
             self._submit_metrics(metrics, metric_name_and_type_by_property)

--- a/yarn/datadog_checks/yarn/yarn.py
+++ b/yarn/datadog_checks/yarn/yarn.py
@@ -197,8 +197,8 @@ class YarnCheck(AgentCheck):
         cluster_name = instance.get('cluster_name')
         if cluster_name is None:
             self.warning(
-                "The cluster_name must be specified in the instance configuration, "
-                "defaulting to '{}'".format(DEFAULT_CLUSTER_NAME)
+                "The cluster_name must be specified in the instance configuration, defaulting to '%s'",
+                DEFAULT_CLUSTER_NAME,
             )
             cluster_name = DEFAULT_CLUSTER_NAME
 

--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -372,12 +372,10 @@ class ZookeeperCheck(AgentCheck):
                 metrics.append(ZKMetric(metric_name, metric_value, metric_type))
 
             except ValueError:
-                self.log.warning(u"Cannot format `mntr` value. key={key}, value{value}".format(key=key, value=value))
+                self.log.warning("Cannot format `mntr` value. key=%s, value=%s", key, value)
                 continue
             except Exception:
-                self.log.exception(
-                    u"Unexpected exception occurred while parsing `mntr` command content:\n{buf}".format(buf=buf)
-                )
+                self.log.exception("Unexpected exception occurred while parsing `mntr` command content:\n%s", buf)
 
         return (metrics, mode)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Use lazy logging format for ALL integrations in `integrations-core`.

Will enforce the rule in another PR. `ddev` is used for integrations extras/internal, so, we need to fix them too, should be faster though since there is less code.

CI results with logging linter enabled: https://github.com/DataDog/integrations-core/pull/5400 (`PR All` is green)

### Motivation
<!-- What inspired you to submit this pull request? -->

Better logging.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
