### PR TITLE
Assign users to QA release tasks

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
@@ -59,8 +59,7 @@ def create_jira_issue(client, teams, pr_title, pr_url, pr_body, dry_run):
                 )
                 time.sleep(wait_time)
             else:
-                echo_success('Created issue for team {}: '.format(team), nl=False)
-                echo_info('https://datadoghq.atlassian.net/jira/software/projects/AR/boards/220?selectedIssue={}'.format(response.json().get('key')))
+                echo_success('Created issue {} for team {}'.format(response.json().get('key'), team))
                 break
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
@@ -48,7 +48,6 @@ def create_jira_issue(client, teams, pr_title, pr_url, pr_body, dry_run):
                 )
                 time.sleep(wait_time)
             elif error:
-                print(error)
                 if attempt + 1 == creation_attempts:
                     echo_failure(f'Error: {error}')
                     break

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
@@ -6,7 +6,6 @@ import time
 
 import click
 from semver import parse_version_info
-from six import iteritems
 
 from ....subprocess import run_command
 from ....utils import basepath, chdir, get_next

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
@@ -70,10 +70,10 @@ def create_jira_issue(client, teams, pr_title, pr_url, pr_body, dry_run, pr_auth
 
 def pick_card_member(config, author, team):
     """Return a member to assign to the created issue.
-    In practice it returns one jira user which is not the PR author, for the given team.
-    For it to work, you a `jira_user_$team` table in your ddev configuration,
-    with keys being github users and values being their corresponding jira
-    IDs (not names).
+    In practice, it returns one jira user which is not the PR author, for the given team.
+    For it to work, you need a `jira_user_$team` table in your ddev configuration,
+    with keys being github users and values being their corresponding jira IDs (not names).
+
     For example::
         [jira_users_integrations]
         john = "xxxxxxxxxxxxxxxxxxxxx"

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
@@ -5,7 +5,8 @@ import time
 
 import click
 from semver import parse_version_info
-
+from six import iteritems
+import random
 from ....subprocess import run_command
 from ....utils import basepath, chdir, get_next
 from ...constants import CHANGELOG_LABEL_PREFIX, CHANGELOG_TYPE_NONE, get_root
@@ -29,17 +30,20 @@ def validate_version(ctx, param, value):
         raise click.BadParameter('needs to be in semver format x.y[.z]')
 
 
-def create_jira_issue(client, teams, pr_title, pr_url, pr_body, dry_run):
+def create_jira_issue(client, teams, pr_title, pr_url, pr_body, dry_run, pr_author, config):
     body = u'Pull request: {}\n\n{}'.format(pr_url, pr_body)
 
     for team in teams:
+        member = pick_card_member(config, pr_author, team)
+        if member:
+            echo_info("Randomly assigned issue to {}".format(member))
         if dry_run:
             echo_success('Will create an issue for team {}: '.format(team), nl=False)
             echo_info(pr_title)
             continue
         creation_attempts = 3
         for attempt in range(3):
-            rate_limited, error, response = client.create_issue(team, pr_title, body)
+            rate_limited, error, response = client.create_issue(team, pr_title, body, member)
             if rate_limited:
                 wait_time = 10
                 echo_warning(
@@ -59,8 +63,26 @@ def create_jira_issue(client, teams, pr_title, pr_url, pr_body, dry_run):
                 )
                 time.sleep(wait_time)
             else:
-                echo_success('Created issue {} for team {}'.format(response.json().get('key'), team))
+                echo_success('Created issue {} for team {} '.format(response.json().get('key'), team))
                 break
+
+
+def pick_card_member(config, author, team):
+    """Return a member to assign to the created issue.
+    In practice it returns one jira user which is not the PR author, for the given team.
+    For it to work, you a `jira_user_$team` table in your ddev configuration,
+    with keys being github users and values being their corresponding jira
+    IDs (not names).
+    For example::
+        [jira_users_integrations]
+        john = "xxxxxxxxxxxxxxxxxxxxx"
+        alice = "yyyyyyyyyyyyyyyyyyyy"
+    """
+    users = config.get('jira_users_{}'.format(team.lower()))
+    if not users:
+        return
+    member = random.choice([key for user, key in users.items() if user != author])
+    return member
 
 
 @click.command(
@@ -249,7 +271,7 @@ def testable(ctx, start_id, agent_version, milestone, dry_run):
 
         teams = [jira.label_team_map[label] for label in pr_labels if label in jira.label_team_map]
         if teams:
-            create_jira_issue(jira, teams, pr_title, pr_url, pr_body, dry_run)
+            create_jira_issue(jira, teams, pr_title, pr_url, pr_body, dry_run, pr_author, user_config)
             continue
 
         finished = False
@@ -308,6 +330,6 @@ def testable(ctx, start_id, agent_version, milestone, dry_run):
                 echo_warning(f'Exited at {format_commit_id(commit_id)}')
                 return
             else:
-                create_jira_issue(jira, [value], pr_title, pr_url, pr_body, dry_run)
+                create_jira_issue(jira, [value], pr_title, pr_url, pr_body, dry_run, pr_author, user_config)
 
             finished = True

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
@@ -1,12 +1,13 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import random
 import time
 
 import click
 from semver import parse_version_info
 from six import iteritems
-import random
+
 from ....subprocess import run_command
 from ....utils import basepath, chdir, get_next
 from ...constants import CHANGELOG_LABEL_PREFIX, CHANGELOG_TYPE_NONE, get_root

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
@@ -34,7 +34,7 @@ def create_jira_issue(client, teams, pr_title, pr_url, pr_body, dry_run):
 
     for team in teams:
         if dry_run:
-            echo_success(f'Will create an issue for team {team}: ', nl=False)
+            echo_success('Will create an issue for team {}: '.format(team), nl=False)
             echo_info(pr_title)
             continue
         creation_attempts = 3
@@ -59,8 +59,8 @@ def create_jira_issue(client, teams, pr_title, pr_url, pr_body, dry_run):
                 )
                 time.sleep(wait_time)
             else:
-                issue_key = response.json().get('key')
-                echo_success(f'Created issue {issue_key} for team {team}')
+                echo_success('Created issue for team {}: '.format(team), nl=False)
+                echo_info(response.json().get('url'))
                 break
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
@@ -60,7 +60,7 @@ def create_jira_issue(client, teams, pr_title, pr_url, pr_body, dry_run):
                 time.sleep(wait_time)
             else:
                 echo_success('Created issue for team {}: '.format(team), nl=False)
-                echo_info(response.json().get('url'))
+                echo_info('https://datadoghq.atlassian.net/jira/software/projects/AR/boards/220?selectedIssue={}'.format(response.json().get('key')))
                 break
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
@@ -71,7 +71,7 @@ def create_jira_issue(client, teams, pr_title, pr_url, pr_body, dry_run, pr_auth
 def pick_card_member(config, author, team):
     """Return a member to assign to the created issue.
     In practice, it returns one jira user which is not the PR author, for the given team.
-    For it to work, you need a `jira_user_$team` table in your ddev configuration,
+    For it to work, you need a `jira_users_$team` table in your ddev configuration,
     with keys being github users and values being their corresponding jira IDs (not names).
 
     For example::

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
@@ -79,7 +79,7 @@ def pick_card_member(config, author, team):
         john = "xxxxxxxxxxxxxxxxxxxxx"
         alice = "yyyyyyyyyyyyyyyyyyyy"
     """
-    users = config.get('jira_users_{}'.format(team.lower()))
+    users = config.get(f'jira_users_{team.lower()}')
     if not users:
         return
     member = random.choice([key for user, key in users.items() if user != author])

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
@@ -30,7 +30,7 @@ def validate_version(ctx, param, value):
 
 
 def create_jira_issue(client, teams, pr_title, pr_url, pr_body, dry_run):
-    body = f'Pull request: {pr_url}\n\n{pr_body}'
+    body = u'Pull request: {}\n\n{}'.format(pr_url, pr_body)
 
     for team in teams:
         if dry_run:
@@ -48,6 +48,7 @@ def create_jira_issue(client, teams, pr_title, pr_url, pr_body, dry_run):
                 )
                 time.sleep(wait_time)
             elif error:
+                print(error)
                 if attempt + 1 == creation_attempts:
                     echo_failure(f'Error: {error}')
                     break
@@ -80,10 +81,14 @@ def testable(ctx, start_id, agent_version, milestone, dry_run):
     `github.user`/`github.token` in your config file or use the
     `DD_GITHUB_USER`/`DD_GITHUB_TOKEN` environment variables.
     \b
+
     To use Jira:
     1. Go to `https://id.atlassian.com/manage/api-tokens` and create an API token.
-    2. Run `ddev config set jira.user` and enter your jira email.
-    3. Run `ddev config set jira.token` and paste your API token.
+
+    2. Run `ddev config set jira.token` and paste your API token.
+
+    3. Run `ddev config set jira.user` and enter your jira email.
+
     """
     root = get_root()
     repo = basepath(root)
@@ -243,10 +248,6 @@ def testable(ctx, start_id, agent_version, milestone, dry_run):
         pr_title = pr_data.get('title', commit_subject)
         pr_author = pr_data.get('user', {}).get('login', '')
         pr_body = pr_data.get('body', '')
-
-        jira_config = user_config['jira']
-        if not (jira_config['user'] and jira_config['token']):
-            abort('Error: You are not authenticated for Jira. Please set your jira ddev config')
 
         teams = [jira.label_team_map[label] for label in pr_labels if label in jira.label_team_map]
         if teams:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/config.py
@@ -20,47 +20,34 @@ SECRET_KEYS = {
     'orgs.*.api_key',
     'orgs.*.app_key',
     'github.token',
-    'jira.token',
     'pypi.pass',
-    'trello.key',
-    'trello.token',
+    'jira.token',
 }
 
-DEFAULT_CONFIG = OrderedDict(
-    [
-        ('core', os.path.join('~', 'dd', 'integrations-core')),
-        ('extras', os.path.join('~', 'dd', 'integrations-extras')),
-        ('agent', os.path.join('~', 'dd', 'datadog-agent')),
-        ('repo', 'core'),
-        ('color', bool(int(os.environ['DDEV_COLOR'])) if 'DDEV_COLOR' in os.environ else None),
-        ('dd_api_key', os.getenv('DD_API_KEY')),
-        ('dd_app_key', os.getenv('DD_APP_KEY')),
-        ('org', 'default'),
-        ('agent6', OrderedDict((('docker', 'datadog/agent-dev:master'), ('local', 'latest')))),
-        ('agent5', OrderedDict((('docker', 'datadog/dev-dd-agent:master'), ('local', 'latest')))),
-        ('github', OrderedDict((('user', ''), ('token', '')))),
-        ('jira', OrderedDict((('user', ''), ('token', '')))),
-        ('pypi', OrderedDict((('user', ''), ('pass', '')))),
-        ('trello', OrderedDict((('key', ''), ('token', '')))),
-        (
-            'orgs',
-            OrderedDict(
-                (
-                    (
-                        'default',
-                        OrderedDict(
-                            (
-                                ('api_key', os.getenv('DD_API_KEY')),
-                                ('app_key', os.getenv('DD_APP_KEY')),
-                                ('site', os.getenv('DD_SITE')),
-                            )
-                        ),
-                    ),
-                )
-            ),
-        ),
-    ]
-)
+DEFAULT_CONFIG = {
+    'core': os.path.join('~', 'dd', 'integrations-core'),
+    'extras': os.path.join('~', 'dd', 'integrations-extras'),
+    'agent': os.path.join('~', 'dd', 'datadog-agent'),
+    'repo': 'core',
+    'color': bool(int(os.environ['DDEV_COLOR'])) if 'DDEV_COLOR' in os.environ else None,
+    'dd_api_key': os.getenv('DD_API_KEY'),
+    'dd_app_key': os.getenv('DD_APP_KEY'),
+    'org': 'default',
+    'agent6': {'docker': 'datadog/agent-dev:master', 'local': 'latest'},
+    'agent5': {'docker': 'datadog/dev-dd-agent:master', 'local': 'latest'},
+    'github': {'user': '', 'token': ''},
+    'pypi': {'user': '', 'pass': ''},
+    'jira': {'user': '', 'token': ''},
+    'orgs': {
+        'default': {
+            'api_key': os.getenv('DD_API_KEY'),
+            'app_key': os.getenv('DD_APP_KEY'),
+            'site': os.getenv('DD_SITE'),
+            'dd_url': os.getenv('DD_DD_URL'),
+            'log_url': os.getenv('DD_LOGS_CONFIG_DD_URL'),
+        }
+    },
+}
 
 
 def config_file_exists():

--- a/datadog_checks_dev/datadog_checks/dev/tooling/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/config.py
@@ -20,10 +20,10 @@ SECRET_KEYS = {
     'orgs.*.api_key',
     'orgs.*.app_key',
     'github.token',
+    'jira.token',
     'pypi.pass',
     'trello.key',
     'trello.token',
-    'jira.token',
 }
 
 DEFAULT_CONFIG = OrderedDict(
@@ -39,9 +39,9 @@ DEFAULT_CONFIG = OrderedDict(
         ('agent6', OrderedDict((('docker', 'datadog/agent-dev:master'), ('local', 'latest')))),
         ('agent5', OrderedDict((('docker', 'datadog/dev-dd-agent:master'), ('local', 'latest')))),
         ('github', OrderedDict((('user', ''), ('token', '')))),
+        ('jira', OrderedDict((('user', ''), ('token', '')))),
         ('pypi', OrderedDict((('user', ''), ('pass', '')))),
         ('trello', OrderedDict((('key', ''), ('token', '')))),
-        ('jira', OrderedDict((('user', ''), ('token', '')))),
         (
             'orgs',
             OrderedDict(

--- a/datadog_checks_dev/datadog_checks/dev/tooling/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/config.py
@@ -21,33 +21,46 @@ SECRET_KEYS = {
     'orgs.*.app_key',
     'github.token',
     'pypi.pass',
+    'trello.key',
+    'trello.token',
     'jira.token',
 }
 
-DEFAULT_CONFIG = {
-    'core': os.path.join('~', 'dd', 'integrations-core'),
-    'extras': os.path.join('~', 'dd', 'integrations-extras'),
-    'agent': os.path.join('~', 'dd', 'datadog-agent'),
-    'repo': 'core',
-    'color': bool(int(os.environ['DDEV_COLOR'])) if 'DDEV_COLOR' in os.environ else None,
-    'dd_api_key': os.getenv('DD_API_KEY'),
-    'dd_app_key': os.getenv('DD_APP_KEY'),
-    'org': 'default',
-    'agent6': {'docker': 'datadog/agent-dev:master', 'local': 'latest'},
-    'agent5': {'docker': 'datadog/dev-dd-agent:master', 'local': 'latest'},
-    'github': {'user': '', 'token': ''},
-    'pypi': {'user': '', 'pass': ''},
-    'jira': {'user': '', 'token': ''},
-    'orgs': {
-        'default': {
-            'api_key': os.getenv('DD_API_KEY'),
-            'app_key': os.getenv('DD_APP_KEY'),
-            'site': os.getenv('DD_SITE'),
-            'dd_url': os.getenv('DD_DD_URL'),
-            'log_url': os.getenv('DD_LOGS_CONFIG_DD_URL'),
-        }
-    },
-}
+DEFAULT_CONFIG = OrderedDict(
+    [
+        ('core', os.path.join('~', 'dd', 'integrations-core')),
+        ('extras', os.path.join('~', 'dd', 'integrations-extras')),
+        ('agent', os.path.join('~', 'dd', 'datadog-agent')),
+        ('repo', 'core'),
+        ('color', bool(int(os.environ['DDEV_COLOR'])) if 'DDEV_COLOR' in os.environ else None),
+        ('dd_api_key', os.getenv('DD_API_KEY')),
+        ('dd_app_key', os.getenv('DD_APP_KEY')),
+        ('org', 'default'),
+        ('agent6', OrderedDict((('docker', 'datadog/agent-dev:master'), ('local', 'latest')))),
+        ('agent5', OrderedDict((('docker', 'datadog/dev-dd-agent:master'), ('local', 'latest')))),
+        ('github', OrderedDict((('user', ''), ('token', '')))),
+        ('pypi', OrderedDict((('user', ''), ('pass', '')))),
+        ('trello', OrderedDict((('key', ''), ('token', '')))),
+        ('jira', OrderedDict((('user', ''), ('token', '')))),
+        (
+            'orgs',
+            OrderedDict(
+                (
+                    (
+                        'default',
+                        OrderedDict(
+                            (
+                                ('api_key', os.getenv('DD_API_KEY')),
+                                ('app_key', os.getenv('DD_APP_KEY')),
+                                ('site', os.getenv('DD_SITE')),
+                            )
+                        ),
+                    ),
+                )
+            ),
+        ),
+    ]
+)
 
 
 def config_file_exists():

--- a/datadog_checks_dev/datadog_checks/dev/tooling/jira.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/jira.py
@@ -80,9 +80,8 @@ class JiraClient:
 
         try:
             response = requests.post(self.CREATE_ENDPOINT, data=data, auth=self.auth, headers=headers)
-            issue_key = json.loads(response.content).get('key')
-            self.move_column(team, issue_key)
-
+            issue_key = response.json().get('key')
+            rate_limited, error, resp = self.move_column(team, issue_key)
         except Exception as e:
             error = str(e)
         else:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/jira.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/jira.py
@@ -57,29 +57,31 @@ class JiraClient:
 
         return rate_limited, error, response
 
-    def create_issue(self, team, name, body):
+    def create_issue(self, team, name, body, member=None):
         rate_limited = False
         error = None
         response = None
 
-        data = json.dumps(
-            {
-                'fields': {
-                    'project': {'key': 'AR'},
-                    'summary': name,
-                    'description': {
-                        'type': 'doc',
-                        'version': 1,
-                        'content': [{'type': 'paragraph', 'content': [{'type': 'text', 'text': body}]}],
-                    },
-                    'issuetype': {'name': 'Task'},
-                }
+        data = {
+            'fields': {
+                'project': {'key': 'AR'},
+                'summary': name,
+                'description': {
+                    'type': 'doc',
+                    'version': 1,
+                    'content': [{'type': 'paragraph', 'content': [{'type': 'text', 'text': body}]}],
+                },
+                'issuetype': {'name': 'Task'},
             }
-        )
+        }
+
+        if member:
+            data['fields']['assignee'] = {"id": member}
+
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
 
         try:
-            response = requests.post(self.CREATE_ENDPOINT, data=data, auth=self.auth, headers=headers)
+            response = requests.post(self.CREATE_ENDPOINT, data=json.dumps(data), auth=self.auth, headers=headers)
             issue_key = response.json().get('key')
             rate_limited, error, resp = self.move_column(team, issue_key)
         except Exception as e:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/jira.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/jira.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2018-present
+# (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
@@ -22,24 +22,28 @@ class JiraClient:
             'Integrations': '41',
             'Logs': '71',
             'Platform': '51',
-            'Process': '81',
+            'Networks': '171',
+            'Processes': '181',
             'Trace': '61',
         }
         self.label_team_map = {
             'team/agent-apm': 'Trace',
             'team/agent-core': 'Core',
             'team/agent-platform': 'Platform',
-            'team/burrito': 'Process',
+            'team/networks': 'Networks',
+            'team/processes': 'Processes',
             'team/containers': 'Containers',
             'team/integrations': 'Integrations',
             'team/logs': 'Logs',
         }
 
+    # We will need two API calls until this is added: https://jira.atlassian.com/browse/JRACLOUD-69559?_ga=2.62950895.1343692979.1578939312-1018831208.1578519746 # noqa
     def move_column(self, team, issue_key):
         rate_limited = False
         error = None
         url = f'{self.CREATE_ENDPOINT}/{issue_key}/transitions'
 
+        # Documentation to transition an issue's status/column: https://developer.atlassian.com/cloud/jira/platform/rest/v3/?_ga=2.39263651.1896629564.1578666825-1018831208.1578519746#api-rest-api-3-issue-issueIdOrKey-transitions-post # noqa
         data = json.dumps({'transition': {'id': self.team_list_map[team]}})
 
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
@@ -65,6 +69,7 @@ class JiraClient:
         error = None
         response = None
 
+        # documentation to create a Jira issue: https://developer.atlassian.com/cloud/jira/platform/rest/v3/?_ga=2.39263651.1896629564.1578666825-1018831208.1578519746#api-rest-api-3-issue-post # noqa
         data = {
             'fields': {
                 'project': {'key': 'AR'},

--- a/datadog_checks_dev/datadog_checks/dev/tooling/jira.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/jira.py
@@ -12,7 +12,10 @@ class JiraClient:
     CREATE_ENDPOINT = API_URL + '/3/issue'
 
     def __init__(self, config):
-        self.auth = HTTPBasicAuth(config['jira']['user'] or None, config['jira']['token'] or None)
+        jira_email = config['jira']['user']
+        jira_token = config['jira']['token']
+
+        self.auth = HTTPBasicAuth(jira_email, jira_token)
         self.team_list_map = {
             'Containers': '21',
             'Core': '31',
@@ -35,7 +38,7 @@ class JiraClient:
     def move_column(self, team, issue_key):
         rate_limited = False
         error = None
-        url = '{}/{}/transitions'.format(self.CREATE_ENDPOINT, issue_key)
+        url = f'{self.CREATE_ENDPOINT}/{issue_key}/transitions'
 
         data = json.dumps({'transition': {'id': self.team_list_map[team]}})
 


### PR DESCRIPTION
### What does this PR do?
Allows the release manager to assign Jira issues to a random team member (but not the PR owner) via the ddev testable script.

### Motivation
This was originally implemented in #4765 but closed due to the migration to Jira.

### Additional Notes
Depends on #5457 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached