### PR TITLE
3. Linting integration README

### DIFF
--- a/cilium/README.md
+++ b/cilium/README.md
@@ -14,55 +14,61 @@ The Cilium check is included in the [Datadog Agent][3] package, but it requires 
 
 1. In order to enable Prometheus metrics in both the `cilium-agent` and `cilium-operator`, deploy Cilium with the `global.prometheus.enabled=true` Helm value set, or:
 
-2. Separately enable Prometheus metrics in the `cilium-agent`:
-    * Add `--prometheus-serve-addr=:9090` to the `args` section of the Cilium DaemonSet config.
-        ```
-        [...]
-            spec:
-                containers:
-                - args:
-                    - --prometheus-serve-addr=:9090
-        ```
-    or in the `cilium-operator`:
-    * Add `--enable-metrics` to the `args` section of the Cilium deployment config.
-        ```
-        [...]
-            spec:
-                containers:
-                - args:
-                    - --enable-metrics
-        ```
+2. Separately enable Prometheus metrics:
 
+   - In the `cilium-agent` add `--prometheus-serve-addr=:9090` to the `args` section of the Cilium DaemonSet config:
+
+     ```yaml
+     # [...]
+     spec:
+       containers:
+         - args:
+             - --prometheus-serve-addr=:9090
+     ```
+
+
+
+   - Or in the `cilium-operator` add `--enable-metrics` to the `args` section of the Cilium deployment config:
+
+     ```yaml
+     # [...]
+     spec:
+       containers:
+         - args:
+             - --enable-metrics
+     ```
 
 ### Configuration
 
 1. Edit the `cilium.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Cilium performance data. See the [sample cilium.d/conf.yaml][4] for all available configuration options.
-    * To collect `cilium-agent` metrics, enable the `agent_endpoint` option.
-    * To collect `cilium-operator` metrics, enable the `operator_endpoint` option.
+
+   - To collect `cilium-agent` metrics, enable the `agent_endpoint` option.
+   - To collect `cilium-operator` metrics, enable the `operator_endpoint` option.
 
 2. [Restart the Agent][5].
 
 #### Log Collection
+
 Cilium contains two types of logs: `cilium-agent` and `cilium-operator`.
 
 #### Available for Agent >6.0
+
 1. Collecting logs is disabled by default in the Datadog Agent. Enable it in your [DaemonSet configuration][4]:
 
-    ```
-      (...)
-        env:
-          (...)
-          - name: DD_LOGS_ENABLED
-              value: "true"
-          - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
-              value: "true"
-      (...)
-    ```
+   ```yaml
+     # (...)
+       env:
+       #  (...)
+         - name: DD_LOGS_ENABLED
+             value: "true"
+         - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+             value: "true"
+     # (...)
+   ```
 
 2. Mount the Docker socket to the Datadog Agent as done in [this manifest][9] or mount the `/var/log/pods` directory if you are not using Docker.
 
 3. [Restart the Agent][5].
-
 
 ### Validation
 

--- a/cisco_aci/README.md
+++ b/cisco_aci/README.md
@@ -4,9 +4,9 @@
 
 The Cisco ACI Integration lets you:
 
-* Track the state and health of your network
-* Track the capacity of your ACI
-* Monitor the switches and controllers themselves
+- Track the state and health of your network
+- Track the capacity of your ACI
+- Monitor the switches and controllers themselves
 
 ## Setup
 
@@ -20,26 +20,29 @@ The Cisco ACI check is packaged with the Agent, so simply [install the Agent][2]
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
-1. Edit the `cisco_aci.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3].
-    See the [sample cisco_aci.d/conf.yaml][4] for all available configuration options:
+1. Edit the `cisco_aci.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3]. See the [sample cisco_aci.d/conf.yaml][4] for all available configuration options:
 
-    ```yaml
-      init_config:
-          # This check makes a lot of API calls
-          # it could sometimes help to add a minimum collection interval
-          # min_collection_interval: 180
-      instances:
-          - aci_url: localhost # the url of the aci controller
-            username: datadog
-            pwd: datadog
-            timeout: 15
-            # if it's an ssl endpoint that doesn't have a certificate, use this to ensure it can still connect
-            ssl_verify: True
-            tenant:
-              - WebApp
-              - Database
-              - Datadog
-    ```
+   ```yaml
+   init_config:
+
+   instances:
+     ## @param aci_url - string - required
+     ## Url to query to gather metrics.
+     #
+     - aci_url: localhost
+
+       ## @param username - string - required
+       ## Authentication can use either a user auth or a certificate.
+       ## If using the user auth, enter in this parameter the associated username.
+       #
+       username: datadog
+
+       ## @param pwd - string - required
+       ## Authentication can use either a user auth or a certificate.
+       ## If using the user auth, enter in this parameter the associated password.
+       #
+       pwd: datadog
+   ```
 
 2. [Restart the Agent][5] to begin sending Cisco ACI metrics to Datadog.
 
@@ -47,10 +50,10 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 For containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying the parameters below.
 
-| Parameter            | Value                                                                                             |
-|----------------------|---------------------------------------------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `teamcity`                                                                                        |
-| `<INIT_CONFIG>`      | blank or `{}`                                                                                     |
+| Parameter            | Value                                                                  |
+| -------------------- | ---------------------------------------------------------------------- |
+| `<INTEGRATION_NAME>` | `teamcity`                                                             |
+| `<INIT_CONFIG>`      | blank or `{}`                                                          |
 | `<INSTANCE_CONFIG>`  | `{"aci_url":"%%host%%", "username":"<USERNAME>", "pwd": "<PASSWORD>"}` |
 
 ### Validation
@@ -58,10 +61,13 @@ For containerized environments, see the [Autodiscovery Integration Templates][1]
 [Run the Agent's `status` subcommand][6] and look for `cisco_aci` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][7] for a list of metrics provided by this integration.
 
 ### Events
+
 The Cisco ACI check sends tenant faults as events.
 
 ### Service Checks
@@ -71,6 +77,7 @@ The Cisco ACI check sends tenant faults as events.
 Returns CRITICAL if the Agent cannot connect to the Cisco ACI API to collect metrics, otherwise OK.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][8].
 
 [1]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -10,8 +10,7 @@ Follow the instructions below to install and configure this check for an Agent r
 
 ### Installation
 
-The ClickHouse check is included in the [Datadog Agent][3] package.
-No additional installation is needed on your server.
+The ClickHouse check is included in the [Datadog Agent][3] package. No additional installation is needed on your server.
 
 ### Configuration
 

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -17,9 +17,7 @@ need to install anything else on your server.
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
-1. Edit the `cockroachdb.d/conf.yaml` file, in the `conf.d/` folder at the root of your
-   [Agent's configuration directory][4] to start collecting your CockroachDB performance data.
-   See the [sample cockroachdb.d/conf.yaml][5] for all available configuration options.
+1. Edit the `cockroachdb.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4] to start collecting your CockroachDB performance data. See the [sample cockroachdb.d/conf.yaml][5] for all available configuration options.
 
 2. [Restart the Agent][6]
 
@@ -27,13 +25,11 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying the parameters below.
 
-
-| Parameter            | Value                                                                               |
-|----------------------|-------------------------------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `cockroachdb`                                                                         |
-| `<INIT_CONFIG>`      | blank or `{}`                                                                       |
+| Parameter            | Value                                                    |
+| -------------------- | -------------------------------------------------------- |
+| `<INTEGRATION_NAME>` | `cockroachdb`                                            |
+| `<INIT_CONFIG>`      | blank or `{}`                                            |
 | `<INSTANCE_CONFIG>`  | `{"prometheus_url":"http://%%host%%:8080/_status/vars"}` |
