### PR TITLE
Copy profiles over to Agent config directory

### DIFF
--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -17,6 +17,12 @@ FILES = [
     "https://ddintegrations.blob.core.windows.net/snmp/3850.snmprec",
 ]
 
+E2E_METADATA = {
+    'start_commands': [
+        # Ensure the Agent has access to profile definition files.
+        'cp -r /home/snmp/datadog_checks/snmp/data/profiles /etc/datadog-agent/conf.d/snmp.d/',
+    ],
+}
 
 @pytest.fixture(scope='session')
 def dd_environment():
@@ -31,4 +37,4 @@ def dd_environment():
                     output.write(response.content)
 
         with docker_run(os.path.join(COMPOSE_DIR, 'docker-compose.yaml'), env_vars=env, log_patterns="Listening at"):
-            yield generate_instance_config(SCALAR_OBJECTS + SCALAR_OBJECTS_WITH_TAGS + TABULAR_OBJECTS)
+            yield generate_instance_config(SCALAR_OBJECTS + SCALAR_OBJECTS_WITH_TAGS + TABULAR_OBJECTS), E2E_METADATA

--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -24,6 +24,7 @@ E2E_METADATA = {
     ],
 }
 
+
 @pytest.fixture(scope='session')
 def dd_environment():
     with TempDir('snmprec', COMPOSE_DIR) as tmp_dir:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Make sure profile definition files are available to the Docker Agent when running an SNMP test environment.

### Motivation
<!-- What inspired you to submit this pull request? -->
As implemented here as well… https://github.com/DataDog/integrations-core/pull/5462/files#diff-41388142f9d79f0a09ec5d5cfa46d400R20-R22

When testing profiles locally, using e.g…

```yaml
init_config:
  profiles:
    idrac:
      definition_file: idrac.yaml
```

the Agent fails running the check with an error that the `idrac.yaml` file does not exist.

This seems to be because `ddev` only copies the generated config file to the Agent container, but not the rest of the `{check}/data` directory.

cc @ChristineTChen 

### Additional Notes
<!-- Anything else we should know when reviewing? -->
There may be a way to not hardcode the file paths, or perhaps even a built-in `ddev` helper for copying items in the `data/` directory. If that's the case, happy to update this PR.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
