### PR TITLE
Add test for historical instance tags and update docs

### DIFF
--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -126,8 +126,9 @@ instances:
     #     - <CLUSTER_REGEX>            # Only possible with "collection_type: historical"
 
     ## @param collect_per_instance_filters - object - optional - default: none
-    ## For each resource type (vm, host, datastore, datacenter, cluster) to collect,
-    ## you can choose which metric you want to collect the instance value using a list of regex.
+    ## Some vsphere metrics can be tagged with instance values.
+    ## For each resource type (vm, host, datastore, cluster) to collect,
+    ## you can choose which metrics you want to collect the instance value as tags using a list of regex.
     ## See https://github.com/DataDog/integrations-core/blob/master/vsphere/datadog_checks/vsphere/metrics.py
     ## for the list of collected metrics (do not prefix them with `vsphere`)
     ## /!\ Use with parsimony, collecting per-instance metrics might be very expensive for big environments.
@@ -139,8 +140,6 @@ instances:
     #     - <HOST_REGEX>               # Only possible with "collection_type: realtime"
     #   datastore:
     #     - <DATASTORE_REGEX>          # Only possible with "collection_type: historical"
-    #   datacenter:
-    #     - <DATACENTER_REGEX>         # Only possible with "collection_type: historical"
     #   cluster:
     #     - <CLUSTER_REGEX>            # Only possible with "collection_type: historical"
 

--- a/vsphere/tests/fixtures/metrics_historical.json
+++ b/vsphere/tests/fixtures/metrics_historical.json
@@ -26,7 +26,7 @@
             2309
         ],
         "counterId": 24,
-        "instance": ""
+        "instance": "8"
     },
     {
         "entity": "Cluster2",
@@ -50,7 +50,7 @@
             7544
         ],
         "counterId": 6,
-        "instance": ""
+        "instance": "16"
     },
     {
         "entity": "Cluster2",
@@ -3192,7 +3192,7 @@
             46580528
         ],
         "counterId": 281,
-        "instance": ""
+        "instance": "value-aa"
     },
     {
         "entity": "NFS Share",

--- a/vsphere/tests/fixtures/metrics_historical.json
+++ b/vsphere/tests/fixtures/metrics_historical.json
@@ -26,7 +26,7 @@
             2309
         ],
         "counterId": 24,
-        "instance": "8"
+        "instance": ""
     },
     {
         "entity": "Cluster2",


### PR DESCRIPTION
### What does this PR do?
Adds an additional test for https://github.com/DataDog/integrations-core/pull/5584 and updates example conf.yaml to remove datacenters from possible filters since none of its metrics have instance values.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
