### PR TITLE
Add tag_prefix argument to the changelog command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -40,7 +40,7 @@ def changelog(ctx, check, version, old_version, initial, quiet, dry_run, output_
 
     # sanity check on the version provided
     cur_version = old_version or get_version_string(check, tag_prefix=tag_prefix)
-    if parse_version_info(version.lstrip(tag_prefix)) <= parse_version_info(cur_version.lstrip(tag_prefix)):
+    if parse_version_info(version.replace(tag_prefix, '', 1)) <= parse_version_info(cur_version.replace(tag_prefix, '', 1)):
         abort(f'Current version is {cur_version}, cannot bump to {version}')
 
     if not quiet:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -28,8 +28,9 @@ ChangelogEntry = namedtuple('ChangelogEntry', 'number, title, url, author, autho
 @click.option('--quiet', '-q', is_flag=True)
 @click.option('--dry-run', '-n', is_flag=True)
 @click.option('--output-file', '-o', default='CHANGELOG.md', show_default=True)
+@click.option('--tag-prefix', '-tp', default='v', show_default=True)
 @click.pass_context
-def changelog(ctx, check, version, old_version, initial, quiet, dry_run, output_file):
+def changelog(ctx, check, version, old_version, initial, quiet, dry_run, output_file, tag_prefix):
     """Perform the operations needed to update the changelog.
 
     This method is supposed to be used by other tasks and not directly.
@@ -38,8 +39,8 @@ def changelog(ctx, check, version, old_version, initial, quiet, dry_run, output_
         abort(f'Check `{check}` is not an Agent-based Integration')
 
     # sanity check on the version provided
-    cur_version = old_version or get_version_string(check)
-    if parse_version_info(version.lstrip('v')) <= parse_version_info(cur_version.lstrip('v')):
+    cur_version = old_version or get_version_string(check, tag_prefix=tag_prefix)
+    if parse_version_info(version.lstrip(tag_prefix)) <= parse_version_info(cur_version.lstrip(tag_prefix)):
         abort(f'Current version is {cur_version}, cannot bump to {version}')
 
     if not quiet:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -40,7 +40,9 @@ def changelog(ctx, check, version, old_version, initial, quiet, dry_run, output_
 
     # sanity check on the version provided
     cur_version = old_version or get_version_string(check, tag_prefix=tag_prefix)
-    if parse_version_info(version.replace(tag_prefix, '', 1)) <= parse_version_info(cur_version.replace(tag_prefix, '', 1)):
+    if parse_version_info(version.replace(tag_prefix, '', 1)) <= parse_version_info(
+        cur_version.replace(tag_prefix, '', 1)
+    ):
         abort(f'Current version is {cur_version}, cannot bump to {version}')
 
     if not quiet:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -127,7 +127,7 @@ def get_latest_tag(pattern=None, tag_prefix='v'):
     Removes prefixed `v` if applicable
     """
     all_tags = sorted(
-        (parse_version_info(t.lstrip(tag_prefix)), t) for t in git_tag_list(rf'^({tag_prefix})?\d+\.\d+\.\d+$')
+        (parse_version_info(t.replace(tag_prefix, '', 1)), t) for t in git_tag_list(rf'^({tag_prefix})?\d+\.\d+\.\d+$')
     )
     # reverse so we have descendant order
     return list(reversed(all_tags))[0][1]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -120,14 +120,15 @@ def git_tag_list(pattern=None):
     return list(filter(regex.search, result))
 
 
-def get_latest_tag(pattern=None):
+def get_latest_tag(pattern=None, tag_prefix='v'):
     """
     Return the highest numbered tag (most recent)
     Filters on pattern first, otherwise based off all tags
     Removes prefixed `v` if applicable
     """
-    all_tags = sorted((parse_version_info(t.lstrip('v')), t) for t in git_tag_list(r'^v?\d+\.\d+\.\d+$'))
-
+    all_tags = sorted(
+        (parse_version_info(t.lstrip(tag_prefix)), t) for t in git_tag_list(rf'^{tag_prefix}v?\d+\.\d+\.\d+$')
+    )
     # reverse so we have descendant order
     return list(reversed(all_tags))[0][1]
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -127,7 +127,7 @@ def get_latest_tag(pattern=None, tag_prefix='v'):
     Removes prefixed `v` if applicable
     """
     all_tags = sorted(
-        (parse_version_info(t.lstrip(tag_prefix)), t) for t in git_tag_list(rf'^{tag_prefix}v?\d+\.\d+\.\d+$')
+        (parse_version_info(t.lstrip(tag_prefix)), t) for t in git_tag_list(rf'^({tag_prefix})?\d+\.\d+\.\d+$')
     )
     # reverse so we have descendant order
     return list(reversed(all_tags))[0][1]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -211,7 +211,7 @@ def read_version_file(check_name):
     return read_file(get_version_file(check_name))
 
 
-def get_version_string(check_name):
+def get_version_string(check_name, tag_prefix='v'):
     """
     Get the version string for the given check.
     """
@@ -222,7 +222,7 @@ def get_version_string(check_name):
         if version:
             return version.group(1)
     else:
-        return get_latest_tag()
+        return get_latest_tag(tag_prefix=tag_prefix)
 
 
 def load_manifest(check_name):


### PR DESCRIPTION
### What does this PR do?

Adds a tag_prefix argument to the changelog ddev command
By default we still strip out `v` but now we allow an arbitrary prefix when searching for git tags

### Motivation
Other repositories may not have their tags prefixed with a `v` but with another arbitrary string before the semver version. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
