### PR TITLE
Fix "Allow help options to ddev run command"

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/run.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/run.py
@@ -14,7 +14,7 @@ from .console import UNKNOWN_OPTIONS
 @click.pass_context
 def run(ctx, args):
     """Run commands in the proper repo."""
-    if not args or '-h' in args or '--help' in args:
+    if not args:
         click.echo(ctx.get_help())
         return
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/run.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/run.py
@@ -14,7 +14,7 @@ from .console import UNKNOWN_OPTIONS
 @click.pass_context
 def run(ctx, args):
     """Run commands in the proper repo."""
-    if not args:
+    if not args or (len(args) == 1 and args[0] in ('-h', '--help')):
         click.echo(ctx.get_help())
         return
 


### PR DESCRIPTION
### Motivation

You can no longer view help

```
$ ddev run git --help
Usage: ddev run [OPTIONS] [ARGS]...

  Run commands in the proper repo.
```

Fixes https://github.com/DataDog/integrations-core/pull/5602