### PR TITLE
Add OIDs to router profiles

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/_generic-router-if.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_generic-router-if.yaml
@@ -1,37 +1,64 @@
 # Generic network interfaces metrics for routers.
-
+#
 metrics:
-  - MIB: IF-MIB
-    table: ifTable
-    forced_type: monotonic_count
-    symbols:
-      - ifInErrors
-      - ifInDiscards
-      - ifOutErrors
-      - ifOutDiscards
-    metric_tags:
-      - tag: interface
-        column: ifDescr
-  - MIB: IF-MIB
-    table: ifTable
-    symbols:
-      - ifAdminStatus
-      - ifOperStatus
-    metric_tags:
-      - tag: interface
-        column: ifDescr
-  - MIB: IF-MIB
-    table: ifXTable
-    forced_type: monotonic_count
-    symbols:
-      - ifHCInOctets
-      - ifHCInUcastPkts
-      - ifHCInMulticastPkts
-      - ifHCInBroadcastPkts
-      - ifHCOutOctets
-      - ifHCOutUcastPkts
-      - ifHCOutMulticastPkts
-      - ifHCOutBroadcastPkts
-    metric_tags:
-      - tag: interface
-        column: ifName
+- MIB: IF-MIB
+  table:
+    OID: 1.3.6.1.2.1.2.2
+    name: ifTable
+  forced_type: monotonic_count
+  symbols:
+  - OID: 1.3.6.1.2.1.2.2.1.14
+    name: ifInErrors
+  - OID: 1.3.6.1.2.1.2.2.1.13
+    name: ifInDiscards
+  - OID: 1.3.6.1.2.1.2.2.1.20
+    name: ifOutErrors
+  - OID: 1.3.6.1.2.1.2.2.1.19
+    name: ifOutDiscards
+  metric_tags:
+  - column:
+      OID: 1.3.6.1.2.1.2.2.1.2
+      name: ifDescr
+    tag: interface
+- MIB: IF-MIB
+  table:
+    OID: 1.3.6.1.2.1.2.2
+    name: ifTable
+  symbols:
+  - OID: 1.3.6.1.2.1.2.2.1.7
+    name: ifAdminStatus
+  - OID: 1.3.6.1.2.1.2.2.1.8
+    name: ifOperStatus
+  metric_tags:
+  - column:
+      OID: 1.3.6.1.2.1.2.2.1.2
+      name: ifDescr
+    tag: interface
+- MIB: IF-MIB
+  table:
+    OID: 1.3.6.1.2.1.31.1.1
+    name: ifXTable
+  forced_type: monotonic_count
+  symbols:
+  - OID: 1.3.6.1.2.1.31.1.1.1.6
+    name: ifHCInOctets
+  - OID: 1.3.6.1.2.1.31.1.1.1.7
+    name: ifHCInUcastPkts
+  - OID: 1.3.6.1.2.1.31.1.1.1.8
+    name: ifHCInMulticastPkts
+  - OID: 1.3.6.1.2.1.31.1.1.1.9
+    name: ifHCInBroadcastPkts
+  - OID: 1.3.6.1.2.1.31.1.1.1.10
+    name: ifHCOutOctets
+  - OID: 1.3.6.1.2.1.31.1.1.1.11
+    name: ifHCOutUcastPkts
+  - OID: 1.3.6.1.2.1.31.1.1.1.12
+    name: ifHCOutMulticastPkts
+  - OID: 1.3.6.1.2.1.31.1.1.1.13
+    name: ifHCOutBroadcastPkts
+  metric_tags:
+  - column:
+      OID: 1.3.6.1.2.1.31.1.1.1.1
+      name: ifName
+    tag: interface
+

--- a/snmp/datadog_checks/snmp/data/profiles/_generic-router-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_generic-router-ip.yaml
@@ -1,75 +1,136 @@
 # Generic IP metrics for routers
 
 metrics:
