### PR TITLE
Refactor root initialization to common utils

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
@@ -1,14 +1,12 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import os
-
 import click
 
-from .utils import initialize_root
 from .commands import ALL_COMMANDS
 from .commands.console import CONTEXT_SETTINGS, echo_success, echo_waiting, echo_warning, set_color, set_debug
 from .config import CONFIG_FILE, config_file_exists, load_config, restore_config
+from .utils import initialize_root
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
@@ -44,12 +44,13 @@ def ddev(ctx, core, extras, agent, here, color, quiet, debug):
     config = load_config()
 
     msg = initialize_root(config, agent, core, extras, here)
-    if msg and not quiet:
-        echo_warning(msg)
+    if not quiet:
+        if msg:
+            echo_warning(msg)
 
-    if debug and not quiet:
-        set_debug()
-        echo_debug(f'Root directory set to: {get_root()}')
+        if debug:
+            set_debug()
+            echo_debug(f'Root directory set to: {get_root()}')
 
     if color is not None:
         config['color'] = color

--- a/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
@@ -4,8 +4,17 @@
 import click
 
 from .commands import ALL_COMMANDS
-from .commands.console import CONTEXT_SETTINGS, echo_success, echo_waiting, echo_warning, set_color, set_debug
+from .commands.console import (
+    CONTEXT_SETTINGS,
+    echo_debug,
+    echo_success,
+    echo_waiting,
+    echo_warning,
+    set_color,
+    set_debug,
+)
 from .config import CONFIG_FILE, config_file_exists, load_config, restore_config
+from .constants import get_root
 from .utils import initialize_root
 
 
@@ -38,12 +47,13 @@ def ddev(ctx, core, extras, agent, here, color, quiet, debug):
     if msg and not quiet:
         echo_warning(msg)
 
+    if debug and not quiet:
+        set_debug()
+        echo_debug(f'Root directory set to: {get_root()}')
+
     if color is not None:
         config['color'] = color
     set_color(config['color'])
-
-    if debug and not quiet:
-        set_debug()
 
     # https://click.palletsprojects.com/en/7.x/api/#click.Context.obj
     ctx.obj = config

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -63,24 +63,22 @@ def string_to_toml_type(s):
 
 
 def check_root():
-    """Check if root has already been set.  Return None if not, a string if yes."""
-    message = ''
+    """Check if root has already been set."""
     existing_root = get_root()
     if existing_root:
-        return message
+        return True
 
     root = os.getenv('DDEV_ROOT', '')
     if root and os.path.isdir(root):
-        message = f'Using root from `DDEV_ROOT` env variable: {root}'
         set_root(root)
-        return message
-    return None
+        return True
+    return False
 
 
 def initialize_root(config, agent=False, core=False, extras=False, here=False):
-    msg = check_root()
-    if msg is not None:
-        return msg if msg else None
+    """Initialize root directory based on config and options"""
+    if check_root():
+        return
 
     repo_choice = 'core' if core else 'extras' if extras else 'agent' if agent else config.get('repo', 'core')
     config['repo_choice'] = repo_choice
@@ -101,8 +99,7 @@ def initialize_root(config, agent=False, core=False, extras=False, here=False):
 
 def complete_set_root(args):
     """Set the root directory within the context of a cli completion operation."""
-    msg = check_root()
-    if msg is not None:
+    if check_root():
         return
 
     config = load_config()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -9,9 +9,9 @@ from ast import literal_eval
 import requests
 import semver
 
-from ..utils import file_exists, read_file, write_file
+from ..utils import dir_exists, file_exists, read_file, write_file
 from .config import load_config
-from .constants import NOT_CHECKS, REPO_OPTIONS_MAP, VERSION_BUMP, get_root, set_root
+from .constants import NOT_CHECKS, REPO_CHOICES, REPO_OPTIONS_MAP, VERSION_BUMP, get_root, set_root
 from .git import get_latest_tag
 
 # match integration's version within the __about__.py module
