### PR TITLE
Fix ddev env test for repos other than core

### DIFF
--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -15,9 +15,9 @@ steps:
 
 - ${{ if eq(parameters.test_e2e, 'true') }}:
   - script: |
-      ENV_TEST_OPTS = ''
+      ENV_TEST_OPTS=''
       if [ "${{ parameters.repo }}" == "core" ]; then
-          ENV_TEST_OPTS = '--base'
+          ENV_TEST_OPTS='--base'
       fi
       ddev env test $ENV_TEST_OPTS --new-env --junit ${{ parameters.check }}
     displayName: 'Run E2E tests'

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -5,6 +5,9 @@ parameters:
   test_e2e: false
   benchmark: false
 
+variables:
+  buildConfiguration: 'Release'
+
 steps:
 - ${{ if eq(parameters.test, 'true') }}:
   - script: ddev test --cov --junit ${{ parameters.check }}

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -13,10 +13,16 @@ steps:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
 
 - ${{ if eq(parameters.test_e2e, 'true') }}:
-  - script: ddev env test --base --new-env --junit ${{ parameters.check }}
-    displayName: 'Run E2E tests'
-    env:
-      DD_API_KEY: $(DD_API_KEY)
+  - ${{ if eq(parameters.repo, 'core') }}:
+    - script: ddev env test --base --new-env --junit ${{ parameters.check }}
+      displayName: 'Run E2E tests'
+      env:
+        DD_API_KEY: $(DD_API_KEY)
+  - ${{ if ne(parameters.repo, 'core') }}:
+    - script: ddev env test --new-env --junit ${{ parameters.check }}
+      displayName: 'Run E2E tests'
+      env:
+        DD_API_KEY: $(DD_API_KEY)
 
 - ${{ if eq(parameters.benchmark, 'true') }}:
   - script: ddev test --bench --junit ${{ parameters.check }}

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -4,9 +4,7 @@ parameters:
   test: false
   test_e2e: false
   benchmark: false
-
-variables:
-  buildConfiguration: 'Release'
+  repo: ''
 
 steps:
 - ${{ if eq(parameters.test, 'true') }}:
@@ -16,16 +14,15 @@ steps:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
 
 - ${{ if eq(parameters.test_e2e, 'true') }}:
-  - ${{ if eq(parameters.repo, 'core') }}:
-    - script: ddev env test --base --new-env --junit ${{ parameters.check }}
-      displayName: 'Run E2E tests'
-      env:
-        DD_API_KEY: $(DD_API_KEY)
-  - ${{ if ne(parameters.repo, 'core') }}:
-    - script: ddev env test --new-env --junit ${{ parameters.check }}
-      displayName: 'Run E2E tests'
-      env:
-        DD_API_KEY: $(DD_API_KEY)
+  - script: |
+      ENV_TEST_OPTS = ''
+      if [ "${{ parameters.repo }}" == "core" ]; then
+          ENV_TEST_OPTS = '--base'
+      fi
+      ddev env test $ENV_TEST_OPTS --new-env --junit ${{ parameters.check }}
+    displayName: 'Run E2E tests'
+    env:
+      DD_API_KEY: $(DD_API_KEY)
 
 - ${{ if eq(parameters.benchmark, 'true') }}:
   - script: ddev test --bench --junit ${{ parameters.check }}

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -38,3 +38,4 @@ jobs:
       test: ${{ parameters.test }}
       test_e2e: ${{ parameters.test_e2e }}
       benchmark: ${{ parameters.benchmark }}
+      repo: ${{ parameters.repo }}

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -40,3 +40,4 @@ jobs:
       test: ${{ parameters.test }}
       test_e2e: ${{ parameters.test_e2e }}
       benchmark: ${{ parameters.benchmark }}
+      repo: ${{ parameters.repo }}


### PR DESCRIPTION
### What does this PR do?

Fix ddev env test for repos other than core

### Motivation

https://dev.azure.com/datadoghq/integrations-extras/_build/results?buildId=9350&view=logs&j=910f82a4-622d-5ace-f877-8b75c045486c&t=1d209c90-b82f-5036-aad2-d801f281c6ff

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
