### PR TITLE
Scylla README: Fix link to Scylla site

### DIFF
--- a/scylla/README.md
+++ b/scylla/README.md
@@ -42,7 +42,7 @@ The Scylla check does not include any events.
 
 Need help? Contact [Datadog support][7].
 
-[1]: https://scylla.io
+[1]: https://scylladb.com
 [2]: https://docs.datadoghq.com/agent
 [3]: https://github.com/DataDog/integrations-core/blob/master/scylla/datadog_checks/scylla/data/conf.yaml.example
 [4]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent


### PR DESCRIPTION
### What does this PR do?
Fix a link to scylladb site

### Motivation
Existing link is wrong, leads to 404

This PR fix a broken link in scylladb README
