### PR TITLE
Remove Agent5 compatibility layer

### DIFF
--- a/consul/datadog_checks/consul/common.py
+++ b/consul/datadog_checks/consul/common.py
@@ -1,0 +1,53 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from math import ceil, sqrt
+
+from datadog_checks.base import AgentCheck
+
+CONSUL_CHECK = 'consul.up'
+CONSUL_CAN_CONNECT = 'consul.can_connect'
+HEALTH_CHECK = 'consul.check'
+
+CONSUL_CATALOG_CHECK = 'consul.catalog'
+
+SOURCE_TYPE_NAME = 'consul'
+
+# seconds
+MAX_CONFIG_TTL = 300
+
+# cap on distinct Consul ServiceIDs to interrogate
+MAX_SERVICES = 50
+
+STATUS_SC = {
+    'up': AgentCheck.OK,
+    'passing': AgentCheck.OK,
+    'warning': AgentCheck.WARNING,
+    'critical': AgentCheck.CRITICAL,
+}
+
+STATUS_SEVERITY = {AgentCheck.UNKNOWN: 0, AgentCheck.OK: 1, AgentCheck.WARNING: 2, AgentCheck.CRITICAL: 3}
+
+
+# More information in https://www.consul.io/docs/internals/coordinates.html,
+# code is based on the snippet there.
+def distance(a, b):
+    a = a['Coord']
+    b = b['Coord']
+    total = 0
+    b_vec = b['Vec']
+    for i, a_p in enumerate(a['Vec']):
+        diff = a_p - b_vec[i]
+        total += diff * diff
+    rtt = sqrt(total) + a['Height'] + b['Height']
+
+    adjusted = rtt + a['Adjustment'] + b['Adjustment']
+    if adjusted > 0.0:
+        rtt = adjusted
+
+    return rtt * 1000.0
+
+
+def ceili(v):
+    return int(ceil(v))

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -6,7 +6,6 @@ from __future__ import division
 from collections import defaultdict
 from datetime import datetime, timedelta
 from itertools import islice
-from math import ceil, sqrt
 from time import time as timestamp
 
 import requests
@@ -14,67 +13,48 @@ from six import iteritems, iterkeys, itervalues
 from six.moves.urllib.parse import urljoin
 
 from datadog_checks.base import AgentCheck, is_affirmative
-from datadog_checks.base.utils.containers import hash_mutable
-
-
-# More information in https://www.consul.io/docs/internals/coordinates.html,
-# code is based on the snippet there.
-def distance(a, b):
-    a = a['Coord']
-    b = b['Coord']
-    total = 0
-    b_vec = b['Vec']
-    for i, a_p in enumerate(a['Vec']):
-        diff = a_p - b_vec[i]
-        total += diff * diff
-    rtt = sqrt(total) + a['Height'] + b['Height']
-
-    adjusted = rtt + a['Adjustment'] + b['Adjustment']
-    if adjusted > 0.0:
-        rtt = adjusted
-
-    return rtt * 1000.0
-
-
-def ceili(v):
-    return int(ceil(v))
-
-
-class ConsulCheckInstanceState(object):
-    def __init__(self):
-        self.local_config = None
-        self.last_config_fetch_time = None
-        self.last_known_leader = None
+from datadog_checks.consul.common import (
+    CONSUL_CAN_CONNECT,
+    CONSUL_CATALOG_CHECK,
+    CONSUL_CHECK,
+    HEALTH_CHECK,
+    MAX_CONFIG_TTL,
+    MAX_SERVICES,
+    SOURCE_TYPE_NAME,
+    STATUS_SC,
+    STATUS_SEVERITY,
+    ceili,
+    distance,
+)
 
 
 class ConsulCheck(AgentCheck):
-    CONSUL_CHECK = 'consul.up'
-    CONSUL_CAN_CONNECT = 'consul.can_connect'
-    HEALTH_CHECK = 'consul.check'
-
-    CONSUL_CATALOG_CHECK = 'consul.catalog'
-
-    SOURCE_TYPE_NAME = 'consul'
-
-    # seconds
-    MAX_CONFIG_TTL = 300
-
-    # cap on distinct Consul ServiceIDs to interrogate
-    MAX_SERVICES = 50
-
-    STATUS_SC = {
-        'up': AgentCheck.OK,
-        'passing': AgentCheck.OK,
-        'warning': AgentCheck.WARNING,
-        'critical': AgentCheck.CRITICAL,
-    }
-
-    STATUS_SEVERITY = {AgentCheck.UNKNOWN: 0, AgentCheck.OK: 1, AgentCheck.WARNING: 2, AgentCheck.CRITICAL: 3}
-
     def __init__(self, name, init_config, instances):
         super(ConsulCheck, self).__init__(name, init_config, instances)
 
