### PR TITLE
Improve assertion messages of aggregator stub

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -150,9 +150,7 @@ class AggregatorStub(object):
             if tag in metric.tags:
                 candidates.append(metric)
 
-        msg = "Candidates size assertion for `{}`, count: {}, at_least: {}) failed".format(
-            metric_name, count, at_least
-        )
+        msg = "Candidates size assertion for `{}`, count: {}, at_least: {}) failed".format(metric_name, count, at_least)
         if count is not None:
             assert len(candidates) == count, msg
         else:
@@ -173,9 +171,7 @@ class AggregatorStub(object):
             else:
                 candidates.append(e)
 
-        msg = "Candidates size assertion for `{}`, count: {}, at_least: {}) failed".format(
-            msg_text, count, at_least
-        )
+        msg = "Candidates size assertion for `{}`, count: {}, at_least: {}) failed".format(msg_text, count, at_least)
         if count is not None:
             assert len(candidates) == count, msg
         else:
@@ -395,9 +391,7 @@ class AggregatorStub(object):
             if len(gtags) > 0:
                 candidates.append(metric)
 
-        msg = "Candidates size assertion for `{}`, count: {}, at_least: {}) failed".format(
-            metric_name, count, at_least
-        )
+        msg = "Candidates size assertion for `{}`, count: {}, at_least: {}) failed".format(metric_name, count, at_least)
         if count is not None:
             assert len(candidates) == count, msg
         else:

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -150,10 +150,13 @@ class AggregatorStub(object):
             if tag in metric.tags:
                 candidates.append(metric)
 
+        msg = "Candidates size assertion for `{}`, count: {}, at_least: {}) failed".format(
+            metric_name, count, at_least
+        )
         if count is not None:
-            assert len(candidates) == count
+            assert len(candidates) == count, msg
         else:
-            assert len(candidates) >= at_least
+            assert len(candidates) >= at_least, msg
 
     # Potential kwargs: aggregation_key, alert_type, event_type,
     # msg_title, source_type_name
@@ -170,7 +173,7 @@ class AggregatorStub(object):
             else:
                 candidates.append(e)
 
-        msg = ("Candidates size assertion for {0}, count: {1}, " "at_least: {2}) failed").format(
+        msg = "Candidates size assertion for `{}`, count: {}, at_least: {}) failed".format(
             msg_text, count, at_least
         )
         if count is not None:
@@ -392,10 +395,13 @@ class AggregatorStub(object):
             if len(gtags) > 0:
                 candidates.append(metric)
 
+        msg = "Candidates size assertion for `{}`, count: {}, at_least: {}) failed".format(
+            metric_name, count, at_least
+        )
         if count is not None:
-            assert len(candidates) == count
+            assert len(candidates) == count, msg
         else:
-            assert len(candidates) >= at_least
+            assert len(candidates) >= at_least, msg
 
     @property
     def metrics_asserted_pct(self):


### PR DESCRIPTION
### What does this PR do?
Improve assertion messages

### Motivation

Before

```
        if count is not None:
            assert len(candidates) == count
        else:
>           assert len(candidates) >= at_least
E           assert 0 >= 1
E            +  where 0 = len([])
```

After

```

E           AssertionError: Candidates size assertion for clickhouse.cache_dictionary.update_queue.batches, count: None, at_least: 1) failed
E           assert 0 >= 1
E            +  where 0 = len([])
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
