### PR TITLE
Allow automatic joins to all kube_{object}_labels in KSM check

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -525,15 +525,18 @@ class OpenMetricsScraperMixin(object):
 
                         self._update_label_mapping(mapping_key, mapping_value, label_dict, scraper_config)
 
-    def _update_label_mapping(self, name, value, label_dict, scraper_config):
+    def _update_label_mapping(self, key, value, label_dict, scraper_config):
+        """
+        Update '_label_mapping' in 'scraper_config' for ('key', 'value')
+        """
         try:
-            if scraper_config['_label_mapping'][name].get(value):
-                scraper_config['_label_mapping'][name][value].update(label_dict)
+            if scraper_config['_label_mapping'][key].get(value):
+                scraper_config['_label_mapping'][key][value].update(label_dict)
             else:
-                scraper_config['_label_mapping'][name][value] = label_dict
+                scraper_config['_label_mapping'][key][value] = label_dict
         except KeyError:
             if value is not None:
-                scraper_config['_label_mapping'][name] = {value: label_dict}
+                scraper_config['_label_mapping'][key] = {value: label_dict}
 
     def _join_labels(self, metric, scraper_config):
         # Filter metric to see if we can enrich with joined labels
@@ -556,13 +559,13 @@ class OpenMetricsScraperMixin(object):
                     # If mapping found add corresponding labels
                     self._join_labels_from_mapping(sample, label_name, label_value, scraper_config)
 
-    def _join_labels_from_mapping(self, sample, mapping_key, mapping_value, scraper_config):
+    def _join_labels_from_mapping(self, sample, key, value, scraper_config):
         """
-        Add labels from label_values dict to sample
+        Enrich 'sample' with labels stored under ('key', 'value') in '_label_mapping'
         """
         try:
             for k, v in iteritems(
-                scraper_config['_label_mapping'][mapping_key][mapping_value]
+                scraper_config['_label_mapping'][key][value]
             ):
                 sample[self.SAMPLE_LABELS][k] = v
         except KeyError:
