### PR TITLE
Drop unused log argument on InstanceConfig

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -69,7 +69,7 @@ class ParsedMetricTag(object):
 def _no_op(*args, **kwargs):
     # type: (*Any, **Any) -> None
     """
-    A 'do-nothing' replacement for the `warning()` and `log()` AgentCheck functions, suitable for when those
+    A 'do-nothing' replacement for the `warning()` AgentCheck function, suitable for when those
     functions are not available (e.g. in unit tests).
     """
 
@@ -87,7 +87,6 @@ class InstanceConfig:
         self,
         instance,  # type: dict
         warning=_no_op,  # type: Callable[..., None]
-        log=_no_op,  # type: Callable[..., None]
         global_metrics=None,  # type: List[dict]
         mibs_path=None,  # type: str
         profiles=None,  # type: Dict[str, dict]
@@ -159,7 +158,7 @@ class InstanceConfig:
 
         self._auth_data = self.get_auth_data(instance)
 
-        self.all_oids, self.bulk_oids, self.parsed_metrics = self.parse_metrics(self.metrics, warning, log)
+        self.all_oids, self.bulk_oids, self.parsed_metrics = self.parse_metrics(self.metrics, warning)
         tag_oids, self.parsed_metric_tags = self.parse_metric_tags(metric_tags)
         if tag_oids:
             self.all_oids.extend(tag_oids)
@@ -167,7 +166,7 @@ class InstanceConfig:
         if profile:
             if profile not in profiles:
                 raise ConfigurationError("Unknown profile '{}'".format(profile))
-            self.refresh_with_profile(profiles[profile], warning, log)
+            self.refresh_with_profile(profiles[profile], warning)
             self.add_profile_tag(profile)
 
         self._context_data = ContextData(*self.get_context_data(instance))
@@ -183,10 +182,10 @@ class InstanceConfig:
         # type: (Any) -> Tuple[Any, Any]
         return self._resolver.resolve_oid(oid)
 
-    def refresh_with_profile(self, profile, warning, log):
-        # type: (Dict[str, Any], Callable[..., None], Callable[..., None]) -> None
+    def refresh_with_profile(self, profile, warning):
+        # type: (Dict[str, Any], Callable[..., None]) -> None
         metrics = profile['definition'].get('metrics', [])
-        all_oids, bulk_oids, parsed_metrics = self.parse_metrics(metrics, warning, log)
+        all_oids, bulk_oids, parsed_metrics = self.parse_metrics(metrics, warning)
 
         metric_tags = profile['definition'].get('metric_tags', [])
         tag_oids, parsed_metric_tags = self.parse_metric_tags(metric_tags)
@@ -317,7 +316,6 @@ class InstanceConfig:
         self,
         metrics,  # type: List[Dict[str, Any]]
         warning,  # type: Callable[..., None]
-        log,  # type: Callable[..., None]
         object_identity_factory=None,  # type: Callable[..., ObjectIdentity]  # For unit tests purposes.
     ):
         # type: (...) -> Tuple[list, list, List[Union[ParsedMetric, ParsedTableMetric]]]

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -17,7 +17,6 @@ from six import iteritems
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.errors import CheckException
-from datadog_checks.base.types import ServiceCheckStatus
 
 from .commands import snmp_bulk, snmp_get, snmp_getnext
 from .compat import read_persistent_cache, total_time_to_temporal_percent, write_persistent_cache
@@ -389,7 +388,7 @@ class SnmpCheck(AgentCheck):
             self.warning(error)
         finally:
             # Report service checks
-            status = self.OK  # type: ServiceCheckStatus
+            status = self.OK
             if error:
                 status = self.CRITICAL
                 if results:

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -45,9 +45,7 @@ def test_parse_metrics(lcd_mock):
 
     # Simple OID
     metrics = [{"OID": "1.2.3", "name": "foo"}]
-    table, _, _ = config.parse_metrics(
-        metrics, check.warning, object_identity_factory=object_identity_factory
-    )
+    table, _, _ = config.parse_metrics(metrics, check.warning, object_identity_factory=object_identity_factory)
     assert len(table) == 1
     object_identity_factory.assert_called_once_with("1.2.3")
     object_identity_factory.reset()
@@ -59,9 +57,7 @@ def test_parse_metrics(lcd_mock):
 
     # MIB with symbol
     metrics = [{"MIB": "foo_mib", "symbol": "foo"}]