-
 
 ### Validation
 
@@ -58,9 +54,10 @@ The CockroachDB check does not include any events.
 Need help? Contact [Datadog support][9].
 
 ## Further Reading
+
 Additional helpful documentation, links, and articles:
 
-* [Monitor CockroachDB performance metrics with Datadog][10]
+- [Monitor CockroachDB performance metrics with Datadog][10]
 
 [1]: https://www.cockroachlabs.com/product/cockroachdb
 [2]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/consul/README.md
+++ b/consul/README.md
@@ -6,16 +6,16 @@
 
 The Datadog Agent collects many metrics from Consul nodes, including those for:
 
-* Total Consul peers
-* Service health - for a given service, how many of its nodes are up, passing, warning, critical?
-* Node health - for a given node, how many of its services are up, passing, warning, critical?
-* Network coordinates - inter- and intra-datacenter latencies
+- Total Consul peers
+- Service health - for a given service, how many of its nodes are up, passing, warning, critical?
+- Node health - for a given node, how many of its services are up, passing, warning, critical?
+- Network coordinates - inter- and intra-datacenter latencies
 
 The _Consul_ Agent can provide further metrics via DogStatsD. These metrics are more related to the internal health of Consul itself, not to services which depend on Consul. There are metrics for:
 
-* Serf events and member flaps
-* The Raft protocol
-* DNS performance
+- Serf events and member flaps
+- The Raft protocol
+- DNS performance
 
 And many more.
 
@@ -37,18 +37,17 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `consul.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4] to start collecting your Consul metrics. See the [sample consul.d/conf.yaml][5] for all available configuration options.
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
-
-          ## @param url - string - required
-          ## Where your Consul HTTP Server Lives
-          ## Point the URL at the leader to get metrics about your Consul Cluster.
-          ## Remind to use https instead of http if your Consul setup is configured to do so.
-          #
-        - url: http://localhost:8500
-    ```
+   instances:
+     ## @param url - string - required
+     ## Where your Consul HTTP Server Lives
+     ## Point the URL at the leader to get metrics about your Consul Cluster.
+     ## Remind to use https instead of http if your Consul setup is configured to do so.
+     #
+     - url: http://localhost:8500
+   ```
 
 2. [Restart the Agent][6].
 
@@ -56,26 +55,26 @@ Reload the Consul Agent to start sending more Consul metrics to DogStatsD.
 
 ##### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in `datadog.yaml` with:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Add this configuration block to your `consul.yaml` file to start collecting your Consul Logs:
 
-    ```yaml
-      logs:
-          - type: file
-            path: /var/log/consul_server.log
-            source: consul
-            service: myservice
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/consul_server.log
+       source: consul
+       service: myservice
+   ```
 
-    Change the `path` and `service` parameter values and configure them for your environment.
-    See the [sample consul.d/conf.yaml][5] for all available configuration options.
+   Change the `path` and `service` parameter values and configure them for your environment.
+   See the [sample consul.d/conf.yaml][5] for all available configuration options.
 
 3. [Restart the Agent][6].
 
@@ -86,19 +85,19 @@ For containerized environments, see the [Autodiscovery Integration Templates][7]
 ##### Metric collection
 
 | Parameter            | Value                              |
-|----------------------|------------------------------------|
+| -------------------- | ---------------------------------- |
 | `<INTEGRATION_NAME>` | `consul`                           |
 | `<INIT_CONFIG>`      | blank or `{}`                      |
 | `<INSTANCE_CONFIG>`  | `{"url": "https://%%host%%:8500"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][8].
 
 | Parameter      | Value                                               |
-|----------------|-----------------------------------------------------|
+| -------------- | --------------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "consul", "service": "<SERVICE_NAME>"}` |
 
 #### DogStatsD
@@ -121,7 +120,7 @@ Alternatively, you can configure Consul to send data to the Agent through [DogSt
 
 **Note**: If your Consul nodes have debug logging enabled, you'll see the Datadog Agent's regular polling in the Consul log:
 
-```
+```text
 2017/03/27 21:38:12 [DEBUG] http: Request GET /v1/status/leader (59.344us) from=127.0.0.1:53768
 2017/03/27 21:38:12 [DEBUG] http: Request GET /v1/status/peers (62.678us) from=127.0.0.1:53770
 2017/03/27 21:38:12 [DEBUG] http: Request GET /v1/health/state/any (106.725us) from=127.0.0.1:53772
@@ -141,6 +140,7 @@ udp        0      0 127.0.0.1:53874         127.0.0.1:8125          ESTABLISHED 
 ```
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][10] for a list of metrics provided by this integration.
@@ -159,17 +159,17 @@ The Datadog Agent emits an event when the Consul cluster elects a new leader, ta
 **consul.check**:<br>
 The Datadog Agent submits a service check for each of Consul's health checks, tagging each with:
 
-* `service:<name>`, if Consul reports a `ServiceName`
-* `consul_service_id:<id>`, if Consul reports a `ServiceID`
+- `service:<name>`, if Consul reports a `ServiceName`
+- `consul_service_id:<id>`, if Consul reports a `ServiceID`
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][13].
 
 ## Further Reading
 
-* [Monitor Consul health and performance with Datadog][14]
-* [Consul at Datadog][15]
-
+- [Monitor Consul health and performance with Datadog][14]
+- [Consul at Datadog][15]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/consul/images/consul-dash.png
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/containerd/README.md
+++ b/containerd/README.md
@@ -18,7 +18,7 @@ If you are using the Agent in a container, setting the `DD_CRI_SOCKET_PATH` envi
 
 For example, to install the integration on Kubernetes, edit your daemonset to mount the Containerd socket from the host node to the Agent container and set the `DD_CRI_SOCKET_PATH` env var to the daemonset mountPath:
 
-```
+```yaml
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -28,10 +28,10 @@ spec:
     spec:
       containers:
         - name: datadog-agent
-          ...
+          # ...
           env:
             - name: DD_CRI_SOCKET_PATH
-              value: "/var/run/containerd/containerd.sock"
+              value: /var/run/containerd/containerd.sock
           volumeMounts:
             - name: containerdsocket
               mountPath: /var/run/containerd/containerd.sock
@@ -51,9 +51,7 @@ spec:
 
 ### Configuration
 
-1. Edit the `containerd.d/conf.yaml` file, in the `conf.d/` folder at the root of your
-   Agent's configuration directory to start collecting your Containerd performance data.
-   See the [sample containerd.d/conf.yaml][1] for all available configuration options.
+1. Edit the `containerd.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Containerd performance data. See the [sample containerd.d/conf.yaml][1] for all available configuration options.
 
 2. [Restart the Agent][2]
 

--- a/coredns/README.md
+++ b/coredns/README.md
@@ -1,6 +1,7 @@
 # CoreDNS Integration
 
 ## Overview
+
 Get metrics from CoreDNS in real time to visualize and monitor DNS failures and cache hits/misses.
 
 ## Setup
@@ -19,22 +20,20 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 Edit the `coredns.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2], to point to your server and port and set the masters to monitor. See the [sample coredns.d/conf.yaml][3] for all available configuration options.
 
-#### Containerized 
+#### Containerized
 
 For containerized environments, see the [Autodiscovery Integration Templates][7] for guidance on applying the parameters below.
 
