### PR TITLE
Fix E2E parsing of JMX collector output

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/__init__.py
@@ -6,3 +6,4 @@ from .base import AgentCheck
 from .network import EventType, NetworkCheck, Status
 
 __all__ = ['AgentCheck', 'NetworkCheck', 'Status', 'EventType']
+

--- a/datadog_checks_base/datadog_checks/base/checks/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/__init__.py
@@ -6,4 +6,3 @@ from .base import AgentCheck
 from .network import EventType, NetworkCheck, Status
 
 __all__ = ['AgentCheck', 'NetworkCheck', 'Status', 'EventType']
-

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -188,7 +188,7 @@ def dd_agent_check(request, aggregator):
         collector_output = collector_output.strip()
         if not collector_output.endswith(']'):
             # JMX needs some additional cleanup
-            collector_output = collector_output[: collector_output.rfind('} ]\n') + 4]
+            collector_output = collector_output[: collector_output.rfind('} ]\n') + 3]
         try:
             collector = json.loads(collector_output)
         except json.decoder.JSONDecodeError as e:

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -188,8 +188,11 @@ def dd_agent_check(request, aggregator):
         collector_output = collector_output.strip()
         if not collector_output.endswith(']'):
             # JMX needs some additional cleanup
-            collector_output = collector_output[: collector_output.rfind(']') + 1]
-        collector = json.loads(collector_output)
+            collector_output = collector_output[: collector_output.rfind('} ]\n') + 4]
+        try:
+            collector = json.loads(collector_output)
+        except json.decoder.JSONDecodeError as e:
+            raise Exception("Error loading json: {}\nCollector Json Output:\n{}".format(e, collector_output))
 
         replay_check_run(collector, aggregator)
 


### PR DESCRIPTION
### What does this PR do?

Fix jmx json collector by making the json ending matcher more precise.

QA BUILD: https://github.com/DataDog/integrations-core/pull/5857


### Motivation

Fix CI: https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=9402&view=logs&j=8157d5c0-6574-55bb-ebb7-ea0affeefc23&t=3dddf064-efde-5c98-a0ff-42c9c36d5848

In this example, we are matching too much, because one of the log lines contain a ending `]` 

```
    raise Exception("Error loading json: {}\nJson Output:\n{}".format(e, collector_output))
E   Exception: Error loading json: Extra data: line 406 column 1 (char 17176)
E   Json Output:
E   [ {
[...]
E       "service_checks" : [ {
E         "check" : "activemq",
E         "message" : null,
E         "host_name" : "default",
E         "timestamp" : 1582579915,
E         "status" : "OK",
E         "tags" : [ "jmx_server:localhost", "instance:activemq-localhost-1616" ]
E       } ]
E     }
E   } ]
E   2020-02-24 21:31:55,175 | DEBUG | App | Trying to recover broken instances...
E   2020-02-24 21:31:55,176 | DEBUG | App | Done trying to recover broken instances.
E   2020-02-24 21:31:55,179 | DEBUG | HttpClient | attempting to connect to: https://localhost:42689/agent/jmx/status
E   2020-02-24 21:31:55,179 | DEBUG | HttpClient | with body: {"checks":{"failed_checks":{},"initialized_checks":{"activemq":[{"instance_name":"activemq-localhost-1616","metric_count":59,"service_check_count":0,"message":null,"status":"OK"}]
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
