### PR TITLE
Properly use default JMX metrics for E2E

### DIFF
--- a/datadog_checks_base/datadog_checks/base/__about__.py
+++ b/datadog_checks_base/datadog_checks/base/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
+# Licensed under a 3-clause BSOD style license (see LICENSE)
 __version__ = "11.1.0"

--- a/datadog_checks_base/datadog_checks/base/__about__.py
+++ b/datadog_checks_base/datadog_checks/base/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
-# Licensed under a 3-clause BSOD style license (see LICENSE)
+# Licensed under a 3-clause BSD style license (see LICENSE)
 __version__ = "11.1.0"

--- a/datadog_checks_dev/datadog_checks/dev/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/utils.py
@@ -210,9 +210,17 @@ def load_jmx_config():
     root = find_check_root(depth=1)
 
     check = basepath(root)
-    jmx_config = path_join(root, 'datadog_checks', check, 'data', 'conf.yaml.example')
+    example_config_path = path_join(root, 'datadog_checks', check, 'data', 'conf.yaml.example')
+    metrics_config_path = path_join(root, 'datadog_checks', check, 'data', 'metrics.yaml')
 
-    return yaml.safe_load(read_file(jmx_config))
+    example_config = yaml.safe_load(read_file(example_config_path))
+    metrics_config = yaml.safe_load(read_file(metrics_config_path))
+
+    # Avoid having to potentially mount multiple files by putting the default metrics
+    # in the user-defined metric location.
+    example_config['init_config']['conf'] = metrics_config['jmx_metrics']
+
+    return example_config
 
 
 def find_check_root(depth=0):


### PR DESCRIPTION
### Motivation

No reason to keep duplicating sections now that A5 is gone (we'll stop when jmx checks move to config specs)