### PR TITLE
Add Kubelet check on Windows

### DIFF
--- a/kube_apiserver_metrics/manifest.json
+++ b/kube_apiserver_metrics/manifest.json
@@ -10,7 +10,9 @@
     "guid": "406b274b-c44d-4499-a329-efd053b3f538",
     "support": "core",
     "supported_os": [
-        "linux"
+        "linux",
+        "mac_os",
+        "windows"
     ],
     "public_title": "Datadog-Kubernetes API server metrics Integration",
     "categories": [

--- a/kubelet/manifest.json
+++ b/kubelet/manifest.json
@@ -15,7 +15,9 @@
   "short_description": "Collects container stats from kubelet.",
   "support": "core",
   "supported_os": [
-    "linux"
+    "linux",
+    "mac_os",
+    "windows"
   ],
   "type": "check",
   "integration_id": "kubelet",

--- a/kubernetes_state/manifest.json
+++ b/kubernetes_state/manifest.json
@@ -17,7 +17,8 @@
   "support": "core",
   "supported_os": [
     "linux",
-    "mac_os"
+    "mac_os",
+    "windows"
   ],
   "type": "check",
   "integration_id": "kubernetes-state",

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -58,14 +58,14 @@ datadog-jboss-wildfly==1.1.1
 datadog-kafka-consumer==2.4.0; sys_platform != 'win32'
 datadog-kafka==2.0.2
 datadog-kong==1.7.1
-datadog-kube-apiserver-metrics==1.2.2; sys_platform == 'linux2'
+datadog-kube-apiserver-metrics==1.2.2
 datadog-kube-controller-manager==1.6.0
 datadog-kube-dns==2.3.0
 datadog-kube-metrics-server==1.1.1
 datadog-kube-proxy==3.3.0
 datadog-kube-scheduler==1.3.0
-datadog-kubelet==3.6.0; sys_platform != 'darwin'
-datadog-kubernetes-state==5.2.1; sys_platform != 'win32'
+datadog-kubelet==3.6.0
+datadog-kubernetes-state==5.2.1
 datadog-kyototycoon==1.9.0
 datadog-lighttpd==1.8.0
 datadog-linkerd==2.4.0

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -64,7 +64,7 @@ datadog-kube-dns==2.3.0
 datadog-kube-metrics-server==1.1.1
 datadog-kube-proxy==3.3.0
 datadog-kube-scheduler==1.3.0
-datadog-kubelet==3.6.0; sys_platform == 'linux2'
+datadog-kubelet==3.6.0; sys_platform != 'darwin'
 datadog-kubernetes-state==5.2.1; sys_platform != 'win32'
 datadog-kyototycoon==1.9.0
 datadog-lighttpd==1.8.0


### PR DESCRIPTION

### What does this PR do?
Release the kubelet check both for Linux and Windows, only exclude MacOS.

### Motivation
We are adding (beta) support for K8s on Windows, so this check should also be included in this platform.

