### PR TITLE
Add script to remove all labels from an issue or pull request

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
@@ -9,7 +9,7 @@ from ..utils import dir_exists
 from .commands import ALL_COMMANDS
 from .commands.console import CONTEXT_SETTINGS, echo_success, echo_waiting, echo_warning, set_color, set_debug
 from .config import CONFIG_FILE, config_file_exists, load_config, restore_config
-from .constants import set_root
+from .constants import REPO_CHOICES, set_root
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
@@ -39,6 +39,7 @@ def ddev(ctx, core, extras, agent, here, color, quiet, debug):
 
     repo_choice = 'core' if core else 'extras' if extras else 'agent' if agent else config.get('repo', 'core')
     config['repo_choice'] = repo_choice
+    config['repo_name'] = REPO_CHOICES[repo_choice]
 
     if color is not None:
         config['color'] = color

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/__init__.py
@@ -5,9 +5,10 @@ import click
 
 from ...console import CONTEXT_SETTINGS
 from .metrics2md import metrics2md
+from .remove_labels import remove_labels
 from .upgrade_python import upgrade_python
 
-ALL_COMMANDS = (metrics2md, upgrade_python)
+ALL_COMMANDS = (metrics2md, remove_labels, upgrade_python)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Miscellaneous scripts that may be useful')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/remove_labels.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/remove_labels.py
@@ -1,0 +1,43 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import click
+import requests
+
+from ...console import CONTEXT_SETTINGS, abort, echo_success
+
+
+@click.command(
+    'remove-labels', context_settings=CONTEXT_SETTINGS, short_help='Remove all labels from an issue or pull request'
+)
+@click.argument('issue_number')
+@click.pass_context
+def remove_labels(ctx, issue_number):
+    """Remove all labels from an issue or pull request. This is useful when there are too
+    many labels and its state cannot be modified (known GitHub issue).
+
+    \b
+    $ ddev meta scripts remove-labels 5626
+    Success!
+    """
+    repo = ctx.obj['repo_name']
+    github_config = ctx.obj['github']
+
+    github_user = github_config.get('user')
+    if not github_user:
+        abort('No `github.user` has been set')
+
+    github_token = github_config.get('token')
+    if not github_token:
+        abort('No `github.token` has been set')
+
+    try:
+        response = requests.delete(
+            f'https://api.github.com/repos/DataDog/{repo}/issues/{issue_number}/labels',
+            auth=(github_user, github_token),
+        )
+        response.raise_for_status()
+    except Exception as e:
+        abort(str(e))
+
+    echo_success('Success!')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -12,6 +12,7 @@ INTEGRATION_REPOS = [
     'integrations-extras',
     'integrations-internal',
 ]
+REPO_CHOICES = {'core': 'integrations-core', 'extras': 'integrations-extras', 'agent': 'datadog-agent'}
 VERSION_BUMP = {
     'Added': semver.bump_minor,
     'Changed': semver.bump_major,


### PR DESCRIPTION
### Motivation

Works around a known GitHub limitation where if an issue has too many labels (100), its state cannot be modified

https://github.com/DataDog/integrations-core/pull/5384
https://github.com/DataDog/integrations-core/pull/5626