### PR TITLE
[PROD] add short_name to openshift metadata.csv

### DIFF
--- a/openshift/metadata.csv
+++ b/openshift/metadata.csv
@@ -1,43 +1,43 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-openshift.clusterquota.cpu.used,gauge,,cpu,,Observed cpu usage by cluster resource quota for all namespaces,0,openshift
-openshift.clusterquota.cpu.limit,gauge,,cpu,,Hard limit for cpu by cluster resource quota for all namespaces,0,openshift
-openshift.clusterquota.cpu.remaining,gauge,,cpu,,Remaining available cpu by cluster resource quota for all namespaces,1,openshift
-openshift.clusterquota.memory.used,gauge,,byte,,Observed memory usage by cluster resource quota for all namespaces,0,openshift
-openshift.clusterquota.memory.limit,gauge,,byte,,Hard limit for memory by cluster resource quota for all namespaces,0,openshift
-openshift.clusterquota.memory.remaining,gauge,,byte,,Remaining available memory by cluster resource quota for all namespaces,1,openshift
-openshift.clusterquota.pods.used,gauge,,,,Observed pods usage by cluster resource quota for all namespaces,0,openshift
-openshift.clusterquota.pods.limit,gauge,,,,Hard limit for pods by cluster resource quota for all namespaces,0,openshift
-openshift.clusterquota.pods.remaining,gauge,,,,Remaining available pods by cluster resource quota for all namespaces,1,openshift
-openshift.clusterquota.services.used,gauge,,,,Observed services usage by cluster resource quota for all namespaces,0,openshift
-openshift.clusterquota.services.limit,gauge,,,,Hard limit for services by cluster resource quota for all namespaces,0,openshift
-openshift.clusterquota.services.remaining,gauge,,,,Remaining available services by cluster resource quota for all namespaces,1,openshift
-openshift.clusterquota.persistentvolumeclaims.used,gauge,,,,Observed persistent volume claims usage by cluster resource quota for all namespaces,0,openshift
-openshift.clusterquota.persistentvolumeclaims.limit,gauge,,,,Hard limit for persistent volume claims by cluster resource quota for all namespaces,0,openshift
-openshift.clusterquota.persistentvolumeclaims.remaining,gauge,,,,Remaining available persistent volume claims by cluster resource quota for all namespaces,1,openshift
-openshift.clusterquota.services.nodeports.used,gauge,,,,Observed service node ports usage by cluster resource quota for all namespaces,0,openshift
-openshift.clusterquota.services.nodeports.limit,gauge,,,,Hard limit for service node ports by cluster resource quota for all namespaces,0,openshift
-openshift.clusterquota.services.nodeports.remaining,gauge,,,,Remaining available service node ports by cluster resource quota for all namespaces,1,openshift
-openshift.clusterquota.services.loadbalancers.used,gauge,,,,Observed service load balancers usage by cluster resource quota for all namespaces,0,openshift
-openshift.clusterquota.services.loadbalancers.limit,gauge,,,,Hard limit for service load balancers by cluster resource quota for all namespaces,0,openshift
-openshift.clusterquota.services.loadbalancers.remaining,gauge,,,,Remaining available service load balancers by cluster resource quota for all namespaces,1,openshift
-openshift.appliedclusterquota.cpu.used,gauge,,cpu,,Observed cpu usage by cluster resource quota and namespace,0,openshift
-openshift.appliedclusterquota.cpu.limit,gauge,,cpu,,Hard limit for cpu by cluster resource quota and namespace,0,openshift
-openshift.appliedclusterquota.cpu.remaining,gauge,,cpu,,Remaining available cpu by cluster resource quota and namespace,1,openshift
-openshift.appliedclusterquota.memory.used,gauge,,byte,,Observed memory usage by cluster resource quota and namespace,0,openshift
-openshift.appliedclusterquota.memory.limit,gauge,,byte,,Hard limit for memory by cluster resource quota and namespace,0,openshift
-openshift.appliedclusterquota.memory.remaining,gauge,,byte,,Remaining available memory by cluster resource quota and namespace,1,openshift
-openshift.appliedclusterquota.pods.used,gauge,,,,Observed pods usage by cluster resource quota and namespace,0,openshift
-openshift.appliedclusterquota.pods.limit,gauge,,,,Hard limit for pods by cluster resource quota and namespace,0,openshift
-openshift.appliedclusterquota.pods.remaining,gauge,,,,Remaining available pods by cluster resource quota and namespace,1,openshift
-openshift.appliedclusterquota.services.used,gauge,,,,Observed services usage by cluster resource quota and namespace,0,openshift
-openshift.appliedclusterquota.services.limit,gauge,,,,Hard limit for services by cluster resource quota and namespace,0,openshift
-openshift.appliedclusterquota.services.remaining,gauge,,,,Remaining available services by cluster resource quota and namespace,1,openshift
-openshift.appliedclusterquota.persistentvolumeclaims.used,gauge,,,,Observed persistent volume claims usage by cluster resource quota and namespace,0,openshift
-openshift.appliedclusterquota.persistentvolumeclaims.limit,gauge,,,,Hard limit for persistent volume claims by cluster resource quota and namespace,0,openshift
-openshift.appliedclusterquota.persistentvolumeclaims.remaining,gauge,,,,Remaining available persistent volume claims by cluster resource quota and namespace,1,openshift
-openshift.appliedclusterquota.services.nodeports.used,gauge,,,,Observed service node ports usage by cluster resource quota and namespace,0,openshift
-openshift.appliedclusterquota.services.nodeports.limit,gauge,,,,Hard limit for service node ports by cluster resource quota and namespace,0,openshift
-openshift.appliedclusterquota.services.nodeports.remaining,gauge,,,,Remaining available service node ports by cluster resource quota and namespace,1,openshift
-openshift.appliedclusterquota.services.loadbalancers.used,gauge,,,,Observed service load balancers usage by cluster resource quota and namespace,0,openshift
-openshift.appliedclusterquota.services.loadbalancers.limit,gauge,,,,Hard limit for service load balancers by cluster resource quota and namespace,0,openshift
-openshift.appliedclusterquota.services.loadbalancers.remaining,gauge,,,,Remaining available service load balancers by cluster resource quota and namespace,1,openshift
+openshift.clusterquota.cpu.used,gauge,,cpu,,Observed cpu usage by cluster resource quota for all namespaces,0,openshift,cq cpu used
+openshift.clusterquota.cpu.limit,gauge,,cpu,,Hard limit for cpu by cluster resource quota for all namespaces,0,openshift,cq cpu limit
+openshift.clusterquota.cpu.remaining,gauge,,cpu,,Remaining available cpu by cluster resource quota for all namespaces,1,openshift,cq cpu remaining
+openshift.clusterquota.memory.used,gauge,,byte,,Observed memory usage by cluster resource quota for all namespaces,0,openshift,cq memory used
+openshift.clusterquota.memory.limit,gauge,,byte,,Hard limit for memory by cluster resource quota for all namespaces,0,openshift,cq memory limit
+openshift.clusterquota.memory.remaining,gauge,,byte,,Remaining available memory by cluster resource quota for all namespaces,1,openshift,cq memory remaining
+openshift.clusterquota.pods.used,gauge,,,,Observed pods usage by cluster resource quota for all namespaces,0,openshift,cq pods used
+openshift.clusterquota.pods.limit,gauge,,,,Hard limit for pods by cluster resource quota for all namespaces,0,openshift,cq pods limit
+openshift.clusterquota.pods.remaining,gauge,,,,Remaining available pods by cluster resource quota for all namespaces,1,openshift,cq pods remaining
+openshift.clusterquota.services.used,gauge,,,,Observed services usage by cluster resource quota for all namespaces,0,openshift,cq services used
+openshift.clusterquota.services.limit,gauge,,,,Hard limit for services by cluster resource quota for all namespaces,0,openshift,cq services limit
+openshift.clusterquota.services.remaining,gauge,,,,Remaining available services by cluster resource quota for all namespaces,1,openshift,cq services remaining
+openshift.clusterquota.persistentvolumeclaims.used,gauge,,,,Observed persistent volume claims usage by cluster resource quota for all namespaces,0,openshift,cq pvcs used
+openshift.clusterquota.persistentvolumeclaims.limit,gauge,,,,Hard limit for persistent volume claims by cluster resource quota for all namespaces,0,openshift,cq pvcs limit
+openshift.clusterquota.persistentvolumeclaims.remaining,gauge,,,,Remaining available persistent volume claims by cluster resource quota for all namespaces,1,openshift,cq pvcs limit
+openshift.clusterquota.services.nodeports.used,gauge,,,,Observed service node ports usage by cluster resource quota for all namespaces,0,openshift,cq svc node ports used
+openshift.clusterquota.services.nodeports.limit,gauge,,,,Hard limit for service node ports by cluster resource quota for all namespaces,0,openshift,cq svc node ports limit
+openshift.clusterquota.services.nodeports.remaining,gauge,,,,Remaining available service node ports by cluster resource quota for all namespaces,1,openshift,cq svc node ports remaining
+openshift.clusterquota.services.loadbalancers.used,gauge,,,,Observed service load balancers usage by cluster resource quota for all namespaces,0,openshift,cq loadbalancers used
+openshift.clusterquota.services.loadbalancers.limit,gauge,,,,Hard limit for service load balancers by cluster resource quota for all namespaces,0,openshift,cq loadbalancers limit
+openshift.clusterquota.services.loadbalancers.remaining,gauge,,,,Remaining available service load balancers by cluster resource quota for all namespaces,1,openshift,cq loadbalancers remaining
+openshift.appliedclusterquota.cpu.used,gauge,,cpu,,Observed cpu usage by cluster resource quota and namespace,0,openshift,acq cpu used
+openshift.appliedclusterquota.cpu.limit,gauge,,cpu,,Hard limit for cpu by cluster resource quota and namespace,0,openshift,acq cpu limit
+openshift.appliedclusterquota.cpu.remaining,gauge,,cpu,,Remaining available cpu by cluster resource quota and namespace,1,openshift,acq cpu remaining
+openshift.appliedclusterquota.memory.used,gauge,,byte,,Observed memory usage by cluster resource quota and namespace,0,openshift,acq memory used
+openshift.appliedclusterquota.memory.limit,gauge,,byte,,Hard limit for memory by cluster resource quota and namespace,0,openshift,acq memory limit
+openshift.appliedclusterquota.memory.remaining,gauge,,byte,,Remaining available memory by cluster resource quota and namespace,1,openshift,acq memory remaining
+openshift.appliedclusterquota.pods.used,gauge,,,,Observed pods usage by cluster resource quota and namespace,0,openshift,acq pods used
+openshift.appliedclusterquota.pods.limit,gauge,,,,Hard limit for pods by cluster resource quota and namespace,0,openshift,acq pods limit
+openshift.appliedclusterquota.pods.remaining,gauge,,,,Remaining available pods by cluster resource quota and namespace,1,openshift,acq pods remaining
+openshift.appliedclusterquota.services.used,gauge,,,,Observed services usage by cluster resource quota and namespace,0,openshift,acq services used
+openshift.appliedclusterquota.services.limit,gauge,,,,Hard limit for services by cluster resource quota and namespace,0,openshift,acq services limit
+openshift.appliedclusterquota.services.remaining,gauge,,,,Remaining available services by cluster resource quota and namespace,1,openshift,acq services remaining
+openshift.appliedclusterquota.persistentvolumeclaims.used,gauge,,,,Observed persistent volume claims usage by cluster resource quota and namespace,0,openshift,acq pvcs used
+openshift.appliedclusterquota.persistentvolumeclaims.limit,gauge,,,,Hard limit for persistent volume claims by cluster resource quota and namespace,0,openshift,acq pvcs limit
+openshift.appliedclusterquota.persistentvolumeclaims.remaining,gauge,,,,Remaining available persistent volume claims by cluster resource quota and namespace,1,openshift,acq pvcs remaining
+openshift.appliedclusterquota.services.nodeports.used,gauge,,,,Observed service node ports usage by cluster resource quota and namespace,0,openshift,acq svc node ports used
+openshift.appliedclusterquota.services.nodeports.limit,gauge,,,,Hard limit for service node ports by cluster resource quota and namespace,0,openshift,acq svc node ports limit
+openshift.appliedclusterquota.services.nodeports.remaining,gauge,,,,Remaining available service node ports by cluster resource quota and namespace,1,openshift,acq svc node ports remaining
+openshift.appliedclusterquota.services.loadbalancers.used,gauge,,,,Observed service load balancers usage by cluster resource quota and namespace,0,openshift,acq loadbalancers used
+openshift.appliedclusterquota.services.loadbalancers.limit,gauge,,,,Hard limit for service load balancers by cluster resource quota and namespace,0,openshift,acq loadbalancers limit
+openshift.appliedclusterquota.services.loadbalancers.remaining,gauge,,,,Remaining available service load balancers by cluster resource quota and namespace,1,openshift,acq loadbalancers remaining


### PR DESCRIPTION
### What does this PR do?
Adds a `short_name` description to each of the Openshift metrics so the CSV renders normally in Github when customers look for it (this may be part of the reason why the complete list of metrics doesn't appear in the corresponding [docs page for this integration](https://docs.datadoghq.com/integrations/openshift/))

![screenshot](https://a.cl.ly/yAuvGB26)

### Motivation
To make the list of Openshift metrics more readable

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
