### PR TITLE
Cache dependencies in core repo

### DIFF
--- a/.azure-pipelines/all_master.yml
+++ b/.azure-pipelines/all_master.yml
@@ -15,5 +15,4 @@ jobs:
     key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
     restoreKeys: |
       pip | $(Agent.OS)
-      pip
     path: $(PIP_CACHE_DIR)

--- a/.azure-pipelines/all_master.yml
+++ b/.azure-pipelines/all_master.yml
@@ -11,8 +11,9 @@ variables:
 
 jobs:
 - template: './templates/test-all-checks.yml'
-  pip_cache_config:
-    key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
-    restoreKeys: |
-      pip | $(Agent.OS)
-    path: $(PIP_CACHE_DIR)
+  parameters:
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)

--- a/.azure-pipelines/all_master.yml
+++ b/.azure-pipelines/all_master.yml
@@ -6,7 +6,14 @@ trigger:
 pr: none
 
 variables:
+  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
   DDEV_COLOR: 1
 
 jobs:
 - template: './templates/test-all-checks.yml'
+  pip_cache_config:
+    key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+    restoreKeys: |
+      pip | $(Agent.OS)
+      pip
+    path: $(PIP_CACHE_DIR)

--- a/.azure-pipelines/all_pr.yml
+++ b/.azure-pipelines/all_pr.yml
@@ -11,7 +11,14 @@ pr:
 trigger: none
 
 variables:
+  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
   DDEV_COLOR: 1
 
 jobs:
 - template: './templates/test-all-checks.yml'
+  pip_cache_config:
+    key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+    restoreKeys: |
+      pip | $(Agent.OS)
+      pip
+    path: $(PIP_CACHE_DIR)

--- a/.azure-pipelines/all_pr.yml
+++ b/.azure-pipelines/all_pr.yml
@@ -20,5 +20,4 @@ jobs:
     key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
     restoreKeys: |
       pip | $(Agent.OS)
-      pip
     path: $(PIP_CACHE_DIR)

--- a/.azure-pipelines/all_pr.yml
+++ b/.azure-pipelines/all_pr.yml
@@ -16,8 +16,9 @@ variables:
 
 jobs:
 - template: './templates/test-all-checks.yml'
-  pip_cache_config:
-    key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
-    restoreKeys: |
-      pip | $(Agent.OS)
-    path: $(PIP_CACHE_DIR)
+  parameters:
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)

--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -22,7 +22,6 @@ jobs:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
       restoreKeys: |
         pip | $(Agent.OS)
-        pip
       path: $(PIP_CACHE_DIR)
 
 - template: './templates/test-single-windows.yml'
@@ -34,5 +33,4 @@ jobs:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
       restoreKeys: |
         pip | $(Agent.OS)
-        pip
       path: $(PIP_CACHE_DIR)

