### PR TITLE
Re-enable `kafka_client_api_version` option

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -127,10 +127,7 @@ class KafkaCheck(AgentCheck):
             bootstrap_servers=kafka_connect_str,
             client_id='dd-agent',
             request_timeout_ms=self.init_config.get('kafka_timeout', DEFAULT_KAFKA_TIMEOUT) * 1000,
-            # There is a bug with kafka-python where pinning api_version for KafkaAdminClient raises an
-            # `IncompatibleBrokerVersion`. Change to `api_version=api_version` once fixed upstream.
-            # See linked issues in PR: https://github.com/dpkp/kafka-python/pull/1953
-            api_version=None,
+            api_version=api_version,
             # While we check for SASL/SSL params, if not present they will default to the kafka-python values for
             # plaintext connections
             security_protocol=self.instance.get('security_protocol', 'PLAINTEXT'),


### PR DESCRIPTION
### What does this PR do?
Re-enables `kafka_client_api_version` to pin the version.

### Motivation
bug is now fixed upstream in [kafka-python 2.0.0](https://github.com/dpkp/kafka-python/releases/tag/2.0.0)

### Additional Notes
- https://github.com/dpkp/kafka-python/pull/1953
- https://github.com/dpkp/kafka-python/releases/tag/2.0.0

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
