### PR TITLE
Add `connection_name` configuration

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -103,14 +103,18 @@ class IBMMQConfig:
         )  # type: Dict[str, str]
 
         custom_tags = instance.get('tags', [])  # type: List[str]
-        self.tags_no_channel = [
+        tags = [
             "queue_manager:{}".format(self.queue_manager_name),
-            "mq_host:{}".format(host),  # 'host' is reserved and 'mq_host' is used instead
-            "port:{}".format(port),
             "connection_name:{}".format(self.connection_name),
-        ] + custom_tags  # type: List[str]
-
-        self.tags = self.tags_no_channel + ["channel:{}".format(self.channel)]  # type: List[str]
+        ]  # type: List[str]
+        tags.extend(custom_tags)
+        if host or port:
+            tags.extend({
+                "mq_host:{}".format(host),  # 'host' is reserved and 'mq_host' is used instead
+                "port:{}".format(port),
+            })
+        self.tags_no_channel = tags
+        self.tags = tags + ["channel:{}".format(self.channel)]  # type: List[str]
 
         self.ssl = is_affirmative(instance.get('ssl_auth', False))  # type: bool
         self.ssl_cipher_spec = instance.get('ssl_cipher_spec', 'TLS_RSA_WITH_AES_256_CBC_SHA')  # type: str

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -109,10 +109,8 @@ class IBMMQConfig:
         ]  # type: List[str]
         tags.extend(custom_tags)
         if host or port:
-            tags.extend({
-                "mq_host:{}".format(host),  # 'host' is reserved and 'mq_host' is used instead
-                "port:{}".format(port),
-            })
+            # 'host' is reserved and 'mq_host' is used instead
+            tags.extend({"mq_host:{}".format(host), "port:{}".format(port)})
         self.tags_no_channel = tags
         self.tags = tags + ["channel:{}".format(self.channel)]  # type: List[str]
 

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -72,7 +72,7 @@ class IBMMQConfig:
         self.connection_name = instance.get('connection_name')  # type: str
         if (host or port) and self.connection_name:
             raise ConfigurationError(
-                'Provide either host/port or connection_name configurations, not both '
+                'Specify only one host/port or connection_name configuration, '
                 '(host={}, port={}, connection_name={}).'.format(host, port, self.connection_name)
             )
 

--- a/ibm_mq/datadog_checks/ibm_mq/connection.py
+++ b/ibm_mq/datadog_checks/ibm_mq/connection.py
@@ -68,7 +68,7 @@ def _get_channel_definition(config):
     # type: (IBMMQConfig) -> pymqi.CD
     cd = pymqi.CD()
     cd.ChannelName = pymqi.ensure_bytes(config.channel)
-    cd.ConnectionName = pymqi.ensure_bytes(config.host_and_port)
+    cd.ConnectionName = pymqi.ensure_bytes(config.connection_name)
     cd.ChannelType = pymqi.CMQC.MQCHT_CLNTCONN
     cd.TransportType = pymqi.CMQC.MQXPT_TCP
     cd.Version = config.mqcd_version

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -11,15 +11,30 @@ instances:
     #
     queue_manager: 'datadog'
 
-    ## @param host - string - required - default: localhost
+    ## @param host - string - optional - default: localhost
     ## The host IBM MQ is running on.
+    ##
+    ## Either `host/port` or `connection_name` configuration must be provided.
     #
     host: 'localhost'
 
-    ## @param port - string - required - default: 1414
+    ## @param port - string - optional - default: 1414
     ## The port IBM MQ is listening on.
     #
     port: '1414'
+
+    ## @param connection_name - string - optional
+    ## Connection name used to connect to IBM MQ with following syntax `<HOSTNAME>(<PORT>)`.
+    ##
+    ## Multiple connection names can be provided using comma as separator.
+    ## The connections are usually tried in the order they are specified in the connection list
+    ## until a connection is successfully established.
+    ##
+    ## Example: `localhost(8080)` or `localhost(8080),localhost(8080),my.server(9090)`
+    ##
+    ## Either `host/port` or `connection_name` configuration must be provided.
+    #
+    # connection_name: <CONNECTION_NAME>
 
     ## @param username - string - optional
     ## <USERNAME> of the IBMMQ Channel to connect to.

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import logging
+from typing import Any
 
 from six import iteritems
 
