### PR TITLE
Add parameters for SSL configuration

### DIFF
--- a/ibm_db2/datadog_checks/ibm_db2/data/conf.yaml.example
+++ b/ibm_db2/datadog_checks/ibm_db2/data/conf.yaml.example
@@ -37,11 +37,11 @@ instances:
     #
     # port: 50000
 
-    ## @param cert_path - string - optional
-    ## The path to a certicate to use, when connecting to a SSL database. It
+    ## @param tls_cert - string - optional
+    ## The path to a SSL certicate to use, when connecting to a database in a secure fashion. It
     ## has to be accessible and readable by the agent user.
     #
-    # cert_path: <PATH>
+    # tls_cert: <PATH>
 
     ## @param tags - list of key:value strings - optional
     ## List of tags to attach to every metric and service check emitted by this instance.

--- a/ibm_db2/datadog_checks/ibm_db2/data/conf.yaml.example
+++ b/ibm_db2/datadog_checks/ibm_db2/data/conf.yaml.example
@@ -37,6 +37,12 @@ instances:
     #
     # port: 50000
 
+    ## @param cert_path - string - optional
+    ## The path to a certicate to use, when connecting to a SSL database. It
+    ## has to be accessible and readable by the agent user.
+    #
+    # cert_path: <PATH>
+
     ## @param tags - list of key:value strings - optional
     ## List of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -29,7 +29,7 @@ class IbmDb2Check(AgentCheck):
         self._host = self.instance.get('host', '')
         self._port = self.instance.get('port', 5000)
         self._tags = self.instance.get('tags', [])
-        self._cert_path = self.instance.get('cert_path')
+        self._tls_cert = self.instance.get('tls_cert')
 
         # Add global database tag
         self._tags.append('db:{}'.format(self._db))
@@ -535,7 +535,7 @@ class IbmDb2Check(AgentCheck):
 
     def get_connection(self):
         target, username, password = self.get_connection_data(
-            self._db, self._username, self._password, self._host, self._port, self._cert_path
+            self._db, self._username, self._password, self._host, self._port, self._tls_cert
         )
 
         # Get column names in lower case
@@ -554,15 +554,15 @@ class IbmDb2Check(AgentCheck):
             return connection
 
     @classmethod
-    def get_connection_data(cls, db, username, password, host, port, cert_path):
+    def get_connection_data(cls, db, username, password, host, port, tls_cert):
         if host:
             target = 'database={};hostname={};port={};protocol=tcpip;uid={};pwd={}'.format(
                 db, host, port, username, password
             )
             username = ''
             password = ''
-            if cert_path:
-                target = '{};security=ssl;sslservercertificate={}'.format(target, cert_path)
+            if tls_cert:
+                target = '{};security=ssl;sslservercertificate={}'.format(target, tls_cert)
         else:  # no cov
             target = db
 

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -29,6 +29,7 @@ class IbmDb2Check(AgentCheck):
         self._host = self.instance.get('host', '')
         self._port = self.instance.get('port', 5000)
         self._tags = self.instance.get('tags', [])
+        self._cert_path = self.instance.get('cert_path')
 
         # Add global database tag
         self._tags.append('db:{}'.format(self._db))
@@ -534,7 +535,7 @@ class IbmDb2Check(AgentCheck):
 
     def get_connection(self):
         target, username, password = self.get_connection_data(
-            self._db, self._username, self._password, self._host, self._port
+            self._db, self._username, self._password, self._host, self._port, self._cert_path
         )
 
         # Get column names in lower case
@@ -553,13 +554,15 @@ class IbmDb2Check(AgentCheck):
             return connection
 
     @classmethod
-    def get_connection_data(cls, db, username, password, host, port):
+    def get_connection_data(cls, db, username, password, host, port, cert_path):
         if host:
             target = 'database={};hostname={};port={};protocol=tcpip;uid={};pwd={}'.format(
                 db, host, port, username, password
             )
             username = ''
             password = ''
+            if cert_path:
+                target = '{};security=ssl;sslservercertificate={}'.format(target, cert_path)
         else:  # no cov
             target = db
 

--- a/ibm_db2/tests/conftest.py
+++ b/ibm_db2/tests/conftest.py
@@ -15,7 +15,7 @@ from .common import COMPOSE_FILE, CONFIG, E2E_METADATA
 class DbManager(object):
     def __init__(self, config):
         self.target, self.username, self.password = IbmDb2Check.get_connection_data(
-            config['db'], config['username'], config['password'], config['host'], config['port']
+            config['db'], config['username'], config['password'], config['host'], config['port'], None
         )
         self.db_name = config['db']
         self.conn = None

--- a/ibm_db2/tests/test_integration.py
+++ b/ibm_db2/tests/test_integration.py
@@ -6,6 +6,9 @@ import pytest
 from datadog_checks.ibm_db2 import IbmDb2Check
 
 from . import metrics
+from .common import DB2_VERSION
+
+CHECK_ID = 'test:123'
 
 pytestmark = pytest.mark.integration
 
@@ -102,3 +105,22 @@ def test_custom_queries_init_config(aggregator, instance):
             metric_type=3,
             tags=['db:datadog', 'foo:bar', 'test:ibm_db2', 'tablespace:{}'.format(table_space)],
         )
+
+
+@pytest.mark.usefixtures('dd_environment')
+def test_metadata(instance, datadog_agent):
+    check = IbmDb2Check('ibm_db2', {}, [instance])
+    check.check_id = CHECK_ID
+
+    check.check(instance)
+
+    # only major and minor are consistent values
+    major, minor = DB2_VERSION.split('.')
+
+    version_metadata = {
+        'version.scheme': 'ibm_db2',
+        'version.major': major,
+        'version.minor': minor,
+    }
+
+    datadog_agent.assert_metadata(CHECK_ID, version_metadata)

--- a/ibm_db2/tox.ini
+++ b/ibm_db2/tox.ini
@@ -21,7 +21,6 @@ passenv =
 setenv =
     ; for macOS https://github.com/ibmdb/python-ibmdb/tree/master/IBM_DB/ibm_db#issues-with-mac-os-x
     DYLD_LIBRARY_PATH={envsitepackagesdir}/clidriver/lib:{env:DYLD_LIBRARY_PATH:none}
-    DB2_VERSION=11.1
     11.1: DB2_VERSION=11.1
 commands =
     pip install -r requirements.in

--- a/ibm_db2/tox.ini
+++ b/ibm_db2/tox.ini
@@ -21,6 +21,7 @@ passenv =
 setenv =
     ; for macOS https://github.com/ibmdb/python-ibmdb/tree/master/IBM_DB/ibm_db#issues-with-mac-os-x
     DYLD_LIBRARY_PATH={envsitepackagesdir}/clidriver/lib:{env:DYLD_LIBRARY_PATH:none}
+    DB2_VERSION=11.1
     11.1: DB2_VERSION=11.1
 commands =
     pip install -r requirements.in


### PR DESCRIPTION
To be able to use a SSL connection, we need to specify a certificate.
While you can do it direct in the database connection, this is more
clear with a new parameter to specify.