### PR TITLE
Use official zookeeper image in tests

### DIFF
--- a/mesos_master/tests/compose/docker-compose.yml
+++ b/mesos_master/tests/compose/docker-compose.yml
@@ -4,10 +4,10 @@ version: "3.5"
 # - https://github.com/mesosphere/docker-containers/tree/master/mesos
 services:
   zookeeper:
-    image: bobrik/zookeeper
+    image: zookeeper
     environment:
-      ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=no,clientPort=2181
-      ZK_ID: 1
+      ZOO_SYNC_LIMIT: 5
+      ZOO_INIT_LIMIT: 10
 
   mesos-master:
     image: mesosphere/mesos-master:${MESOS_MASTER_VERSION}

--- a/mesos_slave/tests/compose/docker-compose.yml
+++ b/mesos_slave/tests/compose/docker-compose.yml
@@ -4,10 +4,10 @@ version: "3.5"
 # - https://github.com/mesosphere/docker-containers/tree/master/mesos
 services:
   zookeeper:
-    image: bobrik/zookeeper
+    image: zookeeper
     environment:
-      ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=no,clientPort=2181
-      ZK_ID: 1
+      ZOO_SYNC_LIMIT: 5
+      ZOO_INIT_LIMIT: 10
 
   mesos-slave:
     image: mesosphere/mesos-slave:${MESOS_SLAVE_VERSION}


### PR DESCRIPTION
Mesos tests need a zookeeper instance, let's use the official instead of
one that hasn't been updated in a while.