### PR TITLE
Support `tls_ignore_warning` at init_config level

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -108,7 +108,9 @@ class RequestsWrapper(object):
         default_fields['log_requests'] = init_config.get('log_requests', default_fields['log_requests'])
         default_fields['skip_proxy'] = init_config.get('skip_proxy', default_fields['skip_proxy'])
         default_fields['timeout'] = init_config.get('timeout', default_fields['timeout'])
-        default_fields['tls_ignore_warning'] = init_config.get('tls_ignore_warning', default_fields['tls_ignore_warning'])
+        default_fields['tls_ignore_warning'] = init_config.get(
+            'tls_ignore_warning', default_fields['tls_ignore_warning']
+        )
 
         # Populate with the default values
         config = {field: instance.get(field, value) for field, value in iteritems(default_fields)}

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -108,6 +108,7 @@ class RequestsWrapper(object):
         default_fields['log_requests'] = init_config.get('log_requests', default_fields['log_requests'])
         default_fields['skip_proxy'] = init_config.get('skip_proxy', default_fields['skip_proxy'])
         default_fields['timeout'] = init_config.get('timeout', default_fields['timeout'])
+        default_fields['tls_ignore_warning'] = init_config.get('tls_ignore_warning', default_fields['tls_ignore_warning'])
 
         # Populate with the default values
         config = {field: instance.get(field, value) for field, value in iteritems(default_fields)}

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -784,6 +784,22 @@ class TestIgnoreTLSWarning:
 
         assert http.ignore_tls_warning is True
 
+    def test_init_config_flag(self):
+        instance = {}
+        init_config = {'tls_ignore_warning': True}
+
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.ignore_tls_warning is True
+
+    def test_instance_and_init_flag(self):
+        instance = {'tls_ignore_warning': False}
+        init_config = {'tls_ignore_warning': True}
+
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.ignore_tls_warning is False
+
     def test_default_no_ignore(self):
         instance = {}
         init_config = {}
@@ -819,6 +835,42 @@ class TestIgnoreTLSWarning:
             http.get('https://www.google.com', verify=False)
 
         assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
+
+    def test_init_ignore(self):
+        instance = {}
+        init_config = {'tls_ignore_warning': True}
+        http = RequestsWrapper(instance, init_config)
+
+        with pytest.warns(None) as record:
+            http.get('https://www.google.com', verify=False)
+
+        assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
+
+    def test_default_init_no_ignore(self):
+        instance = {}
+        init_config = {'tls_ignore_warning': False}
+        http = RequestsWrapper(instance, init_config)
+
+        with pytest.warns(InsecureRequestWarning):
+            http.get('https://www.google.com', verify=False)
+
+    def test_instance_ignore(self):
+        instance = {'tls_ignore_warning': True}
+        init_config = {'tls_ignore_warning': False}
+        http = RequestsWrapper(instance, init_config)
+
+        with pytest.warns(None) as record:
+            http.get('https://www.google.com', verify=False)
+
+        assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
+
+    def test_instance_no_ignore(self):
+        instance = {'tls_ignore_warning': False}
+        init_config = {'tls_ignore_warning': True}
+        http = RequestsWrapper(instance, init_config)
+
+        with pytest.warns(InsecureRequestWarning):
+            http.get('https://www.google.com', verify=False)
 
 
 class TestSession:


### PR DESCRIPTION
Allow `tls_ignore_warning` to apply to all instances