### PR TITLE
Add internal to repo choices

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -12,7 +12,7 @@ INTEGRATION_REPOS = [
     'integrations-extras',
     'integrations-internal',
 ]
-REPO_CHOICES = {'core': 'integrations-core', 'extras': 'integrations-extras', 'agent': 'datadog-agent'}
+REPO_CHOICES = {'core': 'integrations-core', 'extras': 'integrations-extras', 'internal': 'integrations-internal', 'agent': 'datadog-agent'}
 VERSION_BUMP = {
     'Added': semver.bump_minor,
     'Changed': semver.bump_major,

--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -12,7 +12,12 @@ INTEGRATION_REPOS = [
     'integrations-extras',
     'integrations-internal',
 ]
-REPO_CHOICES = {'core': 'integrations-core', 'extras': 'integrations-extras', 'internal': 'integrations-internal', 'agent': 'datadog-agent'}
+REPO_CHOICES = {
+    'core': 'integrations-core',
+    'extras': 'integrations-extras',
+    'internal': 'integrations-internal',
+    'agent': 'datadog-agent',
+}
 VERSION_BUMP = {
     'Added': semver.bump_minor,
     'Changed': semver.bump_major,


### PR DESCRIPTION
### What does this PR do?

Add internal to repo choices

### Motivation

CI error:

```
  File "/opt/hostedtoolcache/Python/3.8.1/x64/lib/python3.8/site-packages/datadog_checks/dev/tooling/cli.py", line 42, in ddev
    config['repo_name'] = REPO_CHOICES[repo_choice]
KeyError: 'internal'

```

### Long term fix

If we intend `ddev` to be used for multiple repository, then repository specific configurations should not reside in `ddev` itself.
