### PR TITLE
Fix legacy print statement

### DIFF
--- a/docker_daemon/test/test_docker_daemon.py
+++ b/docker_daemon/test/test_docker_daemon.py
@@ -259,7 +259,7 @@ class TestCheckDockerDaemon(AgentCheckTest):
             images = [i["RepoTags"][0] for i in self.docker_client.images(c.split(":")[0]) if i["RepoTags"] and i["RepoTags"][0].startswith(c)]
             if len(images) == 0:
                 for line in self.docker_client.pull(c, stream=True):
-                    print line
+                    print(line)
 
         self.containers = []
         for c in CONTAINERS_TO_RUN:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Upgrade a remaining `print ...` statement to the Py2/3 `print(...)` style.

### Motivation
<!-- What inspired you to submit this pull request? -->
Could trigger a `SyntaxError` when running the check under Python 3.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Came across this as it was triggering a warning when running [Rope](https://github.com/python-rope/rope) in VSCode.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
