### PR TITLE
Submit `redis.key.length` metric regardless of `warn_on_missing_keys`

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -274,13 +274,13 @@ class Redis(AgentCheck):
         databases = list(conn.info('keyspace'))
         if not databases:
             self.warning("Redis database is empty")
-            if warn_on_missing_keys:
-                for key in key_list:
-                    key_tags = ['key:{}'.format(key)]
-                    if instance_db:
-                        key_tags.append('redis_db:db{}'.format(instance_db))
-                    key_tags.extend(tags)
-                    self.gauge('redis.key.length', 0, tags=key_tags)
+            for key in key_list:
+                key_tags = ['key:{}'.format(key)]
+                if instance_db:
+                    key_tags.append('redis_db:db{}'.format(instance_db))
+                key_tags.extend(tags)
+                self.gauge('redis.key.length', 0, tags=key_tags)
+                if warn_on_missing_keys:
                     self.warning("%s key not found in redis", key)
             return
 
@@ -364,13 +364,14 @@ class Redis(AgentCheck):
         # Warn if a key is missing from the entire redis instance.
         # Send 0 if the key is missing/empty from the entire redis instance.
         for key, total in iteritems(lengths_overall):
-            if total == 0 and warn_on_missing_keys:
+            if total == 0:
                 key_tags = ['key:{}'.format(key)]
                 if instance_db:
                     key_tags.append('redis_db:db{}'.format(instance_db))
                 key_tags.extend(tags)
                 self.gauge('redis.key.length', 0, tags=key_tags)
-                self.warning("%s key not found in redis", key)
+                if warn_on_missing_keys:
+                    self.warning("%s key not found in redis", key)
 
     def _check_replication(self, info, tags):
         # Save the replication delay for each slave


### PR DESCRIPTION
### What does this PR do?
submit `redis.key.length` metric regardless of `warn_on_missing_keys` parameter.

### Motivation

- `warn_on_missing_keys: False` not only suppresses the warning but also skips on submitting the metric
- 586-rediskeylength-defaults-to-null-with-warnonmissingkeys-false

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
