### PR TITLE
6. Linting integration README

### DIFF
--- a/openldap/README.md
+++ b/openldap/README.md
@@ -5,6 +5,7 @@
 Use the OpenLDAP integration to get metrics from the `cn=Monitor` backend of your OpenLDAP servers.
 
 ## Setup
+
 ### Installation
 
 The OpenLDAP integration is packaged with the Agent. To start gathering your OpenLDAP metrics, you need to:
@@ -20,48 +21,48 @@ If the `cn=Monitor` backend is not configured on your server, follow these steps
 
 1. Check if monitoring is enabled on your installation
 
-    ```
-      sudo ldapsearch -Y EXTERNAL -H ldapi:/// -b cn=module{0},cn=config
-    ```
+   ```shell
+    sudo ldapsearch -Y EXTERNAL -H ldapi:/// -b cn=module{0},cn=config
+   ```
 
-    If you see a line with `olcModuleLoad: back_monitor.la`, monitoring is already enabled, go to step 3.
+   If you see a line with `olcModuleLoad: back_monitor.la`, monitoring is already enabled, go to step 3.
 
 2. Enable monitoring on your server
 
-    ```
-        cat <<EOF | sudo ldapmodify -Y EXTERNAL -H ldapi:///
-        dn: cn=module{0},cn=config
-        changetype: modify
-        add: olcModuleLoad
-        olcModuleLoad: back_monitor.la
-        EOF
-    ```
+   ```text
+       cat <<EOF | sudo ldapmodify -Y EXTERNAL -H ldapi:///
+       dn: cn=module{0},cn=config
+       changetype: modify
+       add: olcModuleLoad
+       olcModuleLoad: back_monitor.la
+       EOF
+   ```
 
 3. Create an encrypted password with `slappasswd`
 4. Add a new user:
 
-    ```
-        cat <<EOF | ldapadd -H ldapi:/// -D <YOUR BIND DN HERE> -w <YOUR PASSWORD HERE>
-        dn: <USER_DISTINGUISHED_NAME>
-        objectClass: simpleSecurityObject
-        objectClass: organizationalRole
-        cn: <COMMON_NAME_OF_THE_NEW_USER>
-        description: LDAP monitor
-        userPassword:<PASSWORD>
-        EOF
-    ```
+   ```text
+       cat <<EOF | ldapadd -H ldapi:/// -D <YOUR BIND DN HERE> -w <YOUR PASSWORD HERE>
+       dn: <USER_DISTINGUISHED_NAME>
+       objectClass: simpleSecurityObject
+       objectClass: organizationalRole
+       cn: <COMMON_NAME_OF_THE_NEW_USER>
+       description: LDAP monitor
+       userPassword:<PASSWORD>
+       EOF
+   ```
 
 5. Configure the monitor database
 
-    ```
-        cat <<EOF | sudo ldapadd -Y EXTERNAL -H ldapi:///
-        dn: olcDatabase=Monitor,cn=config
-        objectClass: olcDatabaseConfig
-        objectClass: olcMonitorConfig
-        olcDatabase: Monitor
-        olcAccess: to dn.subtree='cn=Monitor' by dn.base='<USER_DISTINGUISHED_NAME>' read by * none
-        EOF
-    ```
+   ```text
+       cat <<EOF | sudo ldapadd -Y EXTERNAL -H ldapi:///
+       dn: olcDatabase=Monitor,cn=config
+       objectClass: olcDatabaseConfig
+       objectClass: olcMonitorConfig
+       olcDatabase: Monitor
+       olcAccess: to dn.subtree='cn=Monitor' by dn.base='<USER_DISTINGUISHED_NAME>' read by * none
+       EOF
+   ```
 
 #### Configure the OpenLDAP integration
 
@@ -73,74 +74,73 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit your `openldap.d/conf.yaml` in the `conf.d` folder at the root of your Agent's configuration directory. See the [sample openldap.d/conf.yaml][2] for all available configuration options.
 
-    ```yaml
+   ```yaml
+   init_config:
 
-      init_config:
+   instances:
+     ## @param url - string - required
+     ## Full URL of your ldap server. Use `ldaps` or `ldap` as the scheme to
+     ## use TLS or not, or `ldapi` to connect to a UNIX socket.
+     #
+     - url: ldaps://localhost:636
 
-      instances:
-          ## @param url - string - required
-          ## Full URL of your ldap server. Use `ldaps` or `ldap` as the scheme to
-          ## use TLS or not, or `ldapi` to connect to a UNIX socket.
-          #
-        - url: ldaps://localhost:636
+       ## @param username - string - optional
+       ## The DN of the user that can read the monitor database.
+       #
+       username: "<USER_DISTINGUISHED_NAME>"
 
-          ## @param username - string - optional
-          ## The DN of the user that can read the monitor database.
-          #
-          username: "<USER_DISTINGUISHED_NAME>"
-
-          ## @param password - string - optional
-          ## Password associated with `username`
-          #
-          password: "<PASSWORD>"
-    ```
+       ## @param password - string - optional
+       ## Password associated with `username`
+       #
+       password: "<PASSWORD>"
+   ```
 
 2. [Restart the Agent][3].
 
 ###### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Add this configuration block to your `openldap.d/conf.yaml` file to start collecting your Openldap logs:
 
-    ```
-      logs:
-        - type: file
-          path: /var/log/slapd.log
-          source: openldap
-          service: <SERVICE_NAME>
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/slapd.log
+       source: openldap
+       service: "<SERVICE_NAME>"
+   ```
 
     Change the `path` and `service` parameter values and configure them for your environment. See the [sample openldap.d/conf.yaml][2] for all available configuration options.
 
 3. [Restart the Agent][3].
 
 ##### Containerized
+
 ###### Metric collection
 
 For containerized environments, see the [Autodiscovery Integration Templates][4] for guidance on applying the parameters below.
 
-| Parameter            | Value                                                                                         |
-|----------------------|-----------------------------------------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `openldap`                                                                                    |
-| `<INIT_CONFIG>`      | blank or `{}`                                                                                 |
+| Parameter            | Value                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------- |
+| `<INTEGRATION_NAME>` | `openldap`                                                                                      |
+| `<INIT_CONFIG>`      | blank or `{}`                                                                                   |
 | `<INSTANCE_CONFIG>`  | `{"url":"ldaps://%%host%%:636","username":"<USER_DISTINGUISHED_NAME>","password":"<PASSWORD>"}` |
-
 
 ###### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][5].
 
 | Parameter      | Value                                                 |
-|----------------|-------------------------------------------------------|
+| -------------- | ----------------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "openldap", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
@@ -169,7 +169,6 @@ Returns `CRITICAL` if the integration cannot bind to the monitored OpenLDAP serv
 ## Troubleshooting
 
 Need help? Contact [Datadog support][8].
-
 
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: https://github.com/DataDog/integrations-core/blob/master/openldap/datadog_checks/openldap/data/conf.yaml.example

--- a/openldap/README.md
+++ b/openldap/README.md
@@ -8,7 +8,7 @@ Use the OpenLDAP integration to get metrics from the `cn=Monitor` backend of you
 
 ### Installation
 
-The OpenLDAP integration is packaged with the Agent. To start gathering your OpenLDAP metrics, you need to:
+The OpenLDAP integration is packaged with the Agent. To start gathering your OpenLDAP metrics:
 
 1. Have the `cn=Monitor` backend configured on your OpenLDAP servers.
 2. [Install the Agent][1] on your OpenLDAP servers.
@@ -19,7 +19,7 @@ The OpenLDAP integration is packaged with the Agent. To start gathering your Ope
 
 If the `cn=Monitor` backend is not configured on your server, follow these steps:
 
-1. Check if monitoring is enabled on your installation
+1. Check if monitoring is enabled on your installation:
 
    ```shell
     sudo ldapsearch -Y EXTERNAL -H ldapi:/// -b cn=module{0},cn=config
@@ -27,7 +27,7 @@ If the `cn=Monitor` backend is not configured on your server, follow these steps
 
    If you see a line with `olcModuleLoad: back_monitor.la`, monitoring is already enabled, go to step 3.
 
-2. Enable monitoring on your server
+2. Enable monitoring on your server:
 
    ```text
        cat <<EOF | sudo ldapmodify -Y EXTERNAL -H ldapi:///
@@ -38,7 +38,7 @@ If the `cn=Monitor` backend is not configured on your server, follow these steps
        EOF
    ```
 
-3. Create an encrypted password with `slappasswd`
+3. Create an encrypted password with `slappasswd`.
 4. Add a new user:
 
    ```text
@@ -52,7 +52,7 @@ If the `cn=Monitor` backend is not configured on your server, follow these steps
        EOF
    ```
 
-5. Configure the monitor database
+5. Configure the monitor database:
 
    ```text
        cat <<EOF | sudo ldapadd -Y EXTERNAL -H ldapi:///
@@ -101,13 +101,13 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 _Available for Agent versions >6.0_
 
-1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
+1. Collecting logs is disabled by default in the Datadog Agent. Enable it in your `datadog.yaml` file:
 
    ```yaml
    logs_enabled: true
    ```
 
-2. Add this configuration block to your `openldap.d/conf.yaml` file to start collecting your Openldap logs:
+2. Add this configuration block to your `openldap.d/conf.yaml` file to start collecting your OpenLDAP logs:
 
    ```yaml
    logs:

--- a/openmetrics/README.md
+++ b/openmetrics/README.md
@@ -21,7 +21,7 @@ Edit the `openmetrics.d/conf.yaml` file at the root of your [Agent's configurati
 For each instance the following parameters are required:
 
 | Parameter        | Description                                                                                                                                                                                                                                                              |
-|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `prometheus_url` | The URL where your application metrics are exposed by Prometheus (must be unique).                                                                                                                                                                                       |
 | `namespace`      | The namespace to prepend to all metrics.                                                                                                                                                                                                                                 |
 | `metrics`        | A list of metrics to retrieve as custom metrics. Add each metric to the list as `metric_name` or `metric_name: renamed` to rename it. Use `*` as a wildcard (`metric*`) to fetch all matching metrics. **Note**: Wildcards can potentially send a lot of custom metrics. |
@@ -33,6 +33,7 @@ For more configurations, see [Prometheus and OpenMetrics Metrics Collection][10]
 [Run the Agent's status subcommand][6] and look for `openmetrics` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 All metrics collected by the OpenMetrics check are forwarded to Datadog as custom metrics.
@@ -51,8 +52,8 @@ Need help? Contact [Datadog support][7].
 
 ## Further Reading
 
-* [Configuring a OpenMetrics Check][8]
-* [Writing a custom OpenMetrics Check][9]
+- [Configuring a OpenMetrics Check][8]
+- [Writing a custom OpenMetrics Check][9]
 
 [2]: https://docs.datadoghq.com/agent/autodiscovery/integrations
 [3]: https://docs.datadoghq.com/getting_started/integrations/prometheus/?tab=docker#configuration

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,7 +1,8 @@
 ## Overview
 
 Red Hat OpenShift is an open source container application platform based on the Kubernetes container orchestrator for enterprise application development and deployment.
-> :warning: There is currently no separate `openshift` check, this README describes the necessary configuration to enable collection of  OpenShift specific metrics in the Agent. Data described here are collected by the [`kube-apiserver-metrics` check][1], setting up this check is necessary to collect the `openshift.*` metrics.
+
+> There is currently no separate `openshift` check, this README describes the necessary configuration to enable collection of OpenShift specific metrics in the Agent. Data described here are collected by the [`kube-apiserver-metrics` check][1], setting up this check is necessary to collect the `openshift.*` metrics.
 
 ## Setup
 
@@ -13,22 +14,22 @@ To install the Agent, refer to the [Agent installation instructions][1] for kube
 
 Starting with version 6.1, the Datadog Agent supports monitoring OpenShift Origin and Enterprise clusters. Depending on your needs and the [security constraints][3] of your cluster, three deployment scenarios are supported:
 
-* [Restricted SCC operations](#restricted-scc-operations)
-* [Host network SCC operations](#host-network-scc-operations)
-* [Custom Datadog SCC for all features](#custom-datadog-scc-for-all-features)
+- [Restricted SCC operations](#restricted-scc-operations)
+- [Host network SCC operations](#host-network-scc-operations)
+- [Custom Datadog SCC for all features](#custom-datadog-scc-for-all-features)
 
 | Security Context Constraints   | [Restricted](#restricted-scc-operations) | [Host network](#host-network-scc-operations) | [Custom](#custom-datadog-scc-for-all-features) |
-|--------------------------------|------------------------------------------|----------------------------------------------|------------------------------------------------|
-| Kubernetes layer monitoring    | ✅                                        | ✅                                            | ✅                                              |
-| Kubernetes-based Autodiscovery | ✅                                        | ✅                                            | ✅                                              |
-| Dogstatsd intake               | 🔶                                        | ✅                                            | ✅                                              |
-| APM trace intake               | 🔶                                        | ✅                                            | ✅                                              |
-| Logs network intake            | 🔶                                        | ✅                                            | ✅                                              |
-| Host network metrics           | ❌                                        | ❌                                            | ✅                                              |
-| Docker layer monitoring        | ❌                                        | ❌                                            | ✅                                              |
-| Container logs collection      | ❌                                        | ❌                                            | ✅                                              |
-| Live Container monitoring      | ❌                                        | ❌                                            | ✅                                              |
-| Live Process monitoring        | ❌                                        | ❌                                            | ✅                                              |
+| ------------------------------ | ---------------------------------------- | -------------------------------------------- | ---------------------------------------------- |
+| Kubernetes layer monitoring    | ✅                                       | ✅                                           | ✅                                             |
+| Kubernetes-based Autodiscovery | ✅                                       | ✅                                           | ✅                                             |
+| Dogstatsd intake               | 🔶                                       | ✅                                           | ✅                                             |
+| APM trace intake               | 🔶                                       | ✅                                           | ✅                                             |
+| Logs network intake            | 🔶                                       | ✅                                           | ✅                                             |
+| Host network metrics           | ❌                                       | ❌                                           | ✅                                             |
+| Docker layer monitoring        | ❌                                       | ❌                                           | ✅                                             |
+| Container logs collection      | ❌                                       | ❌                                           | ✅                                             |
+| Live Container monitoring      | ❌                                       | ❌                                           | ✅                                             |
+| Live Process monitoring        | ❌                                       | ❌                                           | ✅                                             |
 
 > :warning: **OpenShift 4.0+**: If you used the OpenShift installer on a supported cloud provider, you will need to deploy the Agent with `hostNetwork: true` to get host tags/aliases as access to metadata servers from PODs network is otherwise restricited.
 
@@ -45,13 +46,13 @@ The Agent suports working on a `sidecar` run mode, to enable running the Agent i
 Add the `allowHostPorts` permission to the pod (either via the standard `hostnetwork` or `hostaccess` SCC, or by creating your own). In this case, you can add the relevant port bindings in your pod specs:
 
 ```yaml