-  - MIB: IP-MIB
-    table: ipSystemStatsTable
-    forced_type: monotonic_count
-    symbols:
-      - ipSystemStatsHCInReceives
-      - ipSystemStatsHCInOctets
-      - ipSystemStatsInHdrErrors
-      - ipSystemStatsInNoRoutes
-      - ipSystemStatsInAddrErrors
-      - ipSystemStatsInUnknownProtos
-      - ipSystemStatsInTruncatedPkts
-      - ipSystemStatsHCInForwDatagrams
-      - ipSystemStatsReasmReqds
-      - ipSystemStatsReasmOKs
-      - ipSystemStatsReasmFails
-      - ipSystemStatsInDiscards
-      - ipSystemStatsHCInDelivers
-      - ipSystemStatsHCOutRequests
-      - ipSystemStatsOutNoRoutes
-      - ipSystemStatsHCOutForwDatagrams
-      - ipSystemStatsOutDiscards
-      - ipSystemStatsOutFragReqds
-      - ipSystemStatsOutFragOKs
-      - ipSystemStatsOutFragFails
-      - ipSystemStatsOutFragCreates
-      - ipSystemStatsHCOutTransmits
-      - ipSystemStatsHCOutOctets
-      - ipSystemStatsHCInMcastPkts
-      - ipSystemStatsHCInMcastOctets
-      - ipSystemStatsHCOutMcastPkts
-      - ipSystemStatsHCOutMcastOctets
-      - ipSystemStatsHCInBcastPkts
-      - ipSystemStatsHCOutBcastPkts
-    metric_tags:
-      - tag: ipversion
-        index: 1
-  - MIB: IP-MIB
-    table: ipIfStatsTable
-    forced_type: monotonic_count
-    symbols:
-      - ipIfStatsHCInOctets
-      - ipIfStatsInHdrErrors
-      - ipIfStatsInNoRoutes
-      - ipIfStatsInAddrErrors
-      - ipIfStatsInUnknownProtos
-      - ipIfStatsInTruncatedPkts
-      - ipIfStatsHCInForwDatagrams
-      - ipIfStatsReasmReqds
-      - ipIfStatsReasmOKs
-      - ipIfStatsReasmFails
-      - ipIfStatsInDiscards
-      - ipIfStatsHCInDelivers
-      - ipIfStatsHCOutRequests
-      - ipIfStatsHCOutForwDatagrams
-      - ipIfStatsOutDiscards
-      - ipIfStatsOutFragReqds
-      - ipIfStatsOutFragOKs
-      - ipIfStatsOutFragFails
-      - ipIfStatsOutFragCreates
-      - ipIfStatsHCOutTransmits
-      - ipIfStatsHCOutOctets
-      - ipIfStatsHCInMcastPkts
-      - ipIfStatsHCInMcastOctets
-      - ipIfStatsHCOutMcastPkts
-      - ipIfStatsHCOutMcastOctets
-      - ipIfStatsHCInBcastPkts
-      - ipIfStatsHCOutBcastPkts
-    metric_tags:
-      - tag: ipversion
-        index: 1
-      - tag: interface
-        index: 2
+- MIB: IP-MIB
+  table:
+    OID: 1.3.6.1.2.1.4.31.1
+    name: ipSystemStatsTable
+  forced_type: monotonic_count
+  symbols:
+  - OID: 1.3.6.1.2.1.4.31.1.1.4
+    name: ipSystemStatsHCInReceives
+  - OID: 1.3.6.1.2.1.4.31.1.1.6
+    name: ipSystemStatsHCInOctets
+  - OID: 1.3.6.1.2.1.4.31.1.1.7
+    name: ipSystemStatsInHdrErrors
+  - OID: 1.3.6.1.2.1.4.31.1.1.8
+    name: ipSystemStatsInNoRoutes
+  - OID: 1.3.6.1.2.1.4.31.1.1.9
+    name: ipSystemStatsInAddrErrors
+  - OID: 1.3.6.1.2.1.4.31.1.1.10
+    name: ipSystemStatsInUnknownProtos
+  - OID: 1.3.6.1.2.1.4.31.1.1.11
+    name: ipSystemStatsInTruncatedPkts
+  - OID: 1.3.6.1.2.1.4.31.1.1.13
+    name: ipSystemStatsHCInForwDatagrams
+  - OID: 1.3.6.1.2.1.4.31.1.1.14
+    name: ipSystemStatsReasmReqds
+  - OID: 1.3.6.1.2.1.4.31.1.1.15
+    name: ipSystemStatsReasmOKs
+  - OID: 1.3.6.1.2.1.4.31.1.1.16
+    name: ipSystemStatsReasmFails
+  - OID: 1.3.6.1.2.1.4.31.1.1.17
+    name: ipSystemStatsInDiscards
+  - OID: 1.3.6.1.2.1.4.31.1.1.19
+    name: ipSystemStatsHCInDelivers
+  - OID: 1.3.6.1.2.1.4.31.1.1.21
+    name: ipSystemStatsHCOutRequests
+  - OID: 1.3.6.1.2.1.4.31.1.1.22
+    name: ipSystemStatsOutNoRoutes
+  - OID: 1.3.6.1.2.1.4.31.1.1.24
+    name: ipSystemStatsHCOutForwDatagrams
+  - OID: 1.3.6.1.2.1.4.31.1.1.25
+    name: ipSystemStatsOutDiscards
+  - OID: 1.3.6.1.2.1.4.31.1.1.26
+    name: ipSystemStatsOutFragReqds
+  - OID: 1.3.6.1.2.1.4.31.1.1.27
+    name: ipSystemStatsOutFragOKs
+  - OID: 1.3.6.1.2.1.4.31.1.1.28
+    name: ipSystemStatsOutFragFails
+  - OID: 1.3.6.1.2.1.4.31.1.1.29
+    name: ipSystemStatsOutFragCreates
+  - OID: 1.3.6.1.2.1.4.31.1.1.31
+    name: ipSystemStatsHCOutTransmits
+  - OID: 1.3.6.1.2.1.4.31.1.1.33
+    name: ipSystemStatsHCOutOctets
+  - OID: 1.3.6.1.2.1.4.31.1.1.35
+    name: ipSystemStatsHCInMcastPkts
+  - OID: 1.3.6.1.2.1.4.31.1.1.37
+    name: ipSystemStatsHCInMcastOctets
+  - OID: 1.3.6.1.2.1.4.31.1.1.39
+    name: ipSystemStatsHCOutMcastPkts
+  - OID: 1.3.6.1.2.1.4.31.1.1.41
+    name: ipSystemStatsHCOutMcastOctets
+  - OID: 1.3.6.1.2.1.4.31.1.1.43
+    name: ipSystemStatsHCInBcastPkts
+  - OID: 1.3.6.1.2.1.4.31.1.1.45
+    name: ipSystemStatsHCOutBcastPkts
+  metric_tags:
+  - index: 1
+    tag: ipversion
+- MIB: IP-MIB
+  table:
+    OID: 1.3.6.1.2.1.4.31.3
+    name: ipIfStatsTable
+  forced_type: monotonic_count
+  symbols:
+  - OID: 1.3.6.1.2.1.4.31.3.1.6
+    name: ipIfStatsHCInOctets
+  - OID: 1.3.6.1.2.1.4.31.3.1.7
+    name: ipIfStatsInHdrErrors
+  - OID: 1.3.6.1.2.1.4.31.3.1.8
+    name: ipIfStatsInNoRoutes
+  - OID: 1.3.6.1.2.1.4.31.3.1.9
+    name: ipIfStatsInAddrErrors
+  - OID: 1.3.6.1.2.1.4.31.3.1.10
+    name: ipIfStatsInUnknownProtos
+  - OID: 1.3.6.1.2.1.4.31.3.1.11
+    name: ipIfStatsInTruncatedPkts
+  - OID: 1.3.6.1.2.1.4.31.3.1.13
+    name: ipIfStatsHCInForwDatagrams
+  - OID: 1.3.6.1.2.1.4.31.3.1.14
+    name: ipIfStatsReasmReqds
+  - OID: 1.3.6.1.2.1.4.31.3.1.15
+    name: ipIfStatsReasmOKs
+  - OID: 1.3.6.1.2.1.4.31.3.1.16
+    name: ipIfStatsReasmFails
+  - OID: 1.3.6.1.2.1.4.31.3.1.17
+    name: ipIfStatsInDiscards
+  - OID: 1.3.6.1.2.1.4.31.3.1.19
+    name: ipIfStatsHCInDelivers
+  - OID: 1.3.6.1.2.1.4.31.3.1.21
+    name: ipIfStatsHCOutRequests
+  - OID: 1.3.6.1.2.1.4.31.3.1.24
+    name: ipIfStatsHCOutForwDatagrams
+  - OID: 1.3.6.1.2.1.4.31.3.1.25
+    name: ipIfStatsOutDiscards
+  - OID: 1.3.6.1.2.1.4.31.3.1.26
+    name: ipIfStatsOutFragReqds
+  - OID: 1.3.6.1.2.1.4.31.3.1.27
+    name: ipIfStatsOutFragOKs
+  - OID: 1.3.6.1.2.1.4.31.3.1.28
+    name: ipIfStatsOutFragFails
+  - OID: 1.3.6.1.2.1.4.31.3.1.29
+    name: ipIfStatsOutFragCreates
+  - OID: 1.3.6.1.2.1.4.31.3.1.31
+    name: ipIfStatsHCOutTransmits
+  - OID: 1.3.6.1.2.1.4.31.3.1.33
+    name: ipIfStatsHCOutOctets
+  - OID: 1.3.6.1.2.1.4.31.3.1.35
+    name: ipIfStatsHCInMcastPkts
+  - OID: 1.3.6.1.2.1.4.31.3.1.37
+    name: ipIfStatsHCInMcastOctets
+  - OID: 1.3.6.1.2.1.4.31.3.1.39
+    name: ipIfStatsHCOutMcastPkts
+  - OID: 1.3.6.1.2.1.4.31.3.1.41
+    name: ipIfStatsHCOutMcastOctets
+  - OID: 1.3.6.1.2.1.4.31.3.1.43
+    name: ipIfStatsHCInBcastPkts
+  - OID: 1.3.6.1.2.1.4.31.3.1.45
+    name: ipIfStatsHCOutBcastPkts
+  metric_tags:
+  - index: 1
+    tag: ipversion
+  - index: 2
+    tag: interface
+

