### PR TITLE
Add `tls_ignore_warning` option

### DIFF
--- a/vsphere/datadog_checks/vsphere/api_rest.py
+++ b/vsphere/datadog_checks/vsphere/api_rest.py
@@ -123,6 +123,7 @@ class VSphereRestClient(object):
             'password': config.password,
             'tls_ca_cert': config.ssl_capath,
             'tls_verify': config.ssl_verify,
+            'tls_ignore_warning': config.tls_ignore_warning,
         }
         self._api_base_url = "https://{}/rest/com/vmware/cis/".format(config.hostname)
         self._http = RequestsWrapper(http_config, {})

--- a/vsphere/datadog_checks/vsphere/config.py
+++ b/vsphere/datadog_checks/vsphere/config.py
@@ -31,6 +31,7 @@ class VSphereConfig(object):
         self.password = instance['password']
         self.ssl_verify = is_affirmative(instance.get('ssl_verify', True))
         self.ssl_capath = instance.get('ssl_capath')
+        self.tls_ignore_warning = instance.get('tls_ignore_warning', False)
 
         # vSphere options
         self.collection_level = instance.get("collection_level", 1)

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -61,6 +61,12 @@ instances:
     #
     # ssl_capath: "<DIRECTORY_PATH>"
 
+    ## @param tls_ignore_warning - boolean - optional - default: false
+    ## If `tls_verify` is disabled, security warnings are logged by the check when making http requests.
+    ## Disable those by setting `tls_ignore_warning` to true.
+    #
+    # tls_ignore_warning: false
+
     ## @param resource_filters - list of objects - optional - default: no filter
     ## Each filter in the list is composed of three parameters.
     ## 'resource' is one of vm/host/datastore/datacenter/cluster on which to apply the filter

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -62,7 +62,7 @@ instances:
     # ssl_capath: "<DIRECTORY_PATH>"
 
     ## @param tls_ignore_warning - boolean - optional - default: false
-    ## If `tls_verify` is disabled, security warnings are logged by the check when making http requests.
+    ## If `ssl_verify ` is disabled, security warnings are logged by the check when making http requests.
     ## Disable those by setting `tls_ignore_warning` to true.
     #
     # tls_ignore_warning: false


### PR DESCRIPTION
Since we use `requests` to make some http calls now, we need to add `tls_ignore_warning` to the integration. Otherwise, the logs are spammed with those InsecureRequestWarning