### PR TITLE
Create `consul_service` tag

### DIFF
--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -259,7 +259,7 @@ class ConsulCheck(AgentCheck):
 
         for tag in tags:
             service_tags.append('consul_{}_service_tag:{}'.format(service, tag))
-            service_tags.append('consul_service_tag:{}'.format(tag))
+            service_tags.append('consul_service:{}'.format(tag))
 
         return service_tags
 

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -259,6 +259,7 @@ class ConsulCheck(AgentCheck):
 
         for tag in tags:
             service_tags.append('consul_{}_service_tag:{}'.format(service, tag))
+            service_tags.append('consul_service_tag:{}'.format(tag))
 
         return service_tags
 

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -25,6 +25,7 @@ def test_get_nodes_with_service(aggregator):
         'consul_datacenter:dc1',
         'consul_service_id:service-1',
         'consul_service-1_service_tag:az-us-east-1a',
+        'consul_service_tag:az-us-east-1a',
     ]
 
     aggregator.assert_metric('consul.catalog.nodes_up', value=1, tags=expected_tags)
@@ -76,6 +77,7 @@ def test_get_nodes_with_service_warning(aggregator):
         'consul_datacenter:dc1',
         'consul_service_id:service-1',
         'consul_service-1_service_tag:az-us-east-1a',
+        'consul_service_tag:az-us-east-1a',
     ]
     aggregator.assert_metric('consul.catalog.nodes_up', value=1, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.nodes_passing', value=0, tags=expected_tags)
@@ -100,6 +102,7 @@ def test_get_nodes_with_service_critical(aggregator):
         'consul_datacenter:dc1',
         'consul_service_id:service-1',
         'consul_service-1_service_tag:az-us-east-1a',
+        'consul_service_tag:az-us-east-1a',
     ]
     aggregator.assert_metric('consul.catalog.nodes_up', value=1, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.nodes_passing', value=0, tags=expected_tags)

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -25,7 +25,7 @@ def test_get_nodes_with_service(aggregator):
         'consul_datacenter:dc1',
         'consul_service_id:service-1',
         'consul_service-1_service_tag:az-us-east-1a',
-        'consul_service_tag:az-us-east-1a',
+        'consul_service:az-us-east-1a',
     ]
 
     aggregator.assert_metric('consul.catalog.nodes_up', value=1, tags=expected_tags)
@@ -77,7 +77,7 @@ def test_get_nodes_with_service_warning(aggregator):
         'consul_datacenter:dc1',
         'consul_service_id:service-1',
         'consul_service-1_service_tag:az-us-east-1a',
-        'consul_service_tag:az-us-east-1a',
+        'consul_service:az-us-east-1a',
     ]
     aggregator.assert_metric('consul.catalog.nodes_up', value=1, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.nodes_passing', value=0, tags=expected_tags)
@@ -102,7 +102,7 @@ def test_get_nodes_with_service_critical(aggregator):
         'consul_datacenter:dc1',
         'consul_service_id:service-1',
         'consul_service-1_service_tag:az-us-east-1a',
-        'consul_service_tag:az-us-east-1a',
+        'consul_service:az-us-east-1a',
     ]
     aggregator.assert_metric('consul.catalog.nodes_up', value=1, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.nodes_passing', value=0, tags=expected_tags)


### PR DESCRIPTION
Creates consul service tag, allowing us to filter on lists of tagged services.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This allows us to use consul tags to group services. Currently we have to select all services individually.

### Motivation
<!-- What inspired you to submit this pull request? -->
Was not able to filter consul metrics in Datadog based on a consul tag. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->
consider this scenario:
service list: a, b, c
tag list: live, staging

A is tagged with live
b is tagged with live
c is tagged with staging

by using `consul_<service>_service_tag:<tag>` data can only be returned one service. i.e. consul_a_service_tag:live returns data for service a.
by using `consul_service_tag:<tag>` data will be returned for all services with similar tag. i.e. consul_service_tag:live returns data for service a and b. consul_service_tag:staging returns data for service c.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
