### PR TITLE
Add `agent_requirements.in` to non testable files

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -68,7 +68,7 @@ NOT_TILES = [
 # If a file changes in a PR with any of these file extensions,
 # a test will run against the check containing the file
 TESTABLE_FILE_EXTENSIONS = ('.py', '.ini', '.in', '.txt', '.yml', '.yaml')
-NON_TESTABLE_FILES = ('auto_conf.yaml', 'metrics.yaml')
+NON_TESTABLE_FILES = ('auto_conf.yaml', 'metrics.yaml', 'agent_requirements.in')
 
 REQUIREMENTS_IN = 'requirements.in'
 


### PR DESCRIPTION
### What does this PR do?

Remove agent_requirements.in from changed checks

That will avoid running tests for base when it's not needed.

`agent_requirements.in` is used by agent, so CI on this repo won't test anything related to this file, hence not need to test it.


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
