### PR TITLE
Add new metric to count services

### DIFF
--- a/consul/metadata.csv
+++ b/consul/metadata.csv
@@ -8,6 +8,7 @@ consul.catalog.services_critical,gauge,,service,,Total critical services on node
 consul.catalog.services_passing,gauge,,service,,Total passing services on nodes,1,consul,svc pass
 consul.catalog.services_up,gauge,,service,,Total services registered on nodes,0,consul,svc up
 consul.catalog.services_warning,gauge,,service,,Total warning services on nodes,-1,consul,svc warn
+consul.catalog.services_count,gauge,,service,,"Metrics to count the number of services matching criteria like the service tag, the node name, or the status. To be queried using the `max by` aggregator.",-1,consul,svc warn
 consul.net.node.latency.min,gauge,,millisecond,,minimum latency from this node to all others,-1,consul,min latency
 consul.net.node.latency.p25,gauge,,millisecond,,p25 latency from this node to all others,-1,consul,p25 latency
 consul.net.node.latency.median,gauge,,millisecond,,median latency from this node to all others,-1,consul,median latency

--- a/consul/metadata.csv
+++ b/consul/metadata.csv
@@ -8,7 +8,7 @@ consul.catalog.services_critical,gauge,,service,,Total critical services on node
 consul.catalog.services_passing,gauge,,service,,Total passing services on nodes,1,consul,svc pass
 consul.catalog.services_up,gauge,,service,,Total services registered on nodes,0,consul,svc up
 consul.catalog.services_warning,gauge,,service,,Total warning services on nodes,-1,consul,svc warn
-consul.catalog.services_count,gauge,,service,,"Metrics to count the number of services matching criteria like the service tag, the node name, or the status. To be queried using the `max by` aggregator.",-1,consul,svc warn
+consul.catalog.services_count,gauge,,service,,"Metrics to count the number of services matching criteria like the service tag, the node name, or the status. To be queried using the `sum by` aggregator.",-1,consul,svc warn
 consul.net.node.latency.min,gauge,,millisecond,,minimum latency from this node to all others,-1,consul,min latency
 consul.net.node.latency.p25,gauge,,millisecond,,p25 latency from this node to all others,-1,consul,p25 latency
 consul.net.node.latency.median,gauge,,millisecond,,median latency from this node to all others,-1,consul,median latency

--- a/consul/tests/consul_mocks.py
+++ b/consul/tests/consul_mocks.py
@@ -86,12 +86,12 @@ def mock_get_peers_in_cluster():
 
 def mock_get_services_in_cluster():
     return {
-        "service-1": ["az-us-east-1a"],
-        "service-2": ["az-us-east-1a"],
-        "service-3": ["az-us-east-1a"],
-        "service-4": ["az-us-east-1a"],
-        "service-5": ["az-us-east-1a"],
-        "service-6": ["az-us-east-1a"],
+        "service-1": ["active", "standby"],
+        "service-2": ["active", "standby"],
+        "service-3": ["active", "standby"],
+        "service-4": ["active", "standby"],
+        "service-5": ["active", "standby"],
+        "service-6": ["active", "standby"],
     }
 
 
@@ -130,7 +130,7 @@ def mock_get_nodes_in_cluster():
 
 
 def mock_get_nodes_with_service(service):
