### PR TITLE
Make new tile integrations private by default

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/manifest.json
@@ -19,7 +19,7 @@
     ""
   ],
   "type": "check",
-  "is_public": true,
+  "is_public": false,
   "integration_id": "{check_name_kebab}",
   "assets": {{
     "dashboards": {{}},


### PR DESCRIPTION
### What does this PR do?
Our `create` command currently makes tile-only integrations public by default.  

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