-        self._instance_states = defaultdict(lambda: ConsulCheckInstanceState())
+        self.url = self.instance.get('url')
+        self.base_tags = self.instance.get('tags', [])
+
+        self.single_node_install = is_affirmative(self.instance.get('single_node_install', False))
+        self.perform_new_leader_checks = is_affirmative(
+            self.instance.get('new_leader_checks', self.init_config.get('new_leader_checks', False))
+        )
+        self.perform_self_leader_check = is_affirmative(
+            self.instance.get('self_leader_check', self.init_config.get('self_leader_check', False))
+        )
+        self.perform_catalog_checks = is_affirmative(
+            self.instance.get('catalog_checks', self.init_config.get('catalog_checks'))
+        )
+        self.perform_network_latency_checks = is_affirmative(
+            self.instance.get('network_latency_checks', self.init_config.get('network_latency_checks'))
+        )
+        self.disable_legacy_service_tag = is_affirmative(self.instance.get('disable_legacy_service_tag', False))
+        self.service_whitelist = self.instance.get('service_whitelist', self.init_config.get('service_whitelist', []))
+        self.max_services = self.instance.get('max_services', self.init_config.get('max_services', MAX_SERVICES))
+
+        self._local_config = None
+        self._last_config_fetch_time = None
+        self._last_known_leader = None
 
         self.HTTP_CONFIG_REMAPPER = {
             'client_cert_file': {'name': 'tls_cert'},
@@ -85,9 +65,9 @@ class ConsulCheck(AgentCheck):
         if 'acl_token' in self.instance:
             self.http.options['headers']['X-Consul-Token'] = self.instance['acl_token']
 
-    def consul_request(self, instance, endpoint):
-        url = urljoin(instance.get('url'), endpoint)
-        service_check_tags = ["url:{}".format(url)] + instance.get("tags", [])
+    def consul_request(self, endpoint):
+        url = urljoin(self.url, endpoint)
+        service_check_tags = ["url:{}".format(url)] + self.base_tags
         try:
             resp = self.http.get(url)
 
@@ -97,38 +77,38 @@ class ConsulCheck(AgentCheck):
             msg = 'Consul request to {} timed out'.format(url)
             self.log.exception(msg)
             self.service_check(
-                self.CONSUL_CAN_CONNECT, self.CRITICAL, tags=service_check_tags, message="{}: {}".format(msg, e)
+                CONSUL_CAN_CONNECT, self.CRITICAL, tags=service_check_tags, message="{}: {}".format(msg, e)
             )
             raise
         except Exception as e:
             msg = "Consul request to {} failed".format(url)
             self.log.exception(msg)
             self.service_check(
-                self.CONSUL_CAN_CONNECT, self.CRITICAL, tags=service_check_tags, message="{}: {}".format(msg, e)
+                CONSUL_CAN_CONNECT, self.CRITICAL, tags=service_check_tags, message="{}: {}".format(msg, e)
             )
             raise
         else:
-            self.service_check(self.CONSUL_CAN_CONNECT, self.OK, tags=service_check_tags)
+            self.service_check(CONSUL_CAN_CONNECT, self.OK, tags=service_check_tags)
 
         return resp.json()
 
     # Consul Config Accessors
-    def _get_local_config(self, instance, instance_state):
+    def _get_local_config(self):
         time_window = 0
-        if instance_state.last_config_fetch_time:
-            time_window = datetime.utcnow() - instance_state.last_config_fetch_time
-        if not instance_state.local_config or time_window > timedelta(seconds=self.MAX_CONFIG_TTL):
-            instance_state.local_config = self.consul_request(instance, '/v1/agent/self')
-            instance_state.last_config_fetch_time = datetime.utcnow()
+        if self._last_config_fetch_time:
+            time_window = datetime.utcnow() - self._last_config_fetch_time
+        if not self._local_config or time_window > timedelta(seconds=MAX_CONFIG_TTL):
+            self._local_config = self.consul_request('/v1/agent/self')
+            self._last_config_fetch_time = datetime.utcnow()
 
-        return instance_state.local_config
+        return self._local_config
 
-    def _get_cluster_leader(self, instance):
-        return self.consul_request(instance, '/v1/status/leader')
+    def _get_cluster_leader(self):
+        return self.consul_request('/v1/status/leader')
 
-    def _get_agent_url(self, instance, instance_state):
+    def _get_agent_url(self):
         self.log.debug("Starting _get_agent_url")
-        local_config = self._get_local_config(instance, instance_state)
+        local_config = self._get_local_config()
 
         # Member key for consul 0.7.x and up; Config key for older versions
         agent_addr = local_config.get('Member', {}).get('Addr') or local_config.get('Config', {}).get('AdvertiseAddr')
@@ -140,40 +120,34 @@ class ConsulCheck(AgentCheck):
         self.log.debug("Agent url is %s", agent_url)
         return agent_url
 
-    def _get_agent_datacenter(self, instance, instance_state):
-        local_config = self._get_local_config(instance, instance_state)
+    def _get_agent_datacenter(self):
+        local_config = self._get_local_config()
         agent_dc = local_config.get('Config', {}).get('Datacenter')
         return agent_dc
 
     # Consul Leader Checks
-    def _is_instance_leader(self, instance, instance_state):
+    def _is_instance_leader(self):
         try:
-            agent_url = self._get_agent_url(instance, instance_state)
-            leader = instance_state.last_known_leader or self._get_cluster_leader(instance)
+            agent_url = self._get_agent_url()
+            leader = self._last_known_leader or self._get_cluster_leader()
             self.log.debug("Consul agent lives at %s . Consul Leader lives at %s", agent_url, leader)
             return agent_url == leader
 
         except Exception:
             return False
 
-    def _check_for_leader_change(self, instance, instance_state):
-        perform_new_leader_checks = is_affirmative(
-            instance.get('new_leader_checks', self.init_config.get('new_leader_checks', False))
-        )
-        perform_self_leader_check = is_affirmative(
-            instance.get('self_leader_check', self.init_config.get('self_leader_check', False))
-        )
+    def _check_for_leader_change(self):
 
-        if perform_new_leader_checks and perform_self_leader_check:
+        if self.perform_new_leader_checks and self.perform_self_leader_check:
             self.log.warning(
                 'Both perform_self_leader_check and perform_new_leader_checks are set, '
                 'ignoring perform_new_leader_checks'
             )
-        elif not perform_new_leader_checks and not perform_self_leader_check:
+        elif not self.perform_new_leader_checks and not self.perform_self_leader_check:
             # Nothing to do here
             return
 
-        leader = self._get_cluster_leader(instance)
+        leader = self._get_cluster_leader()
 
         if not leader:
             # A few things could be happening here.
@@ -183,78 +157,77 @@ class ConsulCheck(AgentCheck):
             self.log.warning('Consul Leader information is not available!')
             return
 
-        if not instance_state.last_known_leader:
+        if not self._last_known_leader:
             # We have no state preserved, store some and return
-            instance_state.last_known_leader = leader
+            self._last_known_leader = leader
             return
 
-        agent = self._get_agent_url(instance, instance_state)
-        agent_dc = self._get_agent_datacenter(instance, instance_state)
+        agent = self._get_agent_url()
+        agent_dc = self._get_agent_datacenter()
 
-        if leader != instance_state.last_known_leader:
+        if leader != self._last_known_leader:
             # There was a leadership change
-            if perform_new_leader_checks or (perform_self_leader_check and agent == leader):
+            if self.perform_new_leader_checks or (self.perform_self_leader_check and agent == leader):
                 # We either emit all leadership changes or emit when we become the leader and that just happened
-                self.log.info(
-                    'Leader change from %s to %s. Sending new leader event', instance_state.last_known_leader, leader
-                )
+                self.log.info('Leader change from %s to %s. Sending new leader event', self._last_known_leader, leader)
 
                 self.event(
                     {
                         "timestamp": timestamp(),
                         "event_type": "consul.new_leader",
-                        "source_type_name": self.SOURCE_TYPE_NAME,
+                        "source_type_name": SOURCE_TYPE_NAME,
                         "msg_title": "New Consul Leader Elected in consul_datacenter:{}".format(agent_dc),
                         "aggregation_key": "consul.new_leader",
                         "msg_text": "The Node at {} is the new leader of the consul datacenter {}".format(
                             leader, agent_dc
                         ),
                         "tags": [
-                            "prev_consul_leader:{}".format(instance_state.last_known_leader),
+                            "prev_consul_leader:{}".format(self._last_known_leader),
                             "curr_consul_leader:{}".format(leader),
                             "consul_datacenter:{}".format(agent_dc),
                         ],
                     }
                 )
 
-        instance_state.last_known_leader = leader
+        self._last_known_leader = leader
 
     # Consul Catalog Accessors
-    def get_peers_in_cluster(self, instance):
-        return self.consul_request(instance, '/v1/status/peers') or []
+    def get_peers_in_cluster(self):
+        return self.consul_request('/v1/status/peers') or []
 
-    def get_services_in_cluster(self, instance):
-        return self.consul_request(instance, '/v1/catalog/services')
+    def get_services_in_cluster(self):
+        return self.consul_request('/v1/catalog/services')
 
-    def get_nodes_with_service(self, instance, service):
+    def get_nodes_with_service(self, service):
         consul_request_url = '/v1/health/service/{}'.format(service)
 
-        return self.consul_request(instance, consul_request_url)
+        return self.consul_request(consul_request_url)
 
-    def _cull_services_list(self, services, service_whitelist, max_services=MAX_SERVICES):
+    def _cull_services_list(self, services):
 
-        if service_whitelist:
-            if len(service_whitelist) > max_services:
-                self.warning('More than %d services in whitelist. Service list will be truncated.', max_services)
+        if self.service_whitelist:
+            if len(self.service_whitelist) > self.max_services:
+                self.warning('More than %d services in whitelist. Service list will be truncated.', self.max_services)
 
-            whitelisted_services = [s for s in services if s in service_whitelist]
-            services = {s: services[s] for s in whitelisted_services[:max_services]}
+            whitelisted_services = [s for s in services if s in self.service_whitelist]
+            services = {s: services[s] for s in whitelisted_services[: self.max_services]}
         else:
-            if len(services) <= max_services:
+            if len(services) <= self.max_services:
                 log_line = 'Consul service whitelist not defined. Agent will poll for all {} services found'.format(
                     len(services)
                 )
                 self.log.debug(log_line)
             else:
                 log_line = 'Consul service whitelist not defined. Agent will poll for at most {} services'.format(
-                    max_services
+                    self.max_services
                 )
                 self.warning(log_line)
-                services = {s: services[s] for s in list(islice(iterkeys(services), 0, max_services))}
+                services = {s: services[s] for s in list(islice(iterkeys(services), 0, self.max_services))}
 
         return services
 
-    def _get_service_tags(self, service, tags):
+    @staticmethod
+    def _get_service_tags(service, tags):
         service_tags = ['consul_service_id:{}'.format(service)]
 
         for tag in tags:
@@ -262,27 +235,23 @@ class ConsulCheck(AgentCheck):
 
         return service_tags
 
-    def check(self, instance):
-        # Instance state is mutable, any changes to it will be reflected in self._instance_states
-        instance_state = self._instance_states[hash_mutable(instance)]
+    def check(self, _):
 
-        self._check_for_leader_change(instance, instance_state)
-        self._collect_metadata(instance, instance_state)
+        self._check_for_leader_change()
+        self._collect_metadata()
 
-        peers = self.get_peers_in_cluster(instance)
+        peers = self.get_peers_in_cluster()
         main_tags = []
-        agent_dc = self._get_agent_datacenter(instance, instance_state)
+        agent_dc = self._get_agent_datacenter()
 
         if agent_dc is not None:
             main_tags.append('consul_datacenter:{}'.format(agent_dc))
 
-        for tag in instance.get('tags', []):
-            main_tags.append(tag)
+        main_tags += self.base_tags
 
-        single_node_install = is_affirmative(instance.get('single_node_install', False))
-        if not self._is_instance_leader(instance, instance_state):
+        if not self._is_instance_leader():
             self.gauge("consul.peers", len(peers), tags=main_tags + ["mode:follower"])
-            if not single_node_install:
+            if not self.single_node_install:
                 self.log.debug(
                     "This consul agent is not the cluster leader. "
                     "Skipping service and catalog checks for this instance"
@@ -291,21 +260,17 @@ class ConsulCheck(AgentCheck):
         else:
             self.gauge("consul.peers", len(peers), tags=main_tags + ["mode:leader"])
 
-        service_check_tags = main_tags + ['consul_url:{}'.format(instance.get('url'))]
-        perform_catalog_checks = is_affirmative(instance.get('catalog_checks', self.init_config.get('catalog_checks')))
-        perform_network_latency_checks = is_affirmative(
-            instance.get('network_latency_checks', self.init_config.get('network_latency_checks'))
-        )
+        service_check_tags = main_tags + ['consul_url:{}'.format(self.url)]
 
         try:
             # Make service checks from health checks for all services in catalog
-            health_state = self.consul_request(instance, '/v1/health/state/any')
+            health_state = self.consul_request('/v1/health/state/any')
 
             sc = {}
             # compute the highest status level (OK < WARNING < CRITICAL) a a check among all the nodes is running on.
             for check in health_state:
                 sc_id = '{}/{}/{}'.format(check['CheckID'], check.get('ServiceID', ''), check.get('ServiceName', ''))
-                status = self.STATUS_SC.get(check['Status'])
+                status = STATUS_SC.get(check['Status'])
                 if status is None:
                     status = AgentCheck.UNKNOWN
 
@@ -313,35 +278,33 @@ class ConsulCheck(AgentCheck):
                     tags = ["check:{}".format(check["CheckID"])]
                     if check["ServiceName"]:
                         tags.append('consul_service:{}'.format(check['ServiceName']))
-                        if not instance.get('disable_legacy_service_tag', False):
+                        if not self.disable_legacy_service_tag:
                             self._log_deprecation('service_tag', 'consul_service')
                             tags.append('service:{}'.format(check['ServiceName']))
                     if check["ServiceID"]:
                         tags.append("consul_service_id:{}".format(check["ServiceID"]))
                     sc[sc_id] = {'status': status, 'tags': tags}
 
-                elif self.STATUS_SEVERITY[status] > self.STATUS_SEVERITY[sc[sc_id]['status']]:
+                elif STATUS_SEVERITY[status] > STATUS_SEVERITY[sc[sc_id]['status']]:
                     sc[sc_id]['status'] = status
 
             for s in itervalues(sc):
-                self.service_check(self.HEALTH_CHECK, s['status'], tags=main_tags + s['tags'])
+                self.service_check(HEALTH_CHECK, s['status'], tags=main_tags + s['tags'])
 
         except Exception as e:
             self.log.error(e)
-            self.service_check(self.CONSUL_CHECK, AgentCheck.CRITICAL, tags=service_check_tags)
+            self.service_check(CONSUL_CHECK, AgentCheck.CRITICAL, tags=service_check_tags)
         else:
-            self.service_check(self.CONSUL_CHECK, AgentCheck.OK, tags=service_check_tags)
+            self.service_check(CONSUL_CHECK, AgentCheck.OK, tags=service_check_tags)
 
-        if perform_catalog_checks:
+        if self.perform_catalog_checks:
             # Collect node by service, and service by node counts for a whitelist of services
 
-            services = self.get_services_in_cluster(instance)
-            service_whitelist = instance.get('service_whitelist', self.init_config.get('service_whitelist', []))
-            max_services = instance.get('max_services', self.init_config.get('max_services', self.MAX_SERVICES))
+            services = self.get_services_in_cluster()
 
-            self.count_all_nodes(instance, main_tags)
+            self.count_all_nodes(main_tags)
 
-            services = self._cull_services_list(services, service_whitelist, max_services)
+            services = self._cull_services_list(services)
 
             # {node_id: {"up: 0, "passing": 0, "warning": 0, "critical": 0}
             nodes_to_service_status = defaultdict(lambda: defaultdict(int))
@@ -356,7 +319,7 @@ class ConsulCheck(AgentCheck):
 
                 service_tags = self._get_service_tags(service, services[service])
 
-                nodes_with_service = self.get_nodes_with_service(instance, service)
+                nodes_with_service = self.get_nodes_with_service(service)
 
                 # {'up': 0, 'passing': 0, 'warning': 0, 'critical': 0}
                 node_status = defaultdict(int)
@@ -415,10 +378,10 @@ class ConsulCheck(AgentCheck):
                             node_status['passing'] += 1
                             nodes_to_service_status[node_id]["passing"] += 1
 
-                for status_key in self.STATUS_SC:
+                for status_key in STATUS_SC:
                     status_value = node_status[status_key]
                     self.gauge(
-                        '{}.nodes_{}'.format(self.CONSUL_CATALOG_CHECK, status_key),
+                        '{}.nodes_{}'.format(CONSUL_CATALOG_CHECK, status_key),
                         status_value,
                         tags=main_tags + service_tags,
                     )
@@ -431,30 +394,28 @@ class ConsulCheck(AgentCheck):
                 # `consul.catalog.services_critical` : Total critical services on node
 
                 node_tags = ['consul_node_id:{}'.format(node)]
-                self.gauge(
-                    '{}.services_up'.format(self.CONSUL_CATALOG_CHECK), len(services), tags=main_tags + node_tags
-                )
+                self.gauge('{}.services_up'.format(CONSUL_CATALOG_CHECK), len(services), tags=main_tags + node_tags)
 
-                for status_key in self.STATUS_SC:
+                for status_key in STATUS_SC:
                     status_value = service_status[status_key]
                     self.gauge(
-                        '{}.services_{}'.format(self.CONSUL_CATALOG_CHECK, status_key),
+                        '{}.services_{}'.format(CONSUL_CATALOG_CHECK, status_key),
                         status_value,
                         tags=main_tags + node_tags,
                     )
 
-        if perform_network_latency_checks:
-            self.check_network_latency(instance, agent_dc, main_tags)
+        if self.perform_network_latency_checks:
+            self.check_network_latency(agent_dc, main_tags)
 
-    def _get_coord_datacenters(self, instance):
-        return self.consul_request(instance, '/v1/coordinate/datacenters')
+    def _get_coord_datacenters(self):
+        return self.consul_request('/v1/coordinate/datacenters')
 
-    def _get_coord_nodes(self, instance):
-        return self.consul_request(instance, 'v1/coordinate/nodes')
+    def _get_coord_nodes(self):
+        return self.consul_request('v1/coordinate/nodes')
 
-    def check_network_latency(self, instance, agent_dc, main_tags):
+    def check_network_latency(self, agent_dc, main_tags):
 
-        datacenters = self._get_coord_datacenters(instance)
+        datacenters = self._get_coord_datacenters()
         for datacenter in datacenters:
             name = datacenter['Datacenter']
             if name == agent_dc:
@@ -484,7 +445,7 @@ class ConsulCheck(AgentCheck):
                 break
 
         # Intra-datacenter
-        nodes = self._get_coord_nodes(instance)
+        nodes = self._get_coord_nodes()
         if len(nodes) == 1:
             self.log.debug("Only 1 node in cluster, skipping network latency metrics.")
         else:
@@ -522,15 +483,15 @@ class ConsulCheck(AgentCheck):
                 )
                 self.gauge('consul.net.node.latency.max', latencies[-1], hostname=node_name, tags=main_tags)
 
-    def _get_all_nodes(self, instance):
-        return self.consul_request(instance, 'v1/catalog/nodes')
+    def _get_all_nodes(self):
+        return self.consul_request('v1/catalog/nodes')
 
-    def count_all_nodes(self, instance, main_tags):
-        nodes = self._get_all_nodes(instance)
+    def count_all_nodes(self, main_tags):
+        nodes = self._get_all_nodes()
         self.gauge('consul.catalog.total_nodes', len(nodes), tags=main_tags)
 
-    def _collect_metadata(self, instance, instance_state):
-        local_config = self._get_local_config(instance, instance_state)
+    def _collect_metadata(self):
+        local_config = self._get_local_config()
         agent_version = local_config.get('Config', {}).get('Version')
         self.log.debug("Agent version is `%s`", agent_version)
         if agent_version:

--- a/consul/tests/consul_mocks.py
+++ b/consul/tests/consul_mocks.py
@@ -55,7 +55,7 @@ def _get_random_ip():
     return "10.0.2.{}".format(rand_int)
 
 
-def mock_get_all_nodes(instance):
+def mock_get_all_nodes():
     return [
         {
             'Address': _get_random_ip(),
@@ -80,11 +80,11 @@ def mock_get_all_nodes(instance):
     ]
 
 
-def mock_get_peers_in_cluster(instance):
+def mock_get_peers_in_cluster():
     return ["10.0.2.14:8300", "10.0.2.15:8300", "10.0.2.16:8300"]
 
 
-def mock_get_services_in_cluster(instance):
+def mock_get_services_in_cluster():
     return {
         "service-1": ["az-us-east-1a"],
         "service-2": ["az-us-east-1a"],
@@ -103,7 +103,7 @@ def mock_get_n_services_in_cluster(n):
     return dct
 
 
-def mock_get_local_config(instance, instance_state):
+def mock_get_local_config():
     return {
         "Config": {
             "AdvertiseAddr": "10.0.2.15",
@@ -121,7 +121,7 @@ def mock_get_local_config(instance, instance_state):
     }
 
 
-def mock_get_nodes_in_cluster(instance):
+def mock_get_nodes_in_cluster():
     return [
         {"Address": "10.0.2.15", "Node": "node-1"},
         {"Address": "10.0.2.25", "Node": "node-2"},
@@ -129,7 +129,7 @@ def mock_get_nodes_in_cluster(instance):
     ]
 
 
-def mock_get_nodes_with_service(instance, service):
+def mock_get_nodes_with_service(service):
     return [
         {
             "Checks": [
@@ -160,7 +160,7 @@ def mock_get_nodes_with_service(instance, service):
     ]
 
 
-def mock_get_nodes_with_service_warning(instance, service):
+def mock_get_nodes_with_service_warning(service):
     return [
         {
             "Checks": [
@@ -191,7 +191,7 @@ def mock_get_nodes_with_service_warning(instance, service):
     ]
 
 
-def mock_get_nodes_with_service_critical(instance, service):
+def mock_get_nodes_with_service_critical(service):
     return [
         {
             "Checks": [
@@ -232,7 +232,7 @@ def mock_get_nodes_with_service_critical(instance, service):
     ]
 
 
-def mock_get_coord_datacenters(instance):
+def mock_get_coord_datacenters():
     return [
         {
             "Datacenter": "dc1",
@@ -283,7 +283,7 @@ def mock_get_coord_datacenters(instance):
     ]
 
 
-def mock_get_coord_nodes(instance):
+def mock_get_coord_nodes():
     return [
         {
             "Node": "host-1",
@@ -324,7 +324,7 @@ def mock_get_coord_nodes(instance):
     ]
 
 
-def mock_get_health_check(instance, endpoint):
+def mock_get_health_check(_):
     return [
         {
             "ModifyIndex": 75214492,
@@ -401,9 +401,9 @@ def mock_get_health_check(instance, endpoint):
     ]
 
 
-def mock_get_cluster_leader_A(instance):
+def mock_get_cluster_leader_A():
     return '10.0.2.15:8300'
 
 
-def mock_get_cluster_leader_B(instance):
+def mock_get_cluster_leader_B():
     return 'My New Leader'

--- a/consul/tests/test_integration.py
+++ b/consul/tests/test_integration.py
@@ -70,7 +70,7 @@ def test_acl_forbidden(instance_bad_token, dd_environment):
 
     got_error_403 = False
     try:
-        consul_check.check(instance_bad_token)
+        consul_check.check(None)
     except HTTPError as e:
         if e.response.status_code == 403:
             got_error_403 = True

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -7,7 +7,7 @@ import mock
 import pytest
 
 from datadog_checks.consul import ConsulCheck
-from datadog_checks.utils.containers import hash_mutable
+from datadog_checks.consul.common import MAX_SERVICES
 
 from . import common, consul_mocks
 
@@ -17,9 +17,9 @@ log = logging.getLogger(__file__)
 
 
 def test_get_nodes_with_service(aggregator):
-    consul_check = ConsulCheck(common.CHECK_NAME, {}, [{}])
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG])
     consul_mocks.mock_check(consul_check, consul_mocks._get_consul_mocks())
-    consul_check.check(consul_mocks.MOCK_CONFIG)
+    consul_check.check(None)
 
     expected_tags = [
         'consul_datacenter:dc1',
@@ -42,35 +42,35 @@ def test_get_nodes_with_service(aggregator):
 
 def test_get_peers_in_cluster(aggregator):
     my_mocks = consul_mocks._get_consul_mocks()
-    consul_check = ConsulCheck(common.CHECK_NAME, {}, [{}])
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG])
     consul_mocks.mock_check(consul_check, my_mocks)
-    consul_check.check(consul_mocks.MOCK_CONFIG)
+    consul_check.check(None)
 
     # When node is leader
     aggregator.assert_metric('consul.peers', value=3, tags=['consul_datacenter:dc1', 'mode:leader'])
 
     my_mocks['_get_cluster_leader'] = consul_mocks.mock_get_cluster_leader_B
     consul_mocks.mock_check(consul_check, my_mocks)
-    consul_check.check(consul_mocks.MOCK_CONFIG)
+    consul_check.check(None)
 
     aggregator.assert_metric('consul.peers', value=3, tags=['consul_datacenter:dc1', 'mode:follower'])
 
 
 def test_count_all_nodes(aggregator):
     my_mocks = consul_mocks._get_consul_mocks()
-    consul_check = ConsulCheck(common.CHECK_NAME, {}, [{}])
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG])
     consul_mocks.mock_check(consul_check, my_mocks)
-    consul_check.check(consul_mocks.MOCK_CONFIG)
+    consul_check.check(None)
 
     aggregator.assert_metric('consul.catalog.total_nodes', value=2, tags=['consul_datacenter:dc1'])
 
 
 def test_get_nodes_with_service_warning(aggregator):
-    consul_check = ConsulCheck(common.CHECK_NAME, {}, [{}])
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG])
     my_mocks = consul_mocks._get_consul_mocks()
     my_mocks['get_nodes_with_service'] = consul_mocks.mock_get_nodes_with_service_warning
     consul_mocks.mock_check(consul_check, my_mocks)
-    consul_check.check(consul_mocks.MOCK_CONFIG)
+    consul_check.check(None)
 
     expected_tags = [
         'consul_datacenter:dc1',
@@ -90,11 +90,11 @@ def test_get_nodes_with_service_warning(aggregator):
 
 
 def test_get_nodes_with_service_critical(aggregator):
-    consul_check = ConsulCheck(common.CHECK_NAME, {}, [{}])
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG])
     my_mocks = consul_mocks._get_consul_mocks()
     my_mocks['get_nodes_with_service'] = consul_mocks.mock_get_nodes_with_service_critical
     consul_mocks.mock_check(consul_check, my_mocks)
-    consul_check.check(consul_mocks.MOCK_CONFIG)
+    consul_check.check(None)
 
     expected_tags = [
         'consul_datacenter:dc1',
@@ -114,16 +114,16 @@ def test_get_nodes_with_service_critical(aggregator):
 
 
 def test_consul_request(aggregator, instance):
-    consul_check = ConsulCheck(common.CHECK_NAME, {}, [{}])
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG])
     with mock.patch("datadog_checks.consul.consul.requests.get") as mock_requests_get:
-        consul_check.consul_request(instance, "foo")
+        consul_check.consul_request("foo")
         url = "{}/{}".format(instance["url"], "foo")
         aggregator.assert_service_check("consul.can_connect", ConsulCheck.OK, tags=["url:{}".format(url)], count=1)
 
         aggregator.reset()
         mock_requests_get.side_effect = Exception("message")
         with pytest.raises(Exception):
-            consul_check.consul_request(instance, "foo")
+            consul_check.consul_request("foo")
         aggregator.assert_service_check(
             "consul.can_connect",
             ConsulCheck.CRITICAL,
@@ -134,11 +134,11 @@ def test_consul_request(aggregator, instance):
 
 
 def test_service_checks(aggregator):
-    consul_check = ConsulCheck(common.CHECK_NAME, {}, [{}])
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG])
     my_mocks = consul_mocks._get_consul_mocks()
     my_mocks['consul_request'] = consul_mocks.mock_get_health_check
     consul_mocks.mock_check(consul_check, my_mocks)
-    consul_check.check(consul_mocks.MOCK_CONFIG)
+    consul_check.check(None)
 
     expected_tags = [
         "consul_datacenter:dc1",
@@ -182,11 +182,11 @@ def test_service_checks(aggregator):
 
 
 def test_service_checks_disable_service_tag(aggregator):
-    consul_check = ConsulCheck(common.CHECK_NAME, {}, [{}])
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG_DISABLE_SERVICE_TAG])
     my_mocks = consul_mocks._get_consul_mocks()
     my_mocks['consul_request'] = consul_mocks.mock_get_health_check
     consul_mocks.mock_check(consul_check, my_mocks)
-    consul_check.check(consul_mocks.MOCK_CONFIG_DISABLE_SERVICE_TAG)
+    consul_check.check(None)
 
     expected_tags = [
         'consul_datacenter:dc1',
@@ -222,71 +222,72 @@ def test_service_checks_disable_service_tag(aggregator):
 
 
 def test_cull_services_list():
-    consul_check = ConsulCheck(common.CHECK_NAME, {}, [{}])
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG_LEADER_CHECK])
     my_mocks = consul_mocks._get_consul_mocks()
     consul_mocks.mock_check(consul_check, my_mocks)
-    consul_check.check(consul_mocks.MOCK_CONFIG_LEADER_CHECK)
 
     # Pad num_services to kick in truncation logic
-    num_services = consul_check.MAX_SERVICES + 20
+    num_services = MAX_SERVICES + 20
 
     # Max services parameter (from consul.yaml) set to be bigger than MAX_SERVICES and smaller than total of services
     max_services = num_services - 10
 
     # Big whitelist
     services = consul_mocks.mock_get_n_services_in_cluster(num_services)
-    whitelist = ['service_{}'.format(k) for k in range(num_services)]
-    assert len(consul_check._cull_services_list(services, whitelist)) == consul_check.MAX_SERVICES
+    consul_check.service_whitelist = ['service_{}'.format(k) for k in range(num_services)]
+    assert len(consul_check._cull_services_list(services)) == MAX_SERVICES
 
     # Big whitelist with max_services
-    assert len(consul_check._cull_services_list(services, whitelist, max_services)) == max_services
+    consul_check.max_services = max_services
+    assert len(consul_check._cull_services_list(services)) == max_services
 
     # Whitelist < MAX_SERVICES should spit out the whitelist
-    whitelist = ['service_{}'.format(k) for k in range(consul_check.MAX_SERVICES - 1)]
-    assert set(consul_check._cull_services_list(services, whitelist)) == set(whitelist)
+    consul_check.service_whitelist = ['service_{}'.format(k) for k in range(MAX_SERVICES - 1)]
+    assert set(consul_check._cull_services_list(services)) == set(consul_check.service_whitelist)
 
     # Whitelist < max_services param should spit out the whitelist
-    whitelist = ['service_{}'.format(k) for k in range(max_services - 1)]
-    assert set(consul_check._cull_services_list(services, whitelist, max_services)) == set(whitelist)
+    consul_check.service_whitelist = ['service_{}'.format(k) for k in range(max_services - 1)]
+    assert set(consul_check._cull_services_list(services)) == set(consul_check.service_whitelist)
 
     # No whitelist, still triggers truncation
-    whitelist = []
-    assert len(consul_check._cull_services_list(services, whitelist)) == consul_check.MAX_SERVICES
+    consul_check.service_whitelist = []
+    consul_check.max_services = MAX_SERVICES
+    assert len(consul_check._cull_services_list(services)) == MAX_SERVICES
 
     # No whitelist with max_services set, also triggers truncation
-    whitelist = []
-    assert len(consul_check._cull_services_list(services, whitelist, max_services)) == max_services
+    consul_check.service_whitelist = []
+    consul_check.max_services = max_services
+    assert len(consul_check._cull_services_list(services)) == max_services
 
     # Num. services < MAX_SERVICES should be no-op in absence of whitelist
-    num_services = consul_check.MAX_SERVICES - 1
+    num_services = MAX_SERVICES - 1
     services = consul_mocks.mock_get_n_services_in_cluster(num_services)
-    assert len(consul_check._cull_services_list(services, whitelist)) == num_services
+    assert len(consul_check._cull_services_list(services,)) == num_services
 
     # Num. services < MAX_SERVICES should spit out only the whitelist when one is defined
-    whitelist = ['service_1', 'service_2', 'service_3']
-    assert set(consul_check._cull_services_list(services, whitelist)) == set(whitelist)
+    consul_check.service_whitelist = ['service_1', 'service_2', 'service_3']
+    assert set(consul_check._cull_services_list(services)) == set(consul_check.service_whitelist)
 
     # Num. services < max_services (from consul.yaml) should be no-op in absence of whitelist
     num_services = max_services - 1
-    whitelist = []
+    consul_check.service_whitelist = []
     services = consul_mocks.mock_get_n_services_in_cluster(num_services)
-    assert len(consul_check._cull_services_list(services, whitelist, max_services)) == num_services
+    assert len(consul_check._cull_services_list(services)) == num_services
 
     # Num. services < max_services should spit out only the whitelist when one is defined
-    whitelist = ['service_1', 'service_2', 'service_3']
-    assert set(consul_check._cull_services_list(services, whitelist, max_services)) == set(whitelist)
+    consul_check.service_whitelist = ['service_1', 'service_2', 'service_3']
+    assert set(consul_check._cull_services_list(services)) == set(consul_check.service_whitelist)
 
 
 def test_new_leader_event(aggregator):
-    consul_check = ConsulCheck(common.CHECK_NAME, {}, [{}])
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG_LEADER_CHECK])
     my_mocks = consul_mocks._get_consul_mocks()
     my_mocks['_get_cluster_leader'] = consul_mocks.mock_get_cluster_leader_B
     consul_mocks.mock_check(consul_check, my_mocks)
 
