### PR TITLE
Rename `to_string()` utility to `to_native_string()`

### DIFF
--- a/datadog_checks_base/datadog_checks/base/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/__init__.py
@@ -6,7 +6,7 @@ from .checks import AgentCheck
 from .checks.openmetrics import OpenMetricsBaseCheck
 from .config import is_affirmative
 from .errors import ConfigurationError
-from .utils.common import ensure_bytes, ensure_unicode, to_string
+from .utils.common import ensure_bytes, ensure_unicode, to_native_string, to_string
 
 # Windows-only
 try:
@@ -30,5 +30,6 @@ __all__ = [
     'ensure_bytes',
     'ensure_unicode',
     'is_affirmative',
-    'to_string',
+    'to_native_string',
+    'to_string',  # For backwards compat before when this was renamed to `to_native_string`.
 ]

--- a/datadog_checks_base/datadog_checks/base/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/__init__.py
@@ -31,5 +31,5 @@ __all__ = [
     'ensure_unicode',
     'is_affirmative',
     'to_native_string',
-    'to_string',  # For backwards compat before when this was renamed to `to_native_string`.
+    'to_string',  # For backwards compat (was renamed to `to_native_string`).
 ]

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -18,7 +18,7 @@ from six import iteritems, text_type
 from ..config import is_affirmative
 from ..constants import ServiceCheck
 from ..utils.agent.utils import should_profile_memory
-from ..utils.common import ensure_bytes, to_string
+from ..utils.common import ensure_bytes, to_native_string
 from ..utils.http import RequestsWrapper
 from ..utils.limiter import Limiter
 from ..utils.metadata import MetadataManager
@@ -522,7 +522,7 @@ class AgentCheck(object):
         if message is None:
             message = ''
         else:
