### PR TITLE
Explicitly check for event value type before coercing to text

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -810,7 +810,7 @@ class AgentCheck(object):
             try:
                 event[key] = to_string(value)  # type: ignore
                 # ^ Mypy complains about dynamic key assignment -- arguably for good reason.
-                # Ideally we should convert this to a dict literal to only submit events with allowed keys.
+                # Ideally we should convert this to a dict literal so that submitted events only include known keys.
             except UnicodeError:
                 self.log.warning('Encoding error with field `%s`, cannot submit event', key)
                 return

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -13,7 +13,7 @@ from collections import defaultdict, deque
 from os.path import basename
 
 import yaml
-from six import binary_type, iteritems, text_type
+from six import iteritems, text_type
 
 from ..config import is_affirmative
 from ..constants import ServiceCheck

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -750,7 +750,7 @@ class AgentCheck(object):
             if not isinstance(value, text_type):
                 continue
             try:
-                event[key] = to_string(event[key])
+                event[key] = to_string(value)
             except UnicodeError:
                 self.log.warning('Encoding error with field `%s`, cannot submit event', key)
                 return

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -14,7 +14,7 @@ from os.path import basename
 from typing import Any, Callable, DefaultDict, Deque, Dict, List, Optional, Sequence, Tuple, Union
 
 import yaml
-from six import iteritems, text_type
+from six import binary_type, iteritems, text_type
 
 from ..config import is_affirmative
 from ..constants import ServiceCheck
@@ -805,7 +805,7 @@ class AgentCheck(object):
         """
         # Enforce types of some fields, considerably facilitates handling in go bindings downstream
         for key, value in iteritems(event):
-            if not isinstance(value, (str, bytes)):
+            if not isinstance(value, (text_type, binary_type)):
                 continue
 
             try:

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -18,7 +18,7 @@ from six import binary_type, iteritems, text_type
 from ..config import is_affirmative
 from ..constants import ServiceCheck
 from ..utils.agent.utils import should_profile_memory
-from ..utils.common import ensure_bytes, ensure_unicode, to_string
+from ..utils.common import ensure_bytes, to_string
 from ..utils.http import RequestsWrapper
 from ..utils.limiter import Limiter
 from ..utils.metadata import MetadataManager
@@ -746,11 +746,11 @@ class AgentCheck(object):
         :param ev event: the event to be sent.
         """
         # Enforce types of some fields, considerably facilitates handling in go bindings downstream
-        for key, value in list(iteritems(event)):
-            if not isinstance(value, binary_type):
+        for key, value in iteritems(event):
+            if not isinstance(value, text_type):
                 continue
             try:
-                event[key] = ensure_unicode(event[key])
+                event[key] = to_string(event[key])
             except UnicodeError:
                 self.log.warning('Encoding error with field `%s`, cannot submit event', key)
                 return

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -805,8 +805,9 @@ class AgentCheck(object):
         """
         # Enforce types of some fields, considerably facilitates handling in go bindings downstream
         for key, value in iteritems(event):
-            if not isinstance(value, text_type):
+            if not isinstance(value, (str, bytes)):
                 continue
+
             try:
                 event[key] = to_string(value)  # type: ignore
                 # ^ Mypy complains about dynamic key assignment -- arguably for good reason.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- When pre-processing an `event` for submission, only coerce `bytes` values to text, instead of relying on `to_string()` doing nothing for non-`bytes` values.

### Motivation
<!-- What inspired you to submit this pull request? -->
We used to have an explicit check, but it was dropped by #5379 (probably an oversight) — see: https://github.com/DataDog/integrations-core/pull/5379/files#diff-874d5159f166811f6c78ff097251312cR716-R722

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Prompted by https://github.com/DataDog/integrations-core/pull/5965#discussion_r389062078

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