-        ports:
-          - containerPort: 8125
-            name: dogstatsdport
-            protocol: UDP
-          - containerPort: 8126
-            name: traceport
-            protocol: TCP
+ports:
+  - containerPort: 8125
+    name: dogstatsdport
+    protocol: UDP
+  - containerPort: 8126
+    name: traceport
+    protocol: TCP
 ```
 
 #### Custom Datadog SCC for all features
@@ -59,10 +60,10 @@ Add the `allowHostPorts` permission to the pod (either via the standard `hostnet
 If SELinux is in permissive mode or disabled, enable the `hostaccess` SCC to benefit from all features.
 If SELinux is in enforcing mode, it is recommended to grant [the `spc_t` type][7] to the datadog-agent pod. In order to deploy the agent you can use the following [datadog-agent SCC][8] that can be applied after [creating the datadog-agent service account][5]. It grants the following permissions:
 
-* `allowHostPorts: true`: Binds Dogstatsd / APM / Logs intakes to the node's IP.
-* `allowHostPID: true`: Enables Origin Detection for Dogstatsd metrics submitted by Unix Socket.
-* `volumes: hostPath`: Accesses the Docker socket and the host's `proc` and `cgroup` folders, for metric collection.
-* `SELinux type: spc_t`: Accesses the Docker socket and all processes' `proc` and `cgroup` folders, for metric collection. You can read more about this type [in this Red Hat article][7].
+- `allowHostPorts: true`: Binds Dogstatsd / APM / Logs intakes to the node's IP.
+- `allowHostPID: true`: Enables Origin Detection for Dogstatsd metrics submitted by Unix Socket.
+- `volumes: hostPath`: Accesses the Docker socket and the host's `proc` and `cgroup` folders, for metric collection.
+- `SELinux type: spc_t`: Accesses the Docker socket and all processes' `proc` and `cgroup` folders, for metric collection. You can read more about this type [in this Red Hat article][7].
 
 > :warning: Do not forget to add [datadog-agent service account][5] to the newly created [datadog-agent SCC][8] by adding `system:serviceaccount:<datadog-agent namespace>:<datadog-agent service account name>` to the `users` section.
 
@@ -89,7 +90,6 @@ The OpenShift check does not include any Service Checks.
 ## Troubleshooting
 
 Need help? Contact [Datadog support][11].
-
 
 [1]: https://github.com/DataDog/integrations-core/tree/master/kube_apiserver_metrics
 [2]: https://docs.datadoghq.com/agent/kubernetes

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -6,7 +6,7 @@
 
 Get metrics from OpenStack service in real time to:
 
-- Visualize and monitor OpenStack states
+- Visualize and monitor OpenStack states.
 - Be notified about OpenStack failovers and events.
 
 ## Setup
@@ -19,7 +19,7 @@ To capture your OpenStack metrics, [install the Agent][2] on your hosts running 
 
 #### Prepare OpenStack
 
-Then configure a Datadog role and user with your identity server:
+Configure a Datadog role and user with your identity server:
 
 ```console
 openstack role create datadog_monitoring
@@ -31,7 +31,7 @@ openstack role add datadog_monitoring \
     --user datadog
 ```
 
-Finally, update your `policy.json` files to grant the needed permissions. `role:datadog_monitoring` requires access to the following operations:
+Then, update your `policy.json` files to grant the needed permissions. `role:datadog_monitoring` requires access to the following operations:
 
 **Nova**
 
@@ -70,9 +70,9 @@ Finally, update your `policy.json` files to grant the needed permissions. `role:
 }
 ```
 
-You may need to restart your Keystone, Neutron and Nova API services to ensure that the policy changes take.
+You may need to restart your Keystone, Neutron, and Nova API services to ensure that the policy changes take.
 
-**Note**: Installing the OpenStack integration could increase the number of VMs that Datadog monitors. For more information on how this may affect your billing, visit our Billing FAQ.
+**Note**: Installing the OpenStack integration could increase the number of VMs that Datadog monitors. For more information on how this may affect your billing, visit the Billing FAQ.
 
 #### Agent Configuration
 
@@ -153,9 +153,9 @@ Need help? Contact [Datadog support][8].
 
 ## Further Reading
 
-To get a better idea of how (or why) to integrate your Nova OpenStack compute module with Datadog, check out our [series of blog posts][9] about it.
+To get a better idea of how (or why) to integrate your Nova OpenStack compute module with Datadog, check out Datadog's [series of blog posts][9] about it.
 
-See also our blog posts:
+See also these other Datadog blog posts:
 
 - [Install OpenStack in two commands for dev and test][10]
 - [OpenStack: host aggregates, flavors, and availability zones][11]

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -6,16 +6,19 @@
 
 Get metrics from OpenStack service in real time to:
 
-* Visualize and monitor OpenStack states
-* Be notified about OpenStack failovers and events.
+- Visualize and monitor OpenStack states
+- Be notified about OpenStack failovers and events.
 
 ## Setup
+
 ### Installation
 
 To capture your OpenStack metrics, [install the Agent][2] on your hosts running hypervisors.
 
 ### Configuration
+
 #### Prepare OpenStack
+
 Then configure a Datadog role and user with your identity server:
 
 ```console
@@ -32,38 +35,38 @@ Finally, update your `policy.json` files to grant the needed permissions. `role:
 
 **Nova**
 
-```
+```json
 {
-    "compute_extension": "aggregates",
-    "compute_extension": "hypervisors",
-    "compute_extension": "server_diagnostics",
-    "compute_extension": "v3:os-hypervisors",
-    "compute_extension": "v3:os-server-diagnostics",
-    "compute_extension": "availability_zone:detail",
-    "compute_extension": "v3:availability_zone:detail",
-    "compute_extension": "used_limits_for_admin",
-    "os_compute_api:os-aggregates:index": "rule:admin_api or role:datadog_monitoring",
-    "os_compute_api:os-aggregates:show": "rule:admin_api or role:datadog_monitoring",
-    "os_compute_api:os-hypervisors": "rule:admin_api or role:datadog_monitoring",
-    "os_compute_api:os-server-diagnostics": "rule:admin_api or role:datadog_monitoring",
-    "os_compute_api:os-used-limits": "rule:admin_api or role:datadog_monitoring"
+  "compute_extension": "aggregates",
+  "compute_extension": "hypervisors",
+  "compute_extension": "server_diagnostics",
+  "compute_extension": "v3:os-hypervisors",
+  "compute_extension": "v3:os-server-diagnostics",
+  "compute_extension": "availability_zone:detail",
+  "compute_extension": "v3:availability_zone:detail",
+  "compute_extension": "used_limits_for_admin",
+  "os_compute_api:os-aggregates:index": "rule:admin_api or role:datadog_monitoring",
+  "os_compute_api:os-aggregates:show": "rule:admin_api or role:datadog_monitoring",
+  "os_compute_api:os-hypervisors": "rule:admin_api or role:datadog_monitoring",
+  "os_compute_api:os-server-diagnostics": "rule:admin_api or role:datadog_monitoring",
+  "os_compute_api:os-used-limits": "rule:admin_api or role:datadog_monitoring"
 }
 ```
 
 **Neutron**
 
-```
+```json
 {
-    "get_network": "rule:admin_or_owner or rule:shared or rule:external or rule:context_is_advsvc or role:datadog_monitoring"
+  "get_network": "rule:admin_or_owner or rule:shared or rule:external or rule:context_is_advsvc or role:datadog_monitoring"
 }
 ```
 
 **Keystone**
 
-```
+```json
 {
-    "identity:get_project": "rule:admin_required or project_id:%(target.project.id)s or role:datadog_monitoring",
-    "identity:list_projects": "rule:admin_required or role:datadog_monitoring"
+  "identity:get_project": "rule:admin_required or project_id:%(target.project.id)s or role:datadog_monitoring",
+  "identity:list_projects": "rule:admin_required or role:datadog_monitoring"
 }
 ```
 
@@ -75,38 +78,36 @@ You may need to restart your Keystone, Neutron and Nova API services to ensure t
 
 1. Configure the Datadog Agent to connect to your Keystone server, and specify individual projects to monitor. Edit the `openstack.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][3] with the configuration below. See the [sample openstack.d/conf.yaml][4] for all available configuration options:
 
-    ```yaml
-        init_config:
+   ```yaml
+   init_config:
+     ## @param keystone_server_url - string - required
+     ## Where your identity server lives.
+     ## Note that the server must support Identity API v3
+     #
+     keystone_server_url: "https://<KEYSTONE_SERVER_ENDPOINT>:<PORT>/"
 
-            ## @param keystone_server_url - string - required
-            ## Where your identity server lives.
-            ## Note that the server must support Identity API v3
-            #
-            keystone_server_url: "https://<KEYSTONE_SERVER_ENDPOINT>:<PORT>/"
+   instances:
+     ## @param name - string - required
+     ## Unique identifier for this instance.
+     #
+     - name: "<INSTANCE_NAME>"
 