-| Parameter            | Value                                                                                             |
-|----------------------|---------------------------------------------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `coredns`                                                                                        |
-| `<INIT_CONFIG>`      | blank or `{}`                                                                                     |
+| Parameter            | Value                                                                            |
+| -------------------- | -------------------------------------------------------------------------------- |
+| `<INTEGRATION_NAME>` | `coredns`                                                                        |
+| `<INIT_CONFIG>`      | blank or `{}`                                                                    |
 | `<INSTANCE_CONFIG>`  | `{"prometheus_url":"http://%%host%%:9153/metrics", "tags":["dns-pod:%%host%%"]}` |
-
 
 **Note:**
 
- * The `dns-pod` tag keeps track of the target DNS pod IP. The other tags are related to the dd-agent that is polling the information using the service discovery.
- * The service discovery annotations need to be done on the pod. In case of a deployment, add the annotations to the metadata of the template's specifications. Do not add it at the outer specification level.
-
+- The `dns-pod` tag keeps track of the target DNS pod IP. The other tags are related to the dd-agent that is polling the information using the service discovery.
+- The service discovery annotations need to be done on the pod. In case of a deployment, add the annotations to the metadata of the template's specifications. Do not add it at the outer specification level.
 
 ### Validation
 

--- a/couch/README.md
+++ b/couch/README.md
@@ -6,8 +6,8 @@
 
 Capture CouchDB data in Datadog to:
 
-* Visualize key CouchDB metrics.
-* Correlate CouchDB performance with the rest of your applications.
+- Visualize key CouchDB metrics.
+- Correlate CouchDB performance with the rest of your applications.
 
 For performance reasons, the CouchDB version you're using is cached, so you cannot monitor CouchDB instances with different versions with the same agent instance.
 
@@ -27,16 +27,15 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `couch.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3] to start collecting your CouchDB performance data. See the [sample couch.d/conf.yaml][4] for all available configuration options:
 
-      ```yaml
-        init_config:
+   ```yaml
+   init_config:
 
-        instances:
-
-            ## @param server - string - required
-            ## The Couch server's url.
-            #
-          - server: http://localhost:5984
-      ```
+   instances:
+     ## @param server - string - required
+     ## The Couch server's url.
+     #
+     - server: http://localhost:5984
+   ```
 
     **Note**: provide a `db_whitelist` and `db_blacklist` to control which databases the Agent should and should not collect metrics from.
 
@@ -44,24 +43,24 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 ##### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Add this configuration block to your `couch.d/conf.yaml` file to start collecting your CouchDB Logs:
 
-    ```yaml
-      logs:
-          - type: file
-            path: /var/log/couchdb/couch.log
-            source: couchdb
-            sourcecategory: database
-            service: couch
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/couchdb/couch.log
+       source: couchdb
+       sourcecategory: database
+       service: couch
+   ```
 
     Change the `path` and `service` parameter values and configure them for your environment. See the [sample couch.d/conf.yaml][4] for all available configuration options.
 
@@ -74,19 +73,19 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 ##### Metric collection
 
 | Parameter            | Value                                |
-|----------------------|--------------------------------------|
+| -------------------- | ------------------------------------ |
 | `<INTEGRATION_NAME>` | `couch`                              |
 | `<INIT_CONFIG>`      | blank or `{}`                        |
 | `<INSTANCE_CONFIG>`  | `{"server": "http://%%host%%:5984"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][7].
 
 | Parameter      | Value                                                |
-|----------------|------------------------------------------------------|
+| -------------- | ---------------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "couchdb", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
@@ -94,6 +93,7 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 [Run the Agent's status subcommand][8] and look for `couch` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][9] for a list of metrics provided by this integration.
@@ -108,11 +108,12 @@ The Couch check does not include any events.
 Returns `Critical` if the Agent cannot connect to CouchDB to collect metrics, otherwise returns `OK`.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][10].
 
 ## Further Reading
 
-* [Monitoring CouchDB performance with Datadog][11]
+- [Monitoring CouchDB performance with Datadog][11]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/couch/images/couchdb_dashboard.png
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/couchbase/README.md
+++ b/couchbase/README.md
@@ -6,11 +6,11 @@
 
 Identify busy buckets, track cache miss ratios, and more. This Agent check collects metrics like:
 
-* Hard disk and memory used by data
-* Current connections
-* Total objects
-* Operations per second
-* Disk write queue size
+- Hard disk and memory used by data
+- Current connections
+- Total objects
+- Operations per second
+- Disk write queue size
 
 And many more.
 
@@ -30,40 +30,39 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `couchbase.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][3] to start collecting your Couchbase data. See the [sample couchbase.d/conf.yaml][4] for all available configuration options.
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
-          ## @param server - string - required
-          ## The server's url.
-          #
-        - server: http://localhost:8091
-    ```
+   instances:
+     ## @param server - string - required
+     ## The server's url.
+     #
+     - server: http://localhost:8091
+   ```
 
 2. [Restart the Agent][5].
 
 #### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Add this configuration block to your `couchbase.d/conf.yaml` file to start collecting your Apache Logs:
 
-    ```yaml
-      logs:
-          - type: file
-            path: /var/log/couchdb/couch.log
-            source: couchdb
-            service: couchbase
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/couchdb/couch.log
+       source: couchdb
+       service: couchbase
+   ```
 
-    Change the `path` and `service` parameter values and configure them for your environment.
-    See the [sample couchbase.d/conf.yaml][4] for all available configuration options.
+    Change the `path` and `service` parameter values and configure them for your environment. See the [sample couchbase.d/conf.yaml][4] for all available configuration options.
 
 3. [Restart the Agent][5].
 
@@ -74,19 +73,19 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 ##### Metric collection
 
 | Parameter            | Value                                |
-|----------------------|--------------------------------------|
+| -------------------- | ------------------------------------ |
 | `<INTEGRATION_NAME>` | `couchbase`                          |
 | `<INIT_CONFIG>`      | blank or `{}`                        |
 | `<INSTANCE_CONFIG>`  | `{"server": "http://%%host%%:8091"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][7].
 
 | Parameter      | Value                                                  |
-|----------------|--------------------------------------------------------|
+| -------------- | ------------------------------------------------------ |
 | `<LOG_CONFIG>` | `{"source": "couchbase", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
@@ -94,6 +93,7 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 [Run the Agent's `status` subcommand][8] and look for `couchbase` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][9] for a list of metrics provided by this integration.
@@ -104,17 +104,17 @@ The Couchbase check emits an event to Datadog each time the cluster rebalances.
 
 ### Service Checks
 
-* `couchbase.can_connect`:
+- `couchbase.can_connect`:
 
 Returns `Critical` if the Agent cannot connect to Couchbase to collect metrics.
 
-* `couchbase.by_node.cluster_membership`:
+- `couchbase.by_node.cluster_membership`:
 
 Returns `Critical` if the node failed over.
 Returns `Warning` if the node is added to the cluster but is waiting for a rebalance.
 Returns `Ok` otherwise.
 
-* `couchbase.by_node.health_status`:
+- `couchbase.by_node.health_status`:
 
 Returns `Critical` if the node is unhealthy. Returns `Ok` otherwise.
 
@@ -124,7 +124,7 @@ Need help? Contact [Datadog support][10].
 
 ## Further Reading
 
-* [Monitor key Couchbase metrics][11].
+- [Monitor key Couchbase metrics][11].
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/couchbase/images/couchbase_graph.png
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/cri/README.md
+++ b/cri/README.md
@@ -20,7 +20,7 @@ If you are using the Agent in a container, setting the `DD_CRI_SOCKET_PATH` envi
 
 For example, to install the integration on Kubernetes, edit your daemonset to mount the CRI socket from the host node to the Agent container and set the `DD_CRI_SOCKET_PATH` env var to the daemonset mountPath:
 
-```
+```yaml
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -30,10 +30,10 @@ spec:
     spec:
       containers:
         - name: datadog-agent
-          ...
+          # ...
           env:
             - name: DD_CRI_SOCKET_PATH
-              value: "/var/run/crio/crio.sock"
+              value: /var/run/crio/crio.sock
           volumeMounts:
             - name: crisocket
               mountPath: /var/run/crio/crio.sock
@@ -53,9 +53,7 @@ spec:
 
 ### Configuration
 
-1. Edit the `cri.d/conf.yaml` file, in the `conf.d/` folder at the root of your
-   Agent's configuration directory to start collecting your crio performance data.
-   See the [sample cri.d/conf.yaml][1] for all available configuration options.
+1. Edit the `cri.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your crio performance data. See the [sample cri.d/conf.yaml][1] for all available configuration options.
 
 2. [Restart the Agent][2]
 