--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -9,19 +9,30 @@ pr:
     - datadog_checks_base/datadog_checks/*
 
 variables:
+  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
   DDEV_COLOR: 1
 
 jobs:
 - template: './templates/test-single-linux.yml'
   parameters:
     job_name: Changed
-    pip_cache_key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
     display: Linux
     validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+        pip
+      path: $(PIP_CACHE_DIR)
 
 - template: './templates/test-single-windows.yml'
   parameters:
     job_name: Changed
-    pip_cache_key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
     check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet disk dotnetclr exchange_server iis pdh_check sqlserver win32_event_log windows_service wmi_check'
     display: Windows
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+        pip
+      path: $(PIP_CACHE_DIR)

--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -15,11 +15,13 @@ jobs:
 - template: './templates/test-single-linux.yml'
   parameters:
     job_name: Changed
+    pip_cache_key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
     display: Linux
     validate: true
 
 - template: './templates/test-single-windows.yml'
   parameters:
     job_name: Changed
+    pip_cache_key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
     check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet disk dotnetclr exchange_server iis pdh_check sqlserver win32_event_log windows_service wmi_check'
     display: Windows

--- a/.azure-pipelines/templates/install-deps.yml
+++ b/.azure-pipelines/templates/install-deps.yml
@@ -4,7 +4,7 @@ parameters:
   - name: pip_cache_config
     displayName: 'Pip cache configuration'
     type: object
-    default: null
+    default: {}
 
 steps:
 # Install the Python version with which to use globally last as
@@ -20,11 +20,10 @@ steps:
     versionSpec: '3.8'
   displayName: 'Use Python 3.8'
 
-- ${{ if parameters.pip_cache_config }}:
-  # See: https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching
-  - task: Cache@2
-    inputs: ${{ parameters.pip_cache_config }}
-    displayName: 'Cache pip dependencies'
+# See: https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching
+- task: Cache@2
+  inputs: ${{ parameters.pip_cache_config }}
+  displayName: 'Cache pip dependencies'
 
 - script: python -m pip install --disable-pip-version-check --upgrade pip setuptools
   displayName: 'Upgrade Python packaging tools'

--- a/.azure-pipelines/templates/install-deps.yml
+++ b/.azure-pipelines/templates/install-deps.yml
@@ -4,7 +4,7 @@ parameters:
   - name: pip_cache_config
     displayName: 'Pip cache configuration'
     type: object
-    default: {}
+    default: null
 
 steps:
 # Install the Python version with which to use globally last as
@@ -21,9 +21,10 @@ steps:
   displayName: 'Use Python 3.8'
 
 # See: https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching
-- task: Cache@2
-  inputs: ${{ parameters.pip_cache_config }}
-  displayName: 'Cache pip dependencies'
+- ${{ if parameters.pip_cache_config }}:
+  - task: Cache@2
+    inputs: ${{ parameters.pip_cache_config }}
+    displayName: 'Cache pip dependencies'
 
 - script: python -m pip install --disable-pip-version-check --upgrade pip setuptools
   displayName: 'Upgrade Python packaging tools'

--- a/.azure-pipelines/templates/install-deps.yml
+++ b/.azure-pipelines/templates/install-deps.yml
@@ -1,5 +1,10 @@
 parameters:
-  repo: 'core'
+  - name: repo
+    default: 'core'
+  - name: pip_cache_config
+    displayName: 'Pip cache configuration'
+    type: object
+    default: null
 
 steps:
 # Install the Python version with which to use globally last as
@@ -14,6 +19,12 @@ steps:
   inputs:
     versionSpec: '3.8'
   displayName: 'Use Python 3.8'
+
+- ${{ if parameters.pip_cache_config }}:
+  # See: https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching
+  - task: Cache@2
+    inputs: ${{ parameters.pip_cache_config }}
+    displayName: 'Cache pip dependencies'
 
 - script: python -m pip install --disable-pip-version-check --upgrade pip setuptools
   displayName: 'Upgrade Python packaging tools'

--- a/.azure-pipelines/templates/test-all-checks.yml
+++ b/.azure-pipelines/templates/test-all-checks.yml
@@ -1,16 +1,10 @@
-variables:
-  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
+parameters:
+  pip_cache_config: null
 
 jobs:
 - template: ./test-all.yml
   parameters:
-    pip_cache_config:
-      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
-      restoreKeys: |
-        pip | $(Agent.OS)
-        pip
-      path: $(PIP_CACHE_DIR)
-
+    pip_cache_config: ${{ parameters.pip_cache_config }}
     checks:
     - checkName: datadog_checks_base
       displayName: Datadog Checks Base (Linux)

--- a/.azure-pipelines/templates/test-all-checks.yml
+++ b/.azure-pipelines/templates/test-all-checks.yml
@@ -1,6 +1,16 @@
+variables:
+  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
+
 jobs:
 - template: ./test-all.yml
   parameters:
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+        pip
+      path: $(PIP_CACHE_DIR)
+
     checks:
     - checkName: datadog_checks_base
       displayName: Datadog Checks Base (Linux)

--- a/.azure-pipelines/templates/test-all.yml
+++ b/.azure-pipelines/templates/test-all.yml
@@ -1,6 +1,7 @@
 parameters:
   checks: []
   repo: 'core'
+  pip_cache_config: null
 
 jobs:
 - ${{ each check in parameters.checks }}:
@@ -10,3 +11,4 @@ jobs:
       display: ${{ check.displayName }}
       validate: true
       repo: ${{ parameters.repo }}
+      pip_cache_config: ${{ parameters.pip_cache_config }}

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -22,6 +22,7 @@ jobs:
   - template: './install-deps.yml'
     parameters:
       repo: ${{ parameters.repo }}
+      pip_cache_config: ${{ parameters.pip_cache_config }}
 
   - template: './set-up-integrations.yml'
     parameters:
@@ -40,4 +41,3 @@ jobs:
       test_e2e: ${{ parameters.test_e2e }}
       benchmark: ${{ parameters.benchmark }}
       repo: ${{ parameters.repo }}
-      pip_cache_config: ${{ parameters.pip_cache_config }}

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -7,6 +7,7 @@ parameters:
   benchmark: true
   validate: false
   repo: 'core'
+  pip_cache_config: null
 
 jobs:
 - job: '${{ coalesce(parameters.job_name, parameters.check) }}_Linux'
@@ -39,3 +40,4 @@ jobs:
       test_e2e: ${{ parameters.test_e2e }}
       benchmark: ${{ parameters.benchmark }}
       repo: ${{ parameters.repo }}
+      pip_cache_config: ${{ parameters.pip_cache_config }}

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -7,6 +7,7 @@ parameters:
   benchmark: false
   validate: false
   repo: 'core'
+  pip_cache_config: null
 
 jobs:
 - job: '${{ coalesce(parameters.job_name, parameters.check) }}_Windows'
@@ -41,3 +42,4 @@ jobs:
       test_e2e: ${{ parameters.test_e2e }}
       benchmark: ${{ parameters.benchmark }}
       repo: ${{ parameters.repo }}
+      pip_cache_config: ${{ parameters.pip_cache_config }}

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -24,6 +24,7 @@ jobs:
   - template: './install-deps.yml'
     parameters:
       repo: ${{ parameters.repo }}
+      pip_cache_config: ${{ parameters.pip_cache_config }}
 
   - template: './set-up-integrations.yml'
     parameters:
@@ -42,4 +43,3 @@ jobs:
       test_e2e: ${{ parameters.test_e2e }}
       benchmark: ${{ parameters.benchmark }}
       repo: ${{ parameters.repo }}
-      pip_cache_config: ${{ parameters.pip_cache_config }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Cache dependencies in `integrations-core` based on the OS (Windows/Linux) contents of the `agent_requirements.in` file.

This means one copy of the cache is built once per OS and set of dependencies. It is rebuilt everytime we update `agent_requirements.in` (but other copies stay available).

More info here: https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching

### Motivation
<!-- What inspired you to submit this pull request? -->
- Speed up CI a little bit.
- (More importantly) [Be kind to PyPI](https://twitter.com/GaelVaroquaux/status/1236357401911209985?s=20). 😄 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
