### PR TITLE
Add support for full server version

### DIFF
--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -37,7 +37,7 @@ class Apache(AgentCheck):
         'connect_timeout': {'name': 'connect_timeout', 'default': 5},
     }
 
-    VERSION_REGEX = re.compile(r'^Apache/([0-9]+\.[0-9]+\.[0-9]+)( \(.*\))?$')
+    VERSION_REGEX = re.compile(r'^Apache/(\d+(?:\.\d+)*)')
 
     def __init__(self, name, init_config, instances):
         super(Apache, self).__init__(name, init_config, instances)
@@ -123,12 +123,14 @@ class Apache(AgentCheck):
             # Can't get it from the mod_status output, try to get it from the server header even though
             # it may not be exposed with some configurations.
             server_version = r.headers.get("Server")
-            if server_version:
+            if server_version.startswith('Apache'):
                 self._submit_metadata(server_version)
 
     def _submit_metadata(self, value):
         """Possible formats:
-            Apache | Apache/X | Apache/X.Y | Apache/X.Y.Z | Apache/X.Y.Z (<OS>)
+            Apache | Apache/X | Apache/X.Y | Apache/X.Y.Z | Apache/X.Y.Z (<OS>) | Apache/X.Y.Z (<OS>) <not specified>
+            https://httpd.apache.org/docs/2.4/mod/core.html#servertokens
+
             Incomplete versions are ignored.
         """
         match = self.VERSION_REGEX.match(value)
@@ -138,5 +140,6 @@ class Apache(AgentCheck):
             return
 
         version = match.groups()[0]
-        self.set_metadata('version', version)
+        version_parts = {name: part for name, part in zip(), version.split('.')}
+        self.set_metadata('version', version, scheme='parts', final_scheme='semver', part_map=version_parts)
         self.log.debug("found apache version %s", version)

--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -140,6 +140,6 @@ class Apache(AgentCheck):
             return
 
         version = match.groups()[0]
-        version_parts = {name: part for name, part in zip(), version.split('.')}
+        version_parts = {name: part for name, part in zip(('major', 'minor', 'patch'), version.split('.'))}
         self.set_metadata('version', version, scheme='parts', final_scheme='semver', part_map=version_parts)
         self.log.debug("found apache version %s", version)

--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -130,8 +130,6 @@ class Apache(AgentCheck):
         """Possible formats:
             Apache | Apache/X | Apache/X.Y | Apache/X.Y.Z | Apache/X.Y.Z (<OS>) | Apache/X.Y.Z (<OS>) <not specified>
             https://httpd.apache.org/docs/2.4/mod/core.html#servertokens
-
-            Incomplete versions are ignored.
         """
         match = self.VERSION_REGEX.match(value)
 

--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -37,7 +37,7 @@ class Apache(AgentCheck):
         'connect_timeout': {'name': 'connect_timeout', 'default': 5},
     }
 
-    VERSION_REGEX = re.compile(r'^Apache/(\d+(?:\.\d+)*)')
+    VERSION_REGEX = re.compile(r'Apache/(\d+(?:\.\d+)*)')
 
     def __init__(self, name, init_config, instances):
         super(Apache, self).__init__(name, init_config, instances)
@@ -123,7 +123,7 @@ class Apache(AgentCheck):
             # Can't get it from the mod_status output, try to get it from the server header even though
             # it may not be exposed with some configurations.
             server_version = r.headers.get("Server")
-            if server_version.startswith('Apache'):
+            if server_version:
                 self._submit_metadata(server_version)
 
     def _submit_metadata(self, value):

--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -139,7 +139,7 @@ class Apache(AgentCheck):
             self.log.info("Cannot parse the complete Apache version from %s.", value)
             return
 
-        version = match.groups()[0]
+        version = match.group(1)
         version_parts = {name: part for name, part in zip(('major', 'minor', 'patch'), version.split('.'))}
         self.set_metadata('version', version, scheme='parts', final_scheme='semver', part_map=version_parts)
         self.log.debug("found apache version %s", version)

--- a/apache/tests/test_apache.py
+++ b/apache/tests/test_apache.py
@@ -155,26 +155,10 @@ def test_invalid_version(check):
             {'major': '2', 'minor': '4', 'patch': '6'},
             id='redhat_version',
         ),