-    table, _, _ = config.parse_metrics(
-        metrics, check.warning, object_identity_factory=object_identity_factory
-    )
+    table, _, _ = config.parse_metrics(metrics, check.warning, object_identity_factory=object_identity_factory)
     assert len(table) == 1
     object_identity_factory.assert_called_once_with("foo_mib", "foo")
     object_identity_factory.reset()
@@ -73,9 +69,7 @@ def test_parse_metrics(lcd_mock):
 
     # MIB with table and symbols
     metrics = [{"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"]}]
-    table, _, _ = config.parse_metrics(
-        metrics, check.warning, object_identity_factory=object_identity_factory
-    )
+    table, _, _ = config.parse_metrics(metrics, check.warning, object_identity_factory=object_identity_factory)
     assert len(table) == 2
     object_identity_factory.assert_any_call("foo_mib", "foo")
     object_identity_factory.assert_any_call("foo_mib", "bar")
@@ -93,9 +87,7 @@ def test_parse_metrics(lcd_mock):
 
     # Table with manual OID
     metrics = [{"MIB": "foo_mib", "table": "foo", "symbols": [{"OID": "1.2.3", "name": "foo"}]}]
-    table, _, _ = config.parse_metrics(
-        metrics, check.warning, object_identity_factory=object_identity_factory
-    )
+    table, _, _ = config.parse_metrics(metrics, check.warning, object_identity_factory=object_identity_factory)
     assert len(table) == 1
     object_identity_factory.assert_any_call("1.2.3")
     object_identity_factory.reset()
@@ -104,9 +96,7 @@ def test_parse_metrics(lcd_mock):
     metrics = [
         {"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{"tag": "foo", "index": "1"}]}
     ]
-    table, _, _ = config.parse_metrics(
-        metrics, check.warning, object_identity_factory=object_identity_factory
-    )
+    table, _, _ = config.parse_metrics(metrics, check.warning, object_identity_factory=object_identity_factory)
     assert len(table) == 2
     object_identity_factory.assert_any_call("foo_mib", "foo")
     object_identity_factory.assert_any_call("foo_mib", "bar")
@@ -116,9 +106,7 @@ def test_parse_metrics(lcd_mock):
     metrics = [
         {"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{"tag": "foo", "column": "baz"}]}
     ]
-    table, _, _ = config.parse_metrics(
-        metrics, check.warning, object_identity_factory=object_identity_factory
-    )
+    table, _, _ = config.parse_metrics(metrics, check.warning, object_identity_factory=object_identity_factory)
     assert len(table) == 3
     object_identity_factory.assert_any_call("foo_mib", "foo")
     object_identity_factory.assert_any_call("foo_mib", "bar")
@@ -134,9 +122,7 @@ def test_parse_metrics(lcd_mock):
             "metric_tags": [{"tag": "foo", "column": {"name": "baz", "OID": "1.5.6"}}],
         }
     ]
-    table, _, _ = config.parse_metrics(
-        metrics, check.warning, object_identity_factory=object_identity_factory
-    )
+    table, _, _ = config.parse_metrics(metrics, check.warning, object_identity_factory=object_identity_factory)
     assert len(table) == 3
     object_identity_factory.assert_any_call("1.5.6")
     object_identity_factory.assert_any_call("foo_mib", "foo")

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -36,18 +36,17 @@ def test_parse_metrics(lcd_mock):
     config = InstanceConfig(
         {"ip_address": "127.0.0.1", "community_string": "public", "metrics": [{"OID": "1.2.3", "name": "foo"}]},
         warning=check.warning,
-        log=check.log,
     )
 
     object_identity_factory = ClassInstantiationSpy(ObjectIdentity)
 
     with pytest.raises(Exception):
-        config.parse_metrics(metrics, check.warning, check.log)
+        config.parse_metrics(metrics, check.warning)
 
     # Simple OID
     metrics = [{"OID": "1.2.3", "name": "foo"}]
     table, _, _ = config.parse_metrics(
-        metrics, check.warning, check.log, object_identity_factory=object_identity_factory
+        metrics, check.warning, object_identity_factory=object_identity_factory
     )
     assert len(table) == 1
     object_identity_factory.assert_called_once_with("1.2.3")
