### PR TITLE
Apply strptime thread-safety fix only on Python 2

### DIFF
--- a/http_check/datadog_checks/http_check/__about__.py
+++ b/http_check/datadog_checks/http_check/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE
+# Licensed under a 3-clause BSD style license (see LICENSE)
 __version__ = "4.6.3"

--- a/http_check/datadog_checks/http_check/__about__.py
+++ b/http_check/datadog_checks/http_check/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
+# Licensed under a 3-clause BSD style license (see LICENSE
 __version__ = "4.6.3"

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -20,6 +20,7 @@ from .adapters import WeakCiphersAdapter, WeakCiphersHTTPSConnection
 from .config import DEFAULT_EXPECTED_CODE, from_instance
 from .utils import get_ca_certs_path
 
+# Apply thread-safety fix, see https://bugs.python.org/issue7980
 if PY2:
     import _strptime  # noqa
 

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import unicode_literals
 
-import _strptime  # noqa
 import copy
 import re
 import socket
@@ -12,7 +11,7 @@ import time
 from datetime import datetime
 
 import requests
-from six import string_types
+from six import PY2, string_types
 from six.moves.urllib.parse import urlparse
 
 from datadog_checks.base import AgentCheck, ensure_unicode
@@ -20,6 +19,9 @@ from datadog_checks.base import AgentCheck, ensure_unicode
 from .adapters import WeakCiphersAdapter, WeakCiphersHTTPSConnection
 from .config import DEFAULT_EXPECTED_CODE, from_instance
 from .utils import get_ca_certs_path
+
+if PY2:
+    import _strptime  # noqa
 
 DEFAULT_EXPIRE_DAYS_WARNING = 14
 DEFAULT_EXPIRE_DAYS_CRITICAL = 7

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import unicode_literals
 
+import _strptime  # noqa
 import copy
 import re
 import socket
@@ -10,7 +11,6 @@ import ssl
 import time
 from datetime import datetime
 
-import _strptime  # noqa
 import requests
 from six import string_types
 from six.moves.urllib.parse import urlparse


### PR DESCRIPTION
### What does this PR do?

Introduced in https://github.com/DataDog/dd-agent/pull/2915
See https://bugs.python.org/issue7980

### Motivation

Noticed while testing https://github.com/DataDog/integrations-core/pull/5617, the import order now (for some reason) properly fails `isort`, see https://discuss.python.org/t/virtualenv-20-0-0-beta1-is-available/3077/22