### PR TITLE
Add basic types to SNMP integration

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -59,7 +59,10 @@ class ParsedMetricTag(object):
 
 def _no_op(*args, **kwargs):
     # type: (*Any, **Any) -> None
-    pass
+    """
+    A 'do-nothing' replacement for the `warning()` and `log()` AgentCheck functions, suitable for when those
+    functions are not available (e.g. in unit tests).
+    """
 
 
 class InstanceConfig:

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import ipaddress
 from collections import defaultdict
+from typing import Any, Callable, DefaultDict, Dict, Iterator, List, Optional, Tuple, Union
 
 from pyasn1.type.univ import OctetString
 from pysnmp import hlapi
@@ -33,7 +34,14 @@ class ParsedTableMetric(object):
 
     __slots__ = ('name', 'index_tags', 'column_tags', 'forced_type')
 
-    def __init__(self, name, index_tags, column_tags, forced_type):
+    def __init__(
+        self,
+        name,  # type: str
+        index_tags,  # type: List[Tuple[str, int]]
+        column_tags,  # type: List[Tuple[str, str]]
+        forced_type=None,  # type: str
+    ):
+        # type: (...) -> None
         self.name = name
         self.index_tags = index_tags
         self.column_tags = column_tags
@@ -49,6 +57,11 @@ class ParsedMetricTag(object):
         self.symbol = symbol
 
 
+def _no_op(*args, **kwargs):
+    # type: (*Any, **Any) -> None
+    pass
+
+
 class InstanceConfig:
     """Parse and hold configuration about a single instance."""
 
@@ -57,7 +70,21 @@ class InstanceConfig:
     DEFAULT_ALLOWED_FAILURES = 3
     DEFAULT_BULK_THRESHOLD = 0
 
-    def __init__(self, instance, warning, log, global_metrics, mibs_path, profiles, profiles_by_oid):
+    def __init__(
+        self,
+        instance,  # type: dict
+        warning=_no_op,  # type: Callable[..., None]
+        log=_no_op,  # type: Callable[..., None]
+        global_metrics=None,  # type: List[dict]
+        mibs_path=None,  # type: str
+        profiles=None,  # type: Dict[str, dict]
+        profiles_by_oid=None,  # type: Dict[str, str]
+    ):
+        # type: (...) -> None
+        global_metrics = [] if global_metrics is None else global_metrics
+        profiles = {} if profiles is None else profiles
+        profiles_by_oid = {} if profiles_by_oid is None else profiles_by_oid
+
         self.instance = instance
         self.tags = instance.get('tags', [])
         self.metrics = instance.get('metrics', [])
@@ -81,8 +108,8 @@ class InstanceConfig:
         self.ip_address = None
         self.ip_network = None
 
-        self.discovered_instances = {}
-        self.failing_instances = defaultdict(int)
+        self.discovered_instances = {}  # type: Dict[str, InstanceConfig]
+        self.failing_instances = defaultdict(int)  # type: DefaultDict[str, int]
         self.allowed_failures = int(instance.get('discovery_allowed_failures', self.DEFAULT_ALLOWED_FAILURES))
 
         self.bulk_threshold = int(instance.get('bulk_threshold', self.DEFAULT_BULK_THRESHOLD))
@@ -125,9 +152,11 @@ class InstanceConfig:
         self._uptime_metric_added = False
 
     def resolve_oid(self, oid):
+        # type: (Any) -> Tuple[Any, Any]
         return self._resolver.resolve_oid(oid)
 
     def refresh_with_profile(self, profile, warning, log):
+        # type: (Dict[str, Any], Callable[..., None], Callable[..., None]) -> None
         metrics = profile['definition']['metrics']
         all_oids, bulk_oids, parsed_metrics = self.parse_metrics(metrics, warning, log)
 
@@ -150,6 +179,7 @@ class InstanceConfig:
             self.all_oids.append(tag_oids)
 
     def call_cmd(self, cmd, *args, **kwargs):
+        # type: (Any, *Any, **Any) -> Iterator[Any]
         return cmd(self._snmp_engine, self._auth_data, self._transport, self._context_data, *args, **kwargs)
 
     @staticmethod
