### PR TITLE
Move metric types to new module

### DIFF
--- a/snmp/datadog_checks/snmp/metrics.py
+++ b/snmp/datadog_checks/snmp/metrics.py
@@ -5,13 +5,28 @@
 Helpers for deriving metrics from SNMP values.
 """
 
-from typing import Any, Optional
+from typing import Any, Optional, Set
 
 from pyasn1.codec.ber.decoder import decode as pyasn1_decode
 
 from .compat import total_time_to_temporal_percent
-from .pysnmp_types import PYSNMP_COUNTER_CLASSES, PYSNMP_GAUGE_CLASSES
 from .types import ForceableMetricType, MetricDefinition
+
+# SNMP value types that we explicitly support.
+SNMP_COUNTER_CLASSES = {
+    'Counter32',
+    'Counter64',
+    # Additional types that are not part of the SNMP protocol (see RFC 2856).
+    'ZeroBasedCounter64',
+}  # type: Set[str]
+SNMP_GAUGE_CLASSES = {
+    'Gauge32',
+    'Integer',
+    'Integer32',
+    'Unsigned32',
+    # Additional types that are not part of the SNMP protocol (see RFC 2856).
+    'CounterBasedGauge64',
+}  # type: Set[str]
 
 
 def as_metric_with_inferred_type(value):
@@ -29,10 +44,10 @@ def as_metric_with_inferred_type(value):
 
     pysnmp_class_name = value.__class__.__name__
 
-    if pysnmp_class_name in PYSNMP_COUNTER_CLASSES:
+    if pysnmp_class_name in SNMP_COUNTER_CLASSES:
         return {'type': 'rate', 'value': int(value)}
 
-    if pysnmp_class_name in PYSNMP_GAUGE_CLASSES:
+    if pysnmp_class_name in SNMP_GAUGE_CLASSES:
         return {'type': 'gauge', 'value': int(value)}
 
     if pysnmp_class_name == 'Opaque':

--- a/snmp/datadog_checks/snmp/pysnmp_types.py
+++ b/snmp/datadog_checks/snmp/pysnmp_types.py
@@ -4,8 +4,6 @@
 """
 Re-export PyASN1/PySNMP types and classes that we use, so that we can access them from a single module.
 """
-from typing import Set
-
 from pyasn1.type.base import Asn1Type
 from pyasn1.type.univ import OctetString
 from pysnmp import hlapi
@@ -23,7 +21,7 @@ from pysnmp.hlapi import (
 from pysnmp.hlapi.asyncore.cmdgen import lcd
 from pysnmp.hlapi.transport import AbstractTransportTarget
 from pysnmp.proto.rfc1902 import ObjectName, Opaque
-from pysnmp.smi.builder import DirMibSource, MibBuilder
+from pysnmp.smi.builder import DirMibSource
 from pysnmp.smi.exval import endOfMibView, noSuchInstance, noSuchObject
 from pysnmp.smi.view import MibViewController
 
@@ -50,22 +48,3 @@ __all__ = [
     'usmHMACMD5AuthProtocol',
     'UsmUserData',
 ]
-
-# SNMP value types that we explicitly support.
-PYSNMP_COUNTER_CLASSES = {
-    'Counter32',
-    'Counter64',
-    # Additional types that are not part of the SNMP protocol (see RFC 2856).
-    'ZeroBasedCounter64',
-}  # type: Set[str]
-PYSNMP_GAUGE_CLASSES = {
-    'Gauge32',
-    'Integer',
-    'Integer32',
-    'Unsigned32',
-    # Additional types that are not part of the SNMP protocol (see RFC 2856).
-    'CounterBasedGauge64',
-}  # type: Set[str]
-
-# Cleanup items we used here but don't want to expose.
-del MibBuilder


### PR DESCRIPTION
Those strings are not pysnmp types, just SNMP constants, and used in one
place, let's move them where they are used.