-        instances:
-
-            ## @param name - string - required
-            ## Unique identifier for this instance.
-            #
-          - name: "<INSTANCE_NAME>"
-
-            ## @param user - object - required
-            ## User credentials
-            ## Password authentication is the only auth method supported.
-            ## `user` object expects the parameter `username`, `password`,
-            ## and `user.domain.id`.
-            ##
-            ## `user` should resolve to a structure like:
-            ##
-            ##  {'password': '<PASSWORD>', 'name': '<USERNAME>', 'domain': {'id': '<DOMAINE_ID>'}}
-            #
-            user:
-              password: "<PASSWORD>"
-              name: datadog
-              domain:
-                id: "<DOMAINE_ID>"
-    ```
+       ## @param user - object - required
+       ## User credentials
+       ## Password authentication is the only auth method supported.
+       ## `user` object expects the parameter `username`, `password`,
+       ## and `user.domain.id`.
+       ##
+       ## `user` should resolve to a structure like:
+       ##
+       ##  {'password': '<PASSWORD>', 'name': '<USERNAME>', 'domain': {'id': '<DOMAINE_ID>'}}
+       #
+       user:
+         password: "<PASSWORD>"
+         name: datadog
+         domain:
+           id: "<DOMAINE_ID>"
+   ```
 
 2. [Restart the Agent][5].
 
@@ -115,13 +116,17 @@ You may need to restart your Keystone, Neutron and Nova API services to ensure t
 [Run the Agent's `status` subcommand][6] and look for `openstack` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][7] for a list of metrics provided by this integration.
 
 ### Events
+
 The OpenStack check does not include any events.
 
 ### Service Checks
+
 **openstack.neutron.api.up**:
 
 Returns `CRITICAL` if the Agent is unable to query the Neutron API, `UNKNOWN` if there is an issue with the Keystone API. Returns `OK` otherwise.
@@ -152,9 +157,8 @@ To get a better idea of how (or why) to integrate your Nova OpenStack compute mo
 
 See also our blog posts:
 
-* [Install OpenStack in two commands for dev and test][10]
-* [OpenStack: host aggregates, flavors, and availability zones][11]
-
+- [Install OpenStack in two commands for dev and test][10]
+- [OpenStack: host aggregates, flavors, and availability zones][11]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/openstack/images/openstack_dashboard.png
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/openstack_controller/README.md
+++ b/openstack_controller/README.md
@@ -5,6 +5,7 @@
 This check monitors [Openstack][1] from the controller node.
 
 ## Setup
+
 ### Installation
 
 The Openstack_controller check is included in the [Datadog Agent][2] package, so you do not need to install anything else on your server.
@@ -21,30 +22,29 @@ Create a `datadog` user that is used in your `openstack_controller.d/conf.yaml` 
 
 1. Edit the `openstack_controller.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your openstack_controller performance data. See the [sample openstack_controller.d/conf.yaml][2] for all available configuration options:
 
-    ```yaml
-        init_config:
+   ```yaml
+   init_config:
 
-        instances:
+   instances:
+     ## @param name - string - required
+     ## Unique identifier for this instance.
+     #
+     - name: "<INSTANCE_NAME>"
 
-            ## @param name - string - required
-            ## Unique identifier for this instance.
-            #
-          - name: "<INSTANCE_NAME>"
-
-            ## @param user - object - required
-            ## Password authentication is the only auth method supported
-            ## User expects username, password, and user domain id
-            ## `user` should resolve to a structure like
-            ## {'password': '<PASSWORD>', 'name': '<USER_NAME>', 'domain': {'id': '<DOMAIN_ID>'}}
-            ## The check uses the Unscoped token method to collect information about
-            ## all available projects to the user.
-            #
-            user:
-                password: "<PASSWORD>"
-                name: "<USER_NAME>"
-                domain:
-                    id: "<DOMAIN_ID>"
-    ```
+       ## @param user - object - required
+       ## Password authentication is the only auth method supported
+       ## User expects username, password, and user domain id
+       ## `user` should resolve to a structure like
+       ## {'password': '<PASSWORD>', 'name': '<USER_NAME>', 'domain': {'id': '<DOMAIN_ID>'}}
+       ## The check uses the Unscoped token method to collect information about
+       ## all available projects to the user.
+       #
+       user:
+         password: "<PASSWORD>"
+         name: "<USER_NAME>"
+         domain:
+           id: "<DOMAIN_ID>"
+   ```
 
 2. [Restart the Agent][3]
 
@@ -59,6 +59,7 @@ Create a `datadog` user that is used in your `openstack_controller.d/conf.yaml` 
 See [metadata.csv][5] for a list of metrics provided by this integration.
 
 ### Service Checks
+
 **openstack.neutron.api.up**
 
 Returns `CRITICAL` if the Agent is unable to query the Neutron API, `UNKNOWN` if there is an issue with the Keystone API. Returns `OK` otherwise.
@@ -78,7 +79,6 @@ Returns `UNKNOWN` if the Agent is unable to get the Hypervisor state, `CRITICAL`
 **openstack.neutron.network.up**
 
 Returns `CRITICAL` if the Network is down. Returns `OK` otherwise.
-
 
 ### Events
 

--- a/openstack_controller/README.md
+++ b/openstack_controller/README.md
@@ -1,26 +1,26 @@
-# Agent Check: Openstack_controller
+# Agent Check: Openstack Controller
 
 ## Overview
 
-This check monitors [Openstack][1] from the controller node.
+This check monitors [OpenStack][1] from the controller node.
 
 ## Setup
 
 ### Installation
 
-The Openstack_controller check is included in the [Datadog Agent][2] package, so you do not need to install anything else on your server.
+The OpenStack Controller check is included in the [Datadog Agent][2] package, so you do not need to install anything else on your server.
 
 ### Configuration
 
-The openstack_controller integration is designed to collect information from all compute nodes and the servers running it. The integration should be run from a single Agent to monitor your openstack environment, and can be deployed on your controller node or an adjacent server that has access to the Keystone and Nova endpoints.
+The OpenStack Controller integration is designed to collect information from all compute nodes and the servers running it. The integration should be run from a single Agent to monitor your OpenStack environment, and can be deployed on your controller node or an adjacent server that has access to the Keystone and Nova endpoints.
 
 #### Prepare OpenStack
 
-Create a `datadog` user that is used in your `openstack_controller.d/conf.yaml` file. This user requires admin read only permissions across your environment so that it can be run from a single node and read high level system information about all compute nodes and servers.
+Create a `datadog` user that is used in your `openstack_controller.d/conf.yaml` file. This user requires admin read-only permissions across your environment so that it can be run from a single node and read high level system information about all nodes and servers.
 
 #### Agent Configuration
 
-1. Edit the `openstack_controller.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your openstack_controller performance data. See the [sample openstack_controller.d/conf.yaml][2] for all available configuration options:
+1. Edit the `openstack_controller.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your OpenStack Controller performance data. See the [sample openstack_controller.d/conf.yaml][2] for all available configuration options:
 
    ```yaml
    init_config:
@@ -82,7 +82,7 @@ Returns `CRITICAL` if the Network is down. Returns `OK` otherwise.
 
 ### Events
 
-Openstack_controller does not include any events.
+OpenStack Controller does not include any events.
 
 ## Troubleshooting
 

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -7,9 +7,11 @@
 Get metrics from Oracle Database servers in real time to visualize and monitor availability and performance.
 
 ## Setup
+
 ### Installation
 
 #### Prerequisite
+
 To use the Oracle integration, either install the Oracle Instant Client libraries, or download the Oracle JDBC Driver. Due to licensing restrictions, these libraries are not included in the Datadog Agent, but can be downloaded directly from Oracle.
 
 ##### JDBC Driver
@@ -25,30 +27,30 @@ The Oracle check requires either access to the `cx_Oracle` Python module, or the
 
     If you are using Linux, after the Instant Client libraries are installed ensure the runtime linker can find the libraries. For example, using `ldconfig`:
 
-    ```
-    # Put the library location in an ld configuration file.
+   ```shell
+   # Put the library location in an ld configuration file.
 
-    sudo sh -c "echo /usr/lib/oracle/12.2/client64/lib > \
-        /etc/ld.so.conf.d/oracle-instantclient.conf"
+   sudo sh -c "echo /usr/lib/oracle/12.2/client64/lib > \
+       /etc/ld.so.conf.d/oracle-instantclient.conf"
 
-    # Update the bindings.
+   # Update the bindings.
 
-    sudo ldconfig
-    ```
+   sudo ldconfig
+   ```
 
 2. Decompress those libraries in a given directory available to all users on the given machine (i.e. `/opt/oracle`):
 
-    ```
-    mkdir -p /opt/oracle/ && cd /opt/oracle/
-    unzip /opt/oracle/instantclient-basic-linux.x64-12.1.0.2.0.zip
-    unzip /opt/oracle/instantclient-sdk-linux.x64-12.1.0.2.0.zip
-    ```
+   ```shell
+   mkdir -p /opt/oracle/ && cd /opt/oracle/
+   unzip /opt/oracle/instantclient-basic-linux.x64-12.1.0.2.0.zip
+   unzip /opt/oracle/instantclient-sdk-linux.x64-12.1.0.2.0.zip
+   ```
 
 3. Update your `LD_LIBRARY_PATH` to include the location of the Instant Client libraries when starting/restarting the agent:
 
-    ```
-    export LD_LIBRARY_PATH=/opt/oracle/instantclient/lib:$LD_LIBRARY_PATH
-    ```
+   ```shell
+   export LD_LIBRARY_PATH=/opt/oracle/instantclient/lib:$LD_LIBRARY_PATH
+   ```
 
 **Note:** Agent 6 uses Upstart or systemd to orchestrate the `datadog-agent` service. Environment variables may need to be added to the service configuration files at the default locations of `/etc/init/datadog-agent.conf` (Upstart) or `/lib/systemd/system/datadog-agent.service` (systemd). See documentation on [Upstart][5] or [systemd][6] for more information on how to configure these settings.
 
@@ -86,7 +88,7 @@ end script
 
 Create a read-only `datadog` user with proper access to your Oracle Database Server. Connect to your Oracle database with an administrative user (e.g. `SYSDBA` or `SYSOPER`) and run:
 
-```
+```text
 -- Enable Oracle Script.
 ALTER SESSION SET "_ORACLE_SCRIPT"=true;
 
@@ -104,58 +106,25 @@ GRANT SELECT ON sys.dba_tablespace_usage_metrics TO datadog;
 
 **Note**: If you're using Oracle 11g, there's no need to run the following line:
 
-```
+```text
 ALTER SESSION SET "_ORACLE_SCRIPT"=true;
 ```
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
 1. Edit the `oracle.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][7]. Update the `server` and `port` to set the masters to monitor. See the [sample oracle.d/conf.yaml][3] for all available configuration options.
 
