### PR TITLE
Isolate logic for converting SNMP values to metrics

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -25,13 +25,21 @@ from .pysnmp_types import (
     usmHMACMD5AuthProtocol,
 )
 from .resolver import OIDResolver
+from .types import ForceableMetricType
 
 
 class ParsedMetric(object):
 
     __slots__ = ('name', 'metric_tags', 'forced_type', 'enforce_scalar')
 
-    def __init__(self, name, metric_tags, forced_type, enforce_scalar=True):
+    def __init__(
+        self,
+        name,  # type: str
+        metric_tags,  # type: list
+        forced_type=None,  # type: ForceableMetricType
+        enforce_scalar=True,  # type: bool
+    ):
+        # type: (...) -> None
         self.name = name
         self.metric_tags = metric_tags
         self.forced_type = forced_type
@@ -47,7 +55,7 @@ class ParsedTableMetric(object):
         name,  # type: str
         index_tags,  # type: List[Tuple[str, int]]
         column_tags,  # type: List[Tuple[str, str]]
-        forced_type=None,  # type: str
+        forced_type=None,  # type: ForceableMetricType
     ):
         # type: (...) -> None
         self.name = name

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -35,7 +35,7 @@ class ParsedMetric(object):
     def __init__(
         self,
         name,  # type: str
-        metric_tags,  # type: list
+        metric_tags,  # type: List[Dict[str, Any]]
         forced_type=None,  # type: ForceableMetricType
         enforce_scalar=True,  # type: bool
     ):

--- a/snmp/datadog_checks/snmp/metrics.py
+++ b/snmp/datadog_checks/snmp/metrics.py
@@ -1,0 +1,79 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+"""
+Helpers for deriving metrics from raw values.
+"""
+
+from typing import Any, Optional
+
+from pyasn1.codec.ber.decoder import decode as pyasn1_decode
+
+from .compat import total_time_to_temporal_percent
+from .pysnmp_types import PYSNMP_CLASS_NAME_TO_SNMP_TYPE
+from .types import SNMP_COUNTERS, SNMP_GAUGES, ForceableMetricType, MetricDefinition, SNMPType
+
+
+def _get_known_snmp_type(value):
+    # type: (Any) -> Optional[SNMPType]
+    pysnmp_class_name = value.__class__.__name__
+    try:
+        return PYSNMP_CLASS_NAME_TO_SNMP_TYPE[pysnmp_class_name]
+    except KeyError:
+        # Unrecognized PySNMP type. Fine -- but let's discard that piece of information to not be
+        # tempted to rely on this information downstream.
+        return None
+
+
+def as_metric_with_inferred_type(value):
+    # type: (Any) -> Optional[MetricDefinition]
+    snmp_type = _get_known_snmp_type(value)
+
+    if snmp_type in SNMP_COUNTERS:
+        return {'type': 'rate', 'value': int(value)}
+
+    if snmp_type in SNMP_GAUGES:
+        return {'type': 'gauge', 'value': int(value)}
+
+    opaque = 'opaque'  # type: SNMPType  # Use type hint to make sure this literal is correct.
+    if snmp_type == opaque:
+        # Try support for float opaque values.
+        try:
+            decoded, _ = pyasn1_decode(bytes(value))
+            value = float(decoded)
+        except Exception:
+            pass
+        else:
+            return {'type': 'gauge', 'value': value}
+
+    if snmp_type is not None:
+        # Make sure we don't implicitly rely on the fallback too much.
+        message = (
+            'Value {!r} was recognized as SNMP type {!r} but not handled explicitly. Consider inferring it explicitly.'
+        ).format(value, snmp_type)
+        raise RuntimeError(message)
+
+    # Fallback for unknown SNMP types.
+    try:
+        number = float(value)
+    except ValueError:
+        return None
+    else:
+        return {'type': 'gauge', 'value': number}
+
+
+def as_metric_with_forced_type(value, forced_type):
+    # type: (Any, ForceableMetricType) -> Optional[MetricDefinition]
+    if forced_type == 'gauge':
+        return {'type': 'gauge', 'value': int(value)}
+
+    if forced_type == 'percent':
+        return {'type': 'rate', 'value': total_time_to_temporal_percent(int(value), scale=1)}
+
+    if forced_type == 'counter':
+        return {'type': 'rate', 'value': int(value)}
+
+    if forced_type == 'monotonic_count':
+        return {'type': 'monotonic_count', 'value': int(value)}
+
+    return None

