### PR TITLE
Fix metric name for e2e test

### DIFF
--- a/kafka/datadog_checks/kafka/data/conf.yaml.example
+++ b/kafka/datadog_checks/kafka/data/conf.yaml.example
@@ -616,7 +616,7 @@ init_config:
         attribute:
           Value:
             metric_type: gauge
-            alias: kafka.net.handler.avg.idle.pct.rate
+            alias: kafka.net.processor.avg.idle.pct.rate
     - include:
         domain: 'kafka.server'
         bean: 'kafka.server:type=KafkaRequestHandlerPool,name=RequestHandlerAvgIdlePercent'

--- a/kafka/tests/common.py
+++ b/kafka/tests/common.py
@@ -22,6 +22,7 @@ Rate type metrics that do not work in our e2e:
     "kafka.net.bytes_in.rate",
     "kafka.net.bytes_out.rate",
     "kafka.net.bytes_rejected.rate",
+    "kafka.net.handler.avg.idle.pct.rate",
     "kafka.replication.isr_expands.rate",
     "kafka.replication.isr_shrinks.rate",
     "kafka.replication.leader_elections.rate",
@@ -35,7 +36,7 @@ Rate type metrics that do not work in our e2e:
 """
 
 KAFKA_E2E_METRICS = [
-    "kafka.net.handler.avg.idle.pct.rate",
+    "kafka.net.processor.avg.idle.pct.rate",
     # Request metrics:
     "kafka.request.channel.queue.size",
     "kafka.request.fetch_consumer.time.99percentile",

--- a/kafka/tests/common.py
+++ b/kafka/tests/common.py
@@ -22,7 +22,6 @@ Rate type metrics that do not work in our e2e:
     "kafka.net.bytes_in.rate",
     "kafka.net.bytes_out.rate",
     "kafka.net.bytes_rejected.rate",
-    "kafka.net.handler.avg.idle.pct.rate",
     "kafka.replication.isr_expands.rate",
     "kafka.replication.isr_shrinks.rate",
     "kafka.replication.leader_elections.rate",

--- a/kafka/tests/conftest.py
+++ b/kafka/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 from datadog_checks.dev import docker_run
+from datadog_checks.dev.conditions import CheckDockerLogs
 from datadog_checks.dev.utils import load_jmx_config
 
 from .common import HERE
@@ -13,5 +14,10 @@ from .common import HERE
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    with docker_run(os.path.join(HERE, 'compose', 'docker-compose.yml')):
+    compose_file = os.path.join(HERE, 'compose', 'docker-compose.yml')
+    
+    with docker_run(
+        compose_file,
+        conditions=[CheckDockerLogs(compose_file, [r'\[KafkaServer id=\d+\] started'], matches="all")]
+    ):
         yield load_jmx_config(), {'use_jmx': True}

--- a/kafka/tests/conftest.py
+++ b/kafka/tests/conftest.py
@@ -15,9 +15,8 @@ from .common import HERE
 @pytest.fixture(scope='session')
 def dd_environment():
     compose_file = os.path.join(HERE, 'compose', 'docker-compose.yml')
-    
+
     with docker_run(
-        compose_file,
-        conditions=[CheckDockerLogs(compose_file, [r'\[KafkaServer id=\d+\] started'], matches="all")]
+        compose_file, conditions=[CheckDockerLogs(compose_file, [r'\[KafkaServer id=\d+\] started'], matches="all")]
     ):
         yield load_jmx_config(), {'use_jmx': True}


### PR DESCRIPTION
The e2e tests use the JMX metrics in `/kafka/datadog_checks/kafka/data/metrics.yaml` which has the correct alias for the metric `kafka.net.processor.avg.idle.pct.rate`. JMX config for e2e tests were changed here https://github.com/DataDog/integrations-core/pull/5961/

This PR also updates the incorrect example used in `conf.yaml.example` which uses `kafka.net.handler.avg.idle.pct.rate`.