### PR TITLE
Avoid cross instance data sharing

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -3,12 +3,12 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import unicode_literals
 
+import copy
 import re
 import socket
 import ssl
 import time
 from datetime import datetime
-import copy
 
 import _strptime  # noqa
 import requests

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -8,6 +8,7 @@ import socket
 import ssl
 import time
 from datetime import datetime
+import copy
 
 import _strptime  # noqa
 import requests
@@ -34,7 +35,7 @@ class HTTPCheck(AgentCheck):
     SC_STATUS = 'http.can_connect'
     SC_SSL_CERT = 'http.ssl_cert'
 
-    HTTP_CONFIG_REMAPPER = {
+    DEFAULT_HTTP_CONFIG_REMAPPER = {
         'client_cert': {'name': 'tls_cert'},
         'client_key': {'name': 'tls_private_key'},
         'disable_ssl_validation': {'name': 'tls_verify', 'invert': True, 'default': True},
@@ -44,6 +45,8 @@ class HTTPCheck(AgentCheck):
 
     def __init__(self, name, init_config, instances):
         super(HTTPCheck, self).__init__(name, init_config, instances)
+
+        self.HTTP_CONFIG_REMAPPER = copy.deepcopy(self.DEFAULT_HTTP_CONFIG_REMAPPER)
 
         self.ca_certs = init_config.get('ca_certs')
         if not self.ca_certs:

--- a/http_check/tests/test_unit.py
+++ b/http_check/tests/test_unit.py
@@ -22,3 +22,11 @@ def test__init__():
     init_config = {'ca_certs': 'foo'}
     http_check = HTTPCheck('http_check', init_config, [{}])
     assert http_check.ca_certs == 'foo'
+
+
+def test_instances_do_not_share_data():
+    http_check_1 = HTTPCheck('http_check', {'ca_certs': 'foo'}, [{}])
+    http_check_2 = HTTPCheck('http_check', {'ca_certs': 'bar'}, [{}])
+
+    assert http_check_1.HTTP_CONFIG_REMAPPER['ca_certs']['default'] == 'foo'
+    assert http_check_2.HTTP_CONFIG_REMAPPER['ca_certs']['default'] == 'bar'


### PR DESCRIPTION
Default ca_certs are overriden when having multiple instances of the http check