### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/libs/thread_pool.py
+++ b/datadog_checks_base/datadog_checks/base/checks/libs/thread_pool.py
@@ -48,7 +48,7 @@ class PoolWorker(threading.Thread):
     """Thread that consumes WorkUnits from a queue to process them"""
 
     def __init__(self, workq, *args, **kwds):
-        """\param workq: Queue object to consume the work units from"""
+        """:param workq: Queue object to consume the work units from"""
         threading.Thread.__init__(self, *args, **kwds)
         self._workq = workq
         self.running = False
@@ -76,8 +76,8 @@ class Pool(object):
 
     def __init__(self, nworkers, name="Pool"):
         """
-        \param nworkers (integer) number of worker threads to start
-        \param name (string) prefix for the worker threads' name
+        :param nworkers (integer) number of worker threads to start
+        :param name (string) prefix for the worker threads' name
         """
         self._workq = queue.Queue()
         self._closed = False
@@ -278,8 +278,8 @@ class Job(WorkUnit):
 
     def __init__(self, func, args, kwds, apply_result):
         """
-        \param func/args/kwds used to call the function
-        \param apply_result ApplyResult object that holds the result
+        :param func/args/kwds used to call the function
+        :param apply_result ApplyResult object that holds the result
         of the function call
         """
         WorkUnit.__init__(self)
@@ -329,10 +329,10 @@ class ApplyResult(object):
 
     def __init__(self, collector=None, callback=None):
         """
-        \param collector when not None, the notify_ready() method of
+        :param collector when not None, the notify_ready() method of
         the collector will be called when the result from the Job is
         ready
-        \param callback when not None, function to call when the
+        :param callback when not None, function to call when the
         result becomes available (this is the paramater passed to the
         Pool::*_async() methods.
         """
@@ -415,7 +415,7 @@ class AbstractResultCollector(object):
 
     def __init__(self, to_notify):
         """
-        \param to_notify ApplyResult object to notify when all the
+        :param to_notify ApplyResult object to notify when all the
         results we're waiting for become available. Can be None.
         """
         self._to_notify = to_notify
@@ -425,7 +425,7 @@ class AbstractResultCollector(object):
         always be called BEFORE the Jobs get submitted to the work
         queue, and BEFORE the __iter__ and _get_result() methods can
         be called
-        \param apply_result ApplyResult object to add in our collection
+        :param apply_result ApplyResult object to add in our collection
         """
         raise NotImplementedError("Children classes must implement it")
 
@@ -433,7 +433,7 @@ class AbstractResultCollector(object):
         """Called by the ApplyResult object (already registered via
         register_result()) that it is now ready (ie. the Job's result
         is available or an exception has been raised).
-        \param apply_result ApplyResult object telling us that the job
+        :param apply_result ApplyResult object telling us that the job
         has been processed
         """
         raise NotImplementedError("Children classes must implement it")
@@ -442,8 +442,8 @@ class AbstractResultCollector(object):
         """Called by the CollectorIterator object to retrieve the
         result's values one after another (order defined by the
         implementation)
-        \param idx The index of the result we want, wrt collector's order
-        \param timeout integer telling how long to wait (in seconds)
+        :param idx The index of the result we want, wrt collector's order
+        :param timeout integer telling how long to wait (in seconds)
         for the result at index idx to be available, or None (wait
         forever)
         """
@@ -461,7 +461,7 @@ class CollectorIterator(object):
     AbstractResultCollector::__iter__() method"""
 
     def __init__(self, collector):
-        """\param AbstractResultCollector instance"""
+        """:param AbstractResultCollector instance"""
         self._collector = collector
         self._idx = 0
 
@@ -494,7 +494,7 @@ class UnorderedResultCollector(AbstractResultCollector):
 
     def __init__(self, to_notify=None):
         """
-        \param to_notify ApplyResult object to notify when all the
+        :param to_notify ApplyResult object to notify when all the
         results we're waiting for become available. Can be None.
         """
         AbstractResultCollector.__init__(self, to_notify)
@@ -507,7 +507,7 @@ class UnorderedResultCollector(AbstractResultCollector):
         always be called BEFORE the Jobs get submitted to the work
         queue, and BEFORE the __iter__ and _get_result() methods can
         be called
-        \param apply_result ApplyResult object to add in our collection
+        :param apply_result ApplyResult object to add in our collection
         """
         self._expected += 1
 
@@ -515,8 +515,8 @@ class UnorderedResultCollector(AbstractResultCollector):
         """Called by the CollectorIterator object to retrieve the
         result's values one after another, in the order the results have
         become available.