--- a/snmp/datadog_checks/snmp/data/profiles/_generic-router-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_generic-router-ip.yaml
@@ -68,6 +68,13 @@ metrics:
   metric_tags:
   - index: 1
     tag: ipversion
+    mapping:
+      0: unknown
+      1: ipv4
+      2: ipv6
+      3: ipv4z
+      4: ipv6z
+      16: dns
 - MIB: IP-MIB
   table:
     OID: 1.3.6.1.2.1.4.31.3
@@ -131,6 +138,13 @@ metrics:
   metric_tags:
   - index: 1
     tag: ipversion
+    mapping:
+      0: unknown
+      1: ipv4
+      2: ipv6
+      3: ipv4z
+      4: ipv6z
+      16: dns
   - index: 2
     tag: interface
 

--- a/snmp/datadog_checks/snmp/data/profiles/_generic-router-tcp.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_generic-router-tcp.yaml
@@ -1,32 +1,53 @@
 # Generic TCP metrics for routers.
 
 metrics:
-  - MIB: TCP-MIB
-    symbol: tcpActiveOpens
-    forced_type: monotonic_count
-  - MIB: TCP-MIB
-    symbol: tcpPassiveOpens
-    forced_type: monotonic_count
-  - MIB: TCP-MIB
-    symbol: tcpAttemptFails
-    forced_type: monotonic_count
-  - MIB: TCP-MIB
-    symbol: tcpEstabResets
-    forced_type: monotonic_count
-  - MIB: TCP-MIB
-    symbol: tcpCurrEstab
-  - MIB: TCP-MIB
-    symbol: tcpHCInSegs
-    forced_type: monotonic_count
-  - MIB: TCP-MIB
-    symbol: tcpHCOutSegs
-    forced_type: monotonic_count
-  - MIB: TCP-MIB
-    symbol: tcpRetransSegs
-    forced_type: monotonic_count
-  - MIB: TCP-MIB
-    symbol: tcpInErrs
-    forced_type: monotonic_count
-  - MIB: TCP-MIB
-    symbol: tcpOutRsts
-    forced_type: monotonic_count
+- MIB: TCP-MIB
+  forced_type: monotonic_count
+  symbol:
+    OID: 1.3.6.1.2.1.6.5
+    name: tcpActiveOpens
+- MIB: TCP-MIB
+  forced_type: monotonic_count
+  symbol:
+    OID: 1.3.6.1.2.1.6.6
+    name: tcpPassiveOpens
+- MIB: TCP-MIB
+  forced_type: monotonic_count
+  symbol:
+    OID: 1.3.6.1.2.1.6.7
+    name: tcpAttemptFails
+- MIB: TCP-MIB
+  forced_type: monotonic_count
+  symbol:
+    OID: 1.3.6.1.2.1.6.8
+    name: tcpEstabResets
+- MIB: TCP-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.6.9
+    name: tcpCurrEstab
+- MIB: TCP-MIB
+  forced_type: monotonic_count
+  symbol:
+    OID: 1.3.6.1.2.1.6.17
+    name: tcpHCInSegs
+- MIB: TCP-MIB
+  forced_type: monotonic_count
+  symbol:
+    OID: 1.3.6.1.2.1.6.18
+    name: tcpHCOutSegs
+- MIB: TCP-MIB
+  forced_type: monotonic_count
+  symbol:
+    OID: 1.3.6.1.2.1.6.12
+    name: tcpRetransSegs
+- MIB: TCP-MIB
+  forced_type: monotonic_count
+  symbol:
+    OID: 1.3.6.1.2.1.6.14
+    name: tcpInErrs
+- MIB: TCP-MIB
+  forced_type: monotonic_count
+  symbol:
+    OID: 1.3.6.1.2.1.6.15
+    name: tcpOutRsts
+

