### PR TITLE
Implement `str()` for `OID` instances

### DIFF
--- a/snmp/datadog_checks/snmp/models.py
+++ b/snmp/datadog_checks/snmp/models.py
@@ -9,7 +9,7 @@ from typing import Any, Sequence, Tuple, Union
 
 from .exceptions import CouldNotDecodeOID
 from .pysnmp_types import ObjectIdentity, ObjectName, ObjectType
-from .utils import parse_as_oid_tuple
+from .utils import format_as_oid_string, parse_as_oid_tuple
 
 
 class OID(object):
@@ -38,14 +38,14 @@ class OID(object):
         # type: () -> Tuple[int, ...]
         return self._parts
 
-    def as_string(self):
-        # type: () -> str
-        return '.'.join(map(str, self.as_tuple()))
-
     def __eq__(self, other):
         # type: (Any) -> bool
         return isinstance(other, OID) and self.as_tuple() == other.as_tuple()
 
+    def __str__(self):
+        # type: () -> str
+        return format_as_oid_string(self.as_tuple())
+
     def __repr__(self):
         # type: () -> str
-        return 'OID({!r})'.format(self.as_string())
+        return 'OID({!r})'.format(str(self))

--- a/snmp/datadog_checks/snmp/utils.py
+++ b/snmp/datadog_checks/snmp/utils.py
@@ -135,6 +135,14 @@ def parse_as_oid_tuple(value):
     raise CouldNotDecodeOID('Building an OID from object {!r} of type {} is not supported'.format(value, type(value)))
 
 
+def format_as_oid_string(parts):
+    # type: (Tuple[int, ...]) -> str
+    """
+    Given an OID in int-tuple form, format it to the conventional dot-separated representation.
+    """
+    return '.'.join(str(part) for part in parts)
+
+
 def oid_pattern_specificity(pattern):
     # type: (str) -> Tuple[int, Tuple[int, ...]]
     """Return a measure of the specificity of an OID pattern.

--- a/snmp/tests/test_utils.py
+++ b/snmp/tests/test_utils.py
@@ -12,10 +12,10 @@ def test_oid():
     # type: () -> None
     oid = OID((1, 3, 6, 1, 2, 1, 0))
     assert oid.as_tuple() == (1, 3, 6, 1, 2, 1, 0)
-    assert oid.as_string() == '1.3.6.1.2.1.0'
     assert oid == OID((1, 3, 6, 1, 2, 1, 0))
     assert oid != OID((1, 3, 6, 1, 4, 0))
     assert repr(oid) == "OID('1.3.6.1.2.1.0')"
+    assert str(oid) == '1.3.6.1.2.1.0'
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
When manipulating an `OID` model instance, have `str()` to return its usual dot-separated representation. Drop `.as_string()` as a result.

### Motivation
<!-- What inspired you to submit this pull request? -->
Small preparatory work for #6014.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
