### PR TITLE
[HOLD] Fix service check name

### DIFF
--- a/jboss_wildfly/assets/service_checks.json
+++ b/jboss_wildfly/assets/service_checks.json
@@ -6,7 +6,7 @@
             "host",
             "instance"
         ],
-        "check": "jboss_wildfly.can_connect",
+        "check": "jbosswildfly.can_connect",
         "statuses": [
             "ok",
             "critical"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix service check name.

The service check name is created from integration name and `_` are stripped out from service check name due to https://github.com/DataDog/jmxfetch/blob/10c216bf3bc9ebfba368780fbb16ba05d05fe6e4/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java#L185-L189

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
