### PR TITLE
Remove message about beta in SNMP docs 

### DIFF
--- a/snmp/README.md
+++ b/snmp/README.md
@@ -19,10 +19,6 @@ The SNMP check is included in the [Datadog Agent][1] package. No additional inst
 
 ### Configuration
 
-<div class="alert alert-warning">
-<b>Note</b>: The following features are in beta.
-</div>
-
 The Datadog SNMP check auto-discovers network devices on a provided subnet, and collects metrics using Datadog's sysOID mapped device profiles.
 
 Edit the subnet, SNMP version, and profiles in the `snmp.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample snmp.d/conf.yaml][3] for all available configuration options.


### PR DESCRIPTION
### What does this PR do?
Removes the message about the SNMP beta in the docs 

### Motivation
This isn't to say that the integration isn't in beta anymore (it is) we just don't want to highlight the word beta anywhere

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
