### PR TITLE
Fix queue metric name

### DIFF
--- a/yarn/metadata.csv
+++ b/yarn/metadata.csv
@@ -51,7 +51,7 @@ yarn.queue.root.used_capacity,gauge,,percent,,The used queue capacity in percent
 yarn.queue.root.capacity,gauge,,percent,,The configured queue capacity in percentage for root queue,0,yarn,q root cap
 yarn.queue.num_pending_applications,gauge,,task,,The number of pending applications in this queue,0,yarn,q pnd apps
 yarn.queue.user_am_resource_limit.memory,gauge,,mebibyte,,The maximum memory resources a user can use for Application Masters (in MB),0,yarn,q usr am res lm m
-yarn.queue.user_am_resource_limit.vCores,gauge,,core,,The maximum vCpus a user can use for Application Masters,0,yarn,q usr am res lm c
+yarn.queue.user_am_resource_limit.vcores,gauge,,core,,The maximum vCpus a user can use for Application Masters,0,yarn,q usr am res lm c
 yarn.queue.absolute_capacity,gauge,,percent,,The absolute capacity percentage this queue can use of entire cluster,0,yarn,q abs cap
 yarn.queue.user_limit_factor,gauge,,,,The minimum user limit percent set in the configuration,0,yarn,q usr lm fac
 yarn.queue.user_limit,gauge,,,,The user limit factor set in the configuration,0,yarn,q usr lm

--- a/yarn/metadata.csv
+++ b/yarn/metadata.csv
@@ -46,28 +46,28 @@ yarn.node.avail_memory_mb,gauge,,mebibyte,,The total amount of memory currently 
 yarn.node.used_virtual_cores,gauge,,core,,The total number of vCores currently used on the node,0,yarn,nd cor usd
 yarn.node.available_virtual_cores,gauge,,core,,The total number of vCores available on the node,0,yarn,nd cor avail
 yarn.node.num_containers,gauge,,,,The total number of containers currently running on the node,0,yarn,nd ctrs tot
-yarn.queue.root.maxCapacity,gauge,,percent,,The configured maximum queue capacity in percentage for root queue,0,yarn,q root max cap
-yarn.queue.root.usedCapacity,gauge,,percent,,The used queue capacity in percentage for root queue,0,yarn,q root usd cap
+yarn.queue.root.max_capacity,gauge,,percent,,The configured maximum queue capacity in percentage for root queue,0,yarn,q root max cap
+yarn.queue.root.used_capacity,gauge,,percent,,The used queue capacity in percentage for root queue,0,yarn,q root usd cap
 yarn.queue.root.capacity,gauge,,percent,,The configured queue capacity in percentage for root queue,0,yarn,q root cap
