### PR TITLE
Add additional (and modern!) test versions for gearmand

### DIFF
--- a/gearmand/tests/common.py
+++ b/gearmand/tests/common.py
@@ -23,3 +23,5 @@ INSTANCE2 = {'server': HOST, 'port': PORT, 'tags': TAGS2}
 BAD_INSTANCE = {'server': HOST, 'port': BAD_PORT, 'tags': TAGS2}
 
 CHECK_NAME = 'gearmand'
+
+GEARMAND_VERSION = os.getenv('GEARMAND_VERSION')

--- a/gearmand/tests/compose/docker-compose.yaml
+++ b/gearmand/tests/compose/docker-compose.yaml
@@ -1,6 +1,6 @@
 version: '2'
 services:
   gearman:
-    image: kendu/gearman
+    image: ${DOCKER_IMAGE}:${DOCKER_TAG}
     ports:
       - 15440:4730

--- a/gearmand/tests/test_integration.py
+++ b/gearmand/tests/test_integration.py
@@ -26,7 +26,7 @@ def test_version_metadata(check, aggregator, datadog_agent):
     check.check(common.INSTANCE)
 
     # hardcoded because we only support one docker image for test env
-    raw_version = '1.0.6'
+    raw_version = common.GEARMAND_VERSION
 
     major, minor, patch = raw_version.split('.')
     version_metadata = {

--- a/gearmand/tox.ini
+++ b/gearmand/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-  py{27,38}-{1.0.6,1.1.17,1.1.18}
+  py{27,38}-{1.0.6,1.1.18}
 
 [testenv]
 description=
@@ -26,6 +26,4 @@ setenv =
     1.0.6: DOCKER_IMAGE=kendu/gearman
     1.0.6: DOCKER_TAG=latest
     1.0.6: GEARMAND_VERSION=1.0.6
-    1.1.17: DOCKER_TAG=1.1.17-alpine
-    1.1.17: GEARMAND_VERSION=1.1.17
 

--- a/gearmand/tox.ini
+++ b/gearmand/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-  py{27,38}
+  py{27,38}-{1.0.6,1.1.17,1.1.18}
 
 [testenv]
 description=
@@ -19,3 +19,13 @@ passenv =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
+setenv =
+    DOCKER_IMAGE=artefactual/gearmand
+    DOCKER_TAG=1.1.18-alpine
+    GEARMAND_VERSION=1.1.18
+    1.0.6: DOCKER_IMAGE=kendu/gearman
+    1.0.6: DOCKER_TAG=latest
+    1.0.6: GEARMAND_VERSION=1.0.6
+    1.1.17: DOCKER_TAG=1.1.17-alpine
+    1.1.17: GEARMAND_VERSION=1.1.17
+


### PR DESCRIPTION
Note: this PR is branched from #5927 so those changes are shown in the diff here as well.

### What does this PR do?
This check had a single version in its test config which dates to 2016.  This adds a few new versions for test and also updates the underlying docker container to one that seems better maintained.

### Motivation
Better testing.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
