### PR TITLE
1. Linting integration README

### DIFF
--- a/active_directory/README.md
+++ b/active_directory/README.md
@@ -12,37 +12,34 @@ The Agent's Active Directory check is included in the [Datadog Agent][1] package
 
 ### Configuration
 
-1. Edit the `active_directory.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2] to start collecting your Active Directory performance data.
-
 #### Metric collection
 
-The default setup should already collect metrics for the localhost.
-See the [sample active_directory.d/conf.yaml][3] for all available configuration options.
+1. Edit the `active_directory.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2] to start collecting your Active Directory performance data. The default setup should already collect metrics for the localhost. See the [sample active_directory.d/conf.yaml][3] for all available configuration options.
 
 2. [Restart the Agent][4]
 
 #### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Add this configuration block to your `active_directory.d/conf.yaml` file to start collecting your Active Directory Logs:
 
-    ```
-      logs:
-        - type: file
-          path: /path/to/my/directory/file.log
-          source: ruby
-          service: <MY_SERVICE>
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: /path/to/my/directory/file.log
+       source: ruby
+       service: "<MY_SERVICE>"
+   ```
 
-    Change the `path` and `service` parameter values and configure them for your environment.
-    See the [sample active_directory.d/conf.yaml][3] for all available configuration options.
+   Change the `path` and `service` parameter values and configure them for your environment.
+   See the [sample active_directory.d/conf.yaml][3] for all available configuration options.
 
 3. This integration is intended for the [Active Directory Module for Ruby][5]. If you are not using the Ruby module, change the below source value to `active_directory` and configure the `path` for your environment.
 
@@ -55,15 +52,19 @@ See the [sample active_directory.d/conf.yaml][3] for all available configuration
 ## Data Collected
 
 ### Metrics
+
 See [metadata.csv][7] for a list of metrics provided by this integration.
 
 ### Events
+
 The Active Directory check does not include any events.
 
 ### Service Checks
+
 The Active Directory check does not include any service checks.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][8].
 
 [1]: https://app.datadoghq.com/account/settings#agent

