### PR TITLE
Remove repo reference 

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
@@ -180,7 +180,7 @@ def testable(ctx, start_id, agent_version, milestone, dry_run):
     for i, (commit_hash, commit_subject) in enumerate(diff_data, 1):
         commit_id = parse_pr_number(commit_subject)
         if commit_id:
-            api_response = get_pr(commit_id, user_config, repo=repo, raw=True)
+            api_response = get_pr(commit_id, user_config, raw=True)
             if api_response.status_code == 401:
                 abort('Access denied. Please ensure your GitHub token has correct permissions.')
             elif api_response.status_code == 403:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

`get_pr()` no longer takes a `repo` argument. 

https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/tooling/github.py#L55

### Motivation
<!-- What inspired you to submit this pull request? -->

`ddev release testable` would get an `unexpected keyword argument`:
```
± |master {5} ✓| → ddev release testable --since 6.16
Branch `6.16.x` will be compared to `origin/master`.
Getting diff... failed!
Local branch `6.16.x` might not exist, trying `origin/6.16.x`... success!
Traceback (most recent call last):
  File "/usr/local/bin/ddev", line 11, in <module>
    load_entry_point('datadog-checks-dev', 'console_scripts', 'ddev')()
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/christine.chen/dev/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py", line 183, in testable
    api_response = get_pr(commit_id, user_config, repo=repo, raw=True)
TypeError: get_pr() got an unexpected keyword argument 'repo'
```
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
