### PR TITLE
Avoid long break in error message

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
@@ -132,8 +132,10 @@ def service_checks(sync):
 
             if integration != expected_display_name:
                 file_failed = True
-                message = f'  {check}: integration name `{integration}` must match \
-                            manifest display_name `{expected_display_name}` '
+                message = (
+                    f'  {check}: integration name `{integration}` must match '
+                    f'manifest display_name `{expected_display_name}` '
+                )
                 display_queue.append((echo_failure, message))
 
             # name


### PR DESCRIPTION
When CI failed in the service check validation test, the browser window was just narrow enough that the full error message wasn't viewable:

https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=7748&view=logs&j=910f82a4-622d-5ace-f877-8b75c045486c&t=78af478c-7ed2-51a7-2823-0a845135c083&l=29

This just cleans up the error message while still being acceptable to `black`.