### PR TITLE
Add Scheduler and Task Metrics for SQL Server

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -105,6 +105,11 @@ files:
       value:
         type: boolean
         example: false
+    - name: include_task_scheduler_metrics
+      description: Include additional Task and Scheduler metrics
+      value:
+        type: boolean
+        example: false
     - template: instances/tags
 
   - template: logs

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -98,6 +98,11 @@ instances:
     #
     # ignore_missing_database: false
 
+    ## @param include_task_scheduler_metrics - boolean - optional - default: false
+    ## Include additional Task and Scheduler metrics
+    #
+    # include_task_scheduler_metrics: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -250,7 +250,11 @@ class SQLServer(AgentCheck):
             row['table'] = table
             row['column'] = column
 
-            metrics_to_collect.append(self.typed_metric(instance, row, table, base_name, None, sql_type, column))
+            metrics_to_collect.append(
+                self.typed_metric(
+                    cfg_inst=row, table=table, base_name=None, user_type=None, sql_type=None, column=column
+                )
+            )
 
         # Load any custom metrics from conf.d/sqlserver.yaml
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -553,7 +553,6 @@ class SQLServer(AgentCheck):
                             metric.fetch_metric(cursor, vfs_rows, vfs_cols, custom_tags)
                         elif type(metric) is SqlOsMemoryClerksStat:
                             metric.fetch_metric(cursor, clerk_rows, clerk_cols, custom_tags)
-                            metric.fetch_metric(cursor, vfs_rows, vfs_cols, custom_tags)
                         elif type(metric) is SqlOsSchedulers:
                             metric.fetch_metric(cursor, scheduler_rows, scheduler_cols, custom_tags)
                         elif type(metric) is SqlOsTasks:

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -29,22 +29,8 @@ LOCAL_SERVER = 'localhost,{}'.format(PORT)
 HERE = get_here()
 CHECK_NAME = "sqlserver"
 
