### PR TITLE
Revert "Submit total_alloc as monotonic count"

### DIFF
--- a/go_expvar/datadog_checks/go_expvar/go_expvar.py
+++ b/go_expvar/datadog_checks/go_expvar/go_expvar.py
@@ -40,6 +40,7 @@ DEFAULT_METRIC_NAMESPACE = "go_expvar"
 DEFAULT_GAUGE_MEMSTAT_METRICS = [
     # General statistics
     "Alloc",
+    "TotalAlloc",
     # Main allocation heap statistics
     "HeapAlloc",
     "HeapSys",
@@ -59,13 +60,9 @@ DEFAULT_RATE_MEMSTAT_METRICS = [
     "NumGC",
 ]
 
-DEFAULT_COUNTER_METRICS = ["TotalAlloc"]
-
-DEFAULT_METRICS = (
-    [{PATH: "memstats/%s" % path, TYPE: GAUGE} for path in DEFAULT_GAUGE_MEMSTAT_METRICS]
-    + [{PATH: "memstats/%s" % path, TYPE: RATE} for path in DEFAULT_RATE_MEMSTAT_METRICS]
-    + [{PATH: "memstats/%s" % path, TYPE: MONOTONIC_COUNTER} for path in DEFAULT_COUNTER_METRICS]
-)
+DEFAULT_METRICS = [{PATH: "memstats/%s" % path, TYPE: GAUGE} for path in DEFAULT_GAUGE_MEMSTAT_METRICS] + [
+    {PATH: "memstats/%s" % path, TYPE: RATE} for path in DEFAULT_RATE_MEMSTAT_METRICS
+]
 
 GO_EXPVAR_URL_PATH = "/debug/vars"
 

--- a/go_expvar/metadata.csv
+++ b/go_expvar/metadata.csv
@@ -16,4 +16,4 @@ go_expvar.memstats.pause_ns.count,rate,,sample,second,Number of submitted GC pau
 go_expvar.memstats.pause_ns.max,gauge,,nanosecond,,Max GC pause duration,0,go_expvar,gc pause max
 go_expvar.memstats.pause_ns.median,gauge,,nanosecond,,Median GC pause duration,0,go_expvar,gc pause median
 go_expvar.memstats.pause_total_ns,gauge,,nanosecond,,Total GC pause duration over lifetime of process,0,go_expvar,gc pause tot
-go_expvar.memstats.total_alloc,count,,byte,,Bytes allocated (even if freed),0,go_expvar,total alloc
+go_expvar.memstats.total_alloc,gauge,,byte,,Bytes allocated (even if freed),0,go_expvar,total alloc

--- a/go_expvar/tests/common.py
+++ b/go_expvar/tests/common.py
@@ -27,6 +27,7 @@ CHECK_GAUGES = [
     'go_expvar.memstats.heap_objects',
     'go_expvar.memstats.heap_released',
     'go_expvar.memstats.heap_sys',
+    'go_expvar.memstats.total_alloc',
 ]
 
 # this is a histogram
@@ -46,8 +47,4 @@ CHECK_RATES = [
     'go_expvar.memstats.mallocs',
     'go_expvar.memstats.num_gc',
     'go_expvar.memstats.pause_total_ns',
-]
-
-CHECK_COUNT = [
-    'go_expvar.memstats.total_alloc',
 ]

--- a/go_expvar/tests/test_e2e.py
+++ b/go_expvar/tests/test_e2e.py
@@ -26,7 +26,5 @@ def test_check_e2e(dd_agent_check):
         aggregator.assert_metric(gauge, count=1, tags=shared_tags)
     for rate in common.CHECK_RATES + CHECK_RATES_CUSTOM:
         aggregator.assert_metric(rate, count=2, tags=shared_tags)
-    for count in common.CHECK_COUNT:
-        aggregator.assert_metric(count, count=2, tags=shared_tags)
 
     aggregator.assert_all_metrics_covered()

--- a/go_expvar/tests/test_integration.py
+++ b/go_expvar/tests/test_integration.py
@@ -27,7 +27,5 @@ def test_go_expvar(check, aggregator):
         aggregator.assert_metric(rate, count=1, tags=shared_tags)
     for rate, value in iteritems(CHECK_RATES_CUSTOM):
         aggregator.assert_metric(rate, count=1, value=value, tags=shared_tags)
-    for count in common.CHECK_COUNT:
-        aggregator.assert_metric(count, count=1, metric_type=3, tags=shared_tags)
 
     aggregator.assert_all_metrics_covered()

--- a/go_expvar/tests/test_unit.py
+++ b/go_expvar/tests/test_unit.py
@@ -20,6 +20,7 @@ CHECK_GAUGES = [
     '{}.memstats.heap_objects',
     '{}.memstats.heap_released',
     '{}.memstats.heap_sys',
+    '{}.memstats.total_alloc',
 ]
 
 # this is a histogram
@@ -32,8 +33,6 @@ CHECK_RATES = [
     '{}.memstats.num_gc',
     '{}.memstats.pause_total_ns',
 ]
-
-CHECK_COUNT = ['{}.memstats.total_alloc']
 
 CHECK_GAUGES_CUSTOM_MOCK = {
     '{}.gauge1': ['metric_tag1:metric_value1', 'metric_tag2:metric_value2', 'path:random_walk'],
@@ -103,10 +102,6 @@ def test_go_expvar_mocked(go_expvar_mock, check, aggregator):
             metric_type=aggregator.COUNT,
             tags=shared_tags + ['path:memstats.NumGC'],
         )
-    for count in CHECK_COUNT:
-        aggregator.assert_metric(
-            count.format(common.CHECK_NAME), count=1, metric_type=aggregator.MONOTONIC_COUNT, tags=shared_tags,
-        )
 
     aggregator.assert_all_metrics_covered()
 
@@ -153,8 +148,6 @@ def test_go_expvar_mocked_namespace(go_expvar_mock, check, aggregator):
         aggregator.assert_metric(
             rate.format(metric_namespace), count=1, tags=shared_tags + ['path:memstats.PauseTotalNs']
         )
-    for count in CHECK_COUNT:
-        aggregator.assert_metric(count.format(metric_namespace), tags=shared_tags)
 
     aggregator.assert_all_metrics_covered()
 


### PR DESCRIPTION
Reverts DataDog/integrations-core#5703.

Changing `go_expvar.memstats.total_alloc`  to submit as monotonic_count will affect graphs on dashboards.