### PR TITLE
Submit collected vsphere tags as host tags for realtime resources

### DIFF
--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -416,7 +416,8 @@ class VSphereCheck(AgentCheck):
                 if not hostname:
                     continue
 
-                tags = [t for t in mor_props['tags'] if t.split(':')[0] not in self.config.excluded_host_tags]
+                mor_tags = mor_props['tags'] + self.tags_cache.get_mor_tags(mor)
+                tags = [t for t in mor_tags if t.split(':')[0] not in self.config.excluded_host_tags]
                 tags.extend(self.config.base_tags)
                 external_host_tags.append((hostname, {self.__NAMESPACE__: tags}))
 

--- a/vsphere/tests/fixtures/host_tags_values.json
+++ b/vsphere/tests/fixtures/host_tags_values.json
@@ -78,6 +78,7 @@
                 "vsphere_cluster:Cluster2",
                 "vsphere_compute:Cluster2",
                 "vsphere_type:host",
+                "my_cat_name_2:my_tag_name_2",
                 "vcenter_server:FAKE"
             ]
         }
@@ -301,6 +302,8 @@
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
                 "vsphere_type:vm",
+                "my_cat_name_1:my_tag_name_1",
+                "my_cat_name_2:my_tag_name_2",
                 "vcenter_server:FAKE"
             ]
         }

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -11,6 +11,7 @@ from mock import MagicMock
 from datadog_checks.base import to_string
 from datadog_checks.vsphere import VSphereCheck
 from datadog_checks.vsphere.api import APIConnectionError
+from datadog_checks.vsphere.api_rest import VSphereRestAPI
 from datadog_checks.vsphere.config import VSphereConfig
 
 from .common import HERE
@@ -49,11 +50,15 @@ def test_historical_metrics(aggregator, dd_run_check, historical_instance):
     aggregator.assert_all_metrics_covered()
 
 
-@pytest.mark.usefixtures("mock_type")
+@pytest.mark.usefixtures("mock_type", 'mock_rest_api')
 def test_external_host_tags(aggregator, realtime_instance):
+    realtime_instance['collect_tags'] = True
     check = VSphereCheck('vsphere', {}, [realtime_instance])
     config = VSphereConfig(realtime_instance, MagicMock())
     check.api = MockedAPI(config)
+    check.api_rest = VSphereRestAPI(config, MagicMock())
+    with check.tags_cache.update():
+        check.refresh_tags_cache()
     with check.infrastructure_cache.update():
         check.refresh_infrastructure_cache()
 


### PR DESCRIPTION
Collected vsphere tags were not submitted as host tags, giving no option to see those tags for realtime resources.