### PR TITLE
Set Read Concern to `majority`

### DIFF
--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -836,6 +836,14 @@ class MongoDb(AgentCheck):
                 connectTimeoutMS=timeout,
                 serverSelectionTimeoutMS=timeout,
                 read_preference=pymongo.ReadPreference.PRIMARY_PREFERRED,
+                # Note about Read Concern:
+                # `majority` Read Concern is needed to have `monotonic reads` guarantee,
+                #   that is necessary to avoid collecting metrics values that might be inconsistent between reads.
+                #   Source Read Concern: https://docs.mongodb.com/manual/core/causal-consistency-read-write-concerns/
+                # Monotonic reads ensures that if a process performs read r1, then r2, then r2 cannot observe a state
+                #   prior to the writes which were reflected in r1; intuitively, reads cannot go backwards.
+                #   Source Monotonic Read: http://jepsen.io/consistency/models/monotonic-reads
+                readConcernLevel='majority',
                 **ssl_params
             )
             # some commands can only go against the admin DB


### PR DESCRIPTION
### What does this PR do?

Set Read Concern to Majority.

```
Note about Read Concern:
`majority` Read Concern is needed to have `monotonic reads` guarantee,
  that is necessary to avoid collecting metrics values that might be inconsistent between reads.
  Source Read Concern: https://docs.mongodb.com/manual/core/causal-consistency-read-write-concerns/
Monotonic reads ensures that if a process performs read r1, then r2, then r2 cannot observe a state
  prior to the writes which were reflected in r1; intuitively, reads cannot go backwards.
  Source Monotonic Read: http://jepsen.io/consistency/models/monotonic-reads
```

### Motivation

Hypothesis: 

Not setting read concern to `majority` might lead to reading stale data. Hence causing inconsistencies in the metrics collected.

Currently, when the read concern is not set, it default to `local` or `available`: https://docs.mongodb.com/manual/reference/read-concern/#read-concern-levels

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