--- a/crio/README.md
+++ b/crio/README.md
@@ -12,9 +12,7 @@ The integration relies on the `--enable-metrics` option of CRI-O that is disable
 
 ### Configuration
 
-1. Edit the `crio.d/conf.yaml` file, in the `conf.d/` folder at the root of your
-   Agent's configuration directory to start collecting your CRI-O performance data.
-   See the [sample crio.d/conf.yaml][3] for all available configuration options.
+1. Edit the `crio.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your CRI-O performance data. See the [sample crio.d/conf.yaml][3] for all available configuration options.
 
 2. [Restart the Agent][4].
 

--- a/directory/README.md
+++ b/directory/README.md
@@ -1,12 +1,13 @@
 # Directory Check
+
 ## Overview
 
 Capture metrics from directories and files of your choosing. The Agent collects:
 
-  * Number of files
-  * File size
-  * Age of the last modification
-  * Age of the creation
+- Number of files
+- File size
+- Age of the last modification
+- Age of the creation
 
 ## Setup
 
@@ -18,17 +19,16 @@ The Directory check is included in the [Datadog Agent][1] package, so you don't 
 
 1. Edit the `directory.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2] to start collecting Directory performance data. See the [sample directory.d/conf.yaml][3] for all available configuration options.
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
-        - directory: "/path/to/directory" # the only required option
-          name: "my_monitored_dir"        # What the Agent will tag this directory's metrics with. Defaults to "directory"
-          pattern: "*.log"                # defaults to "*" (all files)
-          recursive: True                 # default False
-          countonly: False                # set to True to only collect the number of files matching 'pattern'. Useful for very large directories.
-          ignore_missing: False           # set to True to not raise exceptions on missing or inaccessible directories
-    ```
+   instances:
+     ## @param directory - string - required
+     ## The directory to monitor. On windows, please make sure you escape back-slashes otherwise the YAML
+     ## parser fails (eg. - directory: "C:\\Users\\foo\\Downloads").
+     #
+     - directory: "<DIRECTORY_PATH>"
+   ```
 
     Ensure that the user running the Agent process (usually `datadog-agent`) has read access to the directories, subdirectories, and files you configure.
 
@@ -37,6 +37,7 @@ The Directory check is included in the [Datadog Agent][1] package, so you don't 
 2. [Restart the Agent][4].
 
 #### Metrics collection
+
 The Directory check can potentially emit [custom metrics][5], which may impact your [billing][6].
 
 ### Validation
@@ -44,17 +45,21 @@ The Directory check can potentially emit [custom metrics][5], which may impact y
 [Run the Agent's status subcommand][7] and look for `directory` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][8] for a list of metrics provided by this integration.
 
 ### Events
+
 The Directory check does not include any events.
 
 ### Service Checks
+
 The Directory check does not include any service checks.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][9].
 
 [1]: https://app.datadoghq.com/account/settings#agent

--- a/disk/README.md
+++ b/disk/README.md
@@ -20,18 +20,22 @@ If you want to configure the check with custom options, Edit the `disk.d/conf.ya
 [Run the Agent's `status` subcommand][4] and look for `disk` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][5] for a list of metrics provided by this integration.
 
 ### Events
+
 The Disk check does not include any events.
 
 ### Service Checks
+
 **`disk.read_write`**:
 Returns `CRITICAL` if filesystem is in read-only mode.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][6].
 
 [1]: https://app.datadoghq.com/account/settings#agent

--- a/dns_check/README.md
+++ b/dns_check/README.md
@@ -15,19 +15,23 @@ Though many metrics-oriented checks are best run on the same host(s) as the moni
 ### Configuration
 
 1. Edit the `dns_check.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2] to start collecting your DNS data.
-    See the [sample dns_check.d/conf.yaml][3] for all available configuration options:
+   See the [sample dns_check.d/conf.yaml][3] for all available configuration options:
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
-        - name: Example (com)
-          # nameserver: 8.8.8.8   # The nameserver to query, this must be an IP address
-          hostname: example.com # the record to fetch
-          # record_type: AAAA   # default is A
-        - name: Example (org)
-          hostname: example.org
-    ```
+   instances:
+     ## @param name - string - required
+     ## Name of your DNS check instance.
+     ## To create multiple DNS checks, create multiple instances with unique names.
+     #
+     - name: '<INSTANCE_NAME>'
+
+       ## @param hostname - string - required
+       ## Hostname to resolve.
+       #
+       hostname: '<HOSTNAME>'
+   ```
 
     If you omit the `nameserver` option, the check uses whichever nameserver is configured in local network settings.
 
@@ -44,13 +48,15 @@ Though many metrics-oriented checks are best run on the same host(s) as the moni
 See [metadata.csv][6] for a list of metrics provided by this integration.
 
 ### Events
+
 The DNS check does not include any events.
 
 ### Service Checks
+
 This agent check tags all service checks it collects with:
 
-  * `nameserver:<nameserver_in_yaml>`
-  * `resolved_hostname:<hostname_in_yaml>`
+- `nameserver:<nameserver_in_yaml>`
+- `resolved_hostname:<hostname_in_yaml>`
 
 `dns.can_resolve`:
 
@@ -59,6 +65,7 @@ Returns CRITICAL if the Agent fails to resolve the request, otherwise returns UP
 Tagged by `hostname` and `record_type`.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][7].
 
 [1]: https://app.datadoghq.com/account/settings#agent

--- a/docker_daemon/README.md
+++ b/docker_daemon/README.md
@@ -12,10 +12,11 @@
 
 Configure this Agent check to get metrics from the Docker_daemon service in real time to:
 
-* Visualize and monitor Docker_daemon states.
-* Be notified about Docker_daemon failovers and events.
+- Visualize and monitor Docker_daemon states.
+- Be notified about Docker_daemon failovers and events.
 
 ## Setup
+
 ### Installation
 
 To collect Docker metrics about all your containers, run **one** Datadog Agent on every host. There are two ways to run the Agent: directly on each host, or within a [docker-dd-agent container][2] (recommended).
@@ -30,33 +31,36 @@ For either option, your hosts need cgroup memory management enabled for the Dock
 4. Add the Agent user to the Docker group: `usermod -a -G docker dd-agent`
 5. Create a `docker_daemon.yaml` file by copying [the example file in the agent conf.d directory][6]. If you have a standard install of Docker on your host, there shouldn't be anything you need to change to get the integration to work.
 6. To enable other integrations, use `docker ps` to identify the ports used by the corresponding applications.
