### PR TITLE
Fix counter metric types

### DIFF
--- a/coredns/datadog_checks/coredns/coredns.py
+++ b/coredns/datadog_checks/coredns/coredns.py
@@ -103,6 +103,7 @@ class CoreDNSCheck(OpenMetricsBaseCheck):
                 'prometheus_url': endpoint,
                 'namespace': 'coredns',
                 'metrics': metrics,
+                # Submits Prometheus histogram counter metrics as monotonic_count
                 'send_monotonic_with_gauge': True,
             }
         )

--- a/coredns/datadog_checks/coredns/coredns.py
+++ b/coredns/datadog_checks/coredns/coredns.py
@@ -103,7 +103,6 @@ class CoreDNSCheck(OpenMetricsBaseCheck):
                 'prometheus_url': endpoint,
                 'namespace': 'coredns',
                 'metrics': metrics,
-                'send_distribution_counts_as_monotonic': True,
                 'send_monotonic_with_gauge': True,
             }
         )

--- a/coredns/datadog_checks/coredns/coredns.py
+++ b/coredns/datadog_checks/coredns/coredns.py
@@ -104,6 +104,7 @@ class CoreDNSCheck(OpenMetricsBaseCheck):
                 'namespace': 'coredns',
                 'metrics': metrics,
                 'send_distribution_counts_as_monotonic': True,
+                'send_monotonic_with_gauge': True,
             }
         )
 

--- a/coredns/datadog_checks/coredns/coredns.py
+++ b/coredns/datadog_checks/coredns/coredns.py
@@ -98,6 +98,11 @@ class CoreDNSCheck(OpenMetricsBaseCheck):
         metrics = [DEFAULT_METRICS, GO_METRICS]
         metrics.extend(instance.get('metrics', []))
 
-        instance.update({'prometheus_url': endpoint, 'namespace': 'coredns', 'metrics': metrics})
+        instance.update({
+            'prometheus_url': endpoint,
+            'namespace': 'coredns',
+            'metrics': metrics,
+            'send_distribution_counts_as_monotonic': True,
+        })
 
         return instance

--- a/coredns/datadog_checks/coredns/coredns.py
+++ b/coredns/datadog_checks/coredns/coredns.py
@@ -98,11 +98,13 @@ class CoreDNSCheck(OpenMetricsBaseCheck):
         metrics = [DEFAULT_METRICS, GO_METRICS]
         metrics.extend(instance.get('metrics', []))
 
-        instance.update({
-            'prometheus_url': endpoint,
-            'namespace': 'coredns',
-            'metrics': metrics,
-            'send_distribution_counts_as_monotonic': True,
-        })
+        instance.update(
+            {
+                'prometheus_url': endpoint,
+                'namespace': 'coredns',
+                'metrics': metrics,
+                'send_distribution_counts_as_monotonic': True,
+            }
+        )
 
         return instance

--- a/coredns/metadata.csv
+++ b/coredns/metadata.csv
@@ -1,10 +1,10 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-coredns.response_code_count,gauge,,,,number of responses per zone and rcode,1,coredns,response code
-coredns.proxy_request_count,gauge,,request,,query count per upstream.,1,coredns,proxy request count
-coredns.cache_hits_count,gauge,,hit,,Counter of cache hits by cache type,1,coredns,cache hit
-coredns.cache_misses_count,gauge,,miss,,Counter of cache misses.,1,coredns,cache miss
-coredns.request_count,gauge,,request,,total query count.,1,coredns,request count
-coredns.request_type_count,gauge,,,,counter of queries per zone and type,1,coredns,request type
+coredns.response_code_count,count,,,,number of responses per zone and rcode,1,coredns,response code
+coredns.proxy_request_count,count,,request,,query count per upstream.,1,coredns,proxy request count
+coredns.cache_hits_count,count,,hit,,Counter of cache hits by cache type,1,coredns,cache hit
+coredns.cache_misses_count,count,,miss,,Counter of cache misses.,1,coredns,cache miss
+coredns.request_count,count,,request,,total query count.,1,coredns,request count
+coredns.request_type_count,count,,,,counter of queries per zone and type,1,coredns,request type
 coredns.request_duration.seconds.sum,gauge,,second,,duration to process each query,-1,coredns,proxy request duration
 coredns.request_duration.seconds.count,count,,second,,duration to process each query,-1,coredns,request duration
 coredns.proxy_request_duration.seconds.sum,gauge,,second,,duration per upstream interaction,-1,coredns,proxy request duration
