### PR TITLE
[Haproxy] Update Log Collection instructions

### DIFF
--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -65,6 +65,8 @@ Edit the `haproxy.d/conf.yaml` file, in the `conf.d/` folder at the root of your
 
 _Available for Agent versions >6.0_
 
+By default Haproxy will send logs over UDP to port 514. The Agent can listen for these logs on this port, however, binding to a port number under 1024 requires elevated permissions. You can follow the instructions below to set this up, you can also  alternatively use a different port and skip step 3.
+
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
    ```yaml
@@ -84,7 +86,26 @@ _Available for Agent versions >6.0_
 
     Change the `service` parameter value and configure it for your environment. See the [sample haproxy.d/conf.yaml][5] for all available configuration options.
 
-3. [Restart the Agent][6].
+3. Grant access to this port using the `setcap` command:
+
+    ```bash
+    sudo setcap CAP_NET_BIND_SERVICE=+ep /opt/datadog-agent/bin/agent/agent
+    ```
+    
+    You can verify this by running the `getcap` command:
+    
+    ```bash
+    sudo getcap /opt/datadog-agent/bin/agent/agent
+    ```
+    
+    With the expeced output:
+    ```bash
+    /opt/datadog-agent/bin/agent/agent = cap_net_bind_service+ep
+    ```
+    
+    **Note:** This `setcap` command will need to be re-ran following Agent upgrades.
+    
+4. [Restart the Agent][6].
 
 #### Containerized
 

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -65,7 +65,7 @@ Edit the `haproxy.d/conf.yaml` file, in the `conf.d/` folder at the root of your
 
 _Available for Agent versions >6.0_
 
-By default Haproxy will send logs over UDP to port 514. The Agent can listen for these logs on this port, however, binding to a port number under 1024 requires elevated permissions. You can follow the instructions below to set this up, you can also  alternatively use a different port and skip step 3.
+By default Haproxy sends logs over UDP to port 514. The Agent can listen for these logs on this port, however, binding to a port number under 1024 requires elevated permissions. Follow the instructions below to set this up. Alternatively, you can use a different port and skip step 3.
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
@@ -86,24 +86,24 @@ By default Haproxy will send logs over UDP to port 514. The Agent can listen for
 
     Change the `service` parameter value and configure it for your environment. See the [sample haproxy.d/conf.yaml][5] for all available configuration options.
 
-3. Grant access to this port using the `setcap` command:
+3. Grant access to port 514 using the `setcap` command:
 
     ```bash
     sudo setcap CAP_NET_BIND_SERVICE=+ep /opt/datadog-agent/bin/agent/agent
     ```
     
-    You can verify this by running the `getcap` command:
+    Verify the setup is correct by running the `getcap` command:
     
     ```bash
     sudo getcap /opt/datadog-agent/bin/agent/agent
     ```
     
-    With the expeced output:
+    With the expected output:
     ```bash
     /opt/datadog-agent/bin/agent/agent = cap_net_bind_service+ep
     ```
     
-    **Note:** This `setcap` command will need to be re-ran following Agent upgrades.
+    **Note:** Re-run this `setcap` command every time you upgrade the Agent.
     
 4. [Restart the Agent][6].
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update the log collection instructions due to the permission requirements that binding to port 514 requires.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://trello.com/c/TLs5UyPB/1905-default-instructions-for-haproxy-log-collection-use-restricted-port

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