-    instance_hash = hash_mutable(consul_mocks.MOCK_CONFIG_LEADER_CHECK)
-    consul_check._instance_states[instance_hash].last_known_leader = 'My Old Leader'
+    consul_check._last_known_leader = 'My Old Leader'
 
-    consul_check.check(consul_mocks.MOCK_CONFIG_LEADER_CHECK)
+    consul_check.check(None)
     assert len(aggregator.events) == 1
 
     event = aggregator.events[0]
@@ -299,18 +300,17 @@ def test_self_leader_event(aggregator):
     consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG_SELF_LEADER_CHECK])
     my_mocks = consul_mocks._get_consul_mocks()
 
-    instance_hash = hash_mutable(consul_mocks.MOCK_CONFIG_SELF_LEADER_CHECK)
-    consul_check._instance_states[instance_hash].last_known_leader = 'My Old Leader'
+    consul_check._last_known_leader = 'My Old Leader'
 
-    our_url = consul_mocks.mock_get_cluster_leader_A(None)
-    other_url = consul_mocks.mock_get_cluster_leader_B(None)
+    our_url = consul_mocks.mock_get_cluster_leader_A()
+    other_url = consul_mocks.mock_get_cluster_leader_B()
 
     # We become the leader
     my_mocks['_get_cluster_leader'] = consul_mocks.mock_get_cluster_leader_A
     consul_mocks.mock_check(consul_check, my_mocks)
