### PR TITLE
Implement lazy resolution in `OID` model

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -341,7 +341,7 @@ class InstanceConfig:
             if isinstance(symbol, dict):
                 symbol_oid = symbol['OID']
                 symbol = symbol['name']
-                self._resolver.register(OID(symbol_oid).as_tuple(), symbol)
+                self._resolver.register(OID(symbol_oid).resolve_as_tuple(), symbol)
                 identity = object_identity_factory(symbol_oid)
             else:
                 identity = object_identity_factory(mib, symbol)
@@ -452,7 +452,7 @@ class InstanceConfig:
                 oid_object = ObjectType(object_identity_factory(metric['OID']))
 
                 table_oids[metric['OID']] = (oid_object, [])
-                self._resolver.register(OID(metric['OID']).as_tuple(), metric['name'])
+                self._resolver.register(OID(metric['OID']).resolve_as_tuple(), metric['name'])
 
                 parsed_metric = ParsedMetric(metric['name'], metric_tags, forced_type, enforce_scalar=False)
                 parsed_metrics.append(parsed_metric)
@@ -495,7 +495,7 @@ class InstanceConfig:
             else:
                 oid = tag['OID']
                 identity = ObjectIdentity(oid)
-                self._resolver.register(OID(oid).as_tuple(), symbol)
+                self._resolver.register(OID(oid).resolve_as_tuple(), symbol)
             object_type = ObjectType(identity)
             oids.append(object_type)
             parsed_metric_tags.append(ParsedMetricTag(tag_name, symbol))
@@ -509,7 +509,7 @@ class InstanceConfig:
         uptime_oid = '1.3.6.1.2.1.1.3.0'
         oid_object = ObjectType(ObjectIdentity(uptime_oid))
         self.all_oids.append(oid_object)
-        self._resolver.register(OID(uptime_oid).as_tuple(), 'sysUpTimeInstance')
+        self._resolver.register(OID(uptime_oid).resolve_as_tuple(), 'sysUpTimeInstance')
 
         parsed_metric = ParsedMetric('sysUpTimeInstance', [], 'gauge')
         self.parsed_metrics.append(parsed_metric)

--- a/snmp/datadog_checks/snmp/models.py
+++ b/snmp/datadog_checks/snmp/models.py
@@ -9,7 +9,7 @@ from typing import Any, Sequence, Tuple, Union
 
 from .exceptions import CouldNotDecodeOID
 from .pysnmp_types import ObjectIdentity, ObjectName, ObjectType
-from .utils import format_as_oid_string, parse_as_oid_tuple
+from .utils import parse_as_oid_tuple
 
 
 class OID(object):

--- a/snmp/datadog_checks/snmp/models.py
+++ b/snmp/datadog_checks/snmp/models.py
@@ -9,43 +9,61 @@ from typing import Any, Sequence, Tuple, Union
 
 from .exceptions import CouldNotDecodeOID
 from .pysnmp_types import ObjectIdentity, ObjectName, ObjectType
-from .utils import parse_as_oid_tuple
+from .utils import format_as_oid_string, parse_as_oid_tuple
 
 
 class OID(object):
     """
     An SNMP object identifier.
 
-    Acts as a facade for various types used by PySNMP to represent OIDs.
+    Acts as a lazy facade for various types used by PySNMP to represent OIDs.
     """
 
     def __init__(self, value):
         # type: (Union[Sequence[int], str, ObjectName, ObjectIdentity, ObjectType]) -> None
+
+        # NOTE: we can't decode `value` just yet, because it may be a PySNMP object that hasn't been resolved yet.
+        # Passing such unresolved objects here is actually OK: looking up the MIB name of an OID isn't required to query
+        # it from a server. (Eg. we can query '1.3.6.1.2.1.1.2' without saying 'and by the way, this is sysObjectId'.)
+        # Anyway, this is why we do lazy decoding, and why '._initialize()' even exists.
+        self._raw = value
+
+    def _initialize(self):
+        # type: () -> None
+        value = self._raw
+
         try:
             parts = parse_as_oid_tuple(value)
         except CouldNotDecodeOID:
             raise  # Explicitly re-raise this exception.
 
-        # Let's make extra sure we didn't mess up.
-        if not isinstance(parts, tuple):
-            raise RuntimeError(
-                'Expected result {!r} of parsing value {!r} to be a tuple, but got {}'.format(parts, value, type(parts))
-            )  # pragma: no cover
-
         self._parts = parts
 
-    def as_tuple(self):
+    def resolve_as_tuple(self):
         # type: () -> Tuple[int, ...]
+        self._initialize()
         return self._parts
 
-    def as_string(self):
+    def resolve_as_string(self):
         # type: () -> str
-        return '.'.join(map(str, self.as_tuple()))
+        return '.'.join(map(str, self.resolve_as_tuple()))
+
+    def as_object_type(self):
+        # type: () -> ObjectType
+
+        # NOTE: if we have a direct reference to a PySNMP instance, return it without resolving.
+        # The goal is to avoid any 'SmiError: OID not fully initialized' exceptions due to not-resolved-yet OIDs.
+        if isinstance(self._raw, ObjectType):
+            return self._raw
+        elif isinstance(self._raw, ObjectIdentity):
+            return ObjectType(self._raw)
+
+        return ObjectType(ObjectIdentity(self.resolve_as_tuple()))
 
     def __eq__(self, other):
         # type: (Any) -> bool
