### PR TITLE
Add node up/down default metrics

### DIFF
--- a/cassandra/datadog_checks/cassandra/data/metrics.yaml
+++ b/cassandra/datadog_checks/cassandra/data/metrics.yaml
@@ -420,6 +420,12 @@ jmx_metrics:
         - system_schema
         - system_traces
   - include:
+      domain: org.apache.cassandra.net
+      type: FailureDetector
+      attribute:
+        - DownEndpointCount
+        - UpEndpointCount
+  - include:
       domain: org.apache.cassandra.db
       type: ColumnFamilies
       attribute:


### PR DESCRIPTION
# What does this PR do?
Adds two new default cassandra metrics:
* `cassandra.net.up_endpoint_count` - how many healty (UN) nodes the current node sees in the cluster
* `cassanra.net.down_endpoint_count` - how many down (DN) nodes the current node sees in the cluster

Since this data is exposed via JMX we might as well pull those two counts out as default metrics.

JMX check output once these are added:

```
2020-03-02 16:57:20 UTC | CORE | INFO | (pkg/jmxfetch/jmxfetch.go:249 in func1) | 2020-03-02 16:57:20,946 | INFO  | ConsoleReporter | cassanra.net.down_endpoint_count[instance:cassandra-localhost-7199,jmx_domain:org.apache.cassandra.net,type:FailureDetector] - 1583168240 = 1.0
2020-03-02 16:57:20 UTC | CORE | INFO | (pkg/jmxfetch/jmxfetch.go:249 in func1) | 2020-03-02 16:57:20,946 | INFO  | ConsoleReporter | cassandra.net.up_endpoint_count[instance:cassandra-localhost-7199,jmx_domain:org.apache.cassandra.net,type:FailureDetector] - 1583168240 = 50.0
```

### Motivation
There is no way to get the number of `DN` nodes using the default metrics. 

Before this change the only way to get these metrics is by manually running `nodetool status` and counting `UN` vs `DN`. The other option is via the [nodetool check](https://docs.datadoghq.com/integrations/cassandra/#agent-check-cassandra-nodetool) however there is [some concern about overhead](https://mail-archives.apache.org/mod_mbox/cassandra-user/201701.mbox/%3cCACUnPaD-7Tw2694zYpd0eVTTLTyQ2sGvjjuv2COKz84R3ADGKw@mail.gmail.com%3e) of running `nodetool status` very frequently, especially on large clusters.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