@@ -62,31 +62,53 @@ def string_to_toml_type(s):
     return s
 
 
-def complete_set_root(args):
-    """Set the root directory within the context of a cli completion operation."""
-
+def check_root():
+    """Check if root has already been set.  Return None if not, a string if yes."""
+    message = ''
     existing_root = get_root()
     if existing_root:
-        return
+        return message
 
     root = os.getenv('DDEV_ROOT', '')
     if root and os.path.isdir(root):
+        message = f'Using root from `DDEV_ROOT` env variable: {root}'
         set_root(root)
-        return
+        return message
+    return None
 
-    config = load_config()
-    for arg in args:
-        if arg in REPO_OPTIONS_MAP:
-            repo_choice = REPO_OPTIONS_MAP[arg]
-            break
-    else:
-        repo_choice = config.get('repo', 'core')
 
+def initialize_root(config, agent=False, core=False, extras=False, here=False):
+    msg = check_root()
+    if msg is not None:
+        return msg if msg else None
+
+    repo_choice = 'core' if core else 'extras' if extras else 'agent' if agent else config.get('repo', 'core')
+    config['repo_choice'] = repo_choice
+    config['repo_name'] = REPO_CHOICES[repo_choice]
+
+    message = None
     root = os.path.expanduser(config.get(repo_choice, ''))
-    if repo_choice == 'here' or not os.path.exists(root):
+    if here or not dir_exists(root):
+        if not here:
+            repo = 'datadog-agent' if repo_choice == 'agent' else f'integrations-{repo_choice}'
+            message = f'`{repo}` directory `{root}` does not exist, defaulting to the current location.'
+
         root = os.getcwd()
 
     set_root(root)
+    return message
+
+
+def complete_set_root(args):
+    """Set the root directory within the context of a cli completion operation."""
+    msg = check_root()
+    if msg is not None:
+        return
+
+    config = load_config()
+
+    kwargs = {REPO_OPTIONS_MAP[arg]: True for arg in args if arg in REPO_OPTIONS_MAP}
+    initialize_root(config, **kwargs)
 
 
 def complete_testable_checks(ctx, args, incomplete):

--- a/datadog_checks_dev/tests/tooling/test_utils.py
+++ b/datadog_checks_dev/tests/tooling/test_utils.py
@@ -2,10 +2,16 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+
 import mock
 
-from datadog_checks.dev.tooling.utils import get_version_string, parse_agent_req_file, initialize_root, complete_set_root
 from datadog_checks.dev.tooling.config import copy_default_config
+from datadog_checks.dev.tooling.utils import (
+    complete_set_root,
+    get_version_string,
+    initialize_root,
+    parse_agent_req_file,
+)
 
 
 def test_parse_agent_req_file():
@@ -105,4 +111,3 @@ def test_complete_set_root_extras(set_root, get_root):
         complete_set_root(args)
         assert set_root.called
         set_root.assert_called_with(config['extras'])
-

--- a/datadog_checks_dev/tests/tooling/test_utils.py
+++ b/datadog_checks_dev/tests/tooling/test_utils.py
@@ -12,7 +12,8 @@ from datadog_checks.dev.tooling.utils import (
     initialize_root,
     parse_agent_req_file,
 )
-from datadog_checks.utils.platform import Platform
+
+from ..common import not_windows_ci
 
 
 def test_parse_agent_req_file():
@@ -54,12 +55,13 @@ def test_initialize_root_good_path(set_root, get_root):
     set_root.assert_called_with(os.path.expanduser('~'))
 
 
+@not_windows_ci
 @mock.patch('datadog_checks.dev.tooling.utils.get_root')
 @mock.patch('datadog_checks.dev.tooling.utils.set_root')
 def test_initialize_root_env_var(set_root, get_root):
     get_root.return_value = ''
 