--- a/snmp/datadog_checks/snmp/metrics.py
+++ b/snmp/datadog_checks/snmp/metrics.py
@@ -20,15 +20,15 @@ def as_metric_with_inferred_type(value):
     # Ugly hack but couldn't find a cleaner way.
     # Proper way would be to use the ASN1 method isSameTypeWith but it wrongfully returns True in the
     # case of CounterBasedGauge64 and Counter64 for example.
-    pysnmp_class = value.__class__
+    pysnmp_class_name = value.__class__.__name__
 
-    if pysnmp_class in PYSNMP_COUNTER_CLASSES:
+    if pysnmp_class_name in PYSNMP_COUNTER_CLASSES:
         return {'type': 'rate', 'value': int(value)}
 
-    if pysnmp_class in PYSNMP_GAUGE_CLASSES:
+    if pysnmp_class_name in PYSNMP_GAUGE_CLASSES:
         return {'type': 'gauge', 'value': int(value)}
 
-    if pysnmp_class == Opaque:
+    if pysnmp_class_name == 'Opaque':
         # Arbitrary ASN.1 syntax encoded as an octet string. Let's try to decode it as a float.
         # See: http://snmplabs.com/pysnmp/docs/api-reference.html#opaque-type
         try:

--- a/snmp/datadog_checks/snmp/metrics.py
+++ b/snmp/datadog_checks/snmp/metrics.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 """
-Helpers for deriving metrics from raw values.
+Helpers for deriving metrics from SNMP values.
 """
 
 from typing import Any, Optional
@@ -20,8 +20,8 @@ def _get_known_snmp_type(value):
     try:
         return PYSNMP_CLASS_NAME_TO_SNMP_TYPE[pysnmp_class_name]
     except KeyError:
-        # Unrecognized PySNMP type. Fine -- but let's discard that piece of information to not be
-        # tempted to rely on this information downstream.
+        # Unrecognized PySNMP type. Fine -- but let's discard this piece of information
+        # so that we're not tempted to rely on it downstream.
         return None
 
 
@@ -37,7 +37,8 @@ def as_metric_with_inferred_type(value):
 
     opaque = 'opaque'  # type: SNMPType  # Use type hint to make sure this literal is correct.
     if snmp_type == opaque:
-        # Try support for float opaque values.
+        # Arbitrary ASN.1 syntax encoded as an octet string. Let's try to decode it as a float.
+        # See: http://snmplabs.com/pysnmp/docs/api-reference.html#opaque-type
         try:
             decoded, _ = pyasn1_decode(bytes(value))
             value = float(decoded)

--- a/snmp/datadog_checks/snmp/metrics.py
+++ b/snmp/datadog_checks/snmp/metrics.py
@@ -20,15 +20,15 @@ def as_metric_with_inferred_type(value):
     # Ugly hack but couldn't find a cleaner way.
     # Proper way would be to use the ASN1 method isSameTypeWith but it wrongfully returns True in the
     # case of CounterBasedGauge64 and Counter64 for example.
-    pysnmp_class_name = value.__class__.__name__
+    pysnmp_class = value.__class__
 
-    if pysnmp_class_name in PYSNMP_COUNTER_CLASSES:
+    if pysnmp_class in PYSNMP_COUNTER_CLASSES:
         return {'type': 'rate', 'value': int(value)}
 
-    if pysnmp_class_name in PYSNMP_GAUGE_CLASSES:
+    if pysnmp_class in PYSNMP_GAUGE_CLASSES:
         return {'type': 'gauge', 'value': int(value)}
 
-    if pysnmp_class_name == Opaque.__name__:
+    if pysnmp_class == Opaque:
         # Arbitrary ASN.1 syntax encoded as an octet string. Let's try to decode it as a float.
         # See: http://snmplabs.com/pysnmp/docs/api-reference.html#opaque-type
         try:

--- a/snmp/datadog_checks/snmp/pysnmp_types.py
+++ b/snmp/datadog_checks/snmp/pysnmp_types.py
@@ -4,7 +4,6 @@
 """
 Re-export PyASN1/PySNMP types and classes that we use, so that we can access them from a single module.
 """
-from typing import Dict
 
 from pyasn1.type.base import Asn1Type
 from pyasn1.type.univ import OctetString
@@ -27,8 +26,6 @@ from pysnmp.smi.builder import DirMibSource, MibBuilder
 from pysnmp.smi.exval import endOfMibView, noSuchInstance, noSuchObject
 from pysnmp.smi.view import MibViewController
 
