### PR TITLE
Add git dep support to dep validation cmd

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/requirements.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/requirements.py
@@ -20,6 +20,7 @@ class Package:
     version: version of the package: 1.2.3 or a hash like efe345a21b4a for git dependencies
     marker: optional marker e.g. python_version < '3.0' or sys_platform == 'win32'
     """
+
     def __init__(self, name, version, marker):
         if not name:
             raise ValueError("Package must have a valid name")

--- a/datadog_checks_dev/datadog_checks/dev/tooling/requirements.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/requirements.py
@@ -9,7 +9,7 @@ from ..subprocess import run_command
 from ..utils import chdir, resolve_path, stream_file_lines, write_file_lines
 from .constants import REQUIREMENTS_IN, get_root
 
-DEP_PATTERN = re.compile(r'([^=]+)(?:==([^;\s]+)(?:; *(.*))?)?')
+DEP_PATTERN = re.compile(r'^([^=@]+)(?:(?:==|@)([^;\s]+)(?:; *(.*))?)?')
 
 
 class Package:
@@ -22,9 +22,10 @@ class Package:
         self.marker = marker.lower().replace('"', "'") if marker else ""
 
     def __str__(self):
+        version_sep = '@' if self.name.startswith('git+') else '=='
         return '{}{}{}'.format(
             self.name,
-            '=={}'.format(self.version) if self.version else '',
+            '{}{}'.format(version_sep, self.version) if self.version else '',
             '; {}'.format(self.marker) if self.marker else '',
         )
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/requirements.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/requirements.py
@@ -13,6 +13,13 @@ DEP_PATTERN = re.compile(r'^([^=@]+)(?:(?:==|@)([^;\s]+)(?:; *(.*))?)?')
 
 
 class Package:
+    """
+    Structure representing a Python dependency package
+
+    name: name of the package
+    version: version of the package: 1.2.3 or a hash like efe345a21b4a for git dependencies
+    marker: optional marker e.g. python_version < '3.0' or sys_platform == 'win32'
+    """
     def __init__(self, name, version, marker):
         if not name:
             raise ValueError("Package must have a valid name")

--- a/datadog_checks_dev/tests/tooling/test_dep.py
+++ b/datadog_checks_dev/tests/tooling/test_dep.py
@@ -144,10 +144,18 @@ def test_read_packages(catalog, package, tmp_path):
     if six.PY2:
         in_file = str(in_file)
 
-    another = Package("Bar", "4.0", None)
-    lines = ["{}\n".format(package), "{}\n".format(another), "# a comment\n", "   --hash fooBarBaz\n\n"]
+    lines = f'''
+        {package}
+        bar==4.0
+        git+https://github.com/vmware/vsphere-automation-sdk-python@efe345a21b4ab7b346b65e1cb58d56412edd1c10
+        # a comment
+           --hash fooBarBaz
+    '''
     write_file_lines(in_file, lines)
-    result = list(read_packages(in_file))
-    assert len(result) == 2
-    assert result[0].name == "foo"
-    assert result[1].name == "bar"
+    result = [str(p) for p in read_packages(in_file)]
+
+    assert result == [
+        "foo==3.0; sys_platform == 'win32'",
+        'bar==4.0',
+        'git+https://github.com/vmware/vsphere-automation-sdk-python@efe345a21b4ab7b346b65e1cb58d56412edd1c10',
+    ]

--- a/datadog_checks_dev/tests/tooling/test_dep.py
+++ b/datadog_checks_dev/tests/tooling/test_dep.py
@@ -148,6 +148,7 @@ def test_read_packages(catalog, package, tmp_path):
         {package}
         bar==4.0
         git+https://github.com/vmware/vsphere-automation-sdk-python@efe345a21b4ab7b346b65e1cb58d56412edd1c10
+        git+https://github.com/foo/bar@efe345a#my-branch
         # a comment
            --hash fooBarBaz
     '''
@@ -158,4 +159,5 @@ def test_read_packages(catalog, package, tmp_path):
         "foo==3.0; sys_platform == 'win32'",
         'bar==4.0',
         'git+https://github.com/vmware/vsphere-automation-sdk-python@efe345a21b4ab7b346b65e1cb58d56412edd1c10',
+        'git+https://github.com/foo/bar@efe345a#my-branch',
     ]


### PR DESCRIPTION
### What does this PR do?

Add git dep support to dep validation cmd

Example: `git+https://github.com/vmware/vsphere-automation-sdk-python@efe345a21b4ab7b346b65e1cb58d56412edd1c10`

### Motivation

Needed for https://github.com/DataDog/integrations-core/pull/5642

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
