### PR TITLE
Change wmi_check to use lists instead of tuples for filters

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -404,7 +404,7 @@ class WMISampler(object):
                     clause = bool_op.join(
                         [
                             '{0} {1} \'{2}\''.format(k, v[0], v[1])
-                            if isinstance(v, tuple)
+                            if isinstance(v, (list, tuple))
                             else '{0} = \'{1}\''.format(k, v)
                             for k, v in internal_filter
                         ]

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -360,10 +360,10 @@ class WMISampler(object):
         Builds filter from a filter list.
         - filters: expects a list of dicts, typically:
                 - [{'Property': value},...] or
-                - [{'Property': (comparison_op, value)},...]
+                - [{'Property': [comparison_op, value]},...]
 
                 NOTE: If we just provide a value we defailt to '=' comparison operator.
-                Otherwise, specify the operator in a tuple as above: (comp_op, value)
+                Otherwise, specify the operator in a list as above: [comp_op, value]
                 If we detect a wildcard character ('%') we will override the operator
                 to use LIKE
         """
@@ -374,7 +374,7 @@ class WMISampler(object):
             while f:
                 prop, value = f.popitem()
 
-                if isinstance(value, tuple):
+                if isinstance(value, (tuple, list)):
                     oper = value[0]
                     value = value[1]
                 elif isinstance(value, string_types) and '%' in value:
@@ -382,13 +382,13 @@ class WMISampler(object):
                 else:
                     oper = '='
 
-                if isinstance(value, list):
+                if isinstance(value, (tuple, list)):
                     if not len(value):
                         continue
 
                     internal_filter = map(
                         lambda x: (prop, x)
-                        if isinstance(x, tuple)
+                        if isinstance(x, (tuple, list))
                         else (prop, ('LIKE', x))
                         if '%' in x
                         else (prop, (oper, x)),

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -362,7 +362,7 @@ class WMISampler(object):
                 - [{'Property': value},...] or
                 - [{'Property': [comparison_op, value]},...]
 
-                NOTE: If we just provide a value we defailt to '=' comparison operator.
+                NOTE: If we just provide a value we default to '=' comparison operator.
                 Otherwise, specify the operator in a list as above: [comp_op, value]
                 If we detect a wildcard character ('%') we will override the operator
                 to use LIKE

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -357,6 +357,8 @@ class WMISampler(object):
         """
         Transform filters to a comprehensive WQL `WHERE` clause.
 
+        Specifying more than 1 filter defaults to an `OR` operator in the `WHERE` clause.
+
         Builds filter from a filter list.
         - filters: expects a list of dicts, typically:
                 - [{'Property': value},...] or

--- a/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
+++ b/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
@@ -46,7 +46,7 @@ instances:
     ##    [{<FILTER_PROPERTY>: <FILTER_VALUE>},...] or
     ##    [{FILTER_PROPERTY>: [<FILTER_OPERATOR>, <FILTER_VALUE>]},...]
     ##
-    ##  If you just provide a value we defailt to '=' comparison operator.
+    ##  If you just provide a value we default to '=' comparison operator.
     ##
     ##   * <FILTER_PROPERTY> the name of the filter; something like 'PercentProcessorTime'
     ##

--- a/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
+++ b/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
@@ -42,9 +42,18 @@ instances:
 
     ## @param filters - list of strings - optional
     ## `filters` parameter is a list of filters on the WMI query you may want.
+    ##  Filters can be in one of these forms:
+    ##    [{<FILTER_PROPERTY>: <FILTER_VALUE>},...] or
+    ##    [{FILTER_PROPERTY>: [<FILTER_OPERATOR>, <FILTER_VALUE>]},...]
+    ##
+    ##  If you just provide a value we defailt to '=' comparison operator.
+    ##
+    ##   * <FILTER_PROPERTY> the name of the filter; something like 'PercentProcessorTime'
+    ##
     #
     # filters:
-    #   - <FILTER>
+    #   - {<FILTER_PROPERTY>: [<FILTER_OPERATOR>, <FILTER_VALUE>]}
+    #   - {<FILTER_PROPERTY>: <FILTER_VALUE>}
 
     ## @param provider - integer - optional - default: 64
     ## `provider` set the WMI provider.

--- a/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
+++ b/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
@@ -46,9 +46,9 @@ instances:
     ##    [{<FILTER_PROPERTY>: <FILTER_VALUE>},...] or
     ##    [{FILTER_PROPERTY>: [<FILTER_OPERATOR>, <FILTER_VALUE>]},...]
     ##
-    ##  If you just provide a value we default to '=' comparison operator.
+    ##  Providing just a <FILTER_VALUE> defaults to the '=' comparison operator.
     ##
-    ##   * <FILTER_PROPERTY> the name of the filter; something like 'PercentProcessorTime'
+    ##   * <FILTER_PROPERTY> the name of the filter, for example 'PercentProcessorTime'.
     ##
     #
     # filters:

--- a/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
+++ b/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
@@ -46,7 +46,7 @@ instances:
     ##    [{<FILTER_PROPERTY>: <FILTER_VALUE>},...] or
     ##    [{FILTER_PROPERTY>: [<FILTER_OPERATOR>, <FILTER_VALUE>]},...]
     ##
-    ##  All metrics will be filtered out if any of the filters are true.
+    ##  All metrics will be filtered out if any of the filters are false.
     ##
     ##  Providing just a <FILTER_VALUE> defaults to the '=' comparison operator.
     ##

--- a/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
+++ b/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
@@ -46,7 +46,9 @@ instances:
     ##    [{<FILTER_PROPERTY>: <FILTER_VALUE>},...] or
     ##    [{FILTER_PROPERTY>: [<FILTER_OPERATOR>, <FILTER_VALUE>]},...]
     ##
-    ##  All metrics will be filtered out if any of the filters are false.
+    ##  All metrics will be filtered out if any given property:
+    ##    1. Has one or more filter(s) applied to it AND
+    ##    2. None of its filters evaluate to 'True'
     ##
     ##  Providing just a <FILTER_VALUE> defaults to the '=' comparison operator.
     ##

--- a/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
+++ b/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
@@ -46,8 +46,8 @@ instances:
     ##    [{<FILTER_PROPERTY>: <FILTER_VALUE>},...] or
     ##    [{FILTER_PROPERTY>: [<FILTER_OPERATOR>, <FILTER_VALUE>]},...]
     ##
-    ##  All metrics will be filtered out if any given property:
-    ##    1. Has one or more filter(s) applied to it AND
+    ##  All metrics are filtered out if any given property:
+    ##    1. Has one or more filter(s) applied to it, AND
     ##    2. None of its filters evaluate to 'True'
     ##
     ##  Providing just a <FILTER_VALUE> defaults to the '=' comparison operator.

--- a/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
+++ b/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
@@ -46,6 +46,8 @@ instances:
     ##    [{<FILTER_PROPERTY>: <FILTER_VALUE>},...] or
     ##    [{FILTER_PROPERTY>: [<FILTER_OPERATOR>, <FILTER_VALUE>]},...]
     ##
+    ##  All metrics will be filtered out if any of the filters are true.
+    ##
     ##  Providing just a <FILTER_VALUE> defaults to the '=' comparison operator.
     ##
     ##   * <FILTER_PROPERTY> the name of the filter, for example 'PercentProcessorTime'.


### PR DESCRIPTION
### What does this PR do?
Modifies the wmi check to use lists for filters instead of tuples and documents the use of filters more. 

### Motivation
The wmi check relies on tuples in yaml, but the yaml library does not parse tuples (using safe_load).

### Additional Notes
Tested on Windows VM.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
