### PR TITLE
Handle case when servers report two values for entries in `metric_tags`

### DIFF
--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -421,8 +421,8 @@ class SnmpCheck(AgentCheck):
             if tag.symbol not in results:
                 self.log.debug('Ignoring tag %s', tag.symbol)
                 continue
-            [(_, tag_value)] = list(results[tag.symbol].items())
-            extracted_tags.append('{}:{}'.format(tag.name, tag_value))
+            for tag_value in results[tag.symbol].values():
+                extracted_tags.append('{}:{}'.format(tag.name, tag_value))
         return extracted_tags
 
     def report_metrics(

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -421,8 +421,13 @@ class SnmpCheck(AgentCheck):
             if tag.symbol not in results:
                 self.log.debug('Ignoring tag %s', tag.symbol)
                 continue
-            for tag_value in results[tag.symbol].values():
-                extracted_tags.append('{}:{}'.format(tag.name, tag_value))
+            tag_values = list(results[tag.symbol].values())
+            if len(tag_values) > 1:
+                raise CheckException(
+                    'You are trying to use a table column (OID `{}`) as a metric tag. This is not supported as '
+                    '`metric_tags` can only refer to scalar OIDs.'.format(tag.symbol)
+                )
+            extracted_tags.append('{}:{}'.format(tag.name, tag_values[0]))
         return extracted_tags
 
     def report_metrics(

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -869,6 +869,30 @@ def test_metric_tags_misconfiguration():
         common.create_check(instance)
 
 
+def test_metric_tag_multiple(aggregator):
+    metrics = common.SUPPORTED_METRIC_TYPES
+    instance = common.generate_instance_config(metrics)
+    instance['metric_tags'] = [
+        {'MIB': 'SNMPv2-MIB', 'symbol': 'sysName', 'tag': 'snmp_host'},
+        {'MIB': 'IF-MIB', 'symbol': 'ifOutOctets', 'tag': 'out'},
+    ]
+    check = common.create_check(instance)
+
+    check.check(instance)
+
+    tag_prefixes = [t.split(':')[0] for t in common.CHECK_TAGS]
+    tag_prefixes.append('snmp_host')
+    tag_prefixes.append('out')
+
+    for metric in common.SUPPORTED_METRIC_TYPES:
+        metric_name = "snmp." + metric['name']
+        for tag_prefix in tag_prefixes:
+            aggregator.assert_metric_has_tag_prefix(metric_name, tag_prefix, count=1)
+
+    aggregator.assert_metric('snmp.sysUpTimeInstance', count=1)
+    aggregator.all_metrics_asserted()
+
+
 def test_f5(aggregator):
     instance = common.generate_instance_config([])
 


### PR DESCRIPTION
### Motivation

![Capture](https://user-images.githubusercontent.com/9677399/75209473-54cbe100-574c-11ea-8060-72e909883ccb.PNG)
