### PR TITLE
Fix possible IndexError

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -511,7 +511,8 @@ class __AgentCheck(object):
                              raw ``value`` will be submitted and therefore it must be a ``str``
         :param options: keyword arguments to pass to any defined transformer
         """
-        self.metadata_manager.submit(name, value, options)
+        if value and value.strip():
+            self.metadata_manager.submit(name, value.strip(), options)
 
     def send_config_metadata(self):
         self.set_metadata('config', self.instance, section='instance', whitelist=self.METADATA_DEFAULT_CONFIG_INSTANCE)

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -511,8 +511,7 @@ class __AgentCheck(object):
                              raw ``value`` will be submitted and therefore it must be a ``str``
         :param options: keyword arguments to pass to any defined transformer
         """
-        if value and value.strip():
-            self.metadata_manager.submit(name, value.strip(), options)
+        self.metadata_manager.submit(name, value, options)
 
     def send_config_metadata(self):
         self.set_metadata('config', self.instance, section='instance', whitelist=self.METADATA_DEFAULT_CONFIG_INSTANCE)

--- a/postfix/datadog_checks/postfix/postfix.py
+++ b/postfix/datadog_checks/postfix/postfix.py
@@ -118,9 +118,11 @@ class PostfixCheck(AgentCheck):
 
     def _get_postqueue_stats(self, postfix_config_dir, tags):
         pc_output, _, _ = get_subprocess_output(['postconf', 'authorized_mailq_users'], self.log, False)
-        authorized_mailq_users = pc_output.strip('\n').split('=')[1].strip()
 
-        self.log.debug('authorized_mailq_users : %s', authorized_mailq_users)
+        if '=' in pc_output:
+            authorized_mailq_users = pc_output.strip('\n').split('=')[1].strip()
+
+            self.log.debug('authorized_mailq_users : {}'.format(authorized_mailq_users))
 
         output, _, _ = get_subprocess_output(['postqueue', '-c', postfix_config_dir, '-p'], self.log, False)
 
@@ -207,7 +209,7 @@ class PostfixCheck(AgentCheck):
 
         self.log.debug('postconf mail_version output: %s', pc_output)
 
-        postfix_version = pc_output.strip('\n').split('=')[1].strip()
-        self.log.debug('Postfix Version: %s', postfix_version)
-
-        self.set_metadata('version', postfix_version)
+        if '=' in pc_output:
+            postfix_version = pc_output.strip('\n').split('=')[1].strip()
+            self.log.debug('Postfix Version: {}'.format(postfix_version))
+            self.set_metadata('version', postfix_version)

--- a/postfix/datadog_checks/postfix/postfix.py
+++ b/postfix/datadog_checks/postfix/postfix.py
@@ -119,7 +119,7 @@ class PostfixCheck(AgentCheck):
     def _get_postqueue_stats(self, postfix_config_dir, tags):
         pc_output, _, _ = get_subprocess_output(['postconf', 'authorized_mailq_users'], self.log, False)
 
-        if '=' in pc_output:
+        if pc_output:
             authorized_mailq_users = pc_output.strip('\n').split('=')[1].strip()
 
             self.log.debug('authorized_mailq_users : %s', authorized_mailq_users)
@@ -209,7 +209,7 @@ class PostfixCheck(AgentCheck):
 
         self.log.debug('postconf mail_version output: %s', pc_output)
 
-        if '=' in pc_output:
+        if pc_output:
             postfix_version = pc_output.strip('\n').split('=')[1].strip()
             self.log.debug('Postfix Version: %s', postfix_version)
             if postfix_version:

--- a/postfix/datadog_checks/postfix/postfix.py
+++ b/postfix/datadog_checks/postfix/postfix.py
@@ -122,7 +122,7 @@ class PostfixCheck(AgentCheck):
         if '=' in pc_output:
             authorized_mailq_users = pc_output.strip('\n').split('=')[1].strip()
 
-            self.log.debug('authorized_mailq_users : {}'.format(authorized_mailq_users))
+            self.log.debug('authorized_mailq_users : %s', authorized_mailq_users)
 
         output, _, _ = get_subprocess_output(['postqueue', '-c', postfix_config_dir, '-p'], self.log, False)
 
@@ -211,5 +211,5 @@ class PostfixCheck(AgentCheck):
 
         if '=' in pc_output:
             postfix_version = pc_output.strip('\n').split('=')[1].strip()
-            self.log.debug('Postfix Version: {}'.format(postfix_version))
+            self.log.debug('Postfix Version: %s', postfix_version)
             self.set_metadata('version', postfix_version)

--- a/postfix/datadog_checks/postfix/postfix.py
+++ b/postfix/datadog_checks/postfix/postfix.py
@@ -212,4 +212,5 @@ class PostfixCheck(AgentCheck):
         if '=' in pc_output:
             postfix_version = pc_output.strip('\n').split('=')[1].strip()
             self.log.debug('Postfix Version: %s', postfix_version)
-            self.set_metadata('version', postfix_version)
+            if postfix_version:
+                self.set_metadata('version', postfix_version)


### PR DESCRIPTION
### What does this PR do?
Fixes a possible IndexError if subcommand returns empty

### Motivation
1825-postfix-check-doesnt-work-inside-docker-container

### Additional Notes

- this only addresses the IndexError resulting from the postconf binary being missing in a container.
- does not make the `postconf` nor `postqueue` available in a container which are necessary for the check to work

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