-from .types import SNMPType
-
 __all__ = [
     'AbstractTransportTarget',
     'Asn1Type',
@@ -45,6 +42,7 @@ __all__ = [
     'ObjectName',
     'ObjectType',
     'OctetString',
+    'Opaque',
     'SnmpEngine',
     'UdpTransportTarget',
     'usmDESPrivProtocol',
@@ -52,22 +50,24 @@ __all__ = [
     'UsmUserData',
 ]
 
-# Additional types that we support but are not part of the SNMP protocol (see RFC 2856).
+# Additional types that are not part of the SNMP protocol (see RFC 2856).
 CounterBasedGauge64, ZeroBasedCounter64 = MibBuilder().importSymbols(
     'HCNUM-TC', 'CounterBasedGauge64', 'ZeroBasedCounter64'
 )
 
-PYSNMP_CLASS_NAME_TO_SNMP_TYPE = {
-    Counter32.__name__: 'counter32',
-    Counter64.__name__: 'counter64',
-    CounterBasedGauge64.__name__: 'counter-based-gauge64',
-    Gauge32.__name__: 'gauge32',
-    Integer.__name__: 'integer',
-    Integer32.__name__: 'integer32',
-    Opaque.__name__: 'opaque',
-    Unsigned32.__name__: 'unsigned32',
-    ZeroBasedCounter64.__name__: 'zero-based-counter64',
-}  # type: Dict[str, SNMPType]
+# SNMP value types that we explicitly support.
+PYSNMP_COUNTER_CLASSES = {
+    Counter32.__name__,
+    Counter64.__name__,
+    ZeroBasedCounter64.__name__,
+}
+PYSNMP_GAUGE_CLASSES = {
+    Gauge32.__name__,
+    CounterBasedGauge64.__name__,
+    Integer.__name__,
+    Integer32.__name__,
+    Unsigned32.__name__,
+}
 
 # Cleanup items we used here but don't want to expose.
 del MibBuilder
@@ -77,6 +77,5 @@ del CounterBasedGauge64
 del Gauge32
 del Integer
 del Integer32
-del Opaque
 del Unsigned32
 del ZeroBasedCounter64

--- a/snmp/datadog_checks/snmp/pysnmp_types.py
+++ b/snmp/datadog_checks/snmp/pysnmp_types.py
@@ -4,6 +4,7 @@
 """
 Re-export PyASN1/PySNMP types and classes that we use, so that we can access them from a single module.
 """
+from typing import Set
 
 from pyasn1.type.base import Asn1Type
 from pyasn1.type.univ import OctetString
@@ -57,25 +58,17 @@ CounterBasedGauge64, ZeroBasedCounter64 = MibBuilder().importSymbols(
 
 # SNMP value types that we explicitly support.
 PYSNMP_COUNTER_CLASSES = {
-    Counter32.__name__,
-    Counter64.__name__,
-    ZeroBasedCounter64.__name__,
-}
+    Counter32,
+    Counter64,
+    ZeroBasedCounter64,
+}  # type: Set[type]
 PYSNMP_GAUGE_CLASSES = {
-    Gauge32.__name__,
-    CounterBasedGauge64.__name__,
-    Integer.__name__,
-    Integer32.__name__,
-    Unsigned32.__name__,
-}
+    Gauge32,
+    CounterBasedGauge64,
+    Integer,
+    Integer32,
+    Unsigned32,
+}  # type: Set[type]
 
 # Cleanup items we used here but don't want to expose.
 del MibBuilder
-del Counter32
-del Counter64
-del CounterBasedGauge64
-del Gauge32
-del Integer
-del Integer32
-del Unsigned32
-del ZeroBasedCounter64

--- a/snmp/datadog_checks/snmp/pysnmp_types.py
+++ b/snmp/datadog_checks/snmp/pysnmp_types.py
@@ -51,23 +51,20 @@ __all__ = [
     'UsmUserData',
 ]
 
-# Additional types that are not part of the SNMP protocol (see RFC 2856).
-CounterBasedGauge64, ZeroBasedCounter64 = MibBuilder().importSymbols(
-    'HCNUM-TC', 'CounterBasedGauge64', 'ZeroBasedCounter64'
-)
-
 # SNMP value types that we explicitly support.
 PYSNMP_COUNTER_CLASSES = {
     'Counter32',
     'Counter64',
+    # Additional types that are not part of the SNMP protocol (see RFC 2856).
     'ZeroBasedCounter64',
 }  # type: Set[str]
 PYSNMP_GAUGE_CLASSES = {
     'Gauge32',
-    'CounterBasedGauge64',
     'Integer',
     'Integer32',
     'Unsigned32',
+    # Additional types that are not part of the SNMP protocol (see RFC 2856).
+    'CounterBasedGauge64',
 }  # type: Set[str]
 
 # Cleanup items we used here but don't want to expose.

--- a/snmp/datadog_checks/snmp/pysnmp_types.py
+++ b/snmp/datadog_checks/snmp/pysnmp_types.py
@@ -22,7 +22,7 @@ from pysnmp.hlapi import (
 )
 from pysnmp.hlapi.asyncore.cmdgen import lcd
 from pysnmp.hlapi.transport import AbstractTransportTarget
-from pysnmp.proto.rfc1902 import Counter32, Counter64, Gauge32, Integer, Integer32, ObjectName, Opaque, Unsigned32
+from pysnmp.proto.rfc1902 import ObjectName, Opaque
 from pysnmp.smi.builder import DirMibSource, MibBuilder
 from pysnmp.smi.exval import endOfMibView, noSuchInstance, noSuchObject
 from pysnmp.smi.view import MibViewController
@@ -58,17 +58,17 @@ CounterBasedGauge64, ZeroBasedCounter64 = MibBuilder().importSymbols(
 
 # SNMP value types that we explicitly support.
 PYSNMP_COUNTER_CLASSES = {
-    Counter32,
-    Counter64,
-    ZeroBasedCounter64,
-}  # type: Set[type]
+    'Counter32',
+    'Counter64',
+    'ZeroBasedCounter64',
+}  # type: Set[str]
 PYSNMP_GAUGE_CLASSES = {
-    Gauge32,
-    CounterBasedGauge64,
-    Integer,
-    Integer32,
-    Unsigned32,
-}  # type: Set[type]
+    'Gauge32',
+    'CounterBasedGauge64',
+    'Integer',
+    'Integer32',
+    'Unsigned32',
+}  # type: Set[str]
 
 # Cleanup items we used here but don't want to expose.
 del MibBuilder

--- a/snmp/datadog_checks/snmp/pysnmp_types.py
+++ b/snmp/datadog_checks/snmp/pysnmp_types.py
@@ -4,6 +4,7 @@
 """
 Re-export PyASN1/PySNMP types and classes that we use, so that we can access them from a single module.
 """
+from typing import Dict
 
 from pyasn1.type.base import Asn1Type
 from pyasn1.type.univ import OctetString
@@ -21,18 +22,12 @@ from pysnmp.hlapi import (
 )
 from pysnmp.hlapi.asyncore.cmdgen import lcd
 from pysnmp.hlapi.transport import AbstractTransportTarget
-from pysnmp.proto.rfc1902 import Counter32, Counter64, Gauge32, Integer, Integer32, ObjectName, Unsigned32
+from pysnmp.proto.rfc1902 import Counter32, Counter64, Gauge32, Integer, Integer32, ObjectName, Opaque, Unsigned32
 from pysnmp.smi.builder import DirMibSource, MibBuilder
 from pysnmp.smi.exval import endOfMibView, noSuchInstance, noSuchObject
 from pysnmp.smi.view import MibViewController
 
-# Additional types that are not part of the SNMP protocol (see RFC 2856).
-CounterBasedGauge64, ZeroBasedCounter64 = MibBuilder().importSymbols(
-    'HCNUM-TC', 'CounterBasedGauge64', 'ZeroBasedCounter64'
-)
-
-# Cleanup.
-del MibBuilder
+from .types import SNMPType
 
 __all__ = [
     'AbstractTransportTarget',
@@ -40,7 +35,6 @@ __all__ = [
     'DirMibSource',
     'CommunityData',
     'ContextData',
-    'CounterBasedGauge64',
     'endOfMibView',
     'hlapi',
     'lcd',
@@ -56,11 +50,33 @@ __all__ = [
     'usmDESPrivProtocol',
     'usmHMACMD5AuthProtocol',
     'UsmUserData',
-    'ZeroBasedCounter64',
-    'Counter32',
-    'Counter64',
-    'Gauge32',
-    'Unsigned32',
-    'Integer',
-    'Integer32',
 ]
+
+# Additional types that we support but are not part of the SNMP protocol (see RFC 2856).
+CounterBasedGauge64, ZeroBasedCounter64 = MibBuilder().importSymbols(
+    'HCNUM-TC', 'CounterBasedGauge64', 'ZeroBasedCounter64'
+)
+
+PYSNMP_CLASS_NAME_TO_SNMP_TYPE = {
+    Counter32.__name__: 'counter32',
+    Counter64.__name__: 'counter64',
+    CounterBasedGauge64.__name__: 'counter-based-gauge64',
+    Gauge32.__name__: 'gauge32',
+    Integer.__name__: 'integer',
+    Integer32.__name__: 'integer32',
+    Opaque.__name__: 'opaque',
+    Unsigned32.__name__: 'unsigned32',
+    ZeroBasedCounter64.__name__: 'zero-based-counter64',
+}  # type: Dict[str, SNMPType]
+
+# Cleanup items we used here but don't want to expose.
+del MibBuilder
+del Counter32
+del Counter64
+del CounterBasedGauge64
+del Gauge32
+del Integer
+del Integer32
+del Opaque
+del Unsigned32
+del ZeroBasedCounter64

--- a/snmp/datadog_checks/snmp/types.py
+++ b/snmp/datadog_checks/snmp/types.py
@@ -4,20 +4,9 @@
 """
 Type declarations, for type checking purposes only.
 """
-from typing import Literal, Set, TypedDict, Union
+from typing import Literal, TypedDict
 
 ForceableMetricType = Literal['gauge', 'percent']
 MetricDefinition = TypedDict(
     'MetricDefinition', {'type': Literal['gauge', 'rate', 'counter', 'monotonic_count'], 'value': float}
 )
-
-# SNMP value types that we support.
-# NOTE: these literals purposefully do NOT follow the names of PySNMP value classes.
-# This is because they should be completely decoupled from PySNMP classes.
-# Mapping from PySNMP classes to these literals is done elsewhere.
-SNMPCounterType = Literal['counter32', 'counter64', 'zero-based-counter64']
-SNMPGaugeType = Literal['gauge32', 'unsigned32', 'counter-based-gauge64', 'integer', 'integer32']
-SNMPType = Union[SNMPCounterType, SNMPGaugeType, Literal['opaque']]
-
-SNMP_COUNTERS = {'counter32', 'counter64', 'zero-based-counter64'}  # type: Set[SNMPCounterType]
-SNMP_GAUGES = {'gauge32', 'unsigned32', 'counter-based-gauge64', 'integer', 'integer32'}  # type: Set[SNMPGaugeType]

--- a/snmp/datadog_checks/snmp/types.py
+++ b/snmp/datadog_checks/snmp/types.py
@@ -1,0 +1,23 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+"""
+Type declarations, for type checking purposes only.
+"""
+from typing import Literal, Set, TypedDict, Union
+
+ForceableMetricType = Literal['gauge', 'percent']
+MetricDefinition = TypedDict(
+    'MetricDefinition', {'type': Literal['gauge', 'rate', 'counter', 'monotonic_count'], 'value': float}
+)
+
+# SNMP value types that we support.
+# NOTE: these literals purposefully do NOT follow the names of PySNMP value classes.
+# This is because they should be completely decoupled from PySNMP classes.
+# Mapping from PySNMP classes to these literals is done elsewhere.
+SNMPCounterType = Literal['counter32', 'counter64', 'zero-based-counter64']
+SNMPGaugeType = Literal['gauge32', 'unsigned32', 'counter-based-gauge64', 'integer', 'integer32']
+SNMPType = Union[SNMPCounterType, SNMPGaugeType, Literal['opaque']]
+
+SNMP_COUNTERS = {'counter32', 'counter64', 'zero-based-counter64'}  # type: Set[SNMPCounterType]
+SNMP_GAUGES = {'gauge32', 'unsigned32', 'counter-based-gauge64', 'integer', 'integer32'}  # type: Set[SNMPGaugeType]

--- a/snmp/tox.ini
+++ b/snmp/tox.ini
@@ -15,6 +15,14 @@ dd_mypy_args =
     --disallow-untyped-defs
     --follow-imports silent
     datadog_checks/snmp/compat.py
+    datadog_checks/snmp/config.py
+    datadog_checks/snmp/exceptions.py
+    datadog_checks/snmp/metrics.py
+    datadog_checks/snmp/models.py
+    datadog_checks/snmp/pysnmp_types.py
+    datadog_checks/snmp/resolver.py
+    datadog_checks/snmp/types.py
+    datadog_checks/snmp/utils.py
 usedevelop = true
 platform = linux|darwin|win32
 deps =


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Move complex logic for converting SNMP values to metrics into a dedicated module.

Also enforces type checking in added modules and any other existing module that is already OK from a typing perspective.

### Motivation
<!-- What inspired you to submit this pull request? -->
- Preparatory work for #6014.
- Improve readability.
- Reduce coupling with PySNMP.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
