### PR TITLE
Tab completion for ddev CLI

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
@@ -18,8 +18,8 @@ from .constants import set_root
 @click.option('--agent', '-a', is_flag=True, help='Work on `datadog-agent`.')
 @click.option('--here', '-x', is_flag=True, help='Work on the current location.')
 @click.option('--color/--no-color', default=None, help='Whether or not to display colored output (default true).')
-@click.option('--quiet', '-q', is_flag=True)
-@click.option('--debug', '-d', is_flag=True)
+@click.option('--quiet', '-q', help='Silence output', is_flag=True)
+@click.option('--debug', '-d', help='Include debug output', is_flag=True)
 @click.version_option()
 @click.pass_context
 def ddev(ctx, core, extras, agent, here, color, quiet, debug):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations.py
@@ -15,8 +15,7 @@ from .common import get_agent_tags
 
 
 @click.command(
-    context_settings=CONTEXT_SETTINGS,
-    short_help="Provide a list of updated checks on a given Datadog Agent version, in changelog form",
+    context_settings=CONTEXT_SETTINGS, short_help="Generate a markdown file of integrations in an Agent release",
 )
 @click.option('--since', help="Initial Agent version", default='6.3.0')
 @click.option('--to', help="Final Agent version")

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/clean.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/clean.py
@@ -8,11 +8,12 @@ import click
 from ...utils import basepath, dir_exists, resolve_path
 from ..clean import DELETE_EVERYWHERE, DELETE_IN_ROOT, clean_package, remove_compiled_scripts
 from ..constants import get_root
+from ..utils import complete_testable_checks
 from .console import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_waiting, echo_warning
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help="Remove a project's build artifacts")
-@click.argument('check', required=False)
+@click.argument('check', autocompletion=complete_testable_checks, required=False)
 @click.option(
     '--compiled-only', '-c', is_flag=True, help=f"Remove compiled files only ({', '.join(DELETE_EVERYWHERE)}).",
 )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/ls.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/ls.py
@@ -5,12 +5,12 @@ import click
 
 from ...e2e import get_configured_checks, get_configured_envs
 from ...testing import get_available_tox_envs
-from ...utils import get_testable_checks
+from ...utils import complete_testable_checks, get_testable_checks
 from ..console import CONTEXT_SETTINGS, echo_info, echo_success, echo_warning
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='List active or available environments')
-@click.argument('checks', nargs=-1)
+@click.argument('checks', nargs=-1, autocompletion=complete_testable_checks)
 def ls(checks):
     """List active or available environments."""
     if checks:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/reload.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/reload.py
@@ -4,12 +4,13 @@
 import click
 
 from ...e2e import create_interface, get_configured_envs
+from ...testing import complete_active_checks, complete_configured_envs
 from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
 
 
 @click.command('reload', context_settings=CONTEXT_SETTINGS, short_help='Restart an Agent to detect environment changes')
-@click.argument('check')
-@click.argument('env', required=False)
+@click.argument('check', autocompletion=complete_active_checks)
+@click.argument('env', autocompletion=complete_configured_envs, required=False)
 def reload_env(check, env):
     """Restart an Agent to detect environment changes."""
     envs = get_configured_envs(check)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -12,14 +12,14 @@ from ....utils import dir_exists, file_exists, path_join, running_on_ci
 from ...e2e import E2E_SUPPORTED_TYPES, derive_interface, start_environment, stop_environment
 from ...e2e.agent import DEFAULT_PYTHON_VERSION, DEFAULT_SAMPLING_COLLECTION_INTERVAL
 from ...git import get_current_branch
