### PR TITLE
Improve aggregator stub's `assert_all_metrics_covered` error message

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -298,7 +298,7 @@ class AggregatorStub(object):
         if not condition:
             prefix = '\n\t- '
             msg = 'Some metrics are missing:'
-            msg += '\nMetrics Asserted:{}{}'.format(prefix, prefix.join(sorted(self._asserted)))
+            msg += '\nAsserted Metrics:{}{}'.format(prefix, prefix.join(sorted(self._asserted)))
             msg += '\nMissing Metrics:{}{}'.format(prefix, prefix.join(sorted(self.not_asserted())))
         assert condition, msg
 

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -292,10 +292,15 @@ class AggregatorStub(object):
         assert condition, new_msg
 
     def assert_all_metrics_covered(self):
-        missing_metrics = ''
-        if self.metrics_asserted_pct < 100.0:
-            missing_metrics = self.not_asserted()
-        assert self.metrics_asserted_pct >= 100.0, 'Missing metrics: {}'.format(missing_metrics)
+        # use `condition` to avoid building the `msg` if not needed
+        condition = self.metrics_asserted_pct >= 100.0
+        msg = ''
+        if not condition:
+            prefix = '\n\t- '
+            msg = 'Some metrics are missing:'
+            msg += '\nMetrics Asserted:{}{}'.format(prefix, prefix.join(sorted(self._asserted)))
+            msg += '\nMissing Metrics:{}{}'.format(prefix, prefix.join(sorted(self.not_asserted())))
+        assert condition, msg
 
     def assert_no_duplicate_all(self):
         """


### PR DESCRIPTION
### What does this PR do?

Improve assert_all_metrics_covered assert message

```
tests/test_apache.py:81: in test_check_auto
    aggregator.assert_all_metrics_covered()
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:303: in assert_all_metrics_covered
    assert condition, msg
E   AssertionError: Some metrics are missing
E     Metrics Asserted:
E     	- apache.conns_async_closing
E     	- apache.conns_async_keep_alive
E     	- apache.conns_async_writing
E     	- apache.net.bytes_per_s
E     	- apache.net.request_per_s
E     	- apache.performance.busy_workers
E     	- apache.performance.cpu_load
E     	- apache.performance.idle_workers
E     	- apache.performance.uptime
E     Missing Metrics:
E     	- apache.conns_total
E     	- apache.net.bytes
E     	- apache.net.hits
E   assert False
-------------------------------------------------------------- Captured stderr setup ---------------------------------------------------------------

```