### PR TITLE
Prevent crash when a single app fails

### DIFF
--- a/spark/datadog_checks/spark/spark.py
+++ b/spark/datadog_checks/spark/spark.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from bs4 import BeautifulSoup
-from requests.exceptions import ConnectionError, HTTPError, InvalidURL, Timeout, RequestException
+from requests.exceptions import ConnectionError, HTTPError, InvalidURL, RequestException, Timeout
 from simplejson import JSONDecodeError
 from six import iteritems
 from six.moves.urllib.parse import urljoin, urlparse, urlsplit, urlunsplit

--- a/spark/datadog_checks/spark/spark.py
+++ b/spark/datadog_checks/spark/spark.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from bs4 import BeautifulSoup
-from requests.exceptions import ConnectionError, HTTPError, InvalidURL, Timeout
+from requests.exceptions import ConnectionError, HTTPError, InvalidURL, Timeout, RequestException
 from simplejson import JSONDecodeError
 from six import iteritems
 from six.moves.urllib.parse import urljoin, urlparse, urlsplit, urlunsplit
@@ -462,9 +462,13 @@ class SparkCheck(AgentCheck):
         spark_apps = {}
         version_set = False
         for app_id, (app_name, tracking_url) in iteritems(running_apps):
-            if not version_set:
-                version_set = self._collect_version(tracking_url)
-            response = self._rest_request_to_json(tracking_url, SPARK_APPS_PATH, SPARK_SERVICE_CHECK, tags)
+            try:
+                if not version_set:
+                    version_set = self._collect_version(tracking_url)
+                response = self._rest_request_to_json(tracking_url, SPARK_APPS_PATH, SPARK_SERVICE_CHECK, tags)
+            except RequestException as e:
+                self.log.warning("Exception happened when fetching app ids for %s: %s", tracking_url, e)
+                continue
 
             for app in response:
                 app_id = app.get('id')

--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -11,6 +11,7 @@ import mock
 import pytest
 import requests
 import urllib3
+from requests import RequestException
 from six import iteritems
 from six.moves import BaseHTTPServer
 from six.moves.urllib.parse import parse_qsl, unquote_plus, urljoin, urlparse
@@ -998,6 +999,20 @@ def test_ssl_cert():
     c = SparkCheck('spark', {}, [SSL_CERT_CONFIG])
 
     c.check(SSL_CERT_CONFIG)
+
+
+@pytest.mark.unit
+def test_do_not_crash_on_single_app_failure():
+    running_apps = {'foo': ('bar', 'http://foo.bar/'), 'foo2': ('bar', 'http://foo.bar/')}
+    results = []
+    rest_requests_to_json = mock.MagicMock(side_effect=[RequestException, results])
+    c = SparkCheck('spark', {}, [INSTANCE_STANDALONE])
+
+    with mock.patch.object(
+        c, '_rest_request_to_json', rest_requests_to_json
+    ), mock.patch.object(c, '_collect_version'):
+        c._get_spark_app_ids(running_apps, [])
+        assert rest_requests_to_json.call_count == 2
 
 
 class StandaloneAppsResponseHandler(BaseHTTPServer.BaseHTTPRequestHandler):

--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -1008,9 +1008,7 @@ def test_do_not_crash_on_single_app_failure():
     rest_requests_to_json = mock.MagicMock(side_effect=[RequestException, results])
     c = SparkCheck('spark', {}, [INSTANCE_STANDALONE])
 
-    with mock.patch.object(
-        c, '_rest_request_to_json', rest_requests_to_json
-    ), mock.patch.object(c, '_collect_version'):
+    with mock.patch.object(c, '_rest_request_to_json', rest_requests_to_json), mock.patch.object(c, '_collect_version'):
         c._get_spark_app_ids(running_apps, [])
         assert rest_requests_to_json.call_count == 2
 


### PR DESCRIPTION
Sometimes a single request will consistently fail when collecting app ids. The check should continue working.