-    consul_check.check(consul_mocks.MOCK_CONFIG_SELF_LEADER_CHECK)
+    consul_check.check(None)
     assert len(aggregator.events) == 1
-    assert our_url == consul_check._instance_states[instance_hash].last_known_leader
+    assert our_url == consul_check._last_known_leader
     event = aggregator.events[0]
     assert event['event_type'] == 'consul.new_leader'
     assert 'prev_consul_leader:My Old Leader' in event['tags']
@@ -318,24 +318,24 @@ def test_self_leader_event(aggregator):
 
     # We are already the leader, no new events
     aggregator.reset()
-    consul_check.check(consul_mocks.MOCK_CONFIG_SELF_LEADER_CHECK)
+    consul_check.check(None)
     assert len(aggregator.events) == 0
 
     # We lose the leader, no new events
     my_mocks['_get_cluster_leader'] = consul_mocks.mock_get_cluster_leader_B
     consul_mocks.mock_check(consul_check, my_mocks)
     aggregator.reset()
-    consul_check.check(consul_mocks.MOCK_CONFIG_SELF_LEADER_CHECK)
+    consul_check.check(None)
     assert len(aggregator.events) == 0
-    assert other_url == consul_check._instance_states[instance_hash].last_known_leader
+    assert other_url == consul_check._last_known_leader
 
     # We regain the leadership
     my_mocks['_get_cluster_leader'] = consul_mocks.mock_get_cluster_leader_A
     consul_mocks.mock_check(consul_check, my_mocks)
     aggregator.reset()
