### PR TITLE
Append extra_headers option to http method call

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -306,6 +306,7 @@ class RequestsWrapper(object):
 
         extra_headers = options.pop('extra_headers', None)
         if extra_headers is not None:
+            new_options['headers'] = new_options['headers'].copy()
             new_options['headers'].update(extra_headers)
 
         with ExitStack() as stack:

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -302,14 +302,20 @@ class RequestsWrapper(object):
         if persist is None:
             persist = self.persist_connections
 
+        new_options = self.populate_options(options)
+
+        extra_headers = options.pop('extra_headers', None)
+        if extra_headers is not None:
+            new_options['headers'].update(extra_headers)
+
         with ExitStack() as stack:
             for hook in self.request_hooks:
                 stack.enter_context(hook())
 
             if persist:
-                return getattr(self.session, method)(url, **self.populate_options(options))
+                return getattr(self.session, method)(url, **new_options)
             else:
-                return getattr(requests, method)(url, **self.populate_options(options))
+                return getattr(requests, method)(url, **new_options)
 
     def populate_options(self, options):
         # Avoid needless dictionary update if there are no options

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -119,6 +119,25 @@ class TestHeaders:
 
         assert http.options['headers'] == {'User-Agent': 'Datadog Agent/0.0.0', 'answer': '42'}
 
+    def test_extra_headers_on_http_method_call(self):
+        instance = {'extra_headers': {'answer': 42}}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        with mock.patch("requests.get") as get:
+            http.get("http://example.com/hello", extra_headers={"foo": "bar"})
+
+            expected_options = {'foo': 'bar', 'User-Agent': 'Datadog Agent/0.0.0', 'answer': '42'}
+            get.assert_called_with(
+                "http://example.com/hello",
+                headers=expected_options,
+                auth=None,
+                cert=None,
+                proxies=None,
+                timeout=(10.0, 10.0),
+                verify=True,
+            )
+
 
 class TestVerify:
     def test_config_default(self):

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -124,8 +124,9 @@ class TestHeaders:
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
+        extra_headers = {"foo": "bar"}
         with mock.patch("requests.get") as get:
-            http.get("http://example.com/hello", extra_headers={"foo": "bar"})
+            http.get("http://example.com/hello", extra_headers=extra_headers)
 
             expected_options = {'foo': 'bar', 'User-Agent': 'Datadog Agent/0.0.0', 'answer': '42'}
             get.assert_called_with(
@@ -137,6 +138,10 @@ class TestHeaders:
                 timeout=(10.0, 10.0),
                 verify=True,
             )
+
+        # make sure the original headers are not modified
+        assert http.options['headers'] == {'User-Agent': 'Datadog Agent/0.0.0', 'answer': '42'}
+        assert extra_headers == {"foo": "bar"}
 
 
 class TestVerify:


### PR DESCRIPTION
### What does this PR do?

Append extra_headers option to http method call

Needed here: https://github.com/DataDog/integrations-core/pull/5729/files#diff-b778b4343871a44d5bbaa529942c581dR110-R115

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