-    ![Docker ps command][7]
+
+![Docker ps command][7]
 
 #### Container Installation
 
 1. Ensure Docker is running on the host.
 2. As per [the Docker container installation instructions][8], run:
 
-        docker run -d --name dd-agent \
-          -v /var/run/docker.sock:/var/run/docker.sock:ro \
-          -v /proc/:/host/proc/:ro \
-          -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-          -e API_KEY={YOUR_DD_API_KEY} \
-          datadog/docker-dd-agent:latest
+  ```shell
+  docker run -d --name dd-agent \
+    -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    -v /proc/:/host/proc/:ro \
+    -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
+    -e API_KEY={YOUR_DD_API_KEY} \
+    datadog/docker-dd-agent:latest
+  ```
 
 In the command above, you are able to pass your API key to the Datadog Agent using Docker's `-e` environment variable flag. Other variables include:
 
-| **Variable**                                                                                      | **Description**                                                                                                                                                                                                                  |
-|---------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| API_KEY                                                                                           | Sets your Datadog API key.                                                                                                                                                                                                       |
-| DD_HOSTNAME                                                                                       | Sets the hostname in the Agent container's `datadog.conf` file. If this variable is not set, the Agent container defaults to using the `Name` field (as reported by the `docker info` command) as the Agent container hostname.  |
-| DD_URL                                                                                            | Sets the Datadog intake server URL where the Agent sends data. This is useful when [using the Agent as a proxy][9].                                                                                                              |
-| LOG_LEVEL                                                                                         | Sets logging verbosity (CRITICAL, ERROR, WARNING, INFO, DEBUG). For example, `-e LOG_LEVEL=DEBUG` sets logging to debug mode.                                                                                                    |
-| TAGS                                                                                              | Sets host tags as a comma delimited string. Both simple tags and key-value tags are available, for example: `-e TAGS="simple-tag, tag-key:tag-value"`.                                                                           |
-| EC2_TAGS                                                                                          | Enabling this feature allows the agent to query and capture custom tags set using the EC2 API during startup. To enable, use `-e EC2_TAGS=yes`. Note that this feature requires an IAM role associated with the instance.        |
+| **Variable**                                                                                      | **Description**                                                                                                                                                                                                                   |
+| ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| API_KEY                                                                                           | Sets your Datadog API key.                                                                                                                                                                                                        |
+| DD_HOSTNAME                                                                                       | Sets the hostname in the Agent container's `datadog.conf` file. If this variable is not set, the Agent container defaults to using the `Name` field (as reported by the `docker info` command) as the Agent container hostname.   |
+| DD_URL                                                                                            | Sets the Datadog intake server URL where the Agent sends data. This is useful when [using the Agent as a proxy][9].                                                                                                               |
+| LOG_LEVEL                                                                                         | Sets logging verbosity (CRITICAL, ERROR, WARNING, INFO, DEBUG). For example, `-e LOG_LEVEL=DEBUG` sets logging to debug mode.                                                                                                     |
+| TAGS                                                                                              | Sets host tags as a comma delimited string. Both simple tags and key-value tags are available, for example: `-e TAGS="simple-tag, tag-key:tag-value"`.                                                                            |
+| EC2_TAGS                                                                                          | Enabling this feature allows the agent to query and capture custom tags set using the EC2 API during startup. To enable, use `-e EC2_TAGS=yes`. Note that this feature requires an IAM role associated with the instance.         |
 | NON_LOCAL_TRAFFIC                                                                                 | Enabling this feature allows StatsD reporting from any external IP. To enable, use `-e NON_LOCAL_TRAFFIC=yes`. This is used to report metrics from other containers or systems. See [network configuration][10] for more details. |
-| PROXY_HOST, PROXY_PORT, PROXY_USER, PROXY_PASSWORD                                                | Sets proxy configuration details. **Note**: `PROXY_PASSWORD` is required for passing in an authentication password and cannot be renamed. For more information, see the [Agent proxy documentation][11].                                                                                                                                  |
-| SD_BACKEND, SD_CONFIG_BACKEND, SD_BACKEND_HOST, SD_BACKEND_PORT, SD_TEMPLATE_DIR, SD_CONSUL_TOKEN | Enables and configures Autodiscovery. For more information, see the [Autodiscovery guide][12].                                                                                                                                   |
+| PROXY_HOST, PROXY_PORT, PROXY_USER, PROXY_PASSWORD                                                | Sets proxy configuration details. **Note**: `PROXY_PASSWORD` is required for passing in an authentication password and cannot be renamed. For more information, see the [Agent proxy documentation][11].                          |
+| SD_BACKEND, SD_CONFIG_BACKEND, SD_BACKEND_HOST, SD_BACKEND_PORT, SD_TEMPLATE_DIR, SD_CONSUL_TOKEN | Enables and configures Autodiscovery. For more information, see the [Autodiscovery guide][12].                                                                                                                                    |
 
 **Note**: Add `--restart=unless-stopped` if you want your agent to be resistant to restarts.
 
@@ -64,7 +68,7 @@ In the command above, you are able to pass your API key to the Datadog Agent usi
 
 To run the Datadog Agent container on Amazon Linux, make this change to the `cgroup` volume mount location:
 
-```
+```shell
 docker run -d --name dd-agent \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
   -v /proc/:/host/proc/:ro \
@@ -79,7 +83,7 @@ The standard Docker image is based on Debian Linux, but as of Datadog Agent v5.7
 
 To use the Alpine Linux image, append `-alpine` to the version tag. For example:
 
-```
+```shell
 docker run -d --name dd-agent \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
   -v /proc/:/host/proc/:ro \
