### PR TITLE
Fix mapping to account for dag_id containing dots

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -94,7 +94,7 @@ Edit the `airflow.d/conf.yaml` file, in the `conf.d/` folder at the root of your
            name: "airflow.pool.starving_tasks"
            tags:
              pool_name: "$1"
-         - match: "airflow\.dagrun\.dependency-check\.(.*)"
+         - match: 'airflow\.dagrun\.dependency-check\.(.*)'
            match_type: "regex"
            name: "airflow.dagrun.dependency_check"
            tags:

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -46,6 +46,7 @@ Edit the `airflow.d/conf.yaml` file, in the `conf.d/` folder at the root of your
 3. Update the [Datadog Agent main configuration file][10] `datadog.yaml` by adding the following configs:
 
    ```yaml
+   # dogstatsd_mapper_cache_size: 1000  # default to 1000
    dogstatsd_mapper_profiles:
      - name: airflow
        prefix: "airflow."
@@ -138,7 +139,6 @@ Edit the `airflow.d/conf.yaml` file, in the `conf.d/` folder at the root of your
            name: "airflow.task.instance_created"
            tags:
              task_class: "$1"
-   # dogstatsd_mapper_cache_size: 1000  # default to 1000
    ```
 
 #### Step 3: Restart Datadog Agent and Airflow

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -100,6 +100,7 @@ Edit the `airflow.d/conf.yaml` file, in the `conf.d/` folder at the root of your
            tags:
              dag_id: "$1"
          - match: "airflow.dag.*.*.duration"
+           match_type: "regex"
            name: "airflow.dag.task.duration"
            tags:
              dag_id: "$1"
@@ -109,23 +110,28 @@ Edit the `airflow.d/conf.yaml` file, in the `conf.d/` folder at the root of your
            name: "airflow.dag_processing.last_duration"
            tags:
              dag_file: "$1"
-         - match: "airflow.dagrun.duration.success.*"
+         - match: 'airflow\.dagrun\.duration\.success\.(.*)'
+           match_type: "regex"
            name: "airflow.dagrun.duration.success"
            tags:
              dag_id: "$1"
-         - match: "airflow.dagrun.duration.failed.*"
+         - match: 'airflow\.dagrun\.duration\.failed\.(.*)'
+           match_type: "regex"
            name: "airflow.dagrun.duration.failed"
            tags:
              dag_id: "$1"
-         - match: "airflow.dagrun.schedule_delay.*"
+         - match: 'airflow\.dagrun\.schedule_delay\.(.*)'
+           match_type: "regex"
            name: "airflow.dagrun.schedule_delay"
            tags:
              dag_id: "$1"
-         - match: "airflow.task_removed_from_dag.*"
+         - match: 'airflow\.task_removed_from_dag\.(.*)'
+           match_type: "regex"
            name: "airflow.dag.task_removed"
            tags:
              dag_id: "$1"
-         - match: "airflow.task_restored_to_dag.*"
+         - match: 'airflow\.task_restored_to_dag\.(.*)'
+           match_type: "regex"
            name: "airflow.dag.task_restored"
            tags:
              dag_id: "$1"

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -98,7 +98,7 @@ Edit the `airflow.d/conf.yaml` file, in the `conf.d/` folder at the root of your
            name: "airflow.dagrun.dependency_check"
            tags:
              dag_id: "$1"
-         - match: "airflow.dag.*.*.duration"
+         - match: 'airflow\.dag\.(.*)\.([^.]*)\.duration'
            match_type: "regex"
            name: "airflow.dag.task.duration"
            tags:

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -46,7 +46,6 @@ Edit the `airflow.d/conf.yaml` file, in the `conf.d/` folder at the root of your
 3. Update the [Datadog Agent main configuration file][10] `datadog.yaml` by adding the following configs:
 
    ```yaml
-   # dogstatsd_mapper_cache_size: 1000  # default to 1000
    dogstatsd_mapper_profiles:
      - name: airflow
        prefix: "airflow."
@@ -139,6 +138,7 @@ Edit the `airflow.d/conf.yaml` file, in the `conf.d/` folder at the root of your
            name: "airflow.task.instance_created"
            tags:
              task_class: "$1"
+   # dogstatsd_mapper_cache_size: 1000  # default to 1000
    ```
 
 #### Step 3: Restart Datadog Agent and Airflow

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -94,7 +94,8 @@ Edit the `airflow.d/conf.yaml` file, in the `conf.d/` folder at the root of your
            name: "airflow.pool.starving_tasks"
            tags:
              pool_name: "$1"
