### PR TITLE
Add `validate metadata` option to check for more duplicates

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -183,9 +183,26 @@ def normalize_metric_name(metric_name):
     return METRIC_DOTUNDERSCORE_CLEANUP.sub(".", metric_name).strip("_")
 
 
+def check_duplicate_values(current_check, line, row, header_name, duplicates, fail=None):
+    """Check if the given column value has been seen before. 
+    Output a warning and return True if so.
+    """
+    if row[header_name] and row[header_name] not in duplicates:
+        duplicates.add(row[header_name])
+    elif row[header_name] == '':
+        pass
+    else:
+        if fail:
+            echo_failure(f"{current_check}:{line} `{row[header_name]}` is a duplicate {header_name}")
+            return True
+        else:
+            echo_warning(f"{current_check}:{line} `{row[header_name]}` is a duplicate {header_name}")
+    return False
+
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Validate `metadata.csv` files')
+@click.option('--check-duplicates', is_flag=True, help='Output warnings if there are duplicate short names and descriptions')
 @click.argument('check', autocompletion=complete_valid_checks, required=False)
-def metadata(check):
+def metadata(check, check_duplicates):
     """Validates metadata.csv files
 
     If `check` is specified, only the check will be validated,
@@ -219,7 +236,10 @@ def metadata(check):
         metric_prefix_count = defaultdict(int)
         empty_count = defaultdict(int)
         empty_warning_count = defaultdict(int)
-        duplicate_set = set()
+        duplicate_name_set = set()
+        duplicate_short_name_set = set()
+        duplicate_description_set = set()
+
         metric_prefix_error_shown = False
 
         with open(metadata_file, 'r', encoding='utf-8') as f:
@@ -250,12 +270,11 @@ def metadata(check):
 
                     continue
 
-                # duplicate metric_name
-                if row['metric_name'] and row['metric_name'] not in duplicate_set:
-                    duplicate_set.add(row['metric_name'])
-                else:
-                    errors = True
-                    echo_failure(f"{current_check}:{line} `{row['metric_name']}` is a duplicate metric_name")
+                errors = errors or check_duplicate_values(current_check, line, row, 'metric_name', duplicate_name_set, fail=True)
+
+                if check_duplicates:
+                    check_duplicate_values(current_check, line, row, 'short_name', duplicate_short_name_set)
+                    check_duplicate_values(current_check, line, row, 'description', duplicate_description_set)
 
                 normalized_metric_name = normalize_metric_name(row['metric_name'])
                 if row['metric_name'] != normalized_metric_name:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -190,11 +190,12 @@ def check_duplicate_values(current_check, line, row, header_name, duplicates, fa
     if row[header_name] and row[header_name] not in duplicates:
         duplicates.add(row[header_name])
     elif row[header_name] != '':
+        message = f"{current_check}:{line} `{row[header_name]}` is a duplicate {header_name}"
         if fail:
-            echo_failure(f"{current_check}:{line} `{row[header_name]}` is a duplicate {header_name}")
+            echo_failure(message)
             return True
         else:
-            echo_warning(f"{current_check}:{line} `{row[header_name]}` is a duplicate {header_name}")
+            echo_warning(message)
     return False
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Validate `metadata.csv` files')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -184,7 +184,7 @@ def normalize_metric_name(metric_name):
 
 
 def check_duplicate_values(current_check, line, row, header_name, duplicates, fail=None):
-    """Check if the given column value has been seen before. 
+    """Check if the given column value has been seen before.
     Output a warning and return True if so.
     """
     if row[header_name] and row[header_name] not in duplicates:
@@ -198,8 +198,11 @@ def check_duplicate_values(current_check, line, row, header_name, duplicates, fa
             echo_warning(message)
     return False
 
+
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Validate `metadata.csv` files')
-@click.option('--check-duplicates', is_flag=True, help='Output warnings if there are duplicate short names and descriptions')
+@click.option(
+    '--check-duplicates', is_flag=True, help='Output warnings if there are duplicate short names and descriptions'
+)
 @click.argument('check', autocompletion=complete_valid_checks, required=False)
 def metadata(check, check_duplicates):
     """Validates metadata.csv files
@@ -269,7 +272,9 @@ def metadata(check, check_duplicates):
 
                     continue
 
-                errors = errors or check_duplicate_values(current_check, line, row, 'metric_name', duplicate_name_set, fail=True)
+                errors = errors or check_duplicate_values(
+                    current_check, line, row, 'metric_name', duplicate_name_set, fail=True
+                )
 
                 if check_duplicates:
                     check_duplicate_values(current_check, line, row, 'short_name', duplicate_short_name_set)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -189,9 +189,7 @@ def check_duplicate_values(current_check, line, row, header_name, duplicates, fa
     """
     if row[header_name] and row[header_name] not in duplicates:
         duplicates.add(row[header_name])
-    elif row[header_name] == '':
-        pass
-    else:
+    elif row[header_name] != '':
         if fail:
             echo_failure(f"{current_check}:{line} `{row[header_name]}` is a duplicate {header_name}")
             return True


### PR DESCRIPTION
### What does this PR do?
Add option in validate metadata to check for duplicate descriptions and short names.

### Motivation

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
