### PR TITLE
Add an option to skip reporting during restarts

### DIFF
--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -152,6 +152,19 @@ instances:
     #   - <KEY_1>:<VALUE_1>
     #   - <KEY_2>:<VALUE_2>
 
+    ## @param startup_grace_time - integer - optional
+    ## Time to wait on startup or reload of haproxy before sending metrics
+    ##
+    ## When haproxy reloads, if there is a `grace` period on some proxies, 2
+    ## haproxies will stay running for that period, possibly including the
+    ## stats endpoint. Stats returned by haproxy during this period will only
+    ## refer to one of the multiple instances of haproxy, and will not
+    ## accurately reflect the state of the system.
+    ## If this parameter is >0, no datapoints will be sent until the uptime of
+    ## haproxy reaches this many seconds
+    #
+    # startup_grace_seconds: 0
+
     ## @param connect_timeout - integer - optional
     ## Overrides the default connection timeout value,
     ## and fails the check if the time to establish the (TCP) connection

--- a/haproxy/tests/common.py
+++ b/haproxy/tests/common.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from datadog_checks.dev.utils import ON_LINUX
+from datadog_checks.dev.utils import ON_LINUX, ON_MACOS
 from datadog_checks.utils.common import get_docker_hostname
 
 AGG_STATUSES_BY_SERVICE = (
@@ -53,10 +53,16 @@ USERNAME = 'datadog'
 PASSWORD = 'isdevops'
 HAPROXY_VERSION = os.getenv('HAPROXY_VERSION')
 
-platform_supports_sockets = ON_LINUX
+platform_supports_sockets = ON_LINUX or ON_MACOS
+platform_supports_sharing_unix_sockets_through_docker = ON_LINUX
 requires_socket_support = pytest.mark.skipif(
     not platform_supports_sockets, reason='Windows sockets are not file handles'
 )
+requires_shareable_unix_socket = pytest.mark.skipif(
+    not platform_supports_sharing_unix_sockets_through_docker,
+    reason='AF_UNIX sockets cannot be bind-mounted between a macOS host and a linux guest in docker',
+)
+haproxy_less_than_1_7 = os.environ.get('HAPROXY_VERSION', '1.5.11').split('.')[:2] < ['1', '7']
 
 CONFIG_UNIXSOCKET = {'collect_aggregates_only': False}
 

--- a/haproxy/tests/test_haproxy.py
+++ b/haproxy/tests/test_haproxy.py
@@ -224,6 +224,17 @@ def test_version_metadata_http(check, datadog_agent, version_metadata):
     datadog_agent.assert_metadata_count(metadata_count)
 
 
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.integration
+def test_uptime_skip_http(check, aggregator):
+    config = copy.deepcopy(CHECK_CONFIG_OPEN)
+    config['startup_grace_seconds'] = 20
+    check = check(config)
+    check.check(config)
+
+    aggregator.assert_all_metrics_covered()
+
+
 @requires_shareable_unix_socket
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
@@ -265,6 +276,21 @@ def test_version_metadata_tcp_socket(check, version_metadata, datadog_agent):
         else len(version_metadata)
     )
     datadog_agent.assert_metadata_count(metadata_count)
+
+
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.integration
+@pytest.mark.skipif(
+    haproxy_less_than_1_7 or not platform_supports_sockets,
+    reason='Uptime is only reported on the stats socket in v1.7+',
+)
+def test_uptime_skip_tcp(aggregator, check, dd_environment):
+    config = copy.deepcopy(CONFIG_TCPSOCKET)
+    config['startup_grace_seconds'] = 20
+    check = check(config)
+    check.check(config)
+
+    aggregator.assert_all_metrics_covered()
 
 
 @pytest.mark.e2e

--- a/haproxy/tests/test_haproxy.py
+++ b/haproxy/tests/test_haproxy.py
@@ -25,7 +25,9 @@ from .common import (
     STATS_SOCKET,
     STATS_URL,
     STATS_URL_OPEN,
+    haproxy_less_than_1_7,
     platform_supports_sockets,
+    requires_shareable_unix_socket,
     requires_socket_support,
 )
 
@@ -170,7 +172,7 @@ def test_open_config(aggregator, check):
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
 @pytest.mark.skipif(
-    os.environ.get('HAPROXY_VERSION', '1.5.11').split('.')[:2] < ['1', '7'] or not platform_supports_sockets,
+    haproxy_less_than_1_7 or not platform_supports_sockets,
     reason='Sockets with operator level are only available with haproxy 1.7',
 )
 def test_tcp_socket(aggregator, check):
@@ -186,7 +188,7 @@ def test_tcp_socket(aggregator, check):
     aggregator.assert_all_metrics_covered()
 
 
-@requires_socket_support
+@requires_shareable_unix_socket
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
 def test_unixsocket_config(aggregator, check, dd_environment):
@@ -205,6 +207,7 @@ def test_unixsocket_config(aggregator, check, dd_environment):
 
 
 @pytest.mark.usefixtures('dd_environment')
+@pytest.mark.integration
 def test_version_metadata_http(check, datadog_agent, version_metadata):
     config = copy.deepcopy(CHECK_CONFIG_OPEN)
     check = check(config)
@@ -221,7 +224,7 @@ def test_version_metadata_http(check, datadog_agent, version_metadata):
     datadog_agent.assert_metadata_count(metadata_count)
 
 
-@requires_socket_support
+@requires_shareable_unix_socket
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
 def test_version_metadata_unix_socket(check, version_metadata, dd_environment, datadog_agent):
@@ -245,7 +248,7 @@ def test_version_metadata_unix_socket(check, version_metadata, dd_environment, d
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
 @pytest.mark.skipif(
-    os.environ.get('HAPROXY_VERSION', '1.5.11').split('.')[:2] < ['1', '7'] or not platform_supports_sockets,
+    haproxy_less_than_1_7 or not platform_supports_sockets,
     reason='Sockets with operator level are only available with haproxy 1.7',
 )
 def test_version_metadata_tcp_socket(check, version_metadata, datadog_agent):

--- a/haproxy/tox.ini
+++ b/haproxy/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{14,15,16,17,18}
+    py{27,38}-{14,15,16,17,18,20,21}
 
 [testenv]
 dd_check_style = true
@@ -22,6 +22,8 @@ setenv =
   16: HAPROXY_VERSION=1.6.9
   17: HAPROXY_VERSION=1.7.10
   18: HAPROXY_VERSION=1.8.5
+  20: HAPROXY_VERSION=2.0.12
+  21: HAPROXY_VERSION=2.1.2
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?
This PR adds an option and a configuration parameter to skip reporting information for a time after the (re)start of haproxy
### Motivation
When using the `grace` configuration option, during a restart or a reload of haproxy, two (or more) instances of haproxy run concurrently. During this time, statistics reported over the stats socket or stats http endpoint are incorrect or misleading, since they only apply to one of the multiple instances of haproxy running.
Currently haproxy doesn't seem to have the capability of carrying over or merging stats for the multiple instances during a restart, so ignoring the incorrect information would be the next best thing

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