-    consul_check.check(consul_mocks.MOCK_CONFIG_SELF_LEADER_CHECK)
+    consul_check.check(None)
     assert len(aggregator.events) == 1
-    assert our_url == consul_check._instance_states[instance_hash].last_known_leader
+    assert our_url == consul_check._last_known_leader
     event = aggregator.events[0]
     assert event['event_type'] == 'consul.new_leader'
     assert 'prev_consul_leader:{}'.format(other_url) in event['tags']
@@ -343,15 +343,14 @@ def test_self_leader_event(aggregator):
 
 
 def test_network_latency_checks(aggregator):
-    consul_check = ConsulCheck(common.CHECK_NAME, {}, [{}])
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG_NETWORK_LATENCY_CHECKS])
     my_mocks = consul_mocks._get_consul_mocks()
     consul_mocks.mock_check(consul_check, my_mocks)
 
     # We start out as the leader, and stay that way
-    instance_hash = hash_mutable(consul_mocks.MOCK_CONFIG_NETWORK_LATENCY_CHECKS)
-    consul_check._instance_states[instance_hash].last_known_leader = consul_mocks.mock_get_cluster_leader_A(None)
+    consul_check._last_known_leader = consul_mocks.mock_get_cluster_leader_A()
 
-    consul_check.check(consul_mocks.MOCK_CONFIG_NETWORK_LATENCY_CHECKS)
+    consul_check.check(None)
 
     latency = []
     for m_name, metrics in aggregator._metrics.items():
@@ -414,7 +413,7 @@ def test_config(test_case, extra_config, expected_http_kwargs):
     with mock.patch('datadog_checks.base.utils.http.requests') as r:
         r.get.return_value = mock.MagicMock(status_code=200)
 
-        check.check(instance)
+        check.check(None)
 
         http_wargs = dict(
             auth=mock.ANY, cert=mock.ANY, headers=mock.ANY, proxies=mock.ANY, timeout=mock.ANY, verify=mock.ANY


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR aims to simplify the code of the consul integration by removing all the unnecessary logic to deal with multiple config instances.

### Motivation
<!-- What inspired you to submit this pull request? -->
Better code for a better world.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
