### PR TITLE
Document that tls_verify is False by default

### DIFF
--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -297,10 +297,10 @@ instances:
     #
     # kerberos_cache: <KRB5CCNAME>
 
-    ## @param tls_verify - boolean - optional - default: true
+    ## @param tls_verify - boolean - optional - default: false
     ## Instructs the check to validate the TLS certificate of services.
     #
-    # tls_verify: true
+    # tls_verify: false
 
     ## @param tls_ignore_warning - boolean - optional - default: false
     ## If `tls_verify` is disabled, security warnings are logged by the check.


### PR DESCRIPTION
the http_check does not verify the SSL certificate by default. Let's have it documented