### PR TITLE
Fix validate metadata command to catch correct number of rows

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -229,7 +229,7 @@ def metadata(check):
             reader._fieldnames = reader.fieldnames
 
             for line, row in enumerate(reader, 2):
-                # determine if number of rows is complete by checking for None values (We can't check the number of columns because DictReader populates missing columns with None https://docs.python.org/3.4/library/csv.html#csv.DictReader) #noqa
+                # determine if number of columns is complete by checking for None values (DictReader populates missing columns with None https://docs.python.org/3.4/library/csv.html#csv.DictReader) #noqa
                 if None in row.values():
                     errors = True
                     echo_failure(f"{current_check}:{line} {row['metric_name']} Has the wrong amount of columns")

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -229,8 +229,8 @@ def metadata(check):
             reader._fieldnames = reader.fieldnames
 
             for line, row in enumerate(reader, 2):
-                # Number of rows is correct. Since metric is first in the list, should be safe to access
-                if len(row) != len(ALL_HEADERS):
+                # determine if number of rows is complete by checking for None values (We can't check the number of columns because DictReader populates missing columns with None https://docs.python.org/3.4/library/csv.html#csv.DictReader) #noqa
+                if None in row.values():
                     errors = True
                     echo_failure(f"{current_check}:{line} {row['metric_name']} Has the wrong amount of columns")
                     continue

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -229,7 +229,7 @@ def metadata(check):
             reader._fieldnames = reader.fieldnames
 
             for line, row in enumerate(reader, 2):
-                # determine if number of columns is complete by checking for None values (DictReader populates missing columns with None https://docs.python.org/3.8/library/csv.html#csv.DictReader) #noqa
+                # determine if number of columns is complete by checking for None values (DictReader populates missing columns with None https://docs.python.org/3.8/library/csv.html#csv.DictReader) # noqa
                 if None in row.values():
                     errors = True
                     echo_failure(f"{current_check}:{line} {row['metric_name']} Has the wrong amount of columns")

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -229,7 +229,7 @@ def metadata(check):
             reader._fieldnames = reader.fieldnames
 
             for line, row in enumerate(reader, 2):
-                # determine if number of columns is complete by checking for None values (DictReader populates missing columns with None https://docs.python.org/3.4/library/csv.html#csv.DictReader) #noqa
+                # determine if number of columns is complete by checking for None values (DictReader populates missing columns with None https://docs.python.org/3.8/library/csv.html#csv.DictReader) #noqa
                 if None in row.values():
                     errors = True
                     echo_failure(f"{current_check}:{line} {row['metric_name']} Has the wrong amount of columns")


### PR DESCRIPTION
### What does this PR do?
Validate metadata didn't properly check whether a metric row had the correct number of columns, which caused the check to not flag some errors. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
