### PR TITLE
Disconnect vSphere connection to the server on refresh

### DIFF
--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -91,6 +91,8 @@ class VSphereAPI(object):
             err_msg = "Connection to {} failed: {}".format(self.config.hostname, e)
             raise APIConnectionError(err_msg)
 
+        if self._conn:
+            connect.Disconnect(self._conn)
         self._conn = conn
 
     @smart_retry

--- a/vsphere/tests/test_api.py
+++ b/vsphere/tests/test_api.py
@@ -87,6 +87,7 @@ def test_smart_retry(realtime_instance, exception, expected_calls):
         api = VSphereAPI(config, MagicMock())
 
         smart_connect = connect.SmartConnect
+        disconnect = connect.Disconnect
         query_perf_counter = api._conn.content.perfManager.QueryPerfCounterByLevel
         query_perf_counter.side_effect = [exception, 'success']
         try:
@@ -95,6 +96,7 @@ def test_smart_retry(realtime_instance, exception, expected_calls):
             pass
         assert query_perf_counter.call_count == expected_calls
         assert smart_connect.call_count == expected_calls
+        assert disconnect.call_count == expected_calls - 1
 
 
 def test_get_max_query_metrics(realtime_instance):


### PR DESCRIPTION
the vSphere integration keeps a single connection to the server thay may die, in that case the connection is refreshed.

The assumption was that the connection is refreshed only if the connection is already dead. But it is possible that the `@smart_retry` decorator refreshes it for another reason.

To be safe, let's disconnect any existing connection. It doesn't hurt and it adds some safety.