### PR TITLE
Fix TypeError where self._excluded_ifaces is None

### DIFF
--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -48,7 +48,10 @@ class Network(AgentCheck):
         if instance is None:
             instance = {}
 
-        self._excluded_ifaces = instance.get('excluded_interfaces', [])
+        if type(instance.get('excluded_interfaces', [])) is list:
+            self._excluded_ifaces = instance.get('excluded_interfaces', [])
+        else:
+            self._excluded_ifaces = []
         self._collect_cx_state = instance.get('collect_connection_state', False)
         self._collect_rate_metrics = instance.get('collect_rate_metrics', True)
         self._collect_count_metrics = instance.get('collect_count_metrics', False)


### PR DESCRIPTION
### What does this PR do?
The _submit_devicemetrics function in network.py assumed that
self._excluded_ifaces is a list and attempts to iterate over it cecking
to see if the iface var is in the list.

In class Network, the check function does the following:
self._excluded_ifaces = instance.get('excluded_interfaces', [])

The current implementation will set self._excluded_ifaces to None in the
following scenario: instances = {'excluded_interfaces': None}

Since excluded_interfaces is found within the dict, we end up with None
as the value for self._excluded_ifaces instead of an empty list which
causes the loop in _submit_devicemetrics to fail on a TypeError since it
is not list.

This change ensures that self._excluded_ifaces is always a list.

### Motivation
Logs on production systems I manage were filling with errors related to this. Once I realized why this was failing, I decided to push the change upstream.

### Additional Notes
None.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
