### PR TITLE
Fix typo in explicit send_histograms_buckets option

### DIFF
--- a/scylla/datadog_checks/scylla/scylla.py
+++ b/scylla/datadog_checks/scylla/scylla.py
@@ -54,7 +54,7 @@ class ScyllaCheck(OpenMetricsBaseCheck):
                 'tags': tags,
                 'metadata_metric_name': 'scylla_scylladb_current_version',
                 'metadata_label_map': {'version': 'version'},
-                'send_histogram_buckets': True,
+                'send_histograms_buckets': True,  # Default, but ensures we collect histograms sent by Scylla.
             }
         )
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Use `send_histograms_buckets` (what is recognized by the OpenMetrics base check) instead of `send_histograms_buckets`.
- Add note on why we're explicitly setting this option.

### Motivation
<!-- What inspired you to submit this pull request? -->
Discovered while QA'ing the new Scylla integration by grepping for `send_histograms_buckets` and realizing there were no other instances of that in the codebase, which seemed weird.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
This wouldn't have triggered issues because the correctly-named option defaults to `True` (which is what we intended to use), so it all worked out of pure luck. But we should still fix this. :-)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