-        \param idx The index of the result we want, wrt collector's order
-        \param timeout integer telling how long to wait (in seconds)
+        :param idx The index of the result we want, wrt collector's order
+        :param timeout integer telling how long to wait (in seconds)
         for the result at index idx to be available, or None (wait
         forever)
         """
@@ -543,7 +543,7 @@ class UnorderedResultCollector(AbstractResultCollector):
         """Called by the ApplyResult object (already registered via
         register_result()) that it is now ready (ie. the Job's result
         is available or an exception has been raised).
-        \param apply_result ApplyResult object telling us that the job
+        :param apply_result ApplyResult object telling us that the job
         has been processed
         """
         first_item = False
@@ -568,9 +568,9 @@ class OrderedResultCollector(AbstractResultCollector):
 
     def __init__(self, to_notify=None, as_iterator=True):
         """
-        \param to_notify ApplyResult object to notify when all the
+        :param to_notify ApplyResult object to notify when all the
         results we're waiting for become available. Can be None.
-        \param as_iterator boolean telling whether the result value
+        :param as_iterator boolean telling whether the result value
         set on to_notify should be an iterator (available as soon as 1
         result arrived) or a list (available only after the last
         result arrived)
@@ -586,7 +586,7 @@ class OrderedResultCollector(AbstractResultCollector):
         always be called BEFORE the Jobs get submitted to the work
         queue, and BEFORE the __iter__ and _get_result() methods can
         be called
-        \param apply_result ApplyResult object to add in our collection
+        :param apply_result ApplyResult object to add in our collection
         """
         self._results.append(apply_result)
         self._remaining += 1
@@ -595,8 +595,8 @@ class OrderedResultCollector(AbstractResultCollector):
         """Called by the CollectorIterator object to retrieve the
         result's values one after another (order defined by the
         implementation)
-        \param idx The index of the result we want, wrt collector's order
-        \param timeout integer telling how long to wait (in seconds)
+        :param idx The index of the result we want, wrt collector's order
+        :param timeout integer telling how long to wait (in seconds)
         for the result at index idx to be available, or None (wait
         forever)
         """
@@ -608,7 +608,7 @@ class OrderedResultCollector(AbstractResultCollector):
         """Called by the ApplyResult object (already registered via
         register_result()) that it is now ready (ie. the Job's result
         is available or an exception has been raised).
-        \param apply_result ApplyResult object telling us that the job
+        :param apply_result ApplyResult object telling us that the job
         has been processed
         """
         got_first = False

--- a/datadog_checks_base/datadog_checks/base/checks/libs/thread_pool.py
+++ b/datadog_checks_base/datadog_checks/base/checks/libs/thread_pool.py
@@ -76,8 +76,10 @@ class Pool(object):
 
     def __init__(self, nworkers, name="Pool"):
         """
-        :param nworkers (integer) number of worker threads to start
-        :param name (string) prefix for the worker threads' name
+        :param nworkers: number of worker threads to start
+        :type nworkers: integer
+        :param name: prefix for the worker threads' name
+        :type name: string
         """
         self._workq = queue.Queue()
         self._closed = False
@@ -278,8 +280,8 @@ class Job(WorkUnit):
 
     def __init__(self, func, args, kwds, apply_result):
         """
-        :param func/args/kwds used to call the function
-        :param apply_result ApplyResult object that holds the result
+        :param func: /args/kwds used to call the function
+        :param apply_result: ApplyResult object that holds the result
         of the function call
         """
         WorkUnit.__init__(self)
@@ -329,10 +331,10 @@ class ApplyResult(object):
 
     def __init__(self, collector=None, callback=None):
         """
-        :param collector when not None, the notify_ready() method of
+        :param collector: when not None, the notify_ready() method of
         the collector will be called when the result from the Job is
         ready