@@ -570,7 +573,7 @@ class OpenMetricsScraperMixin(object):
 
     def _set_active_label_mapping(self, key, value, scraper_config):
         """
-        Sets active label mapping in scraper_config
+        Sets active '_active_label_mapping' in 'scraper_config' for ('key', 'value')
         """
         if key not in scraper_config['_active_label_mapping']:
             scraper_config['_active_label_mapping'][key] = {}

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -564,9 +564,7 @@ class OpenMetricsScraperMixin(object):
         Enrich 'sample' with labels stored under ('key', 'value') in '_label_mapping'
         """
         try:
-            for k, v in iteritems(
-                scraper_config['_label_mapping'][key][value]
-            ):
+            for k, v in iteritems(scraper_config['_label_mapping'][key][value]):
                 sample[self.SAMPLE_LABELS][k] = v
         except KeyError:
             pass

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -533,9 +533,9 @@ class OpenMetricsScraperMixin(object):
 
                 mapping_value = ','.join([sample_labels[l] for l in matching_labels])
 
-                scraper_config[
-                    '_label_mapping'
-                ].setdefault(mapping_key, {}).setdefault(mapping_value, {}).update(label_dict)
+                scraper_config['_label_mapping'].setdefault(mapping_key, {}).setdefault(mapping_value, {}).update(
+                    label_dict
+                )
 
     def _join_labels(self, metric, scraper_config):
         # Filter metric to see if we can enrich with joined labels

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -10,7 +10,7 @@ from re import compile
 
 import requests
 from prometheus_client.samples import Sample
-from six import PY3, iteritems, itervalues, string_types
+from six import PY3, iteritems, string_types
 
 from ...config import is_affirmative
 from ...errors import CheckException

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -2147,7 +2147,7 @@ def test_label_join_state_change(aggregator, mocked_prometheus_check, mocked_pro
         assert mocked_prometheus_scraper_config['_label_mapping']['pod']['dd-agent-62bgh']['phase'] == 'Test'
 
 
-def test_label_join_benchmark_single(benchmark, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get):
+def test_label_to_match_single(benchmark, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get):
     """ Tests label join and hostname override on a metric """
     check = mocked_prometheus_check
     mocked_prometheus_scraper_config['namespace'] = 'ksm'
@@ -2173,7 +2173,7 @@ def test_label_join_benchmark_single(benchmark, mocked_prometheus_check, mocked_
         # run with submit
         check.process(mocked_prometheus_scraper_config)
 
-def test_label_join_benchmark_multiple(benchmark, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get):
+def test_label_to_match_multiple(benchmark, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get):
     """ Tests label join and hostname override on a metric """
     check = mocked_prometheus_check
     mocked_prometheus_scraper_config['namespace'] = 'ksm'

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -1603,6 +1603,7 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
     mocked_prometheus_scraper_config['namespace'] = 'ksm'
     mocked_prometheus_scraper_config['label_joins'] = {
         'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node', 'pod_ip']},
+        'kube_pod_labels': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['*']},
         'kube_deployment_labels': {
             'label_to_match': 'deployment',
             'labels_to_get': [
@@ -1635,6 +1636,9 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
             'condition:true',
             'node:gke-foobar-test-kube-default-pool-9b4ff111-0kch',
             'pod_ip:11.32.3.14',
+            'label_k8s_app:event-exporter',
+            'label_pod_template_hash:958884745',
+            'label_version:v0.1.7',
         ],
         count=1,
     )
@@ -1647,6 +1651,11 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
             'condition:true',
             'node:gke-foobar-test-kube-default-pool-9b4ff111-0kch',
             'pod_ip:11.132.0.7',
+            'label_controller_revision_hash:3483772856',
+            'label_k8s_app:fluentd-gcp',
+            'label_kubernetes_io_cluster_service:true',
+            'label_pod_template_generation:1',
+            'label_version:v2.0.9',
         ],
         count=1,
     )
@@ -1659,6 +1668,11 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
             'condition:true',
             'node:gke-foobar-test-kube-default-pool-9b4ff111-j75z',
             'pod_ip:11.132.0.14',
+            'label_controller_revision_hash:3483772856',
+            'label_k8s_app:fluentd-gcp',
+            'label_kubernetes_io_cluster_service:true',
+            'label_pod_template_generation:1',
+            'label_version:v2.0.9',
         ],
         count=1,
     )
@@ -1671,6 +1685,9 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
             'condition:true',
             'node:gke-foobar-test-kube-default-pool-9b4ff111-j75z',
             'pod_ip:11.32.5.7',
+            'label_k8s_app:heapster',
+            'label_pod_template_hash:2027615481',
+            'label_version:v1.4.3',
         ],
         count=1,
     )
@@ -1683,6 +1700,8 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
             'condition:true',
             'node:gke-foobar-test-kube-default-pool-9b4ff111-0kch',
             'pod_ip:11.32.3.10',
+            'label_k8s_app:kube-dns',
+            'label_pod_template_hash:3092422022',
         ],
         count=1,
     )
@@ -1695,6 +1714,8 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
             'condition:true',
             'node:gke-foobar-test-kube-default-pool-9b4ff111-0kch',
             'pod_ip:11.32.3.9',
+            'label_k8s_app:kube-dns',
+            'label_pod_template_hash:3092422022',
         ],
         count=1,
     )
@@ -1707,6 +1728,8 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
             'condition:true',
             'node:gke-foobar-test-kube-default-pool-9b4ff111-j75z',
             'pod_ip:11.32.5.6',
+            'label_k8s_app:kube-dns-autoscaler',
+            'label_pod_template_hash:97162954',
         ],
         count=1,
     )
@@ -1719,6 +1742,8 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
             'condition:true',
             'node:gke-foobar-test-kube-default-pool-9b4ff111-0kch',
             'pod_ip:11.132.0.7',
+            'label_component:kube-proxy',
+            'label_tier:node',
         ],
         count=1,
     )
@@ -1731,6 +1756,9 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
             'condition:true',
             'node:gke-foobar-test-kube-default-pool-9b4ff111-j75z',
             'pod_ip:11.32.5.45',
+            'label_app:kube-state-metrics',
+            'label_pod_template_hash:3918010230',
+            'label_release:ungaged-panther',
         ],
         count=1,
     )
@@ -1743,6 +1771,9 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
             'condition:true',
             'node:gke-foobar-test-kube-default-pool-9b4ff111-0kch',
             'pod_ip:11.32.3.14',
+            'label_k8s_app:event-exporter',
+            'label_pod_template_hash:958884745',
+            'label_version:v0.1.7',
         ],
         count=1,
     )
@@ -1755,6 +1786,11 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
             'condition:true',
             'node:gke-foobar-test-kube-default-pool-9b4ff111-0kch',
             'pod_ip:11.132.0.7',
+            'label_controller_revision_hash:3483772856',
+            'label_k8s_app:fluentd-gcp',
+            'label_kubernetes_io_cluster_service:true',
+            'label_pod_template_generation:1',
+            'label_version:v2.0.9',
         ],
         count=1,
     )
@@ -1767,6 +1803,11 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
             'condition:true',
             'node:gke-foobar-test-kube-default-pool-9b4ff111-j75z',
             'pod_ip:11.132.0.14',
+            'label_controller_revision_hash:3483772856',
+            'label_k8s_app:fluentd-gcp',
+            'label_kubernetes_io_cluster_service:true',
+            'label_pod_template_generation:1',
+            'label_version:v2.0.9',
         ],
         count=1,
     )
@@ -1779,6 +1820,9 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
             'condition:true',
             'node:gke-foobar-test-kube-default-pool-9b4ff111-j75z',
             'pod_ip:11.32.5.7',
+            'label_k8s_app:heapster',
+            'label_pod_template_hash:2027615481',
+            'label_version:v1.4.3',
         ],
         count=1,
     )
@@ -1791,6 +1835,8 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
             'condition:true',
             'node:gke-foobar-test-kube-default-pool-9b4ff111-0kch',
             'pod_ip:11.32.3.10',
+            'label_k8s_app:kube-dns',
+            'label_pod_template_hash:3092422022',
         ],
         count=1,
     )
@@ -1803,6 +1849,8 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
             'condition:true',
             'node:gke-foobar-test-kube-default-pool-9b4ff111-0kch',
             'pod_ip:11.32.3.9',
+            'label_k8s_app:kube-dns',
+            'label_pod_template_hash:3092422022',
         ],
         count=1,
     )
@@ -1812,8 +1860,8 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
         tags=[
             'namespace:kube-system',
             'deployment:event-exporter-v0.1.7',
-            'label_k8s_app:event-exporter',
             'label_addonmanager_kubernetes_io_mode:Reconcile',
+            'label_k8s_app:event-exporter',
             'label_kubernetes_io_cluster_service:true',
         ],
         count=1,

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -2147,6 +2147,59 @@ def test_label_join_state_change(aggregator, mocked_prometheus_check, mocked_pro
         assert mocked_prometheus_scraper_config['_label_mapping']['pod']['dd-agent-62bgh']['phase'] == 'Test'
 
 
+def test_label_join_benchmark_single(benchmark, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get):
+    """ Tests label join and hostname override on a metric """
+    check = mocked_prometheus_check
+    mocked_prometheus_scraper_config['namespace'] = 'ksm'
+    mocked_prometheus_scraper_config['label_joins'] = {
+        'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node']},
+        '1': {'label_to_match': 'pod', 'labels_to_get': ['node']},
+        '2': {'label_to_match': 'pod', 'labels_to_get': ['node']},
+        '3': {'label_to_match': 'pod', 'labels_to_get': ['node']},
+        '4': {'label_to_match': 'pod', 'labels_to_get': ['node']},
+        '5': {'label_to_match': 'pod', 'labels_to_get': ['node']},
+        '6': {'label_to_match': 'pod', 'labels_to_get': ['node']},
+        '7': {'label_to_match': 'pod', 'labels_to_get': ['node']},
+        '8': {'label_to_match': 'pod', 'labels_to_get': ['node']},
+        '9': {'label_to_match': 'pod', 'labels_to_get': ['node']},
+    }
+    mocked_prometheus_scraper_config['label_to_hostname'] = 'node'
+    mocked_prometheus_scraper_config['metrics_mapper'] = {'kube_pod_status_ready': 'pod.ready'}
+
+    @benchmark
+    def run_check():
+        # dry run to build mapping
+        check.process(mocked_prometheus_scraper_config)
+        # run with submit
+        check.process(mocked_prometheus_scraper_config)
+
+def test_label_join_benchmark_multiple(benchmark, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get):
+    """ Tests label join and hostname override on a metric """
+    check = mocked_prometheus_check
+    mocked_prometheus_scraper_config['namespace'] = 'ksm'
+    mocked_prometheus_scraper_config['label_joins'] = {
+        'kube_pod_info': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['node']},
+        '1': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['node']},
+        '2': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['node']},
+        '3': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['node']},
+        '4': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['node']},
+        '5': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['node']},
+        '6': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['node']},
+        '7': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['node']},
+        '8': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['node']},
+        '9': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['node']},
+    }
+    mocked_prometheus_scraper_config['label_to_hostname'] = 'node'
+    mocked_prometheus_scraper_config['metrics_mapper'] = {'kube_pod_status_ready': 'pod.ready'}
+
+    @benchmark
+    def run_check():
+        # dry run to build mapping
+        check.process(mocked_prometheus_scraper_config)
+        # run with submit
+        check.process(mocked_prometheus_scraper_config)
+
+
 def test_health_service_check_ok(mock_get, aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
     """ Tests endpoint health service check OK """
     check = mocked_prometheus_check

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -2173,6 +2173,7 @@ def test_label_to_match_single(benchmark, mocked_prometheus_check, mocked_promet
         # run with submit
         check.process(mocked_prometheus_scraper_config)
 
+
 def test_label_to_match_multiple(benchmark, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get):
     """ Tests label join and hostname override on a metric """
     check = mocked_prometheus_check

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -1605,7 +1605,7 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
         'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node', 'pod_ip']},
         'kube_pod_labels': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['*']},
         'kube_deployment_labels': {
-            'label_to_match': 'deployment',
+            'label_to_match': ['deployment'],
             'labels_to_get': [
                 'label_addonmanager_kubernetes_io_mode',
                 'label_k8s_app',

--- a/datadog_checks_base/tox.ini
+++ b/datadog_checks_base/tox.ini
@@ -3,6 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 envlist =
     py{27,38}
+    bench
 
 [testenv]
 dd_check_style = true
@@ -22,4 +23,11 @@ passenv =
     APPVEYOR*
 commands =
     pip install -r requirements.in
-    pytest -v {posargs}
+    pytest -v {posargs} --benchmark-skip
+
+[testenv:bench]
+basepython = python3.8
+
+commands =
+    pip install -r requirements.in
+    pytest -v {posargs} --benchmark-only --benchmark-max-time=10.0

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -362,20 +362,13 @@ class KubernetesState(OpenMetricsBaseCheck):
         ksm_instance['prometheus_url'] = endpoint
 
         if join_kube_labels:
-            ksm_instance['label_joins'].update({
-                'kube_pod_labels': {
-                    'labels_to_match': ['pod', 'namespace'],
-                    'labels_to_get': ['*']
-                },
-                'kube_deployment_labels': {
-                    'labels_to_match': ['deployment', 'namespace'],
-                    'labels_to_get': ['*']
-                },
-                'kube_daemonset_labels': {
-                    'labels_to_match': ['daemonset', 'namespace'],
-                    'labels_to_get': ['*']
-                },
-            })
+            ksm_instance['label_joins'].update(
+                {
+                    'kube_pod_labels': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['*']},
+                    'kube_deployment_labels': {'labels_to_match': ['deployment', 'namespace'], 'labels_to_get': ['*']},
+                    'kube_daemonset_labels': {'labels_to_match': ['daemonset', 'namespace'], 'labels_to_get': ['*']},
+                }
+            )
 
         ksm_instance['label_joins'].update(extra_labels)
         if hostname_override:

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -177,7 +177,7 @@ class KubernetesState(OpenMetricsBaseCheck):
 
         extra_labels = ksm_instance.get('label_joins', {})
         hostname_override = is_affirmative(ksm_instance.get('hostname_override', True))
-        join_kube_labels = is_affirmative(ksm_instance.get('join_kube_labels', True))
+        join_kube_labels = is_affirmative(ksm_instance.get('join_kube_labels', False))
 
         ksm_instance.update(
             {

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -177,6 +177,7 @@ class KubernetesState(OpenMetricsBaseCheck):
 
         extra_labels = ksm_instance.get('label_joins', {})
         hostname_override = is_affirmative(ksm_instance.get('hostname_override', True))
+        join_kube_labels = is_affirmative(ksm_instance.get('join_kube_labels', True))
 
         ksm_instance.update(
             {
@@ -359,6 +360,23 @@ class KubernetesState(OpenMetricsBaseCheck):
             ksm_instance['ignore_metrics'].extend(experimental_metrics_mapping.keys())
 
         ksm_instance['prometheus_url'] = endpoint
+
+        if join_kube_labels:
+            ksm_instance['label_joins'].update({
+                'kube_pod_labels': {
+                    'labels_to_match': ['pod', 'namespace'],
+                    'labels_to_get': ['*']
+                },
+                'kube_deployment_labels': {
+                    'labels_to_match': ['deployment', 'namespace'],
+                    'labels_to_get': ['*']
+                },
+                'kube_daemonset_labels': {
+                    'labels_to_match': ['daemonset', 'namespace'],
+                    'labels_to_get': ['*']
+                },
+            })
+
         ksm_instance['label_joins'].update(extra_labels)
         if hostname_override:
             ksm_instance['label_to_hostname'] = 'node'

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -231,14 +231,29 @@ def mock_from_file(fname):
 
 @pytest.fixture
 def instance():
-    return {'host': 'foo', 'kube_state_url': 'http://foo', 'tags': ['optional:tag1'], 'telemetry': False}
+    return {
+        'host': 'foo',
+        'kube_state_url': 'http://foo',
+        'tags': ['optional:tag1'],
+        'telemetry': False,
+    }
+
+
+def _check(instance):
+    check = KubernetesState(CHECK_NAME, {}, {}, [instance])
+    check.poll = mock.MagicMock(return_value=MockResponse(mock_from_file("prometheus.txt"), 'text/plain'))
+    return check
 
 
 @pytest.fixture
 def check(instance):
-    check = KubernetesState(CHECK_NAME, {}, {}, [instance])
-    check.poll = mock.MagicMock(return_value=MockResponse(mock_from_file("prometheus.txt"), 'text/plain'))
-    return check
+    return _check(instance)
+
+
+@pytest.fixture
+def check_with_join_kube_labels(instance):
+    instance['join_kube_labels'] = True
+    return _check(instance)
 
 
 def assert_not_all_zeroes(aggregator, metric_name):
@@ -359,6 +374,47 @@ def test_update_kube_state_metrics_v040(aggregator, instance, check):
 
     # FIXME: the original assert for resourcequota wasn't working, following line should be uncommented
     # assert resourcequota_was_collected(aggregator)
+
+
+def test_join_kube_labels(aggregator, instance, check_with_join_kube_labels):
+    # run check twice to have pod/node mapping
+    for _ in range(2):
+        check_with_join_kube_labels.check(instance)
+
+    aggregator.assert_metric(
+        NAMESPACE + '.container.ready',
+        tags=[
+            'container:kube-state-metrics',
+            'kube_container_name:kube-state-metrics',
+            'kube_namespace:default',
+            'label_app:kube-state-metrics',
+            'label_pod_template_hash:639670438',
+            'label_release:jaundiced-numbat',
+            'namespace:default',
+            'node:minikube',
+            'optional:tag1',
+            'phase:running',
+            'pod:jaundiced-numbat-kube-state-metrics-b7fbc487d-4phhj',
+            'pod_name:jaundiced-numbat-kube-state-metrics-b7fbc487d-4phhj',
+            'pod_phase:running',
+        ],
+        value=1,
+    )
+    aggregator.assert_metric(
+        NAMESPACE + '.deployment.replicas',
+        tags=[
+            'deployment:jaundiced-numbat-kube-state-metrics',
+            'kube_deployment:jaundiced-numbat-kube-state-metrics',
+            'kube_namespace:default',
+            'label_app:kube-state-metrics',
+            'label_chart:kube-state-metrics-0.3.1',
+            'label_heritage:tiller',
+            'label_release:jaundiced-numbat',
+            'namespace:default',
+            'optional:tag1',
+        ],
+        value=1,
+    )
 
 
 def test_join_custom_labels(aggregator, instance, check):


### PR DESCRIPTION
### What does this PR do?

Allows automatic joining to currently ignored KSM label metrics (info metrics) to help with differentiating them.

- Introduces additional `label_joins` semantics to match on a tuple of labels as opposed to a single label and allow pulling all label values from the target of the join:
```
label_joins:
  kube_pod_labels:
    labels_to_match:
      - pod
      - namespace
    labels_to_get: 
      - *
	...
```
This change is generic for all openmetrics-based checks.

- Introduces a setting in the KSM integration (`join_kube_labels`) to perform automatic joining to all labels for the following objects:
  * pod <- `kube_pod_labels`
  * deployment <- `kube_deployment_labels`
  * daemonset <- `kube_daemonset_labels`

Minimal `kubernetes_state.d/conf.yaml` file demonstrating use of this feature:
```
init_config:

instances:
  - kube_state_url: http://<ksm-address>:8080/metrics
    join_kube_labels: True
```
### Motivation

This should help with differentiating metrics in dashboards using labels from their respective objects.

### Benchmarks

Existing implementation - see benchmarks tests [here](https://github.com/DataDog/integrations-core/compare/xornivore/openmetrics-old-benchmarks?expand=1#diff-31d1c87f59c986d19e2dab0e00ed4228).

```
---------------------------------------------------- benchmark: 1 tests ----------------------------------------------------
Name (time in ms)                      Min      Max     Mean  StdDev   Median     IQR  Outliers      OPS  Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------
test_old_label_to_match_single     14.6399  53.1113  17.2551  3.5887  16.2647  1.5706     37;48  57.9539     558           1
----------------------------------------------------------------------------------------------------------------------------
```

New implementation:
```
--------------------------------------------------------------------------------------- benchmark: 2 tests --------------------------------------------------------------------------------------
Name (time in ms)                    Min                 Max               Mean            StdDev             Median               IQR            Outliers      OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_label_to_match_single       15.5973 (1.0)       63.5607 (1.0)      18.0210 (1.0)      3.7424 (1.0)      17.1802 (1.0)      1.3500 (1.0)         33;52  55.4909 (1.0)         590           1
test_label_to_match_multiple     25.7403 (1.65)     135.7221 (2.14)     29.1773 (1.62)     6.9407 (1.85)     27.7325 (1.61)     1.8579 (1.38)        20;33  34.2733 (0.62)        366           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### Other considerations

With these changes the `label_to_match` setting is being marked for deprecation in the future. To avoid confusion and for compatibility reasons `label_to_match` will accept either a single label or a list (equivalent to `labels_to_match`).

This is still supported:
```
label_to_match: pod
```
As well as this:
```
label_to_match:
      - pod
      - namespace
```
Note however that a warning is shown in logs when `label_to_match` is being used.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
