### PR TITLE
8. Linting integration README

### DIFF
--- a/tcp_check/README.md
+++ b/tcp_check/README.md
@@ -7,6 +7,7 @@
 Monitor TCP connectivity and response time for any host and port.
 
 ## Setup
+
 ### Installation
 
 The TCP check is included in the [Datadog Agent][3] package, so you don't need to install anything else on any host from which you will probe TCP ports. Though many metrics-oriented checks are best run on the same host(s) as the monitored service, you'll probably want to run this check from hosts that do not run the monitored TCP services, i.e. to test remote connectivity.
@@ -19,7 +20,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 Edit the `tcp_check.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][4]. See the [sample tcp_check.d/conf.yaml][5] for all available configuration options:
 
-```
+```yaml
 init_config:
 
 instances:
@@ -29,24 +30,25 @@ instances:
     collect_response_time: true # to collect network.tcp.response_time. Default is false.
 ```
 
-Configuration Options
+Configuration Options:
 
-* `name` (Required) - Name of the service. This will be included as a tag: `instance:<name>`. Note: This tag will have any spaces and dashes converted to underscores.
-* `host` (Required) - Host to be checked. This will be included as a tag: `url:<host>:<port>`.
-* `port` (Required) - Port to be checked. This will be included as a tag: `url:<host>:<port>`.
-* `timeout` (Optional) - Timeout for the check. Defaults to 10 seconds.
-* `collect_response_time` (Optional) - Defaults to false. If this is not set to true, no response time metric will be collected. If it is set to true, the metric returned is `network.tcp.response_time`.
-* `tags` (Optional) - Tags to be assigned to the metric.
+- `name` (Required) - Name of the service. This will be included as a tag: `instance:<name>`. Note: This tag will have any spaces and dashes converted to underscores.
+- `host` (Required) - Host to be checked. This will be included as a tag: `url:<host>:<port>`.
+- `port` (Required) - Port to be checked. This will be included as a tag: `url:<host>:<port>`.
+- `timeout` (Optional) - Timeout for the check. Defaults to 10 seconds.
+- `collect_response_time` (Optional) - Defaults to false. If this is not set to true, no response time metric will be collected. If it is set to true, the metric returned is `network.tcp.response_time`.
+- `tags` (Optional) - Tags to be assigned to the metric.
 
 [Restart the Agent][6] to start sending TCP service checks and response times to Datadog.
 
 #### Containerized
+
 For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying the parameters below.
 
-| Parameter            | Value                                                                                            |
-|----------------------|--------------------------------------------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `tcp_check`                                                                                      |
-| `<INIT_CONFIG>`      | blank or `{}`                                                                                    |
+| Parameter            | Value                                                                         |
+| -------------------- | ----------------------------------------------------------------------------- |
+| `<INTEGRATION_NAME>` | `tcp_check`                                                                   |
+| `<INIT_CONFIG>`      | blank or `{}`                                                                 |
 | `<INSTANCE_CONFIG>`  | `{"name": "<TCP_CHECK_INSTANCE_NAME>", "host":"%%host%%", "port":"%%port%%"}` |
 
 ### Validation
@@ -60,6 +62,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 See [metadata.csv][8] for a list of metrics provided by this check.
 
 ### Events
+
 The TCP check does not include any events.
 
 ### Service Checks
@@ -71,8 +74,8 @@ Returns DOWN if the Agent cannot connect to the configured `host` and `port`, ot
 To create alert conditions on this service check in Datadog, click **Network** on the [Create Monitor][9] page, not **Integration**.
 
 ## Troubleshooting
-Need help? Contact [Datadog support][10].
 
+Need help? Contact [Datadog support][10].
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/tcp_check/images/netgraphs.png
 [2]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/teamcity/README.md
+++ b/teamcity/README.md
@@ -7,11 +7,13 @@ This check watches for successful build-related events and sends them to Datadog
 Unlike most Agent checks, this one doesn't collect any metrics-just events.
 
 ## Setup
+
 ### Installation
 
 The Teamcity check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your Teamcity servers.
 
 ### Configuration
