### PR TITLE
Add support for in-toto >= 0.4.2

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
@@ -14,7 +14,14 @@ import in_toto.settings
 in_toto.settings.SUBPROCESS_TIMEOUT = 60
 
 from in_toto import runlib
-from in_toto.gpg.constants import GPG_COMMAND
+
+try:
+    # in-toto < 0.4.2
+    from in_toto.gpg.constants import GPG_COMMAND
+except ImportError:
+    # in-toto >= 0.4.2
+    # https://github.com/in-toto/in-toto/releases/tag/v0.4.2
+    from securesystemslib.gpg.constants import GPG_COMMAND
 
 from .constants import get_root
 from .git import (

--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -71,7 +71,7 @@ setup(
             'click',
             'colorama',
             'docker-compose>=1.23.1,<1.24.0',
-            'in-toto>=0.4.1',
+            'in-toto==0.4.1',
             'pip-tools',
             'pylint',
             'Pillow',

--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -71,7 +71,7 @@ setup(
             'click',
             'colorama',
             'docker-compose>=1.23.1,<1.24.0',
-            'in-toto==0.4.1',
+            'in-toto>=0.4.1',
             'pip-tools',
             'pylint',
             'Pillow',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Pin in-toto to v0.4.1 since `ddev release make` is broken in v0.4.2.

### Motivation
<!-- What inspired you to submit this pull request? -->
`ddev release make` is broken with `in-toto==0.4.2` (released Jan 7th 2020):

```
$ ddev release make apache ibm_mq                    
Traceback (most recent call last):
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/venv/bin/ddev", line 11, in <module>
    load_entry_point('datadog-checks-dev', 'console_scripts', 'ddev')()
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/venv/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/venv/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/venv/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/venv/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/venv/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/venv/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/venv/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py", line 43, in make
    from ...signing import update_link_metadata, YubikeyException
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/signing.py", line 17, in <module>
    from in_toto.gpg.constants import GPG_COMMAND
ModuleNotFoundError: No module named 'in_toto.gpg'
```

Seems to be due to an internal refactoring of `in_toto` in v0.4.2…

I recently re-built my `venv` which is probably how `in-toto` got upgraded to that version.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Not sure what it would take to fix this, and whether v0.4.2 still contains the functionality we need — would need to be investigated.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