-yarn.queue.numPendingApplications,gauge,,task,,The number of pending applications in this queue,0,yarn,q pnd apps
-yarn.queue.userAMResourceLimit.memory,gauge,,mebibyte,,The maximum memory resources a user can use for Application Masters (in MB),0,yarn,q usr am res lm m
-yarn.queue.userAMResourceLimit.vCores,gauge,,core,,The maximum vCpus a user can use for Application Masters,0,yarn,q usr am res lm c
-yarn.queue.absoluteCapacity,gauge,,percent,,The absolute capacity percentage this queue can use of entire cluster,0,yarn,q abs cap
-yarn.queue.userLimitFactor,gauge,,,,The minimum user limit percent set in the configuration,0,yarn,q usr lm fac
-yarn.queue.userLimit,gauge,,,,The user limit factor set in the configuration,0,yarn,q usr lm
-yarn.queue.numApplications,gauge,,task,,The number of applications currently in the queue,0,yarn,q num app
-yarn.queue.usedAMResource.memory,gauge,,mebibyte,,The memory resources used for Application Masters (in MB),0,yarn,q usd am res m
-yarn.queue.usedAMResource.vCores,gauge,,core,,The vCpus used for Application Masters,0,yarn,q usd am res c
-yarn.queue.absoluteUsedCapacity,gauge,,percent,,The absolute used capacity percentage this queue is using of the entire cluster,0,yarn,q abs used cap
-yarn.queue.resourcesUsed.memory,gauge,,mebibyte,,The total memory resources this queue is using (in MB),0,yarn,q res usd m
-yarn.queue.resourcesUsed.vCores,gauge,,core,,The total vCpus this queue is using,0,yarn,q res usd c
-yarn.queue.AMResourceLimit.vCores,gauge,,core,,The maximum vCpus this queue can use for Application Masters,0,yarn,q am res lim c
-yarn.queue.AMResourceLimit.memory,gauge,,mebibyte,,The maximum memory resources this queue can use for Application Masters (in MB),0,yarn,q am res lim m
+yarn.queue.num_pending_applications,gauge,,task,,The number of pending applications in this queue,0,yarn,q pnd apps
+yarn.queue.user_am_resource_limit.memory,gauge,,mebibyte,,The maximum memory resources a user can use for Application Masters (in MB),0,yarn,q usr am res lm m
+yarn.queue.user_am_resource_limit.vCores,gauge,,core,,The maximum vCpus a user can use for Application Masters,0,yarn,q usr am res lm c
+yarn.queue.absolute_capacity,gauge,,percent,,The absolute capacity percentage this queue can use of entire cluster,0,yarn,q abs cap
+yarn.queue.user_limit_factor,gauge,,,,The minimum user limit percent set in the configuration,0,yarn,q usr lm fac
+yarn.queue.user_limit,gauge,,,,The user limit factor set in the configuration,0,yarn,q usr lm
+yarn.queue.num_applications,gauge,,task,,The number of applications currently in the queue,0,yarn,q num app
+yarn.queue.used_am_resource.memory,gauge,,mebibyte,,The memory resources used for Application Masters (in MB),0,yarn,q usd am res m
+yarn.queue.used_am_resource.vCores,gauge,,core,,The vCpus used for Application Masters,0,yarn,q usd am res c
+yarn.queue.absolute_used_capacity,gauge,,percent,,The absolute used capacity percentage this queue is using of the entire cluster,0,yarn,q abs used cap
+yarn.queue.resources_used.memory,gauge,,mebibyte,,The total memory resources this queue is using (in MB),0,yarn,q res usd m
+yarn.queue.resources_used.vCores,gauge,,core,,The total vCpus this queue is using,0,yarn,q res usd c
+yarn.queue.am_resource_limit.vCores,gauge,,core,,The maximum vCpus this queue can use for Application Masters,0,yarn,q am res lim c
+yarn.queue.am_resource_limit.memory,gauge,,mebibyte,,The maximum memory resources this queue can use for Application Masters (in MB),0,yarn,q am res lim m
 yarn.queue.capacity,gauge,,percent,,The configured queue capacity in percentage relative to its parent queue,0,yarn,q cap
-yarn.queue.numActiveApplications,gauge,,task,,The number of active applications in this queue,0,yarn,q num act apps
-yarn.queue.absoluteMaxCapacity,gauge,,percent,,The absolute maximum capacity percentage this queue can use of the entire cluster,0,yarn,q abs max cap
-yarn.queue.usedCapacity,gauge,,percent,,The used queue capacity in percentage,0,yarn,q usd cap
-yarn.queue.numContainers,gauge,,,,The number of containers being used,0,yarn,q num cont
-yarn.queue.maxCapacity,gauge,,percent,,The configured maximum queue capacity in percentage relative to its parent queue,0,yarn,q max cap
-yarn.queue.maxApplications,gauge,,task,,The maximum number of applications this queue can have,0,yarn,q max app
-yarn.queue.maxApplicationsPerUser,gauge,,task,,The maximum number of active applications per user this queue can have,0,yarn,q max app usr
+yarn.queue.num_active_applications,gauge,,task,,The number of active applications in this queue,0,yarn,q num act apps
+yarn.queue.absolute_max_capacity,gauge,,percent,,The absolute maximum capacity percentage this queue can use of the entire cluster,0,yarn,q abs max cap
+yarn.queue.used_capacity,gauge,,percent,,The used queue capacity in percentage,0,yarn,q usd cap
+yarn.queue.num_containers,gauge,,,,The number of containers being used,0,yarn,q num cont
+yarn.queue.max_capacity,gauge,,percent,,The configured maximum queue capacity in percentage relative to its parent queue,0,yarn,q max cap
+yarn.queue.max_applications,gauge,,task,,The maximum number of applications this queue can have,0,yarn,q max app
+yarn.queue.max_applications_per_user,gauge,,task,,The maximum number of active applications per user this queue can have,0,yarn,q max app usr

