### PR TITLE
Switch back to most specific profile matching

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -12,11 +12,7 @@ from pysnmp.smi import builder, view
 from datadog_checks.base import ConfigurationError, is_affirmative
 
 from .resolver import OIDResolver
-
-
-def to_oid_tuple(oid_string):
-    """Return a OID tuple from a OID string."""
-    return tuple(map(int, oid_string.lstrip('.').split('.')))
+from .utils import to_oid_tuple
 
 
 class ParsedMetric(object):

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -22,7 +22,7 @@ from datadog_checks.base.errors import CheckException
 
 from .compat import read_persistent_cache, total_time_to_temporal_percent, write_persistent_cache
 from .config import InstanceConfig, ParsedMetric, ParsedMetricTag, ParsedTableMetric
-from .utils import get_profile_definition
+from .utils import get_profile_definition, oid_pattern_specificity
 
 # Additional types that are not part of the SNMP protocol. cf RFC 2856
 CounterBasedGauge64, ZeroBasedCounter64 = builder.MibBuilder().importSymbols(
@@ -145,16 +145,14 @@ class SnmpCheck(AgentCheck):
                     continue
 
                 try:
-                    profiles = self._profiles_for_sysobject_oid(sys_object_oid)
+                    profile = self._profile_for_sysobject_oid(sys_object_oid)
                 except ConfigurationError:
                     if not (host_config.all_oids or host_config.bulk_oids):
                         self.log.warning("Host %s didn't match a profile for sysObjectID %s", host, sys_object_oid)
                         continue
                 else:
-                    for profile in profiles:
-                        host_config.refresh_with_profile(self.profiles[profile], self.warning, self.log)
-                    most_specific_profile = profiles[-1]
-                    host_config.add_profile_tag(most_specific_profile)
+                    host_config.refresh_with_profile(self.profiles[profile], self.warning, self.log)
+                    host_config.add_profile_tag(profile)
 
                 config.discovered_instances[host] = host_config
 
@@ -292,21 +290,19 @@ class SnmpCheck(AgentCheck):
         self.log.debug('Returned vars: %s', var_binds)
         return var_binds[0][1].prettyPrint()
 
-    def _profiles_for_sysobject_oid(self, sys_object_oid):
-        # type: (str) -> List[str]
+    def _profile_for_sysobject_oid(self, sys_object_oid):
+        # type: (str) -> str
         """
-        Return all profiles that match the given sysObjectID.
-
-        Profiles are sorted from the most generic to the closest match.
+        Return the most specific profile that matches the given sysObjectID.
         """
         profiles = [profile for oid, profile in self.profiles_by_oid.items() if fnmatch.fnmatch(sys_object_oid, oid)]
 
         if not profiles:
             raise ConfigurationError('No profile matching sysObjectID {}'.format(sys_object_oid))
 
-        profiles.sort(key=lambda profile: self.profiles[profile]['definition']['sysobjectid'])
-
-        return profiles
+        return max(
+            profiles, key=lambda profile: oid_pattern_specificity(self.profiles[profile]['definition']['sysobjectid'])
+        )
 
     def _consume_binds_iterator(self, binds_iterator, config):
         # type: (Iterator[Any], InstanceConfig) -> Tuple[List[Any], Optional[str]]
@@ -385,11 +381,9 @@ class SnmpCheck(AgentCheck):
         try:
             if not (config.all_oids or config.bulk_oids):
                 sys_object_oid = self.fetch_sysobject_oid(config)
-                profiles = self._profiles_for_sysobject_oid(sys_object_oid)
-                for profile in profiles:
-                    config.refresh_with_profile(self.profiles[profile], self.warning, self.log)
-                most_specific_profile = profiles[-1]
-                config.add_profile_tag(most_specific_profile)
+                profile = self._profile_for_sysobject_oid(sys_object_oid)
+                config.refresh_with_profile(self.profiles[profile], self.warning, self.log)
+                config.add_profile_tag(profile)
 
             if config.all_oids or config.bulk_oids:
                 self.log.debug('Querying device %s', config.ip_address)

--- a/snmp/datadog_checks/snmp/utils.py
+++ b/snmp/datadog_checks/snmp/utils.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 import yaml
 
@@ -38,3 +38,31 @@ def _read_profile_definition(definition_file):
 
     with open(definition_file) as f:
         return yaml.safe_load(f)
+
+
+def to_oid_tuple(oid):
+    # type: (str) -> Tuple[int, ...]
+    """Return a OID tuple from a OID string.
+
+    Example:
+    '1.3.6.1.4.1' -> (1, 3, 6, 1, 4, 1)
+    """
+    return tuple(map(int, oid.lstrip('.').split('.')))
+
+
+def oid_pattern_specificity(pattern):
+    # type: (str) -> Tuple[int, Tuple[int, ...]]
+    """Return a measure of the specificity of an OID pattern.
+
+    Suitable for use as a key function when sorting OID patterns.
+    """
+    wildcard_key = -1  # Must be less than all digits, so that e.G. '1.*' is less specific than '1.n' for n = 0...9.
+
+    parts = tuple(
+        wildcard_key if digit == '*' else int(digit) for digit in pattern.lstrip('.').split('.')
+    )
+
+    return (
+        len(parts),  # Shorter OIDs are less specific than longer OIDs, regardless of their contents.
+        parts,  # For same-length OIDs, compare their contents (integer parts).
+    )

--- a/snmp/datadog_checks/snmp/utils.py
+++ b/snmp/datadog_checks/snmp/utils.py
@@ -58,9 +58,7 @@ def oid_pattern_specificity(pattern):
     """
     wildcard_key = -1  # Must be less than all digits, so that e.G. '1.*' is less specific than '1.n' for n = 0...9.
 
-    parts = tuple(
-        wildcard_key if digit == '*' else int(digit) for digit in pattern.lstrip('.').split('.')
-    )
+    parts = tuple(wildcard_key if digit == '*' else int(digit) for digit in pattern.lstrip('.').split('.'))
 
     return (
         len(parts),  # Shorter OIDs are less specific than longer OIDs, regardless of their contents.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Basically reverts #5768, but with a more accurate measure of specificity (string lexicographic order was not enough).

### Motivation
<!-- What inspired you to submit this pull request? -->
Using metrics from all matching profiles was a bad idea, because it induces breaking changes for customers once we want to clean up duplicate metrics for vendor-specific profiles (see #5773) In particular, it creates bad UX as users that want metrics for device X have to include profile X and also profile Y (e.g. `generic-router`). But the profile developer should be the one declaring that "profile X includes metrics from profile Y".

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Once this is merged we can implement a profile extension mechanism such as:

```yaml
# cisco-3850.yml
extends:
  - generic-router.yml  # <-- ?
sysobjectid: ...
metrics:
   - ...
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
