### PR TITLE
Fix dashboard source_type_id

### DIFF
--- a/linkerd/assets/dashboards/overview.json
+++ b/linkerd/assets/dashboards/overview.json
@@ -27,7 +27,6 @@
     "originalHeight": 80,
     "originalWidth": "calc(100% - 32px)",
     "read_only": false,
-    "source_type_id": 10019,
     "template_variables": [],
     "widgets": [
         {

--- a/linkerd/assets/dashboards/overview.json
+++ b/linkerd/assets/dashboards/overview.json
@@ -27,7 +27,7 @@
     "originalHeight": 80,
     "originalWidth": "calc(100% - 32px)",
     "read_only": false,
-    "source_type_id": 10017,
+    "source_type_id": 10019,
     "template_variables": [],
     "widgets": [
         {


### PR DESCRIPTION
### What does this PR do?
The linkerd dashboard was exported with an incorrect `source_type_id`. This PR removes the field.
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
