### PR TITLE
Deprecate `service` tag

### DIFF
--- a/haproxy/datadog_checks/haproxy/haproxy.py
+++ b/haproxy/datadog_checks/haproxy/haproxy.py
@@ -537,9 +537,14 @@ class HAProxy(AgentCheck):
                 agg_statuses[service]
 
         for service in agg_statuses:
-            tags = ['service:%s' % service]
+            tags = ['haproxy_service:%s' % service]
             tags.extend(custom_tags)
             tags.extend(active_tag)
+
+            if not self.instance.get('disable_legacy_service_tag', False):
+                self._log_deprecation('service_tag', 'haproxy_service')
+                tags.append('service:{}'.format(service))
+
             self.gauge(
                 'haproxy.backend_hosts', agg_statuses[service][Services.AVAILABLE], tags=tags + ['available:true']
             )
@@ -590,7 +595,10 @@ class HAProxy(AgentCheck):
 
             tags = []
             if count_status_by_service:
-                tags.append('service:%s' % service)
+                tags.append('haproxy_service:%s' % service)
+                if not self.instance.get('disable_legacy_service_tag', False):
+                    self._log_deprecation('service_tag', 'haproxy_service')
+                    tags.append('service:{}'.format(service))
             if hostname:
                 tags.append('backend:%s' % hostname)
 
@@ -608,7 +616,10 @@ class HAProxy(AgentCheck):
             if not collate_status_tags_per_host:
                 agg_tags = []
                 if count_status_by_service:
-                    agg_tags.append('service:%s' % service)
+                    agg_tags.append('haproxy_service:%s' % service)
+                    if not self.instance.get('disable_legacy_service_tag', False):
+                        self._log_deprecation('service_tag', 'haproxy_service')
+                        agg_tags.append('service:{}'.format(service))
                 # An unknown status will be sent as UNAVAILABLE
                 status_key = Services.STATUS_TO_COLLATED.get(status, Services.UNAVAILABLE)
                 agg_statuses_counter[tuple(agg_tags)][status_key] += count
@@ -636,9 +647,13 @@ class HAProxy(AgentCheck):
         back_or_front = data['back_or_front']
         custom_tags = [] if custom_tags is None else custom_tags
         active_tag = [] if active_tag is None else active_tag
-        tags = ["type:%s" % back_or_front, "instance_url:%s" % url, "service:%s" % service_name]
+        tags = ["type:%s" % back_or_front, "instance_url:%s" % url, "haproxy_service:%s" % service_name]
         tags.extend(custom_tags)
         tags.extend(active_tag)
+
+        if not self.instance.get('disable_legacy_service_tag', False):
+            self._log_deprecation('service_tag', 'haproxy_service')
+            tags.append('service:{}'.format(service_name))
 
         if self._is_service_excl_filtered(service_name, services_incl_filter, services_excl_filter):
             return
@@ -709,10 +724,15 @@ class HAProxy(AgentCheck):
                 alert_type = "info"
             title = "%s reported %s:%s back and %s" % (HAProxy_agent, service_name, hostname, status.upper())
 
-        tags = ["service:%s" % service_name]
+        tags = ["haproxy_service:%s" % service_name]
         if back_or_front == Services.BACKEND:
             tags.append('backend:%s' % hostname)
         tags.extend(custom_tags)
