### PR TITLE
Move remaining flake8 config to .flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,3 +7,4 @@ select = B,C,E,F,G,W,B001,B003,B006,B007,B301,B305,B306,B902
 ignore = E203,E722,W503,G200
 exclude = .eggs,.tox,build,compat.py,__init__.py,datadog_checks/dev/tooling/templates/*,datadog_checks/*/vendor/*
 max-line-length = 120
+enable-extensions=G

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -63,7 +63,7 @@ def add_style_checker(config, sections, make_envconfig, reader):
     ]
 
     commands = [
-        'flake8 --config=../.flake8 --enable-extensions=G .',
+        'flake8 --config=../.flake8 .',
         'black --check --diff .',
         'isort --check-only --diff --recursive .',
     ]


### PR DESCRIPTION
### What does this PR do?
Move flake8 config to .flake8

### Motivation
Let's keep flake8 configs at one location

### Additional Notes

TODO:

- Update extras too

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
