### PR TITLE
Hide internal logging exceptions

### DIFF
--- a/datadog_checks_downloader/datadog_checks/downloader/__init__.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/__init__.py
@@ -1,6 +1,10 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import logging
+
 from .__about__ import __version__
 
+# Do not log internal errors from the logging system
+logging.raiseExceptions = False
 __all__ = ['__version__']


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
If an internal logging exception is raised while using the datadog_checks_downloader, we should not display it to the end user.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
