### PR TITLE
Switch to Python 3.8 in check integration template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/tox.ini
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 skip_missing_interpreters = true
-basepython = py37
+basepython = py38
 envlist =
-    py{{27,37}}
+    py{{27,38}}
 
 [testenv]
 dd_check_style = true


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update the `check` template so that it uses Python 3.8 for Tox environments, instead of Python 3.7.

### Motivation
<!-- What inspired you to submit this pull request? -->
We shouldn't be using Python 3.7 anymore, because we moved to 3.8. See: #5626.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Discovered while working on #5715.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
