### PR TITLE
Streamline exception handling

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -656,9 +656,14 @@ class SQLServer(AgentCheck):
                     self.log.info("Could not close adodbapi db connection\n%s", e)
 
                 self.connections[conn_key]['conn'] = rawconn
-        except Exception:
+        except Exception as e:
             cx = "{} - {}".format(host, database)
-            message = "Unable to connect to SQL Server for instance {}.".format(cx)
+            message = "Unable to connect to SQL Server for instance {}: {}".format(cx, repr(e))
+
+            password = instance.get('password')
+            if password is not None:
+                message = message.replace(password, "*" * 6)
+
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=service_check_tags, message=message)
 
             raise_from(SQLConnectionError(message), None)

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -8,9 +8,10 @@ http://blogs.msdn.com/b/psssql/archive/2013/09/23/interpreting-the-counter-value
 '''
 from __future__ import division
 
-import traceback
 from collections import defaultdict
 from contextlib import contextmanager
+
+from six import raise_from
 
 from datadog_checks.checks import AgentCheck
 from datadog_checks.config import is_affirmative
@@ -660,13 +661,7 @@ class SQLServer(AgentCheck):
             message = "Unable to connect to SQL Server for instance {}.".format(cx)
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=service_check_tags, message=message)
 
-            password = instance.get('password')
-            tracebk = traceback.format_exc()
-            if password is not None:
-                tracebk = tracebk.replace(password, "*" * 6)
-
-            cxn_failure_exp = SQLConnectionError("{} \n {}".format(message, tracebk))
-            raise cxn_failure_exp
+            raise_from(SQLConnectionError(message), None)
 
 
 class SqlServerMetric(object):


### PR DESCRIPTION
When an exception gets raised on a connection problem, this PR avoids nested exceptions by just popping up a single connection error and ignoring the context traceback.