-         - match: "airflow.dagrun.dependency-check.*"
+         - match: "airflow\.dagrun\.dependency-check\.(.*)"
+           match_type: "regex"
            name: "airflow.dagrun.dependency_check"
            tags:
              dag_id: "$1"

--- a/airflow/metadata.csv
+++ b/airflow/metadata.csv
@@ -24,7 +24,6 @@ airflow.pool.open_slots,gauge,,,,Number of open slots in the pool,0,airflow,pool
 airflow.pool.used_slots,gauge,,,,Number of used slots in the pool,0,airflow,pool.used_slots
 airflow.pool.starving_tasks,gauge,,task,,Number of starving tasks in the pool,-1,airflow,pool.starving_tasks
 airflow.dagrun.dependency_check,gauge,,millisecond,,Milliseconds taken to check DAG dependencies,-1,airflow,dagrun.dep_check
-
 airflow.dag.task.duration,gauge,,millisecond,,Milliseconds taken to finish a task,-1,airflow,dag.task.duration
 airflow.dag_processing.last_duration,gauge,,millisecond,,Milliseconds taken to load the given DAG file,-1,airflow,dag_proc.last_duration
 airflow.dagrun.duration.success,gauge,,millisecond,,Milliseconds taken for a DagRun to reach success state,-1,airflow,dagrun.duration.success

--- a/airflow/metadata.csv
+++ b/airflow/metadata.csv
@@ -24,6 +24,7 @@ airflow.pool.open_slots,gauge,,,,Number of open slots in the pool,0,airflow,pool
 airflow.pool.used_slots,gauge,,,,Number of used slots in the pool,0,airflow,pool.used_slots
 airflow.pool.starving_tasks,gauge,,task,,Number of starving tasks in the pool,-1,airflow,pool.starving_tasks
 airflow.dagrun.dependency_check,gauge,,millisecond,,Milliseconds taken to check DAG dependencies,-1,airflow,dagrun.dep_check
+
 airflow.dag.task.duration,gauge,,millisecond,,Milliseconds taken to finish a task,-1,airflow,dag.task.duration
 airflow.dag_processing.last_duration,gauge,,millisecond,,Milliseconds taken to load the given DAG file,-1,airflow,dag_proc.last_duration
 airflow.dagrun.duration.success,gauge,,millisecond,,Milliseconds taken for a DagRun to reach success state,-1,airflow,dagrun.duration.success

--- a/airflow/tests/README.md
+++ b/airflow/tests/README.md
@@ -1,6 +1,6 @@
 # Airflow Dev Readme
 
-## Manual resting Airflow StatsD emitter with Agent DogStatsD
+## Manual testing Airflow StatsD emitter with Agent DogStatsD Mapper
 
 /!\ Works only on Linux. Docker `network_mode` only works as expected on Linux.
 

--- a/airflow/tests/README.md
+++ b/airflow/tests/README.md
@@ -1,24 +1,21 @@
 # Airflow Dev Readme
 
-## Testing Airflow StatsD emitter with Agent DogStatsD
+## Manual resting Airflow StatsD emitter with Agent DogStatsD
 
 /!\ Works only on Linux. Docker `network_mode` only works as expected on Linux.
 
-On a machine/VM with the desired Agent version installed and DogStatsD activated (enabled by default).
+### 1. Start airflow
 
+Example:
+
+```bash
+ddev env start airflow py38
 ```
 
-# 1a. Copy the `dogstatsd_mapper_profiles` mappings from the main readme.md to main `datadog.yaml`
-# 1b. Also set `dogstatsd_metrics_stats_enable=true` in main `datadog.yaml`
-# 1c. Restart Agent
+### 2. Check the agent is receiving the airflow statsd metrics
 
-# 2. Set `network_mode: host` in airflow/tests/compose/docker-compose.yaml
-
-# 3. Start airflow
-
-docker-compose -f airflow/tests/compose/docker-compose.yaml up
-
-# 4. Check the agent is receiving the airflow statsd metrics
-
-sudo -u dd-agent datadog-agent dogstatsd-stats
+```bash
+docker exec -it dd_airflow_py38 agent dogstatsd-stats
 ```
+
+### TODO: Create e2e testing assertions for DogStatsD metrics instead of manual checking the result.

--- a/airflow/tests/compose/.gitignore
+++ b/airflow/tests/compose/.gitignore
@@ -1,0 +1,2 @@
+/tmp_data/*
+!/tmp_data/.keep

--- a/airflow/tests/compose/docker-compose.yaml
+++ b/airflow/tests/compose/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.5'
 services:
     airflow_webserver:
-        network_mode: host  # uncomment for QA, more info in test/README.md
+        network_mode: host  # Necessary for Airflow to send statsd metrics to DogStatsD
         build: .
         restart: always
         volumes:

--- a/airflow/tests/compose/docker-compose.yaml
+++ b/airflow/tests/compose/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.5'
 services:
     airflow_webserver:
-        #network_mode: host  # uncomment for QA, more info in test/README.md
+        network_mode: host  # uncomment for QA, more info in test/README.md
         build: .
         restart: always
         volumes:

--- a/airflow/tests/conftest.py
+++ b/airflow/tests/conftest.py
@@ -26,22 +26,21 @@ def get_readme_mappings():
 
     start = readme.find('dogstatsd_mapper_profiles:')
     end = readme[start:].find('# dogstatsd_mapper_cache_size')
-    return readme[start:start + end]
+    return readme[start : start + end]
 
 
-def create_tmp_data_mappings(mappings):
-    datadog_extras = "dogstatsd_metrics_stats_enable: true\n" \
-                     "dogstatsd_stats_enable: true\n" \
-                     "{}".format(mappings)
+def create_datadog_config(datadog_config):
     with open(path.join(TMP_DATA_FOLDER, 'datadog.yaml'), 'w') as f:
-        f.write(datadog_extras)
-
-
-create_tmp_data_mappings(get_readme_mappings())
+        f.write(datadog_config)
 
 
 @pytest.fixture(scope='session')
 def dd_environment(instance):
+    datadog_config = """
+dogstatsd_metrics_stats_enable: true
+dogstatsd_stats_enable: true
+"""
+    create_datadog_config(datadog_config + get_readme_mappings())
     with docker_run(
         os.path.join(HERE, 'compose', 'docker-compose.yaml'),
         conditions=[CheckEndpoints(URL + '/api/experimental/test', attempts=100)],

--- a/airflow/tests/conftest.py
+++ b/airflow/tests/conftest.py
@@ -38,7 +38,6 @@ def create_datadog_config(datadog_config):
 def dd_environment(instance):
     datadog_config = """
 dogstatsd_metrics_stats_enable: true
-dogstatsd_stats_enable: true
 """
     create_datadog_config(datadog_config + get_readme_mappings())
     with docker_run(

--- a/airflow/tests/conftest.py
+++ b/airflow/tests/conftest.py
@@ -25,7 +25,7 @@ def get_readme_mappings():
         readme = f.read()
 
     start = readme.find('dogstatsd_mapper_profiles:')
-    end = readme[start:].find('# dogstatsd_mapper_cache_size')
+    end = readme[start:].find('```')
     return readme[start : start + end]
 
 


### PR DESCRIPTION
### What does this PR do?

Fix mapping to account for dag_id containing dots.

Example: `airflow.dagrun.dependency_check.foo.bar`

TODO (Separately): Create e2e testing assertions for DogStatsD metrics instead of manual checking the result.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
