### PR TITLE
update metric_to_check for gitlab checks

### DIFF
--- a/gitlab/manifest.json
+++ b/gitlab/manifest.json
@@ -13,7 +13,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "gitlab.",
-  "metric_to_check": "go_gc_duration_seconds",
+  "metric_to_check": "gitlab.process_max_fds",
   "name": "gitlab",
   "public_title": "Datadog-Gitlab Integration",
   "short_description": "Track all your Gitlab metrics with Datadog",

--- a/gitlab_runner/manifest.json
+++ b/gitlab_runner/manifest.json
@@ -11,7 +11,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "gitlab_runner.",
-  "metric_to_check": "go_gc_duration_seconds",
+  "metric_to_check": "gitlab_runner.process_max_fds",
   "name": "gitlab_runner",
   "public_title": "Datadog-Gitlab Runners Integration",
   "short_description": "Track all the metrics from your Gitlab runners with Datadog",


### PR DESCRIPTION
### What does this PR do?
updates the `metric_to_check` for gitlab and gitlab_runner to metrics that are collected by default

### Motivation
integration tile was showing `No Data Received` for these integrations

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
