### PR TITLE
Optimize test envs

### DIFF
--- a/kafka_consumer/tests/common.py
+++ b/kafka_consumer/tests/common.py
@@ -5,6 +5,7 @@ import os
 import socket
 
 from datadog_checks.dev import get_docker_hostname
+from datadog_checks.kafka_consumer.legacy_0_10_2 import LegacyKafkaCheck_0_10_2
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 HOST = get_docker_hostname()
@@ -29,3 +30,7 @@ def is_supported(flavor):
         return False
 
     return True
+
+
+def is_legacy_check(check):
+    return isinstance(check, LegacyKafkaCheck_0_10_2)

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -5,7 +5,7 @@ import pytest
 
 from datadog_checks.kafka_consumer import KafkaCheck
 
-from .common import KAFKA_CONNECT_STR, is_supported
+from .common import KAFKA_CONNECT_STR, is_legacy_check, is_supported
 
 pytestmark = pytest.mark.skipif(
     not is_supported('kafka'), reason='kafka consumer offsets not supported in current environment'
@@ -52,6 +52,10 @@ def assert_check_kafka(aggregator, consumer_groups):
 def test_consumer_config_error(caplog):
     instance = {'kafka_connect_str': KAFKA_CONNECT_STR, 'kafka_consumer_offsets': True, 'tags': ['optional:tag1']}
     kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [instance])
+
+    if is_legacy_check(kafka_consumer_check):
+        pytest.skip("This test does not apply to legacy check")
+
     kafka_consumer_check.check(instance)
     assert 'monitor_unlisted_consumer_groups is False' in caplog.text
 
@@ -61,6 +65,9 @@ def test_no_topics(aggregator, kafka_instance):
     kafka_instance['consumer_groups'] = {'my_consumer': {}}
     kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
     kafka_consumer_check.check(kafka_instance)
+
+    if is_legacy_check(kafka_consumer_check):
+        pytest.skip("This test does not apply to legacy check")
 
     assert_check_kafka(aggregator, {'my_consumer': {'marvel': [0]}})
 

--- a/kafka_consumer/tox.ini
+++ b/kafka_consumer/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py37
 envlist =
-    py27-latest-{kafka,zk}
+    py27-{0.9,latest}-{kafka,zk}
     py37-{0.9,0.11,1.1,2.3,latest}-{kafka,zk}
 
 [testenv]

--- a/kafka_consumer/tox.ini
+++ b/kafka_consumer/tox.ini
@@ -2,7 +2,8 @@
 minversion = 2.0
 basepython = py37
 envlist =
-    py{27,37}-{0.10.2,0.11,1.1,2.3,latest}-{kafka,zk}
+    py27-latest-{kafka,zk}
+    py37-{0.9,0.11,1.1,2.3,latest}-{kafka,zk}
 
 [testenv]
 description =
@@ -22,8 +23,8 @@ commands =
 setenv =
     kafka: KAFKA_OFFSETS_STORAGE=kafka
     zk: KAFKA_OFFSETS_STORAGE=zookeeper
-    # 0.10.2 is for testing legacy implementation
-    0.10.2: KAFKA_VERSION=0.10.2.1
+    # Note: 0.9 is for testing legacy (legacy_0_10_2.py) implementation
+    0.9: KAFKA_VERSION=0.9.0.1-1
     0.11: KAFKA_VERSION=0.11.0.1
     1.1: KAFKA_VERSION=1.1.0
     2.3: KAFKA_VERSION=2.12-2.3.0


### PR DESCRIPTION
### What does this PR do?

Optimize test envs:

- Add back 0.9 that was removed in https://github.com/DataDog/integrations-core/pull/4873, it's actually needed for testing legacy integration.
- `py27-{0.9,latest}-{kafka,zk}` should be enough to test that py2 works, we cover both legacy and new integration code path

Reduce number of envs from 20 to 14.

### Motivation
<!-- What inspired you to submit this pull request? -->

- Faster CI, currently, Kafka Consumer is the slowest integration that takes 40+ mins

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