-        return isinstance(other, OID) and self.as_tuple() == other.as_tuple()
+        return isinstance(other, OID) and self.resolve_as_tuple() == other.resolve_as_tuple()
 
     def __repr__(self):
         # type: () -> str
-        return 'OID({!r})'.format(self.as_string())
+        return 'OID({!r})'.format(self.resolve_as_string())

--- a/snmp/tests/test_models.py
+++ b/snmp/tests/test_models.py
@@ -6,19 +6,19 @@ from datadog_checks.snmp.exceptions import CouldNotDecodeOID
 from datadog_checks.snmp.models import OID
 from datadog_checks.snmp.pysnmp_types import MibViewController, ObjectIdentity, ObjectName, ObjectType, SnmpEngine
 
+pytestmark = pytest.mark.unit
 
-@pytest.mark.unit
+
 def test_oid():
     # type: () -> None
     oid = OID((1, 3, 6, 1, 2, 1, 0))
-    assert oid.as_tuple() == (1, 3, 6, 1, 2, 1, 0)
-    assert oid.as_string() == '1.3.6.1.2.1.0'
+    assert oid.resolve_as_tuple() == (1, 3, 6, 1, 2, 1, 0)
+    assert oid.resolve_as_string() == '1.3.6.1.2.1.0'
     assert oid == OID((1, 3, 6, 1, 2, 1, 0))
     assert oid != OID((1, 3, 6, 1, 4, 0))
     assert repr(oid) == "OID('1.3.6.1.2.1.0')"
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize(
     'value, expected_tuple',
     [
@@ -34,18 +34,23 @@ def test_oid():
             id='resolved-object-identity',
         ),
         pytest.param(
+            lambda controller: ObjectIdentity('SNMPv2-MIB', 'sysObjectID').resolveWithMib(controller),
+            (1, 3, 6, 1, 2, 1, 1, 2),
+            id='resolved-mib-object-identity',
+        ),
+        pytest.param(
             lambda controller: ObjectType(ObjectIdentity((1, 3, 6, 1, 2, 1, 0))).resolveWithMib(controller),
             (1, 3, 6, 1, 2, 1, 0),
             id='resolved-object-type',
         ),
     ],
 )
-def test_oid_parse_valid(value, expected_tuple):
+def test_oid_resolve_ok(value, expected_tuple):
     # type: (Any, Tuple[int, ...]) -> None
     mib_view_controller = MibViewController(SnmpEngine().getMibBuilder())
     if callable(value):
         value = value(mib_view_controller)
-    assert OID(value).as_tuple() == expected_tuple
+    assert OID(value).resolve_as_tuple() == expected_tuple
 
 
 @pytest.mark.unit
@@ -61,7 +66,32 @@ def test_oid_parse_valid(value, expected_tuple):
         pytest.param(ObjectType(ObjectIdentity((1, 3, 6, 1, 2, 1, 0))), id='unresolved-object-type'),
     ],
 )
-def test_oid_parse_invalid(value):
+def test_oid_resolve_failed(value):
     # type: (Any) -> None
+    oid = OID(value)
+
     with pytest.raises(CouldNotDecodeOID):
-        OID(value)
+        oid.resolve_as_tuple()
+
+    with pytest.raises(CouldNotDecodeOID):
+        oid.resolve_as_string()
+
+
+@pytest.mark.parametrize(
+    'value, expected_tuple',
+    [
+        pytest.param((1, 3, 6, 1, 2, 1, 0), (1, 3, 6, 1, 2, 1, 0), id='tuple'),
+        pytest.param('1.3.6.1.2.1.0', (1, 3, 6, 1, 2, 1, 0), id='string'),
+        pytest.param(ObjectIdentity((1, 3, 6, 1, 2, 1, 0)), (1, 3, 6, 1, 2, 1, 0), id='object-identity'),
+        pytest.param(ObjectType(ObjectIdentity((1, 3, 6, 1, 2, 1, 0))), (1, 3, 6, 1, 2, 1, 0), id='object-type'),
+    ],
+)
+def test_oid_as_object_type(value, expected_tuple):
+    # type: (Any, Tuple[int, ...]) -> None
+    oid = OID(value)
+    object_type = oid.as_object_type()
+
+    # Verify a valid ObjectType instance was indeed returned by decoding it.
+    mib_view_controller = MibViewController(SnmpEngine().getMibBuilder())
+    resolved = object_type.resolveWithMib(mib_view_controller)
+    assert OID(resolved).resolve_as_tuple() == (1, 3, 6, 1, 2, 1, 0)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Switch the `OID` model to lazily perform resolution of the underlying PySNMP object.
- Add `.as_object_type()` (will be used to build var_binds for SNMP commands).
- Update tests.

### Motivation
<!-- What inspired you to submit this pull request? -->
Preparatory work for #6014 

More about lazy resolution:
- When making SNMP queries, we always pass unresolved OIDs.
- This is fine (we don't need to tell the server the MIB/symbol name), but the current state of the `OID` model wouldn't allow this because it would try to resolve-on-init, and fail with `SmiError` as the underlying `ObjectType`/`ObjectIdentity` wouldn't be resolved yet.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