-        pytest.param(
-            'Apache/2.14.27',
-            {'major': '2', 'minor': '14', 'patch': '27'},
-            id='min_version',
-        ),
-        pytest.param(
-            'Apache/2.4',
-            {'major': '2', 'minor': '4'},
-            id='only_minor',
-        ),
-        pytest.param(
-            'Apache/2',
-            {'major': '2'},
-            id='only_major',
-        ),
-        pytest.param(
-            'Apache',
-            {},
-            id='only_apache',
-        ),
+        pytest.param('Apache/2.14.27', {'major': '2', 'minor': '14', 'patch': '27'}, id='min_version'),
+        pytest.param('Apache/2.4', {'major': '2', 'minor': '4'}, id='only_minor'),
+        pytest.param('Apache/2', {'major': '2'}, id='only_major'),
+        pytest.param('Apache', {}, id='only_apache'),
     ],
 )
 def test_full_version_regex(check, version, expected_parts, datadog_agent):

--- a/apache/tests/test_apache.py
+++ b/apache/tests/test_apache.py
@@ -21,9 +21,6 @@ from .common import (
 )
 
 
-VERSION_REGEX = re.compile(r'^Apache/(\d+(?:\.\d+)*)')
-
-
 @pytest.mark.usefixtures("dd_environment")
 def test_connection_failure(aggregator, check):
     check = check(BAD_CONFIG)
@@ -148,19 +145,26 @@ def test_invalid_version(check):
 
 
 @pytest.mark.parametrize(
-    'version, pattern, expected_parts',
+    'version, expected_parts',
     [
-        ('Apache/2.4.2 (Unix) PHP/4.2.2 MyMod/1.2', VERSION_REGEX, {'major': '2', 'minor': '4', 'patch': '2'}),
-        (
-            'Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips',
-            VERSION_REGEX,
-            {'major': '2', 'minor': '4', 'patch': '6'},
+        pytest.param(
+            'Apache/2.4.2 (Unix) PHP/4.2.2 MyMod/1.2',
+            {'major': '2', 'minor': '4', 'patch': '2'},
+            id='unix_full_version',
         ),
-        ('Apache/2.14.27', VERSION_REGEX, {'major': '2', 'minor': '14', 'patch': '27'}),
+        pytest.param(
+            'Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips',
+            {'major': '2', 'minor': '4', 'patch': '6'},
+            id='redhat_version',
+        ),
+        pytest.param(
+            'Apache/2.14.27',
+            {'major': '2', 'minor': '14', 'patch': '27'},
+            id='min_version',
+        ),
     ],
-    ids=['unix_full_version', 'redhat_version', 'min_version'],
 )
-def test_full_version_regex(check, version, pattern, expected_parts, datadog_agent):
+def test_full_version_regex(check, version, expected_parts, datadog_agent):
     """The default server token is Full. Full results in server info that can include
     multiple non-Apache version specific information.
     """

--- a/apache/tests/test_apache.py
+++ b/apache/tests/test_apache.py
@@ -154,9 +154,9 @@ def test_invalid_version(check):
                 {'major': '2', 'minor': '4', 'patch': '2'},
             ),
             (
-                'Apache',
+                'Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips',
                 VERSION_REGEX,
-                None,
+                {'major': '2', 'minor': '4', 'patch': '6',
             ),
             (
                 'Apache/2.4.2',
@@ -164,15 +164,10 @@ def test_invalid_version(check):
                 {'major': '2', 'minor': '4', 'patch': '2'},
             )
         ],
-        ids=['full_version', 'prod_version', 'min_version'],
+        ids=['unix_full_version', 'redhat_version', 'min_version'],
 )
 def test_version_regex(check, version, pattern, expected_parts, datadog_agent):
-    # TODO: test other invalid versions
-    """
-    major_version = 'Apache/2'
-    minor_version = "Apache/2.4"
-    os_version = "Apache/2.4.2 (Unix)"
-    """
+
     check = check({})
     check.check_id = 'test:123'
     


### PR DESCRIPTION
### What does this PR do?
Fix version parsing and add test.

We previously had a fix to address the `Full` option for apache serverToken. The full version can include one or more version info that’s not related to the version we submit. 

This PR updates the regex to remove matching the info after `Apache/x.y.z` since we don’t use them and they break with longer server version results.

### Motivation
https://github.com/DataDog/integrations-core/issues/5482

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
