### PR TITLE
Make test more reliable

### DIFF
--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -659,12 +659,16 @@ def test_profile_sys_object_unknown(aggregator, caplog):
         'network_address': network,
         'port': common.PORT,
         'community_string': 'public',
+        'retries': 0,
+        'discovery_interval': 0,
     }
 
     check = SnmpCheck('snmp', init_config, [instance])
     check._start_discovery()
     time.sleep(2)  # Give discovery a chance to fail finding a matching profile.
     check.check(instance)
+    check._running = False
+    check._thread.join()
 
     for record in caplog.records:
         if "Host {} didn't match a profile".format(host) in record.message:
@@ -690,6 +694,8 @@ def test_discovery(aggregator):
         'network_address': network.encode('utf-8'),
         'port': common.PORT,
         'community_string': 'public',
+        'retries': 0,
+        'discovery_interval': 0,
     }
     init_config = {
         'profiles': {
@@ -706,6 +712,7 @@ def test_discovery(aggregator):
             aggregator.reset()
     finally:
         check._running = False
+        check._thread.join()
 
     for metric in common.SUPPORTED_METRIC_TYPES:
         metric_name = "snmp." + metric['name']

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -4,6 +4,7 @@
 
 import os
 import time
+from concurrent import futures
 from typing import List
 
 import mock
@@ -196,6 +197,8 @@ def test_removing_host():
     check._config.discovered_instances['1.1.1.1'] = InstanceConfig(discovered_instance)
     msg = 'No SNMP response received before timeout for instance 1.1.1.1'
 
+    check._start_discovery = lambda: None
+    check._executor = futures.ThreadPoolExecutor(max_workers=1)
     check.check(instance)
     assert warnings == [msg]
 
@@ -220,6 +223,7 @@ def test_cache_discovered_host(read_mock):
 
     read_mock.return_value = '["192.168.0.1"]'
     check = SnmpCheck('snmp', {}, [instance])
+    check.discover_instances = lambda: None
     check.check(instance)
 
     assert '192.168.0.1' in check._config.discovered_instances
@@ -233,6 +237,7 @@ def test_cache_corrupted(write_mock, read_mock):
     instance['network_address'] = '192.168.0.0/24'
     read_mock.return_value = '["192.168.0."]'
     check = SnmpCheck('snmp', {}, [instance])
+    check.discover_instances = lambda: None
     check.check(instance)
 
     assert not check._config.discovered_instances


### PR DESCRIPTION
Mocking the SNMP layer will make the cache test more reliable. Tests that start a discovery thread should stop it too.