### PR TITLE
[PROD] add metrics in docs page, fix warning formattingissue

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -32,7 +32,7 @@ Starting with version 6.1, the Datadog Agent supports monitoring OpenShift Origi
 | Live Process monitoring        | ❌                                       | ❌                                           | ✅                                             |
 
 <div class="alert alert-warning">
-<b>OpenShift 4.0+</b>: If you used the OpenShift installer on a supported cloud provider, you must deploy the Agent with <code>hostNetwork: true</code> in the <code>datadog.yaml</code> configuration file to get host tags/aliases as access to metadata servers from PODs network, which otherwise is restricted.
+<bold>OpenShift 4.0+</bold>: If you used the OpenShift installer on a supported cloud provider, you must deploy the Agent with <code>hostNetwork: true</code> in the <code>datadog.yaml</code> configuration file to get host tags/aliases as access to metadata servers from PODs network, which otherwise is restricted.
 </div>
 
 #### Restricted SCC operations
@@ -69,6 +69,10 @@ If SELinux is in enforcing mode, it is recommended to grant [the `spc_t` type][7
 
 <div class="alert alert-info">
 Do not forget to add <a href="https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#configure-rbac-permissions">datadog-agent service account</a> to the newly created <a href="https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/openshift/scc.yaml">datadog-agent SCC</a> by adding <code>system:serviceaccount:<datadog-agent namespace>:<datadog-agent service account name></code> to the <code>users</code> section.
+</div>
+
+<div class="alert alert-warning">
+<b>OpenShift 4.0+</b>: If you used the OpenShift installer on a supported cloud provider, you must deploy the Agent with <code>allowHostNetwork: true</code> in the <code>datadog.yaml</code> configuration file to get host tags/aliases as access to metadata servers from PODs network, which otherwise is restricted.
 </div>
 
 ### Validation

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -31,7 +31,9 @@ Starting with version 6.1, the Datadog Agent supports monitoring OpenShift Origi
 | Live Container monitoring      | ❌                                       | ❌                                           | ✅                                             |
 | Live Process monitoring        | ❌                                       | ❌                                           | ✅                                             |
 
-> :warning: **OpenShift 4.0+**: If you used the OpenShift installer on a supported cloud provider, you will need to deploy the Agent with `hostNetwork: true` to get host tags/aliases as access to metadata servers from PODs network is otherwise restricited.
+<div class="alert alert-warning">
+**OpenShift 4.0+**: If you used the OpenShift installer on a supported cloud provider, you will need to deploy the Agent with `hostNetwork: true` to get host tags/aliases as access to metadata servers from PODs network is otherwise restricited.
+</div>
 
 #### Restricted SCC operations
 
@@ -77,7 +79,7 @@ See [kube_apiserver_metrics][1]
 
 ### Metrics
 
-See [metadata.csv][10] for a list of metrics specific to OpenShift.
+{{< get-metrics-from-git "openshift" >}}
 
 ### Events
 

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -67,9 +67,13 @@ If SELinux is in enforcing mode, it is recommended to grant [the `spc_t` type][7
 - `volumes: hostPath`: Accesses the Docker socket and the host's `proc` and `cgroup` folders, for metric collection.
 - `SELinux type: spc_t`: Accesses the Docker socket and all processes' `proc` and `cgroup` folders, for metric collection. You can read more about this type [in this Red Hat article][7].
 
-> :warning: Do not forget to add [datadog-agent service account][5] to the newly created [datadog-agent SCC][8] by adding `system:serviceaccount:<datadog-agent namespace>:<datadog-agent service account name>` to the `users` section.
+<div class="alert alert-warning">
+Do not forget to add [datadog-agent service account][5] to the newly created [datadog-agent SCC][8] by adding `system:serviceaccount:<datadog-agent namespace>:<datadog-agent service account name>` to the `users` section.
+</div>
 
-> :warning: **OpenShift 4.0+**: If you used the OpenShift installer on a supported cloud provider, you will need to modify the provided SCC with `allowHostNetwork: true` to get host tags/aliases as access to metadata servers from PODs network is otherwise restricited.
+<div class="alert alert-warning">
+**OpenShift 4.0+**: If you used the OpenShift installer on a supported cloud provider, you will need to modify the provided SCC with `allowHostNetwork: true` to get host tags/aliases as access to metadata servers from PODs network is otherwise restricited.
+</div>
 
 ### Validation
 

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -32,7 +32,7 @@ Starting with version 6.1, the Datadog Agent supports monitoring OpenShift Origi
 | Live Process monitoring        | ❌                                       | ❌                                           | ✅                                             |
 
 <div class="alert alert-warning">
-**OpenShift 4.0+**: If you used the OpenShift installer on a supported cloud provider, you will need to deploy the Agent with `hostNetwork: true` to get host tags/aliases as access to metadata servers from PODs network is otherwise restricited.
+<b>OpenShift 4.0+</b>: If you used the OpenShift installer on a supported cloud provider, you must deploy the Agent with <code>hostNetwork: true</code> in the <code>datadog.yaml</code> configuration file to get host tags/aliases as access to metadata servers from PODs network, which otherwise is restricted.
 </div>
 
 #### Restricted SCC operations
@@ -67,12 +67,8 @@ If SELinux is in enforcing mode, it is recommended to grant [the `spc_t` type][7
 - `volumes: hostPath`: Accesses the Docker socket and the host's `proc` and `cgroup` folders, for metric collection.
 - `SELinux type: spc_t`: Accesses the Docker socket and all processes' `proc` and `cgroup` folders, for metric collection. You can read more about this type [in this Red Hat article][7].
 
-<div class="alert alert-warning">
-Do not forget to add [datadog-agent service account][5] to the newly created [datadog-agent SCC][8] by adding `system:serviceaccount:<datadog-agent namespace>:<datadog-agent service account name>` to the `users` section.
-</div>
-
-<div class="alert alert-warning">
-**OpenShift 4.0+**: If you used the OpenShift installer on a supported cloud provider, you will need to modify the provided SCC with `allowHostNetwork: true` to get host tags/aliases as access to metadata servers from PODs network is otherwise restricited.
+<div class="alert alert-info">
+Do not forget to add <a href="https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#configure-rbac-permissions">datadog-agent service account</a> to the newly created <a href="https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/openshift/scc.yaml">datadog-agent SCC</a> by adding <code>system:serviceaccount:<datadog-agent namespace>:<datadog-agent service account name></code> to the <code>users</code> section.
 </div>
 
 ### Validation
@@ -83,7 +79,7 @@ See [kube_apiserver_metrics][1]
 
 ### Metrics
 
-{{< get-metrics-from-git "openshift" >}}
+See [metadata.csv][10] for a full list of provided metrics by this integration.
 
 ### Events
 

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -32,7 +32,7 @@ Starting with version 6.1, the Datadog Agent supports monitoring OpenShift Origi
 | Live Process monitoring        | ❌                                       | ❌                                           | ✅                                             |
 
 <div class="alert alert-warning">
-<bold>OpenShift 4.0+</bold>: If you used the OpenShift installer on a supported cloud provider, you must deploy the Agent with <code>hostNetwork: true</code> in the <code>datadog.yaml</code> configuration file to get host tags/aliases as access to metadata servers from PODs network, which otherwise is restricted.
+<bold>OpenShift 4.0+</bold>: If you used the OpenShift installer on a supported cloud provider, you must deploy the Agent with <code>hostNetwork: true</code> in the <code>datadog.yaml</code> configuration file to get host tags and aliases. Access to metadata servers from the PODs network is otherwise restricted.
 </div>
 
 #### Restricted SCC operations

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -68,11 +68,11 @@ If SELinux is in enforcing mode, it is recommended to grant [the `spc_t` type][7
 - `SELinux type: spc_t`: Accesses the Docker socket and all processes' `proc` and `cgroup` folders, for metric collection. You can read more about this type [in this Red Hat article][7].
 
 <div class="alert alert-info">
-Do not forget to add <a href="https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#configure-rbac-permissions">datadog-agent service account</a> to the newly created <a href="https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/openshift/scc.yaml">datadog-agent SCC</a> by adding <code>system:serviceaccount:<datadog-agent namespace>:<datadog-agent service account name></code> to the <code>users</code> section.
+Do not forget to add a <a href="https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#configure-rbac-permissions">datadog-agent service account</a> to the newly created <a href="https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/openshift/scc.yaml">datadog-agent SCC</a> by adding <code>system:serviceaccount:<datadog-agent namespace>:<datadog-agent service account name></code> to the <code>users</code> section.
 </div>
 
 <div class="alert alert-warning">
-<b>OpenShift 4.0+</b>: If you used the OpenShift installer on a supported cloud provider, you must deploy the Agent with <code>allowHostNetwork: true</code> in the <code>datadog.yaml</code> configuration file to get host tags/aliases as access to metadata servers from PODs network, which otherwise is restricted.
+<b>OpenShift 4.0+</b>: If you used the OpenShift installer on a supported cloud provider, you must deploy the Agent with <code>allowHostNetwork: true</code> in the <code>datadog.yaml</code> configuration file to get host tags and aliases. Access to metadata servers from the PODs network is otherwise restricted.
 </div>
 
 ### Validation

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -83,7 +83,7 @@ See [kube_apiserver_metrics][1]
 
 ### Metrics
 
-See [metadata.csv][10] for a full list of provided metrics by this integration.
+See [metadata.csv][10] for a list of metrics provided by this integration.
 
 ### Events
 


### PR DESCRIPTION
### What does this PR do?
Adds the metrics collected in this integration to be directly in the docs page vs. a link to the `metadata.csv`

Also fixes a minor formatting issue with one of the warnings that's supposed to be rendered in this page.

### Motivation
[Kubernetes docs include the metrics in the docs page for the integration](https://docs.datadoghq.com/integrations/kubernetes/#data-collected). Since `metadata.csv` is still the source for these metrics, this should be equally up-to-date. 


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