+
+        if not self.instance.get('disable_legacy_service_tag', False):
+            self._log_deprecation('service_tag', 'haproxy_service')
+            tags.append('service:{}'.format(service_name))
+
         return {
             'timestamp': int(time.time() - lastchg),
             'event_type': EVENT_TYPE,
@@ -740,8 +760,13 @@ class HAProxy(AgentCheck):
             return
 
         if status in Services.STATUS_TO_SERVICE_CHECK:
-            service_check_tags = ["service:%s" % service_name]
+            service_check_tags = ["haproxy_service:%s" % service_name]
             service_check_tags.extend(custom_tags)
+
+            if not self.instance.get('disable_legacy_service_tag', False):
+                self._log_deprecation('service_tag', 'haproxy_service')
+                service_check_tags.append('service:{}'.format(service_name))
+
             hostname = data['svname']
             if data['back_or_front'] == Services.BACKEND:
                 service_check_tags.append('backend:%s' % hostname)

--- a/haproxy/tests/common.py
+++ b/haproxy/tests/common.py
@@ -6,11 +6,33 @@ from datadog_checks.dev.utils import ON_LINUX
 from datadog_checks.utils.common import get_docker_hostname
 
 AGG_STATUSES_BY_SERVICE = (
-    (['status:available', 'service:a'], 1),
-    (['status:available', 'service:b'], 4),
-    (['status:unavailable', 'service:b'], 2),
-    (['status:available', 'service:be_edge_http_sre-production_elk-kibana'], 1),
-    (['status:unavailable', 'service:be_edge_http_sre-production_elk-kibana'], 2),
+    (['status:available', 'service:a', 'haproxy_service:a'], 1),
+    (['status:available', 'service:b', 'haproxy_service:b'], 4),
+    (['status:unavailable', 'service:b', 'haproxy_service:b'], 2),
+    (
+        [
+            'status:available',
+            'service:be_edge_http_sre-production_elk-kibana',
+            'haproxy_service:be_edge_http_sre-production_elk-kibana',
+        ],
+        1,
+    ),
+    (
+        [
+            'status:unavailable',
+            'service:be_edge_http_sre-production_elk-kibana',
+            'haproxy_service:be_edge_http_sre-production_elk-kibana',
+        ],
+        2,
+    ),
+)
+
+AGG_STATUSES_BY_SERVICE_DISABLE_SERVICE_TAG = (
+    (['status:available', 'haproxy_service:a'], 1),
+    (['status:available', 'haproxy_service:b'], 4),
+    (['status:unavailable', 'haproxy_service:b'], 2),
+    (['status:available', 'haproxy_service:be_edge_http_sre-production_elk-kibana'], 1),
+    (['status:unavailable', 'haproxy_service:be_edge_http_sre-production_elk-kibana'], 2),
 )
 
 AGG_STATUSES = ((['status:available'], 6), (['status:unavailable'], 4))

--- a/haproxy/tests/test_haproxy.py
+++ b/haproxy/tests/test_haproxy.py
@@ -32,7 +32,7 @@ from .common import (
 
 def _test_frontend_metrics(aggregator, shared_tag, count=1):
     haproxy_version = os.environ.get('HAPROXY_VERSION', '1.5.11').split('.')[:2]
-    frontend_tags = shared_tag + ['type:FRONTEND', 'service:public']
+    frontend_tags = shared_tag + ['type:FRONTEND', 'service:public', 'haproxy_service:public']
     for metric_name, min_version in FRONTEND_CHECK:
         if haproxy_version >= min_version:
             aggregator.assert_metric(metric_name, tags=frontend_tags, count=count)
@@ -44,7 +44,7 @@ def _test_backend_metrics(aggregator, shared_tag, services=None, add_addr_tag=Fa
     if not services:
         services = BACKEND_SERVICES
     for service in services:
-        tags = backend_tags + ['service:' + service, 'backend:BACKEND']
+        tags = backend_tags + ['service:' + service, 'haproxy_service:' + service, 'backend:BACKEND']
 
         if check_aggregates:
             for metric_name, min_version in BACKEND_AGGREGATE_ONLY_CHECK:
@@ -52,7 +52,7 @@ def _test_backend_metrics(aggregator, shared_tag, services=None, add_addr_tag=Fa
                     aggregator.assert_metric(metric_name, tags=tags, count=count)
 
         for backend in BACKEND_LIST:
-            tags = backend_tags + ['service:' + service, 'backend:' + backend]
+            tags = backend_tags + ['service:' + service, 'haproxy_service:' + service, 'backend:' + backend]
 
             if add_addr_tag and haproxy_version >= ['1', '7']:
                 tags.append('server_address:{}'.format(BACKEND_TO_ADDR[backend]))
@@ -64,12 +64,12 @@ def _test_backend_metrics(aggregator, shared_tag, services=None, add_addr_tag=Fa
 
 def _test_backend_hosts(aggregator, count=1):
     for service in BACKEND_SERVICES:
-        available_tag = ['available:true', 'service:' + service]
-        unavailable_tag = ['available:false', 'service:' + service]
+        available_tag = ['available:true', 'service:' + service, 'haproxy_service:' + service]
+        unavailable_tag = ['available:false', 'service:' + service, 'haproxy_service:' + service]
         aggregator.assert_metric(BACKEND_HOSTS_METRIC, tags=available_tag, count=count)
         aggregator.assert_metric(BACKEND_HOSTS_METRIC, tags=unavailable_tag, count=count)
 
-        status_no_check_tags = ['service:' + service, 'status:no_check']
+        status_no_check_tags = ['service:' + service, 'haproxy_service:' + service, 'status:no_check']
         aggregator.assert_metric(BACKEND_STATUS_METRIC, tags=status_no_check_tags, count=count)
 
 
@@ -78,9 +78,9 @@ def _test_service_checks(aggregator, services=None, count=1):
         services = BACKEND_SERVICES
     for service in services:
         for backend in BACKEND_LIST:
-            tags = ['service:' + service, 'backend:' + backend]
+            tags = ['service:' + service, 'haproxy_service:' + service, 'backend:' + backend]
             aggregator.assert_service_check(SERVICE_CHECK_NAME, status=HAProxy.UNKNOWN, count=count, tags=tags)
-        tags = ['service:' + service, 'backend:BACKEND']
+        tags = ['service:' + service, 'haproxy_service:' + service, 'backend:BACKEND']
         aggregator.assert_service_check(SERVICE_CHECK_NAME, status=HAProxy.OK, count=count, tags=tags)
 
 

--- a/haproxy/tests/test_unit.py
+++ b/haproxy/tests/test_unit.py
@@ -9,8 +9,13 @@ from . import common
 BASE_CONFIG = {'url': 'http://localhost/admin?stats', 'collect_status_metrics': True, 'enable_service_check': True}
 
 
-def _assert_agg_statuses(aggregator, count_status_by_service=True, collate_status_tags_per_host=False):
-    expected_statuses = common.AGG_STATUSES_BY_SERVICE if count_status_by_service else common.AGG_STATUSES
+def _assert_agg_statuses(
+    aggregator, count_status_by_service=True, collate_status_tags_per_host=False, disable_service_tag=False
+):
+    if disable_service_tag:
+        expected_statuses = common.AGG_STATUSES_BY_SERVICE_DISABLE_SERVICE_TAG
+    else:
+        expected_statuses = common.AGG_STATUSES_BY_SERVICE if count_status_by_service else common.AGG_STATUSES
     for tags, value in expected_statuses:
         if collate_status_tags_per_host:
             # Assert that no aggregate statuses are sent
@@ -42,16 +47,36 @@ def test_count_per_status_by_service(aggregator, check, haproxy_mock):
     haproxy_check = check(config)
     haproxy_check.check(config)
 
-    aggregator.assert_metric('haproxy.count_per_status', value=1, tags=['status:open', 'service:a'])
-    aggregator.assert_metric('haproxy.count_per_status', value=3, tags=['status:up', 'service:b'])
-    aggregator.assert_metric('haproxy.count_per_status', value=1, tags=['status:open', 'service:b'])
-    aggregator.assert_metric('haproxy.count_per_status', value=1, tags=['status:down', 'service:b'])
-    aggregator.assert_metric('haproxy.count_per_status', value=1, tags=['status:maint', 'service:b'])
-    tags = ['status:up', 'service:be_edge_http_sre-production_elk-kibana']
+    aggregator.assert_metric(
+        'haproxy.count_per_status', value=1, tags=['status:open', 'service:a', 'haproxy_service:a']
+    )
+    aggregator.assert_metric('haproxy.count_per_status', value=3, tags=['status:up', 'service:b', 'haproxy_service:b'])
+    aggregator.assert_metric(
+        'haproxy.count_per_status', value=1, tags=['status:open', 'service:b', 'haproxy_service:b']
+    )
+    aggregator.assert_metric(
+        'haproxy.count_per_status', value=1, tags=['status:down', 'service:b', 'haproxy_service:b']
+    )
+    aggregator.assert_metric(
+        'haproxy.count_per_status', value=1, tags=['status:maint', 'service:b', 'haproxy_service:b']
+    )
+    tags = [
+        'status:up',
+        'service:be_edge_http_sre-production_elk-kibana',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
+    ]
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['status:down', 'service:be_edge_http_sre-production_elk-kibana']
+    tags = [
+        'status:down',
+        'service:be_edge_http_sre-production_elk-kibana',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
+    ]
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['status:no_check', 'service:be_edge_http_sre-production_elk-kibana']
+    tags = [
+        'status:no_check',
+        'service:be_edge_http_sre-production_elk-kibana',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
+    ]
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
     _assert_agg_statuses(aggregator)
 
@@ -62,22 +87,37 @@ def test_count_per_status_by_service_and_host(aggregator, check, haproxy_mock):
     haproxy_check = check(config)
     haproxy_check.check(config)
 
-    tags = ['backend:FRONTEND', 'status:open', 'service:a']
+    tags = ['backend:FRONTEND', 'status:open', 'service:a', 'haproxy_service:a']
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:FRONTEND', 'status:open', 'service:b']
+    tags = ['backend:FRONTEND', 'status:open', 'service:b', 'haproxy_service:b']
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
     for backend in ['i-1', 'i-2', 'i-3']:
-        tags = ['backend:%s' % backend, 'status:up', 'service:b']
+        tags = ['backend:%s' % backend, 'status:up', 'service:b', 'haproxy_service:b']
         aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:i-4', 'status:down', 'service:b']
+    tags = ['backend:i-4', 'status:down', 'service:b', 'haproxy_service:b']
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:i-5', 'status:maint', 'service:b']
+    tags = ['backend:i-5', 'status:maint', 'service:b', 'haproxy_service:b']
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:i-1', 'status:up', 'service:be_edge_http_sre-production_elk-kibana']
+    tags = [
+        'backend:i-1',
+        'status:up',
+        'service:be_edge_http_sre-production_elk-kibana',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
+    ]
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:i-2', 'status:down', 'service:be_edge_http_sre-production_elk-kibana']
+    tags = [
+        'backend:i-2',
+        'status:down',
+        'service:be_edge_http_sre-production_elk-kibana',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
+    ]
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:i-3', 'status:no_check', 'service:be_edge_http_sre-production_elk-kibana']
+    tags = [
+        'backend:i-3',
+        'status:no_check',
+        'service:be_edge_http_sre-production_elk-kibana',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
+    ]
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
 
     _assert_agg_statuses(aggregator)
@@ -90,22 +130,37 @@ def test_count_per_status_by_service_and_collate_per_host(aggregator, check, hap
     config['collate_status_tags_per_host'] = True
     haproxy_check.check(config)
 
-    tags = ['backend:FRONTEND', 'status:available', 'service:a']
+    tags = ['backend:FRONTEND', 'status:available', 'service:a', 'haproxy_service:a']
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:FRONTEND', 'status:available', 'service:b']
+    tags = ['backend:FRONTEND', 'status:available', 'service:b', 'haproxy_service:b']
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
     for backend in ['i-1', 'i-2', 'i-3']:
-        tags = ['backend:%s' % backend, 'status:available', 'service:b']
+        tags = ['backend:%s' % backend, 'status:available', 'service:b', 'haproxy_service:b']
         aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:i-4', 'status:unavailable', 'service:b']
+    tags = ['backend:i-4', 'status:unavailable', 'service:b', 'haproxy_service:b']
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:i-5', 'status:unavailable', 'service:b']
+    tags = ['backend:i-5', 'status:unavailable', 'service:b', 'haproxy_service:b']
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:i-1', 'status:available', 'service:be_edge_http_sre-production_elk-kibana']
+    tags = [
+        'backend:i-1',
+        'status:available',
+        'service:be_edge_http_sre-production_elk-kibana',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
+    ]
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:i-2', 'status:unavailable', 'service:be_edge_http_sre-production_elk-kibana']
+    tags = [
+        'backend:i-2',
+        'status:unavailable',
+        'service:be_edge_http_sre-production_elk-kibana',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
+    ]
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:i-3', 'status:unavailable', 'service:be_edge_http_sre-production_elk-kibana']
+    tags = [
+        'backend:i-3',
+        'status:unavailable',
+        'service:be_edge_http_sre-production_elk-kibana',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
+    ]
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
 
     _assert_agg_statuses(aggregator, collate_status_tags_per_host=True)
@@ -118,22 +173,37 @@ def test_count_per_status_by_service_and_collate_per_host_evil(aggregator, check
     config['collate_status_tags_per_host'] = True
     haproxy_check.check(config)
 
-    tags = ['backend:FRONTEND', 'status:available', 'service:a']
+    tags = ['backend:FRONTEND', 'status:available', 'service:a', 'haproxy_service:a']
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:FRONTEND', 'status:available', 'service:b']
+    tags = ['backend:FRONTEND', 'status:available', 'service:b', 'haproxy_service:b']
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
     for backend in ['i-1', 'i-2', 'i-3']:
-        tags = ['backend:%s' % backend, 'status:available', 'service:b']
+        tags = ['backend:%s' % backend, 'status:available', 'service:b', 'haproxy_service:b']
         aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:i-4', 'status:unavailable', 'service:b']
+    tags = ['backend:i-4', 'status:unavailable', 'service:b', 'haproxy_service:b']
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:i-5', 'status:unavailable', 'service:b']
+    tags = ['backend:i-5', 'status:unavailable', 'service:b', 'haproxy_service:b']
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:i-1', 'status:available', 'service:be_edge_http_sre-production_elk-kibana']
+    tags = [
+        'backend:i-1',
+        'status:available',
+        'service:be_edge_http_sre-production_elk-kibana',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
+    ]
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:i-2', 'status:unavailable', 'service:be_edge_http_sre-production_elk-kibana']
+    tags = [
+        'backend:i-2',
+        'status:unavailable',
+        'service:be_edge_http_sre-production_elk-kibana',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
+    ]
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
-    tags = ['backend:i-3', 'status:unavailable', 'service:be_edge_http_sre-production_elk-kibana']
+    tags = [
+        'backend:i-3',
+        'status:unavailable',
+        'service:be_edge_http_sre-production_elk-kibana',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
+    ]
     aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
 
     _assert_agg_statuses(aggregator, collate_status_tags_per_host=True)
@@ -216,7 +286,7 @@ def test_optional_tags(aggregator, check, haproxy_mock):
     aggregator.assert_metric_has_tag('haproxy.backend.session.current', 'new-tag')
     aggregator.assert_metric_has_tag('haproxy.backend.session.current', 'my:new:tag')
     aggregator.assert_metric_has_tag('haproxy.count_per_status', 'my:new:tag')
-    tags = ['service:a', 'new-tag', 'my:new:tag', 'backend:BACKEND']
+    tags = ['service:a', 'haproxy_service:a', 'new-tag', 'my:new:tag', 'backend:BACKEND']
     aggregator.assert_service_check('haproxy.backend_up', tags=tags)
 
 
@@ -230,6 +300,7 @@ def test_regex_tags(aggregator, check, haproxy_mock):
 
     expected_tags = [
         'service:be_edge_http_sre-production_elk-kibana',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
         'type:BACKEND',
         'instance_url:http://localhost/admin?stats',
         'region:infra',
@@ -243,6 +314,7 @@ def test_regex_tags(aggregator, check, haproxy_mock):
     aggregator.assert_metric_has_tag('haproxy.backend.session.current', 'app:elk-kibana', 1)
     tags = [
         'service:be_edge_http_sre-production_elk-kibana',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
         'region:infra',
         'security:edge_http',
         'app:elk-kibana',
@@ -264,6 +336,37 @@ def test_version_failure(aggregator, check, datadog_agent):
         haproxy_check.check(config)
 
     # Version failed, but we should have some metrics
-    aggregator.assert_metric('haproxy.count_per_status', value=1, tags=['status:open', 'service:a'])
+    aggregator.assert_metric(
+        'haproxy.count_per_status', value=1, tags=['status:open', 'service:a', 'haproxy_service:a']
+    )
     # But no metadata
     datadog_agent.assert_metadata_count(0)
+
+
+def test_count_per_status_by_service_disable_service_tag(aggregator, check, haproxy_mock):
+    config = copy.deepcopy(BASE_CONFIG)
+    config['disable_legacy_service_tag'] = True
+    haproxy_check = check(config)
+    haproxy_check.check(config)
+
+    aggregator.assert_metric('haproxy.count_per_status', value=1, tags=['status:open', 'haproxy_service:a'])
+    aggregator.assert_metric('haproxy.count_per_status', value=3, tags=['status:up', 'haproxy_service:b'])
+    aggregator.assert_metric('haproxy.count_per_status', value=1, tags=['status:open', 'haproxy_service:b'])
+    aggregator.assert_metric('haproxy.count_per_status', value=1, tags=['status:down', 'haproxy_service:b'])
+    aggregator.assert_metric('haproxy.count_per_status', value=1, tags=['status:maint', 'haproxy_service:b'])
+    tags = [
+        'status:up',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
+    ]
+    aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
+    tags = [
+        'status:down',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
+    ]
+    aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
+    tags = [
+        'status:no_check',
+        'haproxy_service:be_edge_http_sre-production_elk-kibana',
+    ]
+    aggregator.assert_metric('haproxy.count_per_status', value=1, tags=tags)
+    _assert_agg_statuses(aggregator, disable_service_tag=True)


### PR DESCRIPTION
### Motivation

`service` is a reserved tag https://docs.datadoghq.com/tagging/