### PR TITLE
Rollback db connection when we get a 'FeatureNotSupported' exception

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -367,9 +367,9 @@ class PostgreSql(AgentCheck):
             results = cursor.fetchall()
         except psycopg2.errors.FeatureNotSupported as e:
             # This happens for example when trying to get replication metrics
-            # from readers in Aurora. Let's ignote it.
+            # from readers in Aurora. Let's ignore it.
             log_func(e)
-            return
+            self.db.rollback()
         except psycopg2.errors.UndefinedFunction as e:
             log_func(e)
             log_func(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
On Aurora readers the `pg_last_wal_replay_lsn` call will raise a "FeatureNotSupported" exception that was handled in #5749

We still need to rollback the database connection after catching the exception otherwise following calls will fail until the db is rollback.
The following calls are the custom queries.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
