### PR TITLE
Install typing dep only for Python 2

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -68,7 +68,7 @@ simplejson==3.6.5
 six==1.12.0
 supervisor==4.0.1
 tuf==0.12.2
-typing==3.7.4.1
+typing==3.7.4.1; python_version < '3.0'
 uptime==3.0.1
 vertica-python==0.10.1
 win-inet-pton==1.1.0; sys_platform == 'win32' and python_version < '3.0'

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -16,6 +16,6 @@ requests-kerberos==0.12.0
 requests_ntlm==1.1.0
 simplejson==3.6.5
 six==1.12.0
-typing==3.7.4.1
+typing==3.7.4.1; python_version < '3.0'
 uptime==3.0.1
 win-inet-pton==1.1.0; sys_platform == 'win32' and python_version < '3.0'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Install typing dep only for Python 2

### Motivation
<!-- What inspired you to submit this pull request? -->

`typing` is shipped with Python 3, no need to install it.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
