### PR TITLE
remove mib dependency notes

### DIFF
--- a/snmp/README.md
+++ b/snmp/README.md
@@ -133,8 +133,6 @@ If necessary, additional metrics can be defined in the instances. These metrics 
 
 Profiles can be used interchangeably, such that devices that share MIB dependencies can reuse the same profiles. For example, the Cisco c3850 profile can be used across many Cisco switches.
 
-**Note**: Profiles require a local version of the MIBs to be referenced.
-
 * [Generic router](#generic-router-profile)
 * [F5 Big IP](#f5-big-ip-profile)
 * [Dell iDRAC](#dell-idrac-profile)
@@ -374,7 +372,6 @@ The Cisco Nexus Profile collects the following metrics.
 
 The Cisco Meraki device profile collects the following metrics.
 
-MIBs needed for local reference: MERAKI-CLOUD-CONTROLLER-MIB.
 
 | Metric                       | Description                                                          | Tags                           |
 |------------------------------|----------------------------------------------------------------------|--------------------------------|


### PR DESCRIPTION
### What does this PR do?
Removes some misleading notes in the SNMP documentation

### Motivation
A few missed references to the MIB dependency that is no longer.

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