@@ -171,6 +201,7 @@ class InstanceConfig:
 
     @staticmethod
     def get_transport_target(instance, timeout, retries):
+        # type: (Dict[str, Any], float, int) -> Any
         """
         Generate a Transport target object based on the instance's configuration
         """
@@ -180,6 +211,7 @@ class InstanceConfig:
 
     @staticmethod
     def get_auth_data(instance):
+        # type: (Dict[str, Any]) -> Any
         """
         Generate a Security Parameters object based on the instance's
         configuration.
@@ -220,6 +252,7 @@ class InstanceConfig:
 
     @staticmethod
     def get_context_data(instance):
+        # type: (Dict[str, Any]) -> Tuple[Optional[OctetString], str]
         """
         Generate a Context Parameters object based on the instance's
         configuration.
@@ -238,13 +271,19 @@ class InstanceConfig:
 
         return context_engine_id, context_name
 
-    def parse_metrics(self, metrics, warning, log):
+    def parse_metrics(
+        self,
+        metrics,  # type: List[Dict[str, Any]]
+        warning,  # type: Callable[..., None]
+        log,  # type: Callable[..., None]
+    ):
+        # type: (...) -> Tuple[list, list, List[Union[ParsedMetric, ParsedTableMetric]]]
         """Parse configuration and returns data to be used for SNMP queries.
 
         `oids` is a dictionnary of SNMP tables to symbols to query.
         """
-        table_oids = {}
-        parsed_metrics = []
+        table_oids = {}  # type: Dict[Tuple[str, str], Tuple[Any, List[Any]]]
+        parsed_metrics = []  # type: List[Union[ParsedMetric, ParsedTableMetric]]
 
         def extract_symbol(mib, symbol):
             if isinstance(symbol, dict):
@@ -354,8 +393,8 @@ class InstanceConfig:
                     except Exception as e:
                         warning("Can't generate MIB object for variable : %s\nException: %s", metric, e)
 
-                    parsed_metric = ParsedTableMetric(parsed_metric_name, index_tags, column_tags, forced_type)
-                    parsed_metrics.append(parsed_metric)
+                    parsed_table_metric = ParsedTableMetric(parsed_metric_name, index_tags, column_tags, forced_type)
+                    parsed_metrics.append(parsed_table_metric)
 
             elif 'OID' in metric:
                 oid_object = hlapi.ObjectType(hlapi.ObjectIdentity(metric['OID']))
@@ -391,6 +430,7 @@ class InstanceConfig:
         return all_oids, bulk_oids, parsed_metrics
 
     def parse_metric_tags(self, metric_tags):
+        # type: (List[Dict[str, Any]]) -> Tuple[List[Any], List[ParsedMetricTag]]
         """Parse configuration for global metric_tags."""
         oids = []
         parsed_metric_tags = []
@@ -414,6 +454,7 @@ class InstanceConfig:
         return oids, parsed_metric_tags
 
     def add_uptime_metric(self):
+        # type: () -> None
         if self._uptime_metric_added:
             return
         # Reference sysUpTimeInstance directly, see http://oidref.com/1.3.6.1.2.1.1.3.0

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -7,7 +7,7 @@ import json
 import threading
 import time
 from collections import defaultdict
-from typing import Dict, List, Optional
+from typing import Any, DefaultDict, Dict, Iterator, List, Optional, Tuple, Union
 
 import pysnmp.proto.rfc1902 as snmp_type
 from pyasn1.codec.ber import decoder
@@ -21,7 +21,7 @@ from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.errors import CheckException
 
 from .compat import read_persistent_cache, total_time_to_temporal_percent, write_persistent_cache
-from .config import InstanceConfig, ParsedTableMetric
+from .config import InstanceConfig, ParsedMetric, ParsedMetricTag, ParsedTableMetric
 from .utils import get_profile_definition
 
 # Additional types that are not part of the SNMP protocol. cf RFC 2856