-        :param callback when not None, function to call when the
+        :param callback: when not None, function to call when the
         result becomes available (this is the paramater passed to the
         Pool::*_async() methods.
         """
@@ -415,7 +417,7 @@ class AbstractResultCollector(object):
 
     def __init__(self, to_notify):
         """
-        :param to_notify ApplyResult object to notify when all the
+        :param to_notify: ApplyResult object to notify when all the
         results we're waiting for become available. Can be None.
         """
         self._to_notify = to_notify
@@ -425,7 +427,7 @@ class AbstractResultCollector(object):
         always be called BEFORE the Jobs get submitted to the work
         queue, and BEFORE the __iter__ and _get_result() methods can
         be called
-        :param apply_result ApplyResult object to add in our collection
+        :param apply_result: ApplyResult object to add in our collection
         """
         raise NotImplementedError("Children classes must implement it")
 
@@ -433,7 +435,7 @@ class AbstractResultCollector(object):
         """Called by the ApplyResult object (already registered via
         register_result()) that it is now ready (ie. the Job's result
         is available or an exception has been raised).
-        :param apply_result ApplyResult object telling us that the job
+        :param apply_result: ApplyResult object telling us that the job
         has been processed
         """
         raise NotImplementedError("Children classes must implement it")
@@ -442,8 +444,8 @@ class AbstractResultCollector(object):
         """Called by the CollectorIterator object to retrieve the
         result's values one after another (order defined by the
         implementation)
-        :param idx The index of the result we want, wrt collector's order
-        :param timeout integer telling how long to wait (in seconds)
+        :param idx: The index of the result we want, wrt collector's order
+        :param timeout: integer telling how long to wait (in seconds)
         for the result at index idx to be available, or None (wait
         forever)
         """
@@ -461,7 +463,10 @@ class CollectorIterator(object):
     AbstractResultCollector::__iter__() method"""
 
     def __init__(self, collector):
-        """:param AbstractResultCollector instance"""
+        """
+        :param collector: instance
+        :type collector: AbstractResultCollector
+        """
         self._collector = collector
         self._idx = 0
 
@@ -494,7 +499,7 @@ class UnorderedResultCollector(AbstractResultCollector):
 
     def __init__(self, to_notify=None):
         """
-        :param to_notify ApplyResult object to notify when all the
+        :param to_notify: ApplyResult object to notify when all the
         results we're waiting for become available. Can be None.
         """
         AbstractResultCollector.__init__(self, to_notify)
@@ -507,7 +512,7 @@ class UnorderedResultCollector(AbstractResultCollector):
         always be called BEFORE the Jobs get submitted to the work
         queue, and BEFORE the __iter__ and _get_result() methods can
         be called
-        :param apply_result ApplyResult object to add in our collection
+        :param apply_result: ApplyResult object to add in our collection
         """
         self._expected += 1
 
@@ -515,8 +520,8 @@ class UnorderedResultCollector(AbstractResultCollector):
         """Called by the CollectorIterator object to retrieve the
         result's values one after another, in the order the results have
         become available.
-        :param idx The index of the result we want, wrt collector's order
-        :param timeout integer telling how long to wait (in seconds)
+        :param idx: The index of the result we want, wrt collector's order
+        :param timeout: integer telling how long to wait (in seconds)
         for the result at index idx to be available, or None (wait
         forever)
         """
@@ -543,7 +548,7 @@ class UnorderedResultCollector(AbstractResultCollector):
         """Called by the ApplyResult object (already registered via
         register_result()) that it is now ready (ie. the Job's result
         is available or an exception has been raised).
-        :param apply_result ApplyResult object telling us that the job
+        :param apply_result: ApplyResult object telling us that the job
         has been processed
         """
         first_item = False
@@ -568,9 +573,9 @@ class OrderedResultCollector(AbstractResultCollector):
 
     def __init__(self, to_notify=None, as_iterator=True):
         """
-        :param to_notify ApplyResult object to notify when all the
+        :param to_notify: ApplyResult object to notify when all the
         results we're waiting for become available. Can be None.
-        :param as_iterator boolean telling whether the result value
+        :param as_iterator: boolean telling whether the result value
         set on to_notify should be an iterator (available as soon as 1
         result arrived) or a list (available only after the last
         result arrived)
@@ -586,7 +591,7 @@ class OrderedResultCollector(AbstractResultCollector):
         always be called BEFORE the Jobs get submitted to the work
         queue, and BEFORE the __iter__ and _get_result() methods can
         be called
-        :param apply_result ApplyResult object to add in our collection
+        :param apply_result: ApplyResult object to add in our collection
         """
         self._results.append(apply_result)
         self._remaining += 1
@@ -595,8 +600,8 @@ class OrderedResultCollector(AbstractResultCollector):
         """Called by the CollectorIterator object to retrieve the
         result's values one after another (order defined by the
         implementation)
-        :param idx The index of the result we want, wrt collector's order
-        :param timeout integer telling how long to wait (in seconds)
+        :param idx: The index of the result we want, wrt collector's order
+        :param timeout: integer telling how long to wait (in seconds)
         for the result at index idx to be available, or None (wait
         forever)
         """
@@ -608,7 +613,7 @@ class OrderedResultCollector(AbstractResultCollector):
         """Called by the ApplyResult object (already registered via
         register_result()) that it is now ready (ie. the Job's result
         is available or an exception has been raised).
-        :param apply_result ApplyResult object telling us that the job
+        :param apply_result: ApplyResult object telling us that the job
         has been processed
         """
         got_first = False


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix this warning:

```
DeprecationWarning: invalid escape sequence \p
    """\param workq: Queue object to consume the work units from"""
```

Also minor reformat in Sphinx compatible style, see: 

- https://stackoverflow.com/a/40596167/5486444
- https://thomas-cokelaer.info/tutorials/sphinx/docstring_python.html

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
