### PR TITLE
Remove `kafka-python` dep for tests

### DIFF
--- a/kafka_consumer/tests/common.py
+++ b/kafka_consumer/tests/common.py
@@ -14,9 +14,6 @@ ZK_CONNECT_STR = '{}:2181'.format(HOST)
 TOPICS = ['marvel', 'dc']
 PARTITIONS = [0, 1]
 
-# TODO: Remove
-E2E_METADATA = {'start_commands': ['pip install kafka-python==1.4.7']}
-
 
 def is_supported(flavor):
     """

--- a/kafka_consumer/tests/conftest.py
+++ b/kafka_consumer/tests/conftest.py
@@ -9,7 +9,7 @@ from kafka import KafkaConsumer
 
 from datadog_checks.dev import WaitFor, docker_run
 
-from .common import E2E_METADATA, HERE, HOST_IP, KAFKA_CONNECT_STR, PARTITIONS, TOPICS, ZK_CONNECT_STR
+from .common import HERE, HOST_IP, KAFKA_CONNECT_STR, PARTITIONS, TOPICS, ZK_CONNECT_STR
 from .runners import KConsumer, Producer, ZKConsumer
 
 
@@ -48,7 +48,7 @@ def dd_environment(e2e_instance):
             'KAFKA_HOST': HOST_IP
         },
     ):
-        yield e2e_instance, E2E_METADATA
+        yield e2e_instance
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
### What does this PR do?

Remove kafka-python dep for tests

cc @jeffwidman 

### Motivation

- Not needed anymore since `kafka-python` is shipped with the agent.
- Faster tests

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
