### PR TITLE
Use top-level kafka imports to be more future-proof

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -4,9 +4,8 @@
 from collections import defaultdict
 from time import time
 
-from kafka import KafkaAdminClient
+from kafka import KafkaAdminClient, KafkaClient
 from kafka import errors as kafka_errors
-from kafka.client_async import KafkaClient
 from kafka.protocol.offset import OffsetRequest, OffsetResetStrategy, OffsetResponse
 from kafka.structs import TopicPartition
 from six import string_types

--- a/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from time import time
 
 from kafka import errors as kafka_errors
-from kafka.client_async import KafkaClient
+from kafka import KafkaClient
 from kafka.protocol.commit import GroupCoordinatorRequest, OffsetFetchRequest
 from kafka.protocol.offset import OffsetRequest, OffsetResetStrategy, OffsetResponse
 from kazoo.client import KazooClient

--- a/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
@@ -6,8 +6,8 @@ from __future__ import division
 from collections import defaultdict
 from time import time
 
-from kafka import errors as kafka_errors
 from kafka import KafkaClient
+from kafka import errors as kafka_errors
 from kafka.protocol.commit import GroupCoordinatorRequest, OffsetFetchRequest
 from kafka.protocol.offset import OffsetRequest, OffsetResetStrategy, OffsetResponse
 from kazoo.client import KazooClient


### PR DESCRIPTION
Now that `kafka-python` 2.0 shipped, you can directly import the async client via the top level.
