### PR TITLE
Corrected Typo - 'couchbase' to 'couchdb'.

### DIFF
--- a/couchbase/README.md
+++ b/couchbase/README.md
@@ -58,7 +58,7 @@ _Available for Agent versions >6.0_
    logs:
      - type: file
        path: /var/log/couchdb/couch.log
-       source: couchdb
+       source: couchbase
        service: couchbase
    ```
 

--- a/couchbase/README.md
+++ b/couchbase/README.md
@@ -86,7 +86,7 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 | Parameter      | Value                                                  |
 | -------------- | ------------------------------------------------------ |
-| `<LOG_CONFIG>` | `{"source": "couchdb", "service": "<SERVICE_NAME>"}` |
+| `<LOG_CONFIG>` | `{"source": "couchbase", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
 

--- a/couchbase/README.md
+++ b/couchbase/README.md
@@ -86,7 +86,7 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 | Parameter      | Value                                                  |
 | -------------- | ------------------------------------------------------ |
-| `<LOG_CONFIG>` | `{"source": "couchbase", "service": "<SERVICE_NAME>"}` |
+| `<LOG_CONFIG>` | `{"source": "couchdb", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
 

--- a/couchbase/datadog_checks/couchbase/data/conf.yaml.example
+++ b/couchbase/datadog_checks/couchbase/data/conf.yaml.example
@@ -225,5 +225,5 @@ instances:
 # logs:
 #   - type: file
 #     path: /var/log/couchdb/couch.log
-#     source: couchdb
+#     source: couchbase
 #     service: couchbase


### PR DESCRIPTION
Our documentation states that users should set their log source to couchdb in one instance, but then contradicts itself in saying it should be set to 'couchbase' later. This pull request is fixing this small typo to make the documentation less confusing.

### What does this PR do?
Fix a typo in the Couchbase documentation

### Motivation
A customer was confused from the typo. Fixing it should hopefully help others not fall for the same issue. 

Ticket: https://datadog.zendesk.com/agent/tickets/309575

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
