### PR TITLE
Add a test for AOF-loading metrics

### DIFF
--- a/redisdb/tests/test_auth.py
+++ b/redisdb/tests/test_auth.py
@@ -12,7 +12,6 @@ from datadog_checks.redisdb import Redis
 from .common import HOST, PASSWORD, PORT
 
 
-@pytest.mark.integration
 def test_redis_auth_ok(aggregator, redis_auth):
     """
     Test the check can authenticate and connect
@@ -23,7 +22,6 @@ def test_redis_auth_ok(aggregator, redis_auth):
     assert aggregator.metric_names, "No metrics returned"
 
 
-@pytest.mark.integration
 def test_redis_auth_empty_pass(redis_auth):
     """
     Test the check providing an empty password
@@ -35,7 +33,6 @@ def test_redis_auth_empty_pass(redis_auth):
         redis.check(instance)
 
 
-@pytest.mark.integration
 def test_redis_auth_wrong_pass(redis_auth):
     """
     Test the check providing the wrong password

--- a/redisdb/tests/test_default.py
+++ b/redisdb/tests/test_default.py
@@ -21,7 +21,40 @@ DB_TAGGED_METRICS = ['redis.persist.percent', 'redis.expires.percent', 'redis.pe
 STAT_METRICS = ['redis.command.calls', 'redis.command.usec_per_call']
 
 
-@pytest.mark.integration
+def test_aof_loading_metrics(aggregator, redis_instance):
+    """AOF loading metrics are only available when redis is loading an AOF file.
+    It is not possible to collect them using integration/e2e testing so let's mock
+    redis output to assert that they are collected correctly (assuming that the redis output is formatted
+    correctly)."""
+    with mock.patch("redis.Redis") as redis:
+        redis_check = Redis('redisdb', {}, {})
+        conn = redis.return_value
+        conn.config_get.return_value = {}
+        conn.info = (
+            lambda *args: []
+            if args
+            else {
+                'role': 'foo',
+                'total_commands_processed': 0,
+                'loading_total_bytes': 42,
+                'loading_loaded_bytes': 43,
+                'loading_loaded_perc': 44,
+                'loading_eta_seconds': 45,
+            }
+        )
+        redis_check._check_db(redis_instance, [])
+
+        aggregator.assert_metric('redis.info.latency_ms')
+        aggregator.assert_metric('redis.net.commands', 0)
+        aggregator.assert_metric('redis.key.length', 0)
+
+        aggregator.assert_metric('redis.aof.loading_total_bytes', 42)
+        aggregator.assert_metric('redis.aof.loading_loaded_bytes', 43)
+        aggregator.assert_metric('redis.aof.loading_loaded_perc', 44)
+        aggregator.assert_metric('redis.aof.loading_eta_seconds', 45)
+        aggregator.assert_all_metrics_covered()
+
+
 def test_redis_default(aggregator, redis_auth, redis_instance):
     db = redis.Redis(port=PORT, db=14, password=PASSWORD, host=HOST)
     db.flushdb()
@@ -62,7 +95,6 @@ def test_redis_default(aggregator, redis_auth, redis_instance):
     db.flushdb()
 
 
-@pytest.mark.integration
 def test_service_check(aggregator, redis_auth, redis_instance):
     redis_check = Redis('redisdb', {}, {})
     redis_check.check(redis_instance)
@@ -72,7 +104,6 @@ def test_service_check(aggregator, redis_auth, redis_instance):
     assert sc.tags == ['foo:bar', 'redis_host:{}'.format(HOST), 'redis_port:6379', 'redis_role:master']
 
 
-@pytest.mark.integration
 def test_disabled_config_get(aggregator, redis_auth, redis_instance):
     redis_check = Redis('redisdb', {}, {})
     with mock.patch.object(redis.client.Redis, 'config_get') as get:
@@ -101,7 +132,6 @@ def test_metadata(master_instance, datadog_agent):
     datadog_agent.assert_metadata_count(len(version_metadata) + 2)
 
 
-@pytest.mark.integration
 def test_redis_command_stats(aggregator, redis_instance):
     db = redis.Redis(port=PORT, db=14, password=PASSWORD, host=HOST)
     version = db.info().get('redis_version')
@@ -127,7 +157,6 @@ def test_redis_command_stats(aggregator, redis_instance):
     assert found
 
 
-@pytest.mark.integration
 def test__check_key_lengths_misconfig(aggregator, redis_instance):
     """
     The check shouldn't send anything if misconfigured
