### PR TITLE
Collect version metadata

### DIFF
--- a/gearmand/datadog_checks/gearmand/gearmand.py
+++ b/gearmand/datadog_checks/gearmand/gearmand.py
@@ -119,7 +119,8 @@ class Gearman(AgentCheck):
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, message=str(e), tags=tags)
             raise
 
-        self._collect_metadata(client)
+        if self.is_metadata_collection_enabled():
+            self._collect_metadata(client)
 
     def _collect_metadata(self, client):
         try:

--- a/gearmand/datadog_checks/gearmand/gearmand.py
+++ b/gearmand/datadog_checks/gearmand/gearmand.py
@@ -123,7 +123,8 @@ class Gearman(AgentCheck):
     def _collect_metadata(self, client):
         resp = client.get_version()
         if not resp.startswith('OK'):
-            self.log.error('Error retrieving version information from server, response: %s', resp)
+            self.log.info('Error retrieving version information from server, response: %s', resp)
+            return
 
         server_version = resp.lstrip('OK ')
         self.log.debug("Agent version is `%s`", server_version)

--- a/gearmand/datadog_checks/gearmand/gearmand.py
+++ b/gearmand/datadog_checks/gearmand/gearmand.py
@@ -128,10 +128,11 @@ class Gearman(AgentCheck):
             self.log.warning('Error retrieving version information: %s', e)
             return
 
-        if not resp.startswith('OK'):
+        if not resp.startswith('OK '):
             self.log.warning('Error retrieving version information from server, response: %s', resp)
             return
 
-        server_version = resp.lstrip('OK ')
+        # strip off the 'OK ' text
+        server_version = resp[3:]
         if server_version:
             self.set_metadata('version', server_version)

--- a/gearmand/datadog_checks/gearmand/gearmand.py
+++ b/gearmand/datadog_checks/gearmand/gearmand.py
@@ -115,6 +115,17 @@ class Gearman(AgentCheck):
                 message="Connection to %s:%s succeeded." % (host, port),
                 tags=tags,
             )
+            self._collect_metadata(client)
         except Exception as e:
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, message=str(e), tags=tags)
             raise
+
+    def _collect_metadata(self, client):
+        resp = client.get_version()
+        if not resp.startswith('OK'):
+            self.log.error('Error retrieving version information from server, response: %s', resp)
+
+        server_version = resp.lstrip('OK ')
+        self.log.debug("Agent version is `%s`", server_version)
+        if server_version:
+            self.set_metadata('version', server_version)

--- a/gearmand/tests/test_integration.py
+++ b/gearmand/tests/test_integration.py
@@ -17,3 +17,24 @@ def test_service_check_broken(check, aggregator):
 
     aggregator.assert_service_check('gearman.can_connect', status=Gearman.CRITICAL, tags=tags, count=1)
     aggregator.assert_all_metrics_covered()
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("dd_environment")
+def test_version_metadata(check, aggregator, datadog_agent):
+    check.check_id = 'test:123'
+    check.check(common.INSTANCE)
+
+    # hardcoded because we only support one docker image for test env
+    raw_version = '1.0.6'
+
+    major, minor, patch = raw_version.split('.')
+    version_metadata = {
+        'version.scheme': 'semver',
+        'version.major': major,
+        'version.minor': minor,
+        'version.patch': patch,
+        'version.raw': raw_version,
+    }
+
+    datadog_agent.assert_metadata('test:123', version_metadata)


### PR DESCRIPTION
### What does this PR do?
Collect metadata version information for `gearmand` check.

Example output:

```
=========
Collector
=========

  Running Checks
  ==============

    gearmand (1.4.0)
    ----------------
      Instance ID: gearmand:f19bd6cd32f8f51f [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/gearmand.d/gearmand.yaml
      Total Runs: 1
      Metric Samples: Last Run: 4, Total: 4
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 1
      Average Execution Time : 4ms
      Last Execution Date : 2020-02-28 20:40:23.000000 UTC
      Last Successful Execution Date : 2020-02-28 20:40:23.000000 UTC
      metadata:
        version.major: 1
        version.minor: 0
        version.patch: 6
        version.raw: 1.0.6
        version.scheme: semver
```

### Additional Notes
The test currently fixes the version number since there is only a single tag for the docker container our tests are using.  Will post a separate PR to update to a more active container version.
