### PR TITLE
[HOLD] Fix wrapt import

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/tracing.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tracing.py
@@ -2,8 +2,8 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-from ddtrace.vendor import wrapt
 from ddtrace import tracer
+from ddtrace.vendor import wrapt
 
 from ..config import is_affirmative
 

--- a/datadog_checks_base/datadog_checks/base/utils/tracing.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tracing.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-import wrapt
+from ddtrace.vendor import wrapt
 from ddtrace import tracer
 
 from ..config import is_affirmative

--- a/openstack_controller/datadog_checks/openstack_controller/utils.py
+++ b/openstack_controller/datadog_checks/openstack_controller/utils.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import wrapt
+from ddtrace.vendor import wrapt
 from ddtrace import tracer
 
 from datadog_checks.base.config import is_affirmative

--- a/openstack_controller/datadog_checks/openstack_controller/utils.py
+++ b/openstack_controller/datadog_checks/openstack_controller/utils.py
@@ -1,8 +1,8 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from ddtrace.vendor import wrapt
 from ddtrace import tracer
+from ddtrace.vendor import wrapt
 
 from datadog_checks.base.config import is_affirmative
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix wrapt import.

The issue appeared on CI https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=7793&view=logs&j=12f53639-7e0c-506b-2b53-a7405df1086b&t=72d0428d-576e-5e1b-640d-0ea2f62b0022 

when we upgraded `dd-trace`: https://github.com/DataDog/integrations-core/pull/5491

Alternative fix: https://github.com/DataDog/integrations-core/pull/5583

---

Not 100% sure this is the right way to fix the issue.

Hi @brettlangdon, need your expertise on this :slightly_smiling_face: Do you know the differences between `ddtrace.vendor.wrapt` and the original `wrapt` ?

Shall we 1. add original `wrapt` as dep 2. use `ddtrace.vendor.wrapt` (this PR) ?

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
