### PR TITLE
Run lab when TEST_VSPHERE_USE_LAB is set

### DIFF
--- a/vsphere/tests/test_lab.py
+++ b/vsphere/tests/test_lab.py
@@ -5,6 +5,7 @@ import os
 
 import pytest
 
+from datadog_checks.base import is_affirmative
 from datadog_checks.vsphere import VSphereCheck
 
 from .common import HERE
@@ -21,12 +22,12 @@ def test_lab(aggregator):
 
     Example usage:
     $ export TEST_VSPHERE_USER='XXXXX' TEST_VSPHERE_PASS='XXXXX'
-    $ TEST_VSPHERE_USE_LAB=1 ddev test vsphere:py38 -k test_lab
+    $ TEST_VSPHERE_RUN_LAB=true ddev test vsphere:py38 -k test_lab
 
     """
-    if not os.environ.get('TEST_VSPHERE_USE_LAB'):
+    if not is_affirmative(os.environ.get('TEST_VSPHERE_RUN_LAB')):
         pytest.skip(
-            "Skipped! Set TEST_VSPHERE_USE_LAB to run this test. "
+            "Skipped! Set TEST_VSPHERE_RUN_LAB to run this test. "
             "TEST_VSPHERE_USER and TEST_VSPHERE_PASS must also be set."
         )
     username = os.environ['TEST_VSPHERE_USER']

--- a/vsphere/tests/test_lab.py
+++ b/vsphere/tests/test_lab.py
@@ -21,13 +21,16 @@ def test_lab(aggregator):
 
     Example usage:
     $ export TEST_VSPHERE_USER='XXXXX' TEST_VSPHERE_PASS='XXXXX'
-    $ ddev test vsphere:py37 -k test_lab
+    $ TEST_VSPHERE_USE_LAB=1 ddev test vsphere:py38 -k test_lab
 
     """
-    username = os.environ.get('TEST_VSPHERE_USER')
-    password = os.environ.get('TEST_VSPHERE_PASS')
-    if not username or not password:
-        pytest.skip("Skipped! TEST_VSPHERE_USER and TEST_VSPHERE_PASS are needed to run this test")
+    if not os.environ.get('TEST_VSPHERE_USE_LAB'):
+        pytest.skip(
+            "Skipped! Set TEST_VSPHERE_USE_LAB to run this test. "
+            "TEST_VSPHERE_USER and TEST_VSPHERE_PASS must also be set."
+        )
+    username = os.environ['TEST_VSPHERE_USER']
+    password = os.environ['TEST_VSPHERE_PASS']
     instance = {
         'host': 'aws.vcenter.localdomain',
         'username': username,


### PR DESCRIPTION
### What does this PR do?

Run lab when TEST_VSPHERE_USE_LAB is set, that way, you can keep `TEST_VSPHERE_USER` and `TEST_VSPHERE_PASSWORD` set all the time in your envs.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
