### PR TITLE
Make e2e tests pass on Mac

### DIFF
--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -6,6 +6,7 @@ import copy
 import logging
 import os
 
+from datadog_checks.dev.docker import get_container_ip
 from datadog_checks.snmp import SnmpCheck
 from datadog_checks.utils.common import get_docker_hostname
 
@@ -20,6 +21,7 @@ AUTH_PROTOCOLS = {'MD5': 'usmHMACMD5AuthProtocol', 'SHA': 'usmHMACSHAAuthProtoco
 PRIV_PROTOCOLS = {'DES': 'usmDESPrivProtocol', 'AES': 'usmAesCfb128Protocol'}
 AUTH_KEY = 'doggiepass'
 PRIV_KEY = 'doggiePRIVkey'
+SNMP_CONTAINER_NAME = 'dd-snmp'
 
 CHECK_TAGS = ['snmp_device:{}'.format(HOST)]
 
@@ -175,6 +177,12 @@ def generate_instance_config(metrics, template=None):
     instance_config['metrics'] = metrics
     instance_config['name'] = HOST
     return instance_config
+
+
+def generate_container_instance_config(metrics):
+    conf = copy.deepcopy(SNMP_CONF)
+    conf['ip_address'] = get_container_ip(SNMP_CONTAINER_NAME)
+    return generate_instance_config(metrics, template=conf)
 
 
 def generate_v3_instance_config(metrics, name=None, user=None, auth=None, auth_key=None, priv=None, priv_key=None):

--- a/snmp/tests/compose/docker-compose.yaml
+++ b/snmp/tests/compose/docker-compose.yaml
@@ -8,3 +8,4 @@ services:
     command: --args-from-file=/usr/snmpsim/data/args_list.txt
     volumes:
       - ${DATA_DIR}:/usr/snmpsim/data/
+    container_name: dd-snmp

--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -10,7 +10,13 @@ import requests
 
 from datadog_checks.dev import TempDir, docker_run
 
-from .common import COMPOSE_DIR, SCALAR_OBJECTS, SCALAR_OBJECTS_WITH_TAGS, TABULAR_OBJECTS, generate_instance_config
+from .common import (
+    COMPOSE_DIR,
+    SCALAR_OBJECTS,
+    SCALAR_OBJECTS_WITH_TAGS,
+    TABULAR_OBJECTS,
+    generate_container_instance_config,
+)
 
 FILES = [
     "https://ddintegrations.blob.core.windows.net/snmp/f5.snmprec",
@@ -38,4 +44,6 @@ def dd_environment():
                     output.write(response.content)
 
         with docker_run(os.path.join(COMPOSE_DIR, 'docker-compose.yaml'), env_vars=env, log_patterns="Listening at"):
-            yield generate_instance_config(SCALAR_OBJECTS + SCALAR_OBJECTS_WITH_TAGS + TABULAR_OBJECTS), E2E_METADATA
+            yield generate_container_instance_config(
+                SCALAR_OBJECTS + SCALAR_OBJECTS_WITH_TAGS + TABULAR_OBJECTS
+            ), E2E_METADATA

--- a/snmp/tests/test_e2e.py
+++ b/snmp/tests/test_e2e.py
@@ -12,15 +12,16 @@ from . import common
 @pytest.mark.e2e
 def test_e2e(dd_agent_check):
     metrics = common.SUPPORTED_METRIC_TYPES
-    instance = common.generate_instance_config(metrics)
+    instance = common.generate_container_instance_config(metrics)
     aggregator = dd_agent_check(instance, rate=True)
+    tags = ['snmp_device:{}'.format(instance['ip_address'])]
 
     # Test metrics
     for metric in common.SUPPORTED_METRIC_TYPES:
         metric_name = "snmp." + metric['name']
-        aggregator.assert_metric(metric_name, tags=common.CHECK_TAGS)
+        aggregator.assert_metric(metric_name, tags=tags)
 
     # Test service check
-    aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
+    aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
 
     aggregator.all_metrics_asserted()


### PR DESCRIPTION
There seems to a bug with UDP forwarding and docker. To work around, use
the container IP instead of localhost when the agent is the one talking
to the SNMP endpoint.