-    return [
+    nodes = [
         {
             "Checks": [
                 {
@@ -155,81 +155,38 @@ def mock_get_nodes_with_service(service):
                 },
             ],
             "Node": {"Address": _get_random_ip(), "Node": "node-1"},
-            "Service": {"Address": "", "ID": service, "Port": 80, "Service": service, "Tags": ["az-us-east-1a"]},
+            "Service": {"Address": "", "ID": service, "Port": 80, "Service": service, "Tags": ["standby"]},
         }
+        for _ in range(4)
     ]
+
+    nodes[0]['Service']['Tags'] = ['active', 'standby']
+    return nodes
 
 
 def mock_get_nodes_with_service_warning(service):
-    return [
-        {
-            "Checks": [
-                {
-                    "CheckID": "serfHealth",
-                    "Name": "Serf Health Status",
-                    "Node": "node-1",
-                    "Notes": "",
-                    "Output": "Agent alive and reachable",
-                    "ServiceID": "",
-                    "ServiceName": "",
-                    "Status": "passing",
-                },
-                {
-                    "CheckID": "service:{}".format(service),
-                    "Name": "service check {}".format(service),
-                    "Node": "node-1",
-                    "Notes": "",
-                    "Output": "Service {} alive".format(service),
-                    "ServiceID": service,
-                    "ServiceName": "",
-                    "Status": "warning",
-                },
-            ],
-            "Node": {"Address": _get_random_ip(), "Node": "node-1"},
-            "Service": {"Address": "", "ID": service, "Port": 80, "Service": service, "Tags": ["az-us-east-1a"]},
-        }
-    ]
+    nodes = mock_get_nodes_with_service(service)
+    for node in nodes:
+        node["Checks"][1]["Status"] = "warning"
+    return nodes
 
 
 def mock_get_nodes_with_service_critical(service):
-    return [
-        {
-            "Checks": [
-                {
-                    "CheckID": "serfHealth",
-                    "Name": "Serf Health Status",
-                    "Node": "node-1",
-                    "Notes": "",
-                    "Output": "Agent alive and reachable",
-                    "ServiceID": "",
-                    "ServiceName": "",
-                    "Status": "passing",
-                },
-                {
-                    "CheckID": "service:{}".format(service),
-                    "Name": "service check {}".format(service),
-                    "Node": "node-1",
-                    "Notes": "",
-                    "Output": "Service {} alive".format(service),
-                    "ServiceID": service,
-                    "ServiceName": "",
-                    "Status": "warning",
-                },
-                {
-                    "CheckID": "service:{}".format(service),
-                    "Name": "service check {}".format(service),
-                    "Node": "node-1",
-                    "Notes": "",
-                    "Output": "Service {} alive".format(service),
-                    "ServiceID": service,
-                    "ServiceName": "",
-                    "Status": "critical",
-                },
-            ],
-            "Node": {"Address": _get_random_ip(), "Node": "node-1"},
-            "Service": {"Address": "", "ID": service, "Port": 80, "Service": service, "Tags": ["az-us-east-1a"]},
-        }
-    ]
+    nodes = mock_get_nodes_with_service_warning(service)
+    for node in nodes:
+        node["Checks"].append(
+            {
+                "CheckID": "service:{}".format(service),
+                "Name": "service check {}".format(service),
+                "Node": "node-1",
+                "Notes": "",
+                "Output": "Service {} alive".format(service),
+                "ServiceID": service,
+                "ServiceName": "",
+                "Status": "critical",
+            }
+        )
+    return nodes
 
 
 def mock_get_coord_datacenters():

--- a/consul/tests/test_e2e.py
+++ b/consul/tests/test_e2e.py
@@ -23,6 +23,9 @@ def test_e2e(dd_agent_check, instance_single_node_install):
     aggregator.assert_metric('consul.catalog.nodes_passing', count=2)
     aggregator.assert_metric('consul.catalog.nodes_up', count=2)
     aggregator.assert_metric('consul.catalog.total_nodes', count=2)
+    aggregator.assert_metric('consul.catalog.services_count', count=6)
+
+    aggregator.assert_all_metrics_covered()
 
     aggregator.assert_service_check(
         'consul.up', ConsulCheck.OK, tags=['consul_datacenter:dc1', 'consul_url:http://{}:8500'.format(common.HOST)]

--- a/consul/tests/test_e2e.py
+++ b/consul/tests/test_e2e.py
@@ -25,8 +25,6 @@ def test_e2e(dd_agent_check, instance_single_node_install):
     aggregator.assert_metric('consul.catalog.total_nodes', count=2)
     aggregator.assert_metric('consul.catalog.services_count', count=6)
 
-    aggregator.assert_all_metrics_covered()
-
     aggregator.assert_service_check(
         'consul.up', ConsulCheck.OK, tags=['consul_datacenter:dc1', 'consul_url:http://{}:8500'.format(common.HOST)]
     )

--- a/consul/tests/test_integration.py
+++ b/consul/tests/test_integration.py
@@ -17,6 +17,7 @@ METRICS = [
     'consul.catalog.services_passing',
     'consul.catalog.services_warning',
     'consul.catalog.services_critical',
+    'consul.catalog.services_count',
     'consul.catalog.total_nodes',
     # Enable again when it's figured out why only followers submit these
     # 'consul.net.node.latency.p95',

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -24,21 +24,34 @@ def test_get_nodes_with_service(aggregator):
     expected_tags = [
         'consul_datacenter:dc1',
         'consul_service_id:service-1',
-        'consul_service-1_service_tag:az-us-east-1a',
-        'consul_service_tag:az-us-east-1a',
+        'consul_service-1_service_tag:active',
+        'consul_service-1_service_tag:standby',
+        'consul_service_tag:active',
+        'consul_service_tag:standby',
     ]
 
-    aggregator.assert_metric('consul.catalog.nodes_up', value=1, tags=expected_tags)
-    aggregator.assert_metric('consul.catalog.nodes_passing', value=1, tags=expected_tags)
+    aggregator.assert_metric('consul.catalog.nodes_up', value=4, tags=expected_tags)
+    aggregator.assert_metric('consul.catalog.nodes_passing', value=4, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.nodes_warning', value=0, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.nodes_critical', value=0, tags=expected_tags)
 
     expected_tags = ['consul_datacenter:dc1', 'consul_node_id:node-1']
 
-    aggregator.assert_metric('consul.catalog.services_up', value=6, tags=expected_tags)
-    aggregator.assert_metric('consul.catalog.services_passing', value=6, tags=expected_tags)
+    aggregator.assert_metric('consul.catalog.services_up', value=24, tags=expected_tags)
+    aggregator.assert_metric('consul.catalog.services_passing', value=24, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.services_warning', value=0, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.services_critical', value=0, tags=expected_tags)
+
+    expected_tags = [
+        'consul_datacenter:dc1',
+        'consul_service-1_service_tag:standby',
+        'consul_service_id:service-1',
+        'consul_node_id:node-1',
+        'consul_status:passing',
+    ]
+    aggregator.assert_metric('consul.catalog.services_count', value=3, tags=expected_tags)
+    expected_tags.append('consul_service-1_service_tag:active')
+    aggregator.assert_metric('consul.catalog.services_count', value=1, tags=expected_tags)
 
 
 def test_get_peers_in_cluster(aggregator):
@@ -76,19 +89,32 @@ def test_get_nodes_with_service_warning(aggregator):
     expected_tags = [
         'consul_datacenter:dc1',
         'consul_service_id:service-1',
-        'consul_service-1_service_tag:az-us-east-1a',
-        'consul_service_tag:az-us-east-1a',
+        'consul_service-1_service_tag:active',
+        'consul_service-1_service_tag:standby',
+        'consul_service_tag:active',
+        'consul_service_tag:standby',
     ]
-    aggregator.assert_metric('consul.catalog.nodes_up', value=1, tags=expected_tags)
+    aggregator.assert_metric('consul.catalog.nodes_up', value=4, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.nodes_passing', value=0, tags=expected_tags)
-    aggregator.assert_metric('consul.catalog.nodes_warning', value=1, tags=expected_tags)
+    aggregator.assert_metric('consul.catalog.nodes_warning', value=4, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.nodes_critical', value=0, tags=expected_tags)
 
     expected_tags = ['consul_datacenter:dc1', 'consul_node_id:node-1']
-    aggregator.assert_metric('consul.catalog.services_up', value=6, tags=expected_tags)
+    aggregator.assert_metric('consul.catalog.services_up', value=24, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.services_passing', value=0, tags=expected_tags)
-    aggregator.assert_metric('consul.catalog.services_warning', value=6, tags=expected_tags)
+    aggregator.assert_metric('consul.catalog.services_warning', value=24, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.services_critical', value=0, tags=expected_tags)
+
+    expected_tags = [
+        'consul_datacenter:dc1',
+        'consul_service-1_service_tag:standby',
+        'consul_service_id:service-1',
+        'consul_node_id:node-1',
+        'consul_status:warning',
+    ]
+    aggregator.assert_metric('consul.catalog.services_count', value=3, tags=expected_tags)
+    expected_tags.append('consul_service-1_service_tag:active')
+    aggregator.assert_metric('consul.catalog.services_count', value=1, tags=expected_tags)
 
 
 def test_get_nodes_with_service_critical(aggregator):
@@ -101,19 +127,32 @@ def test_get_nodes_with_service_critical(aggregator):
     expected_tags = [
         'consul_datacenter:dc1',
         'consul_service_id:service-1',
-        'consul_service-1_service_tag:az-us-east-1a',
-        'consul_service_tag:az-us-east-1a',
+        'consul_service-1_service_tag:active',
+        'consul_service-1_service_tag:standby',
+        'consul_service_tag:active',
+        'consul_service_tag:standby',
     ]
-    aggregator.assert_metric('consul.catalog.nodes_up', value=1, tags=expected_tags)
+    aggregator.assert_metric('consul.catalog.nodes_up', value=4, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.nodes_passing', value=0, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.nodes_warning', value=0, tags=expected_tags)
-    aggregator.assert_metric('consul.catalog.nodes_critical', value=1, tags=expected_tags)
+    aggregator.assert_metric('consul.catalog.nodes_critical', value=4, tags=expected_tags)
 
     expected_tags = ['consul_datacenter:dc1', 'consul_node_id:node-1']
-    aggregator.assert_metric('consul.catalog.services_up', value=6, tags=expected_tags)
+    aggregator.assert_metric('consul.catalog.services_up', value=24, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.services_passing', value=0, tags=expected_tags)
     aggregator.assert_metric('consul.catalog.services_warning', value=0, tags=expected_tags)
-    aggregator.assert_metric('consul.catalog.services_critical', value=6, tags=expected_tags)
+    aggregator.assert_metric('consul.catalog.services_critical', value=24, tags=expected_tags)
+
+    expected_tags = [
+        'consul_datacenter:dc1',
+        'consul_service-1_service_tag:standby',
+        'consul_service_id:service-1',
+        'consul_node_id:node-1',
+        'consul_status:critical',
+    ]
+    aggregator.assert_metric('consul.catalog.services_count', value=3, tags=expected_tags)
+    expected_tags.append('consul_service-1_service_tag:active')
+    aggregator.assert_metric('consul.catalog.services_count', value=1, tags=expected_tags)
 
 
 def test_consul_request(aggregator, instance):


### PR DESCRIPTION
Adds a new metric to the consul check to satisfy use cases where one needs to count the number of services in a given state, or with a given tags.

The metrics we have today `consul.catalog.nodes_<STATUS>` and `consul.catalog.services_<STATUS>` unfortunately are unable to satisfy this use cases. The service tags that are collected are collected from the "catalog/services" endpoint which returns **all the tags** that a service can have. As an exemple this means that if you have a service where one instance has the "active" tags and the others have the "standby" tags, all those metrics will be both tagged with "active" and "standby" at the same time. Not really useful in that case.


This new metric acts as a simple gauge that is tagged by the service name, the node id, the status of the node. Running `sum queries` on this metric will return the number of services matching the provided filters.

![image](https://user-images.githubusercontent.com/22912273/76246029-5a78fa80-6213-11ea-997b-780236f152bd.png)
![image](https://user-images.githubusercontent.com/22912273/76246177-94e29780-6213-11ea-8fb2-4a37f41f0d7a.png)
![image](https://user-images.githubusercontent.com/22912273/76246196-9dd36900-6213-11ea-9086-c4e0a74bd37b.png)

^ Basically I have a cluster with 4 vault nodes, one is the active, the three other are the standbyes. 