### PR TITLE
Deprecate `service` tag

### DIFF
--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -312,7 +312,10 @@ class ConsulCheck(AgentCheck):
                 if sc_id not in sc:
                     tags = ["check:{}".format(check["CheckID"])]
                     if check["ServiceName"]:
-                        tags.append("service:{}".format(check["ServiceName"]))
+                        tags.append('consul_service:{}'.format(check['ServiceName']))
+                        if not instance.get('disable_legacy_service_tag', False):
+                            self._log_deprecation('service_tag', 'consul_service')
+                            tags.append('service:{}'.format(check['ServiceName']))
                     if check["ServiceID"]:
                         tags.append("consul_service_id:{}".format(check["ServiceID"]))
                     sc[sc_id] = {'status': status, 'tags': tags}

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -84,6 +84,12 @@ instances:
     #
     # max_services: 50
 
+    ## @param disable_legacy_service_tag - boolean - optional - default: false
+    ## Whether or not to stop submitting the tag `service` that has been renamed
+    ## to `consul_service` and disable the associated deprecation warning.
+    #
+    # disable_legacy_service_tag: false
+
     ## @param tags - list of key:value element - optional
     ## List of tags to attach to every metric, event, and service check emitted by this integration.
     ##

--- a/consul/tests/consul_mocks.py
+++ b/consul/tests/consul_mocks.py
@@ -6,6 +6,11 @@ import random
 from six import iteritems
 
 MOCK_CONFIG = {'url': 'http://localhost:8500', 'catalog_checks': True}
+MOCK_CONFIG_DISABLE_SERVICE_TAG = {
+    'url': 'http://localhost:8500',
+    'catalog_checks': True,
+    'disable_legacy_service_tag': True,
+}
 
 MOCK_CONFIG_SERVICE_WHITELIST = {
     'url': 'http://localhost:8500',


### PR DESCRIPTION
### Motivation

`service` is a reserved tag https://docs.datadoghq.com/tagging/