### PR TITLE
Upgrade virtualenv dependency to 20.x

### DIFF
--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -84,7 +84,7 @@ setup(
             'toml>=0.9.4, <1.0.0',
             'tox>=3.12.1',
             'twine>=1.11.0',
-            'virtualenv>=20.0.0b1',
+            'virtualenv==20.*',
             'wheel>=0.31.0',
         ]
     },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Pin dependency on `virtualenv` to `20.*`.

### Motivation
<!-- What inspired you to submit this pull request? -->
- `virtualenv` 20.0.0 is officially out of beta: https://twitter.com/gjbernat/status/1226803593535279104
- Follow-up to #5617 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Validated on a fresh install:

```bash
# Upgrade ddev, which installs new `virtualenv`.
pip install -U -e "./datadog_checks_dev[cli]"

# Nuke existing virtualenvs in an integration (pick any)
rm -r http_check/.tox

# Run tests, which will recreate venvs with `virtualenv` 20.x.
ddev test http_check
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
