### PR TITLE
Collect metadata for cockroachdb

### DIFF
--- a/cockroachdb/datadog_checks/cockroachdb/cockroachdb.py
+++ b/cockroachdb/datadog_checks/cockroachdb/cockroachdb.py
@@ -18,6 +18,8 @@ class CockroachdbCheck(OpenMetricsBaseCheck):
                     'namespace': 'cockroachdb',
                     'metrics': [METRIC_MAP],
                     'send_histograms_buckets': True,
+                    'metadata_metric_name': 'build_timestamp',
+                    'metadata_label_map': {'version': 'tag'},
                 }
             },
             default_namespace='cockroachdb',

--- a/cockroachdb/datadog_checks/cockroachdb/cockroachdb.py
+++ b/cockroachdb/datadog_checks/cockroachdb/cockroachdb.py
@@ -24,3 +24,9 @@ class CockroachdbCheck(OpenMetricsBaseCheck):
             },
             default_namespace='cockroachdb',
         )
+
+    def transform_metadata(self, metric, scraper_config):
+        # override the method in the base class to continue to send version metric
+        super(CockroachdbCheck, self).transform_metadata(metric, scraper_config)
+
+        self.submit_openmetric('build.timestamp', metric, scraper_config)

--- a/cockroachdb/datadog_checks/cockroachdb/metrics.py
+++ b/cockroachdb/datadog_checks/cockroachdb/metrics.py
@@ -5,7 +5,6 @@ METRIC_MAP = {
     'addsstable_applications': 'addsstable.applications',
     'addsstable_copies': 'addsstable.copies',
     'addsstable_proposals': 'addsstable.proposals',
-    'build_timestamp': 'build.timestamp',
     'capacity': 'capacity.total',
     'capacity_available': 'capacity.available',
     'capacity_reserved': 'capacity.reserved',

--- a/cockroachdb/datadog_checks/cockroachdb/metrics.py
+++ b/cockroachdb/datadog_checks/cockroachdb/metrics.py
@@ -5,6 +5,7 @@ METRIC_MAP = {
     'addsstable_applications': 'addsstable.applications',
     'addsstable_copies': 'addsstable.copies',
     'addsstable_proposals': 'addsstable.proposals',
+    'build_timestamp': 'build.timestamp',
     'capacity': 'capacity.total',
     'capacity_available': 'capacity.available',
     'capacity_reserved': 'capacity.reserved',

--- a/cockroachdb/tests/common.py
+++ b/cockroachdb/tests/common.py
@@ -1,7 +1,11 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+
 from datadog_checks.dev import get_docker_hostname
 
 HOST = get_docker_hostname()
 PORT = '8080'
+
+COCKROACHDB_VERSION = os.getenv('COCKROACHDB_VERSION')

--- a/cockroachdb/tests/test_cockroachdb.py
+++ b/cockroachdb/tests/test_cockroachdb.py
@@ -34,7 +34,7 @@ def _test_check(aggregator):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
-def test_version_metadata(aggregator, instance, dd_environment, datadog_agent):
+def test_version_metadata(aggregator, instance, datadog_agent):
 
     check_instance = CockroachdbCheck('cockroachdb', {}, [instance])
     check_instance.check_id = 'test:123'

--- a/cockroachdb/tests/test_cockroachdb.py
+++ b/cockroachdb/tests/test_cockroachdb.py
@@ -7,6 +7,8 @@ from six import itervalues
 from datadog_checks.cockroachdb import CockroachdbCheck
 from datadog_checks.cockroachdb.metrics import METRIC_MAP
 
+from .common import COCKROACHDB_VERSION
+
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
@@ -28,3 +30,30 @@ def _test_check(aggregator):
         aggregator.assert_metric('cockroachdb.{}'.format(metric), at_least=0)
 
     assert aggregator.metrics_asserted_pct > 80, 'Missing metrics {}'.format(aggregator.not_asserted())
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("dd_environment")
+def test_version_metadata(aggregator, instance, dd_environment, datadog_agent):
+
+    check_instance = CockroachdbCheck('cockroachdb', {}, [instance])
+    check_instance.check_id = 'test:123'
+    check_instance.check(instance)
+
+    if COCKROACHDB_VERSION == 'latest':
+        m = aggregator._metrics['cockroachdb.build.timestamp'][0]
+        # extract version from tags that looks like this: ['tag:v19.2.4', 'go_version:go1.12.12']
+        raw_version = m.tags[0].split(':', 1)[1]
+    else:
+        raw_version = COCKROACHDB_VERSION
+
+    major, minor, patch = raw_version.split('.')
+    version_metadata = {
+        'version.scheme': 'semver',
+        'version.major': major.lstrip('v'),
+        'version.minor': minor,
+        'version.patch': patch,
+        'version.raw': raw_version,
+    }
+
+    datadog_agent.assert_metadata('test:123', version_metadata)

--- a/cockroachdb/tests/test_cockroachdb.py
+++ b/cockroachdb/tests/test_cockroachdb.py
@@ -43,7 +43,9 @@ def test_version_metadata(aggregator, instance, dd_environment, datadog_agent):
     if COCKROACHDB_VERSION == 'latest':
         m = aggregator._metrics['cockroachdb.build.timestamp'][0]
         # extract version from tags that looks like this: ['tag:v19.2.4', 'go_version:go1.12.12']
-        raw_version = m.tags[0].split(':', 1)[1]
+        version_label = [t for t in m.tags if 'tag' in t]
+        assert len(version_label) == 1
+        raw_version = version_label[0].split(':', 1)[1]
     else:
         raw_version = COCKROACHDB_VERSION
 


### PR DESCRIPTION
### What does this PR do?
Update check to collect version metadata.

Example output from `ddev env check cockroachdb py38-latest`:

```
=========
Collector
=========

  Running Checks
  ==============

    cockroachdb (1.1.0)
    -------------------
      Instance ID: cockroachdb:1da816ec4da2d845 [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/cockroachdb.d/cockroachdb.yaml
      Total Runs: 1
      Metric Samples: Last Run: 495, Total: 495
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 1
      Average Execution Time : 59ms
      Last Execution Date : 2020-02-28 16:51:43.000000 UTC
      Last Successful Execution Date : 2020-02-28 16:51:43.000000 UTC
      metadata:
        version.major: 19
        version.minor: 2
        version.patch: 4
        version.raw: v19.2.4
        version.scheme: semver
```
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