@@ -89,6 +93,7 @@ docker run -d --name dd-agent \
 ```
 
 #### Image versioning
+
 Starting with version 5.5.0 of the Datadog Agent, the Docker image follows a new versioning pattern. This allows us to release changes to the Docker image of the Datadog Agent but with the same version of the Agent.
 
 The Docker image version has the following pattern: **X.Y.Z** where **X** is the major version of the Docker Image, **Y** is the minor version, **Z** represents the Agent version.
@@ -107,41 +112,44 @@ For more information about building custom Docker containers with the Datadog Ag
 
 The latest Docker check is named `docker` and written in Go to take advantage of the new internal architecture. Starting from version 6.0, the Agent won't load the `docker_daemon` check anymore, even if it is still available and maintained for Agent v5. All features are ported on version >6.0 , except the following deprecations:
 
-  * The `url`, `api_version` and `tags*` options are deprecated, direct use of the [standard Docker environment variables][15] is encouraged.
-  * The `ecs_tags`, `performance_tags` and `container_tags` options are deprecated. Every relevant tag is now collected by default.
-  * The `collect_container_count` option to enable the `docker.container.count` metric is not supported. `docker.containers.running` and `.stopped` should be used.
+- The `url`, `api_version` and `tags*` options are deprecated, direct use of the [standard Docker environment variables][15] is encouraged.
+- The `ecs_tags`, `performance_tags` and `container_tags` options are deprecated. Every relevant tag is now collected by default.
+- The `collect_container_count` option to enable the `docker.container.count` metric is not supported. `docker.containers.running` and `.stopped` should be used.
 
 Some options have moved from `docker_daemon.yaml` to the main `datadog.yaml`:
 
-  * `collect_labels_as_tags` has been renamed `docker_labels_as_tags` and now supports high cardinality tags, see the details in `datadog.yaml.example`.
-  * `exclude` and `include` lists have been renamed `ac_include` and `ac_exclude`. To make filtering consistent across all components of the Agent, filtering on arbitrary tags has been dropped. The only supported filtering tags are `image` (image name) and `name` (container name). Regexp filtering is still available, see `datadog.yaml.example` for examples.
-  * The `docker_root` option has been split in two options `container_cgroup_root` and `container_proc_root`.
-  * `exclude_pause_container` has been added to exclude paused containers on Kubernetes and Openshift (defaults to true). This avoids removing them from the exclude list by error.
+- `collect_labels_as_tags` has been renamed `docker_labels_as_tags` and now supports high cardinality tags, see the details in `datadog.yaml.example`.
+- `exclude` and `include` lists have been renamed `ac_include` and `ac_exclude`. To make filtering consistent across all components of the Agent, filtering on arbitrary tags has been dropped. The only supported filtering tags are `image` (image name) and `name` (container name). Regexp filtering is still available, see `datadog.yaml.example` for examples.
+- The `docker_root` option has been split in two options `container_cgroup_root` and `container_proc_root`.
+- `exclude_pause_container` has been added to exclude paused containers on Kubernetes and Openshift (defaults to true). This avoids removing them from the exclude list by error.
 
 Additional changes:
 
-  * The `TAGS` environment variable was renamed to `DD_TAGS`.
-  * The Docker Hub repository has changed from [datadog/docker-dd-agent][16] to [datadog/agent][17].
+- The `TAGS` environment variable was renamed to `DD_TAGS`.
+- The Docker Hub repository has changed from [datadog/docker-dd-agent][16] to [datadog/agent][17].
 
 The [`import`][18] command converts the old `docker_daemon.yaml` to the new `docker.yaml`. The command also moves needed settings from `docker_daemon.yaml` to `datadog.yaml`.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][19] for a list of metrics provided by this integration.
 
 ### Events
+
 The Docker integration produces the following events:
 
-* Delete Image
-* Die
-* Error
-* Fail
-* Kill
-* Out of memory (oom)
-* Pause
-* Restart container
-* Restart Daemon
-* Update
+- Delete Image
+- Die
+- Error
+- Fail
+- Kill
+- Out of memory (oom)
+- Pause
+- Restart container
+- Restart Daemon
+- Update
 
 ### Service Checks
 
@@ -157,13 +165,15 @@ Returns `CRITICAL` if a container exited with a non-zero exit code, otherwise re
 **Note**: To use `docker.exit`, add `collect_exit_code: true` in your [Docker YAML file][20] and restart the Agent.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][21].
 
 ## Further Reading
+
 ### Knowledge Base
 
-* [Compose and the Datadog Agent][22]
-* [DogStatsD and Docker][23]
+- [Compose and the Datadog Agent][22]
+- [DogStatsD and Docker][23]
 
 ### Datadog Blog
 
@@ -171,13 +181,12 @@ Learn more about how to monitor Docker performance metrics with [our series of p
 
 We've also written several other in-depth blog posts to help you get the most out of Datadog and Docker:
 
-* [How to Monitor Docker Resource Metrics][25]
-* [How to Collect Docker Metrics][26]
-* [8 Surprising Facts about Real Docker Adoption][27]
-* [Monitor Docker on AWS ECS][28]
-* [Dockerize Datadog][29]
-* [Monitor Docker with Datadog][30]
-
+- [How to Monitor Docker Resource Metrics][25]
+- [How to Collect Docker Metrics][26]
+- [8 Surprising Facts about Real Docker Adoption][27]
+- [Monitor Docker on AWS ECS][28]
+- [Dockerize Datadog][29]
+- [Monitor Docker with Datadog][30]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/docker_daemon/images/docker.png
 [2]: https://github.com/DataDog/docker-dd-agent

--- a/dotnetclr/README.md
+++ b/dotnetclr/README.md
@@ -4,10 +4,11 @@
 
 Get metrics from the .NET CLR service in real time to:
 
-* Visualize and monitor .NET CLR states.
-* Be notified about .NET CLR failovers and events.
+- Visualize and monitor .NET CLR states.
+- Be notified about .NET CLR failovers and events.
 
 ## Setup
+
 ### Installation
 
 The .NET CLR check is included in the [Datadog Agent][2] package. No additional installation is needed on your server.
@@ -15,7 +16,6 @@ The .NET CLR check is included in the [Datadog Agent][2] package. No additional 
 ### Configuration
 
 1. Edit the `dotnetclr.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3] to start collecting your .NET CLR performance data. See the [sample dotnetclr.d/conf.yaml][4] for all available configuration options.
-
 2. [Restart the Agent][5].
 
 ## Validation
