### PR TITLE
7. Linting integration README

### DIFF
--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -6,8 +6,8 @@
 
 This check monitors [RabbitMQ][2] through the Datadog Agent. It allows you to:
 
-- Track queue-based stats: queue size, consumer count, unacknowledged messages, redelivered messages, etc
-- Track node-based stats: waiting processes, used sockets, used file descriptors, etc
+- Track queue-based stats: queue size, consumer count, unacknowledged messages, redelivered messages, etc.
+- Track node-based stats: waiting processes, used sockets, used file descriptors, etc.
 - Monitor vhosts for aliveness and number of connections
 
 And more.

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -6,9 +6,9 @@
 
 This check monitors [RabbitMQ][2] through the Datadog Agent. It allows you to:
 
-* Track queue-based stats: queue size, consumer count, unacknowledged messages, redelivered messages, etc
-* Track node-based stats: waiting processes, used sockets, used file descriptors, etc
-* Monitor vhosts for aliveness and number of connections
+- Track queue-based stats: queue size, consumer count, unacknowledged messages, redelivered messages, etc
+- Track node-based stats: waiting processes, used sockets, used file descriptors, etc
+- Monitor vhosts for aliveness and number of connections
 
 And more.
 
@@ -32,7 +32,7 @@ Enable the RabbitMQ management plugin. See [RabbitMQ's documentation][4] to enab
 
 Create an Agent user for your default vhost with the following commands:
 
-```
+```text
 rabbitmqctl add_user datadog <SECRET>
 rabbitmqctl set_permissions  -p / datadog "^aliveness-test$" "^amq\.default$" ".*"
 rabbitmqctl set_user_tags datadog monitoring
@@ -48,17 +48,16 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `rabbitmq.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][6] to start collecting your RabbitMQ metrics. See the [sample rabbitmq.d/conf.yaml][7] for all available configuration options.
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
-
-          ## @param rabbit_api_url - string - required
-          ## For every instance a 'rabbitmq_api_url' must be provided, pointing to the api
-          ## url of the RabbitMQ Managment Plugin (http://www.rabbitmq.com/management.html).
-          #
-        - rabbitmq_api_url: http://localhost:15672/api/
-    ```
+   instances:
+     ## @param rabbit_api_url - string - required
+     ## For every instance a 'rabbitmq_api_url' must be provided, pointing to the api
+     ## url of the RabbitMQ Managment Plugin (http://www.rabbitmq.com/management.html).
+     #
+     - rabbitmq_api_url: http://localhost:15672/api/
+   ```
 
     **Note**: The Agent checks all queues, vhosts, and nodes by default, but you can provide lists or regexes to limit this. See the [rabbitmq.d/conf.yaml][7] for examples.
 
@@ -66,34 +65,34 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 ##### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. To modify the default log file location either set the `RABBITMQ_LOGS` environment variable or add the following to your RabbitMQ configuration file (`/etc/rabbitmq/rabbitmq.conf`):
 
-    ```conf
-      log.dir = /var/log/rabbit
-      log.file = rabbit.log
-    ```
+   ```conf
+     log.dir = /var/log/rabbit
+     log.file = rabbit.log
+   ```
 
 2. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 3. Add this configuration block to your `rabbitmq.d/conf.yaml` file to start collecting your RabbitMQ logs:
 
-    ```yaml
-      logs:
-          - type: file
-            path: /var/log/rabbit/*.log
-            source: rabbitmq
-            service: myservice
-            log_processing_rules:
-              - type: multi_line
-                name: logs_starts_with_equal_sign
-                pattern: "="
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/rabbit/*.log
+       source: rabbitmq
+       service: myservice
+       log_processing_rules:
+         - type: multi_line
+           name: logs_starts_with_equal_sign
+           pattern: "="
+   ```
 
 4. [Restart the Agent][8].
 
@@ -103,27 +102,28 @@ For containerized environments, see the [Autodiscovery Integration Templates][9]
 
 ##### Metric collection
 
-| Parameter            | Value                            |
-| -------------------- | -------------------------------- |
-| `<INTEGRATION_NAME>` | `rabbitmq`                       |
-| `<INIT_CONFIG>`      | blank or `{}`                    |
+| Parameter            | Value                                        |
+| -------------------- | -------------------------------------------- |
+| `<INTEGRATION_NAME>` | `rabbitmq`                                   |
+| `<INIT_CONFIG>`      | blank or `{}`                                |
 | `<INSTANCE_CONFIG>`  | `{"rabbitmq_api_url":"%%host%%:15672/api/"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection documentation][10].
 
 | Parameter      | Value                                                                                                                                               |
 | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<LOG_CONFIG>` | `{"source": "rabbitmq", "service": "rabbitmq", "log_processing_rules": {"type":"multi_line","name":"logs_starts_with_equal_sign", "pattern": "="}}` |
+| `<LOG_CONFIG>` | `{"source": "rabbitmq", "service": "rabbitmq", "log_processing_rules": {"type":"multi_line","name":"logs_starts_with_equal_sign", "pattern": "="}}` |
 
 ### Validation
 
 [Run the Agent's status subcommand][11] and look for `rabbitmq` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][12] for a list of metrics provided by this integration.
@@ -149,16 +149,18 @@ Returns `CRITICAL` if the Agent cannot connect to RabbitMQ to collect metrics, o
 Need help? Contact [Datadog support][13].
 
 ## Further Reading
+
 Additional helpful documentation, links, and articles:
 
 ### Datadog Blog
-* [Key metrics for RabbitMQ monitoring][14]
-* [Collecting metrics with RabbitMQ monitoring tools][15]
-* [Monitoring RabbitMQ performance with Datadog][16]
+
+- [Key metrics for RabbitMQ monitoring][14]
+- [Collecting metrics with RabbitMQ monitoring tools][15]
+- [Monitoring RabbitMQ performance with Datadog][16]
 
 ### FAQ
-* [Tagging RabbitMQ queues by tag family][17]
 
+- [Tagging RabbitMQ queues by tag family][17]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/rabbitmq/images/rabbitmq_dashboard.png
 [2]: https://www.rabbitmq.com

--- a/redisdb/README.md
+++ b/redisdb/README.md
@@ -5,11 +5,13 @@
 Whether you use Redis as a database, cache, or message queue, this integration helps you track problems with your Redis servers and the parts of your infrastructure that they serve. The Datadog Agent's Redis check collects metrics related to performance, memory usage, blocked clients, slave connections, disk persistence, expired and evicted keys, and many more.
 
 ## Setup
+
 ### Installation
 
 The Redis check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your Redis servers.
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
@@ -18,63 +20,64 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `redisdb.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3]. The following parameters may require updating. See the [sample redisdb.d/conf.yaml][4] for all available configuration options.
 
-    ```yaml
-      init_config:
-      instances:
-        ## @param host - string - required
-        ## Enter the host to connect to.
-        - host: localhost
-          ## @param port - integer - required
-          ## Enter the port of the host to connect to.
-          port: 6379
-      ```
+   ```yaml
+   init_config:
+   instances:
+     ## @param host - string - required
+     ## Enter the host to connect to.
+     - host: localhost
+       ## @param port - integer - required
+       ## Enter the port of the host to connect to.
+       port: 6379
+   ```
 
 2. [Restart the Agent][5].
 
 ##### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Uncomment and edit this configuration block at the bottom of your `redisdb.d/conf.yaml`:
 
-    ```yaml
-      logs:
-          - type: file
-            path: /var/log/redis_6379.log
-            source: redis
-            sourcecategory: database
-            service: myapplication
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/redis_6379.log
+       source: redis
+       sourcecategory: database
+       service: myapplication
+   ```
 
     Change the `path` and `service` parameter values and configure them for your environment. See the [sample redisdb.yaml][4] for all available configuration options.
 
 3. [Restart the Agent][5].
 
 #### Containerized
+
 For containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying the parameters below.
 
 ##### Metric collection
 
-| Parameter            | Value                                                                                       |
-|----------------------|---------------------------------------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `redisdb`                                                                                   |
-| `<INIT_CONFIG>`      | blank or `{}`                                                                               |
-| `<INSTANCE_CONFIG>`  | <pre>{"host": "%%host%%",<br> "port":"6379",<br> "password":"%%env_REDIS_PASSWORD%%"}</pre> |
+| Parameter            | Value                                                                      |
+| -------------------- | -------------------------------------------------------------------------- |
+| `<INTEGRATION_NAME>` | `redisdb`                                                                  |
+| `<INIT_CONFIG>`      | blank or `{}`                                                              |
+| `<INSTANCE_CONFIG>`  | `{"host": "%%host%%", "port":"6379", "password":"%%env_REDIS_PASSWORD%%"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][11].
 
 | Parameter      | Value                                               |
-|----------------|-----------------------------------------------------|
+| -------------- | --------------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "redis", "service": "<YOUR_APP_NAME>"}` |
 
 ### Validation
@@ -101,11 +104,11 @@ Returns `CRITICAL` if this Redis instance is unable to connect to its master ins
 
 ## Troubleshooting
 
-* [Redis Integration Error: "unknown command 'CONFIG'"][8]
+- [Redis Integration Error: "unknown command 'CONFIG'"][8]
 
 ### Agent cannot connect
 
-```
+```shell
     redisdb
     -------
       - instance #0 [ERROR]: 'Error 111 connecting to localhost:6379. Connection refused.'
@@ -116,7 +119,7 @@ Check that the connection info in `redisdb.yaml` is correct.
 
 ### Agent cannot authenticate
 
-```
+```shell
     redisdb
     -------
       - instance #0 [ERROR]: 'NOAUTH Authentication required.'
@@ -129,8 +132,7 @@ Configure a `password` in `redisdb.yaml`.
 
 Additional helpful documentation, links, and articles:
 
-* [How to monitor Redis performance metrics][10]
-
+- [How to monitor Redis performance metrics][10]
 
 [1]: https://docs.datadoghq.com/agent/autodiscovery/integrations
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/riak/README.md
+++ b/riak/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-This check lets you track node, vnode and ring performance metrics from RiakKV or RiakTS.
+This check lets you track node, vnode, and ring performance metrics from RiakKV or RiakTS.
 
 ## Setup
 

--- a/riak/README.md
+++ b/riak/README.md
@@ -7,11 +7,13 @@
 This check lets you track node, vnode and ring performance metrics from RiakKV or RiakTS.
 
 ## Setup
+
 ### Installation
 
 The Riak check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your Riak servers.
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
@@ -20,56 +22,55 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `riak.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3]. See the [sample riak.yaml][4] for all available configuration options:
 
-    ```yaml
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
-
-          ## @param url - string - required
-          ## Riak stats url to connect to.
-          #
-        - url: http://127.0.0.1:8098/stats
-    ```
+   instances:
+     ## @param url - string - required
+     ## Riak stats url to connect to.
+     #
+     - url: http://127.0.0.1:8098/stats
+   ```
 
 2. [Restart the Agent][5] to start sending Riak metrics to Datadog.
 
 ##### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Add this configuration block to your `riak.d/conf.yaml` file to start collecting your Riak logs:
 
-    ```
-      logs:
-        - type: file
-          path: /var/log/riak/console.log
-          source: riak
-          service: <SERVICE_NAME>
+   ```yaml
+     logs:
+       - type: file
+         path: /var/log/riak/console.log
+         source: riak
+         service: "<SERVICE_NAME>"
 
-        - type: file
-          path: /var/log/riak/error.log
-          source: riak
-          service: <SERVICE_NAME>
-          log_processing_rules:
-            - type: multi_line
-              name: new_log_start_with_date
-              pattern: \d{4}\-\d{2}\-\d{2}
+       - type: file
+         path: /var/log/riak/error.log
+         source: riak
+         service: "<SERVICE_NAME>"
+         log_processing_rules:
+           - type: multi_line
+             name: new_log_start_with_date
+             pattern: \d{4}\-\d{2}\-\d{2}
 
-        - type: file
-          path: /var/log/riak/crash.log
-          source: riak
-          service: <SERVICE_NAME>
-          log_processing_rules:
-            - type: multi_line
-              name: new_log_start_with_date
-              pattern: \d{4}\-\d{2}\-\d{2}
-    ```
+       - type: file
+         path: /var/log/riak/crash.log
+         source: riak
+         service: "<SERVICE_NAME>"
+         log_processing_rules:
+           - type: multi_line
+             name: new_log_start_with_date
+             pattern: \d{4}\-\d{2}\-\d{2}
+   ```
 
 3. [Restart the Agent][5].
 
@@ -79,15 +80,15 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 
 ##### Metric collection
 
-| Parameter            | Value                           |
-| -------------------- | ------------------------------- |
-| `<INTEGRATION_NAME>` | `riak`                          |
-| `<INIT_CONFIG>`      | blank or `{}`                   |
+| Parameter            | Value                                  |
+| -------------------- | -------------------------------------- |
+| `<INTEGRATION_NAME>` | `riak`                                 |
+| `<INIT_CONFIG>`      | blank or `{}`                          |
 | `<INSTANCE_CONFIG>`  | `{"url":"http://%%host%%:8098/stats"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection documentation][7].
 
@@ -100,11 +101,13 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 [Run the Agent's status subcommand][8] and look for `riak` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][9] for a list of metrics provided by this check.
 
 ### Events
+
 The Riak check does not include any events.
 
 ### Service Checks
@@ -113,6 +116,7 @@ The Riak check does not include any events.
 Returns `CRITICAL` if the Agent cannot connect to the Riak stats endpoint to collect metrics, otherwise returns `OK`.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][10].
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/riak/images/riak_graph.png

--- a/riakcs/README.md
+++ b/riakcs/README.md
@@ -6,10 +6,11 @@
 
 Capture RiakCS metrics in Datadog to:
 
-* Visualize key RiakCS metrics.
-* Correlate RiakCS performance with the rest of your applications.
+- Visualize key RiakCS metrics.
+- Correlate RiakCS performance with the rest of your applications.
 
 ## Setup
+
 ### Installation
 
 The RiakCS check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your RiakCS nodes.
@@ -18,21 +19,20 @@ The RiakCS check is included in the [Datadog Agent][2] package, so you don't nee
 
 1. Edit the `riakcs.yamld/conf.` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3]. See the [sample riakcs.d/conf.yaml][4] for all available configuration options:
 
-    ```yaml
-        init_config:
+   ```yaml
+   init_config:
 
-        instances:
+   instances:
+     ## @param access_id - string - required
+     ## Enter you RiakCS access key.
+     #
+     - access_id: "<ACCESS_KEY>"
 
-            ## @param access_id - string - required
-            ## Enter you RiakCS access key.
-            #
-          - access_id: "<ACCESS_KEY>"
-
-            ## @param access_secret - string - required
-            ## Enter the corresponding RiakCS access secret.
-            #
-            access_secret: "<ACCESS_SECRET>"
-    ```
+       ## @param access_secret - string - required
+       ## Enter the corresponding RiakCS access secret.
+       #
+       access_secret: "<ACCESS_SECRET>"
+   ```
 
 2. [Restart the Agent][5].
 
@@ -41,18 +41,19 @@ The RiakCS check is included in the [Datadog Agent][2] package, so you don't nee
 [Run the Agent's `status` subcommand][6] and look for `riakcs` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][7] for a list of metrics provided by this check.
 
 For RiackCS v2.1+, the default metrics collected by this integrations includes most S3 API metrics as well as memory stats. Some have been excluded:
 
-* bucket_acl_(get|put)
-* object_acl_(get|put)
-* bucket_policy_(get|put|delete)
-* _in_(one|total)
-* _time_error_*
-* _time_100
+- bucket*acl*(get|put)
+- object*acl*(get|put)
+- bucket*policy*(get|put|delete)
+- _in_(one|total)
+- _time_error_\*
+- \_time_100
 
 Any of these excluded metrics in addition to many others (there are over 1000 to choose from) can be added by specifying them in the
 `riakcs.d/conf.yaml` configuration file with the `metrics` key in the `instance_config`; the value should be a list of metric names.
@@ -60,6 +61,7 @@ Any of these excluded metrics in addition to many others (there are over 1000 to
 [See the complete list of metrics available][8].
 
 ### Events
+
 The RiackCS check does not include any events.
 
 ### Service Checks
@@ -69,6 +71,7 @@ The RiackCS check does not include any events.
 Returns CRITICAL if the Agent cannot connect to the RiakCS endpoint to collect metrics, otherwise OK.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][9].
 
 ## Further Reading

--- a/sap_hana/README.md
+++ b/sap_hana/README.md
@@ -18,57 +18,57 @@ To query certain views, specific privileges must be granted to the chosen HANA m
 
 1. Connect to the system database and run the following command to create a user:
 
-    ```
-    CREATE RESTRICTED USER <USER> PASSWORD <PASSWORD>
-    ```
+   ```shell
+   CREATE RESTRICTED USER <USER> PASSWORD <PASSWORD>
+   ```
 
 2. Run the following command to allow the user to connect to the system:
 
-    ```
-    ALTER USER <USER> ENABLE CLIENT CONNECT
-    ```
+   ```shell
+   ALTER USER <USER> ENABLE CLIENT CONNECT
+   ```
 
 3. (optional) To avoid service interruption you may want to make the password long-lived:
 
-    ```
-    ALTER USER <USER> DISABLE PASSWORD LIFETIME
-    ```
+   ```shell
+   ALTER USER <USER> DISABLE PASSWORD LIFETIME
+   ```
 
 ##### Granting privileges
 
 1. Run the following command to create a monitoring role (we'll call it `DD_MONITOR` for these examples):
 
-    ```
-    CREATE ROLE DD_MONITOR
-    ```
+   ```shell
+   CREATE ROLE DD_MONITOR
+   ```
 
 2. Run the following command to grant read-only access to all system views:
 
-    ```
-    GRANT CATALOG READ TO DD_MONITOR
-    ```
+   ```shell
+   GRANT CATALOG READ TO DD_MONITOR
+   ```
 
 3. Then run the following commands to grant select privileges on each system view:
 
-    ```
-    GRANT SELECT ON SYS.M_DATABASE TO DD_MONITOR
-    GRANT SELECT ON SYS.M_DATABASES TO DD_MONITOR
-    GRANT SELECT ON SYS_DATABASES.M_BACKUP_PROGRESS TO DD_MONITOR
-    GRANT SELECT ON SYS_DATABASES.M_CONNECTIONS TO DD_MONITOR
-    GRANT SELECT ON SYS_DATABASES.M_DISK_USAGE TO DD_MONITOR
-    GRANT SELECT ON SYS_DATABASES.M_LICENSES TO DD_MONITOR
-    GRANT SELECT ON SYS_DATABASES.M_RS_MEMORY TO DD_MONITOR
-    GRANT SELECT ON SYS_DATABASES.M_SERVICE_COMPONENT_MEMORY TO DD_MONITOR
-    GRANT SELECT ON SYS_DATABASES.M_SERVICE_MEMORY TO DD_MONITOR
-    GRANT SELECT ON SYS_DATABASES.M_SERVICE_STATISTICS TO DD_MONITOR
-    GRANT SELECT ON SYS_DATABASES.M_VOLUME_IO_TOTAL_STATISTICS TO DD_MONITOR
-    ```
+   ```shell
+   GRANT SELECT ON SYS.M_DATABASE TO DD_MONITOR
+   GRANT SELECT ON SYS.M_DATABASES TO DD_MONITOR
+   GRANT SELECT ON SYS_DATABASES.M_BACKUP_PROGRESS TO DD_MONITOR
+   GRANT SELECT ON SYS_DATABASES.M_CONNECTIONS TO DD_MONITOR
+   GRANT SELECT ON SYS_DATABASES.M_DISK_USAGE TO DD_MONITOR
+   GRANT SELECT ON SYS_DATABASES.M_LICENSES TO DD_MONITOR
+   GRANT SELECT ON SYS_DATABASES.M_RS_MEMORY TO DD_MONITOR
+   GRANT SELECT ON SYS_DATABASES.M_SERVICE_COMPONENT_MEMORY TO DD_MONITOR
+   GRANT SELECT ON SYS_DATABASES.M_SERVICE_MEMORY TO DD_MONITOR
+   GRANT SELECT ON SYS_DATABASES.M_SERVICE_STATISTICS TO DD_MONITOR
+   GRANT SELECT ON SYS_DATABASES.M_VOLUME_IO_TOTAL_STATISTICS TO DD_MONITOR
+   ```
 
 4. Finally, run the following command to assign the monitoring role to the desired user:
 
-    ```
-    GRANT DD_MONITOR TO <USER>
-    ```
+   ```shell
+   GRANT DD_MONITOR TO <USER>
+   ```
 
 ### Configuration
 

--- a/solr/README.md
+++ b/solr/README.md
@@ -7,6 +7,7 @@
 The Solr check tracks the state and performance of a Solr cluster. It collects metrics for the number of documents indexed, cache hits and evictions, average request times, average requests per second, and more.
 
 ## Setup
+
 ### Installation
 
 The Solr check is included in the [Datadog Agent][3] package, so you don't need to install anything else on your Solr nodes.
@@ -14,22 +15,23 @@ The Solr check is included in the [Datadog Agent][3] package, so you don't need 
 This check is JMX-based, so you need to enable JMX Remote on your Solr servers. Read the [JMX Check documentation][4] for more details.
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
 1. Edit the `solr.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][5]. See the [sample solr.d/conf.yaml][6] for all available configuration options.
 
-    ```yaml
-      instances:
-        ## @param host - string - required
-        ## Solr host to connect to.
-        - host: localhost
+   ```yaml
+   instances:
+     ## @param host - string - required
+     ## Solr host to connect to.
+     - host: localhost
 
-        ## @param port - integer - required
-        ## Solr port to connect to.
-          port: 9999
-    ```
+       ## @param port - integer - required
+       ## Solr port to connect to.
+       port: 9999
+   ```
 
 2. [Restart the Agent][7].
 
@@ -37,76 +39,79 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 The `conf` parameter is a list of metrics to be collected by the integration. Only 2 keys are allowed:
 
-* `include` (**mandatory**): A dictionary of filters, any attribute that matches these filters are collected unless it also matches the `exclude` filters (see below).
-* `exclude` (**optional**): A dictionary of filters, attributes that match these filters are not collected.
+- `include` (**mandatory**): A dictionary of filters, any attribute that matches these filters are collected unless it also matches the `exclude` filters (see below).
+- `exclude` (**optional**): A dictionary of filters, attributes that match these filters are not collected.
 
 For a given bean, metrics get tagged in the following manner:
 
-```
+```text
 mydomain:attr0=val0,attr1=val1
 ```
 
 In this example, your metric is `mydomain` (or some variation depending on the attribute inside the bean) and has the tags `attr0:val0`, `attr1:val1`, and `domain:mydomain`.
 
-If you specify an alias in an `include` key that is formatted as *camel case*, it is converted to *snake case*. For example, `MyMetricName` is shown in Datadog as `my_metric_name`.
+If you specify an alias in an `include` key that is formatted as _camel case_, it is converted to _snake case_. For example, `MyMetricName` is shown in Datadog as `my_metric_name`.
 
 ##### The attribute filter
 
 The `attribute` filter can accept two types of values:
 
-* A dictionary whose keys are attributes names (see below). For this case, you can specify an alias for the metric that becomes the metric name in Datadog. You can also specify the metric type as a gauge or counter. If you choose counter, a rate per second is computed for the metric.
-    ```yaml
-      conf:
-        - include:
-          attribute:
-            maxThreads:
-              alias: tomcat.threads.max
-              metric_type: gauge
-            currentThreadCount:
-              alias: tomcat.threads.count
-              metric_type: gauge
-            bytesReceived:
-              alias: tomcat.bytes_rcvd
-              metric_type: counter
-    ```
+- A dictionary whose keys are attributes names (see below). For this case, you can specify an alias for the metric that becomes the metric name in Datadog. You can also specify the metric type as a gauge or counter. If you choose counter, a rate per second is computed for the metric.
 
-* A list of attributes names (see below). For this case, the metric type is a gauge, and the metric name is `jmx.\[DOMAIN_NAME].\[ATTRIBUTE_NAME]`.
-    ```yaml
-      conf:
-        - include:
-          domain: org.apache.cassandra.db
-          attribute:
-            - BloomFilterDiskSpaceUsed
-            - BloomFilterFalsePositives
-            - BloomFilterFalseRatio
-            - Capacity
-            - CompressionRatio
-            - CompletedTasks
-            - ExceptionCount
-            - Hits
-            - RecentHitRate
-    ```
+  ```yaml
+  conf:
+    - include:
+      attribute:
+        maxThreads:
+          alias: tomcat.threads.max
+          metric_type: gauge
+        currentThreadCount:
+          alias: tomcat.threads.count
+          metric_type: gauge
+        bytesReceived:
+          alias: tomcat.bytes_rcvd
+          metric_type: counter
+  ```
+
+- A list of attributes names (see below). For this case, the metric type is a gauge, and the metric name is `jmx.\[DOMAIN_NAME].\[ATTRIBUTE_NAME]`.
+
+  ```yaml
+  conf:
+    - include:
+      domain: org.apache.cassandra.db
+      attribute:
+        - BloomFilterDiskSpaceUsed
+        - BloomFilterFalsePositives
+        - BloomFilterFalseRatio
+        - Capacity
+        - CompressionRatio
+        - CompletedTasks
+        - ExceptionCount
+        - Hits
+        - RecentHitRate
+  ```
 
 #### Older versions
 
 List of filters is only supported in Datadog Agent > 5.3.0. If you are using an older version, use singletons and multiple `include` statements instead.
 
-    # Datadog Agent > 5.3.0
-      conf:
-        - include:
-          domain: domain_name
-          bean:
-            - first_bean_name
-            - second_bean_name
-
-    # Older Datadog Agent versions
-      conf:
-        - include:
-          domain: domain_name
-          bean: first_bean_name
-        - include:
-          domain: domain_name
-          bean: second_bean_name
+```yaml
+# Datadog Agent > 5.3.0
+  conf:
+    - include:
+      domain: domain_name
+      bean:
+        - first_bean_name
+        - second_bean_name
+# Older Datadog Agent versions
+  conf:
+    - include:
+      domain: domain_name
+      bean: first_bean_name
+    - include:
+      domain: domain_name
+      bean: second_bean_name
+```
 
 #### Containerized
 
@@ -117,11 +122,13 @@ For containerized environments, see the [Autodiscovery with JMX][2] guide.
 [Run the Agent's status subcommand][8] and look for `solr` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][9] for a list of metrics provided by this check.
 
 ### Events
+
 The Solr check does not include any events.
 
 ### Service Checks
@@ -130,45 +137,47 @@ The Solr check does not include any events.
 Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored SolR instance. Returns `OK` otherwise.
 
 ## Troubleshooting
+
 ### Commands to view the available metrics
 
 The `datadog-agent jmx` command was added in version 4.1.0.
 
-  * List attributes that match at least one of your instances configuration:
-`sudo datadog-agent jmx list matching`
-  * List attributes that do match one of your instances configuration but that are not being collected because it would exceed the number of metrics that can be collected:
-`sudo datadog-agent jmx list limited`
-  * List attributes expected to be collected by your current instances configuration:
-`sudo datadog-agent jmx list collected`
-  * List attributes that don't match any of your instances configuration:
-`sudo datadog-agent jmx list not-matching`
-  * List every attributes available that has a type supported by JMXFetch:
-`sudo datadog-agent jmx list everything`
-  * Start the collection of metrics based on your current configuration and display them in the console:
-`sudo datadog-agent jmx collect`
+- List attributes that match at least one of your instances configuration:
+  `sudo datadog-agent jmx list matching`
+- List attributes that do match one of your instances configuration but that are not being collected because it would exceed the number of metrics that can be collected:
+  `sudo datadog-agent jmx list limited`
+- List attributes expected to be collected by your current instances configuration:
+  `sudo datadog-agent jmx list collected`
+- List attributes that don't match any of your instances configuration:
+  `sudo datadog-agent jmx list not-matching`
+- List every attributes available that has a type supported by JMXFetch:
+  `sudo datadog-agent jmx list everything`
+- Start the collection of metrics based on your current configuration and display them in the console:
+  `sudo datadog-agent jmx collect`
 
 ## Further Reading
+
 ### Parsing a string value into a number
+
 If your jmxfetch returns only string values like **false** and **true** and you want to transform it into a Datadog gauge metric for advanced usages. For instance if you want the following equivalence for your jmxfetch:
 
-```
+```text
 "myJmxfetch:false" = myJmxfetch:0
 "myJmxfetch:true" = myJmxfetch:1
 ```
 
 You may use the `attribute` filter as follow:
 
+```yaml
+# ...
+attribute:
+  myJmxfetch:
+    alias: your_metric_name
+    metric_type: gauge
+    values:
+      "false": 0
+      "true": 1
 ```
-...
-    attribute:
-          myJmxfetch:
-            alias: your_metric_name
-            metric_type: gauge
-            values:
-              "false": 0
-              "true": 1
-```
-
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/solr/images/solrgraph.png
 [2]: https://docs.datadoghq.com/agent/guide/autodiscovery-with-jmx/?tab=containerizedagent

--- a/spark/README.md
+++ b/spark/README.md
@@ -6,46 +6,49 @@
 
 This check monitors [Spark][13] through the Datadog Agent. Collect Spark metrics for:
 
-* Drivers and executors: RDD blocks, memory used, disk used, duration, etc.
-* RDDs: partition count, memory used, and disk used
-* Tasks: number of tasks active, skipped, failed, and total
-* Job state: number of jobs active, completed, skipped, and failed
+- Drivers and executors: RDD blocks, memory used, disk used, duration, etc.
+- RDDs: partition count, memory used, and disk used
+- Tasks: number of tasks active, skipped, failed, and total
+- Job state: number of jobs active, completed, skipped, and failed
 
 **Note**: Spark Structured Streaming metrics are currently not supported.
 
 ## Setup
+
 ### Installation
 
 The Spark check is included in the [Datadog Agent][3] package. No additional installation is needed on your:
 
-* Mesos master (for Spark on Mesos),
-* YARN ResourceManager (for Spark on YARN), or
-* Spark master (for Standalone Spark)
+- Mesos master (for Spark on Mesos),
+- YARN ResourceManager (for Spark on YARN), or
+- Spark master (for Standalone Spark)
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
 1. Edit the `spark.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4]. The following parameters may require updating. See the [sample spark.d/conf.yaml][5] for all available configuration options.
 
-    ```yaml
-        init_config:
+   ```yaml
+   init_config:
 
-        instances:
-          - spark_url: http://localhost:8080 # Spark master web UI
-        #   spark_url: http://<Mesos_master>:5050 # Mesos master web UI
-        #   spark_url: http://<YARN_ResourceManager_address>:8088 # YARN ResourceManager address
+   instances:
+     - spark_url: http://localhost:8080 # Spark master web UI
+       #   spark_url: http://<Mesos_master>:5050 # Mesos master web UI
+       #   spark_url: http://<YARN_ResourceManager_address>:8088 # YARN ResourceManager address
 
-            spark_cluster_mode: spark_standalone_mode # default
-        #   spark_cluster_mode: spark_mesos_mode
-        #   spark_cluster_mode: spark_yarn_mode
-        #   spark_cluster_mode: spark_driver_mode
+       spark_cluster_mode: spark_standalone_mode # default
+       #   spark_cluster_mode: spark_mesos_mode
+       #   spark_cluster_mode: spark_yarn_mode
+       #   spark_cluster_mode: spark_driver_mode
 
-            cluster_name: <CLUSTER_NAME> # required; adds a tag 'cluster_name:<CLUSTER_NAME>' to all metrics
-        #   spark_pre_20_mode: true   # if you use Standalone Spark < v2.0
-        #   spark_proxy_enabled: true # if you have enabled the spark UI proxy
-    ```
+       # required; adds a tag 'cluster_name:<CLUSTER_NAME>' to all metrics
+       cluster_name: "<CLUSTER_NAME>"
+       # spark_pre_20_mode: true   # if you use Standalone Spark < v2.0
+       # spark_proxy_enabled: true # if you have enabled the spark UI proxy
+   ```
 
 2. [Restart the Agent][6].
 
@@ -54,7 +57,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying the parameters below.
 
 | Parameter            | Value                                                             |
-|----------------------|-------------------------------------------------------------------|
+| -------------------- | ----------------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `spark`                                                           |
 | `<INIT_CONFIG>`      | blank or `{}`                                                     |
 | `<INSTANCE_CONFIG>`  | `{"spark_url": "%%host%%:8080", "cluster_name":"<CLUSTER_NAME>"}` |
@@ -64,13 +67,17 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 Run the Agent's [status subcommand][7] and look for `spark` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][8] for a list of metrics provided by this check.
 
 ### Events
+
 The Spark check does not include any events.
 
 ### Service Checks
+
 The Agent submits one of the following service checks, depending on how you're running Spark:
 
 **spark.standalone_master.can_connect**<br>
@@ -89,6 +96,7 @@ Returns `CRITICAL` if the Agent is unable to connect to the Spark instance's Res
 Returns `CRITICAL` if the Agent is unable to connect to the Spark instance's ResourceManager. Returns `OK` otherwise.
 
 ## Troubleshooting
+
 ### Spark on AWS EMR
 
 To receive metrics for Spark on AWS EMR, [use bootstrap actions][9] to install the [Datadog Agent][10] and then create the `/etc/dd-agent/conf.d/spark.yaml` configuration file with the [proper values on each EMR node][11].
@@ -97,8 +105,7 @@ To receive metrics for Spark on AWS EMR, [use bootstrap actions][9] to install t
 
 Additional helpful documentation, links, and articles:
 
-* [Hadoop & Spark monitoring with Datadog][12]
-
+- [Hadoop & Spark monitoring with Datadog][12]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/spark/images/sparkgraph.png
 [2]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/spark/README.md
+++ b/spark/README.md
@@ -7,21 +7,17 @@
 This check monitors [Spark][13] through the Datadog Agent. Collect Spark metrics for:
 
 - Drivers and executors: RDD blocks, memory used, disk used, duration, etc.
-- RDDs: partition count, memory used, and disk used
-- Tasks: number of tasks active, skipped, failed, and total
-- Job state: number of jobs active, completed, skipped, and failed
+- RDDs: partition count, memory used, and disk used.
+- Tasks: number of tasks active, skipped, failed, and total.
+- Job state: number of jobs active, completed, skipped, and failed.
 
-**Note**: Spark Structured Streaming metrics are currently not supported.
+**Note**: Spark Structured Streaming metrics are not supported.
 
 ## Setup
 
 ### Installation
 
-The Spark check is included in the [Datadog Agent][3] package. No additional installation is needed on your:
-
-- Mesos master (for Spark on Mesos),
-- YARN ResourceManager (for Spark on YARN), or
-- Spark master (for Standalone Spark)
+The Spark check is included in the [Datadog Agent][3] package. No additional installation is needed on your Mesos master (for Spark on Mesos), YARN ResourceManager (for Spark on YARN), or Spark master (for Spark Standalone).
 
 ### Configuration
 

--- a/sqlserver/README.md
+++ b/sqlserver/README.md
@@ -23,34 +23,34 @@ Make sure that your SQL Server instance supports SQL Server authentication by en
 
 1. Create a read-only login to connect to your server:
 
-    ```
-        CREATE LOGIN datadog WITH PASSWORD = '<PASSWORD>';
-        CREATE USER datadog FOR LOGIN datadog;
-        GRANT SELECT on sys.dm_os_performance_counters to datadog;
-        GRANT VIEW SERVER STATE to datadog;
-    ```
+   ```text
+       CREATE LOGIN datadog WITH PASSWORD = '<PASSWORD>';
+       CREATE USER datadog FOR LOGIN datadog;
+       GRANT SELECT on sys.dm_os_performance_counters to datadog;
+       GRANT VIEW SERVER STATE to datadog;
+   ```
 
 2. Create a file `sqlserver.d/conf.yaml`, in the `conf.d/` folder at the root of your [Agent's configuration directory][4].
-    See the [sample sqlserver.d/conf.yaml][5] for all available configuration options:
+   See the [sample sqlserver.d/conf.yaml][5] for all available configuration options:
 
-    ```yaml
-        init_config:
+   ```yaml
+   init_config:
 
-        instances:
-          - host: <SQL_HOST>,<SQL_PORT>
-            username: datadog
-            password: <YOUR_PASSWORD>
-            connector: odbc # alternative is 'adodbapi'
-            driver: SQL Server
-    ```
+   instances:
+     - host: "<SQL_HOST>,<SQL_PORT>"
+       username: datadog
+       password: "<YOUR_PASSWORD>"
+       connector: odbc # alternative is 'adodbapi'
+       driver: SQL Server
+   ```
 
     See the [example check configuration][5] for a comprehensive description of all options, including how to use custom queries to create your own metrics.
 
-    **Note**: The (default) provider `SQLOLEDB` is being deprecated. To use the newer `MSOLEDBSQL` provider, set the `adoprovider` variable to `MSOLEDBSQL` in your `sqlserver.d/conf.yaml` file after having downloaded the new provider from [Microsoft][6].
-    **Note**: It is also possible to use the Windows Authentication and not specify the username/password with
-    ```yaml
-    connection_string: "Trusted_Connection=yes"
-    ```
+    **Note**: The (default) provider `SQLOLEDB` is being deprecated. To use the newer `MSOLEDBSQL` provider, set the `adoprovider` variable to `MSOLEDBSQL` in your `sqlserver.d/conf.yaml` file after having downloaded the new provider from [Microsoft][6]. It is also possible to use the Windows Authentication and not specify the username/password with:
+
+      ```yaml
+      connection_string: "Trusted_Connection=yes"
+      ```
 
 3. [Restart the Agent][7] to start sending SQL Server metrics to Datadog.
 
@@ -67,6 +67,7 @@ Extra configuration steps are required to get the SQL Server integration running
 [Run the Agent's `status` subcommand][9] and look for `sqlserver` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][10] for a list of metrics provided by this check.
@@ -74,6 +75,7 @@ See [metadata.csv][10] for a list of metrics provided by this check.
 Most of these metrics come from your SQL Server's `sys.dm_os_performance_counters` table.
 
 ### Events
+
 The SQL server check does not include any events.
 
 ### Service Checks
@@ -83,6 +85,7 @@ The SQL server check does not include any events.
 Returns CRITICAL if the Agent cannot connect to SQL Server to collect metrics, otherwise OK.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][11].
 
 ## Development
@@ -99,7 +102,7 @@ To run the tests on Windows, an instance of MSSQL is expected to run on the host
 
 On Linux, a Docker container running a MSSQL instance is automatically started before running the tests. We use unixODBC and [FreeTDS][13] to talk to the database so, depending on the Linux distribution, you need to install additional dependencies on your local dev environment before running the tests. For example these are the installation steps for Ubuntu 14.04:
 
-```
+```shell
 sudo apt-get install unixodbc unixodbc-dev tdsodbc
 ```
 
@@ -107,18 +110,18 @@ sudo apt-get install unixodbc unixodbc-dev tdsodbc
 
 Same as Linux, MSSQL runs in a Docker container and we talk to the database through unixODBC and [FreeTDS][13]. You can use [homebrew][14] to install the required packages:
 
-```
+```shell
 brew install unixodbc
 brew install freetds --with-unixodbc
 ```
 
 ## Further Reading
 
-* [Monitor your Azure SQL Databases with Datadog][15]
-* [Key metrics for SQL Server monitoring][16]
-* [SQL Server monitoring tools][17]
-* [Monitor SQL Server performance with Datadog][18]
-* [Custom SQL Server metrics for detailed monitoring][19]
+- [Monitor your Azure SQL Databases with Datadog][15]
+- [Key metrics for SQL Server monitoring][16]
+- [SQL Server monitoring tools][17]
+- [Monitor SQL Server performance with Datadog][18]
+- [Custom SQL Server metrics for detailed monitoring][19]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/sqlserver/images/sqlserver_dashboard.png
 [2]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/squid/README.md
+++ b/squid/README.md
@@ -5,11 +5,13 @@
 This check monitors [Squid][9] metrics from the Cache Manager through the Datadog Agent.
 
 ## Setup
+
 ### Installation
 
 The Agent's Squid check is included in the [Datadog Agent][2] package. No additional installation is needed on your Squid server.
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
@@ -22,51 +24,52 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 ##### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-    logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Uncomment and edit this configuration block at the bottom of your `squid.d/conf.yaml` file:
 
-    ```yaml
-    logs:
-          - type: file
-            path: /var/log/squid/cache.log
-            service: "<SERVICE-NAME>"
-            source: squid
-          - type: file
-            path: /var/log/squid/access.log
-            service: "<SERVICE-NAME>"
-            source: squid
-      ```
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/squid/cache.log
+       service: "<SERVICE-NAME>"
+       source: squid
+     - type: file
+       path: /var/log/squid/access.log
+       service: "<SERVICE-NAME>"
+       source: squid
+   ```
 
     Change the `path` and `service` parameter values and configure them for your environment.
 
 3. [Restart the Agent][5].
 
 #### Containerized
+
 For containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying the parameters below.
 
 ##### Metric collection
 
 | Parameter            | Value                                                                  |
-|----------------------|------------------------------------------------------------------------|
+| -------------------- | ---------------------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `squid`                                                                |
 | `<INIT_CONFIG>`      | blank or `{}`                                                          |
 | `<INSTANCE_CONFIG>`  | `{"name": "<SQUID_INSTANCE_NAME>", "host": "%%host%%", "port":"3128"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][10].
 
 | Parameter      | Value                                               |
-|----------------|-----------------------------------------------------|
+| -------------- | --------------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "squid", "service": "<YOUR_APP_NAME>"}` |
 
 ### Validation
@@ -89,8 +92,8 @@ The Squid check does not include any events.
 Returns `CRITICAL` if the Agent cannot connect to Squid to collect metrics, otherwise returns `OK`.
 
 ## Troubleshooting
-Need help? Contact [Datadog support][8].
 
+Need help? Contact [Datadog support][8].
 
 [1]: https://docs.datadoghq.com/agent/autodiscovery/integrations
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/ssh_check/README.md
+++ b/ssh_check/README.md
@@ -5,39 +5,41 @@
 This check lets you monitor SSH connectivity to remote hosts and SFTP response times.
 
 ## Setup
+
 ### Installation
 
 The SSH/SFTP check is included in the [Datadog Agent][1] package, so you don't need to install anything else on your server from which you'd like to test SSH connectivity.
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
-1. Edit the `ssh_check.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][2].
-    See the [sample ssh_check.d/conf.yaml][3] for all available configuration options:
+1. Edit the `ssh_check.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample ssh_check.d/conf.yaml][3] for all available configuration options:
 
-    ```yaml
-        init_config:
+   ```yaml
+   init_config:
 
-        instances:
-          - host: <SOME_REMOTE_HOST>  # required
-            username: <SOME_USERNAME> # required
-            password: <SOME_PASSWORD> # or use private_key_file
-        #   private_key_file: <PATH_TO_PRIVATE_KEY>
-        #   private_key_type:         # rsa or ecdsa; default is rsa
-        #   port: 22                  # default is port 22
-        #   sftp_check: False         # set False to disable SFTP check; default is True
-        #   add_missing_keys: True    # default is False
-    ```
+   instances:
+     - host: "<SOME_REMOTE_HOST>" # required
+       username: "<SOME_USERNAME>" # required
+       password: "<SOME_PASSWORD>" # or use private_key_file
+       # private_key_file: <PATH_TO_PRIVATE_KEY>
+       # private_key_type:         # rsa or ecdsa; default is rsa
+       # port: 22                  # default is port 22
+       # sftp_check: False         # set False to disable SFTP check; default is True
+       # add_missing_keys: True    # default is False
+   ```
 
 2. [Restart the Agent][4] to start sending SSH/SFTP metrics and service checks to Datadog.
 
 #### Containerized
+
 For containerized environments, see the [Autodiscovery Integration Templates][8] for guidance on applying the parameters below.
 
 | Parameter            | Value                                                        |
-|----------------------|--------------------------------------------------------------|
+| -------------------- | ------------------------------------------------------------ |
 | `<INTEGRATION_NAME>` | `ssh`                                                        |
 | `<INIT_CONFIG>`      | blank or `{}`                                                |
 | `<INSTANCE_CONFIG>`  | `{"host": "%%host%%", "port":"22", "username":"<USERNAME>"}` |
@@ -47,11 +49,13 @@ For containerized environments, see the [Autodiscovery Integration Templates][8]
 [Run the Agent's `status` subcommand][5] and look for `ssh_check` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][6] for a list of metrics provided by this check.
 
 ### Events
+
 The SSH Check does not include any events.
 
 ### Service Checks
@@ -65,6 +69,7 @@ Returns CRITICAL if the Agent cannot open an SSH session, otherwise OK.
 Returns CRITICAL if the Agent cannot open an SFTP session, otherwise OK.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][7].
 
 [1]: https://app.datadoghq.com/account/settings#agent

--- a/statsd/README.md
+++ b/statsd/README.md
@@ -7,39 +7,35 @@ This check monitors the availability and uptime of non-Datadog StatsD servers. I
 This check does **NOT** forward application metrics from StatsD servers to Datadog. It collects metrics about StatsD itself.
 
 ## Setup
+
 ### Installation
 
 The StatsD check is included in the [Datadog Agent][1] package, so you don't need to install anything else on any servers that run StatsD.
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
 1. Edit the `statsd.d/conf.yaml` in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample statsd.d/conf.yaml][3] for all available configuration options:
 
-    ```yaml
-        init_config:
+   ```yaml
+   init_config:
 
-        instances:
-            - host: localhost
-            port: 8126 # or wherever your statsd listens
-    ```
-
-    Configuration Options
-
-    - `host` (Optional) - Host to be checked. This will be included as a tag: `host:<host>`. Defaults to `localhost`.
-    - `port` (Optional) - Port to be checked. This will be included as a tag: `port:<port>`. Defaults to `8126`.
-    - `timeout` (Optional) - Timeout for the check. Defaults to 10 seconds.
-    - `tags` (Optional) - Tags to be assigned to the metric.
+   instances:
+     - host: localhost
+       port: 8126 # or wherever your statsd listens
+   ```
 
 2. [Restart the Agent][4] to start sending StatsD metrics and service checks to Datadog.
 
 #### Containerized
+
 For containerized environments, see the [Autodiscovery Integration Templates][10] for guidance on applying the parameters below.
 
 | Parameter            | Value                                 |
-|----------------------|---------------------------------------|
+| -------------------- | ------------------------------------- |
 | `<INTEGRATION_NAME>` | `statsd`                              |
 | `<INIT_CONFIG>`      | blank or `{}`                         |
 | `<INSTANCE_CONFIG>`  | `{"host": "%%host%%", "port":"8126"}` |
@@ -49,10 +45,13 @@ For containerized environments, see the [Autodiscovery Integration Templates][10
 [Run the Agent's `status` subcommand][5] and look for `statsd` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][6] for a list of metrics provided by this integration.
 
 ### Events
+
 The StatsD check does not include any events.
 
 ### Service Checks
@@ -66,13 +65,14 @@ Returns CRITICAL if the StatsD server does not respond to the Agent's health sta
 Returns CRITICAL if the Agent cannot collect metrics about StatsD, otherwise OK.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][7].
 
 ## Further Reading
+
 If you don't know what StatsD is and how does it work, check out [our blog post about it][8]
 
 To get a better idea of how (or why) to visualize StatsD metrics with Counts Graphing with Datadog, check out our [series of blog posts][9] about it.
-
 
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory

--- a/supervisord/README.md
+++ b/supervisord/README.md
@@ -7,6 +7,7 @@
 This check monitors the uptime, status, and number of processes running under supervisord.
 
 ## Setup
+
 ### Installation
 
 The Supervisor check is included in the [Datadog Agent][2] package, so you don't need to install anything else on servers where Supervisor is running.
@@ -21,7 +22,7 @@ The Agent can collect data from Supervisor via HTTP server or UNIX socket. The A
 
 Add a block like this to supervisor's main configuration file (e.g. `/etc/supervisor.conf`):
 
-```
+```text
 [inet_http_server]
 port=localhost:9001
 username=user  # optional
@@ -32,7 +33,7 @@ password=pass  # optional
 
 Add blocks like these to `/etc/supervisor.conf` (if they're not already there):
 
-```
+```text
 [supervisorctl]
 serverurl=unix:///var/run//supervisor.sock
 
@@ -53,42 +54,43 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 Edit the `supervisord.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][3]. See the [sample supervisord.d/conf.yaml][4] for all available configuration options:
 
-```
+```yaml
 init_config:
 
 instances:
-  - name: supervisord0 # used to tag service checks and metrics, i.e. supervisor_server:supervisord0
+  # used to tag service checks and metrics, i.e. supervisor_server:supervisord0
+  - name: supervisord0
     host: localhost
     port: 9001
-
- #To collect from the socket instead
- #- name: supervisord0
- #  host: http://127.0.0.1
- #  socket: unix:///var/run//supervisor.sock
+  #To collect from the socket instead
+  #- name: supervisord0
+  #  host: http://127.0.0.1
+  #  socket: unix:///var/run//supervisor.sock
 ```
 
 Use the `proc_names` and/or `proc_regex` options to list processes you want the Agent to collect metrics on and create service checks for. If you don't provide either option, the Agent tracks _all_ child processes of supervisord. If you provide both options, the Agent tracks processes from both lists (i.e. the two options are not mutually exclusive).
 
 Configuration Options
 
-* `name` (Required) - An arbitrary name to identify the supervisord server.
-* `host` (Optional) - Defaults to localhost. The host where supervisord server is running.
-* `port` (Optional) - Defaults to 9001. The port number.
-* `user` (Optional) - Username
-* `pass` (Optional) - Password
-* `proc_names` (Optional) - Dictionary of process names to monitor
-* `server_check` (Optional) - Defaults to true. Service check for connection to supervisord server.
-* `socket` (Optional) - If using supervisorctl to communicate with supervisor, a socket is needed.
+- `name` (Required) - An arbitrary name to identify the supervisord server.
+- `host` (Optional) - Defaults to localhost. The host where supervisord server is running.
+- `port` (Optional) - Defaults to 9001. The port number.
+- `user` (Optional) - Username
+- `pass` (Optional) - Password
+- `proc_names` (Optional) - Dictionary of process names to monitor
+- `server_check` (Optional) - Defaults to true. Service check for connection to supervisord server.
+- `socket` (Optional) - If using supervisorctl to communicate with supervisor, a socket is needed.
 
 See the [example check configuration][4] for comprehensive descriptions of other check options.
 
 [Restart the Agent][5] to start sending Supervisor metrics to Datadog.
 
 #### Containerized
+
 For containerized environments, see the [Autodiscovery Integration Templates][10] for guidance on applying the parameters below.
 
 | Parameter            | Value                                                                          |
-|----------------------|--------------------------------------------------------------------------------|
+| -------------------- | ------------------------------------------------------------------------------ |
 | `<INTEGRATION_NAME>` | `supervisord`                                                                  |
 | `<INIT_CONFIG>`      | blank or `{}`                                                                  |
 | `<INSTANCE_CONFIG>`  | `{"host":"%%host%%", "port":"9001", "user":"<USERNAME>", "pass":"<PASSWORD>"}` |
@@ -104,6 +106,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][10
 See [metadata.csv][7] for a list of metrics provided by this check.
 
 ### Events
+
 The Supervisord check does not include any events.
 
 ### Service Checks
@@ -119,7 +122,7 @@ The Agent submits this service check for all child processes of supervisord (if 
 This table shows the `supervisord.process.status` that results from each supervisord status:
 
 | supervisord status | supervisord.process.status |
-|--------------------|----------------------------|
+| ------------------ | -------------------------- |
 | STOPPED            | CRITICAL                   |
 | STARTING           | UNKNOWN                    |
 | RUNNING            | OK                         |
@@ -130,12 +133,12 @@ This table shows the `supervisord.process.status` that results from each supervi
 | UNKNOWN            | UNKNOWN                    |
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][8].
 
 ## Further Reading
 
-* [Supervisor monitors your processes. Datadog monitors Supervisor.][9]
-
+- [Supervisor monitors your processes. Datadog monitors Supervisor.][9]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/supervisord/images/supervisorevent.png
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/supervisord/README.md
+++ b/supervisord/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-This check monitors the uptime, status, and number of processes running under supervisord.
+This check monitors the uptime, status, and number of processes running under Supervisor.
 
 ## Setup
 
@@ -20,7 +20,7 @@ The Agent can collect data from Supervisor via HTTP server or UNIX socket. The A
 
 ##### HTTP server
 
-Add a block like this to supervisor's main configuration file (e.g. `/etc/supervisor.conf`):
+Add a block like this to Supervisor's main configuration file (e.g. `/etc/supervisor.conf`):
 
 ```text
 [inet_http_server]
@@ -42,11 +42,11 @@ file=/var/run/supervisor.sock
 chmod=777
 ```
 
-If supervisor is running as root, make sure `chmod` is set so that non-root users (i.e. dd-agent) can read the socket.
+If Supervisor is running as root, make sure `chmod` is set so that non-root users (i.e. dd-agent) can read the socket.
 
 ---
 
-Reload supervisord.
+Reload `supervisord`.
 
 #### Host
 
@@ -68,18 +68,18 @@ instances:
   #  socket: unix:///var/run//supervisor.sock
 ```
 
-Use the `proc_names` and/or `proc_regex` options to list processes you want the Agent to collect metrics on and create service checks for. If you don't provide either option, the Agent tracks _all_ child processes of supervisord. If you provide both options, the Agent tracks processes from both lists (i.e. the two options are not mutually exclusive).
+Use the `proc_names` and/or `proc_regex` options to list processes you want the Agent to collect metrics on and create service checks for. If you don't provide either option, the Agent tracks _all_ child processes of Supervisor. If you provide both options, the Agent tracks processes from both lists (i.e. the two options are not mutually exclusive).
 
 Configuration Options
 
-- `name` (Required) - An arbitrary name to identify the supervisord server.
-- `host` (Optional) - Defaults to localhost. The host where supervisord server is running.
+- `name` (Required) - An arbitrary name to identify the `supervisord` server.
+- `host` (Optional) - Defaults to localhost. The host where the `supervisord` server is running.
 - `port` (Optional) - Defaults to 9001. The port number.
 - `user` (Optional) - Username
 - `pass` (Optional) - Password
 - `proc_names` (Optional) - Dictionary of process names to monitor
-- `server_check` (Optional) - Defaults to true. Service check for connection to supervisord server.
-- `socket` (Optional) - If using supervisorctl to communicate with supervisor, a socket is needed.
+- `server_check` (Optional) - Defaults to true. Service check for connection to the `supervisord` server.
+- `socket` (Optional) - If using `supervisorctl` to communicate with Supervisor, a socket is needed.
 
 See the [example check configuration][4] for comprehensive descriptions of other check options.
 
@@ -107,7 +107,7 @@ See [metadata.csv][7] for a list of metrics provided by this check.
 
 ### Events
 
-The Supervisord check does not include any events.
+The Supervisor check does not include any events.
 
 ### Service Checks
 

--- a/system_core/README.md
+++ b/system_core/README.md
@@ -10,7 +10,7 @@ This check collects the number of CPU cores on a host and CPU times (i.e. system
 
 ### Installation
 
-The system core check is included in the [Datadog Agent][2] package. No additional installation is needed on your server.
+The System Core check is included in the [Datadog Agent][2] package. No additional installation is needed on your server.
 
 ### Configuration
 

--- a/system_core/README.md
+++ b/system_core/README.md
@@ -7,6 +7,7 @@
 This check collects the number of CPU cores on a host and CPU times (i.e. system, user, idle, etc).
 
 ## Setup
+
 ### Installation
 
 The system core check is included in the [Datadog Agent][2] package. No additional installation is needed on your server.
@@ -15,12 +16,12 @@ The system core check is included in the [Datadog Agent][2] package. No addition
 
 1. Edit the `system_core.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][3]. See the [sample system_core.d/conf.yaml][4] for all available configuration options. **Note**: At least one entry is required under `instances` to enable the check, for example:
 
-    ```
-    init_config:
+   ```yaml
+   init_config:
 
-    instances:
-      - foo: bar
-    ```
+   instances:
+     - foo: bar
+   ```
 
 2. [Restart the Agent][5].
 
@@ -29,6 +30,7 @@ The system core check is included in the [Datadog Agent][2] package. No addition
 [Run the Agent's status subcommand][6] and look for `system_core` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][7] for a list of metrics provided by this check.
@@ -36,12 +38,15 @@ See [metadata.csv][7] for a list of metrics provided by this check.
 Depending on the platform, the check may collect other CPU time metrics, e.g. `system.core.interrupt` on Windows, `system.core.iowait` on Linux, etc.
 
 ### Events
+
 The System Core check does not include any events.
 
 ### Service Checks
+
 The System Core check does not include any service checks.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][8].
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/system_core/images/syscoredash.png

--- a/system_swap/README.md
+++ b/system_swap/README.md
@@ -8,7 +8,7 @@ This check monitors the number of bytes a host has swapped in and out.
 
 ### Installation
 
-The system swap check is included in the [Datadog Agent][1] package. No additional installation is needed on your server.
+The System Swap check is included in the [Datadog Agent][1] package. No additional installation is needed on your server.
 
 ### Configuration
 

--- a/system_swap/README.md
+++ b/system_swap/README.md
@@ -5,6 +5,7 @@
 This check monitors the number of bytes a host has swapped in and out.
 
 ## Setup
+
 ### Installation
 
 The system swap check is included in the [Datadog Agent][1] package. No additional installation is needed on your server.
@@ -20,17 +21,21 @@ The system swap check is included in the [Datadog Agent][1] package. No addition
 [Run the Agent's status subcommand][5] and look for `system_swap` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][6] for a list of metrics provided by this check.
 
 ### Events
+
 The System Swap check does not include any events.
 
 ### Service Checks
+
 The System Swap check does not include any service checks.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][7].
 
 [1]: https://app.datadoghq.com/account/settings#agent

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -4,8 +4,8 @@
 
 This check monitors [Systemd][1] and the units it manages through the Datadog Agent.
 
-* Track the state and health of your Systemd
-* Monitor the units, services, sockets managed by Systemd
+- Track the state and health of your Systemd
+- Monitor the units, services, sockets managed by Systemd
 
 ## Setup
 


### PR DESCRIPTION
### What does this PR do?

Follow up on:
* https://github.com/DataDog/integrations-core/pull/5663
* https://github.com/DataDog/integrations-core/pull/5662
* https://github.com/DataDog/integrations-core/pull/5664
* https://github.com/DataDog/integrations-core/pull/5665
* https://github.com/DataDog/integrations-core/pull/5666
* https://github.com/DataDog/integrations-core/pull/5667


This PR lints markdown file to avoid layout issues moving forward with the public doc. I manually checked the layout for all of those integrations.

Change from this lint:

- Bullet list are defined with `-`
- Italic is now defined with `_<TEXT>_`
- Fixes table layout
- Lint code examples displayed
- Each code example has a language assigned, and the default is `text`
- There should be always an empty line before/after a header
- **Available for Agent >6.0** has been transformed into _Available for Agent versions >6.0_

### Motivation
Better doc for a better world
