### PR TITLE
Move PySNMP imports to a separate `pysnmp_types` module

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -7,8 +7,8 @@ from typing import Any, Callable, DefaultDict, Dict, Iterator, List, Optional, S
 
 from datadog_checks.base import ConfigurationError, is_affirmative
 
-from .models import (
-    OID,
+from .models import OID
+from .pysnmp_types import (
     CommunityData,
     ContextData,
     DirMibSource,

--- a/snmp/datadog_checks/snmp/models.py
+++ b/snmp/datadog_checks/snmp/models.py
@@ -2,75 +2,14 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 """
-Re-export PyASN1/PySNMP types and classes that we use, so that we can access them from a single module.
-
-Also define our own SNMP models and interfaces.
+Define our own models and interfaces for dealing with SNMP data.
 """
 
 from typing import Any, Sequence, Tuple, Union
 
-from pyasn1.type.base import Asn1Type
-from pyasn1.type.univ import OctetString
-from pysnmp import hlapi
-from pysnmp.hlapi import (
-    CommunityData,
-    ContextData,
-    ObjectIdentity,
-    ObjectType,
-    SnmpEngine,
-    UdpTransportTarget,
-    UsmUserData,
-    usmDESPrivProtocol,
-    usmHMACMD5AuthProtocol,
-)
-from pysnmp.hlapi.asyncore.cmdgen import lcd
-from pysnmp.hlapi.transport import AbstractTransportTarget
-from pysnmp.proto.rfc1902 import Counter32, Counter64, Gauge32, Integer, Integer32, ObjectName, Unsigned32
-from pysnmp.smi.builder import DirMibSource, MibBuilder
-from pysnmp.smi.exval import endOfMibView, noSuchInstance, noSuchObject
-from pysnmp.smi.view import MibViewController
-
 from .exceptions import CouldNotDecodeOID
+from .pysnmp_types import ObjectIdentity, ObjectName, ObjectType
 from .utils import parse_as_oid_tuple
-
-# Additional types that are not part of the SNMP protocol (see RFC 2856).
-CounterBasedGauge64, ZeroBasedCounter64 = MibBuilder().importSymbols(
-    'HCNUM-TC', 'CounterBasedGauge64', 'ZeroBasedCounter64'
-)
-
-# Cleanup.
-del MibBuilder
-
-__all__ = [
-    'AbstractTransportTarget',
-    'Asn1Type',
-    'DirMibSource',
-    'CommunityData',
-    'ContextData',
-    'CounterBasedGauge64',
-    'endOfMibView',
-    'hlapi',
-    'lcd',
-    'MibViewController',
-    'noSuchInstance',
-    'noSuchObject',
-    'ObjectIdentity',
-    'ObjectName',
-    'ObjectType',
-    'OctetString',
-    'SnmpEngine',
-    'UdpTransportTarget',
-    'usmDESPrivProtocol',
-    'usmHMACMD5AuthProtocol',
-    'UsmUserData',
-    'ZeroBasedCounter64',
-    'Counter32',
-    'Counter64',
-    'Gauge32',
-    'Unsigned32',
-    'Integer',
-    'Integer32',
-]
 
 
 class OID(object):

--- a/snmp/datadog_checks/snmp/pysnmp_types.py
+++ b/snmp/datadog_checks/snmp/pysnmp_types.py
@@ -1,0 +1,66 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+"""
+Re-export PyASN1/PySNMP types and classes that we use, so that we can access them from a single module.
+"""
+
+from pyasn1.type.base import Asn1Type
+from pyasn1.type.univ import OctetString
+from pysnmp import hlapi
+from pysnmp.hlapi import (
+    CommunityData,
+    ContextData,
+    ObjectIdentity,
+    ObjectType,
+    SnmpEngine,
+    UdpTransportTarget,
+    UsmUserData,
+    usmDESPrivProtocol,
+    usmHMACMD5AuthProtocol,
+)
+from pysnmp.hlapi.asyncore.cmdgen import lcd
+from pysnmp.hlapi.transport import AbstractTransportTarget
+from pysnmp.proto.rfc1902 import Counter32, Counter64, Gauge32, Integer, Integer32, ObjectName, Unsigned32
+from pysnmp.smi.builder import DirMibSource, MibBuilder
+from pysnmp.smi.exval import endOfMibView, noSuchInstance, noSuchObject
+from pysnmp.smi.view import MibViewController
+
+# Additional types that are not part of the SNMP protocol (see RFC 2856).
+CounterBasedGauge64, ZeroBasedCounter64 = MibBuilder().importSymbols(
+    'HCNUM-TC', 'CounterBasedGauge64', 'ZeroBasedCounter64'
+)
+
+# Cleanup.
+del MibBuilder
+
+__all__ = [
+    'AbstractTransportTarget',
+    'Asn1Type',
+    'DirMibSource',
+    'CommunityData',
+    'ContextData',
+    'CounterBasedGauge64',
+    'endOfMibView',
+    'hlapi',
+    'lcd',
+    'MibViewController',
+    'noSuchInstance',
+    'noSuchObject',
+    'ObjectIdentity',
+    'ObjectName',
+    'ObjectType',
+    'OctetString',
+    'SnmpEngine',
+    'UdpTransportTarget',
+    'usmDESPrivProtocol',
+    'usmHMACMD5AuthProtocol',
+    'UsmUserData',
+    'ZeroBasedCounter64',
+    'Counter32',
+    'Counter64',
+    'Gauge32',
+    'Unsigned32',
+    'Integer',
+    'Integer32',
+]

--- a/snmp/datadog_checks/snmp/resolver.py
+++ b/snmp/datadog_checks/snmp/resolver.py
@@ -4,7 +4,7 @@
 
 from collections import defaultdict
 
-from .models import ObjectIdentity
+from .pysnmp_types import ObjectIdentity
 
 
 class OIDTreeNode(object):

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -22,7 +22,7 @@ from .commands import snmp_bulk, snmp_get, snmp_getnext
 from .compat import read_persistent_cache, total_time_to_temporal_percent, write_persistent_cache
 from .config import InstanceConfig, ParsedMetric, ParsedMetricTag, ParsedTableMetric
 from .exceptions import PySnmpError
-from .models import (
+from .pysnmp_types import (
     Counter32,
     Counter64,
     CounterBasedGauge64,

--- a/snmp/datadog_checks/snmp/utils.py
+++ b/snmp/datadog_checks/snmp/utils.py
@@ -8,7 +8,7 @@ import yaml
 
 from .compat import get_config
 from .exceptions import CouldNotDecodeOID, SmiError
-from .models import ObjectIdentity, ObjectName, ObjectType, endOfMibView, noSuchInstance
+from .pysnmp_types import ObjectIdentity, ObjectName, ObjectType, endOfMibView, noSuchInstance
 
 
 def get_profile_definition(profile):

--- a/snmp/tests/test_utils.py
+++ b/snmp/tests/test_utils.py
@@ -3,7 +3,8 @@ from typing import Any, Tuple
 import pytest
 
 from datadog_checks.snmp.exceptions import CouldNotDecodeOID
-from datadog_checks.snmp.models import OID, MibViewController, ObjectIdentity, ObjectName, ObjectType, SnmpEngine
+from datadog_checks.snmp.models import OID
+from datadog_checks.snmp.pysnmp_types import MibViewController, ObjectIdentity, ObjectName, ObjectType, SnmpEngine
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Put PySNMP types and our own models apart into dedicated modules.

Cleanup for #5990 

### Motivation
<!-- What inspired you to submit this pull request? -->
Putting PySNMP library types and our own models in the same module tends to lead to circular import when another module requires one but not the other.

Eg `utils.py` was importing PySNMP types from `models.py`, but `models.py` also imports from `utils.py`, so if we tried to import `OID` into `utils.py`, things would break.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
