### PR TITLE
Always pass PROGRAM* to tox

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -95,6 +95,8 @@ def test(
         'TOX_TESTENV_PASSENV': (
             # Used in .coveragerc for whether or not to show missing line numbers for coverage
             'DDEV_COV_MISSING '
+            # Necessary for compilation on Windows: PROGRAMDATA, PROGRAMFILES, PROGRAMFILES(X86)
+            'PROGRAM* '
             # Necessary for getting the user on Windows https://docs.python.org/3/library/getpass.html#getpass.getuser
             'USERNAME '
             # Space-separated list of pytest options

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/run.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/run.py
@@ -30,7 +30,7 @@ def start_environment(check, env):
     env_vars = {
         E2E_TEAR_DOWN: 'false',
         'PYTEST_ADDOPTS': '--benchmark-skip --exitfirst',
-        'TOX_TESTENV_PASSENV': f"{E2E_TEAR_DOWN} USERNAME PYTEST_ADDOPTS {' '.join(get_ci_env_vars())}",
+        'TOX_TESTENV_PASSENV': f"{E2E_TEAR_DOWN} PROGRAM* USERNAME PYTEST_ADDOPTS {' '.join(get_ci_env_vars())}",
     }
 
     result = _execute(check, command, env_vars)
@@ -42,7 +42,7 @@ def stop_environment(check, env, metadata=None):
     env_vars = {
         E2E_SET_UP: 'false',
         'PYTEST_ADDOPTS': '--benchmark-skip --exitfirst',
-        'TOX_TESTENV_PASSENV': '{}* {} USERNAME PYTEST_ADDOPTS {}'.format(
+        'TOX_TESTENV_PASSENV': '{}* {} PROGRAM* USERNAME PYTEST_ADDOPTS {}'.format(
             E2E_ENV_VAR_PREFIX, E2E_SET_UP, ' '.join(get_ci_env_vars())
         ),
     }


### PR DESCRIPTION
### What does this PR do?

Similar to https://github.com/DataDog/integrations-core/pull/5335

### Motivation

Compilation on our Windows runners require extra env vars, noticed https://stackoverflow.com/questions/43847542/rc-exe-no-longer-found-in-vs-2015-command-prompt during https://github.com/DataDog/integrations-core/pull/5626