### PR TITLE
Update .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,6 +10,7 @@ disable_warnings =
 # All paths are relative to each tox.ini
 omit =
     */test_bench.py
+    */test_e2e.py
 
     # Vendored dependencies
     */datadog_checks/*/vendor/*


### PR DESCRIPTION
### Motivation

We cannot run coverage for E2E tests as the code is non-local