@@ -57,25 +57,27 @@ class SnmpCheck(AgentCheck):
     _NON_REPEATERS = 0
     _MAX_REPETITIONS = 25
 
-    def __init__(self, name, init_config, instances):
-        super(SnmpCheck, self).__init__(name, init_config, instances)
+    def __init__(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        super(SnmpCheck, self).__init__(*args, **kwargs)
 
         # Set OID batch size
-        self.oid_batch_size = int(init_config.get('oid_batch_size', DEFAULT_OID_BATCH_SIZE))
+        self.oid_batch_size = int(self.init_config.get('oid_batch_size', DEFAULT_OID_BATCH_SIZE))
 
         # Load Custom MIB directory
-        self.mibs_path = init_config.get('mibs_folder')
+        self.mibs_path = self.init_config.get('mibs_folder')
 
-        self.ignore_nonincreasing_oid = is_affirmative(init_config.get('ignore_nonincreasing_oid', False))
+        self.ignore_nonincreasing_oid = is_affirmative(self.init_config.get('ignore_nonincreasing_oid', False))
 
-        self.profiles = init_config.get('profiles', {})
+        self.profiles = self.init_config.get('profiles', {})  # type: Dict[str, Dict[str, Any]]
         self.profiles_by_oid = {}  # type: Dict[str, str]
         self._load_profiles()
 
-        self.instance['name'] = self._get_instance_key(self.instance)
+        self.instance['name'] = self._get_instance_name(self.instance)
         self._config = self._build_config(self.instance)
 
     def _load_profiles(self):
+        # type: () -> None
         """
         Load the configured SNMP profiles and index them by sysObjectID, if possible.
         """
@@ -91,34 +93,42 @@ class SnmpCheck(AgentCheck):
                 self.profiles_by_oid[sys_object_oid] = name
 
     def _build_config(self, instance):
+        # type: (dict) -> InstanceConfig
         return InstanceConfig(
             instance,
-            self.warning,
-            self.log,
-            self.init_config.get('global_metrics', []),
-            self.mibs_path,
-            self.profiles,
-            self.profiles_by_oid,
+            warning=self.warning,
+            log=self.log,
+            global_metrics=self.init_config.get('global_metrics', []),
+            mibs_path=self.mibs_path,
+            profiles=self.profiles,
+            profiles_by_oid=self.profiles_by_oid,
         )
 
-    def _get_instance_key(self, instance):
-        key = instance.get('name')
-        if key:
-            return key
+    def _get_instance_name(self, instance):
+        # type: (Dict[str, Any]) -> Optional[str]
+        name = instance.get('name')
+        if name:
+            return name
 
-        ip = instance.get('ip_address')
-        port = instance.get('port')
+        ip = instance.get('ip_address')  # type: Optional[str]
+        port = instance.get('port')  # type: Optional[int]
+
         if ip and port:
-            key = '{host}:{port}'.format(host=ip, port=port)
+            return '{host}:{port}'.format(host=ip, port=port)
+        elif ip:
+            return ip
         else:
-            key = ip
-
-        return key
+            return None
 
     def discover_instances(self):
         # type: () -> None
         config = self._config
+
+        if config.ip_network is None:
+            raise RuntimeError("Expected config.ip_network to be set to start discovery")
+
         discovery_interval = config.instance.get('discovery_interval', 3600)
+
         while self._running:
             start_time = time.time()
             for host in config.ip_network.hosts():
@@ -159,11 +169,13 @@ class SnmpCheck(AgentCheck):
                 time.sleep(discovery_interval - time_elapsed)
 
     def raise_on_error_indication(self, error_indication, ip_address):
+        # type: (Any, Optional[str]) -> None
         if error_indication:
             message = '{} for instance {}'.format(error_indication, ip_address)
             raise CheckException(message)
 
     def fetch_results(self, config, all_oids, bulk_oids):
+        # type: (InstanceConfig, list, list) -> Tuple[dict, Optional[str]]
         """
         Perform a snmpwalk on the domain specified by the oids, on the device
         configured in instance.
@@ -172,11 +184,12 @@ class SnmpCheck(AgentCheck):
         dict[oid/metric_name][row index] = value
         In case of scalar objects, the row index is just 0
         """
-        results = defaultdict(dict)
+        results = defaultdict(dict)  # type: DefaultDict[str, dict]
         enforce_constraints = config.enforce_constraints
 
         all_binds = []
-        error = None
+        error = None  # type: Optional[str]
+
         for to_fetch in all_oids:
             binds, current_error = self.fetch_oids(config, to_fetch, enforce_constraints=enforce_constraints)
             all_binds.extend(binds)
@@ -213,6 +226,7 @@ class SnmpCheck(AgentCheck):
         return results, error
 
     def fetch_oids(self, config, oids, enforce_constraints):
+        # type: (InstanceConfig, list, bool) -> Tuple[List[Any], Optional[str]]
         # UPDATE: We used to perform only a snmpgetnext command to fetch metric values.
         # It returns the wrong value when the OID passed is referring to a specific leaf.
         # For example:
@@ -269,6 +283,7 @@ class SnmpCheck(AgentCheck):
         return all_binds, error
 
     def fetch_sysobject_oid(self, config):
+        # type: (InstanceConfig) -> str
         """Return the sysObjectID of the instance."""
         # Reference sysObjectID directly, see http://oidref.com/1.3.6.1.2.1.1.2
         oid = hlapi.ObjectType(hlapi.ObjectIdentity((1, 3, 6, 1, 2, 1, 1, 2)))
@@ -289,8 +304,10 @@ class SnmpCheck(AgentCheck):
         return profiles
 
     def _consume_binds_iterator(self, binds_iterator, config):
-        all_binds = []
-        error = None
+        # type: (Iterator[Any], InstanceConfig) -> Tuple[List[Any], Optional[str]]
+        all_binds = []  # type: List[Any]
+        error = None  # type: Optional[str]
+
         for error_indication, error_status, _, var_binds_table in binds_iterator:
             self.log.debug('Returned vars: %s', var_binds_table)
 
@@ -310,6 +327,7 @@ class SnmpCheck(AgentCheck):
         return all_binds, error
 
     def _start_discovery(self):
+        # type: () -> None
         cache = read_persistent_cache(self.check_id)
         if cache:
             hosts = json.loads(cache)
@@ -331,6 +349,7 @@ class SnmpCheck(AgentCheck):
         self._thread.start()
 
     def check(self, instance):
+        # type: (Dict[str, Any]) -> None
         config = self._config
         if config.ip_network:
             if self._thread is None:
@@ -390,13 +409,20 @@ class SnmpCheck(AgentCheck):
         return error
 
     def extract_metric_tags(self, metric_tags, results):
+        # type: (List[ParsedMetricTag], Dict[str, dict]) -> List[str]
         extracted_tags = []
         for tag in metric_tags:
             [(_, tag_value)] = list(results[tag.symbol].items())
             extracted_tags.append('{}:{}'.format(tag.name, tag_value))
         return extracted_tags
 
-    def report_metrics(self, metrics, results, tags):
+    def report_metrics(
+        self,
+        metrics,  # type: List[Union[ParsedMetric, ParsedTableMetric]]
+        results,  # type: Dict[str, dict]
+        tags,  # type: List[str]
+    ):
+        # type: (...) -> None
         """
         For each of the metrics specified gather the tags requested in the
         instance conf for each row.
@@ -423,7 +449,14 @@ class SnmpCheck(AgentCheck):
                 metric_tags = tags + metric.metric_tags
                 self.submit_metric(name, val, metric.forced_type, metric_tags)
 
-    def get_index_tags(self, index, results, index_tags, column_tags):
+    def get_index_tags(
+        self,
+        index,  # type: Dict[int, float]
+        results,  # type: Dict[str, dict]
+        index_tags,  # type: List[Tuple[str, int]]
+        column_tags,  # type: List[Tuple[str, str]]
+    ):
+        # type: (...) -> List[str]
         """
         Gather the tags for this row of the table (index) based on the
         results (all the results from the query).
@@ -435,7 +468,8 @@ class SnmpCheck(AgentCheck):
            could be a potential result, to use as a tage
            cf. ifDescr in the IF-MIB::ifTable for example
         """
-        tags = []
+        tags = []  # type: List[str]
+
         for idx_tag in index_tags:
             tag_group = idx_tag[0]
             try:
@@ -444,21 +478,24 @@ class SnmpCheck(AgentCheck):
                 self.log.warning('Not enough indexes, skipping tag %s', tag_group)
                 continue
             tags.append('{}:{}'.format(tag_group, tag_value))
+
         for col_tag in column_tags:
             tag_group = col_tag[0]
             try:
-                tag_value = results[col_tag[1]][index]
+                column_value = results[col_tag[1]][index]
             except KeyError:
                 self.log.warning('Column %s not present in the table, skipping this tag', col_tag[1])
                 continue
-            if reply_invalid(tag_value):
+            if reply_invalid(column_value):
                 self.log.warning("Can't deduct tag from column for tag %s", tag_group)
                 continue
-            tag_value = tag_value.prettyPrint()
+            tag_value = column_value.prettyPrint()
             tags.append('{}:{}'.format(tag_group, tag_value))
+
         return tags
 
     def submit_metric(self, name, snmp_value, forced_type, tags):
+        # type: (str, Any, Optional[str], List[str]) -> None
         """
         Convert the values reported as pysnmp-Managed Objects to values and
         report them to the aggregator.
@@ -469,6 +506,8 @@ class SnmpCheck(AgentCheck):
             return
 
         metric_name = self.normalize(name, prefix='snmp')
+
+        value = 0.0  # type: float
 
         if forced_type:
             forced_type = forced_type.lower()

--- a/snmp/datadog_checks/snmp/utils.py
+++ b/snmp/datadog_checks/snmp/utils.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any, Dict
 
 import yaml
 
@@ -6,6 +7,7 @@ from .compat import get_config
 
 
 def get_profile_definition(profile):
+    # type: (Dict[str, Any]) -> Dict[str, Any]
     """
     Return the definition of an SNMP profile,
     either from the filesystem or from the profile configuration itself.
@@ -28,6 +30,7 @@ def get_profile_definition(profile):
 
 
 def _read_profile_definition(definition_file):
+    # type: (str) -> Dict[str, Any]
     confd = get_config('confd_path')
 
     if not os.path.isabs(definition_file):

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -27,12 +27,8 @@ def test_parse_metrics(hlapi_mock):
     metrics = [{"foo": "bar"}]
     config = InstanceConfig(
         {"ip_address": "127.0.0.1", "community_string": "public", "metrics": [{"OID": "1.2.3", "name": "foo"}]},
-        check.warning,
-        check.log,
-        [],
-        None,
-        {},
-        {},
+        warning=check.warning,
+        log=check.log,
     )
     hlapi_mock.reset_mock()
     with pytest.raises(Exception):
@@ -176,7 +172,7 @@ def test_removing_host():
     check = SnmpCheck('snmp', {}, [instance])
     warnings = []
     check.warning = warnings.append
-    check._config.discovered_instances['1.1.1.1'] = InstanceConfig(discovered_instance, None, None, [], '', {}, {})
+    check._config.discovered_instances['1.1.1.1'] = InstanceConfig(discovered_instance)
     msg = 'No SNMP response received before timeout for instance 1.1.1.1'
 
     check.check(instance)
@@ -237,7 +233,7 @@ def test_cache_building(write_mock, read_mock):
 
     check = SnmpCheck('snmp', {}, [instance])
 
-    check._config.discovered_instances['192.168.0.1'] = InstanceConfig(discovered_instance, None, None, [], '', {}, {})
+    check._config.discovered_instances['192.168.0.1'] = InstanceConfig(discovered_instance)
     check._start_discovery()
 
     try:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add basic type annotations to most methods of `SNMPCheck` and `InstanceConfig`.

### Motivation
<!-- What inspired you to submit this pull request? -->
Start type-checking the inside of these methods, and help us know at a glance what types we're manipulating.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