@@ -22,7 +22,7 @@ coredns.response_size.bytes.sum,gauge,,byte,,size of the request in bytes,0,core
 coredns.response_size.bytes.count,count,,byte,,size of the request in bytes,0,coredns,response size
 coredns.cache_size.count,count,,entry,,,1,coredns,cache size
 coredns.panic_count.count,count,,entry,,,1,coredns,total number of panics
-coredns.go.gc_duration_seconds.count,gauge,,second,,Count of the GC invocation durations.,0,coredns,
+coredns.go.gc_duration_seconds.count,count,,second,,Count of the GC invocation durations.,0,coredns,
 coredns.go.gc_duration_seconds.sum,gauge,,second,,Sum of the GC invocation durations.,0,coredns,
 coredns.go.goroutines,gauge,,thread,,Number of goroutines that currently exist.,0,coredns,
 coredns.go.info,gauge,,,,Information about the Go environment.,0,coredns,

--- a/coredns/metadata.csv
+++ b/coredns/metadata.csv
@@ -20,7 +20,7 @@ coredns.request_size.bytes.sum,gauge,,byte,,size of the request in bytes,0,cored
 coredns.request_size.bytes.count,count,,byte,,size of the request in bytes,0,coredns,request size
 coredns.response_size.bytes.sum,gauge,,byte,,size of the request in bytes,0,coredns,response size
 coredns.response_size.bytes.count,count,,byte,,size of the request in bytes,0,coredns,response size
-coredns.cache_size.count,count,,entry,,,1,coredns,cache size
+coredns.cache_size.count,gauge,,entry,,,1,coredns,cache size
 coredns.panic_count.count,count,,entry,,,1,coredns,total number of panics
 coredns.go.gc_duration_seconds.count,count,,second,,Count of the GC invocation durations.,0,coredns,
 coredns.go.gc_duration_seconds.sum,gauge,,second,,Sum of the GC invocation durations.,0,coredns,

--- a/coredns/metadata.csv
+++ b/coredns/metadata.csv
@@ -8,9 +8,11 @@ coredns.request_type_count,count,,,,counter of queries per zone and type,1,cored
 coredns.request_duration.seconds.sum,gauge,,second,,duration to process each query,-1,coredns,proxy request duration
 coredns.request_duration.seconds.count,count,,second,,duration to process each query,-1,coredns,request duration
 coredns.proxy_request_duration.seconds.sum,gauge,,second,,duration per upstream interaction,-1,coredns,proxy request duration
-coredns.proxy_request_duration.seconds.count,count,,second,,duration per upstream interaction,-1,coredns,proxy request duration
+coredns.proxy_request_duration.seconds.count,gauge,,second,,duration per upstream interaction,-1,coredns,proxy request duration
+coredns.proxy_request_duration.seconds.count.total,count,,second,,duration per upstream interaction,-1,coredns,proxy request duration
 coredns.forward_request_duration.seconds.sum,gauge,,second,,duration per upstream interaction,-1,coredns,forward request duration
-coredns.forward_request_duration.seconds.count,count,,second,,duration per upstream interaction,-1,coredns,forward request duration
+coredns.forward_request_duration.seconds.count,gauge,,second,,duration per upstream interaction,-1,coredns,forward request duration
+coredns.forward_request_duration.seconds.count.total,count,,second,,duration per upstream interaction,-1,coredns,forward request duration
 coredns.forward_request_count,count,,request,,query count per upstream,1,coredns,forward request count
 coredns.forward_response_rcode_count,count,,response,,count of RCODEs per upstream,0,coredns,forward rcodes
 coredns.forward_healthcheck_failure_count,count,,entry,,number of failed health checks per upstream,-1,coredns,forward failed healthchecks

--- a/coredns/tests/common.py
+++ b/coredns/tests/common.py
@@ -1,6 +1,22 @@
 CHECK_NAME = 'coredns'
 NAMESPACE = 'coredns'
 
