### PR TITLE
Fix http handler

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -57,7 +57,7 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
 
         super(OpenMetricsBaseCheck, self).__init__(*args, **kwargs)
         self.config_map = {}
-        self.http_handlers = {}
+        self._http_handlers = {}
         self.default_instances = default_instances
         self.default_namespace = default_namespace
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -290,6 +290,10 @@ class OpenMetricsScraperMixin(object):
         return config
 
     def get_http_handler(self, scraper_config):
+        """
+        Get http handler for a specific scrapper config.
+        The http handler is cached using `prometheus_url` as key.
+        """
         prometheus_url = scraper_config['prometheus_url']
         if prometheus_url in self._http_handlers:
             return self._http_handlers[prometheus_url]

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -287,17 +287,18 @@ class OpenMetricsScraperMixin(object):
         if config['metadata_metric_name'] and config['metadata_label_map']:
             config['_default_metric_transformers'][config['metadata_metric_name']] = self.transform_metadata
 
-        # Set up the HTTP wrapper for this endpoint
-        self._set_up_http_handler(endpoint, config)
-
         return config
 
-    def _set_up_http_handler(self, endpoint, scraper_config):
+    def get_http_handler(self, scraper_config):
+        prometheus_url = scraper_config['prometheus_url']
+        if prometheus_url in self._http_handlers:
+            return self._http_handlers[prometheus_url]
+
         # TODO: Deprecate this behavior in Agent 8
         if scraper_config['ssl_verify'] is False:
             scraper_config.setdefault('tls_ignore_warning', True)
 
-        http_handler = self.http_handlers[endpoint] = RequestsWrapper(
+        http_handler = self._http_handlers[prometheus_url] = RequestsWrapper(
             scraper_config, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log
         )
 
@@ -309,6 +310,8 @@ class OpenMetricsScraperMixin(object):
 
         # TODO: Determine if we really need this
         headers.setdefault('accept-encoding', 'gzip')
+
+        return http_handler
 
     def parse_metric_family(self, response, scraper_config):
         """
@@ -580,7 +583,9 @@ class OpenMetricsScraperMixin(object):
         if headers:
             kwargs['headers'] = headers
 
-        return self.http_handlers[scraper_config['prometheus_url']].get(endpoint, stream=True, **kwargs)
+        http_handler = self.get_http_handler(scraper_config)
+
+        return http_handler.get(endpoint, stream=True, **kwargs)
 
     def get_hostname_for_sample(self, sample, scraper_config):
         """

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -2117,7 +2117,7 @@ def test_ssl_verify_not_raise_warning(mocked_openmetrics_check_factory, text_dat
     assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
 
 
-def test_send_request(mocked_openmetrics_check_factory, text_data):
+def test_send_request_with_dynamic_prometheus_url(mocked_openmetrics_check_factory, text_data):
     instance = dict(
         {
             'prometheus_url': 'https://www.example.com',
@@ -2129,6 +2129,7 @@ def test_send_request(mocked_openmetrics_check_factory, text_data):
     check = mocked_openmetrics_check_factory(instance)
     scraper_config = check.get_scraper_config(instance)
 
+    # `prometheus_url` changed just before calling `send_request`
     scraper_config['prometheus_url'] = 'https://www.example.com/foo/bar'
 
     with pytest.warns(None) as record:

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -2115,3 +2115,24 @@ def test_ssl_verify_not_raise_warning(mocked_openmetrics_check_factory, text_dat
 
     assert "httpbin.org" in resp.content.decode('utf-8')
     assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
+
+
+def test_send_request(mocked_openmetrics_check_factory, text_data):
+    instance = dict(
+        {
+            'prometheus_url': 'https://www.example.com',
+            'metrics': [{'foo': 'bar'}],
+            'namespace': 'openmetrics',
+            'ssl_verify': False,
+        }
+    )
+    check = mocked_openmetrics_check_factory(instance)
+    scraper_config = check.get_scraper_config(instance)
+
+    scraper_config['prometheus_url'] = 'https://www.example.com/foo/bar'
+
+    with pytest.warns(None) as record:
+        resp = check.send_request('https://httpbin.org/get', scraper_config)
+
+    assert "httpbin.org" in resp.content.decode('utf-8')
+    assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)

--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -243,7 +243,7 @@ class Vault(OpenMetricsBaseCheck):
             self._scraper_config['custom_tags'] = self._tags
 
             # https://www.vaultproject.io/api/overview#the-x-vault-request-header
-            self._set_header(self.get_http_handler(instance), 'X-Vault-Request', 'true')
+            self._set_header(self.get_http_handler(self._scraper_config), 'X-Vault-Request', 'true')
 
             if not self._no_token:
                 if self._client_token_path:

--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -243,7 +243,7 @@ class Vault(OpenMetricsBaseCheck):
             self._scraper_config['custom_tags'] = self._tags
 
             # https://www.vaultproject.io/api/overview#the-x-vault-request-header
-            self._set_header(self.http_handlers[instance['prometheus_url']], 'X-Vault-Request', 'true')
+            self._set_header(self.get_http_handler(instance), 'X-Vault-Request', 'true')
 
             if not self._no_token:
                 if self._client_token_path:
@@ -257,7 +257,7 @@ class Vault(OpenMetricsBaseCheck):
     def set_client_token(self, client_token):
         self._client_token = client_token
         self._set_header(self.http, 'X-Vault-Token', client_token)
-        self._set_header(self.http_handlers[self._scraper_config['prometheus_url']], 'X-Vault-Token', client_token)
+        self._set_header(self.get_http_handler(self._scraper_config), 'X-Vault-Token', client_token)
 
     def renew_client_token(self):
         with open(self._client_token_path, 'rb') as f:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Before, if the `prometheus_url` is changed after the scrapper is created, we won't be able to find the handler. Hence leading to a `KeyError`.

Initial feature PR: https://github.com/DataDog/integrations-core/pull/5414

Example:

```
Average Execution Time : 223ms
      Error: 'https://10.128.246.166:10250/metrics/cadvisor'
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/base.py", line 673, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/kubelet/kubelet.py", line 285, in check
          self.process(self.cadvisor_scraper_config, metric_transformers=self.transformers)
        File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/openmetrics/mixins.py", line 401, in process
          for metric in self.scrape_metrics(scraper_config):
        File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/openmetrics/mixins.py", line 359, in scrape_metrics
          response = self.poll(scraper_config)
        File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/openmetrics/mixins.py", line 559, in poll
          response = self.send_request(endpoint, scraper_config, headers)
        File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/openmetrics/mixins.py", line 583, in send_request
          return self.http_handlers[scraper_config['prometheus_url']].get(endpoint, stream=True, **kwargs)
      KeyError: 'https://10.128.246.166:10250/metrics/cadvisor'
```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
