### PR TITLE
Make deprecations apparent in UI

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -496,7 +496,7 @@ class __AgentCheck(object):
         Logs a deprecation notice at most once per AgentCheck instance, for the pre-defined `deprecation_key`
         """
         if not self._deprecations[deprecation_key][0]:
-            self.log.warning(self._deprecations[deprecation_key][1])
+            self.warning(self._deprecations[deprecation_key][1])
             self._deprecations[deprecation_key][0] = True
 
     # TODO: Remove once our checks stop calling it


### PR DESCRIPTION
### Motivation

Give customers notice without the need to look at logs. No one will ever see them unless debugging something unrelated.