-    ddev_env = '%temp%' if Platform.is_windows() else '/tmp'
+    ddev_env = '/tmp'
     with mock.patch.dict(os.environ, {'DDEV_ROOT': ddev_env}):
         config = copy_default_config()
         initialize_root(config)
@@ -67,6 +69,7 @@ def test_initialize_root_env_var(set_root, get_root):
         set_root.assert_called_with(os.path.expanduser(ddev_env))
 
 
+@not_windows_ci
 @mock.patch('datadog_checks.dev.tooling.utils.get_root')
 @mock.patch('datadog_checks.dev.tooling.utils.set_root')
 def test_complete_set_root_no_args(set_root, get_root):
@@ -74,7 +77,7 @@ def test_complete_set_root_no_args(set_root, get_root):
 
     with mock.patch('datadog_checks.dev.tooling.utils.load_config') as load_config:
         config = copy_default_config()
-        config['core'] = '%temp%' if Platform.is_windows() else '/tmp'
+        config['core'] = '/tmp'  # ensure we choose a dir that exists
         load_config.return_value = config
 
         args = []
@@ -98,6 +101,7 @@ def test_complete_set_root_here(set_root, get_root):
         set_root.assert_called_with(os.getcwd())
 
 
+@not_windows_ci
 @mock.patch('datadog_checks.dev.tooling.utils.get_root')
 @mock.patch('datadog_checks.dev.tooling.utils.set_root')
 def test_complete_set_root_extras(set_root, get_root):
@@ -105,7 +109,7 @@ def test_complete_set_root_extras(set_root, get_root):
 
     with mock.patch('datadog_checks.dev.tooling.utils.load_config') as load_config:
         config = copy_default_config()
-        config['extras'] = '%temp%' if Platform.is_windows() else '/tmp'
+        config['extras'] = '/tmp'  # ensure we choose a dir that exists
         load_config.return_value = config
 
         args = ['-e']

--- a/datadog_checks_dev/tests/tooling/test_utils.py
+++ b/datadog_checks_dev/tests/tooling/test_utils.py
@@ -12,6 +12,7 @@ from datadog_checks.dev.tooling.utils import (
     initialize_root,
     parse_agent_req_file,
 )
+from datadog_checks.utils.platform import Platform
 
 
 def test_parse_agent_req_file():
@@ -58,7 +59,7 @@ def test_initialize_root_good_path(set_root, get_root):
 def test_initialize_root_env_var(set_root, get_root):
     get_root.return_value = ''
 
-    ddev_env = '/tmp'
+    ddev_env = '%temp%' if Platform.is_windows() else '/tmp'
     with mock.patch.dict(os.environ, {'DDEV_ROOT': ddev_env}):
         config = copy_default_config()
         initialize_root(config)
@@ -73,7 +74,7 @@ def test_complete_set_root_no_args(set_root, get_root):
 
     with mock.patch('datadog_checks.dev.tooling.utils.load_config') as load_config:
         config = copy_default_config()
-        config['core'] = '/tmp'  # ensure we choose a dir that exists
+        config['core'] = '%temp%' if Platform.is_windows() else '/tmp'
         load_config.return_value = config
 
         args = []
@@ -104,7 +105,7 @@ def test_complete_set_root_extras(set_root, get_root):
 
     with mock.patch('datadog_checks.dev.tooling.utils.load_config') as load_config:
         config = copy_default_config()
-        config['extras'] = '/tmp'  # ensure we choose a dir that exists
+        config['extras'] = '%temp%' if Platform.is_windows() else '/tmp'
         load_config.return_value = config
 
         args = ['-e']

--- a/datadog_checks_dev/tests/tooling/test_utils.py
+++ b/datadog_checks_dev/tests/tooling/test_utils.py
@@ -1,9 +1,11 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import os
 import mock
 
