### PR TITLE
Fix application of schema-based metric filtering

### DIFF
--- a/postgres/tests/compose/resources/02_load_data.sh
+++ b/postgres/tests/compose/resources/02_load_data.sh
@@ -2,15 +2,25 @@
 set -e
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" datadog_test <<-EOSQL
+    -- NOTE: ensure all tables have at least one sufficiently large row, so that Postgres'
+    -- TOAST mechanism kicks in for that table and the associated metrics are submitted.
+
     CREATE TABLE persons (personid SERIAL, lastname VARCHAR(255), firstname VARCHAR(255), address VARCHAR(255), city VARCHAR(255));
     INSERT INTO persons (lastname, firstname, address, city) VALUES ('Cavaille', 'Leo', 'Midtown', 'New York'), ('Someveryveryveryveryveryveryveryveryveryverylongname', 'something', 'Avenue des Champs Elysees', 'Beautiful city of lights');
+    SELECT * FROM persons;
+
     CREATE TABLE personsdup1 (personid SERIAL, lastname VARCHAR(255), firstname VARCHAR(255), address VARCHAR(255), city VARCHAR(255));
     INSERT INTO personsdup1 (lastname, firstname, address, city) VALUES ('Cavaille', 'Leo', 'Midtown', 'New York'), ('Someveryveryveryveryveryveryveryveryveryverylongname', 'something', 'Avenue des Champs Elysees', 'Beautiful city of lights');
+    SELECT * FROM personsdup1;
+
     CREATE TABLE Personsdup2 (personid SERIAL, lastname VARCHAR(255), firstname VARCHAR(255), address VARCHAR(255), city VARCHAR(255));
     INSERT INTO Personsdup2 (lastname, firstname, address, city) VALUES ('Cavaille', 'Leo', 'Midtown', 'New York'), ('Someveryveryveryveryveryveryveryveryveryverylongname', 'something', 'Avenue des Champs Elysees', 'Beautiful city of lights');
-    SELECT * FROM persons;
-    SELECT * FROM persons;
-    SELECT * FROM persons;
+    SELECT * FROM Personsdup2;
+
+    CREATE SCHEMA IF NOT EXISTS doghouse;
+    CREATE TABLE doghouse.dog (id SERIAL, name VARCHAR(255), description TEXT);
+    INSERT INTO doghouse.dog (name, description) VALUES ('Bits', 'Proident quis magna reprehenderit elit. Eiusmod elit consectetur adipisicing cupidatat non do ad voluptate ad. Aliqua sint ad deserunt dolor consectetur ex nostrud. Esse sunt est et magna labore aliquip sit ipsum eu do dolor voluptate voluptate eu. Irure ut laboris non laborum sint et sunt adipisicing eiusmod.');
+    SELECT * FROM doghouse.dog;
 EOSQL
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" dogs <<-EOSQL

--- a/postgres/tests/test_integration.py
+++ b/postgres/tests/test_integration.py
@@ -62,17 +62,25 @@ def test_can_connect_service_check(aggregator, integration_check, pg_instance):
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_schema_metrics(aggregator, integration_check, pg_instance):
-    pg_instance['table_count_limit'] = 1
     check = integration_check(pg_instance)
     check.check(pg_instance)
 
-    expected_tags = pg_instance['tags'] + [
+    expected_public_tags = pg_instance['tags'] + [
         'db:{}'.format(DB_NAME),
         'server:{}'.format(HOST),
         'port:{}'.format(PORT),
         'schema:public',
     ]
-    aggregator.assert_metric('postgresql.table.count', value=1, count=1, tags=expected_tags)
+
+    expected_custom_schema_tags = pg_instance['tags'] + [
+        'db:{}'.format(DB_NAME),
+        'server:{}'.format(HOST),
+        'port:{}'.format(PORT),
+        'schema:doghouse',
+    ]
+
+    aggregator.assert_metric('postgresql.table.count', value=3, count=1, tags=expected_public_tags)
+    aggregator.assert_metric('postgresql.table.count', value=1, count=1, tags=expected_custom_schema_tags)
     aggregator.assert_metric('postgresql.db.count', value=2, count=1)
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

The Postgres integration allows filtering metrics based on which relations (i.e. schema + table) they're related to.

Example:

```yaml
# postgres.yaml

instances:
  - # ...
    relations:
      # Only retrieve metrics of tables in schema 'doghouse'
      - relation_regex: .*
        schemas:
          - doghouse
```

When defined, `schemas` were not actually taken into account, resulting in no filtering being performed.

This PR:

- Fixes the bug by registering schemas for filtering.
- Adds/fixes/improves tests to ensure that mechanism *actually* works.
- Refactors a small bit of particularly hard-to-read code.

### Motivation
<!-- What inspired you to submit this pull request? -->
This bug is currently affecting a customer, as reported by a member of the Support team.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
There are several opportunities for refactoring/improving code readability/maintainability in the Postgres check, but this should be tackled in separate PRs.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
