### PR TITLE
Switch to Agent 6+ signature in check integration test

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/tests/test_{check_name}.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/tests/test_{check_name}.py
@@ -6,7 +6,7 @@ from datadog_checks.{check_name} import {check_class}
 
 def test_check(aggregator, instance):
     # type: (AggregatorStub, Dict[str, Any]) -> None
-    check = {check_class}('{check_name}', {{}}, {{}})
+    check = {check_class}('{check_name}', {{}}, [instance])
     check.check(instance)
 
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The `check` template was generating a test using the legacy `MyCheck(name, init_config, agentConfig)` signature (A5). Or maybe this was a typo. In any case, this PR updates the test template to use the proper A6/A7 signature.

### Motivation
<!-- What inspired you to submit this pull request? -->
Encourage usage of up-to-date signature for new integrations.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Discovered while working on #5715. Refs #5573.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
