### PR TITLE
Comment v8 broken docker image from tox.ini

### DIFF
--- a/ibm_was/tox.ini
+++ b/ibm_was/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py37
 envlist =
-    py{27,37}-{8.5,9}
+    py{27,37}-{9}
 
 [testenv]
 description=
@@ -21,5 +21,7 @@ commands =
     pip install -r requirements.in
     pytest -v {posargs}
 setenv =
-    8.5: IBM_WAS_VERSION=8.5.5.14-profile
+    ## Docker image for v8 not available anymore.
+    ## Waiting upstream update, see issue: https://github.com/WASdev/ci.docker.websphere-traditional/issues/198
+    # 8.5: IBM_WAS_VERSION=8.5.5.14-profile
     9: IBM_WAS_VERSION=9.0.0.11


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

`ibmcom/websphere-traditional:8.5.5.14-profile` is not available anymore. Let's wait and see if it will be available again soon.

Upstream Issue has been created.


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
