### PR TITLE
Support Fluentd config API endpoint for metadata collection

### DIFF
--- a/fluentd/datadog_checks/fluentd/fluentd.py
+++ b/fluentd/datadog_checks/fluentd/fluentd.py
@@ -35,6 +35,12 @@ class Fluentd(AgentCheck):
 
         self._fluentd_command = self.instance.get('fluentd', init_config.get('fluentd', 'fluentd'))
 
+        self.url = self.instance.get('monitor_agent_url')
+        parsed_url = urlparse(self.url)
+        self.monitor_agent_host = parsed_url.hostname
+        self.monitor_agent_port = parsed_url.port or 24220
+        self.config_url = '{}:{}/api/config.json'.format(self.monitor_agent_host, self.monitor_agent_port)
+
     """Tracks basic fluentd metrics via the monitor_agent plugin
     * number of retry_count
     * number of buffer_queue_length
@@ -49,7 +55,7 @@ class Fluentd(AgentCheck):
             raise Exception('Fluentd instance missing "monitor_agent_url" value.')
 
         try:
-            url = instance.get('monitor_agent_url')
+
             plugin_ids = instance.get('plugin_ids', [])
             custom_tags = instance.get('tags', [])
 
@@ -57,15 +63,12 @@ class Fluentd(AgentCheck):
             tag_by = instance.get('tag_by')
             tag_by = tag_by if tag_by in self._AVAILABLE_TAGS else 'plugin_id'
 
-            parsed_url = urlparse(url)
-            monitor_agent_host = parsed_url.hostname
-            monitor_agent_port = parsed_url.port or 24220
             service_check_tags = [
-                'fluentd_host:%s' % monitor_agent_host,
-                'fluentd_port:%s' % monitor_agent_port,
+                'fluentd_host:%s' % self.monitor_agent_host,
+                'fluentd_port:%s' % self.monitor_agent_port,
             ] + custom_tags
 
-            r = self.http.get(url)
+            r = self.http.get(self.url)
             r.raise_for_status()
             status = r.json()
 
@@ -90,17 +93,29 @@ class Fluentd(AgentCheck):
 
             self._collect_metadata()
         except Exception as e:
-            msg = "No stats could be retrieved from %s : %s" % (url, str(e))
+            msg = "No stats could be retrieved from %s : %s" % (self.url, str(e))
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=service_check_tags, message=msg)
             raise
         else:
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK, tags=service_check_tags)
 
     def _collect_metadata(self):
-        if self.is_metadata_collection_enabled():
-            raw_version = self._get_raw_version()
-            if raw_version:
-                self.set_metadata('version', raw_version)
+        if not self.is_metadata_collection_enabled():
+            return
+        try:
+            r = self.http.get(self.config_url)
+            r.raise_for_status()
+            config = r.json()
+            if 'version' in config:
+                self.set_metadata('version', config['version'])
+                return
+        except Exception as e:
+            self.log.debug("No config could be retrieved from %s: %s", self.config_url, e)
+
+        # Fall back to command line for older versions of fluentd
+        raw_version = self._get_raw_version()
+        if raw_version:
+            self.set_metadata('version', raw_version)
 
     def _get_raw_version(self):
         version_command = '{} --version'.format(self._fluentd_command)

--- a/fluentd/datadog_checks/fluentd/fluentd.py
+++ b/fluentd/datadog_checks/fluentd/fluentd.py
@@ -39,7 +39,9 @@ class Fluentd(AgentCheck):
         parsed_url = urlparse(self.url)
         self.monitor_agent_host = parsed_url.hostname
         self.monitor_agent_port = parsed_url.port or 24220
-        self.config_url = '{}:{}/api/config.json'.format(self.monitor_agent_host, self.monitor_agent_port)
+        self.config_url = '{}://{}:{}/api/config.json'.format(
+            parsed_url.scheme, self.monitor_agent_host, self.monitor_agent_port
+        )
 
     """Tracks basic fluentd metrics via the monitor_agent plugin
     * number of retry_count

--- a/fluentd/datadog_checks/fluentd/fluentd.py
+++ b/fluentd/datadog_checks/fluentd/fluentd.py
@@ -97,10 +97,10 @@ class Fluentd(AgentCheck):
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK, tags=service_check_tags)
 
     def _collect_metadata(self):
-        raw_version = self._get_raw_version()
-
-        if raw_version:
-            self.set_metadata('version', raw_version)
+        if self.is_metadata_collection_enabled():
+            raw_version = self._get_raw_version()
+            if raw_version:
+                self.set_metadata('version', raw_version)
 
     def _get_raw_version(self):
         version_command = '{} --version'.format(self._fluentd_command)

--- a/fluentd/tests/test_integration.py
+++ b/fluentd/tests/test_integration.py
@@ -10,8 +10,9 @@ from datadog_checks.fluentd import Fluentd
 
 from .common import BAD_PORT, BAD_URL, CHECK_NAME, DEFAULT_INSTANCE, EXPECTED_GAUGES, HOST
 
+pytestmark = [pytest.mark.usefixtures("dd_environment"), pytest.mark.integration]
 
-@pytest.mark.usefixtures("dd_environment")
+
 def test_fluentd_exception(aggregator):
     instance = {"monitor_agent_url": BAD_URL, "plugin_ids": ["plg2"], "tags": ["test"]}
     check = Fluentd(CHECK_NAME, {}, [instance])
@@ -24,7 +25,6 @@ def test_fluentd_exception(aggregator):
     aggregator.assert_all_metrics_covered()
 
 
-@pytest.mark.usefixtures("dd_environment")
 def test_fluentd_with_tag_by_type(aggregator):
     instance = copy.deepcopy(DEFAULT_INSTANCE)
     instance["tag_by"] = "type"
@@ -43,7 +43,6 @@ def test_fluentd_with_tag_by_type(aggregator):
     aggregator.assert_all_metrics_covered()
 
 
-@pytest.mark.usefixtures("dd_environment")
 def test_fluentd_with_tag_by_plugin_id(aggregator):
     instance = copy.deepcopy(DEFAULT_INSTANCE)
     instance["tag_by"] = "plugin_id"
@@ -62,7 +61,6 @@ def test_fluentd_with_tag_by_plugin_id(aggregator):
     aggregator.assert_all_metrics_covered()
 
 
-@pytest.mark.usefixtures("dd_environment")
 def test_fluentd_with_custom_tags(aggregator):
     instance = copy.deepcopy(DEFAULT_INSTANCE)
     custom_tags = ['test', 'tast:tast']

--- a/fluentd/tests/test_integration_and_e2e.py
+++ b/fluentd/tests/test_integration_and_e2e.py
@@ -11,7 +11,6 @@ from datadog_checks.fluentd import Fluentd
 from .common import CHECK_NAME, EXPECTED_GAUGES, HOST, INSTANCE_WITH_PLUGIN
 
 
-@pytest.mark.integration
 def assert_basic_case(aggregator):
     sc_tags = ['fluentd_host:{}'.format(HOST), 'fluentd_port:24220']
 

--- a/fluentd/tests/test_integration_and_e2e.py
+++ b/fluentd/tests/test_integration_and_e2e.py
@@ -11,6 +11,7 @@ from datadog_checks.fluentd import Fluentd
 from .common import CHECK_NAME, EXPECTED_GAUGES, HOST, INSTANCE_WITH_PLUGIN
 
 
+@pytest.mark.integration
 def assert_basic_case(aggregator):
     sc_tags = ['fluentd_host:{}'.format(HOST), 'fluentd_port:24220']
 
@@ -22,6 +23,7 @@ def assert_basic_case(aggregator):
     aggregator.assert_all_metrics_covered()
 
 
+@pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
 def test_basic_case_integration(aggregator):
     instance = copy.deepcopy(INSTANCE_WITH_PLUGIN)

--- a/fluentd/tests/test_metadata.py
+++ b/fluentd/tests/test_metadata.py
@@ -8,7 +8,7 @@ import pytest
 from datadog_checks.fluentd import Fluentd
 
 from .common import CHECK_NAME, FLUENTD_CONTAINER_NAME, FLUENTD_VERSION, HERE
-from .util import requires_0_12_23, requires_1_9
+from .util import requires_above_1_8, requires_below_1_8
 
 pytestmark = [pytest.mark.usefixtures("dd_environment"), pytest.mark.integration, pytest.mark.metadata]
 
@@ -36,7 +36,7 @@ def test_collect_metadata_instance(aggregator, datadog_agent, instance):
     datadog_agent.assert_metadata_count(5)
 
 
-@requires_0_12_23
+@requires_below_1_8
 def test_collect_metadata_missing_version(aggregator, datadog_agent, instance):
     instance["fluentd"] = "python {} 'fluentd not.a.version'".format(VERSION_MOCK_SCRIPT)
 
@@ -48,7 +48,7 @@ def test_collect_metadata_missing_version(aggregator, datadog_agent, instance):
     datadog_agent.assert_metadata_count(0)
 
 
-@requires_0_12_23
+@requires_below_1_8
 def test_collect_metadata_invalid_binary(datadog_agent, instance):
     instance['fluentd'] = '/bin/does_not_exist'
 
@@ -60,7 +60,7 @@ def test_collect_metadata_invalid_binary(datadog_agent, instance):
     datadog_agent.assert_metadata_count(0)
 
 
-@requires_1_9
+@requires_above_1_8
 def test_collect_metadata_invalid_binary_with_endpoint(datadog_agent, instance):
     instance['fluentd'] = '/bin/does_not_exist'
 

--- a/fluentd/tests/test_metadata.py
+++ b/fluentd/tests/test_metadata.py
@@ -7,14 +7,15 @@ import pytest
 
 from datadog_checks.fluentd import Fluentd
 
-from fluentd.tests.util import requires_0_12_23, requires_1_9
 from .common import CHECK_NAME, FLUENTD_CONTAINER_NAME, FLUENTD_VERSION, HERE
+from .util import requires_0_12_23, requires_1_9
+
+pytestmark = [pytest.mark.usefixtures("dd_environment"), pytest.mark.integration, pytest.mark.metadata]
 
 CHECK_ID = 'test:123'
 VERSION_MOCK_SCRIPT = os.path.join(HERE, 'mock', 'fluentd_version.py')
 
 
-@pytest.mark.usefixtures("dd_environment")
 def test_collect_metadata_instance(aggregator, datadog_agent, instance):
     instance['fluentd'] = 'docker exec {} fluentd'.format(FLUENTD_CONTAINER_NAME)
 
@@ -35,7 +36,6 @@ def test_collect_metadata_instance(aggregator, datadog_agent, instance):
     datadog_agent.assert_metadata_count(5)
 
 
-@pytest.mark.usefixtures("dd_environment")
 @requires_0_12_23
 def test_collect_metadata_missing_version(aggregator, datadog_agent, instance):
     instance["fluentd"] = "python {} 'fluentd not.a.version'".format(VERSION_MOCK_SCRIPT)
@@ -48,7 +48,6 @@ def test_collect_metadata_missing_version(aggregator, datadog_agent, instance):
     datadog_agent.assert_metadata_count(0)
 
 
-@pytest.mark.usefixtures("dd_environment")
 @requires_0_12_23
 def test_collect_metadata_invalid_binary(datadog_agent, instance):
     instance['fluentd'] = '/bin/does_not_exist'
@@ -61,7 +60,6 @@ def test_collect_metadata_invalid_binary(datadog_agent, instance):
     datadog_agent.assert_metadata_count(0)
 
 
-@pytest.mark.usefixtures("dd_environment")
 @requires_1_9
 def test_collect_metadata_invalid_binary_with_endpoint(datadog_agent, instance):
     instance['fluentd'] = '/bin/does_not_exist'

--- a/fluentd/tests/util.py
+++ b/fluentd/tests/util.py
@@ -6,12 +6,12 @@ import pytest
 from .common import FLUENTD_VERSION
 
 requires_1_9 = pytest.mark.skipif(
-    FLUENTD_VERSION is None or float(FLUENTD_VERSION) == '1.9',
-    reason='This test is for 1.9 only (make sure FLUENTD_VERSION is set)',
+    FLUENTD_VERSION is None or FLUENTD_VERSION != '1.9.3',
+    reason='This test is for 1.9.3 only (make sure FLUENTD_VERSION is set)',
 )
 
 
 requires_0_12_23 = pytest.mark.skipif(
-    FLUENTD_VERSION is None or float(FLUENTD_VERSION) == '0.12.23',
+    FLUENTD_VERSION is None or FLUENTD_VERSION != '0.12.23',
     reason='This test is for 0.12.23 only (make sure FLUENTD_VERSION is set)',
 )

--- a/fluentd/tests/util.py
+++ b/fluentd/tests/util.py
@@ -1,0 +1,17 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from .common import FLUENTD_VERSION
+
+requires_1_9 = pytest.mark.skipif(
+    FLUENTD_VERSION is None or float(FLUENTD_VERSION) == '1.9',
+    reason='This test is for 1.9 only (make sure FLUENTD_VERSION is set)',
+)
+
+
+requires_0_12_23 = pytest.mark.skipif(
+    FLUENTD_VERSION is None or float(FLUENTD_VERSION) == '0.12.23',
+    reason='This test is for 0.12.23 only (make sure FLUENTD_VERSION is set)',
+)

--- a/fluentd/tests/util.py
+++ b/fluentd/tests/util.py
@@ -2,16 +2,17 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
+from packaging import version
 
 from .common import FLUENTD_VERSION
 
-requires_1_9 = pytest.mark.skipif(
-    FLUENTD_VERSION is None or FLUENTD_VERSION != '1.9.3',
-    reason='This test is for 1.9.3 only (make sure FLUENTD_VERSION is set)',
+requires_above_1_8 = pytest.mark.skipif(
+    FLUENTD_VERSION is None or version.parse(FLUENTD_VERSION) < version.parse('1.8.0'),
+    reason='This test is for versions above 1.8 only (make sure FLUENTD_VERSION is set)',
 )
 
 
-requires_0_12_23 = pytest.mark.skipif(
-    FLUENTD_VERSION is None or FLUENTD_VERSION != '0.12.23',
-    reason='This test is for 0.12.23 only (make sure FLUENTD_VERSION is set)',
+requires_below_1_8 = pytest.mark.skipif(
+    FLUENTD_VERSION is None or version.parse(FLUENTD_VERSION) >= version.parse('1.8.0'),
+    reason='This test is for versions below 1.8 only (make sure FLUENTD_VERSION is set)',
 )

--- a/fluentd/tox.ini
+++ b/fluentd/tox.ini
@@ -19,8 +19,9 @@ passenv =
 setenv =
     0.12.23: FLUENTD_VERSION=0.12.23
     0.12.23: FLUENTD_IMAGE_TAG=v0.12.23
-    1.9: FLUENTD_VERSION=1.9
-    1.9: FLUENTD_IMAGE_TAG=v1.9
+    1.9: FLUENTD_VERSION=1.9.3
+    1.9: FLUENTD_IMAGE_TAG=v1.9.3-1.0
+
 commands =
     pip install -r requirements.in
     pytest -v {posargs}

--- a/fluentd/tox.ini
+++ b/fluentd/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{0.12.23,1.4}
+    py{27,38}-{0.12.23,1.9}
 
 [testenv]
 description=
@@ -19,8 +19,8 @@ passenv =
 setenv =
     0.12.23: FLUENTD_VERSION=0.12.23
     0.12.23: FLUENTD_IMAGE_TAG=v0.12.23
-    1.4: FLUENTD_VERSION=1.4.2
-    1.4: FLUENTD_IMAGE_TAG=v1.4-2
+    1.9: FLUENTD_VERSION=1.9
+    1.9: FLUENTD_IMAGE_TAG=v1.9
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
Use updated config rest endpoint for metadata collection and fallback to cli for older versions of fluentd