-from datadog_checks.dev.tooling.utils import get_version_string, parse_agent_req_file
+from datadog_checks.dev.tooling.utils import get_version_string, parse_agent_req_file, initialize_root, complete_set_root
+from datadog_checks.dev.tooling.config import copy_default_config
 
 
 def test_parse_agent_req_file():
@@ -17,3 +19,90 @@ def test_get_version_string():
     with mock.patch('datadog_checks.dev.tooling.utils.read_version_file') as read:
         read.return_value = '__version__ = "2.0.0"'
         assert get_version_string('foo_check') == '2.0.0'
+
+
+@mock.patch('datadog_checks.dev.tooling.utils.get_root')
+@mock.patch('datadog_checks.dev.tooling.utils.set_root')
+def test_initialize_root_bad_path(set_root, get_root):
+    get_root.return_value = ''
+
+    # bad path in config results in cwd
+    config = copy_default_config()
+    config['core'] = '/path/does/not/exist'
+    initialize_root(config)
+    assert set_root.called
+    set_root.assert_called_with(os.getcwd())
+
+
+@mock.patch('datadog_checks.dev.tooling.utils.get_root')
+@mock.patch('datadog_checks.dev.tooling.utils.set_root')
+def test_initialize_root_good_path(set_root, get_root):
+    get_root.return_value = ''
+
+    # good path in config uses that
+    config = copy_default_config()
+    config['core'] = '~'
+    initialize_root(config)
+    assert set_root.called
+    set_root.assert_called_with(os.path.expanduser('~'))
+
+
+@mock.patch('datadog_checks.dev.tooling.utils.get_root')
+@mock.patch('datadog_checks.dev.tooling.utils.set_root')
+def test_initialize_root_env_var(set_root, get_root):
+    get_root.return_value = ''
+
+    ddev_env = '/tmp'
+    with mock.patch.dict(os.environ, {'DDEV_ROOT': ddev_env}):
+        config = copy_default_config()
+        initialize_root(config)
+        assert set_root.called
+        set_root.assert_called_with(os.path.expanduser(ddev_env))
+
+
+@mock.patch('datadog_checks.dev.tooling.utils.get_root')
+@mock.patch('datadog_checks.dev.tooling.utils.set_root')
+def test_complete_set_root_no_args(set_root, get_root):
+    get_root.return_value = ''
+
+    with mock.patch('datadog_checks.dev.tooling.utils.load_config') as load_config:
+        config = copy_default_config()
+        config['core'] = '/tmp'  # ensure we choose a dir that exists
+        load_config.return_value = config
+
+        args = []
+        complete_set_root(args)
+        assert set_root.called
+        set_root.assert_called_with(config['core'])
+
+
+@mock.patch('datadog_checks.dev.tooling.utils.get_root')
+@mock.patch('datadog_checks.dev.tooling.utils.set_root')
+def test_complete_set_root_here(set_root, get_root):
+    get_root.return_value = ''
+
+    with mock.patch('datadog_checks.dev.tooling.utils.load_config') as load_config:
+        config = copy_default_config()
+        load_config.return_value = config
+
+        args = ['-x']
+        complete_set_root(args)
+        assert set_root.called
+        set_root.assert_called_with(os.getcwd())
+
+
+@mock.patch('datadog_checks.dev.tooling.utils.get_root')
+@mock.patch('datadog_checks.dev.tooling.utils.set_root')
+def test_complete_set_root_extras(set_root, get_root):
+    get_root.return_value = ''
+
+    with mock.patch('datadog_checks.dev.tooling.utils.load_config') as load_config:
+        config = copy_default_config()
+        config['extras'] = '/tmp'  # ensure we choose a dir that exists
+        load_config.return_value = config
+
+        args = ['-e']
+        complete_set_root(args)
+        assert set_root.called
+        set_root.assert_called_with(config['extras'])
+


### PR DESCRIPTION
Following on the addition of tab-completion and tab-completion fixes, this PR refactors the method for determining the repository root directory to reduce duplication.

Plus it adds some tests.