--- a/yarn/metadata.csv
+++ b/yarn/metadata.csv
@@ -61,7 +61,7 @@ yarn.queue.used_am_resource.vcores,gauge,,core,,The vCpus used for Application M
 yarn.queue.absolute_used_capacity,gauge,,percent,,The absolute used capacity percentage this queue is using of the entire cluster,0,yarn,q abs used cap
 yarn.queue.resources_used.memory,gauge,,mebibyte,,The total memory resources this queue is using (in MB),0,yarn,q res usd m
 yarn.queue.resources_used.vcores,gauge,,core,,The total vCpus this queue is using,0,yarn,q res usd c
-yarn.queue.am_resource_limit.vCores,gauge,,core,,The maximum vCpus this queue can use for Application Masters,0,yarn,q am res lim c
+yarn.queue.am_resource_limit.vcores,gauge,,core,,The maximum vCpus this queue can use for Application Masters,0,yarn,q am res lim c
 yarn.queue.am_resource_limit.memory,gauge,,mebibyte,,The maximum memory resources this queue can use for Application Masters (in MB),0,yarn,q am res lim m
 yarn.queue.capacity,gauge,,percent,,The configured queue capacity in percentage relative to its parent queue,0,yarn,q cap
 yarn.queue.num_active_applications,gauge,,task,,The number of active applications in this queue,0,yarn,q num act apps

--- a/yarn/metadata.csv
+++ b/yarn/metadata.csv
@@ -60,7 +60,7 @@ yarn.queue.used_am_resource.memory,gauge,,mebibyte,,The memory resources used fo
 yarn.queue.used_am_resource.vcores,gauge,,core,,The vCpus used for Application Masters,0,yarn,q usd am res c
 yarn.queue.absolute_used_capacity,gauge,,percent,,The absolute used capacity percentage this queue is using of the entire cluster,0,yarn,q abs used cap
 yarn.queue.resources_used.memory,gauge,,mebibyte,,The total memory resources this queue is using (in MB),0,yarn,q res usd m
-yarn.queue.resources_used.vCores,gauge,,core,,The total vCpus this queue is using,0,yarn,q res usd c
+yarn.queue.resources_used.vcores,gauge,,core,,The total vCpus this queue is using,0,yarn,q res usd c
 yarn.queue.am_resource_limit.vCores,gauge,,core,,The maximum vCpus this queue can use for Application Masters,0,yarn,q am res lim c
 yarn.queue.am_resource_limit.memory,gauge,,mebibyte,,The maximum memory resources this queue can use for Application Masters (in MB),0,yarn,q am res lim m
 yarn.queue.capacity,gauge,,percent,,The configured queue capacity in percentage relative to its parent queue,0,yarn,q cap

--- a/yarn/metadata.csv
+++ b/yarn/metadata.csv
@@ -57,7 +57,7 @@ yarn.queue.user_limit_factor,gauge,,,,The minimum user limit percent set in the 
 yarn.queue.user_limit,gauge,,,,The user limit factor set in the configuration,0,yarn,q usr lm
 yarn.queue.num_applications,gauge,,task,,The number of applications currently in the queue,0,yarn,q num app
 yarn.queue.used_am_resource.memory,gauge,,mebibyte,,The memory resources used for Application Masters (in MB),0,yarn,q usd am res m
-yarn.queue.used_am_resource.vCores,gauge,,core,,The vCpus used for Application Masters,0,yarn,q usd am res c
+yarn.queue.used_am_resource.vcores,gauge,,core,,The vCpus used for Application Masters,0,yarn,q usd am res c
 yarn.queue.absolute_used_capacity,gauge,,percent,,The absolute used capacity percentage this queue is using of the entire cluster,0,yarn,q abs used cap
 yarn.queue.resources_used.memory,gauge,,mebibyte,,The total memory resources this queue is using (in MB),0,yarn,q res usd m
 yarn.queue.resources_used.vCores,gauge,,core,,The total vCpus this queue is using,0,yarn,q res usd c


### PR DESCRIPTION
### What does this PR do?
Fix metric_name in metadata

### Motivation
missing metric claim

### Additional Notes

- Reference: https://github.com/DataDog/integrations-core/blob/7.17.x/yarn/datadog_checks/yarn/yarn.py#L119-L150

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
