### PR TITLE
Deprecate `service` tag

### DIFF
--- a/windows_service/datadog_checks/windows_service/data/conf.yaml.example
+++ b/windows_service/datadog_checks/windows_service/data/conf.yaml.example
@@ -14,6 +14,12 @@ instances:
       - <SERVICE_NAME_1>
       - <SERVICE_NAME_2>
 
+    ## @param disable_legacy_service_tag - boolean - optional - default: false
+    ## Whether or not to stop submitting the tag `service` that has been renamed
+    ## to `windows_service` and disable the associated deprecation warning.
+    #
+    # disable_legacy_service_tag: false
+
     ## @param tags - list of key:value element - optional
     ## List of tags to attach to every service check emitted by this integration.
     ##

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -70,8 +70,12 @@ class WindowsService(AgentCheck):
             state = service_status[1]
             status = self.STATE_TO_STATUS.get(state, self.UNKNOWN)
 
-            tags = ['service:{}'.format(short_name)]
+            tags = ['windows_service:{}'.format(short_name)]
             tags.extend(custom_tags)
+
+            if not instance.get('disable_legacy_service_tag', False):
+                self._log_deprecation('service_tag', 'windows_service')
+                tags.append('service:{}'.format(short_name))
 
             self.service_check(self.SERVICE_CHECK_NAME, status, tags=tags)
             self.log.debug('service state for %s %s', short_name, status)
@@ -80,8 +84,12 @@ class WindowsService(AgentCheck):
             for service in services_unseen:
                 status = self.CRITICAL
 
-                tags = ['service:{}'.format(service)]
+                tags = ['windows_service:{}'.format(service)]
                 tags.extend(custom_tags)
+
+                if not instance.get('disable_legacy_service_tag', False):
+                    self._log_deprecation('service_tag', 'windows_service')
+                    tags.append('service:{}'.format(service))
 
                 self.service_check(self.SERVICE_CHECK_NAME, status, tags=tags)
                 self.log.debug('service state for %s %s', service, status)

--- a/windows_service/tests/common.py
+++ b/windows_service/tests/common.py
@@ -2,5 +2,10 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 INSTANCE_BASIC = {'services': ['eventlog', 'Dnscache', 'NonExistentService'], 'tags': ['optional:tag1']}
+INSTANCE_BASIC_DISABLE_SERVICE_TAG = {
+    'services': ['eventlog', 'Dnscache', 'NonExistentService'],
+    'tags': ['optional:tag1'],
+    'disable_legacy_service_tag': True,
+}
 INSTANCE_WILDCARD = {'host': '.', 'services': ['Event.*', 'Dns%']}
 INSTANCE_ALL = {'services': ['ALL']}

--- a/windows_service/tests/conftest.py
+++ b/windows_service/tests/conftest.py
@@ -31,6 +31,11 @@ def instance_basic():
 
 
 @pytest.fixture
+def instance_basic_disable_service_tag():
+    return deepcopy(common.INSTANCE_BASIC_DISABLE_SERVICE_TAG)
+
+
+@pytest.fixture
 def instance_wildcard():
     return deepcopy(common.INSTANCE_WILDCARD)
 

--- a/windows_service/tests/test_windows_service.py
+++ b/windows_service/tests/test_windows_service.py
@@ -16,30 +16,65 @@ def test_basic(aggregator, check, instance_basic):
     c = check(instance_basic)
     c.check(instance_basic)
     aggregator.assert_service_check(
-        c.SERVICE_CHECK_NAME, status=c.OK, tags=['service:EventLog', 'optional:tag1'], count=1
+        c.SERVICE_CHECK_NAME,
+        status=c.OK,
+        tags=['service:EventLog', 'windows_service:EventLog', 'optional:tag1'],
+        count=1,
     )
     aggregator.assert_service_check(
-        c.SERVICE_CHECK_NAME, status=c.OK, tags=['service:Dnscache', 'optional:tag1'], count=1
+        c.SERVICE_CHECK_NAME,
+        status=c.OK,
+        tags=['service:Dnscache', 'windows_service:Dnscache', 'optional:tag1'],
+        count=1,
     )
     aggregator.assert_service_check(
-        c.SERVICE_CHECK_NAME, status=c.CRITICAL, tags=['service:NonExistentService', 'optional:tag1'], count=1
+        c.SERVICE_CHECK_NAME,
+        status=c.CRITICAL,
+        tags=['service:NonExistentService', 'windows_service:NonExistentService', 'optional:tag1'],
+        count=1,
     )
 
 
 def test_wildcard(aggregator, check, instance_wildcard):
     c = check(instance_wildcard)
     c.check(instance_wildcard)
-    aggregator.assert_service_check(c.SERVICE_CHECK_NAME, status=c.OK, tags=['service:EventLog'], count=1)
-    aggregator.assert_service_check(c.SERVICE_CHECK_NAME, status=c.OK, tags=['service:EventSystem'], count=1)
-    aggregator.assert_service_check(c.SERVICE_CHECK_NAME, status=c.OK, tags=['service:Dnscache'], count=1)
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME, status=c.OK, tags=['service:EventLog', 'windows_service:EventLog'], count=1
+    )
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME, status=c.OK, tags=['service:EventSystem', 'windows_service:EventSystem'], count=1
+    )
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME, status=c.OK, tags=['service:Dnscache', 'windows_service:Dnscache'], count=1
+    )
 
 
 def test_all(aggregator, check, instance_all):
     c = check(instance_all)
     c.check(instance_all)
-    aggregator.assert_service_check(c.SERVICE_CHECK_NAME, status=c.OK, tags=['service:EventLog'], count=1)
-    aggregator.assert_service_check(c.SERVICE_CHECK_NAME, status=c.OK, tags=['service:Dnscache'], count=1)
-    aggregator.assert_service_check(c.SERVICE_CHECK_NAME, status=c.OK, tags=['service:EventSystem'], count=1)
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME, status=c.OK, tags=['service:EventLog', 'windows_service:EventLog'], count=1
+    )
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME, status=c.OK, tags=['service:Dnscache', 'windows_service:Dnscache'], count=1
+    )
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME, status=c.OK, tags=['service:EventSystem', 'windows_service:EventSystem'], count=1
+    )
+
+
+def test_basic_disable_service_tag(aggregator, check, instance_basic_disable_service_tag):
+    c = check(instance_basic_disable_service_tag)
+    c.check(instance_basic_disable_service_tag)
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME, status=c.OK, tags=['windows_service:EventLog', 'optional:tag1'], count=1
+    )
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME, status=c.OK, tags=['windows_service:Dnscache', 'optional:tag1'], count=1
+    )
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME, status=c.CRITICAL, tags=['windows_service:NonExistentService', 'optional:tag1'], count=1
+    )
 
 
 @pytest.mark.e2e
@@ -55,6 +90,6 @@ def test_basic_e2e(dd_agent_check, check, instance_basic):
     aggregator.assert_service_check(
         WindowsService.SERVICE_CHECK_NAME,
         status=WindowsService.CRITICAL,
-        tags=['service:NonExistentService', 'optional:tag1'],
+        tags=['service:NonExistentService', 'windows_service:NonExistentService', 'optional:tag1'],
         count=1,
     )


### PR DESCRIPTION
### Motivation

`service` is a reserved tag https://docs.datadoghq.com/tagging/