### PR TITLE
Add option to disable node metrics in rabbitmq

### DIFF
--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -39,8 +39,7 @@ instances:
     # tag_families: false
 
     ## @param collect_node_metrics - boolean - optional - default: true
-    ## Node metrics are collected by default. Disable the collect_node_metrics option to skip node metric collection.
-    ## metrics pertaining to nodes
+    ## Node metrics are collected by default. Setting this parameter to false skips node metric collection.
     #
     # collect_node_metrics: true
 

--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -39,7 +39,7 @@ instances:
     # tag_families: false
 
     ## @param collect_node_metrics - boolean - optional - default: true
-    ## Use the collect_node_metrics paramater if you'd like to collect
+    ## Node metrics are collected by default. Disable the collect_node_metrics option to skip node metric collection.
     ## metrics pertaining to nodes
     #
     # collect_node_metrics: true

--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -38,11 +38,11 @@ instances:
     #
     # tag_families: false
 
-    ## @param disable_node_metrics - boolean - optional - default: false
-    ## Use the disable_node_metrics paramater if you'd like to collect all
-    ## metrics except the ones pertaining to nodes
+    ## @param collect_node_metrics - boolean - optional - default: true
+    ## Use the collect_node_metrics paramater if you'd like to collect
+    ## metrics pertaining to nodes
     #
-    # disable_node_metrics: false
+    # collect_node_metrics: true
 
     ## @param nodes - list of strings - optional
     ## Use the `nodes` parameters to specify the nodes you'd like to

--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -38,6 +38,12 @@ instances:
     #
     # tag_families: false
 
+    ## @param disable_node_metrics - boolean - optional - default: false
+    ## Use the disable_node_metrics paramater if you'd like to collect all
+    ## metrics except the ones pertaining to nodes
+    #
+    # disable_node_metrics: false
+
     ## @param nodes - list of strings - optional
     ## Use the `nodes` parameters to specify the nodes you'd like to
     ## collect metrics on (up to 100 nodes).
@@ -119,7 +125,7 @@ instances:
     # tags:
     #   - <KEY_1>:<VALUE_1>
     #   - <KEY_2>:<VALUE_2>
-    
+
     ## @param username - string - optional
     ## If the API endpoint is behind basic auth, enter here the required username.
     #

--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -229,7 +229,9 @@ class RabbitMQ(AgentCheck):
 
     def check(self, instance):
         self.log.error("Hello")
-        base_url, max_detailed, specified, custom_tags, suppress_warning, disable_node_metrics = self._get_config(instance)
+        base_url, max_detailed, specified, custom_tags, suppress_warning, disable_node_metrics = self._get_config(
+            instance
+        )
         try:
             with warnings.catch_warnings():
                 vhosts = self._get_vhosts(instance, base_url)

--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -159,7 +159,7 @@ class RabbitMQ(AgentCheck):
         if not base_url.endswith('/'):
             base_url += '/'
 
-        collect_nodes = instance.get('collect_node_metrics', True)
+        collect_nodes = is_affirmative(instance.get('collect_node_metrics', True))
         custom_tags = instance.get('tags', [])
         parsed_url = urlparse(base_url)
         if not parsed_url.scheme or "://" not in parsed_url.geturl():

--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -159,7 +159,7 @@ class RabbitMQ(AgentCheck):
         if not base_url.endswith('/'):
             base_url += '/'
 
-        disable_nodes = instance.get('disable_node_metrics')
+        collect_nodes = instance.get('collect_node_metrics', True)
         custom_tags = instance.get('tags', [])
         parsed_url = urlparse(base_url)
         if not parsed_url.scheme or "://" not in parsed_url.geturl():
@@ -200,7 +200,7 @@ class RabbitMQ(AgentCheck):
                 if type(filter_objects) != list:
                     raise TypeError("{0} / {0}_regexes parameter must be a list".format(object_type))
 
-        return base_url, max_detailed, specified, custom_tags, suppress_warning, disable_nodes
+        return base_url, max_detailed, specified, custom_tags, suppress_warning, collect_nodes
 
     def _collect_metadata(self, base_url):
         # Rabbit versions follow semantic versioning https://www.rabbitmq.com/changelog.html
@@ -228,7 +228,7 @@ class RabbitMQ(AgentCheck):
         return vhosts
 
     def check(self, instance):
-        base_url, max_detailed, specified, custom_tags, suppress_warning, disable_node_metrics = self._get_config(
+        base_url, max_detailed, specified, custom_tags, suppress_warning, collect_node_metrics = self._get_config(
             instance
         )
         try:
@@ -264,7 +264,7 @@ class RabbitMQ(AgentCheck):
                     limit_vhosts,
                     custom_tags,
                 )