-            message = to_string(message)
+            message = to_native_string(message)
 
         aggregator.submit_service_check(
             self, self.check_id, self._format_namespace(name, raw), status, tags, hostname, message
@@ -569,7 +569,7 @@ class AgentCheck(object):
         try:
             new_tags = []
             for hostname, source_map in external_tags:
-                new_tags.append((to_string(hostname), source_map))
+                new_tags.append((to_native_string(hostname), source_map))
                 for src_name, tags in iteritems(source_map):
                     source_map[src_name] = self._normalize_tags_type(tags)
             datadog_agent.set_external_tags(new_tags)
@@ -597,7 +597,7 @@ class AgentCheck(object):
         :param list args: format string args used to format warning_message e.g. `warning_message % args`
         :param dict kwargs: not used for now, but added to match Python logger's `warning` method signature
         """
-        warning_message = to_string(warning_message)
+        warning_message = to_native_string(warning_message)
         # Interpolate message only if args is not empty. Same behavior as python logger:
         # https://github.com/python/cpython/blob/1dbe5373851acb85ba91f0be7b83c69563acd68d/Lib/logging/__init__.py#L368-L369
         if args:
@@ -635,9 +635,9 @@ class AgentCheck(object):
 
     def _format_namespace(self, s, raw=False):
         if not raw and self.__NAMESPACE__:
-            return '{}.{}'.format(self.__NAMESPACE__, to_string(s))
+            return '{}.{}'.format(self.__NAMESPACE__, to_native_string(s))
 
-        return to_string(s)
+        return to_native_string(s)
 
     def normalize(self, metric, prefix=None, fix_case=False):
         """
@@ -663,7 +663,7 @@ class AgentCheck(object):
         if prefix is not None:
             name = ensure_bytes(prefix) + b"." + name
 
-        return to_string(name)
+        return to_native_string(name)
 
     def normalize_tag(self, tag):
         """Normalize tag values.
@@ -676,7 +676,7 @@ class AgentCheck(object):
         tag = self.TAG_REPLACEMENT.sub(br'_', tag)
         tag = self.MULTIPLE_UNDERSCORE_CLEANUP.sub(br'_', tag)
         tag = self.DOT_UNDERSCORE_CLEANUP.sub(br'.', tag).strip(b'_')
-        return to_string(tag)
+        return to_native_string(tag)
 
     def check(self, instance):
         raise NotImplementedError
@@ -749,7 +749,7 @@ class AgentCheck(object):
         for key in event:
             # Ensure strings have the correct type
             try:
-                event[key] = to_string(event[key])
+                event[key] = to_native_string(event[key])
             except UnicodeError:
                 self.log.warning('Encoding error with field `%s`, cannot submit event', key)
                 return
@@ -759,7 +759,7 @@ class AgentCheck(object):
         if event.get('timestamp'):
             event['timestamp'] = int(event['timestamp'])
         if event.get('aggregation_key'):
-            event['aggregation_key'] = to_string(event['aggregation_key'])
+            event['aggregation_key'] = to_native_string(event['aggregation_key'])
 
         if self.__NAMESPACE__:
             event.setdefault('source_type_name', self.__NAMESPACE__)
@@ -778,7 +778,7 @@ class AgentCheck(object):
         if device_name:
             self._log_deprecation('device_name')
             try:
-                normalized_tags.append('device:{}'.format(to_string(device_name)))
+                normalized_tags.append('device:{}'.format(to_native_string(device_name)))
             except UnicodeError:
                 self.log.warning(
                     'Encoding error with device name `%r` for metric `%r`, ignoring tag', device_name, metric_name
@@ -788,7 +788,7 @@ class AgentCheck(object):
                 if tag is None:
                     continue
                 try:
-                    tag = to_string(tag)
+                    tag = to_native_string(tag)
                 except UnicodeError:
                     self.log.warning('Encoding error with tag `%s` for metric `%s`, ignoring tag', tag, metric_name)
                     continue

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -14,7 +14,7 @@ from six import PY3, iteritems, itervalues, string_types
 
 from ...config import is_affirmative
 from ...errors import CheckException
-from ...utils.common import to_string
+from ...utils.common import to_native_string
 from ...utils.http import RequestsWrapper
 from .. import AgentCheck
 
@@ -883,7 +883,7 @@ class OpenMetricsScraperMixin(object):
         for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
             if label_name not in scraper_config['exclude_labels']:
                 tag_name = scraper_config['labels_mapper'].get(label_name, label_name)
-                _tags.append('{}:{}'.format(to_string(tag_name), to_string(label_value)))
+                _tags.append('{}:{}'.format(to_native_string(tag_name), to_native_string(label_value)))
         return self._finalize_tags_to_submit(
             _tags, metric_name, val, sample, custom_tags=custom_tags, hostname=hostname
         )

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
@@ -4,7 +4,7 @@
 from six import string_types
 
 from ...errors import CheckException
-from ...utils.common import to_string
+from ...utils.common import to_native_string
 from .. import AgentCheck
 from .mixins import PrometheusScraperMixin
 
@@ -62,7 +62,7 @@ class PrometheusScraper(PrometheusScraperMixin):
                 tag_name = label.name
                 if self.labels_mapper is not None and label.name in self.labels_mapper:
                     tag_name = self.labels_mapper[label.name]
-                _tags.append('{}:{}'.format(to_string(tag_name), to_string(label.value)))
+                _tags.append('{}:{}'.format(to_native_string(tag_name), to_native_string(label.value)))
         return self._finalize_tags_to_submit(
             _tags, metric_name, val, metric, custom_tags=custom_tags, hostname=hostname
         )

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/prometheus_base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/prometheus_base.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from ...utils.common import to_string
+from ...utils.common import to_native_string
 from .. import AgentCheck
 from .mixins import PrometheusScraperMixin
 
@@ -79,7 +79,7 @@ class PrometheusCheck(PrometheusScraperMixin, AgentCheck):
                 tag_name = label.name
                 if self.labels_mapper is not None and label.name in self.labels_mapper:
                     tag_name = self.labels_mapper[label.name]
-                _tags.append('{}:{}'.format(to_string(tag_name), to_string(label.value)))
+                _tags.append('{}:{}'.format(to_native_string(tag_name), to_native_string(label.value)))
         return self._finalize_tags_to_submit(
             _tags, metric_name, val, metric, custom_tags=custom_tags, hostname=hostname
         )

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -5,7 +5,7 @@ import logging
 
 from six import PY2, text_type
 
-from .utils.common import to_string
+from .utils.common import to_native_string
 
 try:
     import datadog_agent
@@ -61,7 +61,7 @@ class AgentLogHandler(logging.Handler):
             getattr(record, '_check_id', '-'),
             getattr(record, '_filename', record.filename),
             getattr(record, '_lineno', record.lineno),
-            to_string(self.format(record)),
+            to_native_string(self.format(record)),
         )
         datadog_agent.log(msg, record.levelno)
 

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -10,7 +10,7 @@ from six import iteritems
 from datadog_checks.base.stubs.common import HistogramBucketStub, MetricStub, ServiceCheckStub
 from datadog_checks.base.stubs.similar import build_similar_elements_msg
 
-from ..utils.common import ensure_unicode, to_string
+from ..utils.common import ensure_unicode, to_native_string
 
 
 def normalize_tags(tags, sort=False):
@@ -18,9 +18,9 @@ def normalize_tags(tags, sort=False):
     # This function makes sure strings are compared with the same type.
     if tags:
         if sort:
-            return sorted(to_string(tag) for tag in tags)
+            return sorted(to_native_string(tag) for tag in tags)
         else:
-            return [to_string(tag) for tag in tags]
+            return [to_native_string(tag) for tag in tags]
     return tags
 
 
@@ -96,7 +96,7 @@ class AggregatorStub(object):
                 ensure_unicode(stub.hostname),
                 stub.device,
             )
-            for stub in self._metrics.get(to_string(name), [])
+            for stub in self._metrics.get(to_native_string(name), [])
         ]
 
     def service_checks(self, name):
@@ -112,7 +112,7 @@ class AggregatorStub(object):
                 ensure_unicode(stub.hostname),
                 ensure_unicode(stub.message),
             )
-            for stub in self._service_checks.get(to_string(name), [])
+            for stub in self._service_checks.get(to_native_string(name), [])
         ]
 
     @property
@@ -136,7 +136,7 @@ class AggregatorStub(object):
                 ensure_unicode(stub.hostname),
                 normalize_tags(stub.tags),
             )
-            for stub in self._histogram_buckets.get(to_string(name), [])
+            for stub in self._histogram_buckets.get(to_native_string(name), [])
         ]
 
     def assert_metric_has_tag(self, metric_name, tag, count=None, at_least=1):

--- a/datadog_checks_base/datadog_checks/base/utils/common.py
+++ b/datadog_checks_base/datadog_checks/base/utils/common.py
@@ -25,7 +25,8 @@ def ensure_unicode(s):
     return s
 
 
-to_string = ensure_unicode if PY3 else ensure_bytes
+to_native_string = ensure_unicode if PY3 else ensure_bytes
+to_string = to_native_string  # For backwards compat before when this was renamed to `to_native_string`.
 
 
 def compute_percent(part, total):

--- a/datadog_checks_base/datadog_checks/base/utils/common.py
+++ b/datadog_checks_base/datadog_checks/base/utils/common.py
@@ -35,7 +35,7 @@ else:
 
 def to_string(value):
     # type: (Any) -> str
-    warnings.warn('`to_string` is deprecated, use `to_native_string` instead.', category=DeprecationWarning)
+    warnings.warn('`to_string` is deprecated, please use `to_native_string` instead.', category=DeprecationWarning)
     return to_native_string(value)
 
 

--- a/datadog_checks_base/datadog_checks/base/utils/common.py
+++ b/datadog_checks_base/datadog_checks/base/utils/common.py
@@ -5,8 +5,9 @@ from __future__ import division
 
 import os
 import re
+import warnings
 from decimal import ROUND_HALF_UP, Decimal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from six import PY3, iteritems, text_type
 from six.moves.urllib.parse import urlparse
@@ -31,7 +32,11 @@ if TYPE_CHECKING:
 else:
     to_native_string = ensure_unicode if PY3 else ensure_bytes
 
-to_string = to_native_string  # For backwards compat before when this was renamed to `to_native_string`.
+
+def to_string(value):
+    # type: (Any) -> str
+    warnings.warn('`to_string` is deprecated, use `to_native_string` instead.', category=DeprecationWarning)
+    return to_native_string(value)
 
 
 def compute_percent(part, total):

--- a/datadog_checks_base/datadog_checks/base/utils/metadata/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/metadata/core.py
@@ -7,7 +7,7 @@ import re
 
 from six import iteritems
 
-from ..common import to_string
+from ..common import to_native_string
 from .constants import DEFAULT_BLACKLIST
 from .utils import is_primitive
 from .version import parse_version
@@ -33,7 +33,7 @@ class MetadataManager(object):
             self.metadata_transformers.update(metadata_transformers)
 
     def submit_raw(self, name, value):
-        datadog_agent.set_check_metadata(self.check_id, to_string(name), to_string(value))
+        datadog_agent.set_check_metadata(self.check_id, to_native_string(name), to_native_string(value))
 
     def submit(self, name, value, options):
         transformer = self.metadata_transformers.get(name)

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -12,7 +12,7 @@ from six import PY3
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base import __version__ as base_package_version
-from datadog_checks.base import to_string
+from datadog_checks.base import to_native_string
 from datadog_checks.base.checks.base import datadog_agent
 
 
@@ -406,7 +406,7 @@ class TestEvents:
             'timestamp': 1,
         }
         check.event(event)
-        aggregator.assert_event(to_string(msg_text), tags=['∆', 'Ω-bar'])
+        aggregator.assert_event(to_native_string(msg_text), tags=['∆', 'Ω-bar'])
 
     def test_namespace(self, aggregator):
         check = AgentCheck()

--- a/datadog_checks_base/tests/test_utils.py
+++ b/datadog_checks_base/tests/test_utils.py
@@ -10,7 +10,14 @@ import mock
 import pytest
 from six import PY3
 
-from datadog_checks.base.utils.common import ensure_bytes, ensure_unicode, pattern_filter, round_value
+from datadog_checks.base.utils.common import (
+    ensure_bytes,
+    ensure_unicode,
+    pattern_filter,
+    round_value,
+    to_native_string,
+    to_string,
+)
 from datadog_checks.base.utils.containers import iter_unique
 from datadog_checks.base.utils.limiter import Limiter
 
@@ -162,3 +169,17 @@ class TestBytesUnicode:
     def test_ensure_unicode(self):
         assert ensure_unicode('éâû') == u'éâû'
         assert ensure_unicode(u'éâû') == u'éâû'
+
+    def test_to_native_string(self):
+        # type: () -> None
+        text = u'éâû'
+        binary = text.encode('utf-8')
+        if PY3:
+            assert to_native_string(binary) == text
+        else:
+            assert to_native_string(binary) == binary
+
+    def test_to_string_deprecated(self):
+        # type: () -> None
+        with pytest.deprecated_call():
+            to_string(b'example')

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -8,7 +8,7 @@ import requests
 from six import iteritems, itervalues
 from six.moves.urllib.parse import urljoin, urlparse
 
-from datadog_checks.base import AgentCheck, to_string
+from datadog_checks.base import AgentCheck, to_native_string
 
 from .config import from_instance
 from .metrics import (
@@ -348,7 +348,7 @@ class ESCheck(AgentCheck):
         )
 
     def _create_event(self, status, tags=None):
-        hostname = to_string(self.hostname)
+        hostname = to_native_string(self.hostname)
         if status == "red":
             alert_type = "error"
             msg_title = "{} is {}".format(hostname, status)

--- a/haproxy/datadog_checks/haproxy/haproxy.py
+++ b/haproxy/datadog_checks/haproxy/haproxy.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from six import PY2, iteritems
 from six.moves.urllib.parse import urlparse
 
-from datadog_checks.base import AgentCheck, is_affirmative, to_string
+from datadog_checks.base import AgentCheck, is_affirmative, to_native_string
 
 STATS_URL = "/;csv;norefresh"
 EVENT_TYPE = SOURCE_TYPE_NAME = 'haproxy'
@@ -779,7 +779,7 @@ class HAProxy(AgentCheck):
         custom_tags = [] if custom_tags is None else custom_tags
         service_name = data['pxname']
         status = data['status']
-        haproxy_hostname = to_string(self.hostname)
+        haproxy_hostname = to_native_string(self.hostname)
         check_hostname = haproxy_hostname if tag_by_host else ''
 
         if self._is_service_excl_filtered(service_name, services_incl_filter, services_excl_filter):

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -12,7 +12,7 @@ from six import iteritems
 from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.config import is_affirmative
 from datadog_checks.errors import CheckException
-from datadog_checks.utils.common import to_string
+from datadog_checks.utils.common import to_native_string
 
 try:
     # this module is only available in agent 6
@@ -459,7 +459,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         Lookups the labels_mapper table to see if replacing the tag name is
         necessary, then returns a "name:value" tag string
         """
-        return '%s:%s' % (scraper_config['labels_mapper'].get(name, name), to_string(value).lower())
+        return '%s:%s' % (scraper_config['labels_mapper'].get(name, name), to_native_string(value).lower())
 
     def _label_to_tag(self, name, labels, scraper_config, tag_name=None):
         """
@@ -829,10 +829,10 @@ class KubernetesState(OpenMetricsBaseCheck):
         tag_name = scraper_config['labels_mapper'].get(label_name, label_name)
         # then try to use the kube_labels_mapper
         kube_tag_name = kube_labels_mapper.get(tag_name, tag_name)
-        label_value = to_string(label_value).lower()
-        tags.append('{}:{}'.format(to_string(kube_tag_name), label_value))
+        label_value = to_native_string(label_value).lower()
+        tags.append('{}:{}'.format(to_native_string(kube_tag_name), label_value))
         if self.keep_ksm_labels and (kube_tag_name != tag_name):
-            tags.append('{}:{}'.format(to_string(tag_name), label_value))
+            tags.append('{}:{}'.format(to_native_string(tag_name), label_value))
         return tags
 
     def _metric_tags(self, metric_name, val, sample, scraper_config, hostname=None):

--- a/linkerd/tests/conftest.py
+++ b/linkerd/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from datadog_checks.base import to_string
+from datadog_checks.base import to_native_string
 from datadog_checks.dev.kube_port_forward import port_forward
 from datadog_checks.dev.terraform import terraform_run
 from datadog_checks.dev.utils import get_here
@@ -13,7 +13,7 @@ from .common import LINKERD_FIXTURE_METRICS, LINKERD_FIXTURE_TYPES
 @pytest.fixture(scope='session')
 def dd_environment():
     with terraform_run(os.path.join(get_here(), 'terraform')) as outputs:
-        kubeconfig = to_string(outputs['kubeconfig']['value'])
+        kubeconfig = to_native_string(outputs['kubeconfig']['value'])
 
         with port_forward(kubeconfig, 'linkerd', 'linkerd-controller', 4191) as (ip, port):
             instance = {

--- a/vsphere/datadog_checks/vsphere/legacy/vsphere_legacy.py
+++ b/vsphere/datadog_checks/vsphere/legacy/vsphere_legacy.py
@@ -18,7 +18,7 @@ from pyVmomi import vmodl  # pylint: disable=E0611
 from six import itervalues
 from six.moves import range
 
-from datadog_checks.base import ensure_unicode, to_string
+from datadog_checks.base import ensure_unicode, to_native_string
 from datadog_checks.base.checks import AgentCheck
 from datadog_checks.base.checks.libs.thread_pool import SENTINEL, Pool
 from datadog_checks.base.checks.libs.timer import Timer
@@ -879,7 +879,7 @@ class VSphereLegacyCheck(AgentCheck):
                     if not hostname:  # no host tags available
                         tags.extend(mor['tags'])
                     else:
-                        hostname = to_string(hostname)
+                        hostname = to_native_string(hostname)
                         if self.excluded_host_tags:
                             tags.extend(mor["excluded_host_tags"])
 

--- a/vsphere/datadog_checks/vsphere/utils.py
+++ b/vsphere/datadog_checks/vsphere/utils.py
@@ -4,7 +4,7 @@
 from pyVmomi import vim
 from six import iteritems
 
-from datadog_checks.base import to_string
+from datadog_checks.base import to_native_string
 from datadog_checks.vsphere.constants import MOR_TYPE_AS_STRING, REFERENCE_METRIC, SHORT_ROLLUP
 
 METRIC_TO_INSTANCE_TAG_MAPPING = {
@@ -31,7 +31,7 @@ METRIC_TO_INSTANCE_TAG_MAPPING = {
 
 def format_metric_name(counter):
     return "{}.{}.{}".format(
-        to_string(counter.groupInfo.key), to_string(counter.nameInfo.key), SHORT_ROLLUP[str(counter.rollupType)],
+        to_native_string(counter.groupInfo.key), to_native_string(counter.nameInfo.key), SHORT_ROLLUP[str(counter.rollupType)],
     )
 
 
@@ -117,7 +117,7 @@ def get_parent_tags_recursively(mor, infrastructure_data):
     if parent:
         tags = []
         parent_props = infrastructure_data.get(parent, {})
-        parent_name = to_string(parent_props.get('name', 'unknown'))
+        parent_name = to_native_string(parent_props.get('name', 'unknown'))
         if isinstance(parent, vim.HostSystem):
             tags.append('vsphere_host:{}'.format(parent_name))
         elif isinstance(parent, vim.Folder):

--- a/vsphere/datadog_checks/vsphere/utils.py
+++ b/vsphere/datadog_checks/vsphere/utils.py
@@ -31,7 +31,9 @@ METRIC_TO_INSTANCE_TAG_MAPPING = {
 
 def format_metric_name(counter):
     return "{}.{}.{}".format(
-        to_native_string(counter.groupInfo.key), to_native_string(counter.nameInfo.key), SHORT_ROLLUP[str(counter.rollupType)],
+        to_native_string(counter.groupInfo.key),
+        to_native_string(counter.nameInfo.key),
+        SHORT_ROLLUP[str(counter.rollupType)],
     )
 
 

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -73,7 +73,9 @@ def test_external_host_tags(aggregator, realtime_instance):
     for ex, sub in zip(expected_tags, submitted_tags):
         ex_host, sub_host = ex[0], sub[0]
         ex_tags, sub_tags = ex[1]['vsphere'], sub[1]['vsphere']
-        ex_tags = [to_native_string(t) for t in ex_tags]  # json library loads data in unicode, let's convert back to native
+        ex_tags = [
+            to_native_string(t) for t in ex_tags
+        ]  # json library loads data in unicode, let's convert back to native
         assert ex_host == sub_host
         assert ex_tags == sub_tags
 

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -8,7 +8,7 @@ import mock
 import pytest
 from mock import MagicMock
 
-from datadog_checks.base import to_string
+from datadog_checks.base import to_native_string
 from datadog_checks.vsphere import VSphereCheck
 from datadog_checks.vsphere.api import APIConnectionError
 from datadog_checks.vsphere.api_rest import VSphereRestAPI
@@ -73,7 +73,7 @@ def test_external_host_tags(aggregator, realtime_instance):
     for ex, sub in zip(expected_tags, submitted_tags):
         ex_host, sub_host = ex[0], sub[0]
         ex_tags, sub_tags = ex[1]['vsphere'], sub[1]['vsphere']
-        ex_tags = [to_string(t) for t in ex_tags]  # json library loads data in unicode, let's convert back to native
+        ex_tags = [to_native_string(t) for t in ex_tags]  # json library loads data in unicode, let's convert back to native
         assert ex_host == sub_host
         assert ex_tags == sub_tags
 
@@ -85,7 +85,7 @@ def test_external_host_tags(aggregator, realtime_instance):
     for ex, sub in zip(expected_tags, submitted_tags):
         ex_host, sub_host = ex[0], sub[0]
         ex_tags, sub_tags = ex[1]['vsphere'], sub[1]['vsphere']
-        ex_tags = [to_string(t) for t in ex_tags if 'vsphere_host:' not in t]
+        ex_tags = [to_native_string(t) for t in ex_tags if 'vsphere_host:' not in t]
         assert ex_host == sub_host
         assert ex_tags == sub_tags
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Rename the `to_string()` utility to `to_native_string()` (keeping the old name for backwards compat - so I don't think this asks for a `changelog/Changed`).

**Question**: should we have `to_string()` throw deprecation warnings? (Probably too noisy…)

### Motivation
<!-- What inspired you to submit this pull request? -->
The name `to_string()` was misleading: intuitively I would expect it to return `str`/`unicode`, but it actually has the following behavior:

- Python 3: return `str` (aka text), utf8-decoding from `bytes` if necessary
- Python 2: return `bytes` utf8-encoding from `unicode` (aka text) if necessary.

The return type in each Python version matches what the Python porting guide calls the [Native string](https://portingguide.readthedocs.io/en/latest/strings.html#the-native-string) type (`str`, which is `str` in Python 3 and `bytes` in Python 2), hence this proposal.

(I initially considered alternatively using `to_text()`, but in Python "text" seems to be more commonly understood as "human-readable strings", i.e. unicode. Eg [`typing.Text`](https://docs.python.org/3/library/typing.html#typing.Text) refers to `str` on Python 3 and `unicode` on Python 2. Native strings is what we're after here.)

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Prompted while working on #5965 — see https://github.com/DataDog/integrations-core/pull/5965#discussion_r389062078.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
