### PR TITLE
Fix service check "topic" tag

### DIFF
--- a/mapr/datadog_checks/mapr/mapr.py
+++ b/mapr/datadog_checks/mapr/mapr.py
@@ -85,7 +85,7 @@ class MaprCheck(AgentCheck):
             conn = self.get_connection()
         except Exception:
             self.service_check(
-                SERVICE_CHECK, AgentCheck.CRITICAL, self.base_tags + ['topic_path:{}'.format(self.topic_path)]
+                SERVICE_CHECK, AgentCheck.CRITICAL, self.base_tags + ['topic:{}'.format(self.topic_path)]
             )
             raise
         else:


### PR DESCRIPTION
The `mapr.can_connect` service check is sent with the `topic` tag but in one place this tag is called `topic_path`. Let's fix the mistake.

Impact would be minimal as I doubt anyone tried to set up a monitor on `mapr.can_connect` by {topic_path}, knowing that:
- the backend doesn't know about that tag so you would have to create a custom check monitor instead of an integration monitor.
- This tag only appears when the MapR endpoint doesn't work.