### PR TITLE
Add integration saved views for Presto

### DIFF
--- a/presto/assets/saved_views/4xx_errors.json
+++ b/presto/assets/saved_views/4xx_errors.json
@@ -1,0 +1,17 @@
+{ 
+  "name": "Presto 4xx errors",
+  "type": "logs",
+  "page": "stream",
+  "query": "source:presto @http.status_code:[400 TO 499]",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "host", "service", "status", "@http.status_code", "@http.method", "@http.url_details.path", "@http.useragent_details.browser.family", "@http.useragent_details.device.family", "@http.useragent_details.os.family", "@network.client.ip"],
+  "options": {
+    "columns": ["status", "@http.method", "@http.url_details.path", "@http.status_code"],
+    "show_date_column": true,
+    "show_message_column": true,
+    "message_display": "inline",
+    "show_timeline": true
+  }
+}

--- a/presto/assets/saved_views/5xx_errors.json
+++ b/presto/assets/saved_views/5xx_errors.json
@@ -1,0 +1,17 @@
+{ 
+  "name": "Presto 5xx errors",
+  "type": "logs",
+  "page": "stream",
+  "query": "source:presto @http.status_code:[500 TO 599]",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "host", "service", "status", "@http.status_code", "@http.method", "@http.url_details.path", "@http.useragent_details.browser.family", "@http.useragent_details.device.family", "@http.useragent_details.os.family", "@network.client.ip"],
+  "options": {
+    "columns": ["status", "@http.method", "@http.url_details.path", "@http.status_code"],
+    "show_date_column": true,
+    "show_message_column": true,
+    "message_display": "inline",
+    "show_timeline": true
+  }
+}

--- a/presto/assets/saved_views/error_patterns.json
+++ b/presto/assets/saved_views/error_patterns.json
@@ -1,0 +1,9 @@
+{ 
+  "name": "Presto error patterns",
+  "type": "logs",
+  "page": "patterns",
+  "query": "source:presto status:error",
+  "timerange": {
+    "interval_ms": 3600000
+  }
+}

--- a/presto/assets/saved_views/response_time.json
+++ b/presto/assets/saved_views/response_time.json
@@ -1,0 +1,21 @@
+{ 
+  "name": "Presto response time per page",
+  "type": "logs",
+  "page": "analytics",
+  "query": "source:presto",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "service", "host", "status", "@http.status_code", "@http.method", "@http.url_details.path", "@http.useragent_details.browser.family", "@http.useragent_details.device.family", "@http.useragent_details.os.family", "@network.client.ip"],
+  "options": {
+    "group_bys": [
+      { "facet": "@http.url_details.path" }
+    ],
+    "aggregations": [
+      { "metric": "@duration", "type": "avg" }
+    ],
+    "step_ms": "30000",
+    "limit": "50",
+    "widget": "timeseries"
+  }
+}

--- a/presto/assets/saved_views/status_code_overview.json
+++ b/presto/assets/saved_views/status_code_overview.json
@@ -1,0 +1,21 @@
+{ 
+  "name": "Presto status code evolution",
+  "type": "logs",
+  "page": "analytics",
+  "query": "source:presto",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "service", "host", "status", "@http.status_code", "@http.method", "@http.url_details.path", "@http.useragent_details.browser.family", "@http.useragent_details.device.family", "@http.useragent_details.os.family", "@network.client.ip"],
+  "options": {
+    "group_bys": [
+      { "facet": "@http.status_code" }
+    ],
+    "aggregations": [
+      { "metric": "count", "type": "count" }
+    ],
+    "step_ms": "30000",
+    "limit": "50",
+    "widget": "timeseries"
+  }
+}

--- a/presto/manifest.json
+++ b/presto/manifest.json
@@ -27,6 +27,13 @@
     "dashboards": {
       "Presto Overview": "assets/dashboards/overview.json"
     },
+    "saved_views": {
+      "4xx_errors": "assets/saved_views/4xx_errors.json",
+      "5xx_errors": "assets/saved_views/5xx_errors.json",
+      "status_code_overview": "assets/saved_views/status_code_overview.json",
+      "error_patterns": "assets/saved_views/error_patterns.json",
+      "response_time_overview": "assets/saved_views/response_time.json"
+    },
     "service_checks": "assets/service_checks.json"
   }
 }


### PR DESCRIPTION
### What does this PR do?
Add integration saved views for Presto

### Motivation
Saved views are now part of integrations

### Additional Notes

- https://github.com/DataDog/integrations-core/pull/5713
- https://github.com/DataDog/integrations-core/pull/5865
- https://github.com/DataDog/integrations-core/pull/5866
- https://github.com/DataDog/integrations-core/pull/5870
- https://github.com/DataDog/integrations-core/pull/5871
- https://github.com/DataDog/integrations-core/pull/5872

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
