### PR TITLE
Add a new metric_tags configuration

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -380,12 +380,12 @@ class InstanceConfig:
         oids = []
         parsed_metric_tags = []
         for tag in metric_tags:
-            if not ('symbol' in tag and 'name' in tag):
-                raise ConfigurationError("A metric tag needs to specify a symbol and a name: {}".format(tag))
+            if not ('symbol' in tag and 'tag' in tag):
+                raise ConfigurationError("A metric tag needs to specify a symbol and a tag: {}".format(tag))
             if not ('OID' in tag or 'MIB' in tag):
                 raise ConfigurationError("A metric tag needs to specify an OID or a MIB: {}".format(tag))
             symbol = tag['symbol']
-            tag_name = tag['name']
+            tag_name = tag['tag']
             if 'MIB' in tag:
                 mib = tag['MIB']
                 identity = hlapi.ObjectIdentity(mib, symbol)

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -40,6 +40,15 @@ class ParsedTableMetric(object):
         self.forced_type = forced_type
 
 
+class ParsedMetricTag(object):
+
+    __slots__ = ('name', 'symbol')
+
+    def __init__(self, name, symbol):
+        self.name = name
+        self.symbol = symbol
+
+
 class InstanceConfig:
     """Parse and hold configuration about a single instance."""
 
@@ -52,6 +61,7 @@ class InstanceConfig:
         self.instance = instance
         self.tags = instance.get('tags', [])
         self.metrics = instance.get('metrics', [])
+        metric_tags = instance.get('metric_tags', [])
 
         profile = instance.get('profile')
 
@@ -62,6 +72,7 @@ class InstanceConfig:
             if profile not in profiles:
                 raise ConfigurationError("Unknown profile '{}'".format(profile))
             self.metrics.extend(profiles[profile]['definition']['metrics'])
+            metric_tags.extend(profiles[profile]['definition'].get('metric_tags', []))
 
         self.enforce_constraints = is_affirmative(instance.get('enforce_mib_constraints', True))
         self._snmp_engine, mib_view_controller = self.create_snmp_engine(mibs_path)
@@ -105,6 +116,9 @@ class InstanceConfig:
         self._auth_data = self.get_auth_data(instance)
 
         self.all_oids, self.bulk_oids, self.parsed_metrics = self.parse_metrics(self.metrics, warning, log)
+        tag_oids, self.parsed_metric_tags = self.parse_metric_tags(metric_tags)
+        if tag_oids:
+            self.all_oids.append(tag_oids)
 
         self._context_data = hlapi.ContextData(*self.get_context_data(instance))
 
@@ -116,6 +130,9 @@ class InstanceConfig:
     def refresh_with_profile(self, profile, warning, log):
         self.metrics.extend(profile['definition']['metrics'])
         self.all_oids, self.bulk_oids, self.parsed_metrics = self.parse_metrics(self.metrics, warning, log)
+        tag_oids, self.parsed_metric_tags = self.parse_metric_tags(profile['definition'].get('metric_tags', []))
+        if tag_oids:
+            self.all_oids.append(tag_oids)
 
     def call_cmd(self, cmd, *args, **kwargs):
         return cmd(self._snmp_engine, self._auth_data, self._transport, self._context_data, *args, **kwargs)
@@ -357,6 +374,29 @@ class InstanceConfig:
             all_oids.insert(0, oids)
 
         return all_oids, bulk_oids, parsed_metrics
