### PR TITLE
Add type checking to integration check template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/{check_name}.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/{check_name}.py
@@ -1,6 +1,9 @@
-{license_header}from datadog_checks.base import AgentCheck
+{license_header}from typing import Any, Dict
+
+from datadog_checks.base import AgentCheck
 
 
 class {check_class}(AgentCheck):
     def check(self, instance):
+        # type: (Dict[str, Any]) -> None
         pass

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/tests/test_{check_name}.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/tests/test_{check_name}.py
@@ -1,7 +1,11 @@
-{license_header}from datadog_checks.{check_name} import {check_class}
+{license_header}from typing import Any, Dict
+
+from datadog_checks.base.stubs.aggregator import AggregatorStub
+from datadog_checks.{check_name} import {check_class}
 
 
 def test_check(aggregator, instance):
+    # type: (AggregatorStub, Dict[str, Any]) -> None
     check = {check_class}('{check_name}', {{}}, {{}})
     check.check(instance)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/tox.ini
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/tox.ini
@@ -7,6 +7,8 @@ envlist =
 
 [testenv]
 dd_check_style = true
+dd_check_types = true
+dd_mypy_args = --py2 datadog_checks/ tests/
 usedevelop = true
 platform = linux|darwin|win32
 deps =

--- a/datadog_checks_dev/tests/tooling/commands/test_create.py
+++ b/datadog_checks_dev/tests/tooling/commands/test_create.py
@@ -17,7 +17,7 @@ def test_new_check_test():
 
     try:
         run_command(
-            [sys.executable, '-m', 'datadog_checks.dev', 'create', '-q', '-l', CORE_ROOT, 'my-check'],
+            [sys.executable, '-m', 'datadog_checks.dev', 'create', '-q', '-l', CORE_ROOT, 'My Check'],
             capture=True,
             check=True,
         )
@@ -30,6 +30,22 @@ def test_new_check_test():
             with EnvVars(ignore=ignored_env_vars):
                 run_command([sys.executable, '-m', 'pytest'], capture=True, check=True)
 
-        run_command([sys.executable, '-m', 'pip', 'uninstall', '-y', 'my-check'], capture=True, check=True)
+        # We only run style checks on the generated integration. Running the entire test suite would result in tox
+        # creating Python environments, which would be too slow with little benefits.
+        result = run_command(
+            [sys.executable, '-m', 'datadog_checks.dev', 'test', '-s', 'my_check'], capture=True, check=True
+        )
+        # `ddev test` will not fail if the provided check name doesn't correspond to an existing integration.
+        # Instead, it will log a message. So we test for that message to verify style checks ran at all.
+        assert 'Nothing to test!' not in result.stdout
+
+        result = run_command(
+            [sys.executable, '-m', 'pip', 'uninstall', '-y', 'datadog-my-check'], capture=True, check=True
+        )
+        # `pip uninstall` is idempotent, so it will not fail if `check_package_name` is incorrect (i.e. the package
+        # could not be found). Instead, it will log a warning, so we test for that warning to verify the package was
+        # successfully uninstalled.
+        # See: https://github.com/pypa/pip/issues/3016
+        assert 'WARNING: Skipping' not in result.stdout
     finally:
         remove_path(check_path)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update the `check` integration template:

- Enable `mypy` type checking all the code (integration code *and* tests).
- Add type annotations to Python code generated by the template. (Will make us *think* about using type hints when writing the integration.)
- Update the check creation test:
  - Fix outdated tested values (several commands ran were actually failing with warnings, although returning with exit code 0).
  - Run style checks on the generated package.

### Motivation
<!-- What inspired you to submit this pull request? -->
Less friction to use type hints for new integrations. :-)

(I was frustrated that I had to set these things up for RethinkDB.)

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Although this is ran as part of the test suite, you can try this out manually using:

```bash
$ ddev create RethinkDB --type check
$ ddev test rethinkdb
# Runs tests, style checks, and mypy checks successfully.
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
