### PR TITLE
Reduce number of tested versions

### DIFF
--- a/harbor/tox.ini
+++ b/harbor/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py37
 envlist =
-    py{27,37}-{1.4,1.5,1.6,1.7,1.8,1.10}
+    py{27,37}-{1.4,1.7,1.10}
 
 [testenv]
 description =
@@ -22,9 +22,6 @@ commands =
     pytest -v {posargs}
 setenv =
     1.4: HARBOR_VERSION=1.4.0
-    1.5: HARBOR_VERSION=1.5.0
-    1.6: HARBOR_VERSION=1.6.0
     1.7: HARBOR_VERSION=1.7.0
-    1.8: HARBOR_VERSION=1.8.0
     1.10: HARBOR_VERSION=1.10.0
     1.10: HARBOR_USE_SSL=1


### PR DESCRIPTION
CI is a bit flaky with 1.10. We're testing 6 versions, 3 would be enough
and keep our coverage.