@@ -151,7 +180,6 @@ def test__check_key_lengths_misconfig(aggregator, redis_instance):
     assert len(list(aggregator.metrics('redis.key.length'))) == 0
 
 
-@pytest.mark.integration
 def test__check_key_lengths_single_db(aggregator, redis_instance):
     """
     Keys are stored in multiple databases but we collect data from
@@ -185,7 +213,6 @@ def test__check_key_lengths_single_db(aggregator, redis_instance):
     aggregator.assert_metric('redis.key.length', value=2)
 
 
-@pytest.mark.integration
 def test__check_key_lengths_multi_db(aggregator, redis_instance):
     """
     Keys are stored across different databases

--- a/redisdb/tests/test_replication.py
+++ b/redisdb/tests/test_replication.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import unicode_literals
 
-import pytest
 import redis
 
 from datadog_checks.redisdb import Redis
@@ -17,7 +16,6 @@ REPLICA_METRICS = [
 ]
 
 
-@pytest.mark.integration
 def test_redis_replication_link_metric(aggregator, replica_instance, dd_environment):
     metric_name = 'redis.replication.master_link_down_since_seconds'
 
@@ -34,7 +32,6 @@ def test_redis_replication_link_metric(aggregator, replica_instance, dd_environm
     assert metrics[0].value > 0
 
 
-@pytest.mark.integration
 def test_redis_replication_service_check(aggregator, replica_instance, dd_environment):
     service_check_name = 'redis.replication.master_link_status'
     redis_check = Redis('redisdb', {}, {})
@@ -52,7 +49,6 @@ def test_redis_replication_service_check(aggregator, replica_instance, dd_enviro
     assert aggregator.service_checks(service_check_name)[0].status == Redis.CRITICAL
 
 
-@pytest.mark.integration
 def test_redis_repl(aggregator, dd_environment, master_instance):
     master_db = redis.Redis(port=MASTER_PORT, db=14, host=HOST)
     replica_db = redis.Redis(port=REPLICA_PORT, db=14, host=HOST)

--- a/redisdb/tests/test_slowlog.py
+++ b/redisdb/tests/test_slowlog.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import random
 
-import pytest
 import redis
 
 from datadog_checks.redisdb import Redis
@@ -15,7 +14,6 @@ from .common import HOST, PASSWORD, PORT
 TEST_KEY = "testkey"
 
 
-@pytest.mark.integration
 def test_slowlog(aggregator, redis_instance):
     db = redis.Redis(port=PORT, db=14, password=PASSWORD, host=HOST)
 
@@ -37,7 +35,6 @@ def test_slowlog(aggregator, redis_instance):
     aggregator.assert_metric('redis.slowlog.micros', tags=expected_tags)
 
 
-@pytest.mark.integration
 def test_custom_slowlog(aggregator, redis_instance):
     redis_instance['slowlog-max-len'] = 1
 

--- a/redisdb/tests/test_unit.py
+++ b/redisdb/tests/test_unit.py
@@ -2,10 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import mock
-import pytest
 from six import iteritems
-
-pytestmark = pytest.mark.unit
 
 
 def test_init(check):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
AOF metrics were not tested. It is not really possible to add them to integration/e2e tests because those metrics are only available when redis is loading a big enough AOF file.
The integration has to run exactly at the time where the AOF file is being loaded.

See #5431
### Motivation
<!-- What inspired you to submit this pull request? -->
Better tests for a better world

### Additional Notes
Also removing all `pytest.mark.(integration|unit)` decorators are they are not used by tox anymore.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
