### PR TITLE
Relax type of `ServiceCheck` enum items

### DIFF
--- a/datadog_checks_base/datadog_checks/base/types.py
+++ b/datadog_checks_base/datadog_checks/base/types.py
@@ -17,7 +17,12 @@ ProxySettings = TypedDict(
 ServiceCheckStatus = Literal[0, 1, 2, 3]  # Can serve as an int enum type for type checking purposes.
 _ServiceCheckType = NamedTuple(
     '_ServiceCheckType',
-    [('OK', Literal[0]), ('WARNING', Literal[1]), ('CRITICAL', Literal[2]), ('UNKNOWN', Literal[3])],
+    [
+        ('OK', ServiceCheckStatus),
+        ('WARNING', ServiceCheckStatus),
+        ('CRITICAL', ServiceCheckStatus),
+        ('UNKNOWN', ServiceCheckStatus),
+    ],
 )
 ServiceCheck = _ServiceCheckType(0, 1, 2, 3)  # For public enum-style use: `ServiceCheck.OK`, ...
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Relax the type of individual service check enum items, eg `ServiceCheck.OK`, etc.

### Motivation
<!-- What inspired you to submit this pull request? -->
Prevent needless type checking nits such as:

```python
status = self.OK
if <condition>:
    status = self.CRITICAL
```

```console
error: Incompatible types in assignment (expression has type "Literal[1]", variable has type "Literal[0]")
```

Eg currently this part of the SNMP check flags red needlessly:

https://github.com/DataDog/integrations-core/blob/f81d3054969ec8e5b7eb3092006306da5de35241/snmp/datadog_checks/snmp/snmp.py#L371-L376

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
