### PR TITLE
Allow and document overriding SNMP host on macOS/Windows

### DIFF
--- a/snmp/tests/README.md
+++ b/snmp/tests/README.md
@@ -1,0 +1,17 @@
+# SNMP Testing
+
+## Known issues
+
+### macOS/Windows: "No SNMP response received before timeout for instance localhost"
+
+This is most likely due to a bug with cross-container UDP communication in Docker for macOS and Windows.
+
+A workaround is to pass set your IPv4 host address as the `DD_SNMP_HOST` environment variable, e.g.:
+
+```shell
+$ ddev env start -e DD_SNMP_HOST=10.98.76.543 snmp py37
+```
+
+The SNMP environment will use this IP instead of the default Docker-provided hostname to connect to the SNMP server container.
+
+This should allow `$ ddev env check ...` and E2E tests to pass locally.

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -11,7 +11,7 @@ from datadog_checks.utils.common import get_docker_hostname
 
 log = logging.getLogger(__name__)
 
-HOST = get_docker_hostname()
+HOST = os.getenv('DD_SNMP_HOST', get_docker_hostname())
 PORT = 1161
 HERE = os.path.dirname(os.path.abspath(__file__))
 COMPOSE_DIR = os.path.join(HERE, 'compose')

--- a/snmp/tox.ini
+++ b/snmp/tox.ini
@@ -17,6 +17,7 @@ deps =
 passenv =
     DOCKER*
     COMPOSE*
+    DD_SNMP_*
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Allow passing the host to use to connect to SNMP via an environment variable.

### Motivation
<!-- What inspired you to submit this pull request? -->
Running the SNMP tests (unit, E2E) and `ddev env check` locally is broken on macOS/Windows due to a bug with UDP in Docker on those platforms.

Unofficial workaround was to hack to `ip_address` used to connect to the SNMP server. This PR makes that hack official and documented. 😄 

### Additional Notes
<!-- Anything else we should know when reviewing? -->
/

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