--- a/activemq/README.md
+++ b/activemq/README.md
@@ -23,98 +23,98 @@ Follow the instructions below to configure this check for an Agent running on a 
 1. **Make sure that [JMX Remote is enabled][4] on your ActiveMQ server.**
 2. Configure the agent to connect to ActiveMQ. Edit `activemq.d/conf.yaml`, in the `conf.d/` folder at the root of your [Agent's configuration directory][5]. See the [sample activemq.d/conf.yaml][6] for all available configuration options.
 
-      ```yaml
-      instances:
-        - host: localhost
-          port: 1616
-          user: username
-          password: password
-          name: activemq_instance
-      # List of metrics to be collected by the integration
-      # You should not have to modify this.
-      init_config:
-        conf:
-          - include:
-            Type: Queue
-            attribute:
-              AverageEnqueueTime:
-                alias: activemq.queue.avg_enqueue_time
-                metric_type: gauge
-              ConsumerCount:
-                alias: activemq.queue.consumer_count
-                metric_type: gauge
-              ProducerCount:
-                alias: activemq.queue.producer_count
-                metric_type: gauge
-              MaxEnqueueTime:
-                alias: activemq.queue.max_enqueue_time
-                metric_type: gauge
-              MinEnqueueTime:
-                alias: activemq.queue.min_enqueue_time
-                metric_type: gauge
-              MemoryPercentUsage:
-                alias: activemq.queue.memory_pct
-                metric_type: gauge
-              QueueSize:
-                alias: activemq.queue.size
-                metric_type: gauge
-              DequeueCount:
-                alias: activemq.queue.dequeue_count
-                metric_type: counter
-              DispatchCount:
-                alias: activemq.queue.dispatch_count
-                metric_type: counter
-              EnqueueCount:
-                alias: activemq.queue.enqueue_count
-                metric_type: counter
-              ExpiredCount:
-                alias: activemq.queue.expired_count
-                type: counter
-              InFlightCount:
-                alias: activemq.queue.in_flight_count
-                metric_type: counter
+   ```yaml
+   instances:
+     - host: localhost
+       port: 1616
+       user: username
+       password: password
+       name: activemq_instance
+   # List of metrics to be collected by the integration
+   # You should not have to modify this.
+   init_config:
+     conf:
+       - include:
+         Type: Queue
+         attribute:
+           AverageEnqueueTime:
+             alias: activemq.queue.avg_enqueue_time
+             metric_type: gauge
+           ConsumerCount:
+             alias: activemq.queue.consumer_count
+             metric_type: gauge
+           ProducerCount:
+             alias: activemq.queue.producer_count
+             metric_type: gauge
+           MaxEnqueueTime:
+             alias: activemq.queue.max_enqueue_time
+             metric_type: gauge
+           MinEnqueueTime:
+             alias: activemq.queue.min_enqueue_time
+             metric_type: gauge
+           MemoryPercentUsage:
+             alias: activemq.queue.memory_pct
+             metric_type: gauge
+           QueueSize:
+             alias: activemq.queue.size
+             metric_type: gauge
+           DequeueCount:
+             alias: activemq.queue.dequeue_count
+             metric_type: counter
+           DispatchCount:
+             alias: activemq.queue.dispatch_count
+             metric_type: counter
+           EnqueueCount:
+             alias: activemq.queue.enqueue_count
+             metric_type: counter
+           ExpiredCount:
+             alias: activemq.queue.expired_count
+             type: counter
+           InFlightCount:
+             alias: activemq.queue.in_flight_count
+             metric_type: counter
 
-          - include:
-            Type: Broker
-            attribute:
-              StorePercentUsage:
-                alias: activemq.broker.store_pct
-                metric_type: gauge
-              TempPercentUsage:
-                alias: activemq.broker.temp_pct
-                metric_type: gauge
-              MemoryPercentUsage:
-                alias: activemq.broker.memory_pct
-                metric_type: gauge
-      ```
+       - include:
+         Type: Broker
+         attribute:
+           StorePercentUsage:
+             alias: activemq.broker.store_pct
+             metric_type: gauge
+           TempPercentUsage:
+             alias: activemq.broker.temp_pct
+             metric_type: gauge
+           MemoryPercentUsage:
+             alias: activemq.broker.memory_pct
+             metric_type: gauge
+   ```
 
 3. [Restart the agent][7]
 
 ##### Log collection
 
- **Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
- 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
+1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
- 2. Add this configuration block to your `activemq.d/conf.yaml` file to start collecting your Riak logs:
+2. Add this configuration block to your `activemq.d/conf.yaml` file to start collecting your Riak logs:
 
-     ```
-      logs:
-        - type: file
-          path: <ACTIVEMQ_BASEDIR>/data/activemq.log
-          source: activemq
-          service: <SERVICE_NAME>
-        - type: file
-          path: <ACTIVEMQ_BASEDIR>/data/audit.log
-          source: activemq
-          service: <SERVICE_NAME>
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: "<ACTIVEMQ_BASEDIR>/data/activemq.log"
+       source: activemq
+       service: "<SERVICE_NAME>"
+     - type: file
+       path: "<ACTIVEMQ_BASEDIR>/data/audit.log"
+       source: activemq
+       service: "<SERVICE_NAME>"
+   ```
 
- 3. [Restart the Agent][7].
+3. [Restart the Agent][7].
 
 #### Containerized
 
@@ -122,20 +122,20 @@ For containerized environments, see the [Autodiscovery Integration Templates][13
 
 ##### Metric collection
 
-| Parameter            | Value                                                                                       |
-|----------------------|---------------------------------------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `activemq`                                                                                   |
-| `<INIT_CONFIG>`      | blank or `{}`                                                                               |
-| `<INSTANCE_CONFIG>`  | <pre>{"host": "%%host%%",<br> "port":"1099"}</pre> |
+| Parameter            | Value                                |
+| -------------------- | ------------------------------------ |
+| `<INTEGRATION_NAME>` | `activemq`                           |
+| `<INIT_CONFIG>`      | blank or `{}`                        |
+| `<INSTANCE_CONFIG>`  | `{"host": "%%host%%","port":"1099"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][13].
 
-| Parameter      | Value                                               |
-|----------------|-----------------------------------------------------|
+| Parameter      | Value                                                  |
+| -------------- | ------------------------------------------------------ |
 | `<LOG_CONFIG>` | `{"source": "activemq", "service": "<YOUR_APP_NAME>"}` |
 
 ### Validation
@@ -143,25 +143,30 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 [Run the Agent's status subcommand][8] and look for `activemq` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][9] for a list of metrics provided by this integration.
 
 ### Events
+
 The ActiveMQ check does not include any events.
 
 ### Service Checks
+
 **activemq.can_connect**:<br>
 Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored ActiveMQ instance, otherwise returns `OK`.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][10].
 
 ## Further Reading
+
 Additional helpful documentation, links, and articles:
 
-* [ActiveMQ architecture and key metrics][11]
-* [Monitor ActiveMQ metrics and performance][12]
-
+- [ActiveMQ architecture and key metrics][11]
+- [Monitor ActiveMQ metrics and performance][12]
 
 [1]: https://raw.githubusercontent.com/DataDog/dd-agent/5.10.1/conf.d/activemq.yaml.example
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/activemq_xml/README.md
+++ b/activemq_xml/README.md
@@ -4,8 +4,8 @@
 
 Get metrics from ActiveMQ XML service in real time to:
 
-* Visualize and monitor ActiveMQ XML states
-* Be notified about ActiveMQ XML failovers and events.
+- Visualize and monitor ActiveMQ XML states
+- Be notified about ActiveMQ XML failovers and events.
 
 ## Setup
 
@@ -21,7 +21,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit `activemq_xml.d/conf.yaml`, in the `conf.d/` folder at the root of your [Agent's configuration directory][112] with your stats `url`. See the [sample activemq_xml.d/conf.yaml][113] for all available configuration options.
 
-    **Note**: The ActiveMQ XML integration can potentially emit [custom metrics][114], which may impact your [billing][115]. By default, there is a limit of 350 metrics. If you require additional metrics, contact [Datadog support][116].
+   **Note**: The ActiveMQ XML integration can potentially emit [custom metrics][114], which may impact your [billing][115]. By default, there is a limit of 350 metrics. If you require additional metrics, contact [Datadog support][116].
 
 2. [Restart the Agent][117].
 
@@ -34,21 +34,26 @@ For containerized environments, see the [Autodiscovery with JMX][118] guide.
 [Run the Agent's status subcommand][119] and look for `activemq_xml` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][1110] for a list of metrics provided by this integration.
 
 ### Events
+
 The ActiveMQ XML check does not include any events.
 
 ### Service Checks
+
 The ActiveMQ XML check does not include any service checks.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][116].
 
 ## Further Reading
 
-* [Monitor ActiveMQ metrics and performance][1111]
+- [Monitor ActiveMQ metrics and performance][1111]
 
 [111]: https://app.datadoghq.com/account/settings#agent
 [112]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory

--- a/activemq_xml/README.md
+++ b/activemq_xml/README.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-Get metrics from ActiveMQ XML service in real time to:
+Get metrics from ActiveMQ XML in real time to:
 
-- Visualize and monitor ActiveMQ XML states
+- Visualize and monitor ActiveMQ XML states.
 - Be notified about ActiveMQ XML failovers and events.
 
 ## Setup

--- a/aerospike/README.md
+++ b/aerospike/README.md
@@ -4,8 +4,8 @@
 
 Get metrics from Aerospike Database in real time to:
 
-* Visualize and monitor Aerospike states
-* Be notified about Aerospike failovers and events.
+- Visualize and monitor Aerospike states
+- Be notified about Aerospike failovers and events.
 
 ## Setup
 
@@ -28,12 +28,10 @@ Follow the instructions below to install and configure this check for an Agent r
 
 For containerized environments, see the [Autodiscovery Integration Templates][6] for guidance on applying the parameters below.
 
-##### Metric collection
-
-| Parameter            | Value                                                                               |
-|----------------------|-------------------------------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `aerospike`                                                                         |
-| `<INIT_CONFIG>`      | blank or `{}`                                                                       |
+| Parameter            | Value                                |
+| -------------------- | ------------------------------------ |
+| `<INTEGRATION_NAME>` | `aerospike`                          |
+| `<INIT_CONFIG>`      | blank or `{}`                        |
 | `<INSTANCE_CONFIG>`  | `{"host":"%%host%%", "port":"3000"}` |
 
 ### Validation

--- a/aerospike/README.md
+++ b/aerospike/README.md
@@ -4,7 +4,7 @@
 
 Get metrics from Aerospike Database in real time to:
 
-- Visualize and monitor Aerospike states
+- Visualize and monitor Aerospike states.
 - Be notified about Aerospike failovers and events.
 
 ## Setup

--- a/agent_metrics/README.md
+++ b/agent_metrics/README.md
@@ -4,7 +4,7 @@
 
 Get metrics from the Agent Metrics service in real time to:
 
-- Visualize and monitor `agent_metrics` states
+- Visualize and monitor `agent_metrics` states.
 - Be notified about `agent_metrics` failovers and events.
 
 **NOTE**: The Agent Metrics check has been rewritten in Go for Agent v6 to take advantage of the new internal architecture. Hence it is still maintained but **only works with Agents prior to major version 6**.

--- a/agent_metrics/README.md
+++ b/agent_metrics/README.md
@@ -4,14 +4,15 @@
 
 Get metrics from the Agent Metrics service in real time to:
 
-* Visualize and monitor `agent_metrics` states
-* Be notified about `agent_metrics` failovers and events.
+- Visualize and monitor `agent_metrics` states
+- Be notified about `agent_metrics` failovers and events.
 
 **NOTE**: The Agent Metrics check has been rewritten in Go for Agent v6 to take advantage of the new internal architecture. Hence it is still maintained but **only works with Agents prior to major version 6**.
 
-To collect Agent metrics for Agent v6+, use the [Go-expvar check][1] with [the `agent_stats.yaml ` configuration file][2] packaged with the Agent.
+To collect Agent metrics for Agent v6+, use the [Go-expvar check][1] with [the `agent_stats.yaml` configuration file][2] packaged with the Agent.
 
 ## Setup
+
 ### Installation
 
 The Agent Metrics check is included in the [Datadog Agent][3] package, so you don't need to install anything else on your servers.
@@ -23,6 +24,7 @@ The Agent Metrics check is included in the [Datadog Agent][3] package, so you do
 2. [Restart the Agent][6].
 
 #### Metrics collection
+
 The Agent Metrics integration can potentially emit [custom metrics][7], which may impact your [billing][8].
 
 ### Validation
@@ -38,12 +40,15 @@ All data collected are only available for Agent v5.
 See [metadata.csv][10] for a list of metrics provided by this integration.
 
 ### Events
+
 The Agent Metrics check does not include any events.
 
 ### Service Checks
+
 The Agent Metrics check does not include any service checks.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][11].
 
 [1]: https://docs.datadoghq.com/integrations/go_expvar

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -17,7 +17,7 @@ In addition to metrics, the Datadog Agent also sends service checks related to A
 
 ### Installation
 
-All three steps below are needed for the Airflow integration to work properly. Before you begin, you [install the Datadog Agent][9] version `>=6.17` or `>=7.17` that includes Statsd/DogStatsD Mapping feature. 
+All three steps below are needed for the Airflow integration to work properly. Before you begin, you [install the Datadog Agent][9] version `>=6.17` or `>=7.17` that includes Statsd/DogStatsD Mapping feature.
 
 #### Step 1: Configure Airflow to collect health metrics and service checks
 
@@ -29,110 +29,110 @@ Edit the `airflow.d/conf.yaml` file, in the `conf.d/` folder at the root of your
 
 1. Install the [Airflow StatsD plugin][1].
 
-    ```
-    pip install 'apache-airflow[statsd]'
-    ```
+   ```shell
+   pip install 'apache-airflow[statsd]'
+   ```
 
 2. Update the Airflow configuration file `airflow.cfg` by adding the following configs:
 
-    ```
-    [scheduler]
-    statsd_on = True
-    statsd_host = localhost
-    statsd_port = 8125
-    statsd_prefix = airflow
-    ```
+   ```conf
+   [scheduler]
+   statsd_on = True
+   statsd_host = localhost
+   statsd_port = 8125
+   statsd_prefix = airflow
+   ```
 
 3. Update the [Datadog Agent main configuration file][10] `datadog.yaml` by adding the following configs:
 
-    ```yaml
-    # dogstatsd_mapper_cache_size: 1000  # default to 1000
-    dogstatsd_mapper_profiles:
-      - name: airflow
-        prefix: 'airflow.'
-        mappings:
-          - match: 'airflow.*_start'
-            name: 'airflow.job.start'
-            tags:
-              job_name: '$1'
-          - match: 'airflow.*_end'
-            name: 'airflow.job.end'
-            tags:
-              job_name: '$1'
-          - match: 'airflow.operator_failures_*'
-            name: 'airflow.operator_failures'
-            tags:
-              operator_name: '$1'
-          - match: 'airflow.operator_successes_*'
-            name: 'airflow.operator_successes'
-            tags:
-              operator_name: '$1'
-          - match: 'airflow\.dag_processing\.last_runtime\.(.*)'
-            match_type: 'regex'
-            name: 'airflow.dag_processing.last_runtime'
-            tags:
-               dag_file: '$1'
-          - match: 'airflow\.dag_processing\.last_run\.seconds_ago\.(.*)'
-            match_type: 'regex'
-            name: 'airflow.dag_processing.last_run.seconds_ago'
-            tags:
-               dag_file: '$1'
-          - match: 'airflow\.dag\.loading-duration\.(.*)'
-            match_type: 'regex'
-            name: 'airflow.dag.loading_duration'
-            tags:
-               dag_file: '$1'
-          - match: 'airflow.pool.open_slots.*'
-            name: 'airflow.pool.open_slots'
-            tags:
-               pool_name: '$1'
-          - match: 'airflow.pool.used_slots.*'
-            name: 'airflow.pool.used_slots'
-            tags:
-               pool_name: '$1'
-          - match: 'airflow.pool.starving_tasks.*'
-            name: 'airflow.pool.starving_tasks'
-            tags:
-               pool_name: '$1'
-          - match: 'airflow.dagrun.dependency-check.*'
-            name: 'airflow.dagrun.dependency_check'
-            tags:
-               dag_id: '$1'
-          - match: 'airflow.dag.*.*.duration'
-            name: 'airflow.dag.task.duration'
-            tags:
-               dag_id: '$1'
-               task_id: '$2'
-          - match: 'airflow\.dag_processing\.last_duration\.(.*)'
-            match_type: 'regex'
-            name: 'airflow.dag_processing.last_duration'
-            tags:
-               dag_file: '$1'
-          - match: 'airflow.dagrun.duration.success.*'
-            name: 'airflow.dagrun.duration.success'
-            tags:
-               dag_id: '$1'
-          - match: 'airflow.dagrun.duration.failed.*'
-            name: 'airflow.dagrun.duration.failed'
-            tags:
-               dag_id: '$1'
-          - match: 'airflow.dagrun.schedule_delay.*'
-            name: 'airflow.dagrun.schedule_delay'
-            tags:
-               dag_id: '$1'
-          - match: 'airflow.task_removed_from_dag.*'
-            name: 'airflow.dag.task_removed'
-            tags:
-               dag_id: '$1'
-          - match: 'airflow.task_restored_to_dag.*'
-            name: 'airflow.dag.task_restored'
-            tags:
-               dag_id: '$1'
-          - match: 'airflow.task_instance_created-*'
-            name: 'airflow.task.instance_created'
-            tags:
-               task_class: '$1'
-    ```
+   ```yaml
+   # dogstatsd_mapper_cache_size: 1000  # default to 1000
+   dogstatsd_mapper_profiles:
+     - name: airflow
+       prefix: "airflow."
+       mappings:
+         - match: "airflow.*_start"
+           name: "airflow.job.start"
+           tags:
+             job_name: "$1"
+         - match: "airflow.*_end"
+           name: "airflow.job.end"
+           tags:
+             job_name: "$1"
+         - match: "airflow.operator_failures_*"
+           name: "airflow.operator_failures"
+           tags:
+             operator_name: "$1"
+         - match: "airflow.operator_successes_*"
+           name: "airflow.operator_successes"
+           tags:
+             operator_name: "$1"
+         - match: 'airflow\.dag_processing\.last_runtime\.(.*)'
+           match_type: "regex"
+           name: "airflow.dag_processing.last_runtime"
+           tags:
+             dag_file: "$1"
+         - match: 'airflow\.dag_processing\.last_run\.seconds_ago\.(.*)'
+           match_type: "regex"
+           name: "airflow.dag_processing.last_run.seconds_ago"
+           tags:
+             dag_file: "$1"
+         - match: 'airflow\.dag\.loading-duration\.(.*)'
+           match_type: "regex"
+           name: "airflow.dag.loading_duration"
+           tags:
+             dag_file: "$1"
+         - match: "airflow.pool.open_slots.*"
+           name: "airflow.pool.open_slots"
+           tags:
+             pool_name: "$1"
+         - match: "airflow.pool.used_slots.*"
+           name: "airflow.pool.used_slots"
+           tags:
+             pool_name: "$1"
+         - match: "airflow.pool.starving_tasks.*"
+           name: "airflow.pool.starving_tasks"
+           tags:
+             pool_name: "$1"
+         - match: "airflow.dagrun.dependency-check.*"
+           name: "airflow.dagrun.dependency_check"
+           tags:
+             dag_id: "$1"
+         - match: "airflow.dag.*.*.duration"
+           name: "airflow.dag.task.duration"
+           tags:
+             dag_id: "$1"
+             task_id: "$2"
+         - match: 'airflow\.dag_processing\.last_duration\.(.*)'
+           match_type: "regex"
+           name: "airflow.dag_processing.last_duration"
+           tags:
+             dag_file: "$1"
+         - match: "airflow.dagrun.duration.success.*"
+           name: "airflow.dagrun.duration.success"
+           tags:
+             dag_id: "$1"
+         - match: "airflow.dagrun.duration.failed.*"
+           name: "airflow.dagrun.duration.failed"
+           tags:
+             dag_id: "$1"
+         - match: "airflow.dagrun.schedule_delay.*"
+           name: "airflow.dagrun.schedule_delay"
+           tags:
+             dag_id: "$1"
+         - match: "airflow.task_removed_from_dag.*"
+           name: "airflow.dag.task_removed"
+           tags:
+             dag_id: "$1"
+         - match: "airflow.task_restored_to_dag.*"
+           name: "airflow.dag.task_restored"
+           tags:
+             dag_id: "$1"
+         - match: "airflow.task_instance_created-*"
+           name: "airflow.task.instance_created"
+           tags:
+             task_class: "$1"
+   ```
 
 #### Step 3: Restart Datadog Agent and Airflow
 
@@ -145,71 +145,71 @@ Use the default configuration of your `airflow.d/conf.yaml` file to activate the
 
 #### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent. Enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Uncomment and edit this configuration block at the bottom of your `airflow.d/conf.yaml`:
 
-    Change the `path` and `service` parameter values and configure them for your environment.
+   Change the `path` and `service` parameter values and configure them for your environment.
 
-    a. Configuration for DAG processor manager and Scheduler logs:
+   a. Configuration for DAG processor manager and Scheduler logs:
 
-    ```yaml
-      logs:
-        - type: file
-          path: <PATH_TO_AIRFLOW>/logs/dag_processor_manager/dag_processor_manager.log
-          source: airflow
-          service: <SERVICE_NAME>
-          log_processing_rules:
-            - type: multi_line
-              name: new_log_start_with_date
-              pattern: \[\d{4}\-\d{2}\-\d{2}
-        - type: file
-          path: <PATH_TO_AIRFLOW>/logs/scheduler/*/*.log
-          source: airflow
-          service: <SERVICE_NAME>
-          log_processing_rules:
-            - type: multi_line
-              name: new_log_start_with_date
-              pattern: \[\d{4}\-\d{2}\-\d{2}
-    ```
-   
-    Regular clean up is recommended for scheduler logs with daily log rotation.
+     ```yaml
+     logs:
+       - type: file
+         path: '<PATH_TO_AIRFLOW>/logs/dag_processor_manager/dag_processor_manager.log'
+         source: airflow
+         service: '<SERVICE_NAME>'
+         log_processing_rules:
+           - type: multi_line
+             name: new_log_start_with_date
+             pattern: \[\d{4}\-\d{2}\-\d{2}
+       - type: file
+         path: '<PATH_TO_AIRFLOW>/logs/scheduler/*/*.log'
+         source: airflow
+         service: '<SERVICE_NAME>'
+         log_processing_rules:
+           - type: multi_line
+             name: new_log_start_with_date
+             pattern: \[\d{4}\-\d{2}\-\d{2}
+     ```
 
-    b. Additional configuration for DAG tasks logs:
+     Regular clean up is recommended for scheduler logs with daily log rotation.
 
-    ```yaml
-      logs:
-        - type: file
-          path: <PATH_TO_AIRFLOW>/logs/*/*/*/*.log
-          source: airflow
-          service: <SERVICE_NAME>
-          log_processing_rules:
-            - type: multi_line
-              name: new_log_start_with_date
-              pattern: \[\d{4}\-\d{2}\-\d{2}
-    ```
+   b. Additional configuration for DAG tasks logs:
 
-    Caveat: By default Airflow use this log file template for tasks: `log_filename_template = {{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log`, the number of log files will grow quickly if not cleaned regularly. This pattern is used by Airflow UI to display logs individually for each executed task.
+     ```yaml
+     logs:
+       - type: file
+         path: '<PATH_TO_AIRFLOW>/logs/*/*/*/*.log'
+         source: airflow
+         service: '<SERVICE_NAME>'
+         log_processing_rules:
+           - type: multi_line
+             name: new_log_start_with_date
+             pattern: \[\d{4}\-\d{2}\-\d{2}
+     ```
 
-    If you do not view logs in Airflow UI, we recommend this configuration in `airflow.cfg`: `log_filename_template = dag_tasks.log`. Then log rotate this file and use this configuration:
+     Caveat: By default Airflow use this log file template for tasks: `log_filename_template = {{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{   try_number }}.log`, the number of log files will grow quickly if not cleaned regularly. This pattern is used by Airflow UI to display logs   individually for each executed task.
 
-    ```yaml
-      logs:
-        - type: file
-          path: <PATH_TO_AIRFLOW>/logs/dag_tasks.log
-          source: airflow
-          service: <SERVICE_NAME>
-          log_processing_rules:
-            - type: multi_line
-              name: new_log_start_with_date
-              pattern: \[\d{4}\-\d{2}\-\d{2}
-    ```
+     If you do not view logs in Airflow UI, we recommend this configuration in `airflow.cfg`: `log_filename_template = dag_tasks.log`. Then log   rotate this file and use this configuration:
+
+     ```yaml
+     logs:
+       - type: file
+         path: '<PATH_TO_AIRFLOW>/logs/dag_tasks.log'
+         source: airflow
+         service: '<SERVICE_NAME>'
+         log_processing_rules:
+           - type: multi_line
+             name: new_log_start_with_date
+             pattern: \[\d{4}\-\d{2}\-\d{2}
+     ```
 
 3. [Restart the Agent][7].
 
@@ -241,7 +241,7 @@ The Airflow check does not include any events.
 
 ### Airflow DatadogHook
 
-In addition, [Airflow DatadogHook][11] can be used to interact with Datadog: 
+In addition, [Airflow DatadogHook][11] can be used to interact with Datadog:
 
 - Send Metric
 - Query Metric

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -17,7 +17,7 @@ In addition to metrics, the Datadog Agent also sends service checks related to A
 
 ### Installation
 
-All three steps below are needed for the Airflow integration to work properly. Before you begin, you [install the Datadog Agent][9] version `>=6.17` or `>=7.17` that includes Statsd/DogStatsD Mapping feature.
+All three steps below are needed for the Airflow integration to work properly. Before you begin, [install the Datadog Agent][9] version `>=6.17` or `>=7.17`, which includes the StatsD/DogStatsD mapping feature.
 
 #### Step 1: Configure Airflow to collect health metrics and service checks
 
@@ -195,9 +195,9 @@ _Available for Agent versions >6.0_
              pattern: \[\d{4}\-\d{2}\-\d{2}
      ```
 
-     Caveat: By default Airflow use this log file template for tasks: `log_filename_template = {{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{   try_number }}.log`, the number of log files will grow quickly if not cleaned regularly. This pattern is used by Airflow UI to display logs   individually for each executed task.
+     Caveat: By default Airflow uses this log file template for tasks: `log_filename_template = {{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{   try_number }}.log`. The number of log files will grow quickly if not cleaned regularly. This pattern is used by Airflow UI to display logs individually for each executed task.
 
-     If you do not view logs in Airflow UI, we recommend this configuration in `airflow.cfg`: `log_filename_template = dag_tasks.log`. Then log   rotate this file and use this configuration:
+     If you do not view logs in Airflow UI, Datadog recommends this configuration in `airflow.cfg`: `log_filename_template = dag_tasks.log`. Then log rotate this file and use this configuration:
 
      ```yaml
      logs:

--- a/amazon_eks/README.md
+++ b/amazon_eks/README.md
@@ -14,15 +14,15 @@ Because Datadog already integrates with Kubernetes and AWS, it is ready-made to 
 
 Monitoring EKS requires that you set up the Datadog integrations for:
 
-* [Kubernetes][3]
-* [AWS][4]
-* [AWS EC2][5]
+- [Kubernetes][3]
+- [AWS][4]
+- [AWS EC2][5]
 
 along with integrations for any other AWS services you're running with EKS (e.g., [ELB][6])
 
 ### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 The setup is exactly the same as for Kubernetes.
 To start collecting logs from all your containers, use your Datadog Agent [environment variables][7].
@@ -37,9 +37,9 @@ Need help? Contact [Datadog support][10].
 
 ## Further Reading
 
-* [Monitor Amazon EKS with Datadog][11]
-* [Key metrics for Amazon EKS monitoring][12]
-* [Amazon EKS on AWS Fargate][13]
+- [Monitor Amazon EKS with Datadog][11]
+- [Key metrics for Amazon EKS monitoring][12]
+- [Amazon EKS on AWS Fargate][13]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/amazon_eks/images/amazon_eks_dashboard.png
 [2]: https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html

--- a/ambari/README.md
+++ b/ambari/README.md
@@ -20,30 +20,29 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `ambari.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Ambari performance data. See the [sample ambari.d/conf.yaml][3] for all available configuration options.
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
-
-          ## @param url - string - required
-          ## The URL of the Ambari Server, include http:// or https://
-          #
-        - url: localhost
-    ```
+   instances:
+     ## @param url - string - required
+     ## The URL of the Ambari Server, include http:// or https://
+     #
+     - url: localhost
+   ```
 
 2. [Restart the Agent][4].
 
 ##### Log collection
 
- **Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
- 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
+1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-     ```yaml
-      logs_enabled: true
+    ```yaml
+    logs_enabled: true
     ```
 
- 2. Edit your `ambari.d/conf.yaml` by uncommenting the `logs` lines at the bottom. Update the logs `path` with the correct path to your Ambari log files.
+2. Edit your `ambari.d/conf.yaml` by uncommenting the `logs` lines at the bottom. Update the logs `path` with the correct path to your Ambari log files.
 
     ```yaml
       logs:
@@ -54,11 +53,12 @@ Follow the instructions below to configure this check for an Agent running on a 
           log_processing_rules:
               - type: multi_line
                 name: new_log_start_with_date
-                pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])  # 2019-04-22 15:47:00,999
+                # 2019-04-22 15:47:00,999
+                pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
       ...
     ```
 
- 3. [Restart the Agent][4].
+3. [Restart the Agent][4].
 
 #### Containerized
 
@@ -67,19 +67,19 @@ For containerized environments, see the [Autodiscovery Integration Templates][5]
 ##### Metric collection
 
 | Parameter            | Value                        |
-|----------------------|------------------------------|
+| -------------------- | ---------------------------- |
 | `<INTEGRATION_NAME>` | `ambari`                     |
 | `<INIT_CONFIG>`      | blank or `{}`                |
 | `<INSTANCE_CONFIG>`  | `{"url": "http://%%host%%"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][6].
 
 | Parameter      | Value                                                                                                                                                                                             |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "ambari", "service": "<SERVICE_NAME>", "log_processing_rules":{"type":"multi_line","name":"new_log_start_with_date","pattern":"\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])"}}` |
 
 ### Validation
@@ -90,13 +90,13 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 This integration collects for every host in every cluster the following system metrics:
 
-* boottime
-* cpu
-* disk
-* memory
-* load
-* network
-* process
+- boottime
+- cpu
+- disk
+- memory
+- load
+- network
+- process
 
 If service metrics collection is enabled with `collect_service_metrics` this integration collects for each whitelisted service component the metrics with headers in the white list.
 

--- a/ambari/README.md
+++ b/ambari/README.md
@@ -36,7 +36,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 _Available for Agent versions >6.0_
 
-1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
+1. Collecting logs is disabled by default in the Datadog Agent. Enable it in your `datadog.yaml` file:
 
     ```yaml
     logs_enabled: true

--- a/apache/README.md
+++ b/apache/README.md
@@ -26,48 +26,47 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `apache.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][3] to start collecting your Apache metrics. See the [sample apache.d/conf.yaml][4] for all available configuration options.
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
-
-          ## @param apache_status_url - string - required
-          ## Status url of your Apache server.
-          #
-        - apache_status_url: http://localhost/server-status?auto
-    ```
+   instances:
+     ## @param apache_status_url - string - required
+     ## Status url of your Apache server.
+     #
+     - apache_status_url: http://localhost/server-status?auto
+   ```
 
 2. [Restart the Agent][5].
 
 ##### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Add this configuration block to your `apache.d/conf.yaml` file to start collecting your Apache Logs:
 
-    ```yaml
-      logs:
-          - type: file
-            path: /var/log/apache2/access.log
-            source: apache
-            sourcecategory: http_web_access
-            service: apache
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/apache2/access.log
+       source: apache
+       sourcecategory: http_web_access
+       service: apache
 
-          - type: file
-            path: /var/log/apache2/error.log
-            source: apache
-            sourcecategory: http_web_access
-            service: apache
-    ```
+     - type: file
+       path: /var/log/apache2/error.log
+       source: apache
+       sourcecategory: http_web_access
+       service: apache
+   ```
 
-    Change the `path` and `service` parameter values and configure them for your environment.
-    See the [sample apache.d/conf.yaml][4] for all available configuration options.
+   Change the `path` and `service` parameter values and configure them for your environment.
+   See the [sample apache.d/conf.yaml][4] for all available configuration options.
 
 3. [Restart the Agent][5].
 
@@ -77,20 +76,20 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 
 ##### Metric collection
 
-| Parameter            | Value                                                          |
-|----------------------|----------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `apache`                                                       |
-| `<INIT_CONFIG>`      | blank or `{}`                                                  |
+| Parameter            | Value                                                         |
+| -------------------- | ------------------------------------------------------------- |
+| `<INTEGRATION_NAME>` | `apache`                                                      |
+| `<INIT_CONFIG>`      | blank or `{}`                                                 |
 | `<INSTANCE_CONFIG>`  | `{"apache_status_url": "http://%%host%%/server-status?auto"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][7].
 
 | Parameter      | Value                                               |
-|----------------|-----------------------------------------------------|
+| -------------- | --------------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "apache", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
@@ -98,11 +97,13 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 [Run the Agent's status subcommand][8] and look for `apache` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][9] for a list of metrics provided by this check.
 
 ### Events
+
 The Apache check does not include any events.
 
 ### Service Checks
@@ -113,18 +114,19 @@ Returns `CRITICAL` if the Agent cannot connect to the configured `apache_status_
 ## Troubleshooting
 
 ### Apache status URL
+
 If you are having issues with your Apache integration, it is mostly like due to the Agent not being able to access your Apache status URL. Try running curl for the `apache_status_url` listed in [your `apache.d/conf.yaml` file][4] (include your login credentials if applicable).
 
-* [Apache SSL certificate issues][10]
+- [Apache SSL certificate issues][10]
 
 ## Further Reading
+
 Additional helpful documentation, links, and articles:
 
-* [Deploying and configuring Datadog with CloudFormation][11]
-* [Monitoring Apache web server performance][12]
-* [How to collect Apache performance metrics][13]
-* [How to monitor Apache web server with Datadog][14]
-
+- [Deploying and configuring Datadog with CloudFormation][11]
+- [Monitoring Apache web server performance][12]
+- [How to collect Apache performance metrics][13]
+- [How to monitor Apache web server with Datadog][14]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/apache/images/apache_dashboard.png
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/aspdotnet/README.md
+++ b/aspdotnet/README.md
@@ -4,7 +4,7 @@
 
 Get metrics from ASP.NET service in real time to:
 
-- Visualize and monitor ASP.NET states
+- Visualize and monitor ASP.NET states.
 - Be notified about ASP.NET failovers and events.
 
 ## Setup

--- a/aspdotnet/README.md
+++ b/aspdotnet/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Get metrics from ASP.NET service in real time to:
+Get metrics from ASP.NET in real time to:
 
 - Visualize and monitor ASP.NET states.
 - Be notified about ASP.NET failovers and events.

--- a/aspdotnet/README.md
+++ b/aspdotnet/README.md
@@ -4,19 +4,18 @@
 
 Get metrics from ASP.NET service in real time to:
 
-* Visualize and monitor ASP.NET states
-* Be notified about ASP.NET failovers and events.
+- Visualize and monitor ASP.NET states
+- Be notified about ASP.NET failovers and events.
 
 ## Setup
+
 ### Installation
 
 The ASP.NET check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your servers.
 
 ### Configuration
 
-1. Edit the `aspdotnet.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3] to start collecting your ASP.NET performance data.
-
-    See the [sample aspdotnet.d/conf.yaml][4] for all available configuration options.
+1. Edit the `aspdotnet.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3] to start collecting your ASP.NET performance data. See the [sample aspdotnet.d/conf.yaml][4] for all available configuration options.
 
 2. [Restart the Agent][5]
 
@@ -25,17 +24,21 @@ The ASP.NET check is included in the [Datadog Agent][2] package, so you don't ne
 [Run the Agent's `status` subcommand][6] and look for `aspdotnet` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][7] for a list of metrics provided by this check.
 
 ### Events
+
 The ASP.NET check does not include any events.
 
 ### Service Checks
+
 The ASP.NET check does not include any service checks.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][8].
 
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/btrfs/README.md
+++ b/btrfs/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Get metrics from Btrfs service in real time to:
+Get metrics from Btrfs in real time to:
 
 - Visualize and monitor Btrfs states.
 - Be notified about Btrfs failovers and events.

--- a/btrfs/README.md
+++ b/btrfs/README.md
@@ -6,7 +6,7 @@
 
 Get metrics from Btrfs service in real time to:
 
-- Visualize and monitor Btrfs states
+- Visualize and monitor Btrfs states.
 - Be notified about Btrfs failovers and events.
 
 ## Setup

--- a/btrfs/README.md
+++ b/btrfs/README.md
@@ -6,18 +6,18 @@
 
 Get metrics from Btrfs service in real time to:
 
-* Visualize and monitor Btrfs states
-* Be notified about Btrfs failovers and events.
+- Visualize and monitor Btrfs states
+- Be notified about Btrfs failovers and events.
 
 ## Setup
+
 ### Installation
 
 The Btrfs check is included in the [Datadog Agent][3] package, so you don't need to install anything else on your servers that use at least one Btrfs filesystem.
 
 ### Configuration
 
-1. Configure the Agent according to your needs, edit the `btrfs.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][4].
-    See the [sample btrfs.d/conf.yaml][5] for all available configuration options.
+1. Configure the Agent according to your needs, edit the `btrfs.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][4]. See the [sample btrfs.d/conf.yaml][5] for all available configuration options.
 
 2. [Restart the Agent][6]
 
@@ -26,16 +26,21 @@ The Btrfs check is included in the [Datadog Agent][3] package, so you don't need
 [Run the Agent's `status` subcommand][7] and look for `btrfs` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][8] for a list of metrics provided by this integration.
 
 ### Events
+
 The Btrfs check does not include any events.
 
 ### Service Checks
+
 The Btrfs check does not include any service checks.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][9].
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/btrfs/images/btrfs_metric.png

--- a/cacti/README.md
+++ b/cacti/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Get metrics from cacti service in real time to:
+Get metrics from Cacti in real time to:
 
 - Visualize and monitor Cacti states.
 - Be notified about Cacti failovers and events.

--- a/cacti/README.md
+++ b/cacti/README.md
@@ -4,8 +4,8 @@
 
 Get metrics from cacti service in real time to:
 
-* Visualize and monitor cacti states
-* Be notified about cacti failovers and events.
+- Visualize and monitor cacti states
+- Be notified about cacti failovers and events.
 
 ## Setup
 
@@ -44,73 +44,72 @@ sudo -u dd-agent /opt/datadog-agent/embedded/bin/pip install rrdtool
 
 1. Create a Datadog user with read-only rights to the Cacti database.
 
-    ```shell
-    sudo mysql -e "create user 'datadog'@'localhost' identified by '<MYSQL_PASSWORD>';"
-    sudo mysql -e "grant select on cacti.* to 'datadog'@'localhost';"
-    ```
+   ```shell
+   sudo mysql -e "create user 'datadog'@'localhost' identified by '<MYSQL_PASSWORD>';"
+   sudo mysql -e "grant select on cacti.* to 'datadog'@'localhost';"
+   ```
 
 2. Check the user and rights:
 
-    ```shell
-    mysql -u datadog --password=<MYSQL_PASSWORD> -e "show status" | \
-    grep Uptime && echo -e "\033[0;32mMySQL user - OK\033[0m" || \
-    echo -e "\033[0;31mCannot connect to MySQL\033[0m"
+   ```shell
+   mysql -u datadog --password=<MYSQL_PASSWORD> -e "show status" | \
+   grep Uptime && echo -e "\033[0;32mMySQL user - OK\033[0m" || \
+   echo -e "\033[0;31mCannot connect to MySQL\033[0m"
 
-    mysql -u datadog --password=<MYSQL_PASSWORD> -D cacti -e "select * from data_template_data limit 1" && \
-    echo -e "\033[0;32mMySQL grant - OK\033[0m" || \
-    echo -e "\033[0;31mMissing SELECT grant\033[0m"
-    ```
+   mysql -u datadog --password=<MYSQL_PASSWORD> -D cacti -e "select * from data_template_data limit 1" && \
+   echo -e "\033[0;32mMySQL grant - OK\033[0m" || \
+   echo -e "\033[0;31mMissing SELECT grant\033[0m"
+   ```
 
 3. Give the `datadog-agent` user access to the RRD files:
 
-    ```shell
-    sudo gpasswd -a dd-agent www-data
-    sudo chmod -R g+rx /var/lib/cacti/rra/
-    sudo su - datadog-agent -c 'if [ -r /var/lib/cacti/rra/ ];
-    then echo -e "\033[0;31mdatadog-agent can read the RRD files\033[0m";
-    else echo -e "\033[0;31mdatadog-agent can not read the RRD files\033[0m";
-    fi'
-    ```
+   ```shell
+   sudo gpasswd -a dd-agent www-data
+   sudo chmod -R g+rx /var/lib/cacti/rra/
+   sudo su - datadog-agent -c 'if [ -r /var/lib/cacti/rra/ ];
+   then echo -e "\033[0;31mdatadog-agent can read the RRD files\033[0m";
+   else echo -e "\033[0;31mdatadog-agent can not read the RRD files\033[0m";
+   fi'
+   ```
 
 #### Configure the Agent
 
 1. Configure the Agent to connect to MySQL, edit your `cacti.d/conf.yaml` file. See the [sample cacti.d/conf.yaml][2] for all available configuration options:
 
-    ```yaml
-        init_config:
+   ```yaml
+   init_config:
 
-        instances:
+   instances:
+     ## @param mysql_host - string - required
+     ## url of your MySQL database
+     #
+     - mysql_host: "localhost"
 
-            ## @param mysql_host - string - required
-            ## url of your MySQL database
-            #
-          - mysql_host: "localhost"
+       ## @param mysql_port - integer - optional - default: 3306
+       ## port of your MySQL database
+       #
+       # mysql_port: 3306
 
-            ## @param mysql_port - integer - optional - default: 3306
-            ## port of your MySQL database
-            #
-            # mysql_port: 3306
+       ## @param mysql_user - string - required
+       ## User to use to connect to MySQL in order to gather metrics
+       #
+       mysql_user: "datadog"
 
-            ## @param mysql_user - string - required
-            ## User to use to connect to MySQL in order to gather metrics
-            #
-            mysql_user: "datadog"
+       ## @param mysql_password - string - required
+       ## Password to use to connect to MySQL in order to gather metrics
+       #
+       mysql_password: "<MYSQL_PASSWORD>"
 
-            ## @param mysql_password - string - required
-            ## Password to use to connect to MySQL in order to gather metrics
-            #
-            mysql_password: "<MYSQL_PASSWORD>"
-
-            ## @param rrd_path - string - required
-            ## The Cacti checks requires access to the Cacti DB in MySQL and to the RRD
-            ## files that contain the metrics tracked in Cacti.
-            ## In almost all cases, you'll only need one instance pointing to the Cacti
-            ## database.
-            ## The `rrd_path` will probably be `/var/lib/cacti/rra` on Ubuntu
-            ## or `/var/www/html/cacti/rra` on any other machines.
-            #
-            rrd_path: "<CACTI_RRA_PATH>"
-    ```
+       ## @param rrd_path - string - required
+       ## The Cacti checks requires access to the Cacti DB in MySQL and to the RRD
+       ## files that contain the metrics tracked in Cacti.
+       ## In almost all cases, you'll only need one instance pointing to the Cacti
+       ## database.
+       ## The `rrd_path` will probably be `/var/lib/cacti/rra` on Ubuntu
+       ## or `/var/www/html/cacti/rra` on any other machines.
+       #
+       rrd_path: "<CACTI_RRA_PATH>"
+   ```
 
 2. [Restart the Agent][3].
 

--- a/cacti/README.md
+++ b/cacti/README.md
@@ -4,8 +4,8 @@
 
 Get metrics from cacti service in real time to:
 
-- Visualize and monitor cacti states
-- Be notified about cacti failovers and events.
+- Visualize and monitor Cacti states.
+- Be notified about Cacti failovers and events.
 
 ## Setup
 

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Get metrics from Cassandra service in real time to:
+Get metrics from Cassandra in real time to:
 
 - Visualize and monitor Cassandra states.
 - Be notified about Cassandra failovers and events.

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -6,7 +6,7 @@
 
 Get metrics from Cassandra service in real time to:
 
-- Visualize and monitor Cassandra states
+- Visualize and monitor Cassandra states.
 - Be notified about Cassandra failovers and events.
 
 ## Setup

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -6,8 +6,8 @@
 
 Get metrics from Cassandra service in real time to:
 
-* Visualize and monitor Cassandra states
-* Be notified about Cassandra failovers and events.
+- Visualize and monitor Cassandra states
+- Be notified about Cassandra failovers and events.
 
 ## Setup
 
@@ -25,40 +25,40 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 ##### Metric Collection
 
-1. The default configuration of your `cassandra.d/conf.yaml` file activate the collection of your [Cassandra metrics](#metrics). See the [sample  cassandra.d/conf.yaml][5] for all available configuration options.
+1. The default configuration of your `cassandra.d/conf.yaml` file activate the collection of your [Cassandra metrics](#metrics). See the [sample cassandra.d/conf.yaml][5] for all available configuration options.
 
 2. [Restart the Agent][6].
 
 ##### Log Collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Add this configuration block to your `cassandra.d/conf.yaml` file to start collecting your Cassandra logs:
 
-    ```yaml
-      logs:
-        - type: file
-          path: /var/log/cassandra/*.log
-          source: cassandra
-          sourcecategory: database
-          service: myapplication
-          log_processing_rules:
-             - type: multi_line
-               name: log_start_with_date
-               # pattern to match: DEBUG [ScheduledTasks:1] 2019-12-30
-               pattern: [A-Z]+ +\[[^\]]+\] +\d{4}-\d{2}-\d{2}
-    ```
+   ```yaml
+     logs:
+       - type: file
+         path: /var/log/cassandra/*.log
+         source: cassandra
+         sourcecategory: database
+         service: myapplication
+         log_processing_rules:
+            - type: multi_line
+              name: log_start_with_date
+              # pattern to match: DEBUG [ScheduledTasks:1] 2019-12-30
+              pattern: [A-Z]+ +\[[^\]]+\] +\d{4}-\d{2}-\d{2}
+   ```
 
-    Change the `path` and `service` parameter values and configure them for your environment.
-    See the [sample  cassandra.d/conf.yaml][5] for all available configuration options.
+   Change the `path` and `service` parameter values and configure them for your environment.
+   See the [sample cassandra.d/conf.yaml][5] for all available configuration options.
 
-    To make sure that stacktraces are properly aggregated as one single log, a [multiline processing rule][7] can be added.
+   To make sure that stacktraces are properly aggregated as one single log, a [multiline processing rule][7] can be added.
 
 3. [Restart the Agent][6].
 
@@ -72,12 +72,12 @@ For containerized environments, see the [Autodiscovery with JMX][9] guide.
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][10].
 
 | Parameter      | Value                                                  |
-|----------------|--------------------------------------------------------|
+| -------------- | ------------------------------------------------------ |
 | `<LOG_CONFIG>` | `{"source": "cassandra", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
@@ -105,9 +105,9 @@ Need help? Contact [Datadog support][4].
 
 ## Further Reading
 
-* [How to monitor Cassandra performance metrics][13]
-* [How to collect Cassandra metrics][14]
-* [Monitoring Cassandra with Datadog][15]
+- [How to monitor Cassandra performance metrics][13]
+- [How to collect Cassandra metrics][14]
+- [Monitoring Cassandra with Datadog][15]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/cassandra/images/cassandra_dashboard.png
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/cassandra_nodetool/README.md
+++ b/cassandra_nodetool/README.md
@@ -16,19 +16,18 @@ The Cassandra Nodetool check is included in the [Datadog Agent][113] package, so
 
 1. Edit the file `cassandra_nodetool.d/conf.yaml` in the `conf.d/` folder at the root of your [Agent's configuration directory][114]. See the [sample cassandra_nodetool.d/conf.yaml][115] for all available configuration options:
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
-
-          ## @param keyspaces - list of string - required
-          ## The list of keyspaces to monitor.
-          ## An empty list results in no metrics being sent.
-          #
-        - keyspaces:
-            - "<KEYSPACE_1>"
-            - "<KEYSPACE_2>"
-    ```
+   instances:
+     ## @param keyspaces - list of string - required
+     ## The list of keyspaces to monitor.
+     ## An empty list results in no metrics being sent.
+     #
+     - keyspaces:
+         - "<KEYSPACE_1>"
+         - "<KEYSPACE_2>"
+   ```
 
 2. [Restart the Agent][116].
 
@@ -57,9 +56,9 @@ Need help? Contact [Datadog support][119].
 
 ## Further Reading
 
-* [How to monitor Cassandra performance metrics][1110]
-* [How to collect Cassandra metrics][1111]
-* [Monitoring Cassandra with Datadog][1112]
+- [How to monitor Cassandra performance metrics][1110]
+- [How to collect Cassandra metrics][1111]
+- [Monitoring Cassandra with Datadog][1112]
 
 [111]: https://raw.githubusercontent.com/DataDog/integrations-core/master/cassandra_nodetool/images/cassandra_dashboard.png
 [112]: https://github.com/DataDog/integrations-core/tree/master/cassandra

--- a/ceph/README.md
+++ b/ceph/README.md
@@ -6,11 +6,12 @@
 
 Enable the Datadog-Ceph integration to:
 
-  * Track disk usage across storage pools
-  * Receive service checks in case of issues
-  * Monitor I/O performance metrics
+- Track disk usage across storage pools
+- Receive service checks in case of issues
+- Monitor I/O performance metrics
 
 ## Setup
+
 ### Installation
 
 The Ceph check is included in the [Datadog Agent][3] package, so you don't need to install anything else on your Ceph servers.
@@ -25,34 +26,34 @@ init_config:
 
 instances:
   - ceph_cmd: /path/to/your/ceph # default is /usr/bin/ceph
-    use_sudo: true               # only if the ceph binary needs sudo on your nodes
+    use_sudo: true # only if the ceph binary needs sudo on your nodes
 ```
 
 If you enabled `use_sudo`, add a line like the following to your `sudoers` file:
 
-```
+```text
 dd-agent ALL=(ALL) NOPASSWD:/path/to/your/ceph
 ```
 
 #### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Next, edit `ceph.d/conf.yaml` by uncommenting the `logs` lines at the bottom. Update the logs `path` with the correct path to your Ceph log files.
 
-    ```
-      logs:
-        - type: file
-          path: /var/log/ceph/*.log
-          source: ceph
-          service: <APPLICATION_NAME>
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/ceph/*.log
+       source: ceph
+       service: "<APPLICATION_NAME>"
+   ```
 
 3. [Restart the Agent][10].
 
@@ -61,6 +62,7 @@ dd-agent ALL=(ALL) NOPASSWD:/path/to/your/ceph
 [Run the Agent's status subcommand][6] and look for `ceph` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][7] for a list of metrics provided by this integration.
@@ -68,6 +70,7 @@ See [metadata.csv][7] for a list of metrics provided by this integration.
 **Note**: If you are running ceph luminous or later, you will not see the metric `ceph.osd.pct_used`.
 
 ### Events
+
 The Ceph check does not include any events.
 
 ### Service Checks
@@ -132,12 +135,12 @@ Returns `OK` requests are taking a normal time to process. Otherwise, returns `W
 Returns `OK` requests are taking a normal time to process. Otherwise, returns `WARNING` if the severity is `HEALTH_WARN`, else `CRITICAL`.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][8].
 
 ## Further Reading
 
-* [Monitor Ceph: From node status to cluster-wide performance][9]
-
+- [Monitor Ceph: From node status to cluster-wide performance][9]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/ceph/images/ceph_dashboard.png
 [3]: https://app.datadoghq.com/account/settings#agent


### PR DESCRIPTION
### What does this PR do?

This PR lints markdown file to avoid layout issues moving forward with the public doc. I manually checked the layout for all of those integrations.

Change from this lint:

- Bullet list are defined with `-`
- Italic is now defined with `_<TEXT>_`
- Fixes table layout
- Lint code examples displayed
- Each code example has a language assigned, and the default is `text`
- There should be always an empty line before/after a header
- **Available for Agent >6.0** has been transformed into _Available for Agent versions >6.0_

### Motivation

Better doc for a better world
