### PR TITLE
[DOCS-702] Not supported on MacOS platform

### DIFF
--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -26,8 +26,7 @@
   "short_description": "Correlate container performance with that of the services running inside them.",
   "support": "core",
   "supported_os": [
-    "linux",
-    "mac_os"
+    "linux"
   ],
   "type": "check",
   "integration_id": "docker",


### PR DESCRIPTION
### What does this PR do?

Removes the mac_os form the supported platform.

### Motivation

It has been confirmed by an escalation, this check is not available on MacOS platforms.
