### PR TITLE
Add missing metadata for down/up metrics

### DIFF
--- a/cassandra/datadog_checks/cassandra/data/metrics.yaml
+++ b/cassandra/datadog_checks/cassandra/data/metrics.yaml
@@ -200,6 +200,12 @@ jmx_metrics:
       attribute:
         DroppableTombstoneRatio:
           alias: cassandra.db.droppable_tombstone_ratio
+  - include:
+      domain: org.apache.cassandra.net
+      type: FailureDetector
+      attribute:
+        - DownEndpointCount
+        - UpEndpointCount
   # Young Gen Collectors (Minor Collections)
   - include:
       domain: java.lang
@@ -419,12 +425,6 @@ jmx_metrics:
         - system_distributed
         - system_schema
         - system_traces
-  - include:
-      domain: org.apache.cassandra.net
-      type: FailureDetector
-      attribute:
-        - DownEndpointCount
-        - UpEndpointCount
   - include:
       domain: org.apache.cassandra.db
       type: ColumnFamilies

--- a/cassandra/metadata.csv
+++ b/cassandra/metadata.csv
@@ -31,6 +31,8 @@ cassandra.max_partition_size,gauge,10,byte,,The size of the largest compacted pa
 cassandra.max_row_size,gauge,10,byte,,The size of the largest compacted row.,0,cassandra,max row
 cassandra.mean_partition_size,gauge,10,byte,,The average size of compacted partition.,0,cassandra,mean partition
 cassandra.mean_row_size,gauge,10,byte,,The average size of compacted rows.,0,cassandra,mean row
+cassandra.net.down_endpoint_count,gauge,10,node,,The number of unhealthy nodes in the cluster.,-1,cassandra,down endpoint count
+cassandra.net.up_endpoint_count,gauge,10,node,,The number of healthy nodes in the cluster.,1,cassandra,up endpoint count
 cassandra.pending_compactions,gauge,10,task,,The number of pending compactions.,-1,cassandra,pending compactions
 cassandra.pending_flushes.count,gauge,10,flush,,The number of pending flushes.,-1,cassandra,pending flushes
 cassandra.pending_tasks,gauge,10,task,,The number of pending tasks for the thread pool.,-1,cassandra,pending tasks

--- a/cassandra/metadata.csv
+++ b/cassandra/metadata.csv
@@ -31,8 +31,8 @@ cassandra.max_partition_size,gauge,10,byte,,The size of the largest compacted pa
 cassandra.max_row_size,gauge,10,byte,,The size of the largest compacted row.,0,cassandra,max row
 cassandra.mean_partition_size,gauge,10,byte,,The average size of compacted partition.,0,cassandra,mean partition
 cassandra.mean_row_size,gauge,10,byte,,The average size of compacted rows.,0,cassandra,mean row
-cassandra.net.down_endpoint_count,gauge,10,node,,The number of unhealthy nodes in the cluster.,-1,cassandra,down endpoint count
-cassandra.net.up_endpoint_count,gauge,10,node,,The number of healthy nodes in the cluster.,1,cassandra,up endpoint count
+cassandra.net.down_endpoint_count,gauge,10,node,,The number of unhealthy nodes in the cluster. They represent each individual node's view of the cluster and thus should not be summed across reporting nodes.,-1,cassandra,down endpoint count
+cassandra.net.up_endpoint_count,gauge,10,node,,The number of healthy nodes in the cluster. They represent each individual node's view of the cluster and thus should not be summed across reporting nodes.,1,cassandra,up endpoint count
 cassandra.pending_compactions,gauge,10,task,,The number of pending compactions.,-1,cassandra,pending compactions
 cassandra.pending_flushes.count,gauge,10,flush,,The number of pending flushes.,-1,cassandra,pending flushes
 cassandra.pending_tasks,gauge,10,task,,The number of pending tasks for the thread pool.,-1,cassandra,pending tasks


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We forgot to add metadata for the down/up_endpoint_count metrics. Let's add them here.


Also moves those metrics in the conf.yaml to be outside of the "deprecated" block

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
