### PR TITLE
[docs] Containerized value for PHP-FPM docs

### DIFF
--- a/php_fpm/README.md
+++ b/php_fpm/README.md
@@ -66,7 +66,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 
 | Parameter            | Value                                                                                                                    |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `<INTEGRATION_NAME>` | `php-fpm`                                                                                                                |
+| `<INTEGRATION_NAME>` | `php_fpm`                                                                                                                |
 | `<INIT_CONFIG>`      | blank or `{}`                                                                                                            |
 | `<INSTANCE_CONFIG>`  | `{"status_url":"http://%%host%%/status", "ping_url":"http://%%host%%/ping", "use_fastcgi": false, "ping_reply": "pong"}` |
 


### PR DESCRIPTION
### What does this PR do?
Corrects php-fpm to php_fpm as the old value is giving users errors.

### Motivation
[Urgent Docs request](https://datadoghq.atlassian.net/browse/DOCS-666)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