-                if not disable_node_metrics:
+                if collect_node_metrics:
                     self.get_stats(
                         instance,
                         base_url,

--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -228,7 +228,6 @@ class RabbitMQ(AgentCheck):
         return vhosts
 
     def check(self, instance):
-        self.log.error("Hello")
         base_url, max_detailed, specified, custom_tags, suppress_warning, disable_node_metrics = self._get_config(
             instance
         )
@@ -307,7 +306,6 @@ class RabbitMQ(AgentCheck):
     def _get_data(self, url):
         try:
             r = self.http.get(url)
-            self.log.error(url)
             r.raise_for_status()
             return r.json()
         except RequestException as e:

--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -158,6 +158,8 @@ class RabbitMQ(AgentCheck):
             raise Exception('Missing "rabbitmq_api_url" in RabbitMQ config.')
         if not base_url.endswith('/'):
             base_url += '/'
+
+        disable_nodes = instance.get('disable_node_metrics')
         custom_tags = instance.get('tags', [])
         parsed_url = urlparse(base_url)
         if not parsed_url.scheme or "://" not in parsed_url.geturl():
@@ -198,7 +200,7 @@ class RabbitMQ(AgentCheck):
                 if type(filter_objects) != list:
                     raise TypeError("{0} / {0}_regexes parameter must be a list".format(object_type))
 
-        return base_url, max_detailed, specified, custom_tags, suppress_warning
+        return base_url, max_detailed, specified, custom_tags, suppress_warning, disable_nodes
 
     def _collect_metadata(self, base_url):
         # Rabbit versions follow semantic versioning https://www.rabbitmq.com/changelog.html
@@ -226,7 +228,8 @@ class RabbitMQ(AgentCheck):
         return vhosts
 
     def check(self, instance):
-        base_url, max_detailed, specified, custom_tags, suppress_warning = self._get_config(instance)
+        self.log.error("Hello")
+        base_url, max_detailed, specified, custom_tags, suppress_warning, disable_node_metrics = self._get_config(instance)
         try:
             with warnings.catch_warnings():
                 vhosts = self._get_vhosts(instance, base_url)
@@ -260,15 +263,16 @@ class RabbitMQ(AgentCheck):
                     limit_vhosts,
                     custom_tags,
                 )
-                self.get_stats(
-                    instance,
-                    base_url,
-                    NODE_TYPE,
-                    max_detailed[NODE_TYPE],
-                    specified[NODE_TYPE],
-                    limit_vhosts,
-                    custom_tags,
-                )
+                if not disable_node_metrics:
+                    self.get_stats(
+                        instance,
+                        base_url,
+                        NODE_TYPE,
+                        max_detailed[NODE_TYPE],
+                        specified[NODE_TYPE],
+                        limit_vhosts,
+                        custom_tags,
+                    )
                 self.get_overview_stats(base_url, custom_tags)
 
                 self.get_connections_stat(instance, base_url, CONNECTION_TYPE, vhosts, limit_vhosts, custom_tags)
@@ -301,6 +305,7 @@ class RabbitMQ(AgentCheck):
     def _get_data(self, url):
         try:
             r = self.http.get(url)
+            self.log.error(url)
             r.raise_for_status()
             return r.json()
         except RequestException as e:

