### PR TITLE
docs: update example openmetrics conf types

### DIFF
--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -47,14 +47,14 @@ instances:
     #       - <EXTRA_LABEL_1>
     #       - <EXTRA_LABEL_2>
 
-    ## @param labels_mapper - object of key:value elements - optional
+    ## @param labels_mapper - object - optional
     ## The label mapper allows you to rename labels.
     ## Format is <LABEL_TO_RENAME>: <NEW_LABEL_NAME>
     #
     # labels_mapper:
     #   flavor: origin
 
-    ## @param type_overrides - object of key:value elements - optional
+    ## @param type_overrides - object - optional
     ## Type override allows you to override a type in the prometheus payload
     ## or type an untyped metrics (they're ignored by default)
     ## Supported <METRIC_TYPE> are `gauge`, `counter`, `histogram`, `summary`
@@ -123,8 +123,8 @@ instances:
     #
     # ssl_ca_cert: "<CA_CERT_PATH>"
 
-    ## @param extra_headers - object of key:value elements - optional
-    ## A list of additional HTTP headers to send in queries to the openmetrics endpoint.
+    ## @param extra_headers - object - optional
+    ## Additional HTTP headers to send in queries to the openmetrics endpoint.
     ## Can be combined with autodiscovery template variables. Eg: "Authorization: Bearer %%env_TOKEN%%".
     ## Note: if the "Authorization" header is present it will be replaced when "bearer_token_auth" is enabled.
     #

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -47,14 +47,14 @@ instances:
     #       - <EXTRA_LABEL_1>
     #       - <EXTRA_LABEL_2>
 
-    ## @param labels_mapper - list of key:value elements - optional
+    ## @param labels_mapper - object of key:value elements - optional
     ## The label mapper allows you to rename labels.
     ## Format is <LABEL_TO_RENAME>: <NEW_LABEL_NAME>
     #
     # labels_mapper:
     #   flavor: origin
 
-    ## @param type_overrides - list of key:value elements - optional
+    ## @param type_overrides - object of key:value elements - optional
     ## Type override allows you to override a type in the prometheus payload
     ## or type an untyped metrics (they're ignored by default)
     ## Supported <METRIC_TYPE> are `gauge`, `counter`, `histogram`, `summary`
@@ -123,7 +123,7 @@ instances:
     #
     # ssl_ca_cert: "<CA_CERT_PATH>"
 
-    ## @param extra_headers - list of key:value elements - optional
+    ## @param extra_headers - object of key:value elements - optional
     ## A list of additional HTTP headers to send in queries to the openmetrics endpoint.
     ## Can be combined with autodiscovery template variables. Eg: "Authorization: Bearer %%env_TOKEN%%".
     ## Note: if the "Authorization" header is present it will be replaced when "bearer_token_auth" is enabled.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Changes `extra_headers`, `type_overrides`, and `labels_mapper` properties from `list` to `object` to be in line with other type documentation. Not sure if changes elsewhere are needed.

### Motivation
<!-- What inspired you to submit this pull request? -->

Ran into errors when deploying the agent with invalid configuration.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
