### PR TITLE
Capture python warnings as logs

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -50,8 +50,6 @@ if datadog_agent.get_config('disable_unsafe_yaml'):
 
     monkey_patch_pyyaml()
 
-# Let's capture warnings as logs so it's easier for log parser to handle them.
-logging.captureWarnings(True)
 
 # Metric types for which it's only useful to submit once per set of tags
 ONE_PER_CONTEXT_METRIC_TYPES = [aggregator.GAUGE, aggregator.RATE, aggregator.MONOTONIC_COUNT]

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -50,6 +50,8 @@ if datadog_agent.get_config('disable_unsafe_yaml'):
 
     monkey_patch_pyyaml()
 
+# Let's capture warnings as logs so it's easier for log parser to handle them.
+logging.captureWarnings(True)
 
 # Metric types for which it's only useful to submit once per set of tags
 ONE_PER_CONTEXT_METRIC_TYPES = [aggregator.GAUGE, aggregator.RATE, aggregator.MONOTONIC_COUNT]

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -104,6 +104,8 @@ def init_logging():
     # Forward to Go backend
     logging.addLevelName(TRACE_LEVEL, 'TRACE')
     logging.setLoggerClass(AgentLogger)
+    logging.captureWarnings(True)  # Capture warnings as logs so it's easier for log parsers to handle them.
+
     rootLogger = logging.getLogger()
     rootLogger.addHandler(AgentLogHandler())
     rootLogger.setLevel(_get_py_loglevel(datadog_agent.get_config('log_level')))

--- a/datadog_checks_base/tests/test_log.py
+++ b/datadog_checks_base/tests/test_log.py
@@ -25,14 +25,14 @@ def test_get_py_loglevel():
 
 def test_logging_capture_warnings():
 
-    with mock.patch('logging.Logger.warning') as warning:
+    with mock.patch('logging.Logger.warning') as log_warning:
         warnings.warn("hello-world")
 
-        warning.assert_not_called()  # warnings are NOT yet captured
+        log_warning.assert_not_called()  # warnings are NOT yet captured
 
         init_logging()  # from here warnings are captured as logs
 
         warnings.warn("hello-world")
-        assert warning.call_count == 1
-        msg = warning.mock_calls[0].args[1]
+        assert log_warning.call_count == 1
+        msg = log_warning.mock_calls[0].args[1]
         assert "hello-world" in msg

--- a/datadog_checks_base/tests/test_log.py
+++ b/datadog_checks_base/tests/test_log.py
@@ -4,8 +4,12 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
+import warnings
+
+import mock
 
 from datadog_checks import log
+from datadog_checks.base.log import init_logging
 
 
 def test_get_py_loglevel():
@@ -17,3 +21,18 @@ def test_get_py_loglevel():
     assert log._get_py_loglevel(u'crit') == logging.CRITICAL
     # check string works
     assert log._get_py_loglevel('crit') == logging.CRITICAL
+
+
+def test_logging_capture_warnings():
+
+    with mock.patch('logging.Logger.warning') as warning:
+        warnings.warn("hello-world")
+
+        warning.assert_not_called()  # warnings are NOT yet captured
+
+        init_logging()  # from here warnings are captured as logs
+
+        warnings.warn("hello-world")
+        assert warning.call_count == 1
+        msg = warning.mock_calls[0].args[1]
+        assert "hello-world" in msg


### PR DESCRIPTION
### What does this PR do?

#### Option 1: Capture python warnings as logs (SELECTED)

Just use `logging.captureWarnings(True)`

#### Option 2: Capture python warning as `AgentCheck.warning()`, so that they are visible in Datadog UI.

Would require patching warning similar to what logging does: https://github.com/python/cpython/blob/master/Lib/logging/__init__.py#L2175-L2207

This is more in line with:

> Warning messages are typically issued in situations where it is useful to alert the user of some condition in a program, where that condition (normally) doesn’t warrant raising an exception and terminating the program. For example, one might want to issue a warning when a program uses an obsolete module.
https://docs.python.org/3/library/warnings.html

### Motivation

Python warnings are printed to stdout which make then hard to parse for logs integration.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
