### PR TITLE
Fix type hint on `prefix` argument to `AgentCheck.normalize()`

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -626,12 +626,13 @@ class AgentCheck(object):
             raise
 
     def convert_to_underscore_separated(self, name):
-        # type: (bytes) -> bytes
+        # type: (Union[str, bytes]) -> bytes
         """
         Convert from CamelCase to camel_case
         And substitute illegal metric characters
         """
-        metric_name = self.FIRST_CAP_RE.sub(br'\1_\2', ensure_bytes(name))
+        name = ensure_bytes(name)
+        metric_name = self.FIRST_CAP_RE.sub(br'\1_\2', name)
         metric_name = self.ALL_CAP_RE.sub(br'\1_\2', metric_name).lower()
         metric_name = self.METRIC_REPLACEMENT.sub(br'_', metric_name)
         return self.DOT_UNDERSCORE_CLEANUP.sub(br'.', metric_name).strip(b'_')
@@ -693,7 +694,7 @@ class AgentCheck(object):
         return to_native_string(s)
 
     def normalize(self, metric, prefix=None, fix_case=False):
-        # type: (Union[str, bytes], bytes, bool) -> str
+        # type: (Union[str, bytes], Union[str, bytes], bool) -> str
         """
         Turn a metric into a well-formed metric name
         prefix.b.c

--- a/datadog_checks_base/datadog_checks/base/utils/common.py
+++ b/datadog_checks_base/datadog_checks/base/utils/common.py
@@ -7,7 +7,7 @@ import os
 import re
 import warnings
 from decimal import ROUND_HALF_UP, Decimal
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Text, Union
 
 from six import PY3, iteritems, text_type
 from six.moves.urllib.parse import urlparse
@@ -16,12 +16,14 @@ from .constants import MILLISECOND
 
 
 def ensure_bytes(s):
+    # type: (Union[Text, bytes]) -> bytes
     if isinstance(s, text_type):
         s = s.encode('utf-8')
     return s
 
 
 def ensure_unicode(s):
+    # type: (Union[Text, bytes]) -> Text
     if isinstance(s, bytes):
         s = s.decode('utf-8')
     return s


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix type hint on the `prefix` argument to `AgentCheck.normalize()`, as it actually handles both text and binary.

Also adds type annotations to `ensure_bytes()` and `ensure_unicode()` to fully type the `.normalize()` implementation.

Cleanup for #5965 

### Motivation
<!-- What inspired you to submit this pull request? -->
Mypy was improperly flagging errors in the SNMP check:

https://github.com/DataDog/integrations-core/blob/27ca9e5c32e1477fd66dfcd80af96d2ac1c11395/snmp/datadog_checks/snmp/snmp.py#L505

```
error: Argument "prefix" to "normalize" of "AgentCheck" has incompatible type "str"; expected "Optional[bytes]
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
