### PR TITLE
Handle FeatureNotSupported errors in queries

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -365,7 +365,11 @@ class PostgreSql(AgentCheck):
                 cursor.execute(query.replace(r'%', r'%%'))
 
             results = cursor.fetchall()
-
+        except psycopg2.errors.FeatureNotSupported as e:
+            # This happens for example when trying to get replication metrics
+            # from readers in Aurora. Let's ignote it.
+            log_func(e)
+            return
         except psycopg2.errors.UndefinedFunction as e:
             log_func(e)
             log_func(

--- a/postgres/tests/test_integration.py
+++ b/postgres/tests/test_integration.py
@@ -9,6 +9,7 @@ import pytest
 from semver import VersionInfo
 
 from datadog_checks.postgres import PostgreSql
+from datadog_checks.postgres.util import fmt, PartialFormatter
 
 from .common import DB_NAME, HOST, PORT, POSTGRES_VERSION, check_bgw_metrics, check_common_metrics
 from .utils import requires_over_10
@@ -43,6 +44,36 @@ def test_common_metrics_without_size(aggregator, integration_check, pg_instance)
     check = integration_check(pg_instance)
     check.check(pg_instance)
     assert 'postgresql.database_size' not in aggregator.metric_names
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_unsupported_replication(aggregator, integration_check, pg_instance):
+    check = integration_check(pg_instance)
+
+    unpatched_fmt = PartialFormatter()
+
+    called = []
+
+    def format_with_error(value, **kwargs):
+        if 'pg_is_in_recovery' in value:
+            called.append(True)
+            raise psycopg2.errors.FeatureNotSupported("Not available")
+        return unpatched_fmt.format(value, **kwargs)
+
+    # This simulate an error in the fmt function, as it's a bit hard to mock psycopg
+    with mock.patch.object(fmt, 'format', passthrough=True) as mock_fmt:
+        mock_fmt.side_effect = format_with_error
+        check.check(pg_instance)
+
+    # Verify our mocking was called
+    assert called == [True]
+
+    expected_tags = pg_instance['tags'] + ['server:{}'.format(HOST), 'port:{}'.format(PORT)]
+    check_bgw_metrics(aggregator, expected_tags)
+
+    expected_tags += ['db:{}'.format(DB_NAME)]
+    check_common_metrics(aggregator, expected_tags=expected_tags)
 
 
 @pytest.mark.integration

--- a/postgres/tests/test_integration.py
+++ b/postgres/tests/test_integration.py
@@ -9,7 +9,7 @@ import pytest
 from semver import VersionInfo
 
 from datadog_checks.postgres import PostgreSql
-from datadog_checks.postgres.util import fmt, PartialFormatter
+from datadog_checks.postgres.util import PartialFormatter, fmt
 
 from .common import DB_NAME, HOST, PORT, POSTGRES_VERSION, check_bgw_metrics, check_common_metrics
 from .utils import requires_over_10


### PR DESCRIPTION
In certain scenarios (like aurora replication readers), calling
`pg_last_xlog_receive_location` can result in an unsupported exception.
This is expected, so it shouldn't make the whole check fails, and we
should ignore the error instead.