@@ -55,10 +56,10 @@ class IbmMqCheck(AgentCheck):
 
     CHANNEL_COUNT_CHECK = 'ibm_mq.channel.count'
 
-    def __init__(self, name, init_config, instances):
-        super(IbmMqCheck, self).__init__(name, init_config, instances)
+    def __init__(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        super(IbmMqCheck, self).__init__(*args, **kwargs)
         self.config = IBMMQConfig(self.instance)
-        self.config.check_properly_configured()
 
     def check(self, instance):
         if not pymqi:

--- a/ibm_mq/tests/common.py
+++ b/ibm_mq/tests/common.py
@@ -38,6 +38,7 @@ INSTANCE = {
     'password': PASSWORD,
     'queues': [QUEUE],
     'channels': [CHANNEL, BAD_CHANNEL],
+    'tags': ['foo:bar'],
 }
 
 INSTANCE_WITH_CONNECTION_NAME = {

--- a/ibm_mq/tests/common.py
+++ b/ibm_mq/tests/common.py
@@ -40,6 +40,16 @@ INSTANCE = {
     'channels': [CHANNEL, BAD_CHANNEL],
 }
 
+INSTANCE_WITH_CONNECTION_NAME = {
+    'channel': CHANNEL,
+    'queue_manager': QUEUE_MANAGER,
+    'connection_name': "{}({})".format(HOST, PORT),
+    'username': USERNAME,
+    'password': PASSWORD,
+    'queues': [QUEUE],
+    'channels': [CHANNEL, BAD_CHANNEL],
+}
+
 INSTANCE_QUEUE_PATTERN = {
     'channel': CHANNEL,
     'queue_manager': QUEUE_MANAGER,

--- a/ibm_mq/tests/conftest.py
+++ b/ibm_mq/tests/conftest.py
@@ -29,6 +29,12 @@ def instance():
 
 
 @pytest.fixture
+def instance_with_connection_name():
+    inst = copy.deepcopy(common.INSTANCE_WITH_CONNECTION_NAME)
+    return inst
+
+
+@pytest.fixture
 def instance_queue_pattern():
     inst = copy.deepcopy(common.INSTANCE_QUEUE_PATTERN)
     return inst

--- a/ibm_mq/tests/test_ibm_mq_int.py
+++ b/ibm_mq/tests/test_ibm_mq_int.py
@@ -27,6 +27,7 @@ def test_check_metrics_and_service_checks(aggregator, instance, seed_data):
         'queue_manager:{}'.format(common.QUEUE_MANAGER),
         'mq_host:{}'.format(common.HOST),
         'port:{}'.format(common.PORT),
+        'connection_name:{}({})'.format(common.HOST, common.PORT),
     ]
 
     channel_tags = tags + ['channel:{}'.format(common.CHANNEL)]
@@ -37,6 +38,26 @@ def test_check_metrics_and_service_checks(aggregator, instance, seed_data):
 
     discoverable_tags = tags + ['channel:*']
     aggregator.assert_service_check('ibm_mq.channel', check.OK, tags=discoverable_tags, count=1)
+
+
+def test_check_connection_name_one(aggregator, instance_with_connection_name):
+    instance_with_connection_name['mqcd_version'] = os.getenv('IBM_MQ_VERSION')
+
+    check = IbmMqCheck('ibm_mq', {}, [instance_with_connection_name])
+    check.check(instance_with_connection_name)
+
+    assert_all_metrics(aggregator)
+
+
+def test_check_connection_names_multi(aggregator, instance_with_connection_name):
+    instance = instance_with_connection_name
+    instance['mqcd_version'] = os.getenv('IBM_MQ_VERSION')
+    instance['connection_name'] = "localhost(9999),{}".format(instance['connection_name'])
+
+    check = IbmMqCheck('ibm_mq', {}, [instance])
+    check.check(instance)
+
+    assert_all_metrics(aggregator)
 
 
 def test_check_all(aggregator, instance_collect_all, seed_data):
@@ -133,6 +154,7 @@ def test_check_regex_tag(aggregator, instance_queue_regex_tag, seed_data):
         'queue_manager:{}'.format(common.QUEUE_MANAGER),
         'mq_host:{}'.format(common.HOST),
         'port:{}'.format(common.PORT),
+        'connection_name:{}({})'.format(common.HOST, common.PORT),
         'channel:{}'.format(common.CHANNEL),
         'queue:{}'.format(common.QUEUE),
         'foo:bar',

--- a/ibm_mq/tests/test_ibm_mq_int.py
+++ b/ibm_mq/tests/test_ibm_mq_int.py
@@ -28,6 +28,7 @@ def test_check_metrics_and_service_checks(aggregator, instance, seed_data):
         'mq_host:{}'.format(common.HOST),
         'port:{}'.format(common.PORT),
         'connection_name:{}({})'.format(common.HOST, common.PORT),
+        'foo:bar',
     ]
 
     channel_tags = tags + ['channel:{}'.format(common.CHANNEL)]
@@ -47,6 +48,14 @@ def test_check_connection_name_one(aggregator, instance_with_connection_name):
     check.check(instance_with_connection_name)
 
     assert_all_metrics(aggregator)
+
+    tags = [
+        'queue_manager:{}'.format(common.QUEUE_MANAGER),
+        'connection_name:{}({})'.format(common.HOST, common.PORT),
+    ]
+
+    channel_tags = tags + ['channel:{}'.format(common.CHANNEL)]
+    aggregator.assert_service_check('ibm_mq.channel', check.OK, tags=channel_tags, count=1)
 
 
 def test_check_connection_names_multi(aggregator, instance_with_connection_name):

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -105,3 +105,66 @@ def test_set_mqcd_version(instance):
     instance['mqcd_version'] = 9
     config = IBMMQConfig(instance)
     assert config.mqcd_version == pymqi.CMQC.MQCD_VERSION_9
+
+
+@pytest.mark.parametrize(
+    'instance_config, expected_connection_name',
+    [
+        pytest.param({}, 'localhost(1414)', id='empty'),
+        pytest.param({'host': 'foo'}, 'foo(1414)', id='only host'),
+        pytest.param({'port': '1234'}, 'localhost(1234)', id='only port'),
+        pytest.param({'host': 'foo', 'port': 3333}, 'foo(3333)', id='host port'),
+        pytest.param({'connection_name': 'baz(8888)'}, 'baz(8888)', id='connection_name'),
+    ],
+)
+def test_connection_config_ok(instance_config, expected_connection_name):
+    instance_config.update({'channel': 'foo', 'queue_manager': 'bar'})
+
+    config = IBMMQConfig(instance_config)
+
+    assert config.connection_name == expected_connection_name
+
+
+@pytest.mark.parametrize(
+    'instance_config',
+    [pytest.param({'host': 'localhost', 'port': 1000, 'connection_name': 'localhost(1234)'}, id='both')],
+)
+def test_connection_config_error(instance_config):
+    instance_config.update({'channel': 'foo', 'queue_manager': 'bar'})
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        IBMMQConfig(instance_config)
+
+    assert 'Provide either host/port or connection_name configurations' in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    'instance_config',
+    [
+        pytest.param({'channel': 'foo'}, id='channel and default queue manager'),
+        pytest.param({'channel': 'foo', 'queue_manager': 'abc'}, id='both'),
+    ],
+)
+def test_channel_queue_config_ok(instance_config):
+    instance_config.update({'host': 'localhost', 'port': 1000})
+
+    IBMMQConfig(instance_config)
+    # finish without configuration error
+
+
+@pytest.mark.parametrize(
+    'instance_config',
+    [
+        pytest.param({}, id='empty'),
+        pytest.param({'channel': 'foo', 'queue_manager': ''}, id='empty queue manager'),
+        pytest.param({'channel': '', 'queue_manager': 'abc'}, id='empty channel'),
+        pytest.param({'channel': '', 'queue_manager': ''}, id='both empty'),
+    ],
+)
+def test_channel_queue_config_error(instance_config):
+    instance_config.update({'host': 'localhost', 'port': 1000})
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        IBMMQConfig(instance_config)
+
+    assert 'channel, queue_manager are required configurations' in str(excinfo.value)

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -135,7 +135,7 @@ def test_connection_config_error(instance_config):
     with pytest.raises(ConfigurationError) as excinfo:
         IBMMQConfig(instance_config)
 
-    assert 'Provide either host/port or connection_name configurations' in str(excinfo.value)
+    assert 'Specify only one host/port or connection_name configuration' in str(excinfo.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?

Add `connection_name` config

### Motivation

User request.

This will allow user to provide multiple host/port.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
