### PR TITLE
Add integration saved views for NGINX ingress controller

### DIFF
--- a/nginx_ingress_controller/assets/saved_views/4xx_errors.json
+++ b/nginx_ingress_controller/assets/saved_views/4xx_errors.json
@@ -1,0 +1,17 @@
+{ 
+  "name": "NGINX Ingress 4xx errors",
+  "type": "logs",
+  "page": "stream",
+  "query": "source:nginx-ingress-controller @http.status_code:[400 TO 499]",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "host", "service", "status", "@http.status_code", "@http.method", "@http.url_details.path", "@http.useragent_details.browser.family", "@http.useragent_details.device.family", "@http.useragent_details.os.family", "@network.client.ip"],
+  "options": {
+    "columns": ["status", "@http.method", "@http.url_details.path", "@http.status_code"],
+    "show_date_column": true,
+    "show_message_column": true,
+    "message_display": "inline",
+    "show_timeline": true
+  }
+}

--- a/nginx_ingress_controller/assets/saved_views/5xx_errors.json
+++ b/nginx_ingress_controller/assets/saved_views/5xx_errors.json
@@ -1,0 +1,17 @@
+{ 
+  "name": "NGINX Ingress 5xx errors",
+  "type": "logs",
+  "page": "stream",
+  "query": "source:nginx-ingress-controller @http.status_code:[500 TO 599]",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "host", "service", "status", "@http.status_code", "@http.method", "@http.url_details.path", "@http.useragent_details.browser.family", "@http.useragent_details.device.family", "@http.useragent_details.os.family", "@network.client.ip"],
+  "options": {
+    "columns": ["status", "@http.method", "@http.url_details.path", "@http.status_code"],
+    "show_date_column": true,
+    "show_message_column": true,
+    "message_display": "inline",
+    "show_timeline": true
+  }
+}

--- a/nginx_ingress_controller/assets/saved_views/bot_errors.json
+++ b/nginx_ingress_controller/assets/saved_views/bot_errors.json
@@ -1,0 +1,23 @@
+{ 
+  "name": "NGINX Ingress pages with error faced by bots",
+  "type": "logs",
+  "page": "analytics",
+  "query": "source:nginx-ingress-controller @http.useragent_details.browser.family:*bot* @http.status_code:[400 TO 599]",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "service", "host", "status", "@http.status_code", "@http.method", "@http.url_details.path", "@http.useragent_details.browser.family", "@http.useragent_details.device.family", "@http.useragent_details.os.family", "@network.client.ip"],
+  "options": {
+    "group_bys": [
+      { "facet": "@http.useragent_details.browser.family" },
+      { "facet": "@http.status_code" },
+      { "facet": "@http.url_details.path" }
+    ],
+    "aggregations": [
+      { "metric": "count", "type": "count" }
+    ],
+    "limit": "5",
+    "order": "top",
+    "widget": "query_table"
+  }
+}

--- a/nginx_ingress_controller/assets/saved_views/status_code_overview.json
+++ b/nginx_ingress_controller/assets/saved_views/status_code_overview.json
@@ -1,0 +1,21 @@
+{ 
+  "name": "NGINX ingress status code evolution",
+  "type": "logs",
+  "page": "analytics",
+  "query": "source:nginx-ingress-controller",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "service", "host", "status", "@http.status_code", "@http.method", "@http.url_details.path", "@http.useragent_details.browser.family", "@http.useragent_details.device.family", "@http.useragent_details.os.family", "@network.client.ip"],
+  "options": {
+    "group_bys": [
+      { "facet": "@http.status_code" }
+    ],
+    "aggregations": [
+      { "metric": "count", "type": "count" }
+    ],
+    "step_ms": "30000",
+    "limit": "50",
+    "widget": "timeseries"
+  }
+}

--- a/nginx_ingress_controller/manifest.json
+++ b/nginx_ingress_controller/manifest.json
@@ -28,6 +28,12 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
+    "saved_views": {
+      "4xx_errors": "assets/saved_views/4xx_errors.json",
+      "5xx_errors": "assets/saved_views/5xx_errors.json",
+      "status_code_overview": "assets/saved_views/status_code_overview.json",
+      "bot_errors": "assets/saved_views/bot_errors.json"
+    },
     "service_checks": "assets/service_checks.json"
   }
 }


### PR DESCRIPTION
### What does this PR do?
Add integration saved views for NGINX ingress controller

### Motivation
Saved views are now part of the integrations

### Additional Notes
- https://github.com/DataDog/integrations-core/pull/5871
- https://github.com/DataDog/integrations-core/pull/5870
- https://github.com/DataDog/integrations-core/pull/5866
- https://github.com/DataDog/integrations-core/pull/5865
- https://github.com/DataDog/integrations-core/pull/5713
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
