### PR TITLE
Fix flaky hive e2e test and add metastore metrics

### DIFF
--- a/hive/tests/common.py
+++ b/hive/tests/common.py
@@ -7,3 +7,6 @@ CHECK_NAME = 'hive'
 
 HERE = get_here()
 HOST = get_docker_hostname()
+
+METASTORE_PORT = 8808
+SERVER_PORT = 8809

--- a/hive/tests/conftest.py
+++ b/hive/tests/conftest.py
@@ -10,7 +10,7 @@ from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs
 from datadog_checks.dev.utils import load_jmx_config
 
-from .common import HERE
+from .common import HERE, HOST, METASTORE_PORT, SERVER_PORT
 
 
 @pytest.fixture(scope="session")
@@ -26,4 +26,8 @@ def dd_environment():
             )
         ],
     ):
-        yield load_jmx_config(), {'use_jmx': True}
+        instance_metastore = {'host': HOST, 'port': METASTORE_PORT}
+        instance_server = {'host': HOST, 'port': SERVER_PORT}
+        config = load_jmx_config()
+        config['instances'] = [instance_metastore, instance_server]
+        yield config, {'use_jmx': True}

--- a/hive/tests/conftest.py
+++ b/hive/tests/conftest.py
@@ -6,7 +6,6 @@ import os
 
 import pytest
 
-
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs
 from datadog_checks.dev.utils import load_jmx_config
@@ -19,6 +18,12 @@ def dd_environment():
     compose_file = os.path.join(HERE, 'compose', 'docker-compose.yaml')
     with docker_run(
         compose_file,
-        conditions=[CheckDockerLogs(compose_file, [r'datanode:\d+ is available', 'Starting Hive Metastore Server', 'Starting HiveServer2'], matches='all')],
+        conditions=[
+            CheckDockerLogs(
+                compose_file,
+                [r'datanode:\d+ is available', 'Starting Hive Metastore Server', 'Starting HiveServer2'],
+                matches='all',
+            )
+        ],
     ):
         yield load_jmx_config(), {'use_jmx': True}

--- a/hive/tests/conftest.py
+++ b/hive/tests/conftest.py
@@ -6,7 +6,9 @@ import os
 
 import pytest
 
+
 from datadog_checks.dev import docker_run
+from datadog_checks.dev.conditions import CheckDockerLogs
 from datadog_checks.dev.utils import load_jmx_config
 
 from .common import HERE
@@ -14,9 +16,9 @@ from .common import HERE
 
 @pytest.fixture(scope="session")
 def dd_environment():
+    compose_file = os.path.join(HERE, 'compose', 'docker-compose.yaml')
     with docker_run(
-        os.path.join(HERE, 'compose', 'docker-compose.yaml'),
-        log_patterns=[r'datanode:\(\d+\) is available', 'Starting Hive Metastore Server', 'Starting HiveServer2'],
-        sleep=2,
+        compose_file,
+        conditions=[CheckDockerLogs(compose_file, [r'datanode:\d+ is available', 'Starting Hive Metastore Server', 'Starting HiveServer2'], matches='all')],
     ):
         yield load_jmx_config(), {'use_jmx': True}

--- a/hive/tests/test_check.py
+++ b/hive/tests/test_check.py
@@ -1,10 +1,7 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-
 import pytest
-
-import time
 
 METASTORE_METRICS = [
     "hive.metastore.api.get_all_tables.active_call",
@@ -14,6 +11,8 @@ METASTORE_METRICS = [
     "hive.metastore.api.get_all_databases.active_call",
     "hive.metastore.api.init.active_call",
 ]
+
+
 @pytest.mark.e2e
 def test(dd_agent_check):
     instance = {}

--- a/hive/tests/test_check.py
+++ b/hive/tests/test_check.py
@@ -4,7 +4,16 @@
 
 import pytest
 
+import time
 
+METASTORE_METRICS = [
+    "hive.metastore.api.get_all_tables.active_call",
+    "hive.metastore.api.get_all_functions.active_call",
+    "hive.metastore.open_connections",
+    "hive.metastore.partition.init",
+    "hive.metastore.api.get_all_databases.active_call",
+    "hive.metastore.api.init.active_call",
+]
 @pytest.mark.e2e
 def test(dd_agent_check):
     instance = {}

--- a/hive/tests/test_check.py
+++ b/hive/tests/test_check.py
@@ -3,20 +3,10 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import pytest
 
-METASTORE_METRICS = [
-    "hive.metastore.api.get_all_tables.active_call",
-    "hive.metastore.api.get_all_functions.active_call",
-    "hive.metastore.open_connections",
-    "hive.metastore.partition.init",
-    "hive.metastore.api.get_all_databases.active_call",
-    "hive.metastore.api.init.active_call",
-]
-
 
 @pytest.mark.e2e
 def test(dd_agent_check):
-    instance = {}
-    aggregator = dd_agent_check(instance)
+    aggregator = dd_agent_check()
     metrics = [
         "hive.server.memory.heap.committed",
         "hive.server.memory.heap.init",
@@ -32,6 +22,12 @@ def test(dd_agent_check):
         "hive.server.memory.total.used",
         "hive.server.session.active",
         "hive.server.session.open",
+        "hive.metastore.api.get_all_tables.active_call",
+        "hive.metastore.api.get_all_functions.active_call",
+        "hive.metastore.open_connections",
+        "hive.metastore.partition.init",
+        "hive.metastore.api.get_all_databases.active_call",
+        "hive.metastore.api.init.active_call",
     ]
     for metric in metrics:
         aggregator.assert_metric(metric)


### PR DESCRIPTION
The first log_pattern condition was incorrect which results in the e2e test failing because the services were not ready.

Also includes some of the metastore metrics to check since we only asserted server metrics.