### PR TITLE
Run flake8 after formatting fixes

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -89,9 +89,17 @@ def add_style_formatter(config, sections, make_envconfig, reader):
         # more info: https://github.com/ambv/black/issues/439#issuecomment-411429907
         'basepython': 'python3',
         'skip_install': 'true',
-        'deps': 'black\nisort[pyproject]>=4.3.15',
+        'deps': 'flake8\nblack\nisort[pyproject]>=4.3.15',
         # Run formatter AFTER sorting imports
-        'commands': 'isort --recursive .\nblack .',
+        'commands': '\n'.join(
+            [
+                'isort --recursive .',
+                'black .',
+                'python -c "print(\'\\n[NOTE] flake8 may still report style errors for things black cannot fix, '
+                'these will need to be fixed manually.\')"',
+                'flake8 --config=../.flake8 .',
+            ]
+        ),
     }
 
     # Always add the environment configurations


### PR DESCRIPTION
### What does this PR do?

Running `ddev test -fs` will address most formatting errors, but there can still be things that `flake8` will complain about.  In those cases, manual updates are needed, but it also requires running `ddev test -s` to find out about them.

This runs `flake8` after `black` makes its changes to notify the user if there are additional fixes required and avoid finding out about them from CI failures :)

