### PR TITLE
[kubernetes_state] rm six.iterkeys

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -7,7 +7,7 @@ import time
 from collections import Counter, defaultdict
 from copy import deepcopy
 
-from six import iteritems, iterkeys
+from six import iteritems
 
 from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.config import is_affirmative
@@ -356,7 +356,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         if experimental_metrics:
             ksm_instance['metrics'].append(experimental_metrics_mapping)
         else:
-            ksm_instance['ignore_metrics'].append(iterkeys(experimental_metrics_mapping))
+            ksm_instance['ignore_metrics'].extend(experimental_metrics_mapping.keys())
 
         ksm_instance['prometheus_url'] = endpoint
         ksm_instance['label_joins'].update(extra_labels)

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -588,6 +588,7 @@ def test_experimental_labels(aggregator, instance):
 
 def test_telemetry(aggregator, instance):
     instance['telemetry'] = True
+    instance['experimental_metrics'] = True
 
     check = KubernetesState(CHECK_NAME, {}, {}, [instance])
     check.poll = mock.MagicMock(return_value=MockResponse(mock_from_file("prometheus.txt"), 'text/plain'))


### PR DESCRIPTION
### What does this PR do?
Fixes a pickle error introduced for py2 in #5447

```
kubernetes_state (5.2.0)
    ------------------------
      Instance ID: kubernetes_state:d52437eab9dd94d4 [ERROR]
      Configuration Source: file:/etc/datadog-agent/conf.d/kubernetes_state.d/auto_conf.yaml
      Total Runs: 95
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 0s
      Last Execution Date : 2020-02-26 18:59:57.000000 UTC
      Last Successful Execution Date : Never
      Error: can't pickle dictionary-keyiterator objects
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/base.py", line 693, in run
          instance = copy.deepcopy(self.instances[0])
        File "/opt/datadog-agent/embedded/lib/python2.7/copy.py", line 163, in deepcopy
          y = copier(x, memo)
        File "/opt/datadog-agent/embedded/lib/python2.7/copy.py", line 257, in _deepcopy_dict
          y[deepcopy(key, memo)] = deepcopy(value, memo)
        File "/opt/datadog-agent/embedded/lib/python2.7/copy.py", line 163, in deepcopy
          y = copier(x, memo)
        File "/opt/datadog-agent/embedded/lib/python2.7/copy.py", line 230, in _deepcopy_list
          y.append(deepcopy(a, memo))
        File "/opt/datadog-agent/embedded/lib/python2.7/copy.py", line 182, in deepcopy
          rv = reductor(2)
      TypeError: can't pickle dictionary-keyiterator objects
```

observed from the output of `agent status`

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
