### PR TITLE
Fix use e2e instance for dd_environment

### DIFF
--- a/harbor/tests/conftest.py
+++ b/harbor/tests/conftest.py
@@ -46,7 +46,7 @@ from .common import (
 
 
 @pytest.fixture(scope='session')
-def dd_environment(instance):
+def dd_environment(e2e_instance):
     compose_file = get_docker_compose_file()
     expected_log = "http server Running on" if HARBOR_VERSION < [1, 10, 0] else "API server is serving at"
     conditions = [
@@ -55,7 +55,7 @@ def dd_environment(instance):
         CreateSimpleUser(),
     ]
     with docker_run(compose_file, conditions=conditions):
-        yield instance
+        yield e2e_instance
 
 
 class CreateSimpleUser(LazyFunction):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix e2e instance.

This didn't work before this fix:
```
ddev env start harbor py37-1.10
ddev env check harbor py37-1.10
```

The error raised was:

```
OSError: Could not find a suitable TLS CA certificate bundle, invalid path: <LOCAL PATH>/harbor/tests/compose/common/cert/ca.crt
```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
