### PR TITLE
2. Linting integration README

### DIFF
--- a/elastic/README.md
+++ b/elastic/README.md
@@ -9,6 +9,7 @@ Stay up-to-date on the health of your Elasticsearch cluster, from its overall st
 The Datadog Agent's Elasticsearch check collects metrics for search and indexing performance, memory usage and garbage collection, node availability, shard statistics, disk space and performance, pending tasks, and many more. The Agent also sends events and service checks for the overall status of your cluster.
 
 ## Setup
+
 ### Installation
 
 The Elasticsearch check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your Elasticsearch nodes, or on some other server if you use a hosted Elasticsearch (e.g. Elastic Cloud).
@@ -23,89 +24,93 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `elastic.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3] to start collecting your Elasticsearch [metrics](#metrics). See the [sample elastic.d/conf.yaml][4] for all available configuration options.
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
-
-          ## @param url - string - required
-          ## The URL where elasticsearch accepts HTTP requests. This is used to
-          ## fetch statistics from the nodes and information about the cluster health.
-          #
-        - url: http://localhost:9200
-    ```
+   instances:
+     ## @param url - string - required
+     ## The URL where elasticsearch accepts HTTP requests. This is used to
+     ## fetch statistics from the nodes and information about the cluster health.
+     #
+     - url: http://localhost:9200
+   ```
 
     **Notes**:
 
-    * If you're collecting Elasticsearch metrics from just one Datadog Agent running outside the cluster - e.g. if you use a hosted Elasticsearch - set `cluster_stats` to true.
-    * To use the Agent's Elasticsearch integration for the AWS Elasticsearch services, set the `url` parameter to point to your AWS Elasticsearch stats URL.
+      - If you're collecting Elasticsearch metrics from just one Datadog Agent running outside the cluster - e.g. if you use a hosted Elasticsearch - set `cluster_stats` to true.
+      - To use the Agent's Elasticsearch integration for the AWS Elasticsearch services, set the `url` parameter to point to your AWS Elasticsearch stats URL.
 
 2. [Restart the Agent][5].
 
 ##### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in the `datadog.yaml` file with:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. To collect search slow logs and index slow logs, [configure your Elasticsearch settings][14]. By default, slow logs are not enabled.
-    * To configure index slow logs for a given index `<INDEX>`:
-      ```
-      curl -X PUT "localhost:9200/<INDEX>/_settings?pretty" -H 'Content-Type: application/json' -d' {
-        "index.indexing.slowlog.threshold.index.warn": "0ms",
-        "index.indexing.slowlog.threshold.index.info": "0ms",
-        "index.indexing.slowlog.threshold.index.debug": "0ms",
-        "index.indexing.slowlog.threshold.index.trace": "0ms",
-        "index.indexing.slowlog.level": "trace",
-        "index.indexing.slowlog.source": "1000"
-      }
-      ```
 
-    * To configure search slow logs for a given index `<INDEX>`:
-      ```
-      curl -X PUT "localhost:9200/<INDEX>/_settings?pretty" -H 'Content-Type: application/json' -d' {
-        "index.search.slowlog.threshold.query.warn": "0ms",
-        "index.search.slowlog.threshold.query.info": "0ms",
-        "index.search.slowlog.threshold.query.debug": "0ms",
-        "index.search.slowlog.threshold.query.trace": "0ms",
-        "index.search.slowlog.threshold.fetch.warn": "0ms",
-        "index.search.slowlog.threshold.fetch.info": "0ms",
-        "index.search.slowlog.threshold.fetch.debug": "0ms",
-        "index.search.slowlog.threshold.fetch.trace": "0ms"
-      }
-      ```
+   - To configure index slow logs for a given index `<INDEX>`:
+
+     ```shell
+     curl -X PUT "localhost:9200/<INDEX>/_settings?pretty" -H 'Content-Type: application/json' -d' {
+       "index.indexing.slowlog.threshold.index.warn": "0ms",
+       "index.indexing.slowlog.threshold.index.info": "0ms",
+       "index.indexing.slowlog.threshold.index.debug": "0ms",
+       "index.indexing.slowlog.threshold.index.trace": "0ms",
+       "index.indexing.slowlog.level": "trace",
+       "index.indexing.slowlog.source": "1000"
+     }
+     ```
+
+   - To configure search slow logs for a given index `<INDEX>`:
+
+     ```shell
+     curl -X PUT "localhost:9200/<INDEX>/_settings?pretty" -H 'Content-Type: application/json' -d' {
+       "index.search.slowlog.threshold.query.warn": "0ms",
+       "index.search.slowlog.threshold.query.info": "0ms",
+       "index.search.slowlog.threshold.query.debug": "0ms",
+       "index.search.slowlog.threshold.query.trace": "0ms",
+       "index.search.slowlog.threshold.fetch.warn": "0ms",
+       "index.search.slowlog.threshold.fetch.info": "0ms",
+       "index.search.slowlog.threshold.fetch.debug": "0ms",
+       "index.search.slowlog.threshold.fetch.trace": "0ms"
+     }
+     ```
 
 3. Add this configuration block to your `elastic.d/conf.yaml` file to start collecting your Elasticsearch logs:
 
-    ```yaml
-      logs:
-          - type: file
-            path: /var/log/elasticsearch/*.log
-            source: elasticsearch
-            service: <SERVICE_NAME>
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/elasticsearch/*.log
+       source: elasticsearch
+       service: "<SERVICE_NAME>"
+   ```
 
-  * Add additional instances to start collecting slow logs:
+   - Add additional instances to start collecting slow logs:
 
-    ```yaml
-        - type: file
-          path: /var/log/elasticsearch/<CLUSTER_NAME>_index_indexing_slowlog.log
-          source: elasticsearch
-          service: <SERVICE_NAME>
- 
-        - type: file
-          path: /var/log/elasticsearch/<CLUSTER_NAME>_index_search_slowlog.log
-          source: elasticsearch
-          service: <SERVICE_NAME>
-    ```
+     ```yaml
+     - type: file
+       path: "/var/log/elasticsearch/\
+             <CLUSTER_NAME>_index_indexing_slowlog.log"
+       source: elasticsearch
+       service: "<SERVICE_NAME>"
 
-    Change the `path` and `service` parameter values and configure them for your environment.
+     - type: file
+       path: "/var/log/elasticsearch/\
+             <CLUSTER_NAME>_index_search_slowlog.log"
+       source: elasticsearch
+       service: "<SERVICE_NAME>"
+     ```
 
-3. [Restart the Agent][5].
+     Change the `path` and `service` parameter values and configure them for your environment.
+
+4. [Restart the Agent][5].
 
 #### Containerized
 
@@ -114,19 +119,19 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 ##### Metric collection
 
 | Parameter            | Value                              |
-|----------------------|------------------------------------|
+| -------------------- | ---------------------------------- |
 | `<INTEGRATION_NAME>` | `elastic`                          |
 | `<INIT_CONFIG>`      | blank or `{}`                      |
 | `<INSTANCE_CONFIG>`  | `{"url": "https://%%host%%:9200"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][7].
 
 | Parameter      | Value                                                      |
-|----------------|------------------------------------------------------------|
+| -------------- | ---------------------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "elasticsearch", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
@@ -137,9 +142,9 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 By default, not all of the following metrics are sent by the Agent. To send all metrics, configure flags in `elastic.yaml` as shown above.
 
-* `pshard_stats` sends **elasticsearch.primaries.\*** and **elasticsearch.indices.count** metrics
-* `index_stats` sends **elasticsearch.index.\*** metrics
-* `pending_task_stats` sends **elasticsearch.pending_\*** metrics
+- `pshard_stats` sends **elasticsearch.primaries.\*** and **elasticsearch.indices.count** metrics
+- `index_stats` sends **elasticsearch.index.\*** metrics
+- `pending_task_stats` sends **elasticsearch.pending\_\*** metrics
 
 For version >=6.3.0, set `xpack.monitoring.collection.enabled` configuration to `true` in your Elasticsearch configuration in order to collect all `elasticsearch.thread_pool.write.*` metrics. See [Elasticsearch release notes - monitoring section][9].
 
@@ -163,12 +168,12 @@ Returns `Critical` if the Agent cannot connect to Elasticsearch to collect metri
 
 ## Troubleshooting
 
-* [Agent can't connect][11]
-* [Why isn't Elasticsearch sending all my metrics?][12]
+- [Agent can't connect][11]
+- [Why isn't Elasticsearch sending all my metrics?][12]
 
 ## Further Reading
-To get a better idea of how (or why) to integrate your Elasticsearch cluster with Datadog, check out our [series of blog posts][13] about it.
 
+To get a better idea of how (or why) to integrate your Elasticsearch cluster with Datadog, check out our [series of blog posts][13] about it.
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/elastic/images/elasticsearch-dash.png
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -29,7 +29,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 
    instances:
      ## @param url - string - required
-     ## The URL where elasticsearch accepts HTTP requests. This is used to
+     ## The URL where Elasticsearch accepts HTTP requests. This is used to
      ## fetch statistics from the nodes and information about the cluster health.
      #
      - url: http://localhost:9200

--- a/envoy/README.md
+++ b/envoy/README.md
@@ -1,4 +1,5 @@
 # Agent Check: Envoy
+
 ## Overview
 
 This check collects distributed system observability metrics from [Envoy][1].
@@ -92,22 +93,20 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `envoy.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][7] to start collecting your Envoy performance data. See the [sample envoy.d/conf.yaml][8] for all available configuration options.
 
-  ```yaml
+    ```yaml
     init_config:
 
     instances:
-
-        ## @param stats_url - string - required
-        ## The admin endpoint to connect to. It must be accessible:
-        ## https://www.envoyproxy.io/docs/envoy/latest/operations/admin
-        ## Add a `?usedonly` on the end if you wish to ignore
-        ## unused metrics instead of reporting them as `0`.
-        #
+      ## @param stats_url - string - required
+      ## The admin endpoint to connect to. It must be accessible:
+      ## https://www.envoyproxy.io/docs/envoy/latest/operations/admin
+      ## Add a `?usedonly` on the end if you wish to ignore
+      ## unused metrics instead of reporting them as `0`.
+      #
       - stats_url: http://localhost:80/stats
-  ```
+    ```
 
 2. Check if the Datadog Agent can access Envoy's [admin endpoint][4].
-
 3. [Restart the Agent][9].
 
 ###### Metric filtering
@@ -139,23 +138,23 @@ If you care only about the cluster name and grpc service, you would add this to 
 
 ##### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Next, edit `envoy.d/conf.yaml` by uncommenting the `logs` lines at the bottom. Update the logs `path` with the correct path to your Envoy log files.
 
-    ```yaml
-      logs:
-        - type: file
-          path: /var/log/envoy.log
-          source: envoy
-          service: envoy
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/envoy.log
+       source: envoy
+       service: envoy
+   ```
 
 3. [Restart the Agent][9].
 
@@ -166,19 +165,19 @@ For containerized environments, see the [Autodiscovery Integration Templates][11
 ##### Metric collection
 
 | Parameter            | Value                                      |
-|----------------------|--------------------------------------------|
+| -------------------- | ------------------------------------------ |
 | `<INTEGRATION_NAME>` | `envoy`                                    |
 | `<INIT_CONFIG>`      | blank or `{}`                              |
 | `<INSTANCE_CONFIG>`  | `{"stats_url": "http://%%host%%:80/stats}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][12].
 
 | Parameter      | Value                                              |
-|----------------|----------------------------------------------------|
+| -------------- | -------------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "envoy", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
@@ -186,6 +185,7 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 [Run the Agent's status subcommand][13] and look for `envoy` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][14] for a list of metrics provided by this integration.
@@ -204,7 +204,6 @@ Returns `CRITICAL` if the Agent cannot connect to Envoy to collect metrics, othe
 ## Troubleshooting
 
 Need help? Contact [Datadog support][15].
-
 
 [1]: https://www.envoyproxy.io
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/etcd/README.md
+++ b/etcd/README.md
@@ -6,9 +6,9 @@
 
 Collect Etcd metrics to:
 
-* Monitor the health of your Etcd cluster.
-* Know when host configurations may be out of sync.
-* Correlate the performance of Etcd with the rest of your applications.
+- Monitor the health of your Etcd cluster.
+- Know when host configurations may be out of sync.
+- Correlate the performance of Etcd with the rest of your applications.
 
 ## Setup
 
@@ -17,6 +17,7 @@ Collect Etcd metrics to:
 The etcd check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your Etcd instance(s).
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
@@ -29,7 +30,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 For containerized environments, see the [Autodiscovery Integration Templates][6] for guidance on applying the parameters below.
 
 | Parameter            | Value                             |
-|----------------------|-----------------------------------|
+| -------------------- | --------------------------------- |
 | `<INTEGRATION_NAME>` | `etcd`                            |
 | `<INIT_CONFIG>`      | blank or `{}`                     |
 | `<INSTANCE_CONFIG>`  | `{"url": "http://%%host%%:2379"}` |
@@ -39,6 +40,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 [Run the Agent's `status` subcommand][7] and look for `etcd` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][8] for a list of metrics provided by this integration.
@@ -46,6 +48,7 @@ See [metadata.csv][8] for a list of metrics provided by this integration.
 Etcd metrics are tagged with `etcd_state:leader` or `etcd_state:follower`, depending on the node status, so you can easily aggregate metrics by status.
 
 ### Events
+
 The Etcd check does not include any events.
 
 ### Service Checks
@@ -59,11 +62,12 @@ Returns 'Critical' if the Agent cannot collect metrics from your Etcd API endpoi
 Returns 'Critical' if a member node is not healthy. Returns 'Unknown' if the Agent can't reach the `/health` endpoint, or if the health status is missing.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][9].
 
 ## Further Reading
-To get a better idea of how (or why) to integrate etcd with Datadog, check out our [blog post][10] about it.
 
+To get a better idea of how (or why) to integrate etcd with Datadog, check out our [blog post][10] about it.
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/etcd/images/etcd_dashboard.png
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/etcd/README.md
+++ b/etcd/README.md
@@ -14,7 +14,7 @@ Collect Etcd metrics to:
 
 ### Installation
 
-The etcd check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your Etcd instance(s).
+The Etcd check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your Etcd instance(s).
 
 ### Configuration
 

--- a/etcd/README.md
+++ b/etcd/README.md
@@ -67,7 +67,7 @@ Need help? Contact [Datadog support][9].
 
 ## Further Reading
 
-To get a better idea of how (or why) to integrate etcd with Datadog, check out our [blog post][10] about it.
+To get a better idea of how (or why) to integrate Etcd with Datadog, check out our [blog post][10] about it.
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/etcd/images/etcd_dashboard.png
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/exchange_server/README.md
+++ b/exchange_server/README.md
@@ -4,7 +4,7 @@
 
 Get metrics from Microsoft Exchange Server
 
-* Visualize and monitor Exchange server performance
+- Visualize and monitor Exchange server performance
 
 ## Setup
 
@@ -23,13 +23,17 @@ The Exchange check is included in the [Datadog Agent][1] package, so you don't n
 [Run the Agent's status subcommand][4] and look for `exchange_server` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][5] for a list of metrics provided by this integration.
 
 ### Events
+
 The Exchange server check does not include any events.
 
 ### Service Checks
+
 The Exchange server check does not include any service checks.
 
 [1]: https://app.datadoghq.com/account/settings#agent

--- a/external_dns/README.md
+++ b/external_dns/README.md
@@ -26,7 +26,7 @@ kind: Pod
 metadata:
   annotations:
     ad.datadoghq.com/external-dns.check_names: '["external_dns"]'
-    ad.datadoghq.com/external-dns.init_configs: "[{}]"
+    ad.datadoghq.com/external-dns.init_configs: '[{}]'
     ad.datadoghq.com/external-dns.instances: '[{"prometheus_url":"http://%%host%%:7979/metrics", "tags":["externaldns-pod:%%host%%"]}]'
 ```
 

--- a/external_dns/README.md
+++ b/external_dns/README.md
@@ -7,6 +7,7 @@ Get metrics from the external DNS service in real time to visualize and monitor 
 For more information about external DNS, see the [Github repo][7].
 
 ## Setup
+
 ### Installation
 
 The external DNS check is included in the [Datadog Agent][1] package, so you don't need to install anything else on your servers.
@@ -25,7 +26,7 @@ kind: Pod
 metadata:
   annotations:
     ad.datadoghq.com/external-dns.check_names: '["external_dns"]'
-    ad.datadoghq.com/external-dns.init_configs: '[{}]'
+    ad.datadoghq.com/external-dns.init_configs: "[{}]"
     ad.datadoghq.com/external-dns.instances: '[{"prometheus_url":"http://%%host%%:7979/metrics", "tags":["externaldns-pod:%%host%%"]}]'
 ```
 

--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -6,8 +6,8 @@
 
 Get metrics from Fluentd to:
 
-* Visualize Fluentd performance.
-* Correlate the performance of Fluentd with the rest of your applications.
+- Visualize Fluentd performance.
+- Correlate the performance of Fluentd with the rest of your applications.
 
 ## Setup
 
@@ -19,7 +19,7 @@ The Fluentd check is included in the [Datadog Agent][3] package, so you don't ne
 
 In your fluentd configuration file, add a `monitor_agent` source:
 
-```
+```text
 <source>
   @type monitor_agent
   bind 0.0.0.0
@@ -37,16 +37,15 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `fluentd.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4] to start collecting your [Fluentd metrics](#metrics). See the [sample fluentd.d/conf.yaml][5] for all available configuration options.
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
-
-          ## @param monitor_agent_url - string - required
-          ## Monitor Agent URL to connect to.
-          #
-        - monitor_agent_url: http://example.com:24220/api/plugins.json
-    ```
+   instances:
+     ## @param monitor_agent_url - string - required
+     ## Monitor Agent URL to connect to.
+     #
+     - monitor_agent_url: http://example.com:24220/api/plugins.json
+   ```
 
 2. [Restart the Agent][6].
 
@@ -65,7 +64,7 @@ Add the `ddsource` attribute with [the name of the log integration][9] in your l
 
 Setup Example:
 
-```
+```conf
   # Match events tagged with "datadog.**" and
   # send them to Datadog
 
@@ -89,17 +88,17 @@ Setup Example:
 
 Additional parameters can be used to change the endpoint used in order to go through a proxy:
 
-* `host`: Proxy endpoint when logs are not directly forwarded to Datadog (default value is `intake.logs.datadoghq.com`)
-* `port`: Proxy port when logs are not directly forwarded to Datadog (default value is `10514`)
-* `ssl_port`: Port used when logs are forwarded in a secure TCP/SSL connection to Datadog (default is `10516`)
-* `use_ssl`: If `true`, the Agent initializes a secure TCP/SSL connection to Datadog. (default value is `true`)
+- `host`: Proxy endpoint when logs are not directly forwarded to Datadog (default value is `intake.logs.datadoghq.com`)
+- `port`: Proxy port when logs are not directly forwarded to Datadog (default value is `10514`)
+- `ssl_port`: Port used when logs are forwarded in a secure TCP/SSL connection to Datadog (default is `10516`)
+- `use_ssl`: If `true`, the Agent initializes a secure TCP/SSL connection to Datadog. (default value is `true`)
 
 This also can be used to send logs to **Datadog EU** by setting:
 
-```
+```conf
 <match datadog.**>
 
-  ...
+  #...
   host 'tcp-intake.logs.datadoghq.eu'
   ssl_port '443'
 
@@ -112,17 +111,17 @@ Datadog tags are critical to be able to jump from one part of the product to ano
 
 If your logs contain any of the following attributes, these attributes are automatically added as Datadog tags on your logs:
 
-* `kubernetes.container_image`
-* `kubernetes.container_name`
-* `kubernetes.namespace_name`
-* `kubernetes.pod_name`
-* `docker.container_id`
+- `kubernetes.container_image`
+- `kubernetes.container_name`
+- `kubernetes.namespace_name`
+- `kubernetes.pod_name`
+- `docker.container_id`
 
 While the Datadog Agent collects Docker and Kubernetes metadata automatically, FluentD requires a plugin for this. We recommend using [fluent-plugin-kubernetes_metadata_filter][13] to collect this metadata.
 
 Configuration example:
 
-```
+```conf
 # Collect metadata for logs tagged with "kubernetes.**"
  <filter kubernetes.*>
    type kubernetes_metadata
@@ -136,19 +135,19 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 ##### Metric collection
 
 | Parameter            | Value                                                             |
-|----------------------|-------------------------------------------------------------------|
+| -------------------- | ----------------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `fluentd`                                                         |
 | `<INIT_CONFIG>`      | blank or `{}`                                                     |
 | `<INSTANCE_CONFIG>`  | `{"monitor_agent_url": "http://%%host%%:24220/api/plugins.json"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][18].
 
 | Parameter      | Value                                                |
-|----------------|------------------------------------------------------|
+| -------------- | ---------------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "fluentd", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
@@ -156,11 +155,13 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 [Run the Agent's status subcommand][14] and look for `fluentd` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][15] for a list of metrics provided by this integration.
 
 ### Events
+
 The FluentD check does not include any events.
 
 ### Service Checks
@@ -174,7 +175,7 @@ Need help? Contact [Datadog support][16].
 
 ## Further Reading
 
-* [How to monitor Fluentd with Datadog][17]
+- [How to monitor Fluentd with Datadog][17]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/fluentd/images/snapshot-fluentd.png
 [2]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -17,7 +17,7 @@ The Fluentd check is included in the [Datadog Agent][3] package, so you don't ne
 
 #### Prepare Fluentd
 
-In your fluentd configuration file, add a `monitor_agent` source:
+In your Fluentd configuration file, add a `monitor_agent` source:
 
 ```text
 <source>

--- a/gearmand/README.md
+++ b/gearmand/README.md
@@ -4,9 +4,9 @@
 
 Collect Gearman metrics to:
 
-* Visualize Gearman performance.
-* Know how many tasks are queued or running.
-* Correlate Gearman performance with the rest of your applications.
+- Visualize Gearman performance.
+- Know how many tasks are queued or running.
+- Correlate Gearman performance with the rest of your applications.
 
 ## Setup
 
@@ -20,15 +20,15 @@ The Gearman check is included in the [Datadog Agent][2] package, so you don't ne
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
-1. Edit the `gearmand.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3] to start collecting your Gearman performance data.
-    See the [sample gearmand.d/conf.yaml][4] for all available configuration options.
-    ```yaml
-    init_config:
+1. Edit the `gearmand.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3] to start collecting your Gearman performance data. See the [sample gearmand.d/conf.yaml][4] for all available configuration options.
 
-    instances:
-        - server: localhost
-          port: 4730
-    ```
+   ```yaml
+   init_config:
+
+   instances:
+     - server: localhost
+       port: 4730
+   ```
 
 2. [Restart the Agent][5]
 
@@ -36,10 +36,10 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 For containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying the parameters below.
 
-| Parameter            | Value                                                                               |
-|----------------------|-------------------------------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `gearmand`                                                                         |
-| `<INIT_CONFIG>`      | blank or `{}`                                                                       |
+| Parameter            | Value                                  |
+| -------------------- | -------------------------------------- |
+| `<INTEGRATION_NAME>` | `gearmand`                             |
+| `<INIT_CONFIG>`      | blank or `{}`                          |
 | `<INSTANCE_CONFIG>`  | `{"server":"%%host%%", "port":"4730"}` |
 
 ### Validation
@@ -47,11 +47,13 @@ For containerized environments, see the [Autodiscovery Integration Templates][1]
 [Run the Agent's `status` subcommand][6] and look for `gearmand` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][7] for a list of metrics provided by this integration.
 
 ### Events
+
 The Gearmand check does not include any events.
 
 ### Service Checks
@@ -61,6 +63,7 @@ The Gearmand check does not include any events.
 Returns `Critical` if the Agent cannot connect to Gearman to collect metrics.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][8].
 
 [1]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -4,7 +4,7 @@
 
 Integration that allows to:
 
-* Visualize and monitor metrics collected via Gitlab through Prometheus
+- Visualize and monitor metrics collected via Gitlab through Prometheus
 
 See the [Gitlab documentation][1] for more information about Gitlab and its integration with Prometheus
 
@@ -15,6 +15,7 @@ See the [Gitlab documentation][1] for more information about Gitlab and its inte
 The Gitlab check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your Gitlab servers.
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
@@ -23,37 +24,37 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `gitlab.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3], to point to the Gitlab's Prometheus metrics endpoint. See the [sample gitlab.d/conf.yaml][4] for all available configuration options.
 
-  **Note**: The `allowed_metrics` item in the `init_config` section allows to specify the metrics that should be extracted.
+    **Note**: The `allowed_metrics` item in the `init_config` section allows to specify the metrics that should be extracted.
 
 2. [Restart the Agent][5]
 
 ##### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Next, edit `gitlab.d/conf.yaml` by uncommenting the `logs` lines at the bottom. Update the logs `path` with the correct path to your Gitlab log files.
 
-    ```
-      logs:
-        - type: file
-          path: /var/log/gitlab/gitlab-rails/production_json.log
-          service: <SERVICE_NAME>
-          source: gitlab
-        - type: file
-          path: /var/log/gitlab/gitlab-rails/production.log
-          service: <SERVICE_NAME>
-          source: gitlab
-        - type: file
-          path: /var/log/gitlab/gitlab-rails/api_json.log
-          service: <SERVICE_NAME>
-          source: gitlab
-    ```
+   ```yaml
+     logs:
+       - type: file
+         path: /var/log/gitlab/gitlab-rails/production_json.log
+         service: '<SERVICE_NAME>'
+         source: gitlab
+       - type: file
+         path: /var/log/gitlab/gitlab-rails/production.log
+         service: '<SERVICE_NAME>'
+         source: gitlab
+       - type: file
+         path: /var/log/gitlab/gitlab-rails/api_json.log
+         service: '<SERVICE_NAME>'
+         source: gitlab
+   ```
 
 3. [Restart the Agent][5].
 
@@ -64,19 +65,19 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 ##### Metric collection
 
 | Parameter            | Value                                                                                      |
-|----------------------|--------------------------------------------------------------------------------------------|
+| -------------------- | ------------------------------------------------------------------------------------------ |
 | `<INTEGRATION_NAME>` | `gitlab`                                                                                   |
 | `<INIT_CONFIG>`      | blank or `{}`                                                                              |
 | `<INSTANCE_CONFIG>`  | `{"gitlab_url":"http://%%host%%/", "prometheus_endpoint":"http://%%host%%:10055/metrics"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][7].
 
 | Parameter      | Value                                       |
-|----------------|---------------------------------------------|
+| -------------- | ------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "gitlab", "service": "gitlab"}` |
 
 ### Validation
@@ -84,17 +85,22 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 [Run the Agent's status subcommand][8] and look for `gitlab` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][9] for a list of metrics provided by this integration.
 
 ### Events
+
 The Gitlab check does not include any events.
 
 ### Service Checks
+
 The Gitlab check includes a readiness and a liveness service check.
 Moreover, it provides a service check to ensure that the local Prometheus endpoint is available.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][10].
 
 [1]: https://docs.gitlab.com/ee/administration/monitoring/prometheus

--- a/gitlab_runner/README.md
+++ b/gitlab_runner/README.md
@@ -4,8 +4,8 @@
 
 Integration that allows to:
 
-* Visualize and monitor metrics collected via Gitlab Runners through Prometheus
-* Validate that the Gitlab Runner can connect to Gitlab
+- Visualize and monitor metrics collected via Gitlab Runners through Prometheus
+- Validate that the Gitlab Runner can connect to Gitlab
 
 See the [Gitlab Runner documentation][1] for
 more information about Gitlab Runner and its integration with Prometheus
@@ -20,8 +20,7 @@ The Gitlab Runner check is included in the [Datadog Agent][3] package, so you do
 
 ### Configuration
 
-Edit the `gitlab_runner.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4], to point to the Runner's Prometheus metrics endpoint and to the Gitlab master to have a service check.
-See the [sample gitlab_runner.d/conf.yaml][5] for all available configuration options.
+Edit the `gitlab_runner.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4], to point to the Runner's Prometheus metrics endpoint and to the Gitlab master to have a service check. See the [sample gitlab_runner.d/conf.yaml][5] for all available configuration options.
 
 **Note**: The `allowed_metrics` item in the `init_config` section allows to specify the metrics that should be extracted.
 
@@ -32,17 +31,22 @@ See the [sample gitlab_runner.d/conf.yaml][5] for all available configuration op
 [Run the Agent's `status` subcommand][6] and look for `gitlab_runner` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][7] for a list of metrics provided by this integration.
 
 ### Events
+
 The Gitlab Runner check does not include any events.
 
 ### Service Checks
+
 The Gitlab Runner check provides a service check to ensure that the Runner can talk to the Gitlab master and another one to ensure that the
 local Prometheus endpoint is available.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][8].
 
 [1]: https://docs.gitlab.com/runner/monitoring/README.html

--- a/go-metro/README.md
+++ b/go-metro/README.md
@@ -17,51 +17,51 @@ The TCP RTT check-also known as [go-metro][2]-is packaged with the Agent, but re
 Debian-based systems should use one of the following:
 
 ```bash
-$ sudo apt-get install libcap
-$ sudo apt-get install libcap2-bin
+sudo apt-get install libcap
+sudo apt-get install libcap2-bin
 ```
 
 Redhat-based systems should use one of these:
 
 ```bash
-$ sudo yum install libcap
-$ sudo yum install compat-libcap1
+sudo yum install libcap
+sudo yum install compat-libcap1
 ```
 
 Finally, configure PCAP:
 
 ```bash
-$ sudo setcap cap_net_raw+ep /opt/datadog-agent/bin/go-metro
+sudo setcap cap_net_raw+ep /opt/datadog-agent/bin/go-metro
 ```
 
 ### Configuration
 
-Edit the ```go-metro.yaml``` file in your agent's ```conf.d``` directory. See the [sample go-metro.yaml][3] for all available configuration options. The following is an example file that will show the TCP RTT times for app.datadoghq.com and 192.168.0.22:
+Edit the `go-metro.yaml` file in your agent's `conf.d` directory. See the [sample go-metro.yaml][3] for all available configuration options. The following is an example file that will show the TCP RTT times for app.datadoghq.com and 192.168.0.22:
 
-  ```yaml
-    init_config:
-      snaplen: 512
-      idle_ttl: 300
-      exp_ttl: 60
-      statsd_ip: 127.0.0.1
-      statsd_port: 8125
-      log_to_file: true
-      log_level: info
-    instances:
-      - interface: eth0
-        tags:
-          - env:prod
-        ips:
-          - 45.33.125.153
-        hosts:
-          - app.datadoghq.com
-  ```
+```yaml
+init_config:
+  snaplen: 512
+  idle_ttl: 300
+  exp_ttl: 60
+  statsd_ip: 127.0.0.1
+  statsd_port: 8125
+  log_to_file: true
+  log_level: info
+instances:
+  - interface: eth0
+    tags:
+      - env:prod
+    ips:
+      - 45.33.125.153
+    hosts:
+      - app.datadoghq.com
+```
 
 ### Validation
 
 To validate that the check is running correctly, you should see `system.net.tcp.rtt` metrics showing in the Datadog interface. Also, if you [Run the Agent's `status` subcommand][4], you should see something similar to the following:
 
-```
+```text
 ● datadog-agent.service - "Datadog Agent"
     Loaded: loaded (/lib/...datadog-agent.service; enabled; vendor preset: enabled)
     Active: active (running) since Thu 2016-03-31 20:35:27 UTC; 42min ago
@@ -81,17 +81,21 @@ If the TCP RTT check has started you should see something similar to the go-metr
 **This is a passive check, so unless there are packets actively being sent to the hosts mentioned in the yaml file, the metrics are not reported.**
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][5] for a list of metrics provided by this check.
 
 ### Events
+
 The Go-metro check does not include any events.
 
 ### Service Checks
+
 The Go-metro check does not include any service checks.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][6].
 
 [1]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/go_expvar/README.md
+++ b/go_expvar/README.md
@@ -39,7 +39,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 For containerized environments, see the [Autodiscovery Integration Templates][12] for guidance on applying the parameters below.
 
 | Parameter            | Value                                    |
-|----------------------|------------------------------------------|
+| -------------------- | ---------------------------------------- |
 | `<INTEGRATION_NAME>` | `go_expvar`                              |
 | `<INIT_CONFIG>`      | blank or `{}`                            |
 | `<INSTANCE_CONFIG>`  | `{"expvar_url": "http://%%host%%:8080"}` |
@@ -68,7 +68,7 @@ Need help? Contact [Datadog support][11].
 
 ## Further Reading
 
-* [Instrument your Go apps with Expvar and Datadog][15]
+- [Instrument your Go apps with Expvar and Datadog][15]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/go_expvar/images/go_graph.png
 [2]: https://github.com/DataDog/datadog-go

--- a/gunicorn/README.md
+++ b/gunicorn/README.md
@@ -8,12 +8,13 @@ The Datadog Agent collects one main metric about Gunicorn: the number of worker 
 
 Gunicorn itself can provide further metrics via DogStatsD, including those for:
 
-* Total request rate
-* Request rate by status code (2xx, 3xx, 4xx, 5xx)
-* Request duration (average, median, max, 95th percentile, etc.)
-* Log message rate by log level (critical, error, warning, exception)
+- Total request rate
+- Request rate by status code (2xx, 3xx, 4xx, 5xx)
+- Request duration (average, median, max, 95th percentile, etc.)
+- Log message rate by log level (critical, error, warning, exception)
 
 ## Setup
+
 ### Installation
 
 The Datadog Agent's Gunicorn check is included in the [Datadog Agent][3] package, so you don't need to install anything else on your Gunicorn servers.
@@ -27,19 +28,19 @@ See the [sample gunicorn.yaml][6] for all available configuration options.
 
 #### Metric collection
 
-* Add this configuration block to your `gunicorn.d/conf.yaml` file to start gathering your [Gunicorn metrics](#metrics):
+1. Add this configuration block to your `gunicorn.d/conf.yaml` file to start gathering your [Gunicorn metrics](#metrics):
 
-    ```yaml
-    init_config:
+```yaml
+init_config:
 
-    instances:
-        # as set
-        # 1) in your app's config.py (proc_name = <YOUR_APP_NAME>), OR
-        # 2) via CLI (gunicorn --name <YOUR_APP_NAME> your:app)
-        - proc_name: <YOUR_APP_NAME>
-    ```
+instances:
+  # as set
+  # 1) in your app's config.py (proc_name = <YOUR_APP_NAME>), OR
+  # 2) via CLI (gunicorn --name <YOUR_APP_NAME> your:app)
+  - proc_name: <YOUR_APP_NAME>
+```
 
-* [Restart the Agent][3] to begin sending Gunicorn metrics to Datadog.
+2. [Restart the Agent][3] to begin sending Gunicorn metrics to Datadog.
 
 #### Connect Gunicorn to DogStatsD
 
@@ -49,13 +50,13 @@ Since version 19.1, Gunicorn [provides an option][7] to send its metrics to a da
 
 #### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Use the following command to configure the path of the access log file as explained in the [Gunicorn Documentation][9]: `--access-logfile <MY_FILE_PATH>`
 
@@ -63,27 +64,26 @@ Since version 19.1, Gunicorn [provides an option][7] to send its metrics to a da
 
 4. Add this configuration block to your `gunicorn.d/conf.yaml` file to start collecting your Gunicorn logs:
 
-    ```
-      logs:
-        - type: file
-          path: /var/log/gunicorn/access.log
-          service: <MY_SERVICE>
-          source: gunicorn
-          sourcecategory: http_web_access
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/gunicorn/access.log
+       service: "<MY_SERVICE>"
+       source: gunicorn
+       sourcecategory: http_web_access
 
-        - type: file
-          path: /var/log/gunicorn/error.log
-          service: <MY_SERVICE>
-          source: gunicorn
-          sourcecategory: sourcecode
-          log_processing_rules:
-            - type: multi_line
-              name: log_start_with_date
-              pattern: \[\d{4}-\d{2}-\d{2}
-    ```
+     - type: file
+       path: /var/log/gunicorn/error.log
+       service: "<MY_SERVICE>"
+       source: gunicorn
+       sourcecategory: sourcecode
+       log_processing_rules:
+         - type: multi_line
+           name: log_start_with_date
+           pattern: \[\d{4}-\d{2}-\d{2}
+   ```
 
-    Change the `service` and `path` parameter values and configure them for your environment.
-    See the [sample gunicorn.yaml][6] for all available configuration options.
+    Change the `service` and `path` parameter values and configure them for your environment. See the [sample gunicorn.yaml][6] for all available configuration options.
 
 5. [Restart the Agent][3].
 
@@ -95,7 +95,7 @@ If the status is not `OK`, see the Troubleshooting section.
 
 Use `netstat` to verify that Gunicorn is sending _its_ metrics, too:
 
-```
+```text
 $ sudo netstat -nup | grep "127.0.0.1:8125.*ESTABLISHED"
 udp        0      0 127.0.0.1:38374         127.0.0.1:8125          ESTABLISHED 15500/gunicorn: mas
 ```
@@ -107,6 +107,7 @@ udp        0      0 127.0.0.1:38374         127.0.0.1:8125          ESTABLISHED 
 See [metadata.csv][12] for a list of metrics provided by this integration.
 
 ### Events
+
 The Gunicorn check does not include any events.
 
 ### Service Checks
@@ -117,7 +118,8 @@ Returns `CRITICAL` if the Agent cannot find a Gunicorn master process, or any wo
 ## Troubleshooting
 
 ### Agent cannot find Gunicorn process
-```
+
+```shell
   Checks
   ======
 
@@ -133,7 +135,7 @@ Either Gunicorn really isn't running, or your app's Python environment doesn't h
 
 If `setproctitle` is not installed, Gunicorn appears in the process table like so:
 
-```
+```text
 $ ps -ef | grep gunicorn
 ubuntu   18013 16695  2 20:23 pts/0    00:00:00 /usr/bin/python /usr/bin/gunicorn --config test-app-config.py gunicorn-test:app
 ubuntu   18018 18013  0 20:23 pts/0    00:00:00 /usr/bin/python /usr/bin/gunicorn --config test-app-config.py gunicorn-test:app
@@ -142,7 +144,7 @@ ubuntu   18019 18013  0 20:23 pts/0    00:00:00 /usr/bin/python /usr/bin/gunicor
 
 If it _is_ installed, `gunicorn` processes appear in the format the Datadog Agent expects:
 
-```
+```text
 $ ps -ef | grep gunicorn
 ubuntu   18457 16695  5 20:26 pts/0    00:00:00 gunicorn: master [my_app]
 ubuntu   18462 18457  0 20:26 pts/0    00:00:00 gunicorn: worker [my_app]
@@ -151,8 +153,7 @@ ubuntu   18463 18457  0 20:26 pts/0    00:00:00 gunicorn: worker [my_app]
 
 ## Further Reading
 
-* [Monitor Gunicorn performance with Datadog][13]
-
+- [Monitor Gunicorn performance with Datadog][13]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/gunicorn/images/gunicorn-dash.png
 [3]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -6,9 +6,9 @@
 
 Capture HAProxy activity in Datadog to:
 
-* Visualize HAProxy load-balancing performance.
-* Know when a server goes down.
-* Correlate the performance of HAProxy with the rest of your applications.
+- Visualize HAProxy load-balancing performance.
+- Know when a server goes down.
+- Correlate the performance of HAProxy with the rest of your applications.
 
 ## Setup
 
@@ -22,20 +22,21 @@ The Agent collects metrics via a stats endpoint:
 
 1. Configure one in your `haproxy.conf`:
 
-    ```conf
-      listen stats # Define a listen section called "stats"
-      bind :9000 # Listen on localhost:9000
-      mode http
-      stats enable  # Enable stats page
-      stats hide-version  # Hide HAProxy version
-      stats realm Haproxy\ Statistics  # Title text for popup window
-      stats uri /haproxy_stats  # Stats URI
-      stats auth Username:Password  # Authentication credentials
-    ```
+   ```conf
+     listen stats # Define a listen section called "stats"
+     bind :9000 # Listen on localhost:9000
+     mode http
+     stats enable  # Enable stats page
+     stats hide-version  # Hide HAProxy version
+     stats realm Haproxy\ Statistics  # Title text for popup window
+     stats uri /haproxy_stats  # Stats URI
+     stats auth Username:Password  # Authentication credentials
+   ```
 
 2. [Restart HAProxy to enable the stats endpoint][3].
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
@@ -46,41 +47,40 @@ Edit the `haproxy.d/conf.yaml` file, in the `conf.d/` folder at the root of your
 
 1. Add this configuration block to your `haproxy.d/conf.yaml` file to start gathering your [Haproxy Metrics](#metrics):
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
-
-          ## @param url - string - required
-          ## Haproxy URL to connect to gather metrics.
-          ## Set the according <USERNAME> and <PASSWORD> or use directly a unix stats
-          ## or admin socket: unix:///var/run/haproxy.sock
-          #
-        - url: http://localhost/admin?stats
-    ```
+   instances:
+     ## @param url - string - required
+     ## Haproxy URL to connect to gather metrics.
+     ## Set the according <USERNAME> and <PASSWORD> or use directly a unix stats
+     ## or admin socket: unix:///var/run/haproxy.sock
+     #
+     - url: http://localhost/admin?stats
+   ```
 
 2. [Restart the Agent][6].
 
 ##### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Add this configuration block to your `haproxy.d/conf.yaml` file to start collecting your Haproxy Logs:
 
-    ```yaml
-      logs:
-          - type: udp
-            port: 514
-            service: haproxy
-            source: haproxy
-            sourcecategory: http_web_access
-    ```
+   ```yaml
+   logs:
+     - type: udp
+       port: 514
+       service: haproxy
+       source: haproxy
+       sourcecategory: http_web_access
+   ```
 
     Change the `service` parameter value and configure it for your environment. See the [sample haproxy.d/conf.yaml][5] for all available configuration options.
 
@@ -93,19 +93,19 @@ For containerized environments, see the [Autodiscovery Integration Templates][7]
 ##### Metric collection
 
 | Parameter            | Value                                     |
-|----------------------|-------------------------------------------|
+| -------------------- | ----------------------------------------- |
 | `<INTEGRATION_NAME>` | `haproxy`                                 |
 | `<INIT_CONFIG>`      | blank or `{}`                             |
 | `<INSTANCE_CONFIG>`  | `{"url": "https://%%host%%/admin?stats"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][8].
 
 | Parameter      | Value                                                |
-|----------------|------------------------------------------------------|
+| -------------- | ---------------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "haproxy", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
@@ -135,11 +135,11 @@ Need help? Contact [Datadog support][11].
 
 ## Further Reading
 
-* [Monitoring HAProxy performance metrics][12]
-* [How to collect HAProxy metrics][13]
-* [Monitor HAProxy with Datadog][14]
-* [HA Proxy Multi Process Configuration][15]
-* [How to collect HAProxy metrics][13]
+- [Monitoring HAProxy performance metrics][12]
+- [How to collect HAProxy metrics][13]
+- [Monitor HAProxy with Datadog][14]
+- [HA Proxy Multi Process Configuration][15]
+- [How to collect HAProxy metrics][13]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/39f2cb0977c0e0446a0e905d15d2e9a4349b3b5d/haproxy/images/haproxy-dash.png
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -5,11 +5,13 @@
 This check monitors [Harbor][1] through the Datadog Agent.
 
 ## Setup
+
 ### Installation
 
 The Harbor check is included in the [Datadog Agent][2] package. No additional installation is needed on your server.
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
@@ -17,29 +19,30 @@ Follow the instructions below to configure this check for an Agent running on a 
 ##### Metric Collection
 
 1. Edit the `harbor.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3] to start collecting your Harbor performance data. See the [sample harbor.d/conf.yaml][4] for all available configuration options.
-  **Note**: You can specify any type of user in the config but an account with admin permissions is required to fetch disk metrics. The metric `harbor.projects.count` only reflects the number of projects the provided user can access.
+
+    **Note**: You can specify any type of user in the config but an account with admin permissions is required to fetch disk metrics. The metric `harbor.projects.count` only reflects the number of projects the provided user can access.
 
 2. [Restart the Agent][5].
 
 ##### Log Collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
 
-    ```yaml
-    logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Add this configuration block to your `harbor.d/conf.yaml` file to start collecting your Harbor logs:
 
-    ```
-      logs:
-        - type: file
-          path: /var/log/harbor/*.log
-          source: harbor
-          service: <SERVICE_NAME>
-    ```
+   ```yaml
+     logs:
+       - type: file
+         path: /var/log/harbor/*.log
+         source: harbor
+         service: '<SERVICE_NAME>'
+   ```
 
 3. [Restart the Agent][5].
 
@@ -50,19 +53,19 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 ##### Metric collection
 
 | Parameter            | Value                                                                                 |
-|----------------------|---------------------------------------------------------------------------------------|
+| -------------------- | ------------------------------------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `harbor`                                                                              |
 | `<INIT_CONFIG>`      | blank or `{}`                                                                         |
 | `<INSTANCE_CONFIG>`  | `{"url": "https://%%host%%", "username": "<USER_ID>", "password": "<USER_PASSWORD>"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][7].
 
 | Parameter      | Value                                               |
-|----------------|-----------------------------------------------------|
+| -------------- | --------------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "harbor", "service": "<SERVICE_NAME>"}` |
 
 ### Validation

--- a/hdfs_datanode/README.md
+++ b/hdfs_datanode/README.md
@@ -20,7 +20,7 @@ The HDFS DataNode check is included in the [Datadog Agent][3] package, so you do
 
 #### Prepare the DataNode
 
-1. The Agent collects metrics from the DataNode's JMX remote interface. The interface is disabled by default, enable it by setting the following option in `hadoop-env.sh` (usually found in \$HADOOP_HOME/conf):
+1. The Agent collects metrics from the DataNode's JMX remote interface. The interface is disabled by default, enable it by setting the following option in `hadoop-env.sh` (usually found in $HADOOP_HOME/conf):
 
    ```conf
    export HADOOP_DATANODE_OPTS="-Dcom.sun.management.jmxremote

--- a/hdfs_datanode/README.md
+++ b/hdfs_datanode/README.md
@@ -17,42 +17,43 @@ Follow the instructions below to install and configure this check for an Agent r
 The HDFS DataNode check is included in the [Datadog Agent][3] package, so you don't need to install anything else on your DataNodes.
 
 ### Configuration
+
 #### Prepare the DataNode
 
-1. The Agent collects metrics from the DataNode's JMX remote interface. The interface is disabled by default, enable it by setting the following option in `hadoop-env.sh` (usually found in $HADOOP_HOME/conf):
+1. The Agent collects metrics from the DataNode's JMX remote interface. The interface is disabled by default, enable it by setting the following option in `hadoop-env.sh` (usually found in \$HADOOP_HOME/conf):
 
-    ```conf
-    export HADOOP_DATANODE_OPTS="-Dcom.sun.management.jmxremote
-      -Dcom.sun.management.jmxremote.authenticate=false
-      -Dcom.sun.management.jmxremote.ssl=false
-      -Dcom.sun.management.jmxremote.port=50075 $HADOOP_DATANODE_OPTS"
-    ```
+   ```conf
+   export HADOOP_DATANODE_OPTS="-Dcom.sun.management.jmxremote
+     -Dcom.sun.management.jmxremote.authenticate=false
+     -Dcom.sun.management.jmxremote.ssl=false
+     -Dcom.sun.management.jmxremote.port=50075 $HADOOP_DATANODE_OPTS"
+   ```
 
 2. Restart the DataNode process to enable the JMX interface.
 
 #### Connect the Agent
+
 ##### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
 1. Edit the `hdfs_datanode.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4]. See the [sample hdfs_datanode.d/conf.yaml][5] for all available configuration options:
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
-
-          ## @param hdfs_datanode_jmx_uri - string - required
-          ## The HDFS DataNode check retrieves metrics from the HDFS DataNode's JMX
-          ## interface via HTTP(S) (not a JMX remote connection). This check must be installed on a HDFS DataNode. The HDFS
-          ## DataNode JMX URI is composed of the DataNode's hostname and port.
-          ##
-          ## The hostname and port can be found in the hdfs-site.xml conf file under
-          ## the property dfs.datanode.http.address
-          ## https://hadoop.apache.org/docs/r2.7.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
-          #
-        - hdfs_datanode_jmx_uri: http://localhost:50075
-    ```
+   instances:
+     ## @param hdfs_datanode_jmx_uri - string - required
+     ## The HDFS DataNode check retrieves metrics from the HDFS DataNode's JMX
+     ## interface via HTTP(S) (not a JMX remote connection). This check must be installed on a HDFS DataNode. The HDFS
+     ## DataNode JMX URI is composed of the DataNode's hostname and port.
+     ##
+     ## The hostname and port can be found in the hdfs-site.xml conf file under
+     ## the property dfs.datanode.http.address
+     ## https://hadoop.apache.org/docs/r2.7.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
+     #
+     - hdfs_datanode_jmx_uri: http://localhost:50075
+   ```
 
 2. [Restart the Agent][6].
 
@@ -61,7 +62,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying the parameters below.
 
 | Parameter            | Value                                                |
-|----------------------|------------------------------------------------------|
+| -------------------- | ---------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `hdfs_datanode`                                      |
 | `<INIT_CONFIG>`      | blank or `{}`                                        |
 | `<INSTANCE_CONFIG>`  | `{"hdfs_datanode_jmx_uri": "http://%%host%%:50075"}` |
@@ -71,10 +72,13 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 [Run the Agent's status subcommand][7] and look for `hdfs_datanode` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][8] for a list of metrics provided by this integration.
 
 ### Events
+
 The HDFS-datanode check does not include any events.
 
 ### Service Checks
@@ -83,15 +87,15 @@ The HDFS-datanode check does not include any events.
 Returns `Critical` if the Agent cannot connect to the DataNode's JMX interface for any reason (e.g. wrong port provided, timeout, un-parseable JSON response).
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][9].
 
 ## Further Reading
 
-* [Hadoop architectural overview][10]
-* [How to monitor Hadoop metrics][11]
-* [How to collect Hadoop metrics][12]
-* [How to monitor Hadoop with Datadog][13]
-
+- [Hadoop architectural overview][10]
+- [How to monitor Hadoop metrics][11]
+- [How to collect Hadoop metrics][12]
+- [How to monitor Hadoop with Datadog][13]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/hdfs_datanode/images/hadoop_dashboard.png
 [2]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/hdfs_namenode/README.md
+++ b/hdfs_namenode/README.md
@@ -17,42 +17,43 @@ Follow the instructions below to install and configure this check for an Agent r
 The HDFS NameNode check is included in the [Datadog Agent][113] package, so you don't need to install anything else on your NameNodes.
 
 ### Configuration
+
 #### Prepare the NameNode
 
-1. The Agent collects metrics from the NameNode's JMX remote interface. The interface is disabled by default, so enable it by setting the following option in `hadoop-env.sh` (usually found in $HADOOP_HOME/conf):
+1. The Agent collects metrics from the NameNode's JMX remote interface. The interface is disabled by default, so enable it by setting the following option in `hadoop-env.sh` (usually found in \$HADOOP_HOME/conf):
 
-  ```conf
-  export HADOOP_NAMENODE_OPTS="-Dcom.sun.management.jmxremote
-    -Dcom.sun.management.jmxremote.authenticate=false
-    -Dcom.sun.management.jmxremote.ssl=false
-    -Dcom.sun.management.jmxremote.port=50070 $HADOOP_NAMENODE_OPTS"
-  ```
+    ```conf
+    export HADOOP_NAMENODE_OPTS="-Dcom.sun.management.jmxremote
+      -Dcom.sun.management.jmxremote.authenticate=false
+      -Dcom.sun.management.jmxremote.ssl=false
+      -Dcom.sun.management.jmxremote.port=50070 $HADOOP_NAMENODE_OPTS"
+    ```
 
 2. Restart the NameNode process to enable the JMX interface.
 
 #### Connect the Agent
+
 ##### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
 1. Edit the `hdfs_namenode.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][114]. See the [sample hdfs_namenode.d/conf.yaml][115] for all available configuration options:
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
-
-        ## @param hdfs_namenode_jmx_uri - string - required
-        ## The HDFS NameNode check retrieves metrics from the HDFS NameNode's JMX
-        ## interface via HTTP(S) (not a JMX remote connection). This check must be installed on
-        ## a HDFS NameNode. The HDFS NameNode JMX URI is composed of the NameNode's hostname and port.
-        ##
-        ## The hostname and port can be found in the hdfs-site.xml conf file under
-        ## the property dfs.namenode.http-address
-        ## https://hadoop.apache.org/docs/r2.7.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
-        #
-        - hdfs_namenode_jmx_uri: http://localhost:50070
-    ```
+   instances:
+     ## @param hdfs_namenode_jmx_uri - string - required
+     ## The HDFS NameNode check retrieves metrics from the HDFS NameNode's JMX
+     ## interface via HTTP(S) (not a JMX remote connection). This check must be installed on
+     ## a HDFS NameNode. The HDFS NameNode JMX URI is composed of the NameNode's hostname and port.
+     ##
+     ## The hostname and port can be found in the hdfs-site.xml conf file under
+     ## the property dfs.namenode.http-address
+     ## https://hadoop.apache.org/docs/r2.7.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
+     #
+     - hdfs_namenode_jmx_uri: http://localhost:50070
+   ```
 
 2. [Restart the Agent][116].
 
@@ -61,7 +62,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 For containerized environments, see the [Autodiscovery Integration Templates][112] for guidance on applying the parameters below.
 
 | Parameter            | Value                                                 |
-|----------------------|-------------------------------------------------------|
+| -------------------- | ----------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `hdfs_namenode`                                       |
 | `<INIT_CONFIG>`      | blank or `{}`                                         |
 | `<INSTANCE_CONFIG>`  | `{"hdfs_namenode_jmx_uri": "https://%%host%%:50070"}` |
@@ -71,11 +72,13 @@ For containerized environments, see the [Autodiscovery Integration Templates][11
 [Run the Agent's status subcommand][117] and look for `hdfs_namenode` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][118] for a list of metrics provided by this integration.
 
 ### Events
+
 The HDFS-namenode check does not include any events.
 
 ### Service Checks
@@ -84,15 +87,15 @@ The HDFS-namenode check does not include any events.
 Returns `Critical` if the Agent cannot connect to the NameNode's JMX interface for any reason (e.g. wrong port provided, timeout, un-parseable JSON response).
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][119].
 
 ## Further Reading
 
-* [Hadoop architectural overview][1110]
-* [How to monitor Hadoop metrics][1111]
-* [How to collect Hadoop metrics][1112]
-* [How to monitor Hadoop with Datadog][1113]
-
+- [Hadoop architectural overview][1110]
+- [How to monitor Hadoop metrics][1111]
+- [How to collect Hadoop metrics][1112]
+- [How to monitor Hadoop with Datadog][1113]
 
 [111]: https://raw.githubusercontent.com/DataDog/integrations-core/master/hdfs_datanode/images/hadoop_dashboard.png
 [112]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/hive/README.md
+++ b/hive/README.md
@@ -5,6 +5,7 @@
 This check monitors two parts of [Hive][1]: Hive Metastore and HiveServer2.
 
 ## Setup
+
 ### Installation
 
 The Hive check is included in the [Datadog Agent][2] package. No additional installation is needed on your server.
@@ -15,26 +16,26 @@ The Hive check is included in the [Datadog Agent][2] package. No additional inst
 
 1. Edit the Hive configuration file in [`HIVE_HOME/conf/hive-site.xml`][3] to enable the Hive Metastore and HiveServer2 metrics by adding these properties:
 
-    ```xml
-    <property>
-      <name>hive.metastore.metrics.enabled</name>
-      <value>true</value>
-    </property>
-    <property>
-      <name>hive.server2.metrics.enabled</name>
-      <value>true</value>
-    </property>
-    ```
+   ```xml
+   <property>
+     <name>hive.metastore.metrics.enabled</name>
+     <value>true</value>
+   </property>
+   <property>
+     <name>hive.server2.metrics.enabled</name>
+     <value>true</value>
+   </property>
+   ```
 
 2. Enable a JMX remote connection for the HiveServer2 and/or for the Hive Metastore. For example, set the `HADOOP_CLIENT_OPTS` environment variable:
 
-    ```conf
-    export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Dcom.sun.management.jmxremote \
-    -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false \
-    -Dcom.sun.management.jmxremote.port=8808"
-    ```
+   ```conf
+   export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Dcom.sun.management.jmxremote \
+   -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false \
+   -Dcom.sun.management.jmxremote.port=8808"
+   ```
 
-    Then restart the HiveServer2 or the Hive Metastore. Hive Metastore and HiveServer2 cannot share the same JMX connection.
+   Then restart the HiveServer2 or the Hive Metastore. Hive Metastore and HiveServer2 cannot share the same JMX connection.
 
 #### Host
 
@@ -51,27 +52,27 @@ Follow now the instructions below to configure this check for an Agent running o
 
 ##### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Add this configuration block to your `hive.d/conf.yaml` file to start collecting your Hive logs:
 
-    ```
-      logs:
-        - type: file
-          path: /tmp/<USER>/hive.log
-          source: hive
-          service: <SERVICE_NAME>
-          log_processing_rules:
-            - type: multi_line
-              name: new_log_start_with_date
-              pattern: \d{4}\-\d{2}\-\d{2}
-    ```
+   ```yaml
+     logs:
+       - type: file
+         path: /tmp/<USER>/hive.log
+         source: hive
+         service: '<SERVICE_NAME>'
+         log_processing_rules:
+           - type: multi_line
+             name: new_log_start_with_date
+             pattern: \d{4}\-\d{2}\-\d{2}
+   ```
 
     Change the `path` and `service` parameter values and configure them for your environment. See the [sample hive.d/conf.yaml][4] for all available configuration options.
 
@@ -87,12 +88,12 @@ To collect metrics with the Datadog-Hive integration, see the [Autodiscovery wit
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][10].
 
 | Parameter      | Value                                                                                                                                                             |
-|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "hive", "service": "<SERVICE_NAME>", "log_processing_rules":{"type":"multi_line","name":"new_log_start_with_date", "pattern":"\d{4}\-\d{2}\-\d{2}"}}` |
 
 ### Validation


### PR DESCRIPTION
### What does this PR do?

Follow up on: https://github.com/DataDog/integrations-core/pull/5662

This PR lints markdown file to avoid layout issues moving forward with the public doc. I manually checked the layout for all of those integrations.

Change from this lint:

- Bullet list are defined with `-`
- Italic is now defined with `_<TEXT>_`
- Fixes table layout
- Lint code examples displayed
- Each code example has a language assigned, and the default is `text`
- There should be always an empty line before/after a header
- **Available for Agent >6.0** has been transformed into _Available for Agent versions >6.0_
### Motivation

Better doc for a better world