-    ```yaml
-      init_config:
-
-      instances:
-
-          ## @param server - string - required
-          ## The IP address or hostname of the Oracle Database Server.
-          #
-        - server: localhost:1521
-
-          ## @param service_name - string - required
-          ## The Oracle Database service name. To view the services available on your server,
-          ## run the following query:
-          ## `SELECT value FROM v$parameter WHERE name='service_names'`
-          #
-          service_name: "<SERVICE_NAME>"
-
-          ## @param user - string - required
-          ## The username for the user account.
-          #
-          user: datadog
-
-          ## @param password - string - required
-          ## The password for the user account.
-          #
-          password: "<PASSWORD>"
-    ```
-
-2. [Restart the Agent][8].
-
-#### Only custom queries
- To skip default metric checks for an instance and only run custom queries with an existing metrics gathering user, insert the tag `only_custom_queries` with a value of true. This allows a configured instance of the Oracle integration to skip the system, process, and tablespace metrics from running, and allows custom queries to be run without having the permissions described in the [Datadog user creation](#datadog-user-creation) section. If this configuration entry is omitted, the user you specify is required to have those table permissions to run a custom query.
-
- ```yaml
+   ```yaml
    init_config:
 
    instances:
-
-       ## @param server - string - required
-       ## The IP address or hostname of the Oracle Database Server.
-       #
+     ## @param server - string - required
+     ## The IP address or hostname of the Oracle Database Server.
+     #
      - server: localhost:1521
 
        ## @param service_name - string - required
@@ -168,25 +137,59 @@ Follow the instructions below to configure this check for an Agent running on a 
        ## @param user - string - required
        ## The username for the user account.
        #
-       user: <USER>
+       user: datadog
 
        ## @param password - string - required
        ## The password for the user account.
        #
        password: "<PASSWORD>"
+   ```
 
-       ## @param only_custom_queries - string - optional
-       ## Set this parameter to any value if you want to only run custom
-       ## queries for this instance.
-       #
-       only_custom_queries: true
- ```
+2. [Restart the Agent][8].
+
+#### Only custom queries
+
+To skip default metric checks for an instance and only run custom queries with an existing metrics gathering user, insert the tag `only_custom_queries` with a value of true. This allows a configured instance of the Oracle integration to skip the system, process, and tablespace metrics from running, and allows custom queries to be run without having the permissions described in the [Datadog user creation](#datadog-user-creation) section. If this configuration entry is omitted, the user you specify is required to have those table permissions to run a custom query.
+
+```yaml
+init_config:
+
+instances:
+  ## @param server - string - required
+  ## The IP address or hostname of the Oracle Database Server.
+  #
+  - server: localhost:1521
+
+    ## @param service_name - string - required
+    ## The Oracle Database service name. To view the services available on your server,
+    ## run the following query:
+    ## `SELECT value FROM v$parameter WHERE name='service_names'`
+    #
+    service_name: "<SERVICE_NAME>"
+
+    ## @param user - string - required
+    ## The username for the user account.
+    #
+    user: <USER>
+
+    ## @param password - string - required
+    ## The password for the user account.
+    #
+    password: "<PASSWORD>"
+
+    ## @param only_custom_queries - string - optional
+    ## Set this parameter to any value if you want to only run custom
+    ## queries for this instance.
+    #
+    only_custom_queries: true
+```
+
 #### Containerized
 
 For containerized environments, see the [Autodiscovery Integration Templates][9] for guidance on applying the parameters below.
 
 | Parameter            | Value                                                                                                     |
-|----------------------|-----------------------------------------------------------------------------------------------------------|
+| -------------------- | --------------------------------------------------------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `oracle`                                                                                                  |
 | `<INIT_CONFIG>`      | blank or `{}`                                                                                             |
 | `<INSTANCE_CONFIG>`  | `{"server": "%%host%%:1521", "service_name":"<SERVICE_NAME>", "user":"datadog", "password":"<PASSWORD>"}` |
@@ -200,7 +203,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][9]
 Providing custom queries is also supported. Each query must have 3 parameters:
 
 | Parameter       | Description                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `metric_prefix` | This is what each metric starts with.                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `query`         | This is the SQL to execute. It can be a simple statement or a multi-line script. All rows of the result are evaluated.                                                                                                                                                                                                                                                                                                                        |
 | `columns`       | This is a list representing each column, ordered sequentially from left to right. There are 2 required pieces of data: <br> a. `type` - This is the submission method (`gauge`, `count`, etc.). <br> b. name - This is the suffix to append to the `metric_prefix` in order to form the full metric name. If `type` is `tag`, this column is instead considered as a tag which is applied to every metric collected by this particular query. |
@@ -218,21 +221,21 @@ is what the following example configuration would become:
 
 ```yaml
 - metric_prefix: oracle.custom_query
-  query: |  # Use the pipe if you require a multi-line script.
-   SELECT columns
-   FROM tester.test_table
-   WHERE conditions
+  query: | # Use the pipe if you require a multi-line script.
+    SELECT columns
+    FROM tester.test_table
+    WHERE conditions
   columns:
-  # Put this for any column you wish to skip:
-  - {}
-  - name: metric1
-    type: gauge
-  - name: tag1
-    type: tag
-  - name: metric2
-    type: count
+    # Put this for any column you wish to skip:
+    - {}
+    - name: metric1
+      type: gauge
+    - name: tag1
+      type: tag
+    - name: metric2
+      type: count
   tags:
-  - tester:oracle
+    - tester:oracle
 ```
 
 See the [sample oracle.d/conf.yaml][3] for all available configuration options.
@@ -240,16 +243,20 @@ See the [sample oracle.d/conf.yaml][3] for all available configuration options.
 ## Data Collected
 
 ### Metrics
+
 See [metadata.csv][11] for a list of metrics provided by this integration.
 
 ### Events
+
 The Oracle Database check does not include any events.
 
 ### Service Checks
+
 **oracle.can_connect**
 Verifies the database is available and accepting connections.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][12].
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/oracle/images/oracle_dashboard.png

--- a/pdh_check/README.md
+++ b/pdh_check/README.md
@@ -4,9 +4,10 @@
 
 Get metrics from Windows performance counters in real time to:
 
-* Visualize and monitor Windows performance counters through the PDH API.
+- Visualize and monitor Windows performance counters through the PDH API.
 
 ## Setup
+
 ### Installation
 
 The PDH check is included in the [Datadog Agent][2] package. No additional installation is needed.
