### PR TITLE
Fix http_check - idea 1

### DIFF
--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -297,10 +297,10 @@ instances:
     #
     # kerberos_cache: <KRB5CCNAME>
 
-    ## @param tls_verify - boolean - optional - default: true
+    ## @param tls_verify - boolean - optional - default: false
     ## Instructs the check to validate the TLS certificate of services.
     #
-    # tls_verify: true
+    tls_verify: false
 
     ## @param tls_ignore_warning - boolean - optional - default: false
     ## If `tls_verify` is disabled, security warnings are logged by the check.

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -51,7 +51,7 @@ class HTTPCheck(AgentCheck):
 
         self.HTTP_CONFIG_REMAPPER['ca_certs']['default'] = self.ca_certs
 
-        if is_affirmative(self.instance.get('disable_ssl_validation', True)):
+        if "tls_verify" not in self.instance and is_affirmative(self.instance.get('disable_ssl_validation', True)):
             # overrides configured `tls_ca_cert` value if `disable_ssl_validation` is enabled
             self.http.options['verify'] = False
 


### PR DESCRIPTION
Bug is: new versions of the http_check configuration file have `tls_verify` but not `disable_ssl_validation`.
Setting `tls_verify` to True is not enough to enforce SSL verification, it also requires to set up `disable_ssl_validation` even though this field is not documented and deprecated.

This fix:
- Uncomment `tls_verify: False` to the config (even though it's optional), this is indeed the default value anyway (because of the HTTP_REMAPPER)
- Update the backward compatibility layer for all version of the config file to take into account the existance of `tls_verify` in the config.

This means that:
- New users will have `tls_verify: False` by default (which means no ssl verification).
- New users can set `tls_verify: True` to enable ssl verification
- Setting `tls_verify: False` and `tls_ca_certs: XXX` will enable ssl_validation
- Setting `disable_ssl_validation: True` and `tls_ca_certs: XXX` will not enable ssl validation (backward compatibility layer for old customers).

Drawbacks:
- Users with the intermediate configuration file (the one without disable_ssl_validation and with `tls_verify` commented out) will have ssl validation disabled (which is what the http check should do) even though the configuration file says that `tls_verify` defaults to True
- Introduces yet another format of the config file, it will be harder to maintain backward compatibility with all of them.