--- a/snmp/datadog_checks/snmp/data/profiles/_generic-router-udp.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_generic-router-udp.yaml
@@ -1,15 +1,24 @@
 # Generic UDP metrics for routers.
 
 metrics:
-  - MIB: UDP-MIB
-    symbol: udpHCInDatagrams
-    forced_type: monotonic_count
-  - MIB: UDP-MIB
-    symbol: udpNoPorts
-    forced_type: monotonic_count
-  - MIB: UDP-MIB
-    symbol: udpInErrors
-    forced_type: monotonic_count
-  - MIB: UDP-MIB
-    symbol: udpHCOutDatagrams
-    forced_type: monotonic_count
+- MIB: UDP-MIB
+  forced_type: monotonic_count
+  symbol:
+    OID: 1.3.6.1.2.1.7.8
+    name: udpHCInDatagrams
+- MIB: UDP-MIB
+  forced_type: monotonic_count
+  symbol:
+    OID: 1.3.6.1.2.1.7.2
+    name: udpNoPorts
+- MIB: UDP-MIB
+  forced_type: monotonic_count
+  symbol:
+    OID: 1.3.6.1.2.1.7.3
+    name: udpInErrors
+- MIB: UDP-MIB
+  forced_type: monotonic_count
+  symbol:
+    OID: 1.3.6.1.2.1.7.9
+    name: udpHCOutDatagrams
+


### PR DESCRIPTION
### What does this PR do?
During performance testing of the SNMP check, there were instances where the `resolve_oids` method was being called very often.  By adding the explicit OIDs to the underlying router profiles this reduces the need for those checks.

### Motivation
Performance improvement

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
