### PR TITLE
Adding Apache integration saved views

### DIFF
--- a/apache/assets/saved_views/4xx_errors.json
+++ b/apache/assets/saved_views/4xx_errors.json
@@ -1,0 +1,17 @@
+{ 
+  "name": "Apache 4xx errors",
+  "type": "logs",
+  "page": "stream",
+  "query": "source:apache @http.status_code:[400 TO 499]",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "host", "service", "status", "@http.status_code", "@http.method", "@http.url_details.path", "@http.useragent_details.browser.family", "@http.useragent_details.device.family", "@http.useragent_details.os.family", "@network.client.ip"],
+  "options": {
+    "columns": ["status", "@http.method", "@http.url_details.path", "@http.status_code"],
+    "show_date_column": true,
+    "show_message_column": true,
+    "message_display": "inline",
+    "show_timeline": true
+  }
+}

--- a/apache/assets/saved_views/5xx_errors.json
+++ b/apache/assets/saved_views/5xx_errors.json
@@ -1,0 +1,17 @@
+{ 
+  "name": "Apache 5xx errors",
+  "type": "logs",
+  "page": "stream",
+  "query": "source:apache @http.status_code:[500 TO 599]",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "host", "service", "status", "@http.status_code", "@http.method", "@http.url_details.path", "@http.useragent_details.browser.family", "@http.useragent_details.device.family", "@http.useragent_details.os.family", "@network.client.ip"],
+  "options": {
+    "columns": ["status", "@http.method", "@http.url_details.path", "@http.status_code"],
+    "show_date_column": true,
+    "show_message_column": true,
+    "message_display": "inline",
+    "show_timeline": true
+  }
+}

--- a/apache/assets/saved_views/bot_errors.json
+++ b/apache/assets/saved_views/bot_errors.json
@@ -1,0 +1,23 @@
+{ 
+  "name": "Apache Pages with error faced by bots",
+  "type": "logs",
+  "page": "analytics",
+  "query": "source:apache @http.useragent_details.browser.family:*bot* @http.status_code:[400 TO 599]",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "service", "host", "status", "@http.status_code", "@http.method", "@http.url_details.path", "@http.useragent_details.browser.family", "@http.useragent_details.device.family", "@http.useragent_details.os.family", "@network.client.ip"],
+  "options": {
+    "group_bys": [
+      { "facet": "@http.useragent_details.browser.family" },
+      { "facet": "@http.status_code" },
+      { "facet": "@http.url_details.path" }
+    ],
+    "aggregations": [
+      { "metric": "count", "type": "count" }
+    ],
+    "limit": "5",
+    "order": "top",
+    "widget": "query_table"
+  }
+}

--- a/apache/assets/saved_views/status_code_overview.json
+++ b/apache/assets/saved_views/status_code_overview.json
@@ -1,0 +1,21 @@
+{ 
+  "name": "Apache status code evolution",
+  "type": "logs",
+  "page": "analytics",
+  "query": "source:apache",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "service", "host", "status", "@http.status_code", "@http.method", "@http.url_details.path", "@http.useragent_details.browser.family", "@http.useragent_details.device.family", "@http.useragent_details.os.family", "@network.client.ip"],
+  "options": {
+    "group_bys": [
+      { "facet": "@http.status_code" }
+    ],
+    "aggregations": [
+      { "metric": "count", "type": "count" }
+    ],
+    "step_ms": "30000",
+    "limit": "50",
+    "widget": "timeseries"
+  }
+}

--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -38,6 +38,12 @@
     },
     "monitors": {},
     "dashboards": {},
+    "saved_views": {
+      "4xx_errors": "assets/saved_views/4xx_errors.json",
+      "5xx_errors": "assets/saved_views/5xx_errors.json",
+      "status_code_overview": "assets/saved_views/status_code_overview.json",
+      "bot_errors": "assets/saved_views/bot_errors.json"
+    },
     "service_checks": "assets/service_checks.json"
   }
 }


### PR DESCRIPTION
### What does this PR do?
Adding integration saved views for Apache

### Motivation
It is now possible to have saved views as part of the integration

### Additional Notes
Bundled with:

- https://github.com/DataDog/integrations-core/pull/5713/files
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
