### PR TITLE
Handle invalid type for excluded_interfaces

### DIFF
--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 import psutil
 from six import PY3, iteritems, itervalues
 
-from datadog_checks.base import AgentCheck, is_affirmative
+from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.utils.common import pattern_filter
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.base.utils.subprocess_output import SubprocessOutputEmptyError, get_subprocess_output
@@ -49,6 +49,11 @@ class Network(AgentCheck):
             instance = {}
 
         self._excluded_ifaces = instance.get('excluded_interfaces', [])
+        if not isinstance(self._excluded_ifaces, list):
+            raise ConfigurationError(
+                "Expected 'excluded_interfaces' to be a list, got '{}'".format(self._excluded_ifaces)
+            )
+
         self._collect_cx_state = instance.get('collect_connection_state', False)
         self._collect_rate_metrics = instance.get('collect_rate_metrics', True)
         self._collect_count_metrics = instance.get('collect_count_metrics', False)

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -345,4 +345,3 @@ def test_invalid_excluded_interfaces(check):
     instance = {'excluded_interfaces': None}
     with pytest.raises(ConfigurationError):
         check.check(instance)
-    check.check(instance)

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -12,6 +12,7 @@ import mock
 import pytest
 from six import PY3, iteritems
 
+from datadog_checks.base import ConfigurationError
 from datadog_checks.dev import EnvVars
 
 from . import common
@@ -338,3 +339,10 @@ def test_proc_permissions_error(aggregator, check, caplog):
         assert 'Unable to read /proc/net/dev.' in caplog.text
         assert 'Unable to read /proc/net/netstat.' in caplog.text
         assert 'Unable to read /proc/net/snmp.' in caplog.text
+
+
+def test_invalid_excluded_interfaces(check):
+    instance = {'excluded_interfaces': None}
+    with pytest.raises(ConfigurationError):
+        check.check(instance)
+    check.check(instance)


### PR DESCRIPTION
Let's raise a proper error when the configuration is incorrect.