@@ -22,6 +23,7 @@ The PDH check is included in the [Datadog Agent][2] package. No additional insta
 Run the [Agent's status subcommand][5] and look for `pdh_check` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][6] for a list of metrics provided by this integration.
@@ -37,7 +39,6 @@ The PDH check does not include any events.
 ### Service Checks
 
 The PDH check does not include any service checks.
-
 
 [2]: https://app.datadoghq.com/account/settings#agent
 [3]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory

--- a/pgbouncer/README.md
+++ b/pgbouncer/README.md
@@ -5,6 +5,7 @@
 The PgBouncer check tracks connection pool metrics and lets you monitor traffic to and from your application.
 
 ## Setup
+
 ### Installation
 
 The PgBouncer check is included in the [Datadog Agent][1] package, so you don't need to install anything else on your PgBouncer nodes.
@@ -13,15 +14,15 @@ This check needs an associated user to query your PgBouncer instance:
 
 1. Create a Datadog user in your PgBouncer `pgbouncer.ini` file:
 
-    ```
-    stats_users = datadog
-    ```
+   ```ini
+   stats_users = datadog
+   ```
 
 2. Add an associated password for the `datadog` user in your PgBouncer `userlist.txt` file:
 
-    ```
-    "datadog" "<PASSWORD>"
-    ```
+   ```text
+   "datadog" "<PASSWORD>"
+   ```
 
 ### Configuration
 
@@ -33,38 +34,37 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `pgbouncer.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample pgbouncer.d/conf.yaml][3] for all available configuration options:
 
-    ```
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
-
-          ## @param database_url - string - required
-          ## `database_url` parameter should point to PgBouncer stats database url
-          #
-        - database_url: postgresql://datadog:<PASSWORD>@<HOSTNAME>:<PORT>/<DATABASE_URL>?sslmode=require
-    ```
+   instances:
+     ## @param database_url - string - required
+     ## `database_url` parameter should point to PgBouncer stats database url
+     #
+     - database_url: "postgresql://datadog:<PASSWORD>@<HOSTNAME>:<PORT>/<DATABASE_URL>?sslmode=require"
+   ```
 
 2. [Restart the Agent][4].
 
 ##### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Add this configuration block to your `pgbouncer.d/conf.yaml` file to start collecting your Pgbouncer logs:
 
-    ```yaml
-      logs:
-        - type: file
-          path: /var/log/postgresql/pgbouncer.log
-          source: pgbouncer
-          service: <SERVICE_NAME>
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/postgresql/pgbouncer.log
+       source: pgbouncer
+       service: "<SERVICE_NAME>"
+   ```
 
     Change the `path` and `service` parameter values and configure them for your environment. See the [sample pgbouncer.d/conf.yaml][3] for all available configuration options.
 
@@ -77,19 +77,19 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 ##### Metric collection
 
 | Parameter            | Value                                                                                                  |
-|----------------------|--------------------------------------------------------------------------------------------------------|
+| -------------------- | ------------------------------------------------------------------------------------------------------ |
 | `<INTEGRATION_NAME>` | `oracle`                                                                                               |
 | `<INIT_CONFIG>`      | blank or `{}`                                                                                          |
 | `<INSTANCE_CONFIG>`  | `{"database_url": "postgresql://datadog:<PASSWORD>@%%host%%:%%port%%/<DATABASE_URL>?sslmode=require"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection documentation][7].
 
 | Parameter      | Value                                           |
-|----------------|-------------------------------------------------|
+| -------------- | ----------------------------------------------- |
 | `<LOG_CONFIG>` | {"source": "pgbouncer", "service": "pgbouncer"} |
 
 ### Validation
@@ -97,12 +97,15 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 [Run the Agent's status subcommand][5] and look for `pgbouncer` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][8] for a list of metrics provided by this check.
 
 **Note**: Not all metrics are available with all versions of PgBouncer.
 
 ### Events
+
 The PgBouncer check does not include any events.
 
 ### Service Checks
@@ -111,8 +114,8 @@ The PgBouncer check does not include any events.
 Returns `CRITICAL` if the Agent cannot connect to PgBouncer to collect metrics, otherwise returns `OK`.
 
 ## Troubleshooting
-Need help? Contact [Datadog support][9].
 
+Need help? Contact [Datadog support][9].
 
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory

--- a/php_fpm/README.md
+++ b/php_fpm/README.md
@@ -74,7 +74,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 
 ##### Multiple pools
 
-It is possible to monitor multiple PHP-FPM pools using the same proxy server, a common scenario when running on Kubernetes. To do so, modify your server's routes to point to different PHP-FPM instances. Here is an example Nginx configuration:
+It is possible to monitor multiple PHP-FPM pools using the same proxy server, a common scenario when running on Kubernetes. To do so, modify your server's routes to point to different PHP-FPM instances. Here is an example NGINX configuration:
 
 ```text
 server {
@@ -109,7 +109,7 @@ If your PHP-FPM installation uses unix sockets, you have to use the below syntax
 | `ping_reply`  | `pong`                            |
 | `use_fastcgi` | `true`                            |
 
-**Note**: With Autodiscovery, if the Agent runs in a separate container/task/pod, it doesn't have access to the unix sockets file of your FPM pool. It order to address this, run the Agent as a sidecar.
+**Note**: With Autodiscovery, if the Agent runs in a separate container/task/pod, it doesn't have access to the Unix sockets file of your FPM pool. It order to address this, run the Agent as a sidecar.
 
 ### Validation
 

--- a/php_fpm/README.md
+++ b/php_fpm/README.md
@@ -7,6 +7,7 @@
 The PHP-FPM check monitors the state of your FPM pool and tracks request performance.
 
 ## Setup
+
 ### Installation
 
 The PHP-FPM check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your servers that use PHP-FPM.
@@ -19,44 +20,43 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `php_fpm.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3]. See the [sample php_fpm.d/conf.yaml][4] for all available configuration options:
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
+   instances:
+     ## @param status_url - string - required
+     ## Get metrics from your FPM pool with this URL
+     ## The status URLs should follow the options from your FPM pool
+     ## See http://php.net/manual/en/install.fpm.configuration.php
+     ##   * pm.status_path
+     ## You should configure your fastcgi passthru (nginx/apache) to catch these URLs and
+     ## redirect them through the FPM pool target you want to monitor (FPM `listen`
+     ## directive in the config, usually a UNIX socket or TCP socket.
+     #
+     - status_url: http://localhost/status
 
-          ## @param status_url - string - required
-          ## Get metrics from your FPM pool with this URL
-          ## The status URLs should follow the options from your FPM pool
-          ## See http://php.net/manual/en/install.fpm.configuration.php
-          ##   * pm.status_path
-          ## You should configure your fastcgi passthru (nginx/apache) to catch these URLs and
-          ## redirect them through the FPM pool target you want to monitor (FPM `listen`
-          ## directive in the config, usually a UNIX socket or TCP socket.
-          #
-        - status_url: http://localhost/status
+       ## @param ping_url - string - required
+       ## Get a reliable service check of your FPM pool with `ping_url` parameter
+       ## The ping URLs should follow the options from your FPM pool
+       ## See http://php.net/manual/en/install.fpm.configuration.php
+       ##   * ping.path
+       ## You should configure your fastcgi passthru (nginx/apache) to
+       ## catch these URLs and redirect them through the FPM pool target
+       ## you want to monitor (FPM `listen` directive in the config, usually
+       ## a UNIX socket or TCP socket.
+       #
+       ping_url: http://localhost/ping
 
-          ## @param ping_url - string - required
-          ## Get a reliable service check of your FPM pool with `ping_url` parameter
-          ## The ping URLs should follow the options from your FPM pool
-          ## See http://php.net/manual/en/install.fpm.configuration.php
-          ##   * ping.path
-          ## You should configure your fastcgi passthru (nginx/apache) to
-          ## catch these URLs and redirect them through the FPM pool target
-          ## you want to monitor (FPM `listen` directive in the config, usually
-          ## a UNIX socket or TCP socket.
-          #
-          ping_url: http://localhost/ping
+       ## @param use_fastcgi - boolean - required - default: false
+       ## Communicate directly with PHP-FPM using FastCGI
+       #
+       use_fastcgi: false
 
-          ## @param use_fastcgi - boolean - required - default: false
-          ## Communicate directly with PHP-FPM using FastCGI
-          #
-          use_fastcgi: false
-
-          ## @param ping_reply - string - required
-          ## Set the expected reply to the ping.
-          #
-          ping_reply: pong
-    ```
+       ## @param ping_reply - string - required
+       ## Set the expected reply to the ping.
+       #
+       ping_reply: pong
+   ```
 
 2. [Restart the Agent][5].
 
@@ -65,17 +65,18 @@ Follow the instructions below to configure this check for an Agent running on a 
 For containerized environments, see the [Autodiscovery Integration Templates][6] for guidance on applying the parameters below.
 
 | Parameter            | Value                                                                                                                    |
-|----------------------|--------------------------------------------------------------------------------------------------------------------------|
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `<INTEGRATION_NAME>` | `php-fpm`                                                                                                                |
 | `<INIT_CONFIG>`      | blank or `{}`                                                                                                            |
 | `<INSTANCE_CONFIG>`  | `{"status_url":"http://%%host%%/status", "ping_url":"http://%%host%%/ping", "use_fastcgi": false, "ping_reply": "pong"}` |
 
 #### Extras
+
 ##### Multiple pools
 
 It is possible to monitor multiple PHP-FPM pools using the same proxy server, a common scenario when running on Kubernetes. To do so, modify your server's routes to point to different PHP-FPM instances. Here is an example Nginx configuration:
 
-```
+```text
 server {
     ...
 
@@ -102,24 +103,26 @@ If you find this approach too tedious at scale, setting `use_fastcgi` to `true` 
 If your PHP-FPM installation uses unix sockets, you have to use the below syntax for `status_url`, `ping_url` and enable `use_fastcgi`:
 
 | Parameter     | Value                             |
-|---------------|-----------------------------------|
+| ------------- | --------------------------------- |
 | `status_url`  | `unix:///<FILE_PATH>.sock/status` |
 | `ping_url`    | `unix:///<FILE_PATH>.sock/ping`   |
 | `ping_reply`  | `pong`                            |
 | `use_fastcgi` | `true`                            |
 
-**Note**: With Autodiscovery, if the Agent runs in a separate container/task/pod, it doesn't have access to the unix sockets  file of your FPM pool. It order to address this, run the Agent as a sidecar.
+**Note**: With Autodiscovery, if the Agent runs in a separate container/task/pod, it doesn't have access to the unix sockets file of your FPM pool. It order to address this, run the Agent as a sidecar.
 
 ### Validation
 
 [Run the Agent's `status` subcommand][7] and look for `php_fpm` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][8] for a list of metrics provided by this check.
 
 ### Events
+
 The PHP-FPM check does not include any events.
 
 ### Service Checks
@@ -129,6 +132,7 @@ The PHP-FPM check does not include any events.
 Returns CRITICAL if the Agent cannot ping PHP-FPM at the configured `ping_url`, otherwise OK.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][9].
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/php_fpm/images/phpfpmoverview.png

--- a/pivotal_pks/README.md
+++ b/pivotal_pks/README.md
@@ -14,7 +14,7 @@ Monitoring PKS requires that you set up the Datadog integration for [Kubernetes]
 
 ### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 The setup is exactly the same as for Kubernetes.
 To start collecting logs from all your containers, use your Datadog Agent [environment variables][3].
@@ -26,7 +26,6 @@ Follow the [container log collection steps][5] to learn more about those environ
 ## Troubleshooting
 
 Need help? Contact [Datadog support][6].
-
 
 [1]: https://pivotal.io/platform/pivotal-container-service
 [2]: https://docs.datadoghq.com/integrations/kubernetes

--- a/postfix/README.md
+++ b/postfix/README.md
@@ -7,6 +7,7 @@
 This check monitors the size of all your Postfix queues.
 
 ## Setup
+
 ### Installation
 
 The Postfix check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your Postfix servers.
@@ -20,46 +21,46 @@ Optionally, you can configure the Agent to use a built in `postqueue -p` command
 **WARNING**: Using `postqueue` to monitor the mail queues doesn't report a count of messages for the `incoming` queue.
 
 #### Metric collection
+
 ##### Using sudo
 
 1. Edit the file `postfix.d/conf.yaml`, in the `conf.d/` folder at the root of your [Agent's configuration directory][3]. See the [sample postfix.d/conf.yaml][4] for all available configuration options:
 
-    ```yaml
-      init_config:
-        ## @param postfix_user - string - required
-        ## The user running dd-agent must have passwordless sudo access for the find
-        ## command to run the postfix check.  Here's an example:
-        ## example /etc/sudoers entry:
-        ##   dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/incoming -type f
-        ##
-        ## Redhat/CentOS/Amazon Linux flavours need to add:
-        ##          Defaults:dd-agent !requiretty
-        #
-        postfix_user: postfix
+   ```yaml
+   init_config:
+     ## @param postfix_user - string - required
+     ## The user running dd-agent must have passwordless sudo access for the find
+     ## command to run the postfix check.  Here's an example:
+     ## example /etc/sudoers entry:
+     ##   dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/incoming -type f
+     ##
+     ## Redhat/CentOS/Amazon Linux flavours need to add:
+     ##          Defaults:dd-agent !requiretty
+     #
+     postfix_user: postfix
 
-      instances:
+   instances:
+     ## @param directory - string - required
+     ## Path to the postfix directory.
+     #
+     - directory: /var/spool/postfix
 
-          ## @param directory - string - required
-          ## Path to the postfix directory.
-          #
-        - directory: /var/spool/postfix
-
-          ## @param queues - list of string - required
-          ## List of queues to monitor.
-          #
-          queues:
-            - incoming
-            - active
-            - deferred
-    ```
+       ## @param queues - list of string - required
+       ## List of queues to monitor.
+       #
+       queues:
+         - incoming
+         - active
+         - deferred
+   ```
 
 2. For each mail queue in `queues`, the Agent forks a `find` on its directory. It uses `sudo` to do this with the privileges of the Postfix user, so you must add the following lines to `/etc/sudoers` for the Agent's user, `dd-agent`, assuming Postfix runs as `postfix`:
 
-    ```
-    dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/incoming -type f
-    dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/active -type f
-    dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/deferred -type f
-    ```
+   ```text
+   dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/incoming -type f
+   dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/active -type f
+   dd-agent ALL=(postfix) NOPASSWD:/usr/bin/find /var/spool/postfix/deferred -type f
+   ```
 
 3. [Restart the Agent][5]
 
@@ -67,68 +68,65 @@ Optionally, you can configure the Agent to use a built in `postqueue -p` command
 
 1. Edit the `postfix.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3]:
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
+     ## @param postqueue - boolean - optional - default: false
+     ## Set `postqueue: true` to gather mail queue counts using `postqueue -p`
+     ## without the use of sudo. Postqueue binary is ran with set-group ID privileges,
+     ## so that it can connect to Postfix daemon processes.
+     ## Only `tags` keys are used from `instances` definition.
+     ## Postfix has internal access controls that limit activities on the mail queue.
+     ## By default, Postfix allows `anyone` to view the queue. On production systems
+     ## where the Postfix installation may be configured with stricter access controls,
+     ## you may need to grant the dd-agent user access to view the mail queue.
+     ##
+     ## postconf -e "authorized_mailq_users = dd-agent"
+     ##
+     ## http://www.postfix.org/postqueue.1.html
+     ##
+     ## authorized_mailq_users (static:anyone)
+     ## List of users who are authorized to view the queue.
+     #
+     postqueue: true
 
-        ## @param postqueue - boolean - optional - default: false
-        ## Set `postqueue: true` to gather mail queue counts using `postqueue -p`
-        ## without the use of sudo. Postqueue binary is ran with set-group ID privileges,
-        ## so that it can connect to Postfix daemon processes.
-        ## Only `tags` keys are used from `instances` definition.
-        ## Postfix has internal access controls that limit activities on the mail queue.
-        ## By default, Postfix allows `anyone` to view the queue. On production systems
-        ## where the Postfix installation may be configured with stricter access controls,
-        ## you may need to grant the dd-agent user access to view the mail queue.
-        ##
-        ## postconf -e "authorized_mailq_users = dd-agent"
-        ##
-        ## http://www.postfix.org/postqueue.1.html
-        ##
-        ## authorized_mailq_users (static:anyone)
-        ## List of users who are authorized to view the queue.
-        #
-        postqueue: true
+   instances:
+     ## @param config_directory - string - optional
+     ## The config_directory option only applies when `postqueue: true`.
+     ## The config_directory is the location of the Postfix configuration directory
+     ## where main.cf lives.
+     #
+     - config_directory: /etc/postfix
 
-      instances:
-
-          ## @param config_directory - string - optional
-          ## The config_directory option only applies when `postqueue: true`.
-          ## The config_directory is the location of the Postfix configuration directory
-          ## where main.cf lives.
-          #
-        - config_directory: /etc/postfix
-
-          ## @param queues - list of string - required
-          ## List of queues to monitor.
-          #
-          queues:
-            - incoming
-            - active
-            - deferred
-    ```
+       ## @param queues - list of string - required
+       ## List of queues to monitor.
+       #
+       queues:
+         - incoming
+         - active
+         - deferred
+   ```
 
 2. For each `config_directory` in `instances`, the Agent forks a `postqueue -c` for the Postfix configuration directory. Postfix has internal access controls that limit activities on the mail queue. By default, Postfix allows `anyone` to view the queue. On production systems where the Postfix installation may be configured with stricter access controls, you may need to grant the `dd-agent` user access to view the mail queue ([postqueue Postfix documentation][6]):
 
-    ```
-    postconf -e "authorized_mailq_users = dd-agent"
-    ```
+   ```shell
+   postconf -e "authorized_mailq_users = dd-agent"
+   ```
 
     List of users who are authorized to view the queue:
 
-    ```
-    authorized_mailq_users (static:anyone)
-    ```
-
+   ```shell
+   authorized_mailq_users (static:anyone)
+   ```
 
 3. [Restart the Agent][5].
 
 #### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 Postfix sends logs to the syslog daemon, which then writes logs to the file system. The naming convention and log file destinations are configurable:
 
-```
+```text
 /etc/syslog.conf:
     mail.err                                    /dev/console
     mail.debug                                  /var/log/mail.log
@@ -136,19 +134,19 @@ Postfix sends logs to the syslog daemon, which then writes logs to the file syst
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Add the following configuration block to your `postfix.d/conf.yaml` file. Change the `path` and `service` parameter values based on your environment. See the [sample postfix.d/conf.yaml][5] for all available configuration options.
 
-    ```yaml
-      logs:
-        - type: file
-          path: /var/log/mail.log
-          source: postfix
-          service: myapp
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/mail.log
+       source: postfix
+       service: myapp
+   ```
 
 3. [Restart the Agent][5].
 
@@ -157,24 +155,28 @@ Postfix sends logs to the syslog daemon, which then writes logs to the file syst
 [Run the Agent's status subcommand][7] and look for `postfix` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][8] for a list of metrics provided by this check.
 
 ### Events
+
 The Postfix check does not include any events.
 
 ### Service Checks
+
 The Postfix check does not include any service checks.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][9].
 
 ## Further Reading
 
 Additional helpful documentation, links, and articles:
 
-* [Monitor Postfix queue performance][10]
-
+- [Monitor Postfix queue performance][10]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/postfix/images/postfixgraph.png
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -6,29 +6,31 @@
 
 Get metrics from the PostgreSQL service in real time to:
 
-* Visualize and monitor PostgreSQL states
-* Received notifications about PostgreSQL failovers and events
+- Visualize and monitor PostgreSQL states
+- Received notifications about PostgreSQL failovers and events
 
 ## Setup
+
 ### Installation
 
 The PostgreSQL check is packaged with the Agent. To start gathering your PostgreSQL metrics and logs, [install the Agent][2].
 
 ### Configuration
+
 #### Prepare Postgres
 
 To get started with the PostgreSQL integration, create a read-only `datadog` user with proper access to your PostgreSQL server. Start `psql` on your PostgreSQL database and run:
 
 For PostgreSQL version 10 and above:
 
-```
+```shell
 create user datadog with password '<PASSWORD>';
 grant pg_monitor to datadog;
 ```
 
 For older PostgreSQL versions:
 
-```
+```shell
 create user datadog with password '<PASSWORD>';
 grant SELECT ON pg_stat_database to datadog;
 ```
@@ -37,7 +39,7 @@ grant SELECT ON pg_stat_database to datadog;
 
 To verify the permissions are correct, run the following command:
 
-```
+```shell
 psql -h localhost -U datadog postgres -c \
 "select * from pg_stat_database LIMIT(1);" \
 && echo -e "\e[0;32mPostgres connection - OK\e[0m" \
@@ -46,10 +48,9 @@ psql -h localhost -U datadog postgres -c \
 
 When it prompts for a password, enter the one used in the first command.
 
-
 **Note**: For PostgreSQL versions 9.6 and below, run the following and create a `SECURITY DEFINER` to read from `pg_stat_activity`.
 
-```
+```shell
 CREATE FUNCTION pg_stat_activity() RETURNS SETOF pg_catalog.pg_stat_activity AS
 $$ SELECT * from pg_catalog.pg_stat_activity; $$
 LANGUAGE sql VOLATILE SECURITY DEFINER;
@@ -66,99 +67,97 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `postgres.d/conf.yaml` file to point to your `host` / `port` and set the masters to monitor. See the [sample postgres.d/conf.yaml][3] for all available configuration options.
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
+   instances:
+     ## @param host - string - required
+     ## The hostname to connect to.
+     ## NOTE: Even if the server name is "localhost", the agent connects to
+     ## PostgreSQL using TCP/IP, unless you also provide a value for the sock key.
+     ## If `use_psycopg2` is enabled, use the directory containing
+     ## the UNIX socket (ex: `/run/postgresql/`) otherwise, use the full path to
+     ##  the socket file (ex: `/run/postgresql/.s.PGSQL.5433`).
+     #
+     - host: localhost
 
-          ## @param host - string - required
-          ## The hostname to connect to.
-          ## NOTE: Even if the server name is "localhost", the agent connects to
-          ## PostgreSQL using TCP/IP, unless you also provide a value for the sock key.
-          ## If `use_psycopg2` is enabled, use the directory containing
-          ## the UNIX socket (ex: `/run/postgresql/`) otherwise, use the full path to
-          ##  the socket file (ex: `/run/postgresql/.s.PGSQL.5433`).
-          #
-        - host: localhost
+       ## @param port - integer - required
+       ## Port to use when connecting to PostgreSQL.
+       #
+       port: 5432
 
-          ## @param port - integer - required
-          ## Port to use when connecting to PostgreSQL.
-          #
-          port: 5432
+       ## @param user - string - required
+       ## Datadog Username created to connect to PostgreSQL.
+       #
+       username: datadog
 
-          ## @param user - string - required
-          ## Datadog Username created to connect to PostgreSQL.
-          #
-          username: datadog
-
-          ## @param pass - string - required
-          ## Password associated with the Datadog user.
-          #
-          password: "<PASSWORD>"
-    ```
+       ## @param pass - string - required
+       ## Password associated with the Datadog user.
+       #
+       password: "<PASSWORD>"
+   ```
 
 2. [Restart the Agent][4].
 
 ##### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 PostgreSQL default logging is to `stderr` and logs do not include detailed information. It is recommended to log into a file with additional details specified in the log line prefix. Refer to the PostgreSQL [documentation][14] on this topic for additional details.
 
 1. Logging is configured within the file `/etc/postgresql/<VERSION>/main/postgresql.conf`, for regular log results including statement outputs uncomment the following parameters in the log section:
 
-    ```conf
-      logging_collector = on
-      log_directory = 'pg_log'  # directory where log files are written,
-                                # can be absolute or relative to PGDATA
-      log_filename = 'pg.log'   # log file name, can include pattern
-      log_statement = 'all'     # log all queries
-      #log_duration = on
-      log_line_prefix= '%m [%p] %d %a %u %h %c '
-      log_file_mode = 0644
-      ## For Windows
-      #log_destination = 'eventlog'
-    ```
+   ```conf
+     logging_collector = on
+     log_directory = 'pg_log'  # directory where log files are written,
+                               # can be absolute or relative to PGDATA
+     log_filename = 'pg.log'   # log file name, can include pattern
+     log_statement = 'all'     # log all queries
+     #log_duration = on
+     log_line_prefix= '%m [%p] %d %a %u %h %c '
+     log_file_mode = 0644
+     ## For Windows
+     #log_destination = 'eventlog'
+   ```
 
-2. To gather detailed duration metrics and make them searchable in the Datadog interface, they should be configured inline with the statement themselves.  See below for the recommended configuration differences from above and note that both `log_statement` and `log_duration` options are commented out. See discussion on this topic [here][15].
-   
-   This config logs all statements, but to reduce the output to those which have a certain duration, set the `log_min_duration_statement` value to the desired minimum duration (in milliseconds):
+2. To gather detailed duration metrics and make them searchable in the Datadog interface, they should be configured inline with the statement themselves. See below for the recommended configuration differences from above and note that both `log_statement` and `log_duration` options are commented out. See discussion on this topic [here][15].
 
-    ```conf
-      log_min_duration_statement = 0    # -1 is disabled, 0 logs all statements
-                                        # and their durations, > 0 logs only
-                                        # statements running at least this number
-                                        # of milliseconds
-      #log_statement = 'all'
-      #log_duration = on
-    ```
+    This config logs all statements, but to reduce the output to those which have a certain duration, set the `log_min_duration_statement` value to the desired minimum duration (in milliseconds):
 
+   ```conf
+     log_min_duration_statement = 0    # -1 is disabled, 0 logs all statements
+                                       # and their durations, > 0 logs only
+                                       # statements running at least this number
+                                       # of milliseconds
+     #log_statement = 'all'
+     #log_duration = on
+   ```
 
-2. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
+3. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
-3.  Add and edit this configuration block to your `postgres.d/conf.yaml` file to start collecting your PostgreSQL logs:
+4. Add and edit this configuration block to your `postgres.d/conf.yaml` file to start collecting your PostgreSQL logs:
 
-    ```yaml
-      logs:
-          - type: file
-            path: <LOG_FILE_PATH>
-            source: postgresql
-            sourcecategory: database
-            service: <SERVICE_NAME>
-            #To handle multi line that starts with yyyy-mm-dd use the following pattern
-            #log_processing_rules:
-            #  - type: multi_line
-            #    pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
-            #    name: new_log_start_with_date
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: "<LOG_FILE_PATH>"
+       source: postgresql
+       sourcecategory: database
+       service: "<SERVICE_NAME>"
+       #To handle multi line that starts with yyyy-mm-dd use the following pattern
+       #log_processing_rules:
+       #  - type: multi_line
+       #    pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
+       #    name: new_log_start_with_date
+   ```
 
-    Change the `service` and `path` parameter values to configure for your environment. See the [sample postgres.d/conf.yaml][3] for all available configuration options.
+      Change the `service` and `path` parameter values to configure for your environment. See the [sample postgres.d/conf.yaml][3] for all available configuration options.
 
-4. [Restart the Agent][4].
+5. [Restart the Agent][4].
 
 #### Containerized
 
@@ -167,19 +166,19 @@ For containerized environments, see the [Autodiscovery Integration Templates][5]
 ##### Metric collection
 
 | Parameter            | Value                                                                           |
-|----------------------|---------------------------------------------------------------------------------|
+| -------------------- | ------------------------------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `postgres`                                                                      |
 | `<INIT_CONFIG>`      | blank or `{}`                                                                   |
 | `<INSTANCE_CONFIG>`  | `{"host":"%%host%%", "port":5432,"username":"datadog","password":"<PASSWORD>"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection documentation][6].
 
 | Parameter      | Value                                               |
-|----------------|-----------------------------------------------------|
+| -------------- | --------------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "postgresql", "service": "postgresql"}` |
 
 ### Validation
@@ -195,6 +194,7 @@ Some of the metrics listed below require additional configuration, see the [samp
 See [metadata.csv][8] for a list of metrics provided by this integration.
 
 ### Events
+
 The PostgreSQL check does not include any events.
 
 ### Service Checks
@@ -203,18 +203,19 @@ The PostgreSQL check does not include any events.
 Returns `CRITICAL` if the Agent is unable to connect to the monitored PostgreSQL instance, otherwie returns `OK`.
 
 ## Further Reading
+
 Additional helpful documentation, links, and articles:
 
 ### FAQ
 
-* [PostgreSQL custom metric collection explained][9]
+- [PostgreSQL custom metric collection explained][9]
 
 ### Blog posts
 
-* [100x faster Postgres performance by changing 1 line][10]
-* [Key metrics for PostgreSQL monitoring][11]
-* [Collecting metrics with PostgreSQL monitoring tools][12]
-* [How to collect and monitor PostgreSQL data with Datadog][13]
+- [100x faster Postgres performance by changing 1 line][10]
+- [Key metrics for PostgreSQL monitoring][11]
+- [Collecting metrics with PostgreSQL monitoring tools][12]
+- [How to collect and monitor PostgreSQL data with Datadog][13]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/postgres/images/postgresql_dashboard.png
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -4,10 +4,10 @@
 
 ## Overview
 
-Get metrics from the PostgreSQL service in real time to:
+Get metrics from PostgreSQL in real time to:
 
-- Visualize and monitor PostgreSQL states
-- Received notifications about PostgreSQL failovers and events
+- Visualize and monitor PostgreSQL states.
+- Received notifications about PostgreSQL failovers and events.
 
 ## Setup
 
@@ -19,16 +19,16 @@ The PostgreSQL check is packaged with the Agent. To start gathering your Postgre
 
 #### Prepare Postgres
 
-To get started with the PostgreSQL integration, create a read-only `datadog` user with proper access to your PostgreSQL server. Start `psql` on your PostgreSQL database and run:
+To get started with the PostgreSQL integration, create a read-only `datadog` user with proper access to your PostgreSQL server. Start `psql` on your PostgreSQL database.
 
-For PostgreSQL version 10 and above:
+For PostgreSQL version 10 and above, run:
 
 ```shell
 create user datadog with password '<PASSWORD>';
 grant pg_monitor to datadog;
 ```
 
-For older PostgreSQL versions:
+For older PostgreSQL versions, run:
 
 ```shell
 create user datadog with password '<PASSWORD>';
@@ -103,9 +103,9 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 _Available for Agent versions >6.0_
 
-PostgreSQL default logging is to `stderr` and logs do not include detailed information. It is recommended to log into a file with additional details specified in the log line prefix. Refer to the PostgreSQL [documentation][14] on this topic for additional details.
+PostgreSQL default logging is to `stderr`, and logs do not include detailed information. It is recommended to log into a file with additional details specified in the log line prefix. Refer to the PostgreSQL [documentation][14] on this topic for additional details.
 
-1. Logging is configured within the file `/etc/postgresql/<VERSION>/main/postgresql.conf`, for regular log results including statement outputs uncomment the following parameters in the log section:
+1. Logging is configured within the file `/etc/postgresql/<VERSION>/main/postgresql.conf`. For regular log results, including statement outputs, uncomment the following parameters in the log section:
 
    ```conf
      logging_collector = on
@@ -200,7 +200,7 @@ The PostgreSQL check does not include any events.
 ### Service Checks
 
 **postgres.can_connect**:<br>
-Returns `CRITICAL` if the Agent is unable to connect to the monitored PostgreSQL instance, otherwie returns `OK`.
+Returns `CRITICAL` if the Agent is unable to connect to the monitored PostgreSQL instance, otherwise returns `OK`.
 
 ## Further Reading
 

--- a/powerdns_recursor/README.md
+++ b/powerdns_recursor/README.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-Track the performance of your PowerDNS Recursor and monitor strange or worrisome traffic. This Agent check collects a wealth of metrics from your recursors, including those for:
+Track the performance of your PowerDNS Recursor and monitor strange or worrisome traffic. This Agent check collects a variety of metrics from your recursors, including those for:
 
-- Query answer times - see how many responses take less than 1ms, 10ms, 100ms, 1s, and greater than 1s
-- Query timeouts
-- Cache hits and misses
-- Answer rates by type - SRVFAIL, NXDOMAIN, NOERROR
-- Ignored and dropped packets
+- Query answer times—see how many responses take less than 1ms, 10ms, 100ms, 1s, or greater than 1s.
+- Query timeouts.
+- Cache hits and misses.
+- Answer rates by type: SRVFAIL, NXDOMAIN, NOERROR.
+- Ignored and dropped packets.
 
 And many more.
 
@@ -22,7 +22,7 @@ The PowerDNS Recursor check is included in the [Datadog Agent][1] package, so yo
 
 #### Prepare PowerDNS
 
-This check collects performance statistics via pdns_recursor's statistics API. Versions of pdns_recursor before 4.1 do not enable the stats API by default. If you're running an older version, enable it by adding the following to your recursor config file (e.g. `/etc/powerdns/recursor.conf`):
+This check collects performance statistics via PowerDNS Recursor's statistics API. Versions of pdns_recursor before 4.1 do not enable the stats API by default. If you're running an older version, enable it by adding the following to your recursor config file (e.g. `/etc/powerdns/recursor.conf`):
 
 ```conf
 webserver=yes

--- a/powerdns_recursor/README.md
+++ b/powerdns_recursor/README.md
@@ -4,11 +4,11 @@
 
 Track the performance of your PowerDNS Recursor and monitor strange or worrisome traffic. This Agent check collects a wealth of metrics from your recursors, including those for:
 
-* Query answer times - see how many responses take less than 1ms, 10ms, 100ms, 1s, and greater than 1s
-* Query timeouts
-* Cache hits and misses
-* Answer rates by type - SRVFAIL, NXDOMAIN, NOERROR
-* Ignored and dropped packets
+- Query answer times - see how many responses take less than 1ms, 10ms, 100ms, 1s, and greater than 1s
+- Query timeouts
+- Cache hits and misses
+- Answer rates by type - SRVFAIL, NXDOMAIN, NOERROR
+- Ignored and dropped packets
 
 And many more.
 
@@ -24,13 +24,13 @@ The PowerDNS Recursor check is included in the [Datadog Agent][1] package, so yo
 
 This check collects performance statistics via pdns_recursor's statistics API. Versions of pdns_recursor before 4.1 do not enable the stats API by default. If you're running an older version, enable it by adding the following to your recursor config file (e.g. `/etc/powerdns/recursor.conf`):
 
-   ```
-   webserver=yes
-   api-key=changeme             # only available since ver 4.0
-   webserver-readonly=yes       # default no
-   #webserver-port=8081         # default 8082
-   #webserver-address=0.0.0.0   # default 127.0.0.1
-   ```
+```conf
+webserver=yes
+api-key=changeme             # only available since ver 4.0
+webserver-readonly=yes       # default no
+#webserver-port=8081         # default 8082
+#webserver-address=0.0.0.0   # default 127.0.0.1
+```
 
 If you're running pdns_recursor 3.x, prepend `experimental-` to these option names, e.g. `experimental-webserver=yes`.
 
@@ -44,41 +44,40 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `powerdns_recursor.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample powerdns_recursor.d/conf.yaml][3] for all available configuration options:
 
-    ```yaml
-        init_config:
+   ```yaml
+   init_config:
 
-        instances:
+   instances:
+     ## @param host - string - required
+     ## Host running the recursor.
+     #
+     - host: 127.0.0.1
 
-            ## @param host - string - required
-            ## Host running the recursor.
-            #
-          - host: 127.0.0.1
+       ## @param port - integer - required
+       ## Recursor web server port.
+       #
+       port: 8082
 
-            ## @param port - integer - required
-            ## Recursor web server port.
-            #
-            port: 8082
+       ## @param api_key - string - required
+       ## Recursor web server api key.
+       #
+       api_key: "<POWERDNS_API_KEY>"
 
-            ## @param api_key - string - required
-            ## Recursor web server api key.
-            #
-            api_key: "<POWERDNS_API_KEY>"
-
-            ## @param version - integer - required - default: 3
-            ## Version 3 or 4 of PowerDNS Recursor to connect to.
-            ## The PowerDNS Recursor in v4 has a production ready web server that allows for
-            ## statistics gathering. In version 3.x the server was marked as experimental.
-            ##
-            ## As the server was marked as experimental in version 3 many of the metrics have
-            ## changed names and the API structure (paths) have also changed. With these changes
-            ## there has been a need to separate the two concerns. The check now has a key value
-            ## version: which if set to version 4 queries with the correct API path on the
-            ## non-experimental web server.
-            ##
-            ## https://doc.powerdns.com/md/httpapi/api_spec/#url-apiv1serversserver95idstatistics
-            #
-            version: 3
-    ```
+       ## @param version - integer - required - default: 3
+       ## Version 3 or 4 of PowerDNS Recursor to connect to.
+       ## The PowerDNS Recursor in v4 has a production ready web server that allows for
+       ## statistics gathering. In version 3.x the server was marked as experimental.
+       ##
+       ## As the server was marked as experimental in version 3 many of the metrics have
+       ## changed names and the API structure (paths) have also changed. With these changes
+       ## there has been a need to separate the two concerns. The check now has a key value
+       ## version: which if set to version 4 queries with the correct API path on the
+       ## non-experimental web server.
+       ##
+       ## https://doc.powerdns.com/md/httpapi/api_spec/#url-apiv1serversserver95idstatistics
+       #
+       version: 3
+   ```
 
 2. [Restart the Agent][4].
 
@@ -87,7 +86,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 For containerized environments, see the [Autodiscovery Integration Templates][5] for guidance on applying the parameters below.
 
 | Parameter            | Value                                                                            |
-|----------------------|----------------------------------------------------------------------------------|
+| -------------------- | -------------------------------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `powerdns_recursor`                                                              |
 | `<INIT_CONFIG>`      | blank or `{}`                                                                    |
 | `<INSTANCE_CONFIG>`  | `{"host":"%%host%%", "port":8082, "api_key":"<POWERDNS_API_KEY>", "version": 3}` |
@@ -107,6 +106,7 @@ See [metadata.csv][7] for a list of metrics provided by this integration.
 The PowerDNS Recursor check does not include any events.
 
 ### Service Checks
+
 **`powerdns.recursor.can_connect`**:
 
 Returns CRITICAL if the Agent is unable to connect to the recursor's statistics API, otherwise OK.

--- a/presto/README.md
+++ b/presto/README.md
@@ -4,8 +4,8 @@
 
 This check collects [Presto][1] metrics, for example:
 
-* Overall activity metrics: completed/failed queries, data input/output size, execution time
-* Performance metrics: cluster memory, input CPU, execution CPU time
+- Overall activity metrics: completed/failed queries, data input/output size, execution time
+- Performance metrics: cluster memory, input CPU, execution CPU time
 
 ## Setup
 
@@ -18,14 +18,9 @@ No additional installation is needed on your server. Install the Agent on each C
 
 ### Configuration
 
-1. Edit the `presto.d/conf.yaml` file, in the `conf.d/` folder at the root of your
-   Agent's configuration directory to start collecting your presto performance data.
-   See the [sample presto.d/conf.yaml][4] for all available configuration options.
+1. Edit the `presto.d/conf.yaml` file, in the `conf.d/` folder at the root of yourAgent's configuration directory to start collecting your presto performance data. See the [sample presto.d/conf.yaml][4] for all available configuration options.
 
-    This check has a limit of 350 metrics per instance. The number of returned metrics is indicated in the info page.
-    You can specify the metrics you are interested in by editing the configuration below.
-    To learn how to customize the metrics to collect visit the [JMX Checks documentation][5] for more detailed instructions.
-    If you need to monitor more metrics, contact [Datadog support][6].
+    This check has a limit of 350 metrics per instance. The number of returned metrics is indicated in the info page. You can specify the metrics you are interested in by editing the configuration below. To learn how to customize the metrics to collect visit the [JMX Checks documentation][5] for more detailed instructions. If you need to monitor more metrics, contact [Datadog support][6].
 
 2. [Restart the Agent][7].
 
@@ -35,24 +30,24 @@ Use the default configuration of your presto.d/conf.yaml file to activate the co
 
 #### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Add this configuration block to your presto.d/conf.yaml file to start collecting your Presto logs:
 
-    ```
-      logs:
-        - type: file
-          path: /var/log/presto/*.log
-          source: presto
-          sourcecategory: database
-          service: <SERVICE_NAME>
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/presto/*.log
+       source: presto
+       sourcecategory: database
+       service: "<SERVICE_NAME>"
+   ```
 
     Change the `path` and `service` parameter values and configure them for your environment. See the sample [presto.d/conf.yaml][4] for all available configuration options.
 
@@ -80,7 +75,6 @@ Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from
 ## Troubleshooting
 
 Need help? Contact [Datadog support][6].
-
 
 [1]: https://docs.datadoghq.com/integrations/presto
 [2]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/presto/README.md
+++ b/presto/README.md
@@ -4,8 +4,8 @@
 
 This check collects [Presto][1] metrics, for example:
 
-- Overall activity metrics: completed/failed queries, data input/output size, execution time
-- Performance metrics: cluster memory, input CPU, execution CPU time
+- Overall activity metrics: completed/failed queries, data input/output size, execution time.
+- Performance metrics: cluster memory, input CPU, execution CPU time.
 
 ## Setup
 
@@ -18,27 +18,27 @@ No additional installation is needed on your server. Install the Agent on each C
 
 ### Configuration
 
-1. Edit the `presto.d/conf.yaml` file, in the `conf.d/` folder at the root of yourAgent's configuration directory to start collecting your presto performance data. See the [sample presto.d/conf.yaml][4] for all available configuration options.
+1. Edit the `presto.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your Presto performance data. See the [sample presto.d/conf.yaml][4] for all available configuration options.
 
-    This check has a limit of 350 metrics per instance. The number of returned metrics is indicated in the info page. You can specify the metrics you are interested in by editing the configuration below. To learn how to customize the metrics to collect visit the [JMX Checks documentation][5] for more detailed instructions. If you need to monitor more metrics, contact [Datadog support][6].
+    This check has a limit of 350 metrics per instance. The number of returned metrics is indicated in the info page. You can specify the metrics you are interested in by editing the configuration below. To learn how to customize the metrics to collect, visit the [JMX Checks documentation][5] for more detailed instructions. If you need to monitor more metrics, contact [Datadog support][6].
 
 2. [Restart the Agent][7].
 
 #### Metric collection
 
-Use the default configuration of your presto.d/conf.yaml file to activate the collection of your Presto metrics. See the sample [presto.d/conf.yaml][4] for all available configuration options.
+Use the default configuration of your `presto.d/conf.yaml` file to activate the collection of your Presto metrics. See the sample [presto.d/conf.yaml][4] for all available configuration options.
 
 #### Log collection
 
 _Available for Agent versions >6.0_
 
-1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
+1. Collecting logs is disabled by default in the Datadog Agent. Enable it in your `datadog.yaml` file:
 
    ```yaml
    logs_enabled: true
    ```
 
-2. Add this configuration block to your presto.d/conf.yaml file to start collecting your Presto logs:
+2. Add this configuration block to your `presto.d/conf.yaml` file to start collecting your Presto logs:
 
    ```yaml
    logs:

--- a/process/README.md
+++ b/process/README.md
@@ -2,22 +2,22 @@
 
 ## Overview
 
-The process check lets you:
+The Process Check lets you:
 
-- Collect resource usage metrics for specific running processes on any host: CPU, memory, I/O, number of threads, etc
+- Collect resource usage metrics for specific running processes on any host: CPU, memory, I/O, number of threads, etc.
 - Use [Process Monitors][1]: configure thresholds for how many instances of a specific process ought to be running and get alerts when the thresholds aren't met (see **Service Checks** below).
 
 ## Setup
 
 ### Installation
 
-The process check is included in the [Datadog Agent][1] package, so you don't need to install anything else on your server.
+The Process Check is included in the [Datadog Agent][1] package, so you don't need to install anything else on your server.
 
 ### Configuration
 
-Unlike many checks, the process check doesn't monitor anything useful by default; you must configure which processes you want to monitor, and how.
+Unlike many checks, the Process Check doesn't monitor anything useful by default. You must configure which processes you want to monitor, and how.
 
-1. While there's no standard default check configuration, here's an example `process.d/conf.yaml` that monitors ssh/sshd processes. See the [sample process.d/conf.yaml][3] for all available configuration options:
+1. While there's no standard default check configuration, here's an example `process.d/conf.yaml` that monitors SSH/SSHD processes. See the [sample process.d/conf.yaml][3] for all available configuration options:
 
    ```yaml
    init_config:
@@ -37,7 +37,7 @@ Unlike many checks, the process check doesn't monitor anything useful by default
        search_string: ["ssh", "sshd"]
    ```
 
-    Some process metrics require either running the Datadog collector as the same user as the monitored process or privileged access to be retrieved. Where the former option is not desired, and to avoid running the Datadog collector as `root`, the `try_sudo` option lets the process check try using `sudo` to collect this metric. As of now, only the `open_file_descriptors` metric on Unix platforms is taking advantage of this setting. Note: the appropriate sudoers rules have to be configured for this to work:
+    Some process metrics require either running the Datadog collector as the same user as the monitored process or privileged access to be retrieved. Where the former option is not desired, and to avoid running the Datadog collector as `root`, the `try_sudo` option lets the Process Check try using `sudo` to collect this metric. As of now, only the `open_file_descriptors` metric on Unix platforms is taking advantage of this setting. Note: the appropriate sudoers rules have to be configured for this to work:
 
    ```text
    dd-agent ALL=NOPASSWD: /bin/ls /proc/*/fd/
@@ -55,8 +55,8 @@ Unlike many checks, the process check doesn't monitor anything useful by default
 
 **Note**: Some metrics are not available on Linux or OSX:
 
-- Process I/O metrics aren't available on Linux or OSX since the files that the agent read (/proc//io) are only readable by the process's owner. For more information, [read the Agent FAQ][9]
-- `system.cpu.iowait` is not available on windows
+- Process I/O metrics are **not** available on Linux or OSX since the files that the Agent reads (`/proc//io`) are only readable by the process's owner. For more information, [read the Agent FAQ][9]
+- `system.cpu.iowait` is not available on Windows.
 
 See [metadata.csv][10] for a list of metrics provided by this check.
 
@@ -64,7 +64,7 @@ All metrics are per `instance` configured in process.yaml, and are tagged `proce
 
 ### Events
 
-The Process check does not include any events.
+The Process Check does not include any events.
 
 ### Service Checks
 
@@ -89,7 +89,7 @@ The Agent submits a `process.up` tagged `process:my_worker_process` whose status
 
 - CRITICAL when there are less than 1 or more than 7 worker processes
 - WARNING when there are 1, 2, 6, or 7 worker processes
-- OK when there are 3, 4 or 5 worker processes
+- OK when there are 3, 4, or 5 worker processes
 
 ## Troubleshooting
 
@@ -97,7 +97,7 @@ Need help? Contact [Datadog support][11].
 
 ## Further Reading
 
-To get a better idea of how (or why) to monitor process resource consumption with Datadog, check out our [series of blog posts][12] about it.
+To get a better idea of how (or why) to monitor process resource consumption with Datadog, check out this [series of blog posts][12] about it.
 
 [1]: https://docs.datadoghq.com/monitoring/#process
 [2]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/process/README.md
+++ b/process/README.md
@@ -4,8 +4,8 @@
 
 The process check lets you:
 
-* Collect resource usage metrics for specific running processes on any host: CPU, memory, I/O, number of threads, etc
-* Use [Process Monitors][1]: configure thresholds for how many instances of a specific process ought to be running and get alerts when the thresholds aren't met (see **Service Checks** below).
+- Collect resource usage metrics for specific running processes on any host: CPU, memory, I/O, number of threads, etc
+- Use [Process Monitors][1]: configure thresholds for how many instances of a specific process ought to be running and get alerts when the thresholds aren't met (see **Service Checks** below).
 
 ## Setup
 
@@ -19,30 +19,29 @@ Unlike many checks, the process check doesn't monitor anything useful by default
 
 1. While there's no standard default check configuration, here's an example `process.d/conf.yaml` that monitors ssh/sshd processes. See the [sample process.d/conf.yaml][3] for all available configuration options:
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
+   instances:
+     ## @param name - string - required
+     ## Used to uniquely identify your metrics
+     ## as they are tagged with this name in Datadog.
+     #
+     - name: ssh
 
-          ## @param name - string - required
-          ## Used to uniquely identify your metrics
-          ## as they are tagged with this name in Datadog.
-          #
-        - name: ssh
-
-          ## @param search_string - list of strings - required
-          ## If one of the elements in the list matches, it return the count of
-          ## all the processes that match the string exactly by default.
-          ## Change this behavior with the parameter `exact_match: false`.
-          #
-          search_string: ['ssh', 'sshd']
-    ```
+       ## @param search_string - list of strings - required
+       ## If one of the elements in the list matches, it return the count of
+       ## all the processes that match the string exactly by default.
+       ## Change this behavior with the parameter `exact_match: false`.
+       #
+       search_string: ["ssh", "sshd"]
+   ```
 
     Some process metrics require either running the Datadog collector as the same user as the monitored process or privileged access to be retrieved. Where the former option is not desired, and to avoid running the Datadog collector as `root`, the `try_sudo` option lets the process check try using `sudo` to collect this metric. As of now, only the `open_file_descriptors` metric on Unix platforms is taking advantage of this setting. Note: the appropriate sudoers rules have to be configured for this to work:
 
-    ```
-    dd-agent ALL=NOPASSWD: /bin/ls /proc/*/fd/
-    ```
+   ```text
+   dd-agent ALL=NOPASSWD: /bin/ls /proc/*/fd/
+   ```
 
 2. [Restart the Agent][7].
 
@@ -51,21 +50,24 @@ Unlike many checks, the process check doesn't monitor anything useful by default
 [Run the Agent's `status` subcommand][8] and look for `process` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 **Note**: Some metrics are not available on Linux or OSX:
 
-* Process I/O metrics aren't available on Linux or OSX since the files that the agent read (/proc//io) are only readable by the process's owner. For more information, [read the Agent FAQ][9]
-* `system.cpu.iowait` is not available on windows
+- Process I/O metrics aren't available on Linux or OSX since the files that the agent read (/proc//io) are only readable by the process's owner. For more information, [read the Agent FAQ][9]
+- `system.cpu.iowait` is not available on windows
 
 See [metadata.csv][10] for a list of metrics provided by this check.
 
 All metrics are per `instance` configured in process.yaml, and are tagged `process_name:<instance_name>`.
 
 ### Events
+
 The Process check does not include any events.
 
 ### Service Checks
+
 **process.up**:
 
 The Agent submits this service check for each instance in `process.yaml`, tagging each with `process:<name>`.
@@ -74,10 +76,10 @@ For an instance with no `thresholds` specified, the service check has a status o
 
 For an instance with `thresholds` specified, consider this example:
 
-```
+```yaml
 instances:
   - name: my_worker_process
-    search_string: ['/usr/local/bin/worker']
+    search_string: ["/usr/local/bin/worker"]
     thresholds:
       critical: [1, 7]
       warning: [3, 5]
@@ -90,11 +92,12 @@ The Agent submits a `process.up` tagged `process:my_worker_process` whose status
 - OK when there are 3, 4 or 5 worker processes
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][11].
 
 ## Further Reading
-To get a better idea of how (or why) to monitor process resource consumption with Datadog, check out our [series of blog posts][12] about it.
 
+To get a better idea of how (or why) to monitor process resource consumption with Datadog, check out our [series of blog posts][12] about it.
 
 [1]: https://docs.datadoghq.com/monitoring/#process
 [2]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -24,10 +24,10 @@ Edit the `prometheus.d/conf.yaml` file to retrieve metrics from applications tha
 
 Each instance is at least composed of:
 
-| Setting          | Description                                                                                                      |
-|------------------|------------------------------------------------------------------------------------------------------------------|
-| `prometheus_url` | A URL that points to the metric route (**Note:** must be unique)                                                 |
-| `namespace`      | This namespace is prepended to all metrics (to avoid metrics name collision)                                     |
+| Setting          | Description                                                                                                         |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `prometheus_url` | A URL that points to the metric route (**Note:** must be unique)                                                    |
+| `namespace`      | This namespace is prepended to all metrics (to avoid metrics name collision)                                        |
 | `metrics`        | A list of metrics to retrieve as custom metrics in the form `- <METRIC_NAME>` or `- <METRIC_NAME>: <RENAME_METRIC>` |
 
 When listing metrics, it's possible to use the wildcard `*` like this `- <METRIC_NAME>*` to retrieve all matching metrics. **Note:** use wildcards with caution as it can potentially send a lot of custom metrics.
@@ -43,6 +43,7 @@ If `send_monotonic_counter: True`, the Agent sends the deltas of the values in q
 [Run the Agent's `status` subcommand][3] and look for `prometheus` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 All metrics collected by the prometheus check are forwarded to Datadog as custom metrics.
@@ -50,6 +51,7 @@ All metrics collected by the prometheus check are forwarded to Datadog as custom
 Note: Bucket data for a given `<HISTOGRAM_METRIC_NAME>` Prometheus histogram metric are stored in the `<HISTOGRAM_METRIC_NAME>.count` metric within Datadog with the tags `upper_bound` including the name of the buckets. To access the `+Inf` bucket, use `upper_bound:none`.
 
 ### Events
+
 The Prometheus check does not include any events.
 
 ### Service Checks
@@ -57,13 +59,14 @@ The Prometheus check does not include any events.
 The Prometheus check does not include any service checks.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][4].
 
 ## Further Reading
 
-* [Introducing Prometheus support for Datadog Agent 6][5]
-* [Configuring a Prometheus Check][6]
-* [Writing a custom Prometheus Check][7]
+- [Introducing Prometheus support for Datadog Agent 6][5]
+- [Configuring a Prometheus Check][6]
+- [Writing a custom Prometheus Check][7]
 
 [2]: https://github.com/DataDog/integrations-core/blob/master/prometheus/datadog_checks/prometheus/data/conf.yaml.example
 [3]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information


### PR DESCRIPTION
### What does this PR do?

Follow up on:
* https://github.com/DataDog/integrations-core/pull/5663
* https://github.com/DataDog/integrations-core/pull/5662
* https://github.com/DataDog/integrations-core/pull/5664
* https://github.com/DataDog/integrations-core/pull/5665
* https://github.com/DataDog/integrations-core/pull/5666

This PR lints markdown file to avoid layout issues moving forward with the public doc. I manually checked the layout for all of those integrations.

Change from this lint:

- Bullet list are defined with `-`
- Italic is now defined with `_<TEXT>_`
- Fixes table layout
- Lint code examples displayed
- Each code example has a language assigned, and the default is `text`
- There should be always an empty line before/after a header
- **Available for Agent >6.0** has been transformed into _Available for Agent versions >6.0_

### Motivation
Better doc for a better world
