### PR TITLE
Fix event submission on leader change

### DIFF
--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -152,6 +152,11 @@ class Vault(OpenMetricsBaseCheck):
                 # Leader has changed but the monitored vault node is not the leader. Because the agent monitors
                 # each vault node in the cluster, let's use this condition to submit a single event.
                 self._previous_leader = current_leader
+                self.log.debug(
+                    "Leader changed from %s to %s but not reporting an event as the current node is not the leader.",
+                    self._previous_leader,
+                    current_leader,
+                )
                 return
 
             if current_leader.leader_addr != self._previous_leader.leader_addr:
@@ -165,6 +170,7 @@ class Vault(OpenMetricsBaseCheck):
                     self._previous_leader.leader_cluster_addr, current_leader.leader_cluster_addr
                 )
 
+            self.log.debug("Leader changed from %s to %s, sending the event.", self._previous_leader, current_leader)
             submission_queue.append(
                 lambda tags: self.event(
                     {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The vault integration is supposed to submit *one* event whenever the leader changes in the cluster.
This used to have two different issues:

1. This doesn't take into account some HA setups where the leader address points to a load balancer (and thus never change). We should also look at the `leader_cluster_address` in that case.
2. When each vault node/container is monitored from an agent, this can lead to duplicate events (one per each monitored node).

To fix both of these issues into one the check now:

1. Reports an event only when the monitored node is the current leader.
2. The error message contains the leader address by default but falls back to the leader cluster address if the leader address has not changed.



### Motivation
<!-- What inspired you to submit this pull request? -->
Bug fixing


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