@@ -56,12 +55,12 @@ def test_parse_metrics(lcd_mock):
     # MIB with no symbol or table
     metrics = [{"MIB": "foo_mib"}]
     with pytest.raises(Exception):
-        config.parse_metrics(metrics, check.warning, check.log)
+        config.parse_metrics(metrics, check.warning)
 
     # MIB with symbol
     metrics = [{"MIB": "foo_mib", "symbol": "foo"}]
     table, _, _ = config.parse_metrics(
-        metrics, check.warning, check.log, object_identity_factory=object_identity_factory
+        metrics, check.warning, object_identity_factory=object_identity_factory
     )
     assert len(table) == 1
     object_identity_factory.assert_called_once_with("foo_mib", "foo")
@@ -70,12 +69,12 @@ def test_parse_metrics(lcd_mock):
     # MIB with table, no symbols
     metrics = [{"MIB": "foo_mib", "table": "foo"}]
     with pytest.raises(Exception):
-        config.parse_metrics(metrics, check.warning, check.log)
+        config.parse_metrics(metrics, check.warning)
 
     # MIB with table and symbols
     metrics = [{"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"]}]
     table, _, _ = config.parse_metrics(
-        metrics, check.warning, check.log, object_identity_factory=object_identity_factory
+        metrics, check.warning, object_identity_factory=object_identity_factory
     )
     assert len(table) == 2
     object_identity_factory.assert_any_call("foo_mib", "foo")
@@ -85,17 +84,17 @@ def test_parse_metrics(lcd_mock):
     # MIB with table, symbols, bad metrics_tags
     metrics = [{"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{}]}]
     with pytest.raises(Exception):
-        config.parse_metrics(metrics, check.warning, check.log)
+        config.parse_metrics(metrics, check.warning)
 
     # MIB with table, symbols, bad metrics_tags
     metrics = [{"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{"tag": "foo"}]}]
     with pytest.raises(Exception):
-        config.parse_metrics(metrics, check.warning, check.log)
+        config.parse_metrics(metrics, check.warning)
 
     # Table with manual OID
     metrics = [{"MIB": "foo_mib", "table": "foo", "symbols": [{"OID": "1.2.3", "name": "foo"}]}]
     table, _, _ = config.parse_metrics(
-        metrics, check.warning, check.log, object_identity_factory=object_identity_factory
+        metrics, check.warning, object_identity_factory=object_identity_factory
     )
     assert len(table) == 1
     object_identity_factory.assert_any_call("1.2.3")
@@ -106,7 +105,7 @@ def test_parse_metrics(lcd_mock):
         {"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{"tag": "foo", "index": "1"}]}
     ]
     table, _, _ = config.parse_metrics(
-        metrics, check.warning, check.log, object_identity_factory=object_identity_factory
+        metrics, check.warning, object_identity_factory=object_identity_factory
     )
     assert len(table) == 2
     object_identity_factory.assert_any_call("foo_mib", "foo")
@@ -118,7 +117,7 @@ def test_parse_metrics(lcd_mock):
         {"MIB": "foo_mib", "table": "foo", "symbols": ["foo", "bar"], "metric_tags": [{"tag": "foo", "column": "baz"}]}
     ]
     table, _, _ = config.parse_metrics(
-        metrics, check.warning, check.log, object_identity_factory=object_identity_factory
+        metrics, check.warning, object_identity_factory=object_identity_factory
     )
     assert len(table) == 3
     object_identity_factory.assert_any_call("foo_mib", "foo")
@@ -136,7 +135,7 @@ def test_parse_metrics(lcd_mock):
         }
     ]
     table, _, _ = config.parse_metrics(
-        metrics, check.warning, check.log, object_identity_factory=object_identity_factory
+        metrics, check.warning, object_identity_factory=object_identity_factory
     )
     assert len(table) == 3
     object_identity_factory.assert_any_call("1.5.6")


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Drop references to the check logger in `InstanceConfig`, as it's not used anywhere.

Using `changelog/Fixed` instead of `changelog/no-changelog` as this should probably be in the changelog/QA, but isn't public API so it should warrant a `changelog/Removed` either.

### Motivation
<!-- What inspired you to submit this pull request? -->
Code cleanup. Also realized this because I had improperly marked it as a `Callable` when it's actually a `Logger` instance, then realizing we don't actually call into that logger anywhere.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
