### PR TITLE
Allow specifying 'ddev release changelog' output file

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -27,8 +27,9 @@ ChangelogEntry = namedtuple('ChangelogEntry', 'number, title, url, author, autho
 @click.option('--initial', is_flag=True)
 @click.option('--quiet', '-q', is_flag=True)
 @click.option('--dry-run', '-n', is_flag=True)
+@click.option('--output-file', '-o', default='CHANGELOG.md', show_default=True)
 @click.pass_context
-def changelog(ctx, check, version, old_version, initial, quiet, dry_run):
+def changelog(ctx, check, version, old_version, initial, quiet, dry_run, output_file):
     """Perform the operations needed to update the changelog.
 
     This method is supposed to be used by other tasks and not directly.
@@ -108,9 +109,9 @@ def changelog(ctx, check, version, old_version, initial, quiet, dry_run):
 
     # read the old contents
     if check:
-        changelog_path = os.path.join(get_root(), check, 'CHANGELOG.md')
+        changelog_path = os.path.join(get_root(), check, output_file)
     else:
-        changelog_path = os.path.join(get_root(), 'CHANGELOG.md')
+        changelog_path = os.path.join(get_root(), output_file)
     old = list(stream_file_lines(changelog_path))
 
     # write the new changelog in memory


### PR DESCRIPTION
### What does this PR do?

Adds `--output-file` argument to `ddev release changelog`

### Motivation

We'd like to use `ddev release changelog` for https://github.com/DataDog/apigentools, but the changelog is supposed to live in `docs/changelog.md` rather than `CHANGELOG.md` file.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