--- a/rabbitmq/tests/common.py
+++ b/rabbitmq/tests/common.py
@@ -32,7 +32,7 @@ CONFIG_NO_NODES = {
     'queues': ['test1'],
     'tags': ["tag1:1", "tag2"],
     'exchanges': ['test1'],
-    'disable_node_metrics': True,
+    'collect_node_metrics': False,
 }
 
 CONFIG_REGEX = {

--- a/rabbitmq/tests/common.py
+++ b/rabbitmq/tests/common.py
@@ -25,6 +25,16 @@ CONFIG = {
     'exchanges': ['test1'],
 }
 
+CONFIG_NO_NODES = {
+    'rabbitmq_api_url': URL,
+    'rabbitmq_user': 'guest',
+    'rabbitmq_pass': 'guest',
+    'queues': ['test1'],
+    'tags': ["tag1:1", "tag2"],
+    'exchanges': ['test1'],
+    'disable_node_metrics': True
+}
+
 CONFIG_REGEX = {
     'rabbitmq_api_url': URL,
     'rabbitmq_user': 'guest',

--- a/rabbitmq/tests/common.py
+++ b/rabbitmq/tests/common.py
@@ -32,7 +32,7 @@ CONFIG_NO_NODES = {
     'queues': ['test1'],
     'tags': ["tag1:1", "tag2"],
     'exchanges': ['test1'],
-    'disable_node_metrics': True
+    'disable_node_metrics': True,
 }
 
 CONFIG_REGEX = {

--- a/rabbitmq/tests/test_integration_e2e.py
+++ b/rabbitmq/tests/test_integration_e2e.py
@@ -233,3 +233,21 @@ def test_connections(aggregator, check):
         aggregator.assert_metric('rabbitmq.connections', tags=['rabbitmq_vhost:test2'], value=0, count=1)
         aggregator.assert_metric('rabbitmq.connections', count=2)
         aggregator.assert_metric('rabbitmq.connections.state', tags=['rabbitmq_conn_state:running'], value=0, count=0)
+
+
+@pytest.mark.usefixtures('dd_environment')
+def test_nodes(aggregator, check):
+
+    # default, node metrics are collected
+    check.check(common.CONFIG)
+
+    for m in metrics.COMMON_METRICS:
+        aggregator.assert_metric(m, count=1)
+
+    aggregator.reset()
+
+    # default, node metrics disabled
+    check.check(common.CONFIG_NO_NODES)
+
+    for m in metrics.COMMON_METRICS:
+        aggregator.assert_metric(m, count=0)

--- a/rabbitmq/tests/test_integration_e2e.py
+++ b/rabbitmq/tests/test_integration_e2e.py
@@ -233,25 +233,3 @@ def test_connections(aggregator, check):
         aggregator.assert_metric('rabbitmq.connections', tags=['rabbitmq_vhost:test2'], value=0, count=1)
         aggregator.assert_metric('rabbitmq.connections', count=2)
         aggregator.assert_metric('rabbitmq.connections.state', tags=['rabbitmq_conn_state:running'], value=0, count=0)
-
-
-@pytest.mark.usefixtures('dd_environment')
-def test_nodes(aggregator, check):
-
-    # default, node metrics are collected
-    check.check(common.CONFIG)
-
-    for m in metrics.COMMON_METRICS:
-        aggregator.assert_metric(m, count=1)
-
-    aggregator.reset()
-
-    # node metrics collection disabled in config, node metrics should not appear
-    check.check(common.CONFIG_NO_NODES)
-
-    for m in metrics.COMMON_METRICS:
-        aggregator.assert_metric(m, count=0)
-
-    # check to ensure other metrics are being collected
-    for m in metrics.Q_METRICS:
-        aggregator.assert_metric(m, count=1)

--- a/rabbitmq/tests/test_integration_e2e.py
+++ b/rabbitmq/tests/test_integration_e2e.py
@@ -246,8 +246,12 @@ def test_nodes(aggregator, check):
 
     aggregator.reset()
 
-    # default, node metrics disabled
+    # node metrics collection disabled in config, node metrics should not appear
     check.check(common.CONFIG_NO_NODES)
 
     for m in metrics.COMMON_METRICS:
         aggregator.assert_metric(m, count=0)
+
+    # check to ensure other metrics are being collected
+    for m in metrics.Q_METRICS:
+        aggregator.assert_metric(m, count=1)

--- a/rabbitmq/tests/test_unit.py
+++ b/rabbitmq/tests/test_unit.py
@@ -150,9 +150,10 @@ def test_config(check, test_case, extra_config, expected_http_kwargs):
 
 
 @pytest.mark.unit
-def test_nodes_unit(aggregator, check):
+def test_nodes(aggregator, check):
 
     # default, node metrics are collected
+    check = RabbitMQ('rabbitmq', {}, instances=[common.CONFIG])
     check.check(common.CONFIG)
 
     for m in metrics.COMMON_METRICS:
@@ -160,7 +161,12 @@ def test_nodes_unit(aggregator, check):
 
     aggregator.reset()
 
+
+@pytest.mark.unit
+def test_disable_nodes(aggregator, check):
+
     # node metrics collection disabled in config, node metrics should not appear
+    check = RabbitMQ('rabbitmq', {}, instances=[common.CONFIG_NO_NODES])
     check.check(common.CONFIG_NO_NODES)
 
     for m in metrics.COMMON_METRICS:


### PR DESCRIPTION
### What does this PR do?

Add config option to disable node metric collection in rabbitmq, since some users do not have permission to view node metrics.

### Motivation

Resolves https://github.com/DataDog/integrations-core/issues/3207