+
+    def parse_metric_tags(self, metric_tags):
+        """Parse configuration for global metric_tags."""
+        oids = []
+        parsed_metric_tags = []
+        for tag in metric_tags:
+            if not ('symbol' in tag and 'name' in tag):
+                raise ConfigurationError("A metric tag needs to specify a symbol and a name: {}".format(tag))
+            if not ('OID' in tag or 'MIB' in tag):
+                raise ConfigurationError("A metric tag needs to specify an OID or a MIB: {}".format(tag))
+            symbol = tag['symbol']
+            tag_name = tag['name']
+            if 'MIB' in tag:
+                mib = tag['MIB']
+                identity = hlapi.ObjectIdentity(mib, symbol)
+            else:
+                oid = tag['OID']
+                identity = hlapi.ObjectIdentity(oid)
+                self._resolver.register(to_oid_tuple(oid), symbol)
+            object_type = hlapi.ObjectType(identity)
+            oids.append(object_type)
+            parsed_metric_tags.append(ParsedMetricTag(tag_name, symbol))
+        return oids, parsed_metric_tags
 
     def add_uptime_metric(self):
         if self._uptime_metric_added:

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -314,4 +314,5 @@ instances:
     #    tag: snmp_host
     #  - # From an OID:
     #    OID: 1.3.6.1.2.1.1.5
-    #    name: snmp_host
+    #    symbol: sysName
+    #    tag: snmp_host

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -309,14 +309,14 @@ instances:
     ##
     ## - MIB: SNMPv2-MIB
     ##   symbol: sysName
-    ##   name: snmp_host
+    ##   tag: snmp_host
     ##
     ## Or:
     ##
     ## - OID: 1.3.6.1.2.1.1.5
-    ##   name: snmp_host
+    ##   tag: snmp_host
     #
     # metric_tags:
     #  - MIB: SNMPv2-MIB
     #    symbol: sysName
-    #    name: snmp_host
+    #    tag: snmp_host

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -306,17 +306,12 @@ instances:
 
     ## @param metric_tags - list of elements - optional
     ## Specify tags that you want applied to all metrics. A tag can be applied from a symbol or an OID.
-    ##
-    ## - MIB: SNMPv2-MIB
-    ##   symbol: sysName
-    ##   tag: snmp_host
-    ##
-    ## Or:
-    ##
-    ## - OID: 1.3.6.1.2.1.1.5
-    ##   tag: snmp_host
     #
     # metric_tags:
-    #  - MIB: SNMPv2-MIB
+    #  - # From a symbol
+    #    MIB: SNMPv2-MIB
     #    symbol: sysName
     #    tag: snmp_host
+    #  - # From an OID:
+    #    OID: 1.3.6.1.2.1.1.5
+    #    name: snmp_host

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -303,3 +303,20 @@ instances:
         name: tcpPassiveOpens
         metric_tags:
           - TCP
+
+    ## @param metric_tags - list of elements - optional
+    ## Specify tags that you want applied to all metrics. It can be a symbol or a OID.
+    ##
+    ## - MIB: SNMPv2-MIB
+    ##   symbol: sysName
+    ##   name: snmp_host
+    ##
+    ## Or:
+    ##
+    ## - OID: 1.3.6.1.2.1.1.5
+    ##   name: snmp_host
+    #
+    # metric_tags:
+    #  - MIB: SNMPv2-MIB
+    #    symbol: sysName
+    #    name: snmp_host

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -305,7 +305,7 @@ instances:
           - TCP
 
     ## @param metric_tags - list of elements - optional
-    ## Specify tags that you want applied to all metrics. It can be a symbol or a OID.
+    ## Specify tags that you want applied to all metrics. A tag can be applied from a symbol or an OID.
     ##
     ## - MIB: SNMPv2-MIB
     ##   symbol: sysName

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -85,7 +85,6 @@ class SnmpCheck(AgentCheck):
                 raise ConfigurationError("Couldn't read profile '{}': {}".format(name, exc))
 
             self.profiles[name] = {'definition': definition}
-
             sys_object_oid = definition.get('sysobjectid')
             if sys_object_oid is not None:
                 self.profiles_by_oid[sys_object_oid] = name
@@ -353,6 +352,7 @@ class SnmpCheck(AgentCheck):
         # Reset errors
         instance = config.instance
         error = results = None
+        tags = config.tags
         try:
             if not (config.all_oids or config.bulk_oids):
                 sys_object_oid = self.fetch_sysobject_oid(config)
@@ -363,7 +363,9 @@ class SnmpCheck(AgentCheck):
                 self.log.debug('Querying device %s', config.ip_address)
                 config.add_uptime_metric()
                 results, error = self.fetch_results(config, config.all_oids, config.bulk_oids)
-                self.report_metrics(config.parsed_metrics, results, config.tags)
+                tags = self.extract_metric_tags(config.parsed_metric_tags, results)
+                tags.extend(config.tags)
+                self.report_metrics(config.parsed_metrics, results, tags)
         except CheckException as e:
             error = str(e)
             self.warning(error)
@@ -373,15 +375,20 @@ class SnmpCheck(AgentCheck):
             self.warning(error)
         finally:
             # Report service checks
-            sc_tags = ['snmp_device:{}'.format(instance['ip_address'])]
-            sc_tags.extend(instance.get('tags', []))
             status = self.OK
             if error:
                 status = self.CRITICAL
                 if results:
                     status = self.WARNING
-            self.service_check(self.SC_STATUS, status, tags=sc_tags, message=error)
+            self.service_check(self.SC_STATUS, status, tags=tags, message=error)
         return error
+
+    def extract_metric_tags(self, metric_tags, results):
+        extracted_tags = []
+        for tag in metric_tags:
+            result = list(results[tag.symbol].items())[0]
+            extracted_tags.append('{}:{}'.format(tag.name, result[1]))
+        return extracted_tags
 
     def report_metrics(self, metrics, results, tags):
         """

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -386,8 +386,8 @@ class SnmpCheck(AgentCheck):
     def extract_metric_tags(self, metric_tags, results):
         extracted_tags = []
         for tag in metric_tags:
-            result = list(results[tag.symbol].items())[0]
-            extracted_tags.append('{}:{}'.format(tag.name, result[1]))
+            [(_, tag_value)] = list(results[tag.symbol].items())
+            extracted_tags.append('{}:{}'.format(tag.name, tag_value))
         return extracted_tags
 
     def report_metrics(self, metrics, results, tags):

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -729,7 +729,7 @@ def test_different_tables(aggregator):
 def test_metric_tag_symbol(aggregator):
     metrics = common.SUPPORTED_METRIC_TYPES
     instance = common.generate_instance_config(metrics)
-    instance['metric_tags'] = [{'MIB': 'SNMPv2-MIB', 'symbol': 'sysName', 'name': 'snmp_host'}]
+    instance['metric_tags'] = [{'MIB': 'SNMPv2-MIB', 'symbol': 'sysName', 'tag': 'snmp_host'}]
     check = common.create_check(instance)
 
     check.check(instance)
@@ -750,7 +750,7 @@ def test_metric_tag_symbol(aggregator):
 def test_metric_tag_oid(aggregator):
     metrics = common.SUPPORTED_METRIC_TYPES
     instance = common.generate_instance_config(metrics)
-    instance['metric_tags'] = [{'OID': '1.3.6.1.2.1.1.5', 'symbol': 'sysName', 'name': 'snmp_host'}]
+    instance['metric_tags'] = [{'OID': '1.3.6.1.2.1.1.5', 'symbol': 'sysName', 'tag': 'snmp_host'}]
     check = common.create_check(instance)
 
     check.check(instance)
@@ -772,7 +772,7 @@ def test_metric_tag_profile_manual(aggregator):
     instance = common.generate_instance_config([])
     instance['profile'] = 'profile1'
     definition = {
-        'metric_tags': [{'OID': '1.3.6.1.2.1.1.5', 'symbol': 'sysName', 'name': 'snmp_host'}],
+        'metric_tags': [{'OID': '1.3.6.1.2.1.1.5', 'symbol': 'sysName', 'tag': 'snmp_host'}],
         'metrics': common.SUPPORTED_METRIC_TYPES,
     }
     init_config = {'profiles': {'profile1': {'definition': definition}}}
@@ -796,7 +796,7 @@ def test_metric_tag_profile_manual(aggregator):
 def test_metric_tag_profile_sysoid(aggregator):
     instance = common.generate_instance_config([])
     definition = {
-        'metric_tags': [{'OID': '1.3.6.1.2.1.1.5', 'symbol': 'sysName', 'name': 'snmp_host'}],
+        'metric_tags': [{'OID': '1.3.6.1.2.1.1.5', 'symbol': 'sysName', 'tag': 'snmp_host'}],
         'metrics': common.SUPPORTED_METRIC_TYPES,
         'sysobjectid': '1.3.6.1.4.1.8072.3.2.10',
     }
@@ -822,7 +822,7 @@ def test_metric_tags_misconfiguration():
     metrics = common.SUPPORTED_METRIC_TYPES
     instance = common.generate_instance_config(metrics)
 
-    instance['metric_tags'] = [{'OID': '1.3.6.1.2.1.1.5', 'name': 'snmp_host'}]
+    instance['metric_tags'] = [{'OID': '1.3.6.1.2.1.1.5', 'tag': 'snmp_host'}]
     with pytest.raises(ConfigurationError):
         common.create_check(instance)
 
@@ -830,7 +830,7 @@ def test_metric_tags_misconfiguration():
     with pytest.raises(ConfigurationError):
         common.create_check(instance)
 
-    instance['metric_tags'] = [{'name': 'sysName', 'symbol': 'sysName'}]
+    instance['metric_tags'] = [{'tag': 'sysName', 'symbol': 'sysName'}]
     with pytest.raises(ConfigurationError):
         common.create_check(instance)
 

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -771,8 +771,10 @@ def test_metric_tag_oid(aggregator):
 def test_metric_tag_profile_manual(aggregator):
     instance = common.generate_instance_config([])
     instance['profile'] = 'profile1'
-    definition = {'metric_tags': [{'OID': '1.3.6.1.2.1.1.5', 'symbol': 'sysName', 'name': 'snmp_host'}],
-                  'metrics': common.SUPPORTED_METRIC_TYPES}
+    definition = {
+        'metric_tags': [{'OID': '1.3.6.1.2.1.1.5', 'symbol': 'sysName', 'name': 'snmp_host'}],
+        'metrics': common.SUPPORTED_METRIC_TYPES,
+    }
     init_config = {'profiles': {'profile1': {'definition': definition}}}
     check = SnmpCheck('snmp', init_config, [instance])
 
@@ -793,9 +795,11 @@ def test_metric_tag_profile_manual(aggregator):
 
 def test_metric_tag_profile_sysoid(aggregator):
     instance = common.generate_instance_config([])
-    definition = {'metric_tags': [{'OID': '1.3.6.1.2.1.1.5', 'symbol': 'sysName', 'name': 'snmp_host'}],
-                  'metrics': common.SUPPORTED_METRIC_TYPES,
-                  'sysobjectid': '1.3.6.1.4.1.8072.3.2.10'}
+    definition = {
+        'metric_tags': [{'OID': '1.3.6.1.2.1.1.5', 'symbol': 'sysName', 'name': 'snmp_host'}],
+        'metrics': common.SUPPORTED_METRIC_TYPES,
+        'sysobjectid': '1.3.6.1.4.1.8072.3.2.10',
+    }
     init_config = {'profiles': {'profile1': {'definition': definition}}}
     check = SnmpCheck('snmp', init_config, [instance])
 

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -726,6 +726,111 @@ def test_different_tables(aggregator):
     aggregator.assert_metric_has_tag_prefix('snmp.ifInOctets', 'speed')
 
 
+def test_metric_tag_symbol(aggregator):
+    metrics = common.SUPPORTED_METRIC_TYPES
+    instance = common.generate_instance_config(metrics)
+    instance['metric_tags'] = [{'MIB': 'SNMPv2-MIB', 'symbol': 'sysName', 'name': 'snmp_host'}]
+    check = common.create_check(instance)
+
+    check.check(instance)
+
+    tags = list(common.CHECK_TAGS)
+    tags.append('snmp_host:41ba948911b9')
+
+    for metric in common.SUPPORTED_METRIC_TYPES:
+        metric_name = "snmp." + metric['name']
+        aggregator.assert_metric(metric_name, tags=tags, count=1)
+    aggregator.assert_metric('snmp.sysUpTimeInstance', count=1)
+
+    aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
+
+    aggregator.all_metrics_asserted()
+
+
+def test_metric_tag_oid(aggregator):
+    metrics = common.SUPPORTED_METRIC_TYPES
+    instance = common.generate_instance_config(metrics)
+    instance['metric_tags'] = [{'OID': '1.3.6.1.2.1.1.5', 'symbol': 'sysName', 'name': 'snmp_host'}]
+    check = common.create_check(instance)
+
+    check.check(instance)
+
+    tags = list(common.CHECK_TAGS)
+    tags.append('snmp_host:41ba948911b9')
+
+    for metric in common.SUPPORTED_METRIC_TYPES:
+        metric_name = "snmp." + metric['name']
+        aggregator.assert_metric(metric_name, tags=tags, count=1)
+    aggregator.assert_metric('snmp.sysUpTimeInstance', count=1)
+
+    aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
+
+    aggregator.all_metrics_asserted()
+
+
+def test_metric_tag_profile_manual(aggregator):
+    instance = common.generate_instance_config([])
+    instance['profile'] = 'profile1'
+    definition = {'metric_tags': [{'OID': '1.3.6.1.2.1.1.5', 'symbol': 'sysName', 'name': 'snmp_host'}],
+                  'metrics': common.SUPPORTED_METRIC_TYPES}
+    init_config = {'profiles': {'profile1': {'definition': definition}}}
+    check = SnmpCheck('snmp', init_config, [instance])
+
+    check.check(instance)
+
+    tags = list(common.CHECK_TAGS)
+    tags.append('snmp_host:41ba948911b9')
+
+    for metric in common.SUPPORTED_METRIC_TYPES:
+        metric_name = "snmp." + metric['name']
+        aggregator.assert_metric(metric_name, tags=tags, count=1)
+    aggregator.assert_metric('snmp.sysUpTimeInstance', count=1)
+
+    aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
+
+    aggregator.all_metrics_asserted()
+
+
+def test_metric_tag_profile_sysoid(aggregator):
+    instance = common.generate_instance_config([])
+    definition = {'metric_tags': [{'OID': '1.3.6.1.2.1.1.5', 'symbol': 'sysName', 'name': 'snmp_host'}],
+                  'metrics': common.SUPPORTED_METRIC_TYPES,
+                  'sysobjectid': '1.3.6.1.4.1.8072.3.2.10'}
+    init_config = {'profiles': {'profile1': {'definition': definition}}}
+    check = SnmpCheck('snmp', init_config, [instance])
+
+    check.check(instance)
+
+    tags = list(common.CHECK_TAGS)
+    tags.append('snmp_host:41ba948911b9')
+
+    for metric in common.SUPPORTED_METRIC_TYPES:
+        metric_name = "snmp." + metric['name']
+        aggregator.assert_metric(metric_name, tags=tags, count=1)
+    aggregator.assert_metric('snmp.sysUpTimeInstance', count=1)
+
+    aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
+
+    aggregator.all_metrics_asserted()
+
+
+def test_metric_tags_misconfiguration():
+    metrics = common.SUPPORTED_METRIC_TYPES
+    instance = common.generate_instance_config(metrics)
+
+    instance['metric_tags'] = [{'OID': '1.3.6.1.2.1.1.5', 'name': 'snmp_host'}]
+    with pytest.raises(ConfigurationError):
+        common.create_check(instance)
+
+    instance['metric_tags'] = [{'OID': '1.3.6.1.2.1.1.5', 'symbol': 'sysName'}]
+    with pytest.raises(ConfigurationError):
+        common.create_check(instance)
+
+    instance['metric_tags'] = [{'name': 'sysName', 'symbol': 'sysName'}]
+    with pytest.raises(ConfigurationError):
+        common.create_check(instance)
+
+
 def test_f5(aggregator):
     instance = common.generate_instance_config([])
     # We need the full path as we're not in installed mode


### PR DESCRIPTION
This adds a new `metric_tags` configuration section to be able to
globally tag metrics by SNMP values.