### PR TITLE
Remove some unnecessary warnings

### DIFF
--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -22,6 +22,21 @@ def smart_retry(f):
     def wrapper(api_instance, *args, **kwargs):
         try:
             return f(api_instance, *args, **kwargs)
+        except vmodl.fault.InvalidArgument:
+            # This error is raised when the api call request is invalid. This error also appear when
+            # requesting non existing metrics. Retrying won't help
+            # https://code.vmware.com/apis/704/vsphere/vmodl.fault.InvalidArgument.html
+            raise
+        except vim.fault.InvalidName:
+            # For the scope of this integration, this is raised when fetching a config value from vCenter
+            # that doesn't exist (especially maxQueryMetrics). Retrying won't help
+            # https://code.vmware.com/apis/704/vsphere/vim.fault.InvalidName.html
+            raise
+        except vim.fault.RestrictedByAdministrator:
+            # The operation cannot complete because of some restriction set by the server administrator.
+            # Retrying won't help
+            # https://code.vmware.com/apis/704/vsphere/vim.fault.RestrictedByAdministrator.html
+            raise
         except Exception as e:
             api_instance.log.debug(
                 "An exception occurred when executing %s: %s. Refreshing the connection to vCenter and retrying",

--- a/vsphere/datadog_checks/vsphere/metrics.py
+++ b/vsphere/datadog_checks/vsphere/metrics.py
@@ -425,8 +425,9 @@ DATACENTER_METRICS = {
 
 # All metrics that can be collected from Clusters.
 CLUSTER_METRICS = {
-    # clusterServices are only available for DRS and HA clusters, and are causing errors. Let's deactivate for now
-    # but they were collected before so investigate why
+    # clusterServices are only available for DRS and HA clusters, and can cause errors that are caught down
+    # the line by the integration. That means some API calls are unnecessary.
+    # TODO: Look if we can prevent those unnecessary API calls
     'clusterServices.cpufairness.latest',
     'clusterServices.effectivecpu.avg',
     'clusterServices.effectivemem.avg',

--- a/vsphere/tests/test_api.py
+++ b/vsphere/tests/test_api.py
@@ -91,7 +91,7 @@ def test_smart_retry(realtime_instance, exception, expected_calls):
         query_perf_counter.side_effect = [exception, 'success']
         try:
             api.get_perf_counter_by_level(None)
-        except:
+        except Exception:
             pass
         assert query_perf_counter.call_count == expected_calls
         assert smart_connect.call_count == expected_calls

--- a/vsphere/tests/test_api.py
+++ b/vsphere/tests/test_api.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import pytest
 from mock import ANY, MagicMock, patch
-from pyVmomi import vim
+from pyVmomi import vim, vmodl
 
 from datadog_checks.vsphere.api import APIConnectionError, VSphereAPI
 from datadog_checks.vsphere.config import VSphereConfig
@@ -72,17 +72,29 @@ def test_get_infrastructure(realtime_instance):
         container_view.Destroy.assert_called_once()
 
 
-def test_smart_retry(realtime_instance):
+@pytest.mark.parametrize(
+    'exception, expected_calls',
+    [
+        (Exception('error'), 2,),
+        (vmodl.fault.InvalidArgument(), 1,),
+        (vim.fault.InvalidName(), 1,),
+        (vim.fault.RestrictedByAdministrator(), 1,),
+    ],
+)
+def test_smart_retry(realtime_instance, exception, expected_calls):
     with patch('datadog_checks.vsphere.api.connect') as connect:
         config = VSphereConfig(realtime_instance, MagicMock())
         api = VSphereAPI(config, MagicMock())
 
         smart_connect = connect.SmartConnect
         query_perf_counter = api._conn.content.perfManager.QueryPerfCounterByLevel
-        query_perf_counter.side_effect = [Exception('error'), 'success']
-        api.get_perf_counter_by_level(None)
-        assert query_perf_counter.call_count == 2
-        assert smart_connect.call_count == 2
+        query_perf_counter.side_effect = [exception, 'success']
+        try:
+            api.get_perf_counter_by_level(None)
+        except:
+            pass
+        assert query_perf_counter.call_count == expected_calls
+        assert smart_connect.call_count == expected_calls
 
 
 def test_get_max_query_metrics(realtime_instance):


### PR DESCRIPTION
Some vSphere metrics (those [ones](https://code.vmware.com/apis/704/vsphere/cluster_services_counters.html)) are only available for cluster resources with DRS or HA configured. When that's not the case, the API call will return "vim.fault.InvalidArgument" (which means that the query is invalid).

To prevent logging unnecessary warnings, this catches and ignore this exception in the `collect_metrics_async` method.

Also, the `smart_retry` decorator is improved to prevent refreshing the connection if we know it doesn't help.