### PR TITLE
Stop mounting the docker socket to allow jmx tests to pass

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -232,9 +232,7 @@ class DockerInterface(object):
             # Mount the check directory
             f'{path_join(get_root(), self.check)}:{self.check_mount_dir}',
             # Mount the /proc directory
-            '/proc:/host/proc',
-            # Mount the docker socket
-            '/var/run/docker.sock:/var/run/docker.sock',
+            '/proc:/host/proc'
         ]
         volumes.extend(self.metadata.get('docker_volumes', []))
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -232,7 +232,7 @@ class DockerInterface(object):
             # Mount the check directory
             f'{path_join(get_root(), self.check)}:{self.check_mount_dir}',
             # Mount the /proc directory
-            '/proc:/host/proc'
+            '/proc:/host/proc',
         ]
         volumes.extend(self.metadata.get('docker_volumes', []))
 


### PR DESCRIPTION
Somehow, mounting the docker socket inside the agent container puts the `agent check` command into an infinite loop with jmx integrations 🤷‍♂ 

Mounting the socket is not required anyway so it's safe to remove