### PR TITLE
Revert "Bump securesystemslib to 0.14.1"

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -61,7 +61,7 @@ requests==2.22.0
 requests-kerberos==0.12.0
 requests_ntlm==1.1.0
 scandir==1.8
-securesystemslib[crypto,pynacl]==0.14.1
+securesystemslib[crypto,pynacl]==0.14.0
 selectors34==1.2.0; sys_platform == 'win32' and python_version < '3.4'
 semver==2.9.0
 serpent==1.27; sys_platform == 'win32'

--- a/datadog_checks_downloader/requirements.in
+++ b/datadog_checks_downloader/requirements.in
@@ -9,4 +9,4 @@ in-toto==0.4.2
 # both use in common. At the time of writing (Jan 30 2020), this was the latest
 # version of the library.
 #
-securesystemslib[crypto,pynacl]==0.14.1
+securesystemslib[crypto,pynacl]==0.14.0


### PR DESCRIPTION
Reverts DataDog/integrations-core#5874

There is a regression in version 0.14.1, waiting for a fix: https://github.com/secure-systems-lab/securesystemslib/pull/214