### PR TITLE
Improve url join to not mutate the base url when proxying a call

### DIFF
--- a/kubelet/datadog_checks/kubelet/__init__.py
+++ b/kubelet/datadog_checks/kubelet/__init__.py
@@ -1,5 +1,5 @@
 from .__about__ import __version__
-from .common import KubeletCredentials, PodListUtils, get_pod_by_uid, is_static_pending_pod
+from .common import KubeletCredentials, PodListUtils, get_pod_by_uid, is_static_pending_pod, urljoin
 from .kubelet import KubeletCheck
 
 __all__ = [
@@ -7,6 +7,7 @@ __all__ = [
     '__version__',
     'PodListUtils',
     'KubeletCredentials',
+    'urljoin',
     'get_pod_by_uid',
     'is_static_pending_pod',
 ]

--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -54,6 +54,15 @@ def get_pod_by_uid(uid, podlist):
     return None
 
 
+def urljoin(*args):
+    """
+    Joins given arguments into an url. Trailing but not leading slashes are
+    stripped for each argument.
+    :return: string
+    """
+    return '/'.join(arg.strip('/') for arg in args)
+
+
 def is_static_pending_pod(pod):
     """
     Return if the pod is a static pending pod

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -13,7 +13,6 @@ from datetime import datetime, timedelta
 import requests
 from kubeutil import get_connection_info
 from six import iteritems
-from six.moves.urllib.parse import urljoin
 
 from datadog_checks.base.utils.date import UTC, parse_rfc3339
 from datadog_checks.base.utils.tagging import tagger
@@ -22,7 +21,7 @@ from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.errors import CheckException
 
 from .cadvisor import CadvisorScraper
-from .common import CADVISOR_DEFAULT_PORT, KubeletCredentials, PodListUtils, replace_container_rt_prefix
+from .common import CADVISOR_DEFAULT_PORT, KubeletCredentials, PodListUtils, replace_container_rt_prefix, urljoin
 from .prometheus import CadvisorPrometheusScraperMixin
 
 try:

--- a/kubelet/tests/test_common.py
+++ b/kubelet/tests/test_common.py
@@ -9,7 +9,7 @@ import mock
 import pytest
 
 from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
-from datadog_checks.kubelet import KubeletCredentials, PodListUtils, get_pod_by_uid, is_static_pending_pod
+from datadog_checks.kubelet import KubeletCredentials, PodListUtils, get_pod_by_uid, is_static_pending_pod, urljoin
 
 from .test_kubelet import mock_from_file
 
@@ -98,6 +98,17 @@ def test_pod_by_uid():
 
     pod = get_pod_by_uid("unknown", podlist)
     assert pod is None
+
+
+def test_url_join():
+    res = urljoin("https://10.100.0.1:443/api/fargate-XX.us-east-2.compute.internal/proxy", "/pods")
+    assert res == 'https://10.100.0.1:443/api/fargate-XX.us-east-2.compute.internal/proxy/pods'
+    res = urljoin("https://10.100.0.1:443/api/fargate-XX.us-east-2.compute.internal/proxy", "pods")
+    assert res == 'https://10.100.0.1:443/api/fargate-XX.us-east-2.compute.internal/proxy/pods'
+    res = urljoin("https://10.100.0.1:443/api/fargate-XX.us-east-2.compute.internal/proxy/", "pods")
+    assert res == 'https://10.100.0.1:443/api/fargate-XX.us-east-2.compute.internal/proxy/pods'
+    res = urljoin("https://10.100.0.1:443/api/fargate-XX.us-east-2.compute.internal/proxy/", "/pods")
+    assert res == 'https://10.100.0.1:443/api/fargate-XX.us-east-2.compute.internal/proxy/pods'
 
 
 def test_is_static_pod():


### PR DESCRIPTION
### What does this PR do?

For the EKS-Fargate check we need to proxy calls to the kubelet through the APIServer.
Through the C-Bridge we pass the endpoint that looks like:
`"https://10.100.0.1:443/api/v1/nodes/fargate-ip-XXX-XXX-XX-XXX.us-east-2.compute.internal/proxy"`
To which we need to join the [kubelet specific API endpoints](https://github.com/DataDog/integrations-core/blob/7.16.0-rc.9/kubelet/datadog_checks/kubelet/kubelet.py#L36-L41):

```python
KUBELET_HEALTH_PATH = '/healthz'
NODE_SPEC_PATH = '/spec'
POD_LIST_PATH = '/pods'
CADVISOR_METRICS_PATH = '/metrics/cadvisor'
KUBELET_METRICS_PATH = '/metrics'
STATS_PATH = '/stats/summary/'
```

With the current logic, `urljoin` considers that the leading `/` in the suffix means that it is a relative URLs (as found in HTML documents). The result end up being:
```python
>>> from six.moves.urllib.parse import urljoin
>>> urljoin("https://10.100.0.1:443/api/v1/nodes/fargate-ip-XXX-XXX-XXX-XXX.us-east-2.compute.internal/proxy","/pods")
'https://10.100.0.1:443/pods'
```

Which is the wrong endpoint and makes the check fail.
Using the new logic, we append correctly the kubelet specific API endpoint as follows:
```python
>>> urljoin("https://10.100.0.1:443/api/v1/nodes/fargate-ip-XXX-XXX-XXX-XXX.us-east-2.compute.internal/proxy", "/pods")
'https://10.100.0.1:443/api/v1/nodes/fargate-ip-XXX-XXX-XXX-XXX.us-east-2.compute.internal/proxy/pods'

>>> urljoin("https://10.100.0.1:443/api/v1/nodes/fargate-ip-XXX-XXX-XXX-XXX.us-east-2.compute.internal/proxy/", "/pods")
'https://10.100.0.1:443/api/v1/nodes/fargate-ip-XXX-XXX-XXX-XXX.us-east-2.compute.internal/proxy/pods'
```

### Motivation
This new logic allows for the kubelet check to work seamlessly in EKS Fargate environments.

### Additional Notes
N/A

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