-from ...testing import get_available_tox_envs, get_tox_env_python_version
-from ...utils import get_tox_file
+from ...testing import complete_envs, get_available_tox_envs, get_tox_env_python_version
+from ...utils import complete_testable_checks, get_tox_file
 from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_waiting, echo_warning
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Start an environment')
-@click.argument('check')
-@click.argument('env')
+@click.argument('check', autocompletion=complete_testable_checks)
+@click.argument('env', autocompletion=complete_envs)
 @click.option(
     '--agent',
     '-a',

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/stop.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/stop.py
@@ -8,14 +8,15 @@ import click
 from ....utils import running_on_ci
 from ...e2e import create_interface, get_configured_checks, get_configured_envs, stop_environment
 from ...e2e.agent import DEFAULT_SAMPLING_WAIT_TIME
+from ...testing import complete_active_checks, complete_configured_envs
 from ..console import CONTEXT_SETTINGS, DEFAULT_INDENT, abort, echo_failure, echo_info, echo_success, echo_waiting
 
 
-@click.command(context_settings=CONTEXT_SETTINGS, short_help='Stop environments')
-@click.argument('check')
-@click.argument('env', required=False)
+@click.command(context_settings=CONTEXT_SETTINGS, short_help='Stop environments.')
+@click.argument('check', autocompletion=complete_active_checks)
+@click.argument('env', autocompletion=complete_configured_envs, required=False)
 def stop(check, env):
-    """Stop environments."""
+    """Stop environments, use "all" as check argument to stop everything."""
     all_checks = check == 'all'
     checks = get_configured_checks() if all_checks else [check]
     on_ci = running_on_ci()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
@@ -6,7 +6,7 @@ import click
 from .... import EnvVars
 from ...e2e import create_interface, get_configured_envs
 from ...e2e.agent import DEFAULT_PYTHON_VERSION
-from ...testing import get_tox_envs
+from ...testing import complete_active_checks, get_tox_envs
 from ..console import CONTEXT_SETTINGS, DEBUG_OUTPUT, echo_info, echo_warning
 from ..test import test as test_command
 from .start import start
@@ -14,7 +14,7 @@ from .stop import stop
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Test an environment')
-@click.argument('checks', nargs=-1)
+@click.argument('checks', autocompletion=complete_active_checks, nargs=-1)
 @click.option(
     '--agent',
     '-a',

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/prometheus.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/prometheus.py
@@ -103,14 +103,15 @@ def info(endpoint):
 
 
 @prom.command(
-    context_settings=CONTEXT_SETTINGS, short_help='Interactively parse metric info from a Prometheus endpoint'
+    context_settings=CONTEXT_SETTINGS,
+    short_help='Interactively parse metric info from a Prometheus endpoint and write to metadata.csv',
 )
 @click.argument('endpoint')
 @click.argument('check')
 @click.option('--here', '-x', is_flag=True, help='Output to the current location')
 @click.pass_context
 def parse(ctx, endpoint, check, here):
-    """Interactively parse metric info from a Prometheus endpoint."""
+    """Interactively parse metric info from a Prometheus endpoint and write it to metadata.csv."""
     if here:
         output_dir = os.getcwd()
     else:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/build.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/build.py
@@ -8,12 +8,12 @@ import click
 from ....utils import basepath, dir_exists, remove_path, resolve_path
 from ...constants import get_root
 from ...release import build_package
-from ...utils import get_valid_checks
+from ...utils import complete_testable_checks, get_valid_checks
 from ..console import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_waiting
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Build a wheel for a check')
-@click.argument('check')
+@click.argument('check', autocompletion=complete_testable_checks)
 @click.option('--sdist', '-s', is_flag=True)
 def build(check, sdist):
     """Build a wheel for a check as it is on the repo HEAD"""

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -14,14 +14,14 @@ from ...constants import CHANGELOG_TYPE_NONE, get_root
 from ...git import get_commits_since
 from ...github import from_contributor, get_changelog_types, get_pr, parse_pr_numbers
 from ...release import get_release_tag_string
-from ...utils import get_valid_checks, get_version_string
+from ...utils import complete_testable_checks, get_valid_checks, get_version_string
 from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, validate_check_arg
 
 ChangelogEntry = namedtuple('ChangelogEntry', 'number, title, url, author, author_url, from_contributor')
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Update the changelog for a check')
-@click.argument('check', callback=validate_check_arg)
+@click.argument('check', autocompletion=complete_testable_checks, callback=validate_check_arg)
 @click.argument('version')
 @click.argument('old_version', required=False)
 @click.option('--initial', is_flag=True)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py
@@ -9,14 +9,14 @@ from semver import finalize_version, parse_version_info
 from ...constants import BETA_PACKAGES, NOT_CHECKS, VERSION_BUMP, get_agent_release_requirements
 from ...git import get_current_branch, git_commit
 from ...release import get_agent_requirement_line, update_agent_requirements, update_version_module
-from ...utils import get_bump_function, get_valid_checks, get_version_string
+from ...utils import complete_valid_checks, get_bump_function, get_valid_checks, get_version_string
 from ..console import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_waiting, echo_warning
 from . import changelog
 from .show import changes
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Release one or more checks')
-@click.argument('checks', nargs=-1, required=True)
+@click.argument('checks', autocompletion=complete_valid_checks, nargs=-1, required=True)
 @click.option('--version')
 @click.option('--new', 'initial_release', is_flag=True, help='Ensure versions are at 1.0.0')
 @click.option('--skip-sign', is_flag=True, help='Skip the signing of release metadata')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
@@ -6,12 +6,12 @@ import click
 from ....git import get_commits_since
 from ....github import get_changelog_types, get_pr, parse_pr_numbers
 from ....release import get_release_tag_string
-from ....utils import get_valid_checks, get_version_string
+from ....utils import complete_valid_checks, get_valid_checks, get_version_string
 from ...console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_warning, validate_check_arg
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Show all the pending PRs for a given check.')
-@click.argument('check', callback=validate_check_arg)
+@click.argument('check', autocompletion=complete_valid_checks, callback=validate_check_arg)
 @click.option('--dry-run', '-n', is_flag=True)
 @click.pass_context
 def changes(ctx, check, dry_run):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/tag.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/tag.py
@@ -5,12 +5,12 @@ import click
 
 from ...git import git_tag
 from ...release import get_release_tag_string
-from ...utils import get_valid_checks, get_version_string
+from ...utils import complete_valid_checks, get_valid_checks, get_version_string
 from ..console import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_waiting, echo_warning
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Tag the git repo with the current release of a check')
-@click.argument('check')
+@click.argument('check', autocompletion=complete_valid_checks)
 @click.argument('version', required=False)
 @click.option('--push/--no-push', default=True)
 @click.option('--dry-run', '-n', is_flag=True)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/upload.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/upload.py
@@ -9,12 +9,12 @@ from ....subprocess import run_command
 from ....utils import basepath, chdir, dir_exists, resolve_path
 from ...constants import get_root
 from ...release import build_package
-from ...utils import get_valid_checks
+from ...utils import complete_valid_checks, get_valid_checks
 from ..console import CONTEXT_SETTINGS, abort, echo_success, echo_waiting
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Build and upload a check to PyPI')
-@click.argument('check')
+@click.argument('check', autocompletion=complete_valid_checks)
 @click.option('--sdist', '-s', is_flag=True)
 @click.option('--dry-run', '-n', is_flag=True)
 @click.pass_context

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -11,6 +11,7 @@ from ...subprocess import run_command
 from ...utils import chdir, file_exists, get_ci_env_vars, remove_path, running_on_ci
 from ..constants import get_root
 from ..testing import construct_pytest_options, fix_coverage_report, get_tox_envs, pytest_coverage_sources
+from ..utils import complete_testable_checks
 from .console import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_waiting, echo_warning
 
 
@@ -22,7 +23,7 @@ def display_envs(check_envs):
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Run tests')
-@click.argument('checks', nargs=-1)
+@click.argument('checks', autocompletion=complete_testable_checks, nargs=-1)
 @click.option('--format-style', '-fs', is_flag=True, help='Run only the code style formatter')
 @click.option('--style', '-s', is_flag=True, help='Run only style checks')
 @click.option('--bench', '-b', is_flag=True, help='Run only benchmarks')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -11,6 +11,7 @@ from datadog_checks.dev.tooling.configuration.consumers import ExampleConsumer
 
 from ....utils import basepath, file_exists, path_join, read_file, write_file
 from ...utils import (
+    complete_valid_checks,
     get_config_files,
     get_config_spec,
     get_data_directory,
@@ -26,7 +27,7 @@ IGNORE_DEFAULT_INSTANCE = {'ceph', 'dotnetclr', 'gunicorn', 'marathon', 'pgbounc
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Validate default configuration files')
-@click.argument('check', required=False)
+@click.argument('check', autocompletion=complete_valid_checks, required=False)
 @click.option('--sync', is_flag=True, help='Generate example configuration files based on specifications')
 @click.pass_context
 def config(ctx, check, sync):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -8,8 +8,8 @@ from io import open
 
 import click
 
-from ...utils import get_metadata_file, get_metric_sources, load_manifest
-from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_warning
+from ...utils import complete_valid_checks, get_metadata_file, get_metric_sources, load_manifest
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_success, echo_warning
 
 REQUIRED_HEADERS = {'metric_name', 'metric_type', 'orientation', 'integration'}
 
@@ -184,7 +184,7 @@ def normalize_metric_name(metric_name):
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Validate `metadata.csv` files')
-@click.argument('check', required=False)
+@click.argument('check', autocompletion=complete_valid_checks, required=False)
 def metadata(check):
     """Validates metadata.csv files
 
@@ -329,3 +329,5 @@ def metadata(check):
 
     if errors:
         abort()
+
+    echo_success('Validated!')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/__init__.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from .config import get_configured_checks, get_configured_envs
+from .config import get_active_checks, get_configured_checks, get_configured_envs
 from .core import create_interface, derive_interface
 from .run import start_environment, stop_environment
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/config.py
@@ -59,6 +59,19 @@ def get_configured_checks():
     return envs
 
 
+def get_active_checks():
+    """Check for config files to guess whether a check env is active"""
+    checks = get_configured_checks()
+    active_checks = []
+
+    root_dir = path_join(ENV_DIR)
+    for c in checks:
+        check_dir = path_join(root_dir, c)
+        if os.path.isdir(check_dir) and os.listdir(check_dir):
+            active_checks.append(c)
+    return active_checks
+
+
 def remove_env_root(check):
     remove_path(path_join(ENV_DIR, check))
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -11,6 +11,19 @@ from ..utils import chdir
 from .constants import get_root
 
 
+def get_git_root():
+    """
+    Get root of git repo from current location.  Returns 'None' if not in a repo.
+    """
+    command = 'git rev-parse --show-toplevel'
+
+    result = run_command(command, capture='both')
+    if result.stdout:
+        return result.stdout.strip()
+    elif result.stderr:
+        return None
+
+
 def get_current_branch():
     """
     Get the current branch name.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -6,12 +6,26 @@ import re
 from ..subprocess import run_command
 from ..utils import chdir, path_join, read_file_binary, write_file_binary
 from .constants import NON_TESTABLE_FILES, TESTABLE_FILE_EXTENSIONS, get_root
+from .e2e import get_active_checks, get_configured_envs
 from .git import files_changed
 from .utils import get_testable_checks
 
 STYLE_CHECK_ENVS = {'flake8', 'style'}
 STYLE_ENVS = {'flake8', 'style', 'format_style'}
 PYTHON_MAJOR_PATTERN = r'py(\d)'
+
+
+def complete_envs(ctx, args, incomplete):
+    return sorted(e for e in get_available_tox_envs(args[-1], e2e_only=True) if e.startswith(incomplete))
+
+
+# this test makes more sense under tooling/utils, but that causes circular import
+def complete_active_checks(ctx, args, incomplete):
+    return [k for k in get_active_checks() if k.startswith(incomplete)]
+
+
+def complete_configured_envs(ctx, args, incomplete):
+    return [e for e in get_configured_envs(args[-1]) if e.startswith(incomplete)]
 
 
 def get_tox_envs(

--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -7,7 +7,7 @@ from ..subprocess import run_command
 from ..utils import chdir, path_join, read_file_binary, write_file_binary
 from .constants import NON_TESTABLE_FILES, TESTABLE_FILE_EXTENSIONS, get_root
 from .e2e import get_active_checks, get_configured_envs
-from .git import files_changed
+from .git import files_changed, get_git_root
 from .utils import get_testable_checks
 
 STYLE_CHECK_ENVS = {'flake8', 'style'}
@@ -92,7 +92,7 @@ def get_available_tox_envs(check, sort=False, e2e_only=False, e2e_tests_only=Fal
     else:
         tox_command = 'tox --listenvs'
 
-    with chdir(path_join(get_root(), check)):
+    with chdir(path_join(get_root() or get_git_root(), check)):
         output = run_command(tox_command, capture='out').stdout
 
     env_list = [e.strip() for e in output.splitlines()]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 from ast import literal_eval
+from pathlib import Path
 
 import requests
 import semver
@@ -143,19 +144,23 @@ def get_config_files(check_name):
 def get_valid_checks(root=None):
     if root is None:
         root = get_root()
-    return {path for path in os.listdir(root) if file_exists(get_version_file(path))}
+    root = Path(root)
+    return {path for path in os.listdir(root) if file_exists(get_version_file(root / path))}
 
 
 def get_valid_integrations(root=None):
     if root is None:
         root = get_root()
-    return {path for path in os.listdir(root) if file_exists(get_manifest_file(path))}
+    root = Path(root)
+    return {path for path in os.listdir(root) if file_exists(get_manifest_file(root / path))}
 
 
 def get_testable_checks(root=None):
     if root is None:
         root = get_root()
-    return {path for path in os.listdir(root) if file_exists(get_tox_file(path))}
+
+    root = Path(root)
+    return {path for path in os.listdir(root) if file_exists(get_tox_file(root / path))}
 
 
 def get_metric_sources():

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -11,7 +11,7 @@ import semver
 
 from ..utils import file_exists, read_file, write_file
 from .constants import NOT_CHECKS, VERSION_BUMP, get_root
-from .git import get_latest_tag
+from .git import get_git_root, get_latest_tag
 
 # match integration's version within the __about__.py module
 VERSION = re.compile(r'__version__ *= *(?:[\'"])(.+?)(?:[\'"])')
@@ -59,6 +59,16 @@ def string_to_toml_type(s):
         s = literal_eval(s)
 
     return s
+
+
+def complete_testable_checks(ctx, args, incomplete):
+    root = get_git_root() or os.getcwd()
+    return sorted(k for k in get_testable_checks(root) if k.startswith(incomplete))
+
+
+def complete_valid_checks(ctx, args, incomplete):
+    root = get_git_root() or os.getcwd()
+    return [k for k in get_valid_checks(root) if k.startswith(incomplete)]
 
 
 def get_version_file(check_name):
@@ -130,16 +140,22 @@ def get_config_files(check_name):
     return sorted(files)
 
 
-def get_valid_checks():
-    return {path for path in os.listdir(get_root()) if file_exists(get_version_file(path))}
+def get_valid_checks(root=None):
+    if root is None:
+        root = get_root()
+    return {path for path in os.listdir(root) if file_exists(get_version_file(path))}
 
 
-def get_valid_integrations():
-    return {path for path in os.listdir(get_root()) if file_exists(get_manifest_file(path))}
+def get_valid_integrations(root=None):
+    if root is None:
+        root = get_root()
+    return {path for path in os.listdir(root) if file_exists(get_manifest_file(path))}
 
 
-def get_testable_checks():
-    return {path for path in os.listdir(get_root()) if file_exists(get_tox_file(path))}
+def get_testable_checks(root=None):
+    if root is None:
+        root = get_root()
+    return {path for path in os.listdir(root) if file_exists(get_tox_file(path))}
 
 
 def get_metric_sources():

--- a/docs/datadog_checks_dev.cli.rst
+++ b/docs/datadog_checks_dev.cli.rst
@@ -44,7 +44,7 @@ Commands
 Command Tab Completion
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Many of the `ddev` commands have tab-completion enabled for them.
+Many of the `ddev` commands have tab-completion enabled.
 There are a couple of ways to activate this for your system. The first is to
 execute the following in your shell:
 
@@ -58,11 +58,11 @@ or for `zsh`:
 
     $ eval "$(_DDEV_COMPLETE=source_zsh ddev)"
 
-Now hitting `tab` at any point in your `ddev` command should autocomplete with available
-options.  Note the limitation that this will only work for `integrations-core` repo, and
+Hitting `tab` at any point in your `ddev` command will autocomplete with available
+options.  Note that this will only work for `integrations-core` repo, and
 not any of the extended repos `ddev` can support.
 
-For a more permenant solition, you can add those lines to either your `.bashrc` or `.zhsrc`
+For a more permenant solution, you can add the lines to either your `.bashrc` or `.zhsrc`
 files respectively, but this may introduce a bit of a lag on startup.  As an alternative,
 run the following command then load the resulting file into your startup script:
 

--- a/docs/datadog_checks_dev.cli.rst
+++ b/docs/datadog_checks_dev.cli.rst
@@ -40,3 +40,33 @@ Commands
 .. click:: datadog_checks.dev.tooling.cli:ddev
    :prog: ddev
    :show-nested:
+
+Command Tab Completion
+^^^^^^^^^^^^^^^^^^^^^^
+
+Many of the `ddev` commands have tab-completion enabled for them.
+There are a couple of ways to activate this for your system. The first is to
+execute the following in your shell:
+
+.. code-block:: bash
+
+    $ eval "$(_DDEV_COMPLETE=source ddev)"
+
+or for `zsh`:
+
+.. code-block:: bash
+
+    $ eval "$(_DDEV_COMPLETE=source_zsh ddev)"
+
+Now hitting `tab` at any point in your `ddev` command should autocomplete with available
+options.  Note the limitation that this will only work for `integrations-core` repo, and
+not any of the extended repos `ddev` can support.
+
+For a more permenant solition, you can add those lines to either your `.bashrc` or `.zhsrc`
+files respectively, but this may introduce a bit of a lag on startup.  As an alternative,
+run the following command then load the resulting file into your startup script:
+
+.. code-block:: bash
+
+    $ _DDEV_COMPLETE=source_zsh ddev > ddev-zsh-completion.sh
+


### PR DESCRIPTION
Tab completion to autocomplete most commands.

Mostly tested in `zsh`, but there are instructions for activating in both `bash` and `zsh` in the doc page.

Example workflow:

```
$ ddev env start sc<TAB>
(autocompletes scylla)

$ ddev env start scylla <TAB>
(shows available tox envs: py27-3.1     py27-3.2     py27-latest  py38-3.1     py38-3.2     py38-latest)
```

Once an env is started, `ddev env stop <TAB>` will autocomplete for active envs.


