### PR TITLE
Make `ignore_metrics` support `*` wildcard for OpenMetrics

### DIFF
--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -142,3 +142,13 @@ instances:
     ## Note: bearer_token_auth should be set to true to enable adding the token to HTTP headers for authentication.
     #
     # bearer_token_path: "<TOKEN_PATH>"
+
+    ## @param ignore_metrics - list of strings - optional
+    ## List of metrics to be ignored, the "*" wildcard can be used to match multiple metric names.
+    #
+    # ignore_metrics:
+    #  - <IGNORED_METRIC_NAME>
+    #  - <PREFIX_*>
+    #  - <*_SUFFIX>
+    #  - <PREFIX_*_SUFFIX>
+    #  - <*_SUBSTRING_*>


### PR DESCRIPTION
### What does this PR do?
- Metrics can be ignored if they match a`fnmatchcase` pattern
- Document the `ignore_metrics` openmetrics check parameter

### Motivation
More flexible config to ignore metrics

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
