### PR TITLE
Move MIB-based resolution logic out of `OIDResolver`

### DIFF
--- a/snmp/datadog_checks/snmp/resolver.py
+++ b/snmp/datadog_checks/snmp/resolver.py
@@ -5,7 +5,7 @@
 from collections import defaultdict
 from typing import DefaultDict, Dict, List, Optional, Tuple
 
-from .pysnmp_types import MibViewController, ObjectIdentity, ObjectType
+from .pysnmp_types import ObjectType
 
 
 class OIDTreeNode(object):
@@ -83,12 +83,10 @@ class OIDResolver(object):
     ```
     """
 
-    def __init__(self, mib_view_controller, enforce_constraints):
-        # type: (MibViewController, bool) -> None
-        self._mib_view_controller = mib_view_controller
+    def __init__(self):
+        # type: () -> None
         self._resolver = OIDTrie()
         self._index_resolvers = defaultdict(dict)  # type: DefaultDict[str, Dict[int, Dict[int, str]]]
-        self._enforce_constraints = enforce_constraints
 
     def register(self, oid, name):
         # type: (Tuple[int, ...], str) -> None
@@ -105,18 +103,6 @@ class OIDResolver(object):
         Corresponds to XXX(3) in the summary listing.
         """
         self._index_resolvers[tag][index] = mapping
-
-    def _resolve_from_mibs(self, oid_tuple, oid):
-        # type: (Tuple[int, ...], ObjectType) -> Tuple[str, Tuple[str, ...]]
-        if not self._enforce_constraints:
-            # if enforce_constraints is false, then MIB resolution has not been done yet
-            # so we need to do it manually. We have to specify the mibs that we will need
-            # to resolve the name.
-            oid = ObjectIdentity(oid_tuple).resolveWithMib(self._mib_view_controller)
-
-        _, name, indexes = oid.getMibSymbol()
-
-        return name, tuple(index.prettyPrint() for index in indexes)
 
     def _resolve_tag_index(self, tail, name):
         # type: (Tuple[int, ...], str) -> Tuple[str, ...]
@@ -141,23 +127,18 @@ class OIDResolver(object):
         return tuple(tags)
 
     def resolve_oid(self, oid):
-        # type: (ObjectType) -> Tuple[str, Tuple[str, ...]]
+        # type: (ObjectType) -> Optional[Tuple[str, Tuple[str, ...]]]
         """Resolve an OID to a name and its indexes.
 
-        This will perform either:
-        1. MIB-based resolution, if `oid` doesn't match any registered OID.
-        2. Manual resolution, if `oid` matched. In this case, indexes are resolved using any registered mappings.
-
-        Returns
-        -------
-        name: the name of the metric associated to `oid`.
-        tag_index: a sequence of tag values. k-th item in the sequence corresponds to the k-th entry in `metric_tags`.
+        Returns `None` if `oid` didn't match any registered OID, otherwise a 2-tuple containing:
+        - name: the name of the metric associated to `oid`.
+        - tag_index: a sequence of tag values. k-th item in the sequence corresponds to the k-th entry in `metric_tags`.
         """
         oid_tuple = oid.asTuple()
         prefix, name = self._resolver.match(oid_tuple)
 
         if name is None:
-            return self._resolve_from_mibs(oid_tuple, oid=oid)
+            return None
 
         # Example: oid: (1, 3, 6, 1, 2, 1, 1), prefix: (1, 3, 6, 1) -> tail: (2, 1, 1)
         tail = oid_tuple[len(prefix) :]

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -161,9 +161,8 @@ class SnmpCheck(AgentCheck):
         In case of scalar objects, the row index is just 0
         """
         results = defaultdict(dict)  # type: DefaultDict[str, Dict[Tuple[str, ...], Any]]
-        enforce_constraints = config.enforce_constraints
 
-        all_binds, error = self.fetch_oids(config, all_oids, enforce_constraints=enforce_constraints)
+        all_binds, error = self.fetch_oids(config, all_oids)
 
         for oid in bulk_oids:
             try:
@@ -173,7 +172,7 @@ class SnmpCheck(AgentCheck):
                     oid,
                     self._NON_REPEATERS,
                     self._MAX_REPETITIONS,
-                    enforce_constraints,
+                    config.enforce_constraints,
                     self.ignore_nonincreasing_oid,
                 )
                 all_binds.extend(binds)
@@ -191,8 +190,8 @@ class SnmpCheck(AgentCheck):
         results.default_factory = None
         return results, error
 
-    def fetch_oids(self, config, oids, enforce_constraints):
-        # type: (InstanceConfig, list, bool) -> Tuple[List[Any], Optional[str]]
+    def fetch_oids(self, config, oids):
+        # type: (InstanceConfig, list) -> Tuple[List[Any], Optional[str]]
         # UPDATE: We used to perform only a snmpgetnext command to fetch metric values.
         # It returns the wrong value when the OID passed is referring to a specific leaf.
         # For example:
@@ -207,7 +206,7 @@ class SnmpCheck(AgentCheck):
                 oids_batch = oids[first_oid : first_oid + self.oid_batch_size]
                 self.log.debug('Running SNMP command get on OIDS: %s', OIDPrinter(oids_batch, with_values=False))
 
-                var_binds = snmp_get(config, oids_batch, lookup_mib=enforce_constraints)
+                var_binds = snmp_get(config, oids_batch, lookup_mib=config.enforce_constraints)
                 self.log.debug('Returned vars: %s', OIDPrinter(var_binds, with_values=True))
 
                 missing_results = []
@@ -230,7 +229,7 @@ class SnmpCheck(AgentCheck):
                         snmp_getnext(
                             config,
                             missing_results,
-                            lookup_mib=enforce_constraints,
+                            lookup_mib=config.enforce_constraints,
                             ignore_nonincreasing_oid=self.ignore_nonincreasing_oid,
                         )
                     )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Move logic about falling back to MIB resolution when an OID couldn't be resolved from registered OIDs to the `InstanceConfig` level. This way, `OIDResolver` is only responsible for resolving OIDs registered explicitly on it.

### Motivation
<!-- What inspired you to submit this pull request? -->
Separation of concerns, and also helps as prep work for #6014. :-)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