+COUNT_METRICS = [
+    NAMESPACE + '.request_count',
+    NAMESPACE + '.request_type_count',
+    NAMESPACE + '.cache_misses_count',
+    NAMESPACE + '.cache_hits_count',
+    NAMESPACE + '.response_code_count',
+    NAMESPACE + '.proxy_request_count',
+    NAMESPACE + '.response_size.bytes.count',
+    NAMESPACE + '.request_size.bytes.count',
+    NAMESPACE + '.proxy_request_duration.seconds.count',
+    NAMESPACE + '.request_duration.seconds.count',
+    NAMESPACE + '.forward_request_count',
+    NAMESPACE + '.forward_request_duration.seconds.count',
+    NAMESPACE + '.forward_response_rcode_count',
+]
+
 METRICS = [
     NAMESPACE + '.request_count',
     NAMESPACE + '.cache_size.count',

--- a/coredns/tests/common.py
+++ b/coredns/tests/common.py
@@ -8,13 +8,12 @@ COUNT_METRICS = [
     NAMESPACE + '.cache_hits_count',
     NAMESPACE + '.response_code_count',
     NAMESPACE + '.proxy_request_count',
-    NAMESPACE + '.response_size.bytes.count',
-    NAMESPACE + '.request_size.bytes.count',
     NAMESPACE + '.forward_request_count',
     NAMESPACE + '.forward_response_rcode_count',
     NAMESPACE + '.forward_request_duration.seconds.count.total',
     NAMESPACE + '.proxy_request_duration.seconds.count.total',
     NAMESPACE + '.request_duration.seconds.count.total',
+    NAMESPACE + '.response_size.bytes.count.total',
 ]
 
 METRICS = [
@@ -41,4 +40,5 @@ METRICS = [
     NAMESPACE + '.proxy_request_duration.seconds.count.total',
     NAMESPACE + '.forward_request_duration.seconds.count.total',
     NAMESPACE + '.request_duration.seconds.count.total',
+    NAMESPACE + '.response_size.bytes.count.total',
 ]

--- a/coredns/tests/common.py
+++ b/coredns/tests/common.py
@@ -10,11 +10,11 @@ COUNT_METRICS = [
     NAMESPACE + '.proxy_request_count',
     NAMESPACE + '.response_size.bytes.count',
     NAMESPACE + '.request_size.bytes.count',
-    NAMESPACE + '.proxy_request_duration.seconds.count',
-    NAMESPACE + '.request_duration.seconds.count',
     NAMESPACE + '.forward_request_count',
-    NAMESPACE + '.forward_request_duration.seconds.count',
     NAMESPACE + '.forward_response_rcode_count',
+    NAMESPACE + '.forward_request_duration.seconds.count.total',
+    NAMESPACE + '.proxy_request_duration.seconds.count.total',
+    NAMESPACE + '.request_duration.seconds.count.total',
 ]
 
 METRICS = [
@@ -37,4 +37,8 @@ METRICS = [
     NAMESPACE + '.forward_request_duration.seconds.count',
     NAMESPACE + '.forward_response_rcode_count',
     NAMESPACE + '.forward_sockets_open',
+    # The following are histogram counts that are now submitted as monotonic_count
+    NAMESPACE + '.proxy_request_duration.seconds.count.total',
+    NAMESPACE + '.forward_request_duration.seconds.count.total',
+    NAMESPACE + '.request_duration.seconds.count.total',
 ]

--- a/coredns/tests/test_check.py
+++ b/coredns/tests/test_check.py
@@ -7,6 +7,7 @@ from datadog_checks.coredns import CoreDNSCheck
 from datadog_checks.dev.utils import ON_WINDOWS
 
 from .common import CHECK_NAME, METRICS, NAMESPACE
+from .utils import _assert_metric
 
 
 class TestCoreDNS:
@@ -26,7 +27,7 @@ class TestCoreDNS:
         metrics = METRICS + [NAMESPACE + '.cache_hits_count']
 
         for metric in metrics:
-            aggregator.assert_metric(metric)
+            _assert_metric(aggregator, metric)
 
     @pytest.mark.skipif(ON_WINDOWS, reason='No `dig` utility on Windows')
     def test_docker(self, aggregator, dd_environment, dockerinstance):
@@ -38,4 +39,4 @@ class TestCoreDNS:
         check.check(dockerinstance)
 
         for metric in METRICS:
-            aggregator.assert_metric(metric)
+            _assert_metric(aggregator, metric)

--- a/coredns/tests/test_e2e.py
+++ b/coredns/tests/test_e2e.py
@@ -1,11 +1,11 @@
 import pytest
 
 from .common import METRICS
-from .utils import _assert_metric
+from .utils import _assert_metric_e2e
 
 
 @pytest.mark.e2e
 def test_check_ok(dd_agent_check, instance):
     aggregator = dd_agent_check(instance, rate=True)
     for metric in METRICS:
-        _assert_metric(aggregator, metric)
+        _assert_metric_e2e(aggregator, metric)

--- a/coredns/tests/test_e2e.py
+++ b/coredns/tests/test_e2e.py
@@ -1,10 +1,11 @@
 import pytest
 
 from .common import METRICS
+from .utils import _assert_metric
 
 
 @pytest.mark.e2e
 def test_check_ok(dd_agent_check, instance):
     aggregator = dd_agent_check(instance, rate=True)
     for metric in METRICS:
-        aggregator.assert_metric(metric)
+        _assert_metric(aggregator, metric)

--- a/coredns/tests/utils.py
+++ b/coredns/tests/utils.py
@@ -10,3 +10,10 @@ def _assert_metric(aggregator, metric):
         aggregator.assert_metric(metric, metric_type=aggregator.MONOTONIC_COUNT)
     else:
         aggregator.assert_metric(metric, metric_type=aggregator.GAUGE)
+
+
+def _assert_metric_e2e(aggregator, metric):
+    if metric in COUNT_METRICS:
+        aggregator.assert_metric(metric, metric_type=aggregator.COUNT)
+    else:
+        aggregator.assert_metric(metric, metric_type=aggregator.GAUGE)

--- a/coredns/tests/utils.py
+++ b/coredns/tests/utils.py
@@ -1,0 +1,12 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from .common import COUNT_METRICS
+
+
+def _assert_metric(aggregator, metric):
+    if metric in COUNT_METRICS:
+        aggregator.assert_metric(metric, metric_type=aggregator.MONOTONIC_COUNT)
+    else:
+        aggregator.assert_metric(metric, metric_type=aggregator.GAUGE)

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -742,7 +742,9 @@ class OpenMetricsScraperMixin(object):
                     # Metric is a "counter" but legacy behavior has "send_as_monotonic" defaulted to false
                     # Submit metric as monotonic_count with appended name
                     if metric.type == "counter" and scraper_config['send_monotonic_with_gauge']:
-                        self.monotonic_count(metric_name_with_namespace + '.total', val, tags=tags, hostname=custom_hostname)
+                        self.monotonic_count(
+                            metric_name_with_namespace + '.total', val, tags=tags, hostname=custom_hostname
+                        )
         elif metric.type == "histogram":
             self._submit_gauges_from_histogram(metric_name, metric, scraper_config)
         elif metric.type == "summary":
@@ -950,7 +952,9 @@ class OpenMetricsScraperMixin(object):
             tags,
         )
 
-    def _submit_distribution_count(self, monotonic, send_monotonic_with_gauge, metric_name, value, tags=None, hostname=None):
+    def _submit_distribution_count(
+        self, monotonic, send_monotonic_with_gauge, metric_name, value, tags=None, hostname=None
+    ):
         if send_monotonic_with_gauge:
             self.monotonic_count(metric_name + ".total", value, tags=tags, hostname=hostname)
         if monotonic:

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -205,7 +205,7 @@ class OpenMetricsScraperMixin(object):
 
         # Submit Prometheus counter metrics as monotonic_count along with gauge
         if not config['send_monotonic_counter']:
-            config['send_monotonic_with_gauge' = True
+            config['send_monotonic_with_gauge'] = True
 
         config['send_distribution_counts_as_monotonic'] = is_affirmative(
             instance.get(
@@ -788,12 +788,14 @@ class OpenMetricsScraperMixin(object):
                     val,
                     tags=tags,
                     hostname=custom_hostname,
+                    send_monotonic_with_gauge=scraper_config['send_monotonic_with_gauge'],
                 )
             elif sample[self.SAMPLE_NAME].endswith("_count"):
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname=custom_hostname)
                 self._submit_distribution_count(
                     scraper_config['send_distribution_counts_as_monotonic'],
                     "{}.{}.count".format(scraper_config['namespace'], metric_name),
+                    scraper_config['send_monotonic_with_gauge'],
                     val,
                     tags=tags,
                     hostname=custom_hostname,
@@ -824,6 +826,7 @@ class OpenMetricsScraperMixin(object):
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname)
                 self._submit_distribution_count(
                     scraper_config['send_distribution_sums_as_monotonic'],
+                    scraper_config['send_monotonic_with_gauge'],
                     "{}.{}.sum".format(scraper_config['namespace'], metric_name),
                     val,
                     tags=tags,
@@ -835,6 +838,7 @@ class OpenMetricsScraperMixin(object):
                     tags.append("upper_bound:none")
                 self._submit_distribution_count(
                     scraper_config['send_distribution_counts_as_monotonic'],
+                    scraper_config['send_monotonic_with_gauge'],
                     "{}.{}.count".format(scraper_config['namespace'], metric_name),
                     val,
                     tags=tags,
@@ -848,6 +852,7 @@ class OpenMetricsScraperMixin(object):
                     tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname)
                     self._submit_distribution_count(
                         scraper_config['send_distribution_counts_as_monotonic'],
+                        scraper_config['send_monotonic_with_gauge'],
                         "{}.{}.count".format(scraper_config['namespace'], metric_name),
                         val,
                         tags=tags,
@@ -949,7 +954,7 @@ class OpenMetricsScraperMixin(object):
             tags,
         )
 
-    def _submit_distribution_count(self, monotonic, metric_name, value, tags=None, hostname=None, send_monotonic_with_gauge=False):
+    def _submit_distribution_count(self, monotonic, send_monotonic_with_gauge, metric_name, value, tags=None, hostname=None):
         if monotonic:
             self.monotonic_count(metric_name, value, tags=tags, hostname=hostname)
         else:

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -951,12 +951,12 @@ class OpenMetricsScraperMixin(object):
         )
 
     def _submit_distribution_count(self, monotonic, send_monotonic_with_gauge, metric_name, value, tags=None, hostname=None):
+        if send_monotonic_with_gauge:
+            self.monotonic_count(metric_name + ".total", value, tags=tags, hostname=hostname)
         if monotonic:
             self.monotonic_count(metric_name, value, tags=tags, hostname=hostname)
         else:
             self.gauge(metric_name, value, tags=tags, hostname=hostname)
-            if send_monotonic_with_gauge:
-                self.monotonic_count(metric_name + ".total", value, tags=tags, hostname=hostname)
 
     def _metric_tags(self, metric_name, val, sample, scraper_config, hostname=None):
         custom_tags = scraper_config['custom_tags']

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -199,6 +199,14 @@ class OpenMetricsScraperMixin(object):
             instance.get('send_monotonic_counter', default_instance.get('send_monotonic_counter', True))
         )
 
+        config['send_monotonic_with_gauge'] = is_affirmative(
+            instance.get('send_monotonic_with_gauge', default_instance.get('send_monotonic_with_gauge', False))
+        )
+
+        # Submit Prometheus counter metrics as monotonic_count along with gauge
+        if not config['send_monotonic_counter']:
+            config['send_monotonic_with_gauge' = True
+
         config['send_distribution_counts_as_monotonic'] = is_affirmative(
             instance.get(
                 'send_distribution_counts_as_monotonic',

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -203,10 +203,6 @@ class OpenMetricsScraperMixin(object):
             instance.get('send_monotonic_with_gauge', default_instance.get('send_monotonic_with_gauge', False))
         )
 
-        # Submit Prometheus counter metrics as monotonic_count along with gauge
-        if not config['send_monotonic_counter']:
-            config['send_monotonic_with_gauge'] = True
-
         config['send_distribution_counts_as_monotonic'] = is_affirmative(
             instance.get(
                 'send_distribution_counts_as_monotonic',
@@ -784,18 +780,18 @@ class OpenMetricsScraperMixin(object):
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname=custom_hostname)
                 self._submit_distribution_count(
                     scraper_config['send_distribution_sums_as_monotonic'],
+                    scraper_config['send_monotonic_with_gauge'],
                     "{}.{}.sum".format(scraper_config['namespace'], metric_name),
                     val,
                     tags=tags,
                     hostname=custom_hostname,
-                    send_monotonic_with_gauge=scraper_config['send_monotonic_with_gauge'],
                 )
             elif sample[self.SAMPLE_NAME].endswith("_count"):
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname=custom_hostname)
                 self._submit_distribution_count(
                     scraper_config['send_distribution_counts_as_monotonic'],
-                    "{}.{}.count".format(scraper_config['namespace'], metric_name),
                     scraper_config['send_monotonic_with_gauge'],
+                    "{}.{}.count".format(scraper_config['namespace'], metric_name),
                     val,
                     tags=tags,
                     hostname=custom_hostname,


### PR DESCRIPTION
### What does this PR do?
The metric types for the following are emitted as counter metrics but their metadata metric type is gauge. This PR updates them as well as enforce submitting `_count` ending histogram metrics as a count as well (https://prometheus.io/docs/practices/histograms/#count-and-sum-of-observations)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
