### PR TITLE
Revert "Pin virtualenv to 20.0.5"

### DIFF
--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -84,7 +84,7 @@ setup(
             'toml>=0.9.4, <1.0.0',
             'tox>=3.12.1',
             'twine>=1.11.0',
-            'virtualenv==20.0.5',  # pin virtualenv version due to https://github.com/pypa/virtualenv/issues/1669
+            'virtualenv==20.*',
             'wheel>=0.31.0',
         ]
     },


### PR DESCRIPTION
Reverts DataDog/integrations-core#5891

The issue have been solved by revert the culprit feature: https://github.com/pypa/virtualenv/issues/1669#issuecomment-591508506