### PR TITLE
Add 'postgres.max_connections' to the manifest 'metric_to_check'

### DIFF
--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -14,7 +14,10 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "postgresql.",
-  "metric_to_check": "postgresql.connections",
+  "metric_to_check": [
+    "postgresql.connections",
+    "postgresql.max_connections"
+  ],
   "name": "postgres",
   "process_signatures": [
     "postgres -D",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
For some simple setups (databases that do not contain non-default tables for example), the postgres.connections metric was not collected.

This PR adds an extra metric to assert for.


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
