### PR TITLE
Add airflow logs

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -179,7 +179,7 @@ Use the default configuration of your `airflow.d/conf.yaml` file to activate the
               pattern: \[\d{4}\-\d{2}\-\d{2}
     ```
    
-    Regular clean up is recommended for scheduler logs, since one log file is created per day.
+    Regular clean up is recommended for scheduler logs with daily log rotation.
 
     b. Additional configuration for DAG tasks logs:
 

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -155,10 +155,14 @@ Use the default configuration of your `airflow.d/conf.yaml` file to activate the
 
 2. Uncomment and edit this configuration block at the bottom of your `airflow.d/conf.yaml`:
 
+    Change the `path` and `service` parameter values and configure them for your environment.
+
+    Configuration for DAG processor manager and Scheduler logs:
+
     ```yaml
       logs:
         - type: file
-          path: <PATH_TO_AIRFLOW>/logs/*/*.log
+          path: <PATH_TO_AIRFLOW>/logs/dag_processor_manager/dag_processor_manager.log
           source: airflow
           service: <SERVICE_NAME>
           log_processing_rules:
@@ -166,13 +170,19 @@ Use the default configuration of your `airflow.d/conf.yaml` file to activate the
               name: new_log_start_with_date
               pattern: \[\d{4}\-\d{2}\-\d{2}
         - type: file
-          path: <PATH_TO_AIRFLOW>/logs/*/*/*.log
+          path: <PATH_TO_AIRFLOW>/logs/scheduler/*/*.log
           source: airflow
           service: <SERVICE_NAME>
           log_processing_rules:
             - type: multi_line
               name: new_log_start_with_date
               pattern: \[\d{4}\-\d{2}\-\d{2}
+    ```
+
+    Additional configuration for DAG tasks logs:
+
+    ```yaml
+      logs:
         - type: file
           path: <PATH_TO_AIRFLOW>/logs/*/*/*/*.log
           source: airflow
@@ -183,7 +193,21 @@ Use the default configuration of your `airflow.d/conf.yaml` file to activate the
               pattern: \[\d{4}\-\d{2}\-\d{2}
     ```
 
-    Change the `path` and `service` parameter values and configure them for your environment.
+    Caveat: By default Airflow use this log file template for tasks: `log_filename_template = {{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log`, the number of log files will grow quickly if not cleaned regularly. This pattern is used by Airflow UI to display logs individually for each executed task.
+
+    If you do not view logs in Airflow UI, we recommend this configuration in `airflow.cfg`: `log_filename_template = dag_tasks.log`. Then log rotate this file and use this configuration:
+
+    ```yaml
+      logs:
+        - type: file
+          path: <PATH_TO_AIRFLOW>/logs/dag_tasks.log
+          source: airflow
+          service: <SERVICE_NAME>
+          log_processing_rules:
+            - type: multi_line
+              name: new_log_start_with_date
+              pattern: \[\d{4}\-\d{2}\-\d{2}
+    ```
 
 3. [Restart the Agent][7].
 

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -157,7 +157,7 @@ Use the default configuration of your `airflow.d/conf.yaml` file to activate the
 
     Change the `path` and `service` parameter values and configure them for your environment.
 
-    Configuration for DAG processor manager and Scheduler logs:
+    a. Configuration for DAG processor manager and Scheduler logs:
 
     ```yaml
       logs:
@@ -178,8 +178,10 @@ Use the default configuration of your `airflow.d/conf.yaml` file to activate the
               name: new_log_start_with_date
               pattern: \[\d{4}\-\d{2}\-\d{2}
     ```
+   
+    Regular clean up is recommended for scheduler logs, since one log file is created per day.
 
-    Additional configuration for DAG tasks logs:
+    b. Additional configuration for DAG tasks logs:
 
     ```yaml
       logs:

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -158,7 +158,15 @@ Use the default configuration of your `airflow.d/conf.yaml` file to activate the
     ```yaml
       logs:
         - type: file
-          path: <PATH_TO_AIRFLOW>/logs/**/*.log
+          path: <PATH_TO_AIRFLOW>/logs/*/*.log
+          source: airflow
+          service: <SERVICE_NAME>
+          log_processing_rules:
+            - type: multi_line
+              name: new_log_start_with_date
+              pattern: \[\d{4}\-\d{2}\-\d{2}
+        - type: file
+          path: <PATH_TO_AIRFLOW>/logs/*/*/*.log
           source: airflow
           service: <SERVICE_NAME>
           log_processing_rules:

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -173,6 +173,14 @@ Use the default configuration of your `airflow.d/conf.yaml` file to activate the
             - type: multi_line
               name: new_log_start_with_date
               pattern: \[\d{4}\-\d{2}\-\d{2}
+        - type: file
+          path: <PATH_TO_AIRFLOW>/logs/*/*/*/*.log
+          source: airflow
+          service: <SERVICE_NAME>
+          log_processing_rules:
+            - type: multi_line
+              name: new_log_start_with_date
+              pattern: \[\d{4}\-\d{2}\-\d{2}
     ```
 
     Change the `path` and `service` parameter values and configure them for your environment.

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -147,7 +147,7 @@ Use the default configuration of your `airflow.d/conf.yaml` file to activate the
 
 **Available for Agent >6.0**
 
-1. Collecting logs is disabled by default in the Datadog Agent, enable it in your datadog.yaml file:
+1. Collecting logs is disabled by default in the Datadog Agent. Enable it in your `datadog.yaml` file:
 
     ```yaml
       logs_enabled: true

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -143,6 +143,34 @@ Edit the `airflow.d/conf.yaml` file, in the `conf.d/` folder at the root of your
 
 Use the default configuration of your `airflow.d/conf.yaml` file to activate the collection of your Airflow service checks. See the sample [airflow.d/conf.yaml][3] for all available configuration options.
 
+#### Log collection
+
+**Available for Agent >6.0**
+
+1. Collecting logs is disabled by default in the Datadog Agent, enable it in your datadog.yaml file:
+
+    ```yaml
+      logs_enabled: true
+    ```
+
+2. Uncomment and edit this configuration block at the bottom of your `airflow.d/conf.yaml`:
+
+    ```yaml
+      logs:
+        - type: file
+          path: <PATH_TO_AIRFLOW>/logs/**/*.log
+          source: airflow
+          service: <SERVICE_NAME>
+          log_processing_rules:
+            - type: multi_line
+              name: new_log_start_with_date
+              pattern: \[\d{4}\-\d{2}\-\d{2}
+    ```
+
+    Change the `path` and `service` parameter values and configure them for your environment.
+
+3. [Restart the Agent][7].
+
 ### Validation
 
 [Run the Agent's status subcommand][5] and look for `airflow` under the Checks section.

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -214,3 +214,24 @@ instances:
     # tags:
     #   - <KEY_1>:<VALUE_1>
     #   - <KEY_2>:<VALUE_2>
+
+## Log Section (Available for Agent >=6.0)
+##
+## type - mandatory - Type of log input source (tcp / udp / file / windows_event)
+## port / path / channel_path - mandatory - Set port if the type is tcp or udp. Set path if the type is file. Set channel_path if the type is windows_event.
+## service - mandatory - Name of the service that generated the log
+## source  - mandatory - Attribute that defines which integration sent the logs
+## sourcecategory - optional - A multiple value attribute used to refine the source attribute.
+## tags: - optional - Add tags to the collected logs
+##
+## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
+#
+# logs:
+#   - type: file
+#     path: <PATH_TO_AIRFLOW>/logs/**/*.log
+#     source: airflow
+#     service: <SERVICE_NAME>
+#     log_processing_rules:
+#       - type: multi_line
+#         name: new_log_start_with_date
+#         pattern: \[\d{4}\-\d{2}\-\d{2}

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -243,3 +243,11 @@ instances:
 #       - type: multi_line
 #         name: new_log_start_with_date
 #         pattern: \[\d{4}\-\d{2}\-\d{2}
+#   - type: file
+#     path: <PATH_TO_AIRFLOW>/logs/*/*/*/*.log
+#     source: airflow
+#     service: <SERVICE_NAME>
+#     log_processing_rules:
+#       - type: multi_line
+#         name: new_log_start_with_date
+#         pattern: \[\d{4}\-\d{2}\-\d{2}

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -228,7 +228,15 @@ instances:
 #
 # logs:
 #   - type: file
-#     path: <PATH_TO_AIRFLOW>/logs/**/*.log
+#     path: <PATH_TO_AIRFLOW>/logs/*/*.log
+#     source: airflow
+#     service: <SERVICE_NAME>
+#     log_processing_rules:
+#       - type: multi_line
+#         name: new_log_start_with_date
+#         pattern: \[\d{4}\-\d{2}\-\d{2}
+#   - type: file
+#     path: <PATH_TO_AIRFLOW>/logs/*/*/*.log
 #     source: airflow
 #     service: <SERVICE_NAME>
 #     log_processing_rules:

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -228,7 +228,7 @@ instances:
 #
 # logs:
 #   - type: file
-#     path: <PATH_TO_AIRFLOW>/logs/*/*.log
+#     path: <PATH_TO_AIRFLOW>/logs/dag_processor_manager/dag_processor_manager.log
 #     source: airflow
 #     service: <SERVICE_NAME>
 #     log_processing_rules:
@@ -236,7 +236,7 @@ instances:
 #         name: new_log_start_with_date
 #         pattern: \[\d{4}\-\d{2}\-\d{2}
 #   - type: file
-#     path: <PATH_TO_AIRFLOW>/logs/*/*/*.log
+#     path: <PATH_TO_AIRFLOW>/logs/scheduler/*/*.log
 #     source: airflow
 #     service: <SERVICE_NAME>
 #     log_processing_rules:

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -225,6 +225,8 @@ instances:
 ## tags: - optional - Add tags to the collected logs
 ##
 ## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
+##
+## Info/caveat about collecting DAG tasks logs: https://docs.datadoghq.com/fr/integrations/airflow/#log-collection
 #
 # logs:
 #   - type: file
@@ -237,14 +239,6 @@ instances:
 #         pattern: \[\d{4}\-\d{2}\-\d{2}
 #   - type: file
 #     path: <PATH_TO_AIRFLOW>/logs/scheduler/*/*.log
-#     source: airflow
-#     service: <SERVICE_NAME>
-#     log_processing_rules:
-#       - type: multi_line
-#         name: new_log_start_with_date
-#         pattern: \[\d{4}\-\d{2}\-\d{2}
-#   - type: file
-#     path: <PATH_TO_AIRFLOW>/logs/*/*/*/*.log
 #     source: airflow
 #     service: <SERVICE_NAME>
 #     log_processing_rules:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add airflow logs

3 rules needed because airflow logs might be at different levels:

```
airflow/tests/compose/logs
├── dag_processor_manager
│   └── dag_processor_manager.log
├── scheduler
│   ├── 2020-01-08
│   │   ├── dag_file_error.py.log
│   │   ├── task_fail.py.log
│   │   ├── task_ok.py.log
│   │   ├── task_sleep10.py.log
│   │   ├── task_sleep5.py.log
│   │   └── tuto.py.log
│   └── latest -> /usr/local/airflow/logs/scheduler/2020-01-08
└── tutorial
    ├── print_date
    │   ├── 2015-06-01T00:00:00+00:00
    │   │   └── 1.log
    │   └── 2015-08-09T00:00:00+00:00
    │       └── 1.log
    └── templated
        ├── 2015-06-01T00:00:00+00:00
        │   └── 1.log
        ├── 2015-08-07T00:00:00+00:00
        │   └── 1.log
        └── 2015-08-08T00:00:00+00:00
            └── 1.log

```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
