### PR TITLE
Handle error in config_get

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -191,7 +191,12 @@ class Redis(AgentCheck):
             latency_ms = round_value((time.time() - start) * 1000, 2)
             tags = sorted(tags + ["redis_role:%s" % info["role"]])
             self.gauge('redis.info.latency_ms', latency_ms, tags=tags)
-            config = conn.config_get("maxclients")
+            try:
+                config = conn.config_get("maxclients")
+            except redis.ResponseError:
+                # config_get is disabled on some environments
+                self.log.debug("Error querying config")
+                config = {}
             status = AgentCheck.OK
             self.service_check('redis.can_connect', status, tags=tags)
             self._collect_metadata(info)


### PR DESCRIPTION
The CONFIG command can be disabled server side, in which case we'll have
an error querying for maxclients. Let's handle that error and skip the
metrics if it's the case.