### PR TITLE
Add meta command to convert metadata.csv files to Markdown tables

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/__init__.py
@@ -7,9 +7,10 @@ from ..console import CONTEXT_SETTINGS
 from .changes import changes
 from .dashboard import dash
 from .prometheus import prom
+from .scripts import scripts
 from .snmp import snmp
 
-ALL_COMMANDS = (changes, dash, prom, snmp)
+ALL_COMMANDS = (changes, dash, prom, scripts, snmp)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Collection of useful utilities')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/__init__.py
@@ -1,0 +1,18 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import click
+
+from ...console import CONTEXT_SETTINGS
+from .metrics2md import metrics2md
+
+ALL_COMMANDS = (metrics2md,)
+
+
+@click.group(context_settings=CONTEXT_SETTINGS, short_help='Miscellaneous scripts that may be useful')
+def scripts():
+    pass
+
+
+for command in ALL_COMMANDS:
+    scripts.add_command(command)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/metrics2md.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/metrics2md.py
@@ -8,7 +8,7 @@ import click
 import pyperclip
 
 from ....utils import read_metric_data_file
-from ...console import CONTEXT_SETTINGS, abort
+from ...console import CONTEXT_SETTINGS, abort, echo_success
 
 VALID_FIELDS = {
     'metric_name',
@@ -59,12 +59,14 @@ def metrics2md(check, fields):
     reader = csv.DictReader(StringIO(metric_data), delimiter=',')
 
     rows = []
-    for row in reader:
-        rows.append(' | '.join(row[field] or 'N/A' for field in fields))
+    for csv_row in reader:
+        rows.append(' | '.join(csv_row[field] or 'N/A' for field in fields))
 
     rows.sort()
+    num_metrics = len(rows)
 
     md_table_rows = [' | '.join(fields), ' | '.join('---' for _ in fields)]
     md_table_rows.extend(rows)
 
     pyperclip.copy('\n'.join(md_table_rows))
+    echo_success('Successfully copied table with {} metric{}'.format(num_metrics, 's' if num_metrics > 1 else ''))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/metrics2md.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/metrics2md.py
@@ -1,0 +1,70 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import csv
+from io import StringIO
+
+import click
+import pyperclip
+
+from ....utils import read_metric_data_file
+from ...console import CONTEXT_SETTINGS, abort
+
+VALID_FIELDS = {
+    'metric_name',
+    'metric_type',
+    'interval',
+    'unit_name',
+    'per_unit_name',
+    'description',
+    'orientation',
+    'integration',
+    'short_name',
+}
+
+DEFAULT_FIELDS = ('metric_name', 'description', 'metric_type', 'unit_name')
+
+
+@click.command(context_settings=CONTEXT_SETTINGS, short_help='Convert metadata.csv files to Markdown tables')
+@click.argument('check')
+@click.argument('fields', nargs=-1)
+def metrics2md(check, fields):
+    """Convert a check's metadata.csv file to a Markdown table, which will be copied to your clipboard.
+
+    By default it will be compact and only contain the most useful fields. If you wish to use arbitrary
+    metric data, you may set the check to `cb` to target the current contents of your clipboard.
+    """
+    if not fields:
+        fields = DEFAULT_FIELDS
+    else:
+        chosen_fields = set(fields)
+        if chosen_fields - VALID_FIELDS:
+            abort('You must select only from the following fields: {}'.format(', '.join(VALID_FIELDS)))
+
+        # Deduplicate and retain order
+        old_fields = fields
+        fields = []
+        for field in old_fields:
+            if field not in chosen_fields:
+                continue
+
+            fields.append(field)
+            chosen_fields.discard(field)
+
+    if check == 'cb':
+        metric_data = pyperclip.paste()
+    else:
+        metric_data = read_metric_data_file(check)
+
+    reader = csv.DictReader(StringIO(metric_data), delimiter=',')
+
+    rows = []
+    for row in reader:
+        rows.append(' | '.join(row[field] or 'N/A' for field in fields))
+
+    rows.sort()
+
+    md_table_rows = [' | '.join(fields), ' | '.join('---' for _ in fields)]
+    md_table_rows.extend(rows)
+
+    pyperclip.copy('\n'.join(md_table_rows))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -148,6 +148,10 @@ def get_metric_sources():
     return {path for path in os.listdir(get_root()) if file_exists(get_metadata_file(path))}
 
 
+def read_metric_data_file(check_name):
+    return read_file(os.path.join(get_root(), check_name, 'metadata.csv'))
+
+
 def read_version_file(check_name):
     return read_file(get_version_file(check_name))
 


### PR DESCRIPTION
### Motivation

We usually have to do this for every RFC

### Example

`ddev meta scripts metrics2md kafka_consumer`

metric_name | description | metric_type | unit_name
--- | --- | --- | ---
kafka.broker_offset | Current message offset on broker. | gauge | offset
kafka.consumer_lag | Lag in messages between consumer and broker. | gauge | offset
kafka.consumer_offset | Current message offset on consumer. | gauge | offset