### PR TITLE
Improve naming in `.get_index_tags()`

### DIFF
--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -478,7 +478,7 @@ class SnmpCheck(AgentCheck):
             try:
                 column_value = results[raw_column_value][index]
             except KeyError:
-                self.log.warning('Column %s not present in the table, skipping this tag', value)
+                self.log.warning('Column %s not present in the table, skipping this tag', raw_column_value)
                 continue
             if reply_invalid(column_value):
                 self.log.warning("Can't deduct tag from column for tag %s", name)

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -447,7 +447,7 @@ class SnmpCheck(AgentCheck):
 
     def get_index_tags(
         self,
-        index,  # type: Dict[int, float]
+        index,  # type: Tuple[str, ...]
         results,  # type: Dict[str, dict]
         index_tags,  # type: List[Tuple[str, int]]
         column_tags,  # type: List[Tuple[str, str]]
@@ -466,27 +466,25 @@ class SnmpCheck(AgentCheck):
         """
         tags = []  # type: List[str]
 
-        for idx_tag in index_tags:
-            tag_group = idx_tag[0]
+        for name, raw_index_value in index_tags:
             try:
-                tag_value = index[idx_tag[1] - 1]
+                value = index[raw_index_value - 1]
             except IndexError:
-                self.log.warning('Not enough indexes, skipping tag %s', tag_group)
+                self.log.warning('Not enough indexes, skipping tag %s', name)
                 continue
-            tags.append('{}:{}'.format(tag_group, tag_value))
+            tags.append('{}:{}'.format(name, value))
 
-        for col_tag in column_tags:
-            tag_group = col_tag[0]
+        for name, raw_column_value in column_tags:
             try:
-                column_value = results[col_tag[1]][index]
+                column_value = results[raw_column_value][index]
             except KeyError:
-                self.log.warning('Column %s not present in the table, skipping this tag', col_tag[1])
+                self.log.warning('Column %s not present in the table, skipping this tag', value)
                 continue
             if reply_invalid(column_value):
-                self.log.warning("Can't deduct tag from column for tag %s", tag_group)
+                self.log.warning("Can't deduct tag from column for tag %s", name)
                 continue
-            tag_value = column_value.prettyPrint()
-            tags.append('{}:{}'.format(tag_group, tag_value))
+            value = column_value.prettyPrint()
+            tags.append('{}:{}'.format(name, value))
 
         return tags
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Improve the naming of variables manipulated inside the `SnmpCheck.get_index_tags()` method.

Also fixes an improper type hint on one of the parameters (same fix as in https://github.com/DataDog/integrations-core/pull/6017 — will resolve conflicts depending on whichever gets merged first).

### Motivation
<!-- What inspired you to submit this pull request? -->
Naming was a bit obscure; it wasn't all that clear that we are actually just deriving tag name/value pairs.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
