### PR TITLE
Update public title

### DIFF
--- a/ecs_fargate/manifest.json
+++ b/ecs_fargate/manifest.json
@@ -13,7 +13,7 @@
   "metric_prefix": "ecs.",
   "metric_to_check": "ecs.fargate.cpu.user",
   "name": "ecs_fargate",
-  "public_title": "Datadog-ECS Fargate Integration",
+  "public_title": "Datadog-Amazon Fargate Integration",
   "short_description": "Track metrics for containers running with ECS Fargate",
   "support": "core",
   "supported_os": [


### PR DESCRIPTION
ecs_fargate's public facing name (on tile and dashboards) is Amazon fargate. Updating the public title as well. Updating for consistency.
