### PR TITLE
Add type checking support to Tox plugin

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -70,8 +70,9 @@ def add_style_checker(config, sections, make_envconfig, reader):
 
     if sections['testenv'].get(TYPES_FLAG, 'false').lower() == 'true':
         # For command line options accepted by mypy, see: https://mypy.readthedocs.io/en/stable/command_line.html
-        # Defaults to type-checking the entire integration package.
-        mypy_args = sections['testenv'].get(MYPY_ARGS_OPTION, 'datadog_checks')
+        # Each integration should explicitly specify its options and which files it'd like to type check, which is
+        # why we're defaulting to 'no arguments' by default.
+        mypy_args = sections['testenv'].get(MYPY_ARGS_OPTION, '')
 
         dependencies.append('mypy>=0.761')
         commands.append('mypy --config-file=../mypy.ini {}'.format(mypy_args))

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -74,6 +74,9 @@ def add_style_checker(config, sections, make_envconfig, reader):
         # why we're defaulting to 'no arguments' by default.
         mypy_args = sections['testenv'].get(MYPY_ARGS_OPTION, '')
 
+        # Allow using multiple lines for enhanced readability in case of large amount of options/files to check.
+        mypy_args = mypy_args.replace('\n', ' ')
+
         dependencies.append('mypy>=0.761')
         commands.append('mypy --config-file=../mypy.ini {}'.format(mypy_args))
 

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -11,6 +11,8 @@ import tox.config
 STYLE_CHECK_ENV_NAME = 'style'
 STYLE_FORMATTER_ENV_NAME = 'format_style'
 STYLE_FLAG = 'dd_check_style'
+TYPES_FLAG = 'dd_check_types'
+MYPY_ARGS_OPTION = 'dd_mypy_args'
 E2E_READY_CONDITION = 'e2e ready if'
 
 
@@ -51,20 +53,37 @@ def tox_configure(config):
 def add_style_checker(config, sections, make_envconfig, reader):
     # testenv:style
     section = '{}{}'.format(tox.config.testenvprefix, STYLE_CHECK_ENV_NAME)
+
+    dependencies = [
+        'flake8',
+        'flake8-bugbear',
+        'flake8-logging-format',
+        'black',
+        'isort[pyproject]>=4.3.15',
+    ]
+
+    commands = [
+        'flake8 --config=../.flake8 --enable-extensions=G .',
+        'black --check --diff .',
+        'isort --check-only --diff --recursive .',
+    ]
+
+    if sections['testenv'].get(TYPES_FLAG, 'false').lower() == 'true':
+        # For command line options accepted by mypy, see: https://mypy.readthedocs.io/en/stable/command_line.html
+        # Defaults to type-checking the entire integration package.
+        mypy_args = sections['testenv'].get(MYPY_ARGS_OPTION, 'datadog_checks')
+
+        dependencies.append('mypy>=0.761')
+        commands.append('mypy --config-file=../mypy.ini {}'.format(mypy_args))
+
     sections[section] = {
         'platform': 'linux|darwin|win32',
-        # These tools require Python 3.6+
+        # Tools used here require Python 3.6+
         # more info: https://github.com/ambv/black/issues/439#issuecomment-411429907
         'basepython': 'python3',
         'skip_install': 'true',
-        'deps': 'flake8\nflake8-bugbear\nflake8-logging-format\nblack\nisort[pyproject]>=4.3.15',
-        'commands': '\n'.join(
-            [
-                'flake8 --config=../.flake8 --enable-extensions=G .',
-                'black --check --diff .',
-                'isort --check-only --diff --recursive .',
-            ]
-        ),
+        'deps': '\n'.join(dependencies),
+        'commands': '\n'.join(commands),
     }
 
     # Always add the environment configurations

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,16 @@
+; See: https://mypy.readthedocs.io/en/stable/config_file.html
+
+[mypy]
+; Follows imports and type-check imported modules.
+follow_imports = normal
+
+; Ignore errors about imported packages that don't provide type hints.
+ignore_missing_imports = true
+
+; Don't require that all functions be annotated, as it would create
+; a lot of noise for imported modules that aren't annotated yet.
+; Note that this is the default behavior, but we're making our choice explicit here.
+disallow_untyped_defs = false
+
+; Include column numbers in errors.
+show_column_numbers = true


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Allow configuring each integration's `tox.ini` to run `mypy`, e.g...

```ini
[testenv]
dd_check_types = true
dd_mypy_args = --py2 /path/to/file.py /path/to/more/files/
```

Not enabled anywhere for now.

### Motivation
<!-- What inspired you to submit this pull request? -->
Allow us to start running `mypy` as part of test suites.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Extracted from https://github.com/DataDog/integrations-core/pull/5548.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
