### PR TITLE
Fix CPU metrics

### DIFF
--- a/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
@@ -157,11 +157,11 @@ class FargateCheck(AgentCheck):
 
             value_system = cpu_stats.get('system_cpu_usage')
             if value_system is not None:
-                self.rate('ecs.fargate.cpu.system', value_system, tags)
+                self.gauge('ecs.fargate.cpu.system', value_system, tags)
 
             value_total = cpu_stats.get('cpu_usage', {}).get('total_usage')
             if value_total is not None:
-                self.rate('ecs.fargate.cpu.user', value_total, tags)
+                self.gauge('ecs.fargate.cpu.user', value_total, tags)
 
             prevalue_total = prev_cpu_stats.get('cpu_usage', {}).get('total_usage')
             prevalue_system = prev_cpu_stats.get('system_cpu_usage')

--- a/ecs_fargate/metadata.csv
+++ b/ecs_fargate/metadata.csv
@@ -3,8 +3,8 @@ ecs.fargate.io.ops.write,rate,,,,# write operations to the disk,0,amazon_fargate
 ecs.fargate.io.bytes.write,rate,,byte,,# bytes written to the disk,0,amazon_fargate,io write
 ecs.fargate.io.ops.read,rate,,,,# read operation on the disk,0,amazon_fargate,io read count
 ecs.fargate.io.bytes.read,rate,,byte,,# bytes read on the disk,0,amazon_fargate,io read
-ecs.fargate.cpu.user,gauge,,percent,,The percent of time the CPU is under direct control of processes of this container,0,amazon_fargate,cpu user
-ecs.fargate.cpu.system,gauge,,percent,,The percent of time the CPU is executing system calls on behalf of processes of this container,0,amazon_fargate,cpu system
+ecs.fargate.cpu.user,gauge,,nanosecond,,Total CPU time consumed per container,0,amazon_fargate,cpu user
+ecs.fargate.cpu.system,gauge,,nanosecond,,Total CPU time consumed by the system,0,amazon_fargate,cpu system
 ecs.fargate.cpu.limit,gauge,,percent,,Limit in percent of the CPU usage,0,amazon_fargate,cpu limit
 ecs.fargate.cpu.percent,gauge,,percent,,Percentage of CPU used per container,0,amazon_fargate,cpu percent
 ecs.fargate.mem.cache,gauge,,byte,,# of bytes of page cache memory,0,amazon_fargate,mem cache


### PR DESCRIPTION
### What does this PR do?

- Update the description of `ecs.fargate.cpu.system` and `ecs.fargate.cpu.user` 
- Add `ecs.fargate.cpu.system.gauge` and `ecs.fargate.cpu.user.gauge` 

### Motivation

`ecs.fargate.cpu.system` and `ecs.fargate.cpu.user` are in nanoseconds, not percentages, and should be gauges not rates


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
