### PR TITLE
Add aof loading metrics

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -44,6 +44,10 @@ class Redis(AgentCheck):
         'aof_rewrite_in_progress': 'redis.aof.rewrite',
         'aof_current_size': 'redis.aof.size',
         'aof_buffer_length': 'redis.aof.buffer_length',
+        'loading_total_bytes': 'redis.aof.loading_total_bytes',
+        'loading_loaded_bytes': 'redis.aof.loading_loaded_bytes',
+        'loading_loaded_perc': 'redis.aof.loading_loaded_perc',
+        'loading_eta_seconds': 'redis.aof.loading_eta_seconds',
         # Network
         'connected_clients': 'redis.net.clients',
         'connected_slaves': 'redis.net.slaves',

--- a/redisdb/metadata.csv
+++ b/redisdb/metadata.csv
@@ -8,6 +8,10 @@ redis.aof.buffer_length,gauge,,byte,,Size of the AOF buffer.,0,redis,aof buf len
 redis.aof.last_rewrite_time,gauge,,second,,Duration of the last AOF rewrite.,0,redis,last aof rewrite time
 redis.aof.rewrite,gauge,,,,Flag indicating a AOF rewrite operation is on-going.,0,redis,aof rewrite
 redis.aof.size,gauge,,byte,,AOF current file size (aof_current_size).,0,redis,aof size
+redis.aof.loading_total_bytes,gauge,,byte,,The total amount of bytes already loaded.,0,redis,aof total bytes to load
+redis.aof.loading_loaded_bytes,gauge,,byte,,The amount of bytes to load.,0,redis,aof total bytes loaded
+redis.aof.loading_loaded_perc,gauge,,percent,,The percent loaded.,0,redis,aof loaded percent
+redis.aof.loading_eta_seconds,gauge,,second,,The estimated amount of time left to load.,0,redis,aof loading time left
 redis.clients.biggest_input_buf,gauge,,,,The biggest input buffer among current client connections.,0,redis,biggest input buf
 redis.clients.blocked,gauge,,connection,,The number of connections waiting on a blocking call.,0,redis,clients blocked
 redis.clients.longest_output_list,gauge,,,,The longest output list among current client connections.,0,redis,long output list


### PR DESCRIPTION
### What does this PR do?

Adds metrics regarding the loading of the AOF file

### Motivation
It is helpful to be able to see when Redis is loading the file and being able to keep track of the progress without having to use the redis-cli.

### Additional Notes
These metrics _only_ show up while an AOF file is being loaded, otherwise they are not included in the INFO call. 

I was unsure of the best approach for adding tests for this due to the fact that unless the AOF file is quite large, loading happens very quickly

Additionally, the names of these metrics do not make it obvious, but they are _only_ about the AOF, not RDB, according to https://redis.io/commands/info

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
