### PR TITLE
[PROD] point kube docs link to correct location

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -8,7 +8,7 @@ Red Hat OpenShift is an open source container application platform based on the 
 
 ### Installation
 
-To install the Agent, refer to the [Agent installation instructions][1] for kubernetes. The default configuration targets OpenShift 3.7.0+ and OpenShift 4.0+, as it relies on features and endpoints introduced in this version.
+To install the Agent, refer to the [Agent installation instructions][2] for kubernetes. The default configuration targets OpenShift 3.7.0+ and OpenShift 4.0+, as it relies on features and endpoints introduced in this version.
 
 ### Configuration
 


### PR DESCRIPTION
### What does this PR do?
Link to Kubernetes install docs was misconfigured. This is misleading during setup. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
