### PR TITLE
Fix usage of old OID list attributes on InstanceConfig

### DIFF
--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -265,7 +265,7 @@ class SnmpCheck(AgentCheck):
                         *missing_results,
                         lookupMib=enforce_constraints,
                         ignoreNonIncreasingOid=self.ignore_nonincreasing_oid,
-                        lexicographicMode=False
+                        lexicographicMode=False,
                     )
                     binds, error = self._consume_binds_iterator(binds_iterator, config)
                     all_binds.extend(binds)

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -158,7 +158,7 @@ class SnmpCheck(AgentCheck):
                 try:
                     profile = self._profile_for_sysobject_oid(sys_object_oid)
                 except ConfigurationError:
-                    if not (host_config.table_oids or host_config.raw_oids):
+                    if not (host_config.all_oids or host_config.bulk_oids):
                         self.log.warning("Host %s didn't match a profile for sysObjectID %s", host, sys_object_oid)
                         continue
                 else:

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -265,7 +265,7 @@ class SnmpCheck(AgentCheck):
                         *missing_results,
                         lookupMib=enforce_constraints,
                         ignoreNonIncreasingOid=self.ignore_nonincreasing_oid,
-                        lexicographicMode=False,
+                        lexicographicMode=False
                     )
                     binds, error = self._consume_binds_iterator(binds_iterator, config)
                     all_binds.extend(binds)

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 import ipaddress
+import logging
 import os
 import socket
 import time
@@ -580,18 +581,46 @@ def test_profile_sys_object_prefix(aggregator):
     aggregator.assert_all_metrics_covered()
 
 
-def test_profile_sys_object_unknown(aggregator):
+def test_profile_sys_object_unknown(aggregator, caplog):
     """If the fetched sysObjectID is not referenced by any profiles, check fails."""
-    instance = common.generate_instance_config([])
+    caplog.set_level(logging.WARNING)
+
+    unknown_sysobjectid = '1.2.3.4.5'
     init_config = {
-        'profiles': {'profile1': {'definition': {'metrics': common.SUPPORTED_METRIC_TYPES, 'sysobjectid': '1.2.3.4.5'}}}
+        'profiles': {
+            'profile1': {'definition': {'metrics': common.SUPPORTED_METRIC_TYPES, 'sysobjectid': unknown_sysobjectid}}
+        }
     }
+
+    # Via config...
+
+    instance = common.generate_instance_config([])
     check = SnmpCheck('snmp', init_config, [instance])
     check.check(instance)
 
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.CRITICAL, tags=common.CHECK_TAGS, at_least=1)
-
     aggregator.all_metrics_asserted()
+    assert len(caplog.records) == 1
+
+    # Via network discovery...
+
+    host = socket.gethostbyname(common.HOST)
+    network = ipaddress.ip_network(u'{}/29'.format(host), strict=False).with_prefixlen
+    instance = {
+        'name': 'snmp_conf',
+        'network_address': network,
+        'port': common.PORT,
+        'community_string': 'public',
+    }
+
+    check = SnmpCheck('snmp', init_config, [instance])
+    check._start_discovery()
+    time.sleep(2)  # Give discovery a chance to fail finding a matching profile.
+    check.check(instance)
+
+    assert len(caplog.records) == 2
+    record = caplog.records[-1]
+    assert "Host {} didn't match a profile".format(host) in record.message
 
 
 def test_profile_sys_object_no_metrics():

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -584,6 +584,7 @@ def test_profile_sys_object_prefix(aggregator):
 def test_profile_sys_object_unknown(aggregator, caplog):
     """If the fetched sysObjectID is not referenced by any profiles, check fails."""
     caplog.set_level(logging.WARNING)
+    initial_num_of_log_records = len(caplog.records)
 
     unknown_sysobjectid = '1.2.3.4.5'
     init_config = {
@@ -600,7 +601,7 @@ def test_profile_sys_object_unknown(aggregator, caplog):
 
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.CRITICAL, tags=common.CHECK_TAGS, at_least=1)
     aggregator.all_metrics_asserted()
-    assert len(caplog.records) == 1
+    assert len(caplog.records) == initial_num_of_log_records + 1
 
     # Via network discovery...
 
@@ -618,7 +619,7 @@ def test_profile_sys_object_unknown(aggregator, caplog):
     time.sleep(2)  # Give discovery a chance to fail finding a matching profile.
     check.check(instance)
 
-    assert len(caplog.records) == 2
+    assert len(caplog.records) == initial_num_of_log_records + 2
     record = caplog.records[-1]
     assert "Host {} didn't match a profile".format(host) in record.message
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
#5368 changed `InstanceConfig` so that it now has `.all_oids` and `.bulk_oids` instead of `.table_oids` and `.raw_oids`.

### Motivation
<!-- What inspired you to submit this pull request? -->
Cleanup for #5368 

### Additional Notes
<!-- Anything else we should know when reviewing? -->
/

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
