### PR TITLE
Add `ignored_ip_addresses` option to ignore specific IP addresses when scanning a network.

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -140,7 +140,7 @@ class InstanceConfig:
                 network_address = network_address.decode('utf-8')
             self.ip_network = ipaddress.ip_network(network_address)
 
-        ignored_ip_addresses = instance.get('ignored_ip_addresses')
+        ignored_ip_addresses = instance.get('ignored_ip_addresses', [])
 
         if not isinstance(ignored_ip_addresses, list):
             raise ConfigurationError(

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import ipaddress
 from collections import defaultdict
-from typing import Iterator, List
+from typing import Iterator, Set
 
 from pyasn1.type.univ import OctetString
 from pysnmp import hlapi
@@ -111,7 +111,14 @@ class InstanceConfig:
                 network_address = network_address.decode('utf-8')
             self.ip_network = ipaddress.ip_network(network_address)
 
-        self.ignored_ip_addresses = instance.get('ignored_ip_addresses', [])  # type: List[str]
+        ignored_ip_addresses = instance.get('ignored_ip_addresses')
+
+        if not isinstance(ignored_ip_addresses, list):
+            raise ConfigurationError(
+                'ignored_ip_addresses should be a list (got {})'.format(type(ignored_ip_addresses))
+            )
+
+        self.ignored_ip_addresses = set(ignored_ip_addresses)  # type: Set[str]
 
         if not self.metrics and not profiles_by_oid:
             raise ConfigurationError('Instance should specify at least one metric or profiles should be defined')

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -132,6 +132,13 @@ instances:
     #
     # network_address: <NETWORK_ADRESS>
 
+    ## @param ignored_ip_addresses - list of string - optional
+    ## A list of IP addresses to ignore when scanning the network.
+    #
+    # ignored_ip_addresses:
+    #   - <IP_ADDRESS_1>
+    #   - <IP_ADDRESS_2>
+
     ## @param port - integer - optional - default: 161
     ## Default SNMP port.
     #

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -121,10 +121,7 @@ class SnmpCheck(AgentCheck):
         discovery_interval = config.instance.get('discovery_interval', 3600)
         while self._running:
             start_time = time.time()
-            for host in config.ip_network.hosts():
-                host = str(host)
-                if host in config.discovered_instances:
-                    continue
+            for host in config.network_hosts():
                 instance = config.instance.copy()
                 instance.pop('network_address')
                 instance['ip_address'] = host

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -130,6 +130,20 @@ def test_parse_metrics(hlapi_mock):
     hlapi_mock.reset_mock()
 
 
+def test_ignore_ip_addresses():
+    # type: () -> None
+    instance = common.generate_instance_config(common.SUPPORTED_METRIC_TYPES)
+    instance.pop('ip_address')
+    instance['network_address'] = '192.168.1.0/29'
+    instance['ignored_ip_addresses'] = ['192.168.1.2', '192.168.1.3', '192.168.1.5']
+
+    config = InstanceConfig(
+        instance, warning=None, log=None, global_metrics={}, mibs_path='', profiles={}, profiles_by_oid={}
+    )
+
+    assert list(config.network_hosts()) == ['192.168.1.1', '192.168.1.4', '192.168.1.6']
+
+
 def test_profile_error():
     instance = common.generate_instance_config([])
     instance['profile'] = 'profile1'

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -137,11 +137,14 @@ def test_ignore_ip_addresses():
     instance['network_address'] = '192.168.1.0/29'
     instance['ignored_ip_addresses'] = ['192.168.1.2', '192.168.1.3', '192.168.1.5']
 
-    config = InstanceConfig(
-        instance, warning=None, log=None, global_metrics={}, mibs_path='', profiles={}, profiles_by_oid={}
-    )
+    check = SnmpCheck('snmp', {}, [instance])
+    assert list(check._config.network_hosts()) == ['192.168.1.1', '192.168.1.4', '192.168.1.6']
 
-    assert list(config.network_hosts()) == ['192.168.1.1', '192.168.1.4', '192.168.1.6']
+    instance = common.generate_instance_config(common.SUPPORTED_METRIC_TYPES)
+    string_not_in_a_list = '192.168.1.0/29'
+    instance['ignored_ip_addresses'] = string_not_in_a_list
+    with pytest.raises(ConfigurationError):
+        SnmpCheck('snmp', {}, [instance])
 
 
 def test_profile_error():


### PR DESCRIPTION
# What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Allow users to ignore specific IP addresses when scanning for SNMP devices in autodiscovery mode.

```yaml
instances:
  - network_address: 1.2.3.0/24
    ignore_ip_addresses:
      - 1.2.3.1
      - 1.2.3.42
```

### Motivation
<!-- What inspired you to submit this pull request? -->
Allow users to prevent the Agent from collecting metrics from a specific set of known SNMP devices when discovering them via a network subnet.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
/

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
