### PR TITLE
Don't rely on file extension for cert loading

### DIFF
--- a/tls/tests/test_config.py
+++ b/tls/tests/test_config.py
@@ -78,14 +78,6 @@ def test_validation_data():
     assert isinstance(c.validation_data, tuple)
 
 
-def test_local_cert_loader():
-    c = TLSCheck('tls', {}, [{}])
-
-    assert c._local_cert_loader is None
-    assert c.local_cert_loader == c._local_cert_loader
-    assert callable(c.local_cert_loader)
-
-
 def test_tls_context():
     c = TLSCheck('tls', {}, [{}])
 


### PR DESCRIPTION
We tried filtering between PEM and DER based on file extensions, but
those can be confusing. We can simply check the file content for a
possible PEM certificate.

Closes #5611 