### PR TITLE
Fix error when scrubbing non-org secrets

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/config.py
@@ -123,7 +123,7 @@ def scrub_secrets(config):
             else:
                 break
 
-    for data in config['orgs'].values():
+    for data in config.get('orgs', {}).values():
         api_key = data.get('api_key')
         if api_key:
             data['api_key'] = '*' * len(api_key)


### PR DESCRIPTION
### Motivation

(I added a print)

```
ofek@ozone ~\Desktop $ ddev config set jira.token
Value for `jira.token`:
{'jira': {'token': '************************'}}
Traceback (most recent call last):
  File "C:\Users\ofek\AppData\Local\Programs\Python\Python38\Scripts\ddev-script.py", line 11, in <module>
    load_entry_point('datadog-checks-dev', 'console_scripts', 'ddev')()
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 717, in main
    rv = self.invoke(ctx)
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "c:\users\ofek\desktop\code\integrations-core\datadog_checks_dev\datadog_checks\dev\tooling\commands\config.py", line 134, in set_value
    output_config = scrub_secrets(branch_config_root) if scrubbing else branch_config_root
  File "c:\users\ofek\desktop\code\integrations-core\datadog_checks_dev\datadog_checks\dev\tooling\config.py", line 126, in scrub_secrets
    for data in config['orgs'].values():
KeyError: 'orgs'
```