### PR TITLE
Swap httpstat for httpbin in `test_session_timeout`

### DIFF
--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -1151,6 +1151,6 @@ class TestAPI:
 
 class TestIntegration:
     def test_session_timeout(self):
-        http = RequestsWrapper({'persist_connections': True}, {'timeout': 0.300})
+        http = RequestsWrapper({'persist_connections': True}, {'timeout': 0.001})
         with pytest.raises(requests.exceptions.Timeout):
-            http.get('https://httpstat.us/200?sleep=500')
+            http.get('https://httpbin.org/get')

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -1151,6 +1151,6 @@ class TestAPI:
 
 class TestIntegration:
     def test_session_timeout(self):
-        http = RequestsWrapper({'persist_connections': True}, {'timeout': 0.001})
+        http = RequestsWrapper({'persist_connections': True}, {'timeout': 0.08})
         with pytest.raises(requests.exceptions.Timeout):
-            http.get('https://httpbin.org/get')
+            http.get('https://httpbin.org/delay/0.10')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix test_session_timeout.

`httpstat.us` seems down/not reliable, use httpbin instead.

Long term fix: use a docker container equivalent of services like `httpbin` and `httpstat`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
