### PR TITLE
Accept string values for `proc_regex` and `proc_names`

### DIFF
--- a/supervisord/README.md
+++ b/supervisord/README.md
@@ -77,7 +77,8 @@ Configuration Options
 - `port` (Optional) - Defaults to 9001. The port number.
 - `user` (Optional) - Username
 - `pass` (Optional) - Password
-- `proc_names` (Optional) - Dictionary of process names to monitor
+- `proc_names` (Optional) - List of process names to monitor
+- `proc_regex` (Optional) - List of Regex pattern/s matching the names of processes to monitor.
 - `server_check` (Optional) - Defaults to true. Service check for connection to the `supervisord` server.
 - `socket` (Optional) - If using `supervisorctl` to communicate with Supervisor, a socket is needed.
 

--- a/supervisord/datadog_checks/supervisord/supervisord.py
+++ b/supervisord/datadog_checks/supervisord/supervisord.py
@@ -114,10 +114,14 @@ class SupervisordCheck(AgentCheck):
 
         # Filter monitored processes on configuration directives
         proc_regex = instance.get('proc_regex', [])
+        if isinstance(proc_regex, str):
+            proc_regex = [proc_regex]
         if not isinstance(proc_regex, list):
             raise Exception("Empty or invalid proc_regex.")
 
         proc_names = instance.get('proc_names', [])
+        if isinstance(proc_names, str):
+            proc_names = [proc_names]
         if not isinstance(proc_names, list):
             raise Exception("Empty or invalid proc_names.")
 

--- a/supervisord/tests/common.py
+++ b/supervisord/tests/common.py
@@ -260,4 +260,41 @@ TEST_CASES = [
             ]
         },
     },
+    {
+        'instances': [{'name': 'server0', 'host': 'localhost', 'port': 9001, 'proc_regex': '^mysq.$'}],
+        'expected_metrics': {
+            'server0': [
+                (
+                    'supervisord.process.count',
+                    1,
+                    {'type': 'gauge', 'tags': ['supervisord_server:server0', 'status:up']},
+                ),
+                (
+                    'supervisord.process.count',
+                    0,
+                    {'type': 'gauge', 'tags': ['supervisord_server:server0', 'status:down']},
+                ),
+                (
+                    'supervisord.process.count',
+                    0,
+                    {'type': 'gauge', 'tags': ['supervisord_server:server0', 'status:unknown']},
+                ),
+                (
+                    'supervisord.process.uptime',
+                    125,
+                    {'type': 'gauge', 'tags': ['supervisord_server:server0', 'supervisord_process:mysql']},
+                ),
+            ]
+        },
+        'expected_service_checks': {
+            'server0': [
+                {'status': ServiceCheck.OK, 'tags': ['supervisord_server:server0'], 'check': 'supervisord.can_connect'},
+                {
+                    'status': ServiceCheck.OK,
+                    'tags': ['supervisord_server:server0', 'supervisord_process:mysql'],
+                    'check': 'supervisord.process.status',
+                },
+            ]
+        },
+    },
 ]


### PR DESCRIPTION
### What does this PR do?
Accept string values for `proc_regex` and `proc_names`. If string values are set, they will be converted to a single element list

### Motivation
- Addresses https://github.com/DataDog/integrations-core/issues/5826

### Additional Notes
-  `proc_regex` and `proc_names` should be list of strings. https://github.com/DataDog/integrations-core/blob/7.18.x/supervisord/datadog_checks/supervisord/data/conf.yaml.example#L30-L42

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