+
 #### Prepare Teamcity
 
 Follow [Teamcity's documentation][3] to enable Guest Login.
@@ -22,20 +24,15 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 Edit the `teamcity.d/conf.yaml` in the `conf.d/` folder at the root of your [Agent's configuration directory][4]. See the [sample teamcity.d/conf.yaml][5] for all available configuration options:
 
-```
+```yaml
 init_config:
 
 instances:
   - name: My Website
     server: teamcity.mycompany.com
- #  server: user:password@teamcity.mycompany.com # if you set basic_http_authentication to true
- #  basic_http_authentication: true # default is false
-    build_configuration: MyWebsite_Deploy # the internal build ID of the build configuration you wish to track
- #  host_affected: msicalweb6 # defaults to hostname of the Agent's host
- #  is_deployment: true       # causes events to use the word 'deployment' in their messaging
- #  tls_verify: false     # default is true
- #  tags:                     # add custom tags to events
- #    - test
+
+    # the internal build ID of the build configuration you wish to track
+    build_configuration: MyWebsite_Deploy
 ```
 
 Add an item like the above to `instances` for each build configuration you want to track.
@@ -43,10 +40,11 @@ Add an item like the above to `instances` for each build configuration you want 
 [Restart the Agent][6] to start collecting and sending Teamcity events to Datadog.
 
 #### Containerized
+
 For containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying the parameters below.
 
 | Parameter            | Value                                                                                             |
-|----------------------|---------------------------------------------------------------------------------------------------|
+| -------------------- | ------------------------------------------------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `teamcity`                                                                                        |
 | `<INIT_CONFIG>`      | blank or `{}`                                                                                     |
 | `<INSTANCE_CONFIG>`  | `{"name": "<BUILD_NAME>", "server":"%%host%%", "build_configuration":"<BUILD_CONFIGURATION_ID>"}` |
@@ -56,22 +54,26 @@ For containerized environments, see the [Autodiscovery Integration Templates][1]
 [Run the Agent's `status` subcommand][7] and look for `teamcity` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 The Teamcity check does not include any metrics.
 
 ### Events
+
 Teamcity events representing successful builds are forwarded to your Datadog application.
 
 ### Service Checks
+
 The Teamcity check does not include any service checks.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][8].
 
 ## Further Reading
 
-* [Track performance impact of code changes with TeamCity and Datadog.][9]
-
+- [Track performance impact of code changes with TeamCity and Datadog.][9]
 
 [1]: https://docs.datadoghq.com/agent/autodiscovery/integrations
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/teamcity/README.md
+++ b/teamcity/README.md
@@ -4,7 +4,7 @@
 
 This check watches for successful build-related events and sends them to Datadog.
 
-Unlike most Agent checks, this one doesn't collect any metrics-just events.
+Unlike most Agent checks, this one doesn't collect any metrics—just events.
 
 ## Setup
 

--- a/tls/README.md
+++ b/tls/README.md
@@ -7,12 +7,14 @@ This check monitors [TLS][1] protocol versions, certificate expiration & validit
 **Note**: Currently, only TCP is supported.
 
 ## Setup
+
 ### Installation
 
 The TLS check is included in the [Datadog Agent][2] package.
 No additional installation is needed on your server.
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
@@ -22,10 +24,11 @@ Follow the instructions below to configure this check for an Agent running on a 
 2. [Restart the Agent][4].
 
 #### Containerized
+
 For containerized environments, see the [Autodiscovery Integration Templates][9] for guidance on applying the parameters below.
 
 | Parameter            | Value                                  |
-|----------------------|----------------------------------------|
+| -------------------- | -------------------------------------- |
 | `<INTEGRATION_NAME>` | `tls`                                  |
 | `<INIT_CONFIG>`      | blank or `{}`                          |
 | `<INSTANCE_CONFIG>`  | `{"server": "%%host%%", "port":"443"}` |
@@ -46,7 +49,7 @@ TLS does not include any events.
 
 ### Service Checks
 
-See [service_checks.json][7] for a list of service checks provided by this integration.
+See [service_checks.json][7] for a list of service checks provided by this integration:
 
 - `tls.can_connect` - Returns `CRITICAL` if the Agent is unable to connect to the monitored endpoint, otherwise returns `OK`.
 - `tls.version` - Returns `CRITICAL` if a connection is made with a protocol version that is not allowed, otherwise returns `OK`.

--- a/tls/README.md
+++ b/tls/README.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-This check monitors [TLS][1] protocol versions, certificate expiration & validity, etc.
+This check monitors [TLS][1] protocol versions, certificate expiration and validity, etc.
 
-**Note**: Currently, only TCP is supported.
+**Note**: Only TCP is supported.
 
 ## Setup
 

--- a/tokumx/README.md
+++ b/tokumx/README.md
@@ -2,13 +2,11 @@
 
 ## Overview
 
-This check collects TokuMX metrics like:
+This check collects TokuMX metrics, including:
 
-- Opcounters
-- Replication lag
-- Cache table utilization and storage size
-
-And more.
+- Opcounters.
+- Replication lag.
+- Cache table utilization and storage size.
 
 ## Setup
 
@@ -34,7 +32,7 @@ The TokuMX check is included in the [Datadog Agent][2] package, so you don't nee
    echo -e "\033[0;32mpymongo python module - OK\033[0m"
    ```
 
-3. Start the mongo shell.In it create a read-only user for the Datadog Agent in the `admin` database:
+3. Start the Mongo shell. In the shell, create a read-only user for the Datadog Agent in the `admin` database:
 
    ```shell
    # Authenticate as the admin user.
@@ -44,7 +42,7 @@ The TokuMX check is included in the [Datadog Agent][2] package, so you don't nee
    db.addUser("datadog", "<UNIQUEPASSWORD>", true)
    ```
 
-4. Verify that you created the user with the following command (not in the mongo shell).
+4. Verify that you created the user with the following command (not in the Mongo shell).
 
    ```shell
    python -c 'from pymongo import Connection; print Connection().admin.authenticate("datadog", "<UNIQUEPASSWORD>")' | \

--- a/tokumx/README.md
+++ b/tokumx/README.md
@@ -4,47 +4,54 @@
 
 This check collects TokuMX metrics like:
 
-* Opcounters
-* Replication lag
-* Cache table utilization and storage size
+- Opcounters
+- Replication lag
+- Cache table utilization and storage size
 
 And more.
 
 ## Setup
+
 ### Installation
 
 The TokuMX check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your TokuMX servers.
 
 ### Configuration
+
 #### Prepare TokuMX
 
-1.  Install the Python MongoDB module on your MongoDB server using the following command:
+1. Install the Python MongoDB module on your MongoDB server using the following command:
 
-        sudo pip install --upgrade "pymongo<3.0"
+   ```shell
+   sudo pip install --upgrade "pymongo<3.0"
+   ```
 
+2. You can verify that the module is installed using this command:
 
-2.  You can verify that the module is installed using this command:
+   ```shell
+   python -c "import pymongo" 2>&1 | grep ImportError && \
+   echo -e "\033[0;31mpymongo python module - Missing\033[0m" || \
+   echo -e "\033[0;32mpymongo python module - OK\033[0m"
+   ```
 
-        python -c "import pymongo" 2>&1 | grep ImportError && \
-        echo -e "\033[0;31mpymongo python module - Missing\033[0m" || \
-        echo -e "\033[0;32mpymongo python module - OK\033[0m"
+3. Start the mongo shell.In it create a read-only user for the Datadog Agent in the `admin` database:
 
+   ```shell
+   # Authenticate as the admin user.
+   use admin
+   db.auth("admin", "<YOUR_TOKUMX_ADMIN_PASSWORD>")
+   # Add a user for Datadog Agent
+   db.addUser("datadog", "<UNIQUEPASSWORD>", true)
+   ```
 
-3.  Start the mongo shell.In it create a read-only user for the Datadog Agent in the `admin` database:
+4. Verify that you created the user with the following command (not in the mongo shell).
 
-        # Authenticate as the admin user.
-        use admin
-        db.auth("admin", "<YOUR_TOKUMX_ADMIN_PASSWORD>")
-        # Add a user for Datadog Agent
-        db.addUser("datadog", "<UNIQUEPASSWORD>", true)
-
-
-4.  Verify that you created the user with the following command (not in the mongo shell).
-
-        python -c 'from pymongo import Connection; print Connection().admin.authenticate("datadog", "<UNIQUEPASSWORD>")' | \
-        grep True && \
-        echo -e "\033[0;32mdatadog user - OK\033[0m" || \
-        echo -e "\033[0;31mdatadog user - Missing\033[0m"
+   ```shell
+   python -c 'from pymongo import Connection; print Connection().admin.authenticate("datadog", "<UNIQUEPASSWORD>")' | \
+   grep True && \
+   echo -e "\033[0;32mdatadog user - OK\033[0m" || \
+   echo -e "\033[0;31mdatadog user - Missing\033[0m"
+   ```
 
 For more details about creating and managing users in MongoDB, see [the MongoDB documentation][3].
 
@@ -53,14 +60,14 @@ For more details about creating and managing users in MongoDB, see [the MongoDB 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
 1. Edit the `tokumx.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][4].
-    See the [sample tokumx.d/conf.yaml][5] for all available configuration options:
+   See the [sample tokumx.d/conf.yaml][5] for all available configuration options:
 
-    ```yaml
-        init_config:
+   ```yaml
+   init_config:
 
-        instances:
-            - server: mongodb://<USER>:<PASSWORD>@localhost:27017
-    ```
+   instances:
+     - server: "mongodb://<USER>:<PASSWORD>@localhost:27017"
+   ```
 
 2. [Restart the Agent][6] to start sending TokuMX metrics to Datadog.
 
@@ -69,7 +76,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 For containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying the parameters below.
 
 | Parameter            | Value                                                      |
-|----------------------|------------------------------------------------------------|
+| -------------------- | ---------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `tokumx`                                                   |
 | `<INIT_CONFIG>`      | blank or `{}`                                              |
 | `<INSTANCE_CONFIG>`  | `{"server": "mongodb://<USER>:<PASSWORD>@%%host%%:27017"}` |
@@ -79,10 +86,13 @@ For containerized environments, see the [Autodiscovery Integration Templates][1]
 [Run the Agent's `status` subcommand][7] and look for `tokumx` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][8] for a list of metrics provided by this check.
 
 ### Events
+
 **Replication state changes**:
 
 This check emits an event each time a TokuMX node has a change in its replication state.
@@ -94,12 +104,12 @@ This check emits an event each time a TokuMX node has a change in its replicatio
 Returns CRITICAL if the Agent cannot connect to TokuMX to collect metrics, otherwise OK.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][9].
 
 ## Further Reading
 
-* [Monitor key TokuMX metrics for MongoDB applications][10].
-
+- [Monitor key TokuMX metrics for MongoDB applications][10].
 
 [1]: https://docs.datadoghq.com/agent/autodiscovery/integrations
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -6,13 +6,14 @@
 
 This check collects Tomcat metrics, for example:
 
-* Overall activity metrics: error count, request count, processing times
-* Thread pool metrics: thread count, number of threads busy
-* Servlet processing times
+- Overall activity metrics: error count, request count, processing times
+- Thread pool metrics: thread count, number of threads busy
+- Servlet processing times
 
 And more.
 
 ## Setup
+
 ### Installation
 
 The Tomcat check is included in the [Datadog Agent][3] package, so you don't need to install anything else on your Tomcat servers.
@@ -20,6 +21,7 @@ The Tomcat check is included in the [Datadog Agent][3] package, so you don't nee
 This check is JMX-based, so you need to enable JMX Remote on your Tomcat servers. Follow the instructions in the [Tomcat documentation][4].
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
@@ -34,154 +36,157 @@ See the [JMX Check documentation][8] for a list of configuration options usable 
 
 The `conf` parameter is a list of metrics to be collected by the integration. Only two keys are allowed:
 
-* `include` (**mandatory**): A dictionary of filters. Any attribute that matches these filters is collected unless it also matches the `exclude` filters (see below).
-* `exclude` (**optional**): A dictionary of filters. Attributes that match these filters are not collected.
+- `include` (**mandatory**): A dictionary of filters. Any attribute that matches these filters is collected unless it also matches the `exclude` filters (see below).
+- `exclude` (**optional**): A dictionary of filters. Attributes that match these filters are not collected.
 
 For a given bean, metrics get tagged in the following manner:
 
-```
+```text
 mydomain:attr0=val0,attr1=val1
 ```
 
 In this example, your metric is `mydomain` (or some variation depending on the attribute inside the bean) and has the tags `attr0:val0`, `attr1:val1`, and `domain:mydomain`.
 
-If you specify an alias in an `include` key that is formatted as *camel case*, it is converted to *snake case*. For example, `MyMetricName` is shown in Datadog as `my_metric_name`.
+If you specify an alias in an `include` key that is formatted as _camel case_, it is converted to _snake case_. For example, `MyMetricName` is shown in Datadog as `my_metric_name`.
 
 ##### The attribute filter
 
 The `attribute` filter can accept two types of values:
 
-* A dictionary whose keys are attributes names (see below). For this case, you can specify an alias for the metric that becomes the metric name in Datadog. You can also specify the metric type as a gauge or counter. If you choose counter, a rate per second is computed for the metric.
-    ```yaml
-      conf:
-        - include:
-          attribute:
-            maxThreads:
-              alias: tomcat.threads.max
-              metric_type: gauge
-            currentThreadCount:
-              alias: tomcat.threads.count
-              metric_type: gauge
-            bytesReceived:
-              alias: tomcat.bytes_rcvd
-              metric_type: counter
-    ```
+- A dictionary whose keys are attributes names (see below). For this case, you can specify an alias for the metric that becomes the metric name in Datadog. You can also specify the metric type as a gauge or counter. If you choose counter, a rate per second is computed for the metric.
 
-* A list of attributes names (see below). For this case, the metric type is a gauge, and the metric name is `jmx.\[DOMAIN_NAME].\[ATTRIBUTE_NAME]`.
-    ```yaml
-      conf:
-        - include:
-          domain: org.apache.cassandra.db
-          attribute:
-            - BloomFilterDiskSpaceUsed
-            - BloomFilterFalsePositives
-            - BloomFilterFalseRatio
-            - Capacity
-            - CompressionRatio
-            - CompletedTasks
-            - ExceptionCount
-            - Hits
-            - RecentHitRate
-    ```
+  ```yaml
+  conf:
+    - include:
+      attribute:
+        maxThreads:
+          alias: tomcat.threads.max
+          metric_type: gauge
+        currentThreadCount:
+          alias: tomcat.threads.count
+          metric_type: gauge
+        bytesReceived:
+          alias: tomcat.bytes_rcvd
+          metric_type: counter
+  ```
+
+- A list of attributes names (see below). For this case, the metric type is a gauge, and the metric name is `jmx.\[DOMAIN_NAME].\[ATTRIBUTE_NAME]`.
+
+  ```yaml
+  conf:
+    - include:
+      domain: org.apache.cassandra.db
+      attribute:
+        - BloomFilterDiskSpaceUsed
+        - BloomFilterFalsePositives
+        - BloomFilterFalseRatio
+        - Capacity
+        - CompressionRatio
+        - CompletedTasks
+        - ExceptionCount
+        - Hits
+        - RecentHitRate
+  ```
 
 #### Older versions
 
 List of filters is only supported in Datadog Agent > 5.3.0. If you are using an older version, use singletons and multiple `include` statements instead.
 
-    # Datadog Agent > 5.3.0
-      conf:
-        - include:
-          domain: domain_name
-          bean:
-            - first_bean_name
-            - second_bean_name
-
-    # Older Datadog Agent versions
-      conf:
-        - include:
-          domain: domain_name
-          bean: first_bean_name
-        - include:
-          domain: domain_name
-          bean: second_bean_name
+```yaml
+# Datadog Agent > 5.3.0
+  conf:
+    - include:
+      domain: domain_name
+      bean:
+        - first_bean_name
+        - second_bean_name
+# Older Datadog Agent versions
+  conf:
+    - include:
+      domain: domain_name
+      bean: first_bean_name
+    - include:
+      domain: domain_name
+      bean: second_bean_name
+```
 
 #### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Tomcat uses by default the `log4j` logger. To activate the logging into a file and customize the log format edit the `log4j.properties` file in the `$CATALINA_BASE/lib` directory as follows:
 
-    ```
-      log4j.rootLogger = INFO, CATALINA
+   ```conf
+     log4j.rootLogger = INFO, CATALINA
 
-      # Define all the appenders
-      log4j.appender.CATALINA = org.apache.log4j.DailyRollingFileAppender
-      log4j.appender.CATALINA.File = /var/log/tomcat/catalina.log
-      log4j.appender.CATALINA.Append = true
+     # Define all the appenders
+     log4j.appender.CATALINA = org.apache.log4j.DailyRollingFileAppender
+     log4j.appender.CATALINA.File = /var/log/tomcat/catalina.log
+     log4j.appender.CATALINA.Append = true
 
-      # Roll-over the log once per day
-      log4j.appender.CATALINA.layout = org.apache.log4j.PatternLayout
-      log4j.appender.CATALINA.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+     # Roll-over the log once per day
+     log4j.appender.CATALINA.layout = org.apache.log4j.PatternLayout
+     log4j.appender.CATALINA.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
-      log4j.appender.LOCALHOST = org.apache.log4j.DailyRollingFileAppender
-      log4j.appender.LOCALHOST.File = /var/log/tomcat/localhost.log
-      log4j.appender.LOCALHOST.Append = true
-      log4j.appender.LOCALHOST.layout = org.apache.log4j.PatternLayout
-      log4j.appender.LOCALHOST.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+     log4j.appender.LOCALHOST = org.apache.log4j.DailyRollingFileAppender
+     log4j.appender.LOCALHOST.File = /var/log/tomcat/localhost.log
+     log4j.appender.LOCALHOST.Append = true
+     log4j.appender.LOCALHOST.layout = org.apache.log4j.PatternLayout
+     log4j.appender.LOCALHOST.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
-      log4j.appender.MANAGER = org.apache.log4j.DailyRollingFileAppender
-      log4j.appender.MANAGER.File = /var/log/tomcat/manager.log
-      log4j.appender.MANAGER.Append = true
-      log4j.appender.MANAGER.layout = org.apache.log4j.PatternLayout
-      log4j.appender.MANAGER.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+     log4j.appender.MANAGER = org.apache.log4j.DailyRollingFileAppender
+     log4j.appender.MANAGER.File = /var/log/tomcat/manager.log
+     log4j.appender.MANAGER.Append = true
+     log4j.appender.MANAGER.layout = org.apache.log4j.PatternLayout
+     log4j.appender.MANAGER.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
-      log4j.appender.HOST-MANAGER = org.apache.log4j.DailyRollingFileAppender
-      log4j.appender.HOST-MANAGER.File = /var/log/tomcat/host-manager.log
-      log4j.appender.HOST-MANAGER.Append = true
-      log4j.appender.HOST-MANAGER.layout = org.apache.log4j.PatternLayout
-      log4j.appender.HOST-MANAGER.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+     log4j.appender.HOST-MANAGER = org.apache.log4j.DailyRollingFileAppender
+     log4j.appender.HOST-MANAGER.File = /var/log/tomcat/host-manager.log
+     log4j.appender.HOST-MANAGER.Append = true
+     log4j.appender.HOST-MANAGER.layout = org.apache.log4j.PatternLayout
+     log4j.appender.HOST-MANAGER.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
-      log4j.appender.CONSOLE = org.apache.log4j.ConsoleAppender
-      log4j.appender.CONSOLE.layout = org.apache.log4j.PatternLayout
-      log4j.appender.CONSOLE.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+     log4j.appender.CONSOLE = org.apache.log4j.ConsoleAppender
+     log4j.appender.CONSOLE.layout = org.apache.log4j.PatternLayout
+     log4j.appender.CONSOLE.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
-      # Configure which loggers log to which appenders
-      log4j.logger.org.apache.catalina.core.ContainerBase.[Catalina].[localhost] = INFO, LOCALHOST
-      log4j.logger.org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager] =\
-        INFO, MANAGER
-      log4j.logger.org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager] =\
-        INFO, HOST-MANAGER
-    ```
+     # Configure which loggers log to which appenders
+     log4j.logger.org.apache.catalina.core.ContainerBase.[Catalina].[localhost] = INFO, LOCALHOST
+     log4j.logger.org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager] =\
+       INFO, MANAGER
+     log4j.logger.org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager] =\
+       INFO, HOST-MANAGER
+   ```
 
 2. By default, Datadog's integration pipeline support the following conversion patterns:
 
-    ```
-      %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
-      %d [%t] %-5p %c - %m%n
-    ```
+   ```text
+     %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+     %d [%t] %-5p %c - %m%n
+   ```
 
     Clone and edit the [integration pipeline][10] if you have a different format. Check Tomcat [logging documentation][9] for more information about Tomcat logging capabilities.
 
 3. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 4. Add this configuration block to your `tomcat.d/conf.yaml` file to start collecting your Tomcat Logs:
 
-    ```yaml
-      logs:
-        - type: file
-          path: /var/log/tomcat/*.log
-          source: tomcat
-          service: myapp
-          #To handle multi line that starts with yyyy-mm-dd use the following pattern
-          #log_processing_rules:
-          #  - type: multi_line
-          #    name: log_start_with_date
-          #    pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/tomcat/*.log
+       source: tomcat
+       service: "<SERVICE>"
+       #To handle multi line that starts with yyyy-mm-dd use the following pattern
+       #log_processing_rules:
+       #  - type: multi_line
+       #    name: log_start_with_date
+       #    pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
+   ```
 
     Change the `path` and `service` parameter values and configure them for your environment. See the [sample tomcat.yaml][6] for all available configuration options.
 
@@ -196,10 +201,13 @@ For containerized environments, see the [Autodiscovery with JMX][2] guide.
 [Run the Agent's status subcommand][11] and look for `tomcat` under the **Checks** section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][12] for a list of metrics provided by this check.
 
 ### Events
+
 The Tomcat check does not include any events.
 
 ### Service Checks
@@ -208,29 +216,30 @@ The Tomcat check does not include any events.
 Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Tomcat instance, otherwise returns `OK`.
 
 ## Troubleshooting
+
 ### Commands to view the available metrics
 
 The `datadog-agent jmx` command was added in version 4.1.0.
 
-  * List attributes that match at least one of your instance configurations:
-`sudo /etc/init.d/datadog-agent jmx list_matching_attributes`
-  * List attributes that match one of your instance configurations but that are not collected because it would exceed the number of metrics that can be collected:
-`sudo /etc/init.d/datadog-agent jmx list_limited_attributes`
-  * List attributes that are actually collected by your current instance configurations:
-`sudo /etc/init.d/datadog-agent jmx list_collected_attributes`
-  * List attributes that don't match any of your instance configurations:
-`sudo /etc/init.d/datadog-agent jmx list_not_matching_attributes`
-  * List every attribute available that has a type supported by JMXFetch:
-`sudo /etc/init.d/datadog-agent jmx list_everything`
-  * Start the collection of metrics based on your current configuration and display them in the console:
-`sudo /etc/init.d/datadog-agent jmx collect`
+- List attributes that match at least one of your instance configurations:
+  `sudo /etc/init.d/datadog-agent jmx list_matching_attributes`
+- List attributes that match one of your instance configurations but that are not collected because it would exceed the number of metrics that can be collected:
+  `sudo /etc/init.d/datadog-agent jmx list_limited_attributes`
+- List attributes that are actually collected by your current instance configurations:
+  `sudo /etc/init.d/datadog-agent jmx list_collected_attributes`
+- List attributes that don't match any of your instance configurations:
+  `sudo /etc/init.d/datadog-agent jmx list_not_matching_attributes`
+- List every attribute available that has a type supported by JMXFetch:
+  `sudo /etc/init.d/datadog-agent jmx list_everything`
+- Start the collection of metrics based on your current configuration and display them in the console:
+  `sudo /etc/init.d/datadog-agent jmx collect`
 
 ## Further Reading
+
 Additional helpful documentation, links, and articles:
 
-* [Monitor Tomcat metrics with Datadog][13]
-* [Key metrics for monitoring Tomcat][14]
-
+- [Monitor Tomcat metrics with Datadog][13]
+- [Key metrics for monitoring Tomcat][14]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/tomcat/images/tomcat_dashboard.png
 [2]: https://docs.datadoghq.com/agent/guide/autodiscovery-with-jmx/?tab=containerizedagent

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -6,11 +6,9 @@
 
 This check collects Tomcat metrics, for example:
 
-- Overall activity metrics: error count, request count, processing times
-- Thread pool metrics: thread count, number of threads busy
+- Overall activity metrics: error count, request count, processing times, etc.
+- Thread pool metrics: thread count, number of threads busy, etc.
 - Servlet processing times
-
-And more.
 
 ## Setup
 

--- a/twemproxy/README.md
+++ b/twemproxy/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Track overall and per-pool stats on each of your twemproxy servers. This Agent check collects metrics for client and server connections and errors, request and response rates, bytes in and out of the proxy, and more.
+Track overall and per-pool stats on each of your Twemproxy servers. This Agent check collects metrics for client and server connections and errors, request and response rates, bytes in and out of the proxy, and more.
 
 ## Setup
 
@@ -26,7 +26,7 @@ Follow the instructions below to configure this check for an Agent running on a 
        port: 22222
    ```
 
-2. [Restart the Agent][5] to begin sending twemproxy metrics to Datadog.
+2. [Restart the Agent][5] to begin sending Twemproxy metrics to Datadog.
 
 #### Containerized
 

--- a/twemproxy/README.md
+++ b/twemproxy/README.md
@@ -5,32 +5,35 @@
 Track overall and per-pool stats on each of your twemproxy servers. This Agent check collects metrics for client and server connections and errors, request and response rates, bytes in and out of the proxy, and more.
 
 ## Setup
+
 ### Installation
 
 The Agent's Twemproxy check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your Twemproxy servers.
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
 1. Edit the `twemproxy.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][3]. See the [sample twemproxy.d/conf.yaml][4] for all available configuration options:
 
-    ```
-    init_config:
+   ```yaml
+   init_config:
 
-    instances:
-        - host: localhost
-          port: 22222 # change if your twemproxy doesn't use the default stats monitoring port
-    ```
+   instances:
+     - host: localhost
+       port: 22222
+   ```
 
 2. [Restart the Agent][5] to begin sending twemproxy metrics to Datadog.
 
 #### Containerized
+
 For containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying the parameters below.
 
 | Parameter            | Value                                  |
-|----------------------|----------------------------------------|
+| -------------------- | -------------------------------------- |
 | `<INTEGRATION_NAME>` | `twemproxy`                            |
 | `<INIT_CONFIG>`      | blank or `{}`                          |
 | `<INSTANCE_CONFIG>`  | `{"host": "%%host%%", "port":"22222"}` |
@@ -40,11 +43,13 @@ For containerized environments, see the [Autodiscovery Integration Templates][1]
 [Run the Agent's `status` subcommand][6] and look for `twemproxy` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][7] for a list of metrics provided by this check.
 
 ### Events
+
 The Twemproxy check does not include any events.
 
 ### Service Checks
@@ -54,6 +59,7 @@ The Twemproxy check does not include any events.
 Returns CRITICAL if the Agent cannot connect to the Twemproxy stats endpoint to collect metrics, otherwise OK.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][8].
 
 [1]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/twistlock/README.md
+++ b/twistlock/README.md
@@ -5,11 +5,13 @@
 [Twistlock][1] is a security scanner. It scans containers, hosts, and packages to find vulnerabilities and compliance issues.
 
 ## Setup
+
 ### Installation
 
 The Twistlock check is included in the [Datadog Agent][3] package, so you do not need to install anything else on your server.
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
@@ -21,12 +23,13 @@ Follow the instructions below to configure this check for an Agent running on a 
 2. [Restart the Agent][4].
 
 #### Containerized
+
 For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying the parameters below.
 
 ##### Metric collection
 
 | Parameter            | Value                                                                               |
-|----------------------|-------------------------------------------------------------------------------------|
+| -------------------- | ----------------------------------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `twistlock`                                                                         |
 | `<INIT_CONFIG>`      | blank or `{}`                                                                       |
 | `<INSTANCE_CONFIG>`  | `{"url":"http://%%host%%:8083", "username":"<USERNAME>", "password": "<PASSWORD>"}` |
@@ -36,7 +39,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 If you're using Kubernetes, add the config to replication controller section of twistlock_console.yaml before deploying:
 
 ```yaml
-...
+---
 apiVersion: v1
 kind: ReplicationController
 metadata:
@@ -50,48 +53,47 @@ spec:
     metadata:
       annotations:
         ad.datadoghq.com/twistlock-console.check_names: '["twistlock"]'
-        ad.datadoghq.com/twistlock-console.init_configs: '[{}]'
+        ad.datadoghq.com/twistlock-console.init_configs: "[{}]"
         ad.datadoghq.com/twistlock-console.instances: '[{"url":"http://%%host%%:8083", "username":"<USERNAME>", "password": "<PASSWORD>"}]'
         ad.datadoghq.com/twistlock-console.logs: '[{"source": "twistlock", "service": "twistlock"}]'
       name: twistlock-console
       namespace: twistlock
       labels:
         name: twistlock-console
-...
 ```
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][8].
 
 | Parameter      | Value                                             |
-|----------------|---------------------------------------------------|
+| -------------- | ------------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "twistlock", "service": "twistlock"}` |
 
 ###### Kubernetes
 
 1. Collecting logs is disabled by default in the Datadog Agent. Enable it in your [daemonset configuration][6]:
 
-    ```
-      (...)
-        env:
-          (...)
-          - name: DD_LOGS_ENABLED
-              value: "true"
-          - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
-              value: "true"
-      (...)
-    ```
+   ```yaml
+     #(...)
+       env:
+         #(...)
+         - name: DD_LOGS_ENABLED
+             value: "true"
+         - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+             value: "true"
+     #(...)
+   ```
 
 2. Make sure that the Docker socket is mounted to the Datadog Agent as done in [this manifest][7].
 
 3. Make sure the log section is included in the Pod annotation for the defender, where the container name can be found just below in the pod spec:
 
-    ```yaml
-      ad.datadoghq.com/<container-name>.logs: '[{"source": "twistlock", "service": "twistlock"}]'
-    ```
+   ```yaml
+   ad.datadoghq.com/<container-name>.logs: '[{"source": "twistlock", "service": "twistlock"}]'
+   ```
 
 4. [Restart the Agent][4].
 
@@ -99,15 +101,15 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 1. Collecting logs is disabled by default in the Datadog Agent. Enable it with the environment variable:
 
-    ```
-      DD_LOGS_ENABLED=true
-    ```
+   ```shell
+   DD_LOGS_ENABLED=true
+   ```
 
 2. Add a label on the defender container:
 
-    ```yaml
-      ad.datadoghq.com/<container-name>.logs: '[{"source": "twistlock", "service": "twistlock"}]'
-    ```
+   ```yaml
+   ad.datadoghq.com/<container-name>.logs: '[{"source": "twistlock", "service": "twistlock"}]'
+   ```
 
 3. Make sure that the Docker socket is mounted to the Datadog Agent. More information about the required configuration to collect logs with the Datadog Agent available in the [Docker documentation][8]
 

--- a/varnish/README.md
+++ b/varnish/README.md
@@ -6,19 +6,21 @@
 
 This check collects varnish metrics regarding:
 
-* Clients: connections and requests
-* Cache performance: hits, evictions, etc
-* Threads: creations, failures, and threads queued
-* Backends: successful, failed, and retried connections
+- Clients: connections and requests
+- Cache performance: hits, evictions, etc
+- Threads: creations, failures, and threads queued
+- Backends: successful, failed, and retried connections
 
 It also submits service checks for the health of each backend.
 
 ## Setup
+
 ### Installation
 
 The Varnish check is included in the [Datadog Agent][3] package. No additional installation is needed on your server.
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
@@ -27,7 +29,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 If you're running Varnish 4.1+, add the `dd-agent` system user to the Varnish group using:
 
-```
+```text
 sudo usermod -G varnish -a dd-agent
 ```
 
@@ -35,64 +37,60 @@ sudo usermod -G varnish -a dd-agent
 
 1. Edit the `varnish.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4]. See the [sample varnish.d/conf.yaml][5] for all available configuration options.
 
-    ```
-      init_config:
+   ```yaml
+   init_config:
 
-      instances:
-        - varnishstat: /usr/bin/varnishstat        # or wherever varnishstat lives
-          varnishadm: <PATH_TO_VARNISHADM_BIN>     # to submit service checks for the health of each backend
-      #   secretfile: <PATH_TO_VARNISH_SECRETFILE> # if you configured varnishadm and your secret file isn't /etc/varnish/secret
-      #   tags:
-      #     - instance:production
-    ```
+   instances:
+     - varnishstat: /usr/bin/varnishstat
+       varnishadm: <PATH_TO_VARNISHADM_BIN>
+   ```
 
     **Note**: If you don't set `varnishadm`, the Agent won't check backend health. If you do set it, the Agent needs privileges to execute the binary with root privileges. Add the following to your `/etc/sudoers` file:
 
-    ```
-      dd-agent ALL=(ALL) NOPASSWD:/usr/bin/varnishadm
-    ```
+   ```shell
+     dd-agent ALL=(ALL) NOPASSWD:/usr/bin/varnishadm
+   ```
 
 2. [Restart the Agent][6].
 
 ##### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. To enable Varnish logging uncomment the following in `/etc/default/varnishncsa`:
 
-    ```
-      VARNISHNCSA_ENABLED=1
-    ```
+   ```text
+     VARNISHNCSA_ENABLED=1
+   ```
 
 2. Add the following at the end of the same file:
 
-    ```
-      LOG_FORMAT="{\"date_access\": \"%{%Y-%m-%dT%H:%M:%S%z}t\", \"network.client.ip\":\"%h\", \"http.auth\" : \"%u\", \"varnish.x_forwarded_for\" : \"%{X-Forwarded-For}i\", \"varnish.hit_miss\":  \"%{Varnish:hitmiss}x\", \"network.bytes_written\": %b, \"http.response_time\": %D, \"http.status_code\": \"%s\", \"http.url\": \"%r\", \"http.ident\": \"%{host}i\", \"http.method\": \"%m\", \"varnish.time_first_byte\" : %{Varnish:time_firstbyte}x, \"varnish.handling\" : \"%{Varnish:handling}x\", \"http.referer\": \"%{Referer}i\", \"http.useragent\": \"%{User-agent}i\" }"
+   ```text
+     LOG_FORMAT="{\"date_access\": \"%{%Y-%m-%dT%H:%M:%S%z}t\", \"network.client.ip\":\"%h\", \"http.auth\" : \"%u\", \"varnish.x_forwarded_for\" : \"%{X-Forwarded-For}i\", \"varnish.hit_miss\":  \"%{Varnish:hitmiss}x\", \"network.bytes_written\": %b, \"http.response_time\": %D, \"http.status_code\": \"%s\", \"http.url\": \"%r\", \"http.ident\": \"%{host}i\", \"http.method\": \"%m\", \"varnish.time_first_byte\" : %{Varnish:time_firstbyte}x, \"varnish.handling\" : \"%{Varnish:handling}x\", \"http.referer\": \"%{Referer}i\", \"http.useragent\": \"%{User-agent}i\" }"
 
-      DAEMON_OPTS="$DAEMON_OPTS -c -a -F '${LOG_FORMAT}'"
-    ```
+     DAEMON_OPTS="$DAEMON_OPTS -c -a -F '${LOG_FORMAT}'"
+   ```
 
 3. Restart Varnishncsa to apply the changes.
 
-
 4. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 5. Add this configuration block to your `varnish.d/conf.yaml` file to start collecting your Varnish logs:
 
-    ```yaml
-      logs:
-        - type: file
-          path: /var/log/varnish/varnishncsa.log
-          source: varnish
-          sourcecategory: http_web_access
-          service: varnish
-    ```
-    Change the `path` and `service` parameter value and configure them for your environment.
-    See the [sample varnish.yaml][5] for all available configuration options.
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/varnish/varnishncsa.log
+       source: varnish
+       sourcecategory: http_web_access
+       service: varnish
+   ```
+
+    Change the `path` and `service` parameter value and configure them for your environment. See the [sample varnish.yaml][5] for all available configuration options.
 
 6. [Restart the Agent][6].
 
@@ -100,34 +98,39 @@ sudo usermod -G varnish -a dd-agent
 
 Configuration of the Varnish check using Autodiscovery in containerized environments is not supported. Collecting metrics in this type of environment may be possible by pushing metrics to DogStatsD using a StatsD plugin. The following 3rd party plugins are available:
 
-* [libvmod-statsd][7]
-* [prometheus_varnish_exporter][8]
+- [libvmod-statsd][7]
+- [prometheus_varnish_exporter][8]
 
 ### Validation
 
 [Run the Agent's status subcommand][10] and look for `varnish` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][11] for a list of metrics provided by this check.
 
 ### Events
+
 The Varnish check does not include any events.
 
 ### Service Checks
+
 **varnish.backend_healthy**:<br>
 The Agent submits this service check if you configure `varnishadm`. It submits a service check for each Varnish backend, tagging each with `backend:<BACKEND_NAME>`.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][12].
 
 ## Further Reading
+
 Additional helpful documentation, links, and articles:
 
-* [Top Varnish performance metrics][13]
-* [How to collect Varnish metrics][14]
-* [Monitor Varnish using Datadog][15]
-
+- [Top Varnish performance metrics][13]
+- [How to collect Varnish metrics][14]
+- [Monitor Varnish using Datadog][15]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/varnish/images/varnish.png
 [2]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/varnish/README.md
+++ b/varnish/README.md
@@ -4,10 +4,10 @@
 
 ## Overview
 
-This check collects varnish metrics regarding:
+This check collects Varnish metrics regarding:
 
 - Clients: connections and requests
-- Cache performance: hits, evictions, etc
+- Cache performance: hits, evictions, etc.
 - Threads: creations, failures, and threads queued
 - Backends: successful, failed, and retried connections
 
@@ -71,7 +71,7 @@ _Available for Agent versions >6.0_
      DAEMON_OPTS="$DAEMON_OPTS -c -a -F '${LOG_FORMAT}'"
    ```
 
-3. Restart Varnishncsa to apply the changes.
+3. Restart the `varnishncsa` utility to apply the changes.
 
 4. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 

--- a/vault/README.md
+++ b/vault/README.md
@@ -1,14 +1,17 @@
 # Agent Check: Vault
+
 ## Overview
 
 This check monitors [Vault][1] cluster health and leader changes.
 
 ## Setup
+
 ### Installation
 
 The Vault check is included in the [Datadog Agent][3] package. No additional installation is needed on your server.
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
@@ -18,57 +21,64 @@ Follow the instructions below to configure this check for an Agent running on a 
 2. [Restart the Agent][6].
 
 #### Containerized
+
 For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying the parameters below.
 
 | Parameter            | Value                                    |
-|----------------------|------------------------------------------|
+| -------------------- | ---------------------------------------- |
 | `<INTEGRATION_NAME>` | `vault`                                  |
 | `<INIT_CONFIG>`      | blank or `{}`                            |
 | `<INSTANCE_CONFIG>`  | `{"api_url": "http://%%host%%:8200/v1"}` |
 
 #### Log Collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-```
-logs_enabled: true
-```
+   ```yaml
+   logs_enabled: true
+   ```
 
 2. Configure Vault to enable audit and server logs.
-    * Audit logs must be enabled by a privileged user with the appropriate policies. See [Enabling audit devices][11] for more information.
-        ```
-        $ vault audit enable file file_path=/vault/vault-audit.log
-        ```
-    *  Make sure that [server logs][12] are written to file. You can configure static server logs in the [Vault systemd startup script][13].
-        The following script is outputting the logs to `/var/log/vault.log`.
-        ```
-        ...
-        [Service]
-        ...
-        ExecStart=/bin/sh -c '/home/vagrant/bin/vault server -config=/home/vagrant/vault_nano/config/vault -log-level="trace" > /var/log/vault.log
-        ...
-        ```
- 
+
+   - Audit logs must be enabled by a privileged user with the appropriate policies. See [Enabling audit devices][11] for more information.
+
+     ```shell
+     vault audit enable file file_path=/vault/vault-audit.log
+     ```
+
+   - Make sure that [server logs][12] are written to file. You can configure static server logs in the [Vault systemd startup script][13].
+     The following script is outputting the logs to `/var/log/vault.log`.
+
+     ```text
+     ...
+     [Service]
+     ...
+     ExecStart=/bin/sh -c '/home/vagrant/bin/vault server -config=/home/vagrant/vault_nano/config/vault -log-level="trace" > /var/log/vault.log
+     ...
+     ```
+
 3. Add this configuration block to your `vault.d/conf.yaml` file to start collecting your Vault logs:
-    ````yaml
-    logs:
-    - type: file
-      path: /vault/vault-audit.log
-      source: vault
-      service: <SERVICE_NAME>
-    - type: file
-      path: /var/log/vault.log
-      source: vault
-      service: <SERVICE_NAME>
-    ```
+
+   ```yaml
+   logs:
+     - type: file
+       path: /vault/vault-audit.log
+       source: vault
+       service: "<SERVICE_NAME>"
+     - type: file
+       path: /var/log/vault.log
+       source: vault
+       service: "<SERVICE_NAME>"
+   ```
 
 ### Validation
 
 [Run the Agent's status subcommand][7] and look for `vault` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][8] for a list of metrics provided by this integration.
@@ -97,9 +107,10 @@ Returns CRITICAL if the check cannot access the metrics endpoint. Otherwise, ret
 Need help? Contact [Datadog support][9].
 
 ## Further Reading
+
 Additional helpful documentation, links, and articles:
 
-* [Monitor HashiCorp Vault with Datadog][10]
+- [Monitor HashiCorp Vault with Datadog][10]
 
 [1]: https://www.vaultproject.io
 [2]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/vertica/README.md
+++ b/vertica/README.md
@@ -18,13 +18,13 @@ Edit the `vertica.d/conf.yaml` file, in the `conf.d/` folder at the root of your
 
 Create a database user for the Datadog Agent. From [vsql][11], connect to the database as a superuser. Then run the `CREATE USER` statement.
 
-```
+```text
 CREATE USER datadog IDENTIFIED BY '<PASSWORD>';
 ```
 
 The user used to connect to the database must be granted the [SYSMONITOR][3] role in order to access the monitoring system tables.
 
-```
+```text
 GRANT SYSMONITOR TO datadog WITH ADMIN OPTION;
 ```
 
@@ -34,23 +34,23 @@ Additionally, as the metrics for current license usage use the values from the m
 
 #### Log Collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-```
-logs_enabled: true
-```
+    ```yaml
+    logs_enabled: true
+    ```
 
 2. Add this configuration block to your `vertica.d/conf.yaml` file to start collecting your Vertica logs:
 
-```
-logs:
-  - source: vertica
-    type: file
-    path: /<CATALOG_PATH>/<DATABASE_NAME>/<NODE_NAME>_catalog/vertica.log
-    service: vertica
-```
+    ```yaml
+    logs:
+      - source: vertica
+        type: file
+        path: "/<CATALOG_PATH>/<DATABASE_NAME>/<NODE_NAME>_catalog/vertica.log"
+        service: vertica
+    ```
 
 3. [Restart the Agent][7].
 

--- a/vsphere/README.md
+++ b/vsphere/README.md
@@ -7,6 +7,7 @@
 This check collects resource usage metrics from your vSphere cluster-CPU, disk, memory, and network usage. It also watches your vCenter server for events and emits them to Datadog.
 
 ## Setup
+
 ### Installation
 
 The vSphere check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your vCenter server.
@@ -17,7 +18,7 @@ In the **Administration** section of vCenter, add a read-only user called `datad
 
 Then, edit the `vsphere.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][3]. See the [sample vsphere.d/conf.yaml][4] for all available configuration options:
 
-```
+```YAML
 init_config:
 
 instances:
@@ -38,17 +39,19 @@ Starting with version 3.3.0 of the check, shipped in Agent version 6.5.0/5.27.0,
 By default, starting with version 3.3.0, the `collection_level` is set to 1 and the new metric names with the additional suffix are sent by the integration.
 
 The following scenarios are possible when using the vSphere integration:
+
 1. You never used the integration before, and you just installed an Agent with version 6.5.0+ / 5.27.0+. There is nothing specific in this case. Use the integration, configure the `collection_level`, and view your metrics in Datadog.
 
-2. You used the integration with an Agent older than 6.5.0/5.27.0, and upgraded to a newer version.
-    - If your configuration specifically set the `all_metrics` parameter to either `true` or `false`, nothing changes (the same metrics are sent to Datadog). You should then update your dashboards and monitors to use the new metric names before switching to the new `collection_level` parameter, since `all_metrics` is deprecated and will eventually be removed.
-    - If your configuration did not specify the `all_metrics` parameter, upon upgrade the integration defaults to the `collection_level` parameter set to 1 and sends the metrics with the new name to Datadog.
-    **Warning**: this breaks your dashboard graphs and monitors scoped on the deprecated metrics, which stop being sent. To prevent this, you should explicitly set `all_metrics: false` in your configuration to continue reporting the same metrics, then update your dashboards and monitors to use the new metrics before switching back to using `collection_level`.
+2. You used the integration with an Agent older than 6.5.0/5.27.0, and upgraded to a newer version/
+
+   - If your configuration specifically set the `all_metrics` parameter to either `true` or `false`, nothing changes (the same metrics are sent to Datadog). You should then update your dashboards and monitors to use the new metric names before switching to the new `collection_level` parameter, since `all_metrics` is deprecated and will eventually be removed.
+   - If your configuration did not specify the `all_metrics` parameter, upon upgrade the integration defaults to the `collection_level` parameter set to 1 and sends the metrics with the new name to Datadog.
+     **Warning**: this breaks your dashboard graphs and monitors scoped on the deprecated metrics, which stop being sent. To prevent this, you should explicitly set `all_metrics: false` in your configuration to continue reporting the same metrics, then update your dashboards and monitors to use the new metrics before switching back to using `collection_level`.
 
 #### Configuration Options
 
 | Options                   | Required | Description                                                                                                                                                                                                                                                                                                                                                      |
-|---------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ssl_verify`              | No       | Set to false to disable SSL verification, when connecting to vCenter.                                                                                                                                                                                                                                                                                            |
 | `ssl_capath`              | No       | Set to the absolute file path of a directory containing CA certificates in PEM format.                                                                                                                                                                                                                                                                           |
 | `host_include_only_regex` | No       | Use a regex like this if you want the check to only fetch metrics for these ESXi hosts and the VMs running on it.                                                                                                                                                                                                                                                |
@@ -63,6 +66,7 @@ The following scenarios are possible when using the vSphere integration:
 [Run the Agent's status subcommand][7] and look for `vsphere` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][8] for a list of metrics provided by this check.
@@ -71,22 +75,22 @@ See [metadata.csv][8] for a list of metrics provided by this check.
 
 This check watches vCenter's Event Manager for events and emits them to Datadog. It does NOT emit the following event types:
 
-* AlarmStatusChangedEvent:Gray
-* VmBeingHotMigratedEvent
-* VmResumedEvent
-* VmReconfiguredEvent
-* VmPoweredOnEvent
-* VmMigratedEvent
-* TaskEvent:Initialize powering On
-* TaskEvent:Power Off virtual machine
-* TaskEvent:Power On virtual machine
-* TaskEvent:Reconfigure virtual machine
-* TaskEvent:Relocate virtual machine
-* TaskEvent:Suspend virtual machine
-* TaskEvent:Migrate virtual machine
-* VmMessageEvent
-* VmSuspendedEvent
-* VmPoweredOffEvent
+- AlarmStatusChangedEvent:Gray
+- VmBeingHotMigratedEvent
+- VmResumedEvent
+- VmReconfiguredEvent
+- VmPoweredOnEvent
+- VmMigratedEvent
+- TaskEvent:Initialize powering On
+- TaskEvent:Power Off virtual machine
+- TaskEvent:Power On virtual machine
+- TaskEvent:Reconfigure virtual machine
+- TaskEvent:Relocate virtual machine
+- TaskEvent:Suspend virtual machine
+- TaskEvent:Migrate virtual machine
+- VmMessageEvent
+- VmSuspendedEvent
+- VmPoweredOffEvent
 
 ### Service Checks
 
@@ -95,11 +99,11 @@ Returns CRITICAL if the Agent cannot connect to vCenter to collect metrics, othe
 
 ## Troubleshooting
 
-* [Can I limit the number of VMs that are pulled in via the VMWare integration?][9]
+- [Can I limit the number of VMs that are pulled in via the VMWare integration?][9]
 
 ## Further Reading
-See our [blog post][10] on monitoring vSphere environments with Datadog.
 
+See our [blog post][10] on monitoring vSphere environments with Datadog.
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/vsphere/images/vsphere_graph.png
 [2]: https://app.datadoghq.com/account/settings#agent

--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -8,6 +8,7 @@ The Win 32 event log check watches for Windows Event Logs and forwards them to D
 - Correlate system and application events with the rest of your application.
 
 ## Setup
+
 ### Installation
 
 The Windows Event Log check is included in the [Datadog Agent][1] package. There is no additional installation required.
@@ -36,7 +37,7 @@ Get-WinEvent -ListLog * | sort RecordCount -Descending
 
 This command displays channels in the format `LogMode MaximumSizeInBytes RecordCount LogName`. Example response:
 
-```
+```text
 LogMode MaximumSizeInBytes RecordCount LogName
 Circular 134217728 249896 Security
 ```
@@ -45,17 +46,17 @@ The value under the column `LogName` is the name of the channel. In the above ex
 
 Then add the channels in your `win32_event_log.d/conf.yaml` configuration file:
 
-```
+```yaml
 logs:
   - type: windows_event
-    channel_path: <CHANNEL_1>
-    source: <CHANNEL_1>
+    channel_path: "<CHANNEL_1>"
+    source: "<CHANNEL_1>"
     service: myservice
     sourcecategory: windowsevent
 
   - type: windows_event
-    channel_path: <CHANNEL_2>
-    source: <CHANNEL_2>
+    channel_path: "<CHANNEL_2>"
+    source: "<CHANNEL_2>"
     service: myservice
     sourcecategory: windowsevent
 ```
@@ -68,17 +69,18 @@ Finally, [restart the Agent][4].
 **Note**: For the Security logs channel, add your Datadog Agent user to the `Event Log Readers` user group.
 
 ### Filters
+
 Use the Windows Event Viewer GUI to list all the event logs available for capture with this integration.
 
 To determine the exact values, set your filters to use the following PowerShell command:
 
-```
+```text
 Get-WmiObject -Class Win32_NTLogEvent
 ```
 
 For instance, to see the latest event logged in the `Security` LogFile, use:
 
-```
+```text
 Get-WmiObject -Class Win32_NTLogEvent -Filter "LogFile='Security'" | select -First 1
 ```
 
@@ -89,43 +91,43 @@ The information given by the  <code> Get-EventLog</code> PowerShell command or t
 Double-check your filters' values with <code>Get-WmiObject</code> if the integration doesn't capture the events you set up.
 </div>
 
-1 - Configure one or more filters for the event log. A filter allows you to choose what log events you want to get into Datadog.
+1. Configure one or more filters for the event log. A filter allows you to choose what log events you want to get into Datadog.
 
-Filter on the following properties:
+    Filter on the following properties:
 
-* type: Warning, Error, Information
-* log_file: Application, System, Setup, Security
-* source_name: Any available source name
-* user: Any valid user name
+      - type: Warning, Error, Information
+      - log_file: Application, System, Setup, Security
+      - source_name: Any available source name
+      - user: Any valid user name
 
-For each filter, add an instance in the configuration file at `conf.d/win32_event_log.yaml`.
+    For each filter, add an instance in the configuration file at `conf.d/win32_event_log.yaml`.
 
-Some example filters:
+    Some example filters:
 
-```yaml
-instances:
-    # The following captures errors and warnings from SQL Server which
-    # puts all events under the MSSQLSERVER source and tag them with #sqlserver.
-    -   tags:
-            - sqlserver
-        type:
-            - Warning
-            - Error
-        log_file:
-            - Application
-        source_name:
-            - MSSQLSERVER
+   ```yaml
+   instances:
+     # The following captures errors and warnings from SQL Server which
+     # puts all events under the MSSQLSERVER source and tag them with #sqlserver.
+     - tags:
+         - sqlserver
+       type:
+         - Warning
+         - Error
+       log_file:
+         - Application
+       source_name:
+         - MSSQLSERVER
 
-    # This instance captures all system errors and tags them with #system.
-    -   tags:
-            - system
-        type:
-            - Error
-        log_file:
-            - System
-```
+     # This instance captures all system errors and tags them with #system.
+     - tags:
+         - system
+       type:
+         - Error
+       log_file:
+         - System
+   ```
 
-2 - [Restart the Agent][4] using the Agent Manager (or restart the service)
+2. [Restart the Agent][4] using the Agent Manager (or restart the service)
 
 ### Validation
 
@@ -144,13 +146,17 @@ Checks
 ```
 
 ## Data Collected
+
 ### Metrics
+
 The Win32 Event log check does not include any metrics.
 
 ### Events
+
 All Windows Event are forwarded to your Datadog application.
 
 ### Service Checks
+
 The Win32 Event log check does not include any service checks.
 
 ## Troubleshooting
@@ -158,16 +164,16 @@ The Win32 Event log check does not include any service checks.
 Need help? Contact [Datadog support][7].
 
 ## Further Reading
+
 ### Documentation
 
-* [How to add event log files to the `Win32_NTLogEvent` WMI class][8]
+- [How to add event log files to the `Win32_NTLogEvent` WMI class][8]
 
 ### Blog
 
-* [Monitoring Windows Server 2012][9]
-* [How to collect Windows Server 2012 metrics][10]
-* [Monitoring Windows Server 2012 with Datadog][11]
-
+- [Monitoring Windows Server 2012][9]
+- [How to collect Windows Server 2012 metrics][10]
+- [Monitoring Windows Server 2012 with Datadog][11]
 
 [1]: https://app.datadoghq.com/account/settings#agent/windows
 [2]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory

--- a/windows_service/README.md
+++ b/windows_service/README.md
@@ -1,4 +1,5 @@
 # Agent Check: Windows Service
+
 ## Overview
 
 This check monitors the state of any Windows Service and submits a service check to Datadog.
@@ -13,7 +14,7 @@ The Windows Service check is included in the [Datadog Agent][1] package, so you 
 
 Edit the `windows_service.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample windows_service.d/conf.yaml][3] for all available configuration options:
 
-```
+```yaml
 init_config:
 
 instances:
@@ -26,9 +27,8 @@ instances:
   ## For an exact match, use ^service$
   #
   - services:
-      - <SERVICE_NAME_1>
-      - <SERVICE_NAME_2>
-
+      - "<SERVICE_NAME_1>"
+      - "<SERVICE_NAME_2>"
   ## @param tags - list of key:value element - optional
   ## List of tags to attach to every service check emitted by this integration.
   ##
@@ -44,6 +44,7 @@ Provide service names as they appear in the `services.msc` properties field (e.g
 [Restart the Agent][4] to start monitoring the services and sending service checks to Datadog.
 
 #### Metrics collection
+
 The Windows Service check can potentially emit [custom metrics][5], which may impact your [billing][6].
 
 ### Validation
@@ -51,19 +52,22 @@ The Windows Service check can potentially emit [custom metrics][5], which may im
 [Run the Agent's status subcommand][7] and look for `windows_service` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 The Windows Service check does not include any metrics.
 
 ### Events
+
 The Windows Service check does not include any events.
 
 ### Service Checks
+
 **windows_service.state**:
 The Agent submits this service check for each Windows service configured in `services`, tagging the service check with 'service:<service_name>'. The service check takes on the following statuses depending on Windows status:
 
 | Windows status   | windows_service.state |
-| ---              | ---                   |
+| ---------------- | --------------------- |
 | Stopped          | CRITICAL              |
 | Start Pending    | WARNING               |
 | Stop Pending     | WARNING               |
@@ -74,14 +78,14 @@ The Agent submits this service check for each Windows service configured in `ser
 | Unknown          | UNKNOWN               |
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][8].
 
 ## Further Reading
 
-* [Monitoring Windows Server 2012][9]
-* [How to collect Windows Server 2012 metrics][10]
-* [Monitoring Windows Server 2012 with Datadog][11]
-
+- [Monitoring Windows Server 2012][9]
+- [How to collect Windows Server 2012 metrics][10]
+- [Monitoring Windows Server 2012 with Datadog][11]
 
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory

--- a/wmi_check/README.md
+++ b/wmi_check/README.md
@@ -4,12 +4,12 @@
 
 ## Overview
 
-Get metrics from your Windows applications/servers with Windows Management Instrumentation (WMI) in real time to
+Get metrics from your Windows applications and servers with Windows Management Instrumentation (WMI) in real time to
 
 - Visualize their performance.
 - Correlate their activity with the rest of your applications.
 
-**Note:** It is recommended that the [PDH check][14] be used instead in all cases due to its significantly less overhead and thus better scalability.
+**Note:** It is recommended that the [PDH check][14] be used instead in all cases due to its significantly lower overhead and thus better scalability.
 
 ## Setup
 
@@ -60,8 +60,8 @@ The default configuration uses the filter clause to limit the metrics pulled. Ei
 
 The metrics definitions include three components:
 
-- Class property in WMI
-- Metric name as it appears in Datadog
+- Class property in WMI.
+- Metric name as it appears in Datadog.
 - The metric type.
 
 #### Configuration Options

--- a/wmi_check/README.md
+++ b/wmi_check/README.md
@@ -6,18 +6,19 @@
 
 Get metrics from your Windows applications/servers with Windows Management Instrumentation (WMI) in real time to
 
-* Visualize their performance.
-* Correlate their activity with the rest of your applications.
+- Visualize their performance.
+- Correlate their activity with the rest of your applications.
 
 **Note:** It is recommended that the [PDH check][14] be used instead in all cases due to its significantly less overhead and thus better scalability.
 
 ## Setup
+
 ### Installation
 
 If you are only collecting standard metrics from Microsoft Windows and other packaged applications, there are no installation steps. If you need to define new metrics to collect from your application, then you have a few options:
 
-1.  Submit perfomance counters using System.Diagnostics in .NET, then access them via WMI.
-2.  Implement a COM-based WMI provider for your application. You would typically only do this if you are using a non-.NET language.
+1. Submit perfomance counters using System.Diagnostics in .NET, then access them via WMI.
+2. Implement a COM-based WMI provider for your application. You would typically only do this if you are using a non-.NET language.
 
 To learn more about using System.Diagnostics, see [the MSDN documentation][2]. After adding your metric you should be able to find it in WMI. To browse the WMI namespaces you may find this tool useful: [WMI Explorer][3]. You can find the same information with Powershell [here][4]. Also review the information in the [Datadog Knowledge Base article][5].
 
@@ -26,34 +27,32 @@ If you assign the new metric a category of My_New_Metric, the WMI path is
 
 If the metric isn't showing up in WMI, try running `winmgmt /resyncperf` to force the computer to reregister the performance libraries with WMI.
 
-
 ## Configuration
 
-1.  Click the **Install Integration** button on the WMI Integration Tile.
-2.  Open the Datadog Agent Manager on the Windows server.
-3.  Edit the `Wmi Check` configuration.
+1. Click the **Install Integration** button on the WMI Integration Tile.
+2. Open the Datadog Agent Manager on the Windows server.
+3. Edit the `Wmi Check` configuration.
 
-        init_config:
-
-        instances:
-          - class: Win32_OperatingSystem
-            metrics:
-              - [NumberOfProcesses, system.proc.count, gauge]
-              - [NumberOfUsers, system.users.count, gauge]
-
-          - class: Win32_PerfFormattedData_PerfProc_Process
-            metrics:
-              - [ThreadCount, proc.threads.count, gauge]
-              - [VirtualBytes, proc.mem.virtual, gauge]
-              - [PercentProcessorTime, proc.cpu_pct, gauge]
-            tag_by: Name
-
-          - class: Win32_PerfFormattedData_PerfProc_Process
-            metrics:
-              - [IOReadBytesPerSec, proc.io.bytes_read, gauge]
-            tag_by: Name
-            tag_queries:
-              - [IDProcess, Win32_Process, Handle, CommandLine]
+```yaml
+init_config:
+instances:
+  - class: Win32_OperatingSystem
+    metrics:
+      - [NumberOfProcesses, system.proc.count, gauge]
+      - [NumberOfUsers, system.users.count, gauge]
+  - class: Win32_PerfFormattedData_PerfProc_Process
+    metrics:
+      - [ThreadCount, proc.threads.count, gauge]
+      - [VirtualBytes, proc.mem.virtual, gauge]
+      - [PercentProcessorTime, proc.cpu_pct, gauge]
+    tag_by: Name
+  - class: Win32_PerfFormattedData_PerfProc_Process
+    metrics:
+      - [IOReadBytesPerSec, proc.io.bytes_read, gauge]
+    tag_by: Name
+    tag_queries:
+      - [IDProcess, Win32_Process, Handle, CommandLine]
+```
 
 <div class="alert alert-info">
 The default configuration uses the filter clause to limit the metrics pulled. Either set the filters to valid values or remove them as shown above to collect the metrics.
@@ -61,50 +60,54 @@ The default configuration uses the filter clause to limit the metrics pulled. Ei
 
 The metrics definitions include three components:
 
-* Class property in WMI
-* Metric name as it appears in Datadog
-* The metric type.
+- Class property in WMI
+- Metric name as it appears in Datadog
+- The metric type.
 
 #### Configuration Options
-*This feature is available starting with version 5.3 of the agent*
+
+_This feature is available starting with version 5.3 of the agent_
 
 Each WMI query has 2 required options, `class` and `metrics` and six optional options, `host`, `namespace`, `filters`, `provider`, `tag_by`, `constant_tags` and `tag_queries`.
 
-* `class` is the name of the WMI class, for example `Win32_OperatingSystem` or `Win32_PerfFormattedData_PerfProc_Process`. You can find many of the standard class names on the [MSDN docs][6]. The `Win32_FormattedData_*` classes provide many useful performance counters by default.
+- `class` is the name of the WMI class, for example `Win32_OperatingSystem` or `Win32_PerfFormattedData_PerfProc_Process`. You can find many of the standard class names on the [MSDN docs][6]. The `Win32_FormattedData_*` classes provide many useful performance counters by default.
 
-* `metrics` is a list of metrics you want to capture, with each item in the
-list being a set of `[<WMI_PROPERTY_NAME>, <METRIC_NAME>, <METRIC_TYPE>]`:
-  *  `<WMI_PROPERTY_NAME>` is something like `NumberOfUsers` or `ThreadCount`. The standard properties are also available on the MSDN docs for each class.
-  *  `<METRIC_NAME>` is the name you want to show up in Datadog.
-  * `<METRIC_TYPE>` is from the standard choices for all agent checks, such as gauge, rate, histogram or counter.
+- `metrics` is a list of metrics you want to capture, with each item in the
+  list being a set of `[<WMI_PROPERTY_NAME>, <METRIC_NAME>, <METRIC_TYPE>]`:
 
-* `host` is the optional target of the WMI query, `localhost` is assumed by default. If you set this option, make sure that Remote Management is enabled on the target host [see here][7] for more information.
+  - `<WMI_PROPERTY_NAME>` is something like `NumberOfUsers` or `ThreadCount`. The standard properties are also available on the MSDN docs for each class.
+  - `<METRIC_NAME>` is the name you want to show up in Datadog.
+  - `<METRIC_TYPE>` is from the standard choices for all agent checks, such as gauge, rate, histogram or counter.
 
-* `namespace` is the optional WMI namespace to connect to (default to `cimv2`).
+- `host` is the optional target of the WMI query, `localhost` is assumed by default. If you set this option, make sure that Remote Management is enabled on the target host [see here][7] for more information.
 
-* `filters` is a list of filters on the WMI query you may want. For example, for a process-based WMI class you may want metrics for only certain processes running on your machine, so you could add a filter for each process name. You can also use the '%' character as a wildcard.
+- `namespace` is the optional WMI namespace to connect to (default to `cimv2`).
 
-* `provider` is the optional WMI provider (default to `32` on Datadog Agent 32-bit or `64`). It is used to request WMI data from the non-default provider. Available options are: `32` or `64`.
-See [MSDN][8] for more information.
+- `filters` is a list of filters on the WMI query you may want. For example, for a process-based WMI class you may want metrics for only certain processes running on your machine, so you could add a filter for each process name. You can also use the '%' character as a wildcard.
 
-* `tag_by` optionally lets you tag each metric with a property from the WMI class you're using. This is only useful when you have multiple values for your WMI query.
+- `provider` is the optional WMI provider (default to `32` on Datadog Agent 32-bit or `64`). It is used to request WMI data from the non-default provider. Available options are: `32` or `64`.
+  See [MSDN][8] for more information.
 
-* `tags` optionally lets you tag each metric with a set of fixed values.
+- `tag_by` optionally lets you tag each metric with a property from the WMI class you're using. This is only useful when you have multiple values for your WMI query.
 
-* `tag_queries` optionally lets you specify a list of queries, to tag metrics with a target class property. Each item in the list is a set of `[<LINK_SOURCE_PROPERTY>, <TARGET_CLASS>, <LINK_TARGET_CLASS_PROPERTY>, <TARGET_PROPERTY>]` where:
-  * `<LINK_SOURCE_PROPERTY>` contains the link value
-  * `<TARGET_CLASS>` is the class to link to
-  * `<LINK_TARGET_CLASS_PROPERTY>` is the target class property to link to
-  * `<TARGET_PROPERTY>` contains the value to tag with
+- `tags` optionally lets you tag each metric with a set of fixed values.
+
+- `tag_queries` optionally lets you specify a list of queries, to tag metrics with a target class property. Each item in the list is a set of `[<LINK_SOURCE_PROPERTY>, <TARGET_CLASS>, <LINK_TARGET_CLASS_PROPERTY>, <TARGET_PROPERTY>]` where:
+
+  - `<LINK_SOURCE_PROPERTY>` contains the link value
+  - `<TARGET_CLASS>` is the class to link to
+  - `<LINK_TARGET_CLASS_PROPERTY>` is the target class property to link to
+  - `<TARGET_PROPERTY>` contains the value to tag with
 
   It translates to a WMI query:
   `SELECT '<TARGET_PROPERTY>' FROM '<TARGET_CLASS>' WHERE '<LINK_TARGET_CLASS_PROPERTY>' = '<LINK_SOURCE_PROPERTY>'`
 
-  ##### Example
-  The setting `[IDProcess, Win32_Process, Handle, CommandLine]` tags each process with its command line. Any instance number will be removed from tag_by values i.e. name:process#1 => name:process. NB: The agent must be running under an **Administrator** account for this to work as the `CommandLine` property is not accessible to non-admins.
+##### Example
 
+The setting `[IDProcess, Win32_Process, Handle, CommandLine]` tags each process with its command line. Any instance number will be removed from tag_by values i.e. name:process#1 => name:process. NB: The agent must be running under an **Administrator** account for this to work as the `CommandLine` property is not accessible to non-admins.
 
 #### Metrics collection
+
 The WMI check can potentially emit [custom metrics][9], which may impact your [billing][10].
 
 ### Validation
@@ -112,16 +115,21 @@ The WMI check can potentially emit [custom metrics][9], which may impact your [b
 [Run the Agent's `status` subcommand][11] and look for `wmi_check` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
+
 See [metadata.csv][12] for a list of metrics provided by this integration.
 
 ### Events
+
 The WMI check does not include any events.
 
 ### Service Checks
+
 The WMI check does not include any service checks.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][13].
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/wmi_check/images/wmimetric.png

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -4,15 +4,15 @@
 
 ## Overview
 
-This check collects metrics from your YARN ResourceManager, including (but not limited to)::
+This check collects metrics from your YARN ResourceManager, including (but not limited to):
 
 - Cluster-wide metrics (e.g. number of running apps, running containers, unhealthy nodes, etc.)
 - Per-application metrics (e.g. app progress, elapsed running time, running containers, memory use, etc.)
-- Node metrics (e.g. available vCores, time of last health update, etc/)
+- Node metrics (e.g. available vCores, time of last health update, etc.)
 
 ### Deprecation notice
 
-`yarn.apps.<METRIC>` metrics have been deprecated in favor of `yarn.apps.<METRIC>_gauge` metrics, because `yarn.apps` metrics are incorrectly reported as a `RATE` instead of a `GAUGE`.
+`yarn.apps.<METRIC>` metrics are deprecated in favor of `yarn.apps.<METRIC>_gauge` metrics because `yarn.apps` metrics are incorrectly reported as a `RATE` instead of a `GAUGE`.
 
 ## Setup
 
@@ -87,7 +87,7 @@ Returns `CRITICAL` if the Agent cannot connect to the ResourceManager URI to col
 
 **yarn.application.status**:
 
-Returns per application status according to the mapping specified in the [`conf.yaml`][5] file.
+Returns per-application status according to the mapping specified in the [`conf.yaml`][5] file.
 
 ## Troubleshooting
 

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -6,33 +6,50 @@
 
 This check collects metrics from your YARN ResourceManager, including (but not limited to)::
 
-* Cluster-wide metrics (e.g. number of running apps, running containers, unhealthy nodes, etc.)
-* Per-application metrics (e.g. app progress, elapsed running time, running containers, memory use, etc.)
-* Node metrics (e.g. available vCores, time of last health update, etc/)
+- Cluster-wide metrics (e.g. number of running apps, running containers, unhealthy nodes, etc.)
+- Per-application metrics (e.g. app progress, elapsed running time, running containers, memory use, etc.)
+- Node metrics (e.g. available vCores, time of last health update, etc/)
 
 ### Deprecation notice
+
 `yarn.apps.<METRIC>` metrics have been deprecated in favor of `yarn.apps.<METRIC>_gauge` metrics, because `yarn.apps` metrics are incorrectly reported as a `RATE` instead of a `GAUGE`.
 
 ## Setup
+
 ### Installation
 
 The YARN check is included in the [Datadog Agent][3] package, so you don't need to install anything else on your YARN ResourceManager.
 
 ### Configuration
+
 #### Host
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
 1. Edit the `yarn.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][4].
 
-    ```yaml
-    	init_config:
+   ```yaml
+   init_config:
 
-    	instances:
-      	  - resourcemanager_uri: http://localhost:8088 # or whatever your resource manager listens
-          	cluster_name: MyCluster # used to tag metrics, i.e. 'cluster_name:MyCluster'; default is 'default_cluster'
-        	collect_app_metrics: true
-    ```
+   instances:
+     ## @param resourcemanager_uri - string - required
+     ## The YARN check retrieves metrics from YARNS's ResourceManager. This
+     ## check must be run from the Master Node and the ResourceManager URI must
+     ## be specified below. The ResourceManager URI is composed of the
+     ## ResourceManager's hostname and port.
+     ## The ResourceManager hostname can be found in the yarn-site.xml conf file
+     ## under the property yarn.resourcemanager.address
+     ##
+     ## The ResourceManager port can be found in the yarn-site.xml conf file under
+     ## the property yarn.resourcemanager.webapp.address
+     #
+     - resourcemanager_uri: http://localhost:8088
+
+       ## @param cluster_name - string - required - default: default_cluster
+       ## A friendly name for the cluster.
+       #
+       cluster_name: default_cluster
+   ```
 
     See the [example check configuration][5] for a comprehensive list and description of all check options.
 
@@ -42,10 +59,10 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying the parameters below.
 
-| Parameter            | Value                                                                                    |
-|----------------------|------------------------------------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `yarn`                                                                                   |
-| `<INIT_CONFIG>`      | blank or `{}`                                                                            |
+| Parameter            | Value                                                                                   |
+| -------------------- | --------------------------------------------------------------------------------------- |
+| `<INTEGRATION_NAME>` | `yarn`                                                                                  |
+| `<INIT_CONFIG>`      | blank or `{}`                                                                           |
 | `<INSTANCE_CONFIG>`  | `{"resourcemanager_uri": "http://%%host%%:%%port%%", "cluster_name": "<CLUSTER_NAME>"}` |
 
 ### Validation
@@ -53,14 +70,17 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 [Run the Agent's `status` subcommand][7] and look for `yarn` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 See [metadata.csv][8] for a list of metrics provided by this check.
 
 ### Events
+
 The Yarn check does not include any events.
 
 ### Service Checks
+
 **yarn.can_connect**:
 
 Returns `CRITICAL` if the Agent cannot connect to the ResourceManager URI to collect metrics, otherwise `OK`.
@@ -70,15 +90,15 @@ Returns `CRITICAL` if the Agent cannot connect to the ResourceManager URI to col
 Returns per application status according to the mapping specified in the [`conf.yaml`][5] file.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][9].
 
 ## Further Reading
 
-* [Hadoop architectural overview][10]
-* [How to monitor Hadoop metrics][11]
-* [How to collect Hadoop metrics][12]
-* [How to monitor Hadoop with Datadog][13]
-
+- [Hadoop architectural overview][10]
+- [How to monitor Hadoop metrics][11]
+- [How to collect Hadoop metrics][12]
+- [How to monitor Hadoop with Datadog][13]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/yarn/images/yarn_dashboard.png
 [2]: https://docs.datadoghq.com/agent/autodiscovery/integrations

--- a/zk/README.md
+++ b/zk/README.md
@@ -7,6 +7,7 @@
 The Zookeeper check tracks client connections and latencies, monitors the number of unprocessed requests, and more.
 
 ## Setup
+
 ### Installation
 
 The Zookeeper check is included in the [Datadog Agent][3] package, so you don't need to install anything else on your Zookeeper servers.
@@ -14,6 +15,7 @@ The Zookeeper check is included in the [Datadog Agent][3] package, so you don't 
 ### Configuration
 
 #### Zookeepr whitelist
+
 As of version 3.5, Zookeeper has a `4lw.commands.whitelist` parameter (see [Zookeeper documentation][7]) that whitelists [four letter word commands][8]. By default, only `srvr` is whitelisted. Add `stat` and `mntr` to the whitelist, as the integration is based on these commands.
 
 #### Host
@@ -21,54 +23,54 @@ As of version 3.5, Zookeeper has a `4lw.commands.whitelist` parameter (see [Zook
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
 1. Edit the `zk.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4] to start collecting your Zookeeper [metrics](#metric-collection) and [logs](#log-collection).
-  See the [sample zk.d/conf.yaml][5] for all available configuration options.
+   See the [sample zk.d/conf.yaml][5] for all available configuration options.
 
 2. [Restart the Agent][6].
 
 #### Log collection
 
-**Available for Agent >6.0**
+_Available for Agent versions >6.0_
 
 1. Zookeeper uses the `log4j` logger per default. To activate the logging into a file and customize the format edit the `log4j.properties` file:
 
-    ```
-      # Set root logger level to INFO and its only appender to R
-      log4j.rootLogger=INFO, R
-      log4j.appender.R.File=/var/log/zookeeper.log
-      log4j.appender.R.layout=org.apache.log4j.PatternLayout
-      log4j.appender.R.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
-    ```
+   ```text
+     # Set root logger level to INFO and its only appender to R
+     log4j.rootLogger=INFO, R
+     log4j.appender.R.File=/var/log/zookeeper.log
+     log4j.appender.R.layout=org.apache.log4j.PatternLayout
+     log4j.appender.R.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+   ```
 
 2. By default, our integration pipeline support the following conversion patterns:
 
-    ```
-      %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
-      %d [%t] %-5p %c - %m%n
-      %r [%t] %p %c %x - %m%n
-    ```
+   ```text
+     %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+     %d [%t] %-5p %c - %m%n
+     %r [%t] %p %c %x - %m%n
+   ```
 
     Make sure you clone and edit the integration pipeline if you have a different format.
 
 3. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-      logs_enabled: true
-    ```
+   ```yaml
+   logs_enabled: true
+   ```
 
 4. Uncomment and edit this configuration block at the bottom of your `zk.d/conf.yaml`:
 
-    ```yaml
-      logs:
-        - type: file
-          path: /var/log/zookeeper.log
-          source: zookeeper
-          service: myapp
-          #To handle multi line that starts with yyyy-mm-dd use the following pattern
-          #log_processing_rules:
-          #  - type: multi_line
-          #    name: log_start_with_date
-          #    pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
-    ```
+   ```yaml
+   logs:
+     - type: file
+       path: /var/log/zookeeper.log
+       source: zookeeper
+       service: myapp
+       #To handle multi line that starts with yyyy-mm-dd use the following pattern
+       #log_processing_rules:
+       #  - type: multi_line
+       #    name: log_start_with_date
+       #    pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
+   ```
 
     Change the `path` and `service` parameter values and configure them for your environment. See the [sample zk.d/conf.yaml][5] for all available configuration options.
 
@@ -81,19 +83,19 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 ##### Metric collection
 
 | Parameter            | Value                                  |
-|----------------------|----------------------------------------|
+| -------------------- | -------------------------------------- |
 | `<INTEGRATION_NAME>` | `zk`                                   |
 | `<INIT_CONFIG>`      | blank or `{}`                          |
 | `<INSTANCE_CONFIG>`  | `{"host": "%%host%%", "port": "2181"}` |
 
 ##### Log collection
 
-**Available for Agent v6.5+**
+_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][12].
 
 | Parameter      | Value                                           |
-|----------------|-------------------------------------------------|
+| -------------- | ----------------------------------------------- |
 | `<LOG_CONFIG>` | `{"source": "zk", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
@@ -101,17 +103,18 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 [Run the Agent's status subcommand][9] and look for `zk` under the Checks section.
 
 ## Data Collected
+
 ### Metrics
 
 As of zookeeper 3.4.0, the `mntr` admin command is provided for easy parsing of zookeeper stats. This check first parses the `stat` admin command for a version number. If the zookeeper version supports `mntr`, it is also parsed.
 
 Duplicate information is being reported by both `mntr` and `stat`: the duplicated
- `stat` metrics are only kept for backward compatibility.
+`stat` metrics are only kept for backward compatibility.
 
 **Important:** if available, make use of the data reported by `mntr`, not `stat`.
 
 | Metric reported by `mntr`         | Duplicate reported by `stat` |
-|-----------------------------------|------------------------------|
+| --------------------------------- | ---------------------------- |
 | `zookeeper.avg_latency`           | `zookeeper.latency.avg`      |
 | `zookeeper.max_latency`           | `zookeeper.latency.max`      |
 | `zookeeper.min_latency`           | `zookeeper.latency.min`      |
@@ -126,10 +129,11 @@ See [metadata.csv][10] for a list of metrics provided by this check.
 
 Following metrics are still sent but will be removed eventually:
 
- * `zookeeper.bytes_received`
- * `zookeeper.bytes_sent`
+- `zookeeper.bytes_received`
+- `zookeeper.bytes_sent`
 
 ### Events
+
 The Zookeeper check does not include any events.
 
 ### Service Checks
@@ -141,6 +145,7 @@ Sends `ruok` to the monitored node. Returns `OK` with an `imok` response, `WARN`
 The Agent submits this service check if `expected_mode` is configured in `zk.yaml`. The check returns `OK` when Zookeeper's actual mode matches `expected_mode`, otherwise returns `CRITICAL`.
 
 ## Troubleshooting
+
 Need help? Contact [Datadog support][11].
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/zk/images/zk_dashboard.png


### PR DESCRIPTION
### What does this PR do?

Follow up on:
* https://github.com/DataDog/integrations-core/pull/5663
* https://github.com/DataDog/integrations-core/pull/5662
* https://github.com/DataDog/integrations-core/pull/5664
* https://github.com/DataDog/integrations-core/pull/5665
* https://github.com/DataDog/integrations-core/pull/5666
* https://github.com/DataDog/integrations-core/pull/5667
* https://github.com/DataDog/integrations-core/pull/5668

This PR lints markdown file to avoid layout issues moving forward with the public doc. I manually checked the layout for all of those integrations.

Change from this lint:

- Bullet list are defined with `-`
- Italic is now defined with `_<TEXT>_`
- Fixes table layout
- Lint code examples displayed
- Each code example has a language assigned, and the default is `text`
- There should be always an empty line before/after a header
- **Available for Agent >6.0** has been transformed into _Available for Agent versions >6.0_

### Motivation
Better doc for a better world
