### PR TITLE
Fix tab completion

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -12,12 +12,25 @@ INTEGRATION_REPOS = [
     'integrations-extras',
     'integrations-internal',
 ]
+
+REPO_OPTIONS_MAP = {
+    '--core': 'core',
+    '-c': 'core',
+    '--extras': 'extras',
+    '-e': 'extras',
+    '--agent': 'agent',
+    '-a': 'agent',
+    '--here': 'here',
+    '-x': 'here',
+}
+
 REPO_CHOICES = {
     'core': 'integrations-core',
     'extras': 'integrations-extras',
     'internal': 'integrations-internal',
     'agent': 'datadog-agent',
 }
+
 VERSION_BUMP = {
     'Added': semver.bump_minor,
     'Changed': semver.bump_major,

--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -7,8 +7,8 @@ from ..subprocess import run_command
 from ..utils import chdir, path_join, read_file_binary, write_file_binary
 from .constants import NON_TESTABLE_FILES, TESTABLE_FILE_EXTENSIONS, get_root
 from .e2e import get_active_checks, get_configured_envs
-from .git import files_changed, get_git_root
-from .utils import get_testable_checks
+from .git import files_changed
+from .utils import complete_set_root, get_testable_checks
 
 STYLE_CHECK_ENVS = {'flake8', 'style'}
 STYLE_ENVS = {'flake8', 'style', 'format_style'}
@@ -16,15 +16,18 @@ PYTHON_MAJOR_PATTERN = r'py(\d)'
 
 
 def complete_envs(ctx, args, incomplete):
+    complete_set_root(args)
     return sorted(e for e in get_available_tox_envs(args[-1], e2e_only=True) if e.startswith(incomplete))
 
 
 # this test makes more sense under tooling/utils, but that causes circular import
 def complete_active_checks(ctx, args, incomplete):
+    complete_set_root(args)
     return [k for k in get_active_checks() if k.startswith(incomplete)]
 
 
 def complete_configured_envs(ctx, args, incomplete):
+    complete_set_root(args)
     return [e for e in get_configured_envs(args[-1]) if e.startswith(incomplete)]
 
 
@@ -92,7 +95,7 @@ def get_available_tox_envs(check, sort=False, e2e_only=False, e2e_tests_only=Fal
     else:
         tox_command = 'tox --listenvs'
 
-    with chdir(path_join(get_root() or get_git_root(), check)):
+    with chdir(path_join(get_root(), check)):
         output = run_command(tox_command, capture='out').stdout
 
     env_list = [e.strip() for e in output.splitlines()]


### PR DESCRIPTION
Reverts some of the special casing for tab-completion.

Instead of only working under `integrations-core` repo, now it will read the user config and handle any of the configured repos just like the regular command-line operation.

Also added the option to read the desired repo from an env variable.