### PR TITLE
Fix debug logging

### DIFF
--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -109,6 +109,7 @@ class ProcessCheck(AgentCheck):
 
         refresh_ad_cache = self.should_refresh_ad_cache(name)
 
+        encountered_process_names = set()
         matching_pids = set()
 
         for proc in psutil.process_iter():
@@ -119,16 +120,19 @@ class ProcessCheck(AgentCheck):
             found = False
             for string in search_string:
                 try:
+                    proc_name = proc.name()
+                    encountered_process_names.add(proc_name)
+
                     # FIXME 8.x: All has been deprecated
                     # from the doc, should be removed
                     if string == 'All':
                         found = True
                     if exact_match:
                         if os.name == 'nt':
-                            if proc.name().lower() == string.lower():
+                            if proc_name.lower() == string.lower():
                                 found = True
                         else:
-                            if proc.name() == string:
+                            if proc_name == string:
                                 found = True
 
                     else:
@@ -160,7 +164,7 @@ class ProcessCheck(AgentCheck):
             self.log.debug(
                 "Unable to find process named '%s' from among processes:\n%s",
                 search_string,
-                ', '.join(repr(p) for p in psutil.process_iter()),
+                ', '.join(sorted(encountered_process_names)),
             )
 
         self.pid_cache[name] = matching_pids


### PR DESCRIPTION
### Motivation

1. Doing 2 iterations over every process causes too much of a CPU spike
2. The output was too verbose to be useful https://github.com/giampaolo/psutil/blob/0b21b19fb2ef008d3cdb9a82e494b1a024a5c14b/psutil/__init__.py#L395-L416

`
psutil.Process(pid=0, name='System Idle Process', started='2020-01-09 01:09:05'), psutil.Process(pid=4, name='System', started='2020-01-09 01:09:05'), psutil.Process(pid=104, name='Secure System', started='2020-01-09 01:09:01'), psutil.Process(pid=176, name='Registry', started='2020-01-09 01:09:01'), psutil.Process(pid=292, name='Keybase.exe', started='2020-01-09 21:10:40'), psutil.Process(pid=336, name='RuntimeBroker.exe', started='2020-01-09 01:49:17'), psutil.Process(pid=384, name='svchost.exe', start........................
`