### PR TITLE
Add snmp_host tag by default to profiles

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/generic-router.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/generic-router.yaml
@@ -149,3 +149,7 @@ metrics:
   - MIB: UDP-MIB
     symbol: udpHCOutDatagrams
     forced_type: monotonic_count
+metric_tags:
+  - MIB: SNMPv2-MIB
+    symbol: sysName
+    tag: snmp_host

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -419,6 +419,9 @@ class SnmpCheck(AgentCheck):
         # type: (List[ParsedMetricTag], Dict[str, dict]) -> List[str]
         extracted_tags = []
         for tag in metric_tags:
+            if tag.symbol not in results:
+                self.log.debug('Ignoring tag %s', tag.symbol)
+                continue
             [(_, tag_value)] = list(results[tag.symbol].items())
             extracted_tags.append('{}:{}'.format(tag.name, tag_value))
         return extracted_tags

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -1109,7 +1109,8 @@ def test_f5_router(aggregator):
         'ipSystemStatsHCOutMcastPkts',
     ]
     interfaces = ['1.0', 'mgmt', '/Common/internal', '/Common/http-tunnel', '/Common/socks-tunnel']
-    common_tags = common.CHECK_TAGS + ['snmp_profile:router']
+    common_tags = ['snmp_profile:router', 'snmp_host:f5-big-ip-adc-good-byol-1-vm.c.datadog-integrations-lab.internal']
+    common_tags.extend(common.CHECK_TAGS)
     for interface in interfaces:
         tags = ['interface:{}'.format(interface)] + common_tags
         for metric in if_counts:


### PR DESCRIPTION
This adds the snmp_host tag coming from the sysName value in the generic
profile, so that it's available by default.
It also ignores if the value is absent, to prevent failures.