### PR TITLE
Support `metric_prefix` in query manager

### DIFF
--- a/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
+++ b/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
@@ -6,8 +6,7 @@ init_config:
     ## `use_global_custom_queries` setting at the instance level.
     #
     # global_custom_queries:
-    #   - metric_prefix: clickhouse
-    #     query: <QUERY>
+    #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
 

--- a/datadog_checks_base/datadog_checks/base/utils/db/query.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/query.py
@@ -44,6 +44,8 @@ class Query(object):
         if tags is not None and not isinstance(tags, list):
             raise ValueError('field `tags` for {} must be a list'.format(query_name))
 
+        prefix = self.query_data.get('metric_prefix')
+
         # Keep track of all defined names
         sources = {}
 
@@ -83,8 +85,11 @@ class Query(object):
 
             modifiers = {key: value for key, value in column.items() if key not in ('name', 'type')}
 
+            data_name = column_name
+            if prefix:
+                data_name = '{}.{}'.format(prefix, data_name)
             try:
-                transformer = column_transformers[column_type](column_transformers, column_name, **modifiers)
+                transformer = column_transformers[column_type](column_transformers, data_name, **modifiers)
             except Exception as e:
                 error = 'error compiling type `{}` for column {} of {}: {}'.format(
                     column_type, column_name, query_name, e

--- a/datadog_checks_base/tests/test_db.py
+++ b/datadog_checks_base/tests/test_db.py
@@ -1721,3 +1721,25 @@ class TestCustomQueries:
 
         with pytest.raises(ValueError, match='^field `query` for custom query #1 is required$'):
             query_manager.compile_queries()
+
+    def test_prefix(self, aggregator):
+        query_manager = create_query_manager(
+            check=AgentCheck(
+                'test',
+                {},
+                [
+                    {
+                        'custom_queries': [
+                            {'metric_prefix': 'prefix', 'query': 'foo', 'columns': [{'name': 'test.foo', 'type': 'gauge'}], 'tags': ['test:bar']},
+                        ],
+                    },
+                ],
+            ),
+            executor=mock_executor([[1]]),
+            tags=['test:foo'],
+        )
+        query_manager.compile_queries()
+        query_manager.execute()
+
+        aggregator.assert_metric('prefix.test.foo', 1, metric_type=aggregator.GAUGE, tags=['test:foo', 'test:bar'])
+        aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
Custom queries can specify a namespace in which metrics are going to be
submitted. It was documented but not supported, this adds support for
it.