### PR TITLE
Prevent out of bounds on systems with an odd number of counter strings

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/win/winpdh.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/winpdh.py
@@ -132,7 +132,7 @@ class WinPDHCounter(object):
         # create a table of the keys to the counter index, because we want to look up
         # by counter name. Some systems may have an odd number of entries, don't 
         # accidentaly index at val[len(val]
-        for idx in range(0, len(val), 2):
+        for idx in range(0, len(val) - 1, 2):
             WinPDHCounter.pdh_counter_dict[val[idx + 1]].append(val[idx])
 
     def _make_counter_path(self, machine_name, counter_name, instance_name, counters):

--- a/datadog_checks_base/datadog_checks/base/checks/win/winpdh.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/winpdh.py
@@ -130,14 +130,10 @@ class WinPDHCounter(object):
         # for more detail
 
         # create a table of the keys to the counter index, because we want to look up
-        # by counter name.
-
-        idx = 0
-        idx_max = len(val) - 1 # some systems may have an odd number of entries, don't accidentaly index at val[len(val]
-        while idx < idx_max:
-            # counter index is idx , counter name is idx + 1
+        # by counter name. Some systems may have an odd number of entries, don't 
+        # accidentaly index at val[len(val]
+        for idx in range(0, len(val), 2):
             WinPDHCounter.pdh_counter_dict[val[idx + 1]].append(val[idx])
-            idx += 2
 
     def _make_counter_path(self, machine_name, counter_name, instance_name, counters):
         """

--- a/datadog_checks_base/datadog_checks/base/checks/win/winpdh.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/winpdh.py
@@ -133,7 +133,7 @@ class WinPDHCounter(object):
         # by counter name.
 
         idx = 0
-        idx_max = len(val)
+        idx_max = len(val) - 1 # some systems may have an odd number of entries, don't accidentaly index at val[len(val]
         while idx < idx_max:
             # counter index is idx , counter name is idx + 1
             WinPDHCounter.pdh_counter_dict[val[idx + 1]].append(val[idx])


### PR DESCRIPTION
In my system (Windows Server 2016) the length of val (line: 136) is 13033. This causes winpdh.py to error out (caught on line 42) due to indexing val beyond it's size.

Not sure of the etiquette around submitting pull requests - but this request checks that we don't index beyond the capacity of the string-array.

### What does this PR do?
Prevent out of bounds on systems with an odd number of counter strings

### Motivation
In my system (Windows Server 2016) the length of val (line: 136) is 13033. This causes winpdh.py to error out (caught on line 42) due to indexing val beyond it's size.

### Additional Notes
Not sure of the etiquette around submitting pull requests - but this request checks that we don't index beyond the capacity of the string-array.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
