### PR TITLE
Update auto_conf yaml to default to preview

### DIFF
--- a/etcd/datadog_checks/etcd/data/auto_conf.yaml
+++ b/etcd/datadog_checks/etcd/data/auto_conf.yaml
@@ -6,7 +6,9 @@ init_config:
 instances:
 
     ## @param url - string - optional
-    ## Note: the following configuration param is only available when the `use_preview` param is set to 'false'.
-    ## API endpoint of your etcd instance.
+    ## Prometheus endpoint of your etcd instance.
+    ##
+    ## Note: To monitor ETCD versions pre-3.x.x set 
+    ##`use_preview` param to 'false' and use the `url` param
     #
-  - url: "http://%%host%%:2379"
+  - prometheus: "http://%%host%%:2379/metrics"

--- a/etcd/datadog_checks/etcd/data/auto_conf.yaml
+++ b/etcd/datadog_checks/etcd/data/auto_conf.yaml
@@ -11,4 +11,4 @@ instances:
     ## Note: To monitor ETCD versions pre-3.x.x set 
     ##`use_preview` param to 'false' and use the `url` param
     #
-  - prometheus: "http://%%host%%:2379/metrics"
+  - prometheus_url: "http://%%host%%:2379/metrics"

--- a/etcd/datadog_checks/etcd/data/auto_conf.yaml
+++ b/etcd/datadog_checks/etcd/data/auto_conf.yaml
@@ -5,7 +5,7 @@ init_config:
 
 instances:
 
-    ## @param url - string - optional
+    ## @param prometheus_url - string - required
     ## Prometheus endpoint of your etcd instance.
     ##
     ## Note: To monitor ETCD versions pre-3.x.x set 


### PR DESCRIPTION
ETCD check is now using post_3/preview version by default. This PR updates the auto_conf yaml to support the prometheus endpoint.