### PR TITLE
Do not fail on octet stream content type

### DIFF
--- a/coredns/tests/conftest.py
+++ b/coredns/tests/conftest.py
@@ -67,6 +67,7 @@ class MockResponse:
     def __init__(self, content, content_type):
         self.content = content
         self.headers = {'Content-Type': content_type}
+        self.encoding = 'utf-8'
 
     def iter_lines(self, **_):
         for elt in self.content.split("\n"):

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -342,6 +342,8 @@ class OpenMetricsScraperMixin(object):
 
         # TODO: Determine if we really need this
         headers.setdefault('accept-encoding', 'gzip')
+
+        # Explicitly set the content type we accept
         headers.setdefault('accept', 'text/plain')
 
         return http_handler

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -342,6 +342,7 @@ class OpenMetricsScraperMixin(object):
 
         # TODO: Determine if we really need this
         headers.setdefault('accept-encoding', 'gzip')
+        headers.setdefault('accept', 'text/plain')
 
         return http_handler
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -359,6 +359,8 @@ class OpenMetricsScraperMixin(object):
         :param response: requests.Response
         :return: core.Metric
         """
+        if response.encoding is None:
+            response.encoding = 'utf-8'
         input_gen = response.iter_lines(chunk_size=self.REQUESTS_CHUNK_SIZE, decode_unicode=True)
         if scraper_config['_text_filter_blacklist']:
             input_gen = self._text_filter_input(input_gen, scraper_config)

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -2271,3 +2271,21 @@ def test_send_request_with_dynamic_prometheus_url(mocked_openmetrics_check_facto
 
     assert "httpbin.org" in resp.content.decode('utf-8')
     assert all(not issubclass(warning.category, InsecureRequestWarning) for warning in record)
+
+
+def test_http_handler(mocked_openmetrics_check_factory):
+    instance = dict(
+        {
+            'prometheus_url': 'https://www.example.com',
+            'metrics': [{'foo': 'bar'}],
+            'namespace': 'openmetrics',
+            'ssl_verify': False,
+        }
+    )
+    check = mocked_openmetrics_check_factory(instance)
+    scraper_config = check.get_scraper_config(instance)
+
+    http_handler = check.get_http_handler(scraper_config)
+
+    assert http_handler.options['headers']['accept-encoding'] == 'gzip'
+    assert http_handler.options['headers']['accept'] == 'text/plain'

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -16,6 +16,7 @@ from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily, Histo
 from six import iteritems
 from urllib3.exceptions import InsecureRequestWarning
 
+from datadog_checks.base import ensure_bytes
 from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.dev import get_here
 
@@ -30,6 +31,7 @@ class MockResponse:
     def __init__(self, content, content_type):
         self.content = content
         self.headers = {'Content-Type': content_type}
+        self.encoding = 'utf-8'
 
     def iter_lines(self, **_):
         for elt in self.content.split("\n"):
@@ -181,7 +183,7 @@ def test_poll_octet_stream(mocked_prometheus_check, mocked_prometheus_scraper_co
     check = mocked_prometheus_check
 
     mock_response = requests.Response()
-    mock_response.raw = io.BytesIO(bytes(text_data, encoding='utf-8'))
+    mock_response.raw = io.BytesIO(ensure_bytes(text_data))
     mock_response.status_code = 200
     mock_response.headers = {'Content-Type': 'application/octet-stream'}
 

--- a/istio/tests/test_check.py
+++ b/istio/tests/test_check.py
@@ -119,6 +119,7 @@ class MockResponse:
         self.content = content if isinstance(content, list) else [content]
         self.headers = {'Content-Type': content_type}
         self.status = status
+        self.encoding = 'utf-8'
 
     def iter_lines(self, **_):
         content = self.content.pop(0)

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -214,6 +214,7 @@ class MockResponse:
     def __init__(self, content, content_type):
         self.content = content
         self.headers = {'Content-Type': content_type}
+        self.encoding = 'utf-8'
 
     def iter_lines(self, **_):
         for elt in self.content.split(b"\n"):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

1. Set encoding to `utf-8` when there is no encoding to avoid failure down the road.

Content might be in bytes when the service exposing the openmetrics endpoint doesn't set correctly the Content-Type and Encoding.

The openmetrics/prometheus exposition format suggest using `utf-8`: https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md

2. Explicitly set the content type we accept to `text/plain`

### Motivation

Currently, if `bytes` content is received. In Python 3 (works for Python 2), the openmetrics check will fail with the following issue:

```
openmetrics (1.3.0)
-------------------
  Instance ID: openmetrics:idm-mhcf74:efee10b119b1d5b0 [ERROR]
  Configuration Source: file:/etc/datadog-agent/conf.d/openmetrics.yaml
  Total Runs: 13
  Metric Samples: Last Run: 0, Total: 0
  Events: Last Run: 0, Total: 0
  Service Checks: Last Run: 1, Total: 13
  Average Execution Time : 11ms
  Error: startswith first arg must be bytes or a tuple of bytes, not str
  Traceback (most recent call last):
    File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/base.py", line 678, in run
      self.check(instance)
    File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/openmetrics/base_check.py", line 82, in check
      self.process(scraper_config)
    File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/openmetrics/mixins.py", line 378, in process
      for metric in self.scrape_metrics(scraper_config):
    File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/openmetrics/mixins.py", line 352, in scrape_metrics
      for metric in self.parse_metric_family(response, scraper_config):
    File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/openmetrics/mixins.py", line 301, in parse_metric_family
      for metric in text_fd_to_metric_families(input_gen):
    File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/prometheus_client/parser.py", line 138, in text_fd_to_metric_families
      if line.startswith('#'):
  TypeError: startswith first arg must be bytes or a tuple of bytes, not str

```


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