@@ -23,6 +23,7 @@ The .NET CLR check is included in the [Datadog Agent][2] package. No additional 
 [Run the Agent's status subcommand][6] and look for `dotnetclr` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][7] for a list of all metrics provided by this integration.
@@ -36,6 +37,7 @@ The .NET CLR check does not include any service checks.
 The .NET CLR check does not include any events.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][8].
 
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/druid/README.md
+++ b/druid/README.md
@@ -23,7 +23,6 @@ Both steps below are needed for Druid integration to work properly. Before you b
 Configure the Druid check included in the [Datadog Agent][5] package to collect health metrics and service checks.
 
 1. Edit the `druid.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your druid service checks. See the [sample druid.d/conf.yaml][6] for all available configuration options.
-
 2. [Restart the Agent][7].
 
 #### Step 2: Connect Druid to DogStatsD (included in the Datadog Agent) by using the extension `statsd-emitter` to collect metrics
@@ -32,39 +31,39 @@ Step to configure `statsd-emitter` extension to collect the majority of [Druid m
 
 1. Install the Druid extension [`statsd-emitter`][8].
 
-    ```shell
-    $ java \
-      -cp "lib/*" \
-      -Ddruid.extensions.directory="./extensions" \
-      -Ddruid.extensions.hadoopDependenciesDir="hadoop-dependencies" \
-      org.apache.druid.cli.Main tools pull-deps \
-      --no-default-hadoop \
-      -c "org.apache.druid.extensions.contrib:statsd-emitter:0.15.0-incubating"
-    ```
+   ```shell
+   $ java \
+     -cp "lib/*" \
+     -Ddruid.extensions.directory="./extensions" \
+     -Ddruid.extensions.hadoopDependenciesDir="hadoop-dependencies" \
+     org.apache.druid.cli.Main tools pull-deps \
+     --no-default-hadoop \
+     -c "org.apache.druid.extensions.contrib:statsd-emitter:0.15.0-incubating"
+   ```
 
     More info about this step can be found on the [official guide for loading Druid extensions][9]
 
 2. Update Druid java properties by adding the following configs:
 
-    ```conf
-    # Add `statsd-emitter` to the extensions list to be loaded
-    druid.extensions.loadList=[..., "statsd-emitter"]
+   ```conf
+   # Add `statsd-emitter` to the extensions list to be loaded
+   druid.extensions.loadList=[..., "statsd-emitter"]
 
-    # By default druid emission period is 1 minute (PT1M).
-    # We recommend using 15 seconds instead:
-    druid.monitoring.emissionPeriod=PT15S
+   # By default druid emission period is 1 minute (PT1M).
+   # We recommend using 15 seconds instead:
+   druid.monitoring.emissionPeriod=PT15S
 
-    # Use `statsd-emitter` extension as metric emitter
-    druid.emitter=statsd
+   # Use `statsd-emitter` extension as metric emitter
+   druid.emitter=statsd
 
-    # Configure `statsd-emitter` endpoint
-    druid.emitter.statsd.hostname=127.0.0.1
-    druid.emitter.statsd.port:8125
+   # Configure `statsd-emitter` endpoint
+   druid.emitter.statsd.hostname=127.0.0.1
+   druid.emitter.statsd.port:8125
 
-    # Configure `statsd-emitter` to use dogstatsd format. Must be set to true, otherwise tags are not reported correctly to Datadog.
-    druid.emitter.statsd.dogstatsd=true
-    druid.emitter.statsd.dogstatsdServiceAsTag=true
-    ```
+   # Configure `statsd-emitter` to use dogstatsd format. Must be set to true, otherwise tags are not reported correctly to Datadog.
+   druid.emitter.statsd.dogstatsd=true
+   druid.emitter.statsd.dogstatsdServiceAsTag=true
+   ```
 
 3. Restart Druid to start sending your Druid metrics to the Agent through DogStatsD.
 
@@ -74,27 +73,27 @@ Use the default configuration of your `druid.d/conf.yaml` file to activate the c
 
 #### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your datadog.yaml file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Uncomment and edit this configuration block at the bottom of your `druid.d/conf.yaml`:
 
-    ```yaml
-      logs:
-        - type: file
-          path: <PATH_TO_DRUID_DIR>/var/sv/*.log
-          source: druid
-          service: <SERVICE_NAME>
-          log_processing_rules:
-            - type: multi_line
-              name: new_log_start_with_date
-              pattern: \d{4}\-\d{2}\-\d{2}
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: '<PATH_TO_DRUID_DIR>/var/sv/*.log'
+       source: druid
+       service: '<SERVICE_NAME>'
+       log_processing_rules:
+         - type: multi_line
+           name: new_log_start_with_date
+           pattern: \d{4}\-\d{2}\-\d{2}
+   ```
 
     Change the `path` and `service` parameter values and configure them for your environment.
 

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -4,8 +4,8 @@
 
 Get metrics from all your containers running in ECS Fargate:
 
-* CPU/Memory usage & limit metrics
-* Monitor your applications running on Fargate via Datadog integrations or custom metrics.
+- CPU/Memory usage & limit metrics
+- Monitor your applications running on Fargate via Datadog integrations or custom metrics.
 
 The Datadog Agent retrieves metrics for the task definition's containers via the ECS Task Metadata endpoint. According to the [ECS Documentation][1] on that endpoint:
 
@@ -48,7 +48,7 @@ The instructions below show you how to configure the task using the [AWS CLI too
 9. For **Image** enter `datadog/agent:latest`.
 10. For **Memory Limits** enter `256` soft limit.
 11. Scroll down to the **Advanced container configuration** section and enter `10` in **CPU units**.
-12. For **Env Variables**, add the **Key** `DD_API_KEY` and enter your [Datadog API Key][5] as the value. *If you feel more comfortable storing secrets in s3, refer to the [ECS Configuration guide][6].*
+12. For **Env Variables**, add the **Key** `DD_API_KEY` and enter your [Datadog API Key][5] as the value. _If you feel more comfortable storing secrets in s3, refer to the [ECS Configuration guide][6]._
 13. Add another environment variable using the **Key** `ECS_FARGATE` and the value `true`. Click **Add** to add the container.
 14. (Optional) If you use datadog.eu, add another environment variable using the **Key** `DD_SITE` and the value `datadoghq.eu`.
 15. Add your other containers such as your app. For details on collecting integration metrics, see [Integration Setup for ECS Fargate][7].
@@ -70,7 +70,7 @@ aws ecs register-task-definition --cli-input-json file://<PATH_TO_FILE>/datadog-
 Add the following permissions to your [Datadog IAM policy][9] to collect ECS Fargate metrics. For more information on ECS policies, [review the documentation on the AWS website][10].
 
 | AWS Permission                   | Description                                                       |
-|----------------------------------|-------------------------------------------------------------------|
+| -------------------------------- | ----------------------------------------------------------------- |
 | `ecs:ListClusters`               | List available clusters.                                          |
 | `ecs:ListContainerInstances`     | List instances of a cluster.                                      |
 | `ecs:DescribeContainerInstances` | Describe instances to add metrics on resources and tasks running. |
@@ -162,6 +162,7 @@ Example for the Agent container:
 In addition to the metrics collected by the Datadog Agent, Datadog has a CloudWatch based ECS integration. This integration collects the [Amazon ECS CloudWatch Metrics][17].
 
 As noted there, Fargate tasks also report metrics in this way:
+
 > The metrics made available will depend on the launch type of the tasks and services in your clusters. If you are using the Fargate launch type for your services then CPU and memory utilization metrics are provided to assist in the monitoring of your services.
 
 Since this method does not use the Datadog Agent, you need to configure our AWS integration by checking **ECS** on the integration tile. Then, our application pulls these CloudWatch metrics (namespaced `aws.ecs.*` in Datadog) on your behalf. See the [Data Collected][18] section of the documentation.
@@ -180,58 +181,58 @@ Configure the AWS FireLens integration built on Datadog's Fluent Bit output plug
 
 1. Enable Fluent Bit in the FireLens log router container in your Fargate task. For more information about enabling FireLens, see the dedicated [AWS Firelens docs][20]. For more information about Fargate container definitons, see the [AWS docs on Container Definitions][21]. AWS reccomends that you use [the regional Docker image][22]. Here is an example snippet of a task definition where the Fluent Bit image is configured:
 
-    ```json
-    {
-      "essential": true,
-      "image": "amazon/aws-for-fluent-bit:latest",
-      "name": "log_router",
-      "firelensConfiguration": {
-        "type": "fluentbit",
-        "options": {"enable-ecs-log-metadata": "true"}
-      }
-    }
-    ```
+   ```json
+   {
+     "essential": true,
+     "image": "amazon/aws-for-fluent-bit:latest",
+     "name": "log_router",
+     "firelensConfiguration": {
+       "type": "fluentbit",
+       "options": { "enable-ecs-log-metadata": "true" }
+     }
+   }
+   ```
 
     If your containers are publishing serialized JSON logs over stdout, you should use this [extra firelens configuration][23] to get them correctly parsed within Datadog:
 
-    ```json
-    {
-      "essential": true,
-      "image": "amazon/aws-for-fluent-bit:latest",
-      "name": "log_router",
-      "firelensConfiguration": {
-        "type": "fluentbit",
-        "options": {
-          "enable-ecs-log-metadata": "true",
-          "config-file-type": "file",
-          "config-file-value": "/fluent-bit/configs/parse-json.conf"
-        }
-      }
-    }
-    ```
+   ```json
+   {
+     "essential": true,
+     "image": "amazon/aws-for-fluent-bit:latest",
+     "name": "log_router",
+     "firelensConfiguration": {
+       "type": "fluentbit",
+       "options": {
+         "enable-ecs-log-metadata": "true",
+         "config-file-type": "file",
+         "config-file-value": "/fluent-bit/configs/parse-json.conf"
+       }
+     }
+   }
+   ```
 
     This converts serialized JSON from the `log:` field into top-level fields. See the AWS sample [Parsing container stdout logs that are serialized JSON][24] for more details.
 
 2. Next, in the same Fargate task, define a log configuration with AWS FireLens as the log driver, and with data being output to Fluent Bit. Here is an example snippet of a task definition where the FireLens is the log driver, and it is outputting data to Fluent Bit:
 
-    ```json
-    {
-      "logConfiguration": {
-        "logDriver": "awsfirelens",
-        "options": {
-          "Name": "datadog",
-          "apikey": "<DATADOG_API_KEY>",
-          "Host": "http-intake.logs.datadoghq.com",
-          "dd_service": "firelens-test",
-          "dd_source": "redis",
-          "dd_message_key": "log",
-          "dd_tags": "project:fluentbit",
-          "TLS": "on",
-          "provider": "ecs"
-        }
-      }
-    }
-    ```
+   ```json
+   {
+     "logConfiguration": {
+       "logDriver": "awsfirelens",
+       "options": {
+         "Name": "datadog",
+         "apikey": "<DATADOG_API_KEY>",
+         "Host": "http-intake.logs.datadoghq.com",
+         "dd_service": "firelens-test",
+         "dd_source": "redis",
+         "dd_message_key": "log",
+         "dd_tags": "project:fluentbit",
+         "TLS": "on",
+         "provider": "ecs"
+       }
+     }
+   }
+   ```
 
     **Note**: If your organization is in Datadog EU site, use `http-intake.logs.datadoghq.eu` for the `Host` option instead. The full list of available parameters is described in the [Datadog Fluentbit documentation][25].
 
@@ -245,22 +246,20 @@ Monitor Fargate logs by using the `awslogs` log driver and a Lambda function to 
 
 2. Fargate task definitions only support the awslogs log driver for the log configuration. This configures your Fargate tasks to send log information to Amazon CloudWatch Logs. The following shows a snippet of a task definition where the awslogs log driver is configured:
 
-    ```json
-    {
-      "logConfiguration": {
-        "logDriver": "awslogs",
-        "options": {
-          "awslogs-group": "/ecs/fargate-task-definition",
-          "awslogs-region": "us-east-1",
-          "awslogs-stream-prefix": "ecs"
-        }
-      }
-    }
-    ```
+   ```json
+   {
+     "logConfiguration": {
+       "logDriver": "awslogs",
+       "options": {
+         "awslogs-group": "/ecs/fargate-task-definition",
+         "awslogs-region": "us-east-1",
+         "awslogs-stream-prefix": "ecs"
+       }
+     }
+   }
+   ```
 
-    For more information about using the awslogs log driver in your task definitions to send container logs to CloudWatch Logs, see [Using the awslogs Log Driver][30].
-
-    This driver collects logs generated by the container and sends them to CloudWatch directly.
+    For more information about using the awslogs log driver in your task definitions to send container logs to CloudWatch Logs, see [Using the awslogs Log Driver][30]. This driver collects logs generated by the container and sends them to CloudWatch directly.
 
 3. Finally, use a [Lambda function][31] to collect logs from CloudWatch and send them to Datadog.
 
@@ -293,9 +292,9 @@ Need help? Contact [Datadog support][19].
 
 ## Further Reading
 
-* Blog post: [Monitor AWS Fargate applications with Datadog][34]
-* FAQ: [Integration Setup for ECS Fargate][7]
-* Blog post: [Monitor your Fargate container logs with FireLens and Datadog][24]
+- Blog post: [Monitor AWS Fargate applications with Datadog][34]
+- FAQ: [Integration Setup for ECS Fargate][7]
+- Blog post: [Monitor your Fargate container logs with FireLens and Datadog][24]
 
 [1]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html
 [2]: https://docs.docker.com/engine/api/v1.30/#operation/ContainerStats

--- a/eks_fargate/README.md
+++ b/eks_fargate/README.md
@@ -10,10 +10,10 @@ These steps cover the setup of the Datadog Agent v7.17+ in a container within Am
 
 AWS Fargate pods are not physical pod, which means they exclude [host-based system-checks][2], like CPU, memory, etc. In order to collect data from your AWS Fargate pods, you must run the Agent as a sidecar of your application pod with custom RBAC, which enables these features:
 
-* Kubernetes metrics collection from the pod running your application containers and the Agent
-* [Autodiscovery][3]
-* Configuration of custom Agent Checks to target containers in the same pod
-* APM and DogStatsD for containers in the same pod
+- Kubernetes metrics collection from the pod running your application containers and the Agent
+- [Autodiscovery][3]
+- Configuration of custom Agent Checks to target containers in the same pod
+- APM and DogStatsD for containers in the same pod
 
 ### EC2 Node
 
@@ -23,10 +23,10 @@ If you don't specify through [AWS Fargate Profile][4] that your pods should run 
 
 To get the best observability coverage monitoring workloads in AWS EKS Fargate, install the Datadog integrations for:
 
-* [Kubernetes][8]
-* [AWS][9]
-* [EKS][10]
-* [EC2][11] (if you are running an EC2-type node)
+- [Kubernetes][8]
+- [AWS][9]
+- [EKS][10]
+- [EC2][11] (if you are running an EC2-type node)
 
 Also, set up integrations for any other AWS services you are running with EKS (for example, [ELB][12]).
 
@@ -40,9 +40,9 @@ If the Agent is running as a sidecar, it can communicate only with containers on
 
 To collect data from your applications running in AWS EKS Fargate over a Fargate node, follow these setup steps:
 
-* [Set up AWS EKS Fargate RBAC rules](#aws-eks-fargate-rbac).
-* [Deploy the Agent as a sidecar](#running-the-agent-as-a-side-car).
-* Set up Datadog [metrics](#metrics-collection), [events](#events-collection), and [traces](#traces-collection) collection.
+- [Set up AWS EKS Fargate RBAC rules](#aws-eks-fargate-rbac).
+- [Deploy the Agent as a sidecar](#running-the-agent-as-a-side-car).
+- Set up Datadog [metrics](#metrics-collection), [events](#events-collection), and [traces](#traces-collection) collection.
 
 #### AWS EKS Fargate RBAC
 

--- a/eks_fargate/README.md
+++ b/eks_fargate/README.md
@@ -8,7 +8,7 @@ Amazon EKS on AWS Fargate is a managed Kubernetes service that automates certain
 
 These steps cover the setup of the Datadog Agent v7.17+ in a container within Amazon EKS on AWS Fargate. Refer to the [Datadog-Amazon EKS integration documentation][1] if you are not using AWS Fargate.
 
-AWS Fargate pods are not physical pod, which means they exclude [host-based system-checks][2], like CPU, memory, etc. In order to collect data from your AWS Fargate pods, you must run the Agent as a sidecar of your application pod with custom RBAC, which enables these features:
+AWS Fargate pods are not physical pods, which means they exclude [host-based system-checks][2], like CPU, memory, etc. In order to collect data from your AWS Fargate pods, you must run the Agent as a sidecar of your application pod with custom RBAC, which enables these features:
 
 - Kubernetes metrics collection from the pod running your application containers and the Agent
 - [Autodiscovery][3]


### PR DESCRIPTION
### What does this PR do?

Follow up on:
* https://github.com/DataDog/integrations-core/pull/5663
* https://github.com/DataDog/integrations-core/pull/5662

This PR lints markdown file to avoid layout issues moving forward with the public doc. I manually checked the layout for all of those integrations.

Change from this lint:

- Bullet list are defined with `-`
- Italic is now defined with `_<TEXT>_`
- Fixes table layout
- Lint code examples displayed
- Each code example has a language assigned, and the default is `text`
- There should be always an empty line before/after a header
- **Available for Agent >6.0** has been transformed into _Available for Agent versions >6.0_

### Motivation
Better doc for a better world
