### PR TITLE
Ignore pyenv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,9 @@ tmp
 .rbenv-gemsets
 .ruby-version
 
+# pyenv versioning
+.python-version
+
 # Common IDEs & editors
 .idea/
 .vscode/


### PR DESCRIPTION
When using pyenv for managing different python versions, you can add multiple versions as part of the local config which will then make them available to tox for testing.

At the root of the `integrations-core` directory, running the command `pyenv local 3.8.1 2.7.17` will make those two versions available to all tox tests, and this creates a `.python-version` file.

This PR adds that file to `.gitignore`.