### PR TITLE
Improve performance of pattern matching in OpenMetrics

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -515,21 +515,22 @@ class OpenMetricsScraperMixin(object):
         # If targeted metric, store labels
         self._store_labels(metric, scraper_config)
 
-        if metric.name in scraper_config['_ignored_metrics']:
-            self._send_telemetry_counter(
-                self.TELEMETRY_COUNTER_METRICS_IGNORE_COUNT, len(metric.samples), scraper_config
-            )
-            return  # Ignore the metric
-
-        for ignore_pattern in scraper_config['_ignored_patterns']:
-            if fnmatchcase(metric.name, ignore_pattern):
-                # Metric must be ignored
-                # Cache the ignored metric name to avoid calling fnmatchcase in the next check run
-                scraper_config['_ignored_metrics'].add(metric.name)
+        if scraper_config['ignore_metrics']:
+            if metric.name in scraper_config['_ignored_metrics']:
                 self._send_telemetry_counter(
                     self.TELEMETRY_COUNTER_METRICS_IGNORE_COUNT, len(metric.samples), scraper_config
                 )
                 return  # Ignore the metric
+
+            for ignore_pattern in scraper_config['_ignored_patterns']:
+                if fnmatchcase(metric.name, ignore_pattern):
+                    # Metric must be ignored
+                    # Cache the ignored metric name to avoid calling fnmatchcase in the next check run
+                    scraper_config['_ignored_metrics'].add(metric.name)
+                    self._send_telemetry_counter(
+                        self.TELEMETRY_COUNTER_METRICS_IGNORE_COUNT, len(metric.samples), scraper_config
+                    )
+                    return  # Ignore the metric
 
         self._send_telemetry_counter(self.TELEMETRY_COUNTER_METRICS_PROCESS_COUNT, len(metric.samples), scraper_config)
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
-from fnmatch import fnmatchcase, translate
+from fnmatch import translate
 from math import isinf, isnan
 from os.path import isfile
 from re import compile
@@ -98,8 +98,16 @@ class OpenMetricsScraperMixin(object):
 
         config['metrics_mapper'] = metrics_mapper
 
-        # `_metrics_wildcards` holds the potential wildcards to match for metrics
-        config['_metrics_wildcards'] = None
+        # `_wildcards_re` is a Pattern object used to match metric wildcards
+        config['_wildcards_re'] = None
+
+        wildcards = set()
+        for metric in config['metrics_mapper']:
+            if "*" in metric:
+                wildcards.add(translate(metric))
+
+        if wildcards:
+            config['_wildcards_re'] = compile('|'.join(wildcards))
 
         # `prometheus_metrics_prefix` allows to specify a prefix that all
         # prometheus metrics should have. This can be used when the prometheus
@@ -148,18 +156,20 @@ class OpenMetricsScraperMixin(object):
         # skipped without a 'Unable to handle metric' debug line in the logs
         config['ignore_metrics'] = instance.get('ignore_metrics', default_instance.get('ignore_metrics', []))
         config['_ignored_metrics'] = set()
-        config['_ignored_patterns'] = set()
+
+        # `_ignored_re` is a Pattern object used to match ignored metric patterns
         config['_ignored_re'] = None
+        ignored_patterns = set()
 
         # Separate ignored metric names and ignored patterns in different sets for faster lookup later
         for metric in config['ignore_metrics']:
             if '*' in metric:
-                config['_ignored_patterns'].add(translate(metric))
+                ignored_patterns.add(translate(metric))
             else:
                 config['_ignored_metrics'].add(metric)
 
-        if config['_ignored_patterns']:
-            config['_ignored_re'] = compile('|'.join(config['_ignored_patterns']))
+        if ignored_patterns:
+            config['_ignored_re'] = compile('|'.join(ignored_patterns))
 
         # If you want to send the buckets as tagged values when dealing with histograms,
         # set send_histograms_buckets to True, set to False otherwise.
@@ -529,7 +539,6 @@ class OpenMetricsScraperMixin(object):
 
             if scraper_config['_ignored_re'] and scraper_config['_ignored_re'].search(metric.name):
                 # Metric must be ignored
-                # Cache the ignored metric name to avoid calling fnmatchcase in the next check run
                 scraper_config['_ignored_metrics'].add(metric.name)
                 self._send_telemetry_counter(
                     self.TELEMETRY_COUNTER_METRICS_IGNORE_COUNT, len(metric.samples), scraper_config
@@ -560,15 +569,10 @@ class OpenMetricsScraperMixin(object):
 
                 return
 
-            # build the wildcard list if first pass
-            if scraper_config['_metrics_wildcards'] is None:
-                scraper_config['_metrics_wildcards'] = [x for x in scraper_config['metrics_mapper'] if '*' in x]
-
-            # try matching wildcard
-            for wildcard in scraper_config['_metrics_wildcards']:
-                if fnmatchcase(metric.name, wildcard):
-                    self.submit_openmetric(metric.name, metric, scraper_config)
-                    return
+            # try matching wildcards
+            if scraper_config['_wildcards_re'] and scraper_config['_wildcards_re'].search(metric.name):
+                self.submit_openmetric(metric.name, metric, scraper_config)
+                return
 
             self.log.debug(
                 'Skipping metric `%s` as it is not defined in the metrics mapper, '


### PR DESCRIPTION
### What does this PR do?
Follow-up on https://github.com/DataDog/integrations-core/pull/5759/files#r380296940

Compile and cache wildcards instead of calling `fnmatchcase` to match metric names.

### Motivation
Perf improvment

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
