### PR TITLE
Properly cast `max_returned_metrics` option to an integer

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -224,7 +224,7 @@ class AgentCheck(object):
 
         # Setup metric limits
         try:
-            metric_limit = self.instances[0].get('max_returned_metrics', self.DEFAULT_METRIC_LIMIT)
+            metric_limit = int(self.instances[0].get('max_returned_metrics', self.DEFAULT_METRIC_LIMIT))
             # Do not allow to disable limiting if the class has set a non-zero default value
             if metric_limit == 0 and self.DEFAULT_METRIC_LIMIT > 0:
                 metric_limit = self.DEFAULT_METRIC_LIMIT

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -224,7 +224,7 @@ class AgentCheck(object):
 
         # Setup metric limits
         try:
-            metric_limit = int(self.instances[0].get('max_returned_metrics', self.DEFAULT_METRIC_LIMIT))
+            metric_limit = int(self.instance.get('max_returned_metrics', self.DEFAULT_METRIC_LIMIT))
             # Do not allow to disable limiting if the class has set a non-zero default value
             if metric_limit == 0 and self.DEFAULT_METRIC_LIMIT > 0:
                 metric_limit = self.DEFAULT_METRIC_LIMIT

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -628,6 +628,7 @@ class TestLimits:
         assert len(check.get_warnings()) == 1
         assert len(aggregator.metrics("metric")) == 4
 
+
 class TestCheckInitializations:
     def test_default(self):
         class TestCheck(AgentCheck):

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -614,6 +614,19 @@ class TestLimits:
         assert len(check.get_warnings()) == 1  # get_warnings resets the array
         assert len(aggregator.metrics("metric")) == 10
 
+    def test_metric_limit_instance_config_string(self, aggregator):
+        instances = [{"max_returned_metrics": "4"}]
+        check = AgentCheck("test", {}, instances)
+        assert check.get_warnings() == []
+
+        for _ in range(0, 4):
+            check.gauge("metric", 0)
+        assert len(check.get_warnings()) == 0
+        assert len(aggregator.metrics("metric")) == 4
+
+        check.gauge("metric", 0)
+        assert len(check.get_warnings()) == 1
+        assert len(aggregator.metrics("metric")) == 4
 
 class TestCheckInitializations:
     def test_default(self):


### PR DESCRIPTION
### What does this PR do?
`max_returned_metric` throws TypeError when yaml value is a string.

### Motivation
Fixes https://github.com/DataDog/integrations-core/issues/5534

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
