### PR TITLE
Add Networks and Processes teams in ddev trello tool

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/testable.py
@@ -156,9 +156,10 @@ def testable(ctx, start_id, agent_version, milestone, dry_run):
             '2': 'Containers',
             '3': 'Logs',
             '4': 'Platform',
-            '5': 'Process',
-            '6': 'Trace',
-            '7': 'Integrations',
+            '5': 'Networks',
+            '6': 'Processes',
+            '7': 'Trace',
+            '8': 'Integrations',
             's': 'Skip',
             'q': 'Quit',
         }

--- a/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
@@ -16,14 +16,16 @@ class TrelloClient:
             'Integrations': '5ae1e3e2c81fff836d00497e',
             'Logs': '5aeca4c19707c4222bf6d883',
             'Platform': '5d9b687492952e6578ecf04d',
-            'Process': '5aeca4c8621e4359b9cb9c27',
+            'Networks': '5e1de8cf867357791ec5ee47',
+            'Processes': '5aeca4c8621e4359b9cb9c27',
             'Trace': '5bcf3ffbe0651642ae029038',
         }
         self.label_team_map = {
             'team/agent-apm': 'Trace',
             'team/agent-core': 'Core',
             'team/agent-platform': 'Platform',
-            'team/burrito': 'Process',
+            'team/networks': 'Networks',
+            'team/processes': 'Processes',
             'team/containers': 'Containers',
             'team/integrations': 'Integrations',
             'team/logs': 'Logs',


### PR DESCRIPTION
### What does this PR do?

Adds the two new teams, Networks and Processes (formerly Burrito), to the ddev trello tool.

### Motivation

New Networks & Processes teams.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
