### PR TITLE
Raise error on invalid content type

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -359,6 +359,8 @@ class OpenMetricsScraperMixin(object):
         :param response: requests.Response
         :return: core.Metric
         """
+        if response.encoding is None:
+            response.encoding = 'utf-8'
         input_gen = response.iter_lines(chunk_size=self.REQUESTS_CHUNK_SIZE, decode_unicode=True)
         if scraper_config['_text_filter_blacklist']:
             input_gen = self._text_filter_input(input_gen, scraper_config)

--- a/linkerd/tests/test_linkerd.py
+++ b/linkerd/tests/test_linkerd.py
@@ -10,6 +10,8 @@ from datadog_checks.linkerd import LinkerdCheck
 
 from .common import EXPECTED_METRICS_V2, EXPECTED_METRICS_V2_E2E, LINKERD_FIXTURE_VALUES, MOCK_INSTANCE
 
+MOCK_HEADERS = {'Content-Type': 'text/plain'}
+
 
 def get_response(filename):
     metrics_file_path = os.path.join(os.path.dirname(__file__), 'fixtures', filename)
@@ -24,7 +26,7 @@ def test_linkerd(aggregator):
     """
     check = LinkerdCheck('linkerd', {}, [MOCK_INSTANCE])
     with requests_mock.Mocker() as metric_request:
-        metric_request.get('http://fake.tld/prometheus', text=get_response('linkerd.txt'))
+        metric_request.get('http://fake.tld/prometheus', text=get_response('linkerd.txt'), headers=MOCK_HEADERS)
         check.check(MOCK_INSTANCE)
 
     for metric in LINKERD_FIXTURE_VALUES:
@@ -42,7 +44,7 @@ def test_linkerd(aggregator):
 def test_linkerd_v2(aggregator):
     check = LinkerdCheck('linkerd', {}, [MOCK_INSTANCE])
     with requests_mock.Mocker() as metric_request:
-        metric_request.get('http://fake.tld/prometheus', text=get_response('linkerd_v2.txt'))
+        metric_request.get('http://fake.tld/prometheus', text=get_response('linkerd_v2.txt'), headers=MOCK_HEADERS)
         check.check(MOCK_INSTANCE)
 
     for metric_name, metric_type in EXPECTED_METRICS_V2.items():


### PR DESCRIPTION
### What does this PR do?

Raise error on invalid content type

### Motivation

Currently, in Python 3 when the content type is `application/octet-stream` the payload is in `bytes` and leads to a cryptic errors like this one.

There is no error for Python 2.

```
openmetrics (1.3.0)
-------------------
  Instance ID: openmetrics:idm-mhcf74:efee10b119b1d5b0 [ERROR]
  Configuration Source: file:/etc/datadog-agent/conf.d/openmetrics.yaml
  Total Runs: 13
  Metric Samples: Last Run: 0, Total: 0
  Events: Last Run: 0, Total: 0
  Service Checks: Last Run: 1, Total: 13
  Average Execution Time : 11ms
  Error: startswith first arg must be bytes or a tuple of bytes, not str
  Traceback (most recent call last):
    File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/base.py", line 678, in run
      self.check(instance)
    File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/openmetrics/base_check.py", line 82, in check
      self.process(scraper_config)
    File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/openmetrics/mixins.py", line 378, in process
      for metric in self.scrape_metrics(scraper_config):
    File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/openmetrics/mixins.py", line 352, in scrape_metrics
      for metric in self.parse_metric_family(response, scraper_config):
    File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/openmetrics/mixins.py", line 301, in parse_metric_family
      for metric in text_fd_to_metric_families(input_gen):
    File "/opt/datadog-agent/embedded/lib/python3.7/site-packages/prometheus_client/parser.py", line 138, in text_fd_to_metric_families
      if line.startswith('#'):
  TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
