### PR TITLE
Add `OID` helper class

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, DefaultDict, Dict, Iterator, List, Optional, S
 from datadog_checks.base import ConfigurationError, is_affirmative
 
 from .models import (
+    OID,
     CommunityData,
     ContextData,
     DirMibSource,
@@ -24,7 +25,6 @@ from .models import (
     usmHMACMD5AuthProtocol,
 )
 from .resolver import OIDResolver
-from .utils import to_oid_tuple
 
 
 class ParsedMetric(object):
@@ -335,7 +335,7 @@ class InstanceConfig:
             if isinstance(symbol, dict):
                 symbol_oid = symbol['OID']
                 symbol = symbol['name']
-                self._resolver.register(to_oid_tuple(symbol_oid), symbol)
+                self._resolver.register(OID(symbol_oid).as_tuple(), symbol)
                 identity = object_identity_factory(symbol_oid)
             else:
                 identity = object_identity_factory(mib, symbol)
@@ -446,7 +446,7 @@ class InstanceConfig:
                 oid_object = ObjectType(object_identity_factory(metric['OID']))
 
                 table_oids[metric['OID']] = (oid_object, [])
-                self._resolver.register(to_oid_tuple(metric['OID']), metric['name'])
+                self._resolver.register(OID(metric['OID']).as_tuple(), metric['name'])
 
                 parsed_metric = ParsedMetric(metric['name'], metric_tags, forced_type, enforce_scalar=False)
                 parsed_metrics.append(parsed_metric)
@@ -489,7 +489,7 @@ class InstanceConfig:
             else:
                 oid = tag['OID']
                 identity = ObjectIdentity(oid)
-                self._resolver.register(to_oid_tuple(oid), symbol)
+                self._resolver.register(OID(oid).as_tuple(), symbol)
             object_type = ObjectType(identity)
             oids.append(object_type)
             parsed_metric_tags.append(ParsedMetricTag(tag_name, symbol))
@@ -503,7 +503,7 @@ class InstanceConfig:
         uptime_oid = '1.3.6.1.2.1.1.3.0'
         oid_object = ObjectType(ObjectIdentity(uptime_oid))
         self.all_oids.append(oid_object)
-        self._resolver.register(to_oid_tuple(uptime_oid), 'sysUpTimeInstance')
+        self._resolver.register(OID(uptime_oid).as_tuple(), 'sysUpTimeInstance')
 
         parsed_metric = ParsedMetric('sysUpTimeInstance', [], 'gauge')
         self.parsed_metrics.append(parsed_metric)

--- a/snmp/datadog_checks/snmp/exceptions.py
+++ b/snmp/datadog_checks/snmp/exceptions.py
@@ -9,3 +9,15 @@ from pysnmp.error import PySnmpError
 from pysnmp.smi.error import SmiError
 
 __all__ = ['PySnmpError', 'SmiError']
+
+
+class SNMPException(Exception):
+    """
+    Base exception class for SNMP integration exceptions.
+    """
+
+
+class CouldNotDecodeOID(SNMPException):
+    """
+    A value could not be decoded as an OID.
+    """

--- a/snmp/datadog_checks/snmp/models.py
+++ b/snmp/datadog_checks/snmp/models.py
@@ -3,7 +3,11 @@
 # Licensed under Simplified BSD License (see LICENSE)
 """
 Re-export PyASN1/PySNMP types and classes that we use, so that we can access them from a single module.
+
+Also define our own SNMP models and interfaces.
 """
+
+from typing import Any, Sequence, Tuple, Union
 
 from pyasn1.type.base import Asn1Type
 from pyasn1.type.univ import OctetString
@@ -25,6 +29,9 @@ from pysnmp.proto.rfc1902 import Counter32, Counter64, Gauge32, Integer, Integer
 from pysnmp.smi.builder import DirMibSource, MibBuilder
 from pysnmp.smi.exval import endOfMibView, noSuchInstance, noSuchObject
 from pysnmp.smi.view import MibViewController
+
+from .exceptions import CouldNotDecodeOID
+from .utils import parse_as_oid_tuple
 
 # Additional types that are not part of the SNMP protocol (see RFC 2856).
 CounterBasedGauge64, ZeroBasedCounter64 = MibBuilder().importSymbols(
@@ -64,3 +71,42 @@ __all__ = [
     'Integer',
     'Integer32',
 ]
+
+
+class OID(object):
+    """
+    An SNMP object identifier.
+
+    Acts as a facade for various types used by PySNMP to represent OIDs.
+    """
+
+    def __init__(self, value):
+        # type: (Union[Sequence[int], str, ObjectName, ObjectIdentity, ObjectType]) -> None
+        try:
+            parts = parse_as_oid_tuple(value)
+        except CouldNotDecodeOID:
+            raise  # Explicitly re-raise this exception.
+
+        # Let's make extra sure we didn't mess up.
+        if not isinstance(parts, tuple):
+            raise RuntimeError(
+                'Expected result {!r} of parsing value {!r} to be a tuple, but got {}'.format(parts, value, type(parts))
+            )  # pragma: no cover
+
+        self._parts = parts
+
+    def as_tuple(self):
+        # type: () -> Tuple[int, ...]
+        return self._parts
+
+    def as_string(self):
+        # type: () -> str
+        return '.'.join(map(str, self.as_tuple()))
+
+    def __eq__(self, other):
+        # type: (Any) -> bool
+        return isinstance(other, OID) and self.as_tuple() == other.as_tuple()
+
+    def __repr__(self):
+        # type: () -> str
+        return 'OID({!r})'.format(self.as_string())

--- a/snmp/datadog_checks/snmp/utils.py
+++ b/snmp/datadog_checks/snmp/utils.py
@@ -7,8 +7,8 @@ from typing import Any, Dict, Mapping, Sequence, Tuple, Union
 import yaml
 
 from .compat import get_config
-from .exceptions import SmiError
-from .models import ObjectName, ObjectType, endOfMibView, noSuchInstance
+from .exceptions import CouldNotDecodeOID, SmiError
+from .models import ObjectIdentity, ObjectName, ObjectType, endOfMibView, noSuchInstance
 
 
 def get_profile_definition(profile):
@@ -74,14 +74,65 @@ def recursively_expand_base_profiles(definition):
         definition.setdefault('metric_tags', []).extend(base_definition.get('metric_tags', []))
 
 
-def to_oid_tuple(oid):
-    # type: (str) -> Tuple[int, ...]
-    """Return a OID tuple from a OID string.
-
-    Example:
-    '1.3.6.1.4.1' -> (1, 3, 6, 1, 4, 1)
+def parse_as_oid_tuple(value):
+    # type: (Union[Sequence[int], str, ObjectName, ObjectIdentity, ObjectType]) -> Tuple[int, ...]
     """
-    return tuple(map(int, oid.lstrip('.').split('.')))
+    Given an OID in one of many forms, return its int-tuple representation.
+
+    NOTE: not meant to be used directly -- use `models.OID` for a consistent interface instead.
+
+    Raises:
+    -------
+    CouldNotDecodeOID:
+        If `value` is of an unsupported type, or if it is supported by the OID could not be inferred from it.
+    """
+    if isinstance(value, (list, tuple)):
+        # Eg: `(1, 3, 6, 1, 2, 1, 1, 1, 0)`
+        try:
+            return tuple(int(digit) for digit in value)
+        except (TypeError, ValueError) as exc:
+            raise CouldNotDecodeOID(exc)
+
+    if isinstance(value, str):
+        # Eg: ``'1.3.6.1.2.1.1.1.0'`
+
+        # NOTE: There's an obscure and optional convention [0][1] that OIDs *CAN* be prefixed with a leading dot to
+        # mark them as 'absolute', eg '.1.3.6.1.<etc>', as opposed to relative to a some non-agreed-upon root OID.
+        # [0]: http://oid-info.com/faq.htm#mib
+        # [1]: https://comp.protocols.snmp.narkive.com/3UtKdsqv/leading-dot-in-enterprise-oid-in-snmp-traps
+        # This integration can only deal with absolute OIDs anyway, so let's assume that's what we get.
+        value = value.lstrip('.')
+        return parse_as_oid_tuple(value.split('.'))
+
+    if isinstance(value, ObjectName):
+        # Eg: ObjectName('1.3.6.1.2.1.1.1.0'), ObjectName((1, 3, 6, 1, 2, 1, 1, 1, 0)), etc.
+        return value.asTuple()
+
+    if isinstance(value, ObjectIdentity):
+        # Eg: `ObjectIdentity('1.3.6.1.2.1.1.0').resolveWithMib(mibViewController)``
+        # NOTE: inputs of this type most likely come from the execution of a PySNMP command.
+        try:
+            object_name = value.getOid()  # type: ObjectName
+        except SmiError as exc:
+            # Not resolved yet. Probably us building an `ObjectIdentity` instance manually...
+            # We should be using our `OID` model in that case, so let's fail.
+            raise CouldNotDecodeOID('Could not infer OID from `ObjectIdentity`: {!r}'.format(exc))
+
+        return parse_as_oid_tuple(object_name)
+
+    if isinstance(value, ObjectType):
+        # Eg: `ObjectType(some_object_identity)`
+        # NOTE: inputs of this type most likely come from the execution of a PySNMP command.
+        try:
+            object_identity = value[0]
+        except SmiError as exc:
+            # Not resolved yet. Probably us building an `ObjectType` instance manually...
+            # We should be using our `OID` model in that case, so let's fail.
+            raise CouldNotDecodeOID('Could not infer OID from `ObjectType`: {!r}'.format(exc))
+
+        return parse_as_oid_tuple(object_identity)
+
+    raise CouldNotDecodeOID('Building an OID from object {!r} of type {} is not supported'.format(value, type(value)))
 
 
 def oid_pattern_specificity(pattern):

--- a/snmp/tests/test_utils.py
+++ b/snmp/tests/test_utils.py
@@ -1,0 +1,66 @@
+from typing import Any, Tuple
+
+import pytest
+
+from datadog_checks.snmp.exceptions import CouldNotDecodeOID
+from datadog_checks.snmp.models import OID, MibViewController, ObjectIdentity, ObjectName, ObjectType, SnmpEngine
+
+
+@pytest.mark.unit
+def test_oid():
+    # type: () -> None
+    oid = OID((1, 3, 6, 1, 2, 1, 0))
+    assert oid.as_tuple() == (1, 3, 6, 1, 2, 1, 0)
+    assert oid.as_string() == '1.3.6.1.2.1.0'
+    assert oid == OID((1, 3, 6, 1, 2, 1, 0))
+    assert oid != OID((1, 3, 6, 1, 4, 0))
+    assert repr(oid) == "OID('1.3.6.1.2.1.0')"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'value, expected_tuple',
+    [
+        pytest.param((1, 3, 6, 1, 2, 1, 0), (1, 3, 6, 1, 2, 1, 0), id='tuple'),
+        pytest.param('1.3.6.1.2.1.0', (1, 3, 6, 1, 2, 1, 0), id='string'),
+        pytest.param((1, '3', 6, '1', 2, 1, '0'), (1, 3, 6, 1, 2, 1, 0), id='mixed-tuple'),
+        pytest.param('.1.3.6.1.2.1.0', (1, 3, 6, 1, 2, 1, 0), id='string-with-leading-dot'),
+        pytest.param(ObjectName((1, 3, 6, 1, 2, 1, 0)), (1, 3, 6, 1, 2, 1, 0), id='object-name-tuple'),
+        pytest.param(ObjectName('1.3.6.1.2.1.0'), (1, 3, 6, 1, 2, 1, 0), id='object-name-string'),
+        pytest.param(
+            lambda controller: ObjectIdentity((1, 3, 6, 1, 2, 1, 0)).resolveWithMib(controller),
+            (1, 3, 6, 1, 2, 1, 0),
+            id='resolved-object-identity',
+        ),
+        pytest.param(
+            lambda controller: ObjectType(ObjectIdentity((1, 3, 6, 1, 2, 1, 0))).resolveWithMib(controller),
+            (1, 3, 6, 1, 2, 1, 0),
+            id='resolved-object-type',
+        ),
+    ],
+)
+def test_oid_parse_valid(value, expected_tuple):
+    # type: (Any, Tuple[int, ...]) -> None
+    mib_view_controller = MibViewController(SnmpEngine().getMibBuilder())
+    if callable(value):
+        value = value(mib_view_controller)
+    assert OID(value).as_tuple() == expected_tuple
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'value',
+    [
+        pytest.param((1, 2, 'a'), id='non-digit-parts'),
+        pytest.param('1.2.a', id='non-digit-parts'),
+        pytest.param('abc123', id='not-dot-separated-string'),
+        pytest.param(True, id='not-tuple-or-str'),
+        pytest.param(42, id='not-tuple-or-str'),
+        pytest.param(ObjectIdentity((1, 3, 6, 1, 2, 1, 0)), id='unresolved-object-identity'),
+        pytest.param(ObjectType(ObjectIdentity((1, 3, 6, 1, 2, 1, 0))), id='unresolved-object-type'),
+    ],
+)
+def test_oid_parse_invalid(value):
+    # type: (Any) -> None
+    with pytest.raises(CouldNotDecodeOID):
+        OID(value)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add a model class for representing (non-valued) OIDs under a single consistent interface.

### Motivation
<!-- What inspired you to submit this pull request? -->
PySNMP conflates MIB variables, variable bindings, and plain OIDs in several types that aren't easy to work with: `ObjectName`, `ObjectIdentity`, `ObjectType`, etc.

A single `OID` interface (which we can confidently feed PySNMP's stuff to) should be easier to work with, and help with refactoring as we can now type-check for `OID` instances (PySNMP does not ship with type hints).

### Additional Notes
<!-- Anything else we should know when reviewing? -->
This PR introduces the class and uses it in a few obvious places, to limit the scope and the potential for breakage.

So this may feel like a step sideways for now, but…

Once this is in, we can start using it more broadly, and eventually remove any direct usage of `ObjectType`/`ObjectIdentity`:

- In SNMP command functions.
- In `OIDPrinter`.
- When parsing metrics.
- In the main `SnmpCheck` body.
- Etc...

 (This may require us to eventually introduce a `Variable` interface to represent an OID associated to a value. Eg see [here](https://github.com/DataDog/integrations-core/pull/5531/files#diff-65fa2be8e374f641f9840b88837ac74dR69).)

Extra "nice-to-have" improvements include: use `oid_pattern_specificity` to implement comparison magic methods on `OID`, etc.

Inspired by https://github.com/DataDog/integrations-core/pull/5531/

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
