### PR TITLE
Add scylla compaction to default metrics

### DIFF
--- a/scylla/datadog_checks/scylla/data/conf.yaml.example
+++ b/scylla/datadog_checks/scylla/data/conf.yaml.example
@@ -14,7 +14,6 @@ instances:
     #   - scylla.alien
     #   - scylla.batchlog
     #   - scylla.commitlog
-    #   - scylla.compaction
     #   - scylla.cql
     #   - scylla.database
     #   - scylla.execution

--- a/scylla/datadog_checks/scylla/metrics.py
+++ b/scylla/datadog_checks/scylla/metrics.py
@@ -364,6 +364,7 @@ SCYLLA_TRANSPORT = {
 
 INSTANCE_DEFAULT_METRICS = [
     SCYLLA_CACHE,
+    SCYLLA_COMPACTION,
     SCYLLA_GOSSIP,
     SCYLLA_NODE,
     SCYLLA_REACTOR,
@@ -377,7 +378,6 @@ ADDITIONAL_METRICS_MAP = {
     'scylla.alien': SCYLLA_ALIEN,
     'scylla.batchlog': SCYLLA_BATCHLOG,
     'scylla.commitlog': SCYLLA_COMMITLOG,
-    'scylla.compaction': SCYLLA_COMPACTION,
     'scylla.cql': SCYLLA_CQL,
     'scylla.database': SCYLLA_DATABASE,
     'scylla.execution': SCYLLA_EXECUTION,

--- a/scylla/tests/common.py
+++ b/scylla/tests/common.py
@@ -345,6 +345,7 @@ INSTANCE_METRIC_GROUP_MAP = {
 
 INSTANCE_DEFAULT_GROUPS = [
     'scylla.cache',
+    'scylla.compaction_manager',
     'scylla.gossip',
     'scylla.node',
     'scylla.reactor',


### PR DESCRIPTION
This moves the metric `scylla.compaction_manager.compactions` to be collected by default in alignment with updated RFC.