### PR TITLE
Make aggregator stub support multiple jmx instances

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import json
 import os
+import re
 from base64 import urlsafe_b64encode
 
 import pytest
@@ -177,24 +178,23 @@ def dd_agent_check(request, aggregator):
                     check_command.append(str(value))
 
         result = run_command(check_command, capture=True)
-        if AGENT_COLLECTOR_SEPARATOR not in result.stdout:
+
+        matches = re.findall(AGENT_COLLECTOR_SEPARATOR + r'\n(.*?\n\} \])', result.stdout, re.DOTALL)
+
+        if not matches:
             raise ValueError(
                 '{}{}\nCould not find `{}` in the output'.format(
                     result.stdout, result.stderr, AGENT_COLLECTOR_SEPARATOR
                 )
             )
 
-        _, _, collector_output = result.stdout.partition(AGENT_COLLECTOR_SEPARATOR)
-        collector_output = collector_output.strip()
-        if not collector_output.endswith(']'):
-            # JMX needs some additional cleanup
-            collector_output = collector_output[: collector_output.rfind('} ]\n') + 3]
-        try:
-            collector = json.loads(collector_output)
-        except json.decoder.JSONDecodeError as e:
-            raise Exception("Error loading json: {}\nCollector Json Output:\n{}".format(e, collector_output))
+        for raw_json in matches:
+            try:
+                collector = json.loads(raw_json)
+            except json.decoder.JSONDecodeError as e:
+                raise Exception("Error loading json: {}\nCollector Json Output:\n{}".format(e, raw_json))
 
-        replay_check_run(collector, aggregator)
+            replay_check_run(collector, aggregator)
 
         return aggregator
 


### PR DESCRIPTION
Support multiple jmx instances

Example:

```
2020-03-04 15:24:44,851 | INFO  | App | Successfully initialized instance: confluent_platform-localhost-31001
2020-03-04 15:24:45,002 | INFO  | Reporter | Instance confluent_platform-localhost-31002 is sending 38 metrics to the metrics reporter during collection #1
2020-03-04 15:24:45,011 | DEBUG | JsonReporter | Displaying JSON output
=== JSON ===
[ {
  "aggregator" : {
  }
} ]
2020-03-04 15:24:45,072 | INFO  | Reporter | Instance confluent_platform-localhost-31001 is sending 254 metrics to the metrics reporter during collection #1
2020-03-04 15:24:45,077 | DEBUG | JsonReporter | Displaying JSON output
=== JSON ===
[ {
  "aggregator" : {
  }
} ]
2020-03-04 15:24:45,105 | DEBUG | App | Trying to recover broken instances...
2020-03-04 15:24:45,110 | DEBUG | App | Done trying to recover broken instances.
```