### PR TITLE
Add auto_conf.yaml files

### DIFF
--- a/kube_controller_manager/datadog_checks/kube_controller_manager/data/auto_conf.yaml
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/data/auto_conf.yaml
@@ -1,0 +1,16 @@
+ad_identifiers:
+  - kube-controller-manager
+
+init_config:
+
+instances:
+    ## @param prometheus_url - string - required
+    ## The URL where your application metrics are exposed by Prometheus.
+    #
+  - prometheus_url: "http://%%host%%:10252/metrics"
+
+    ## @param bearer_token_auth - string - optional
+    ## Used if you are using RBACs and need the Agent to authenticate
+    ## against the APIServer to retrieve metrics. Default to true.
+    #
+    bearer_token_auth: true

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/auto_conf.yaml
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/auto_conf.yaml
@@ -1,0 +1,16 @@
+ad_identifiers:
+  - kube-scheduler
+
+init_config:
+
+instances:
+    ## @param prometheus_url - string - required
+    ## The URL where your application metrics are exposed by Prometheus.
+    #
+  - prometheus_url: "http://%%host%%:10251/metrics"
+
+    ## @param bearer_token_auth - string - optional
+    ## Used if you are using RBACs and need the Agent to authenticate
+    ## against the APIServer to retrieve metrics. Default to true.
+    #
+    bearer_token_auth: true


### PR DESCRIPTION
### What does this PR do?
Enable automatic autodiscovery for `kube_scheduler` and `kube_controller_manager` based on official images `k8s.gcr.io/kube-scheduler` and `k8s.gcr.io/kube-controller-manager`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