-CUSTOM_METRICS = [
-                   'sqlserver.clr.execution',
-                   'sqlserver.exec.in_progress',
-                   'sqlserver.scheduler.current_workers_count',
-                   'sqlserver.scheduler.active_workers_count',
-                   'sqlserver.scheduler.current_tasks_count',
-                   'sqlserver.scheduler.runnable_tasks_count',
-                   'sqlserver.scheduler.work_queue_count',
-                   'sqlserver.task.context_switches_count',
-                   'sqlserver.task.pending_io_count',
-                   'sqlserver.task.pending_io_byte_count',
-                   'sqlserver.task.pending_io_byte_average',
-                 ]
-EXPECTED_METRICS = [m[0] for m in SQLServer.METRICS] + CUSTOM_METRICS
-DM_OS_SCHEDULERS = "sys.dm_os_schedulers"
-DM_OS_TASKS = "sys.dm_os_tasks"
+CUSTOM_METRICS = ['sqlserver.clr.execution', 'sqlserver.exec.in_progress']
+EXPECTED_METRICS = [m[0] for m in SQLServer.METRICS] + [m[0] for m in SQLServer.ADDITIONAL] + CUSTOM_METRICS
 
 INSTANCE_DOCKER = {
     'host': '{},1433'.format(HOST),
@@ -79,22 +65,6 @@ INIT_CONFIG = {
             'name': 'sqlserver.db.commit_table_entries',
             'type': 'gauge',
             'counter_name': 'Log Flushes/sec',
-            'instance_name': 'ALL',
-            'tag_by': 'db',
-        },
-        {
-            'name': 'sqlserver.scheduler',
-            'table': DM_OS_SCHEDULERS,
-            'type': 'gauge',
-            'columns': ['current_workers_count', 'active_workers_count', 'current_tasks_count', 'runnable_tasks_count', 'work_queue_count', 'num_reads'],
-            'instance_name': 'ALL',
-            'tag_by': 'db',
-        },
-        {
-            'name': 'sqlserver.task',
-            'table': DM_OS_TASKS,
-            'type': 'gauge',
-            'columns': ['context_switches_count', 'pending_io_count', 'pending_io_byte_count', 'pending_io_byte_average'],
             'instance_name': 'ALL',
             'tag_by': 'db',
         },

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -1,4 +1,5 @@
 # (C) Datadog, Inc. 2018-present
+
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -28,8 +29,22 @@ LOCAL_SERVER = 'localhost,{}'.format(PORT)
 HERE = get_here()
 CHECK_NAME = "sqlserver"
 
-CUSTOM_METRICS = ['sqlserver.clr.execution', 'sqlserver.exec.in_progress']
+CUSTOM_METRICS = [
+                   'sqlserver.clr.execution',
+                   'sqlserver.exec.in_progress',
+                   'sqlserver.scheduler.current_workers_count',
+                   'sqlserver.scheduler.active_workers_count',
+                   'sqlserver.scheduler.current_tasks_count',
+                   'sqlserver.scheduler.runnable_tasks_count',
+                   'sqlserver.scheduler.work_queue_count',
+                   'sqlserver.task.context_switches_count',
+                   'sqlserver.task.pending_io_count',
+                   'sqlserver.task.pending_io_byte_count',
+                   'sqlserver.task.pending_io_byte_average',
+                 ]
 EXPECTED_METRICS = [m[0] for m in SQLServer.METRICS] + CUSTOM_METRICS
+DM_OS_SCHEDULERS = "sys.dm_os_schedulers"
+DM_OS_TASKS = "sys.dm_os_tasks"
 
 INSTANCE_DOCKER = {
     'host': '{},1433'.format(HOST),
@@ -64,6 +79,22 @@ INIT_CONFIG = {
             'name': 'sqlserver.db.commit_table_entries',
             'type': 'gauge',
             'counter_name': 'Log Flushes/sec',
+            'instance_name': 'ALL',
+            'tag_by': 'db',
+        },
+        {
+            'name': 'sqlserver.scheduler',
+            'table': DM_OS_SCHEDULERS,
+            'type': 'gauge',
+            'columns': ['current_workers_count', 'active_workers_count', 'current_tasks_count', 'runnable_tasks_count', 'work_queue_count', 'num_reads'],
+            'instance_name': 'ALL',
+            'tag_by': 'db',
+        },
+        {
+            'name': 'sqlserver.task',
+            'table': DM_OS_TASKS,
+            'type': 'gauge',
+            'columns': ['context_switches_count', 'pending_io_count', 'pending_io_byte_count', 'pending_io_byte_average'],
             'instance_name': 'ALL',
             'tag_by': 'db',
         },

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -30,7 +30,9 @@ HERE = get_here()
 CHECK_NAME = "sqlserver"
 
 CUSTOM_METRICS = ['sqlserver.clr.execution', 'sqlserver.exec.in_progress']
-EXPECTED_METRICS = [m[0] for m in SQLServer.METRICS] + [m[0] for m in SQLServer.ADDITIONAL] + CUSTOM_METRICS
+EXPECTED_METRICS = (
+    [m[0] for m in SQLServer.PERF_METRICS] + [m[0] for m in SQLServer.TASK_SCHEDULER_METRICS] + CUSTOM_METRICS
+)
 
 INSTANCE_DOCKER = {
     'host': '{},1433'.format(HOST),
@@ -39,6 +41,7 @@ INSTANCE_DOCKER = {
     'username': 'sa',
     'password': 'Password123',
     'tags': ['optional:tag1'],
+    'include_task_scheduler_metrics': True,
 }
 
 INSTANCE_E2E = INSTANCE_DOCKER.copy()
@@ -50,6 +53,7 @@ INSTANCE_SQL2017 = {
     'password': 'Password12!',
     'connector': 'odbc',
     'driver': '{ODBC Driver 17 for SQL Server}',
+    'include_task_scheduler_metrics': True,
 }
 
 INIT_CONFIG = {

--- a/sqlserver/tests/test_sqlserver.py
+++ b/sqlserver/tests/test_sqlserver.py
@@ -20,6 +20,7 @@ except ImportError:
 @not_windows_ci
 @pytest.mark.usefixtures("dd_environment")
 def test_check_invalid_password(aggregator, init_config, instance_docker):
+
     instance_docker['password'] = 'FOO'
 
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
@@ -111,7 +112,7 @@ def test_check_stored_procedure(aggregator, init_config, instance_docker):
 
     cursor.commit()
     cursor.close()
-
+    
     sqlserver_check.check(instance_docker)
 
     expected_tags = instance_docker.get('tags', []) + sp_tags.split(',')
@@ -171,6 +172,6 @@ def _assert_metrics(aggregator, expected_tags):
     """
     aggregator.assert_metric_has_tag('sqlserver.db.commit_table_entries', 'db:master')
     for mname in EXPECTED_METRICS:
-        aggregator.assert_metric(mname, count=1)
+        aggregator.assert_metric(mname)
     aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK, tags=expected_tags)
     aggregator.assert_all_metrics_covered()

--- a/sqlserver/tests/test_sqlserver.py
+++ b/sqlserver/tests/test_sqlserver.py
@@ -112,7 +112,7 @@ def test_check_stored_procedure(aggregator, init_config, instance_docker):
 
     cursor.commit()
     cursor.close()
-    
+
     sqlserver_check.check(instance_docker)
 
     expected_tags = instance_docker.get('tags', []) + sp_tags.split(',')


### PR DESCRIPTION
### What does this PR do?

Added collecting metrics from two additional tables: 
- sys.dm_os_schedulers
- sys.dm_os_tasks

Their class names are SqlOsSchedulers & SqlOsTasks respectively. 

**SqlOsSchedulers** 
- Tagged with session_id
- Metrics: [Link](https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-schedulers-transact-sql?view=sql-server-2016)

**SqlOsTasks**
- Tagged with session_id & scheduler_id
- Metrics: [Link](https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-tasks-transact-sql?view=sql-server-ver15)

### Motivation
Requested by customer
Issue [AI-559](https://datadoghq.atlassian.net/browse/AI-559)

### Additional Notes

- These additional metrics are added by default and are **not** via custom metrics. 
- This PR does not fully address the customer's request as they would like metrics from custom queries which is not a supported feature at the moment.  

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
