### PR TITLE
Fix ssl context

### DIFF
--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -73,6 +73,11 @@ class VSphereAPI(object):
         context = None
         if not self.config.ssl_verify:
             context = ssl.SSLContext(PROTOCOL_TLS_CLIENT)
+
+            # IMPORTANT: This must be set before verify_mode in Python 3.7+, see:
+            # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.check_hostname
+            context.check_hostname = False
+
             context.verify_mode = ssl.CERT_NONE
         elif self.config.ssl_capath:
             context = ssl.SSLContext(PROTOCOL_TLS_CLIENT)

--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -72,10 +72,10 @@ class VSphereAPI(object):
         """
         context = None
         if not self.config.ssl_verify:
-            context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+            context = ssl.SSLContext(PROTOCOL_TLS_CLIENT)
             context.verify_mode = ssl.CERT_NONE
         elif self.config.ssl_capath:
-            context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            context = ssl.SSLContext(PROTOCOL_TLS_CLIENT)
             context.verify_mode = ssl.CERT_REQUIRED
             context.load_verify_locations(capath=self.config.ssl_capath)
 

--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -9,9 +9,6 @@ from pyVmomi import vim, vmodl
 
 from datadog_checks.vsphere.constants import ALL_RESOURCES, MAX_QUERY_METRICS_OPTION, UNLIMITED_HIST_METRICS_PER_QUERY
 
-# Python 3 only
-PROTOCOL_TLS_CLIENT = getattr(ssl, 'PROTOCOL_TLS_CLIENT', ssl.PROTOCOL_TLS)
-
 
 def smart_retry(f):
     """A function decorated with this `@smart_retry` will trigger a new authentication if it fails. The function
@@ -72,16 +69,13 @@ class VSphereAPI(object):
         """
         context = None
         if not self.config.ssl_verify:
-            context = ssl.SSLContext(PROTOCOL_TLS_CLIENT)
-
-            # IMPORTANT: This must be set before verify_mode in Python 3.7+, see:
-            # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.check_hostname
-            context.check_hostname = False
-
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS)
             context.verify_mode = ssl.CERT_NONE
         elif self.config.ssl_capath:
-            context = ssl.SSLContext(PROTOCOL_TLS_CLIENT)
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS)
             context.verify_mode = ssl.CERT_REQUIRED
+            # `check_hostname` must be enabled as well to verify the authenticity of a cert.
+            context.check_hostname = True
             context.load_verify_locations(capath=self.config.ssl_capath)
 
         try:

--- a/vsphere/tests/test_api.py
+++ b/vsphere/tests/test_api.py
@@ -13,7 +13,6 @@ from datadog_checks.vsphere.config import VSphereConfig
 
 def test_ssl_verify_false(realtime_instance):
     realtime_instance['ssl_verify'] = False
-    realtime_instance['ssl_capath'] = '/dummy/path'
 
     with patch('datadog_checks.vsphere.api.connect') as connect, patch(
         'ssl.SSLContext.load_verify_locations'

--- a/vsphere/tests/test_api.py
+++ b/vsphere/tests/test_api.py
@@ -4,17 +4,11 @@
 import ssl
 
 import pytest
-import six
 from mock import ANY, MagicMock, patch
 from pyVmomi import vim, vmodl
 
 from datadog_checks.vsphere.api import APIConnectionError, VSphereAPI
 from datadog_checks.vsphere.config import VSphereConfig
-
-if six.PY3:
-    EXPECTED_PROTOCOL = ssl.PROTOCOL_TLS_CLIENT
-else:
-    EXPECTED_PROTOCOL = ssl.PROTOCOL_TLS
 
 
 def test_ssl_verify_false(realtime_instance):
@@ -30,7 +24,7 @@ def test_ssl_verify_false(realtime_instance):
         VSphereAPI(config, MagicMock())
 
         actual_context = smart_connect.call_args.kwargs['sslContext']  # type: ssl.SSLContext
-        assert actual_context.protocol == EXPECTED_PROTOCOL
+        assert actual_context.protocol == ssl.PROTOCOL_TLS
         assert actual_context.verify_mode == ssl.CERT_NONE
         load_verify_locations.assert_not_called()
 
@@ -48,8 +42,9 @@ def test_ssl_cert(realtime_instance):
         VSphereAPI(config, MagicMock())
 
         actual_context = smart_connect.call_args.kwargs['sslContext']  # type: ssl.SSLContext
-        assert actual_context.protocol == EXPECTED_PROTOCOL
+        assert actual_context.protocol == ssl.PROTOCOL_TLS
         assert actual_context.verify_mode == ssl.CERT_REQUIRED
+        assert actual_context.check_hostname is True
         load_verify_locations.assert_called_with(capath='/dummy/path')
 
 

--- a/vsphere/tests/test_api.py
+++ b/vsphere/tests/test_api.py
@@ -1,12 +1,56 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import ssl
+
 import pytest
+import six
 from mock import ANY, MagicMock, patch
 from pyVmomi import vim, vmodl
 
 from datadog_checks.vsphere.api import APIConnectionError, VSphereAPI
 from datadog_checks.vsphere.config import VSphereConfig
+
+if six.PY3:
+    EXPECTED_PROTOCOL = ssl.PROTOCOL_TLS_CLIENT
+else:
+    EXPECTED_PROTOCOL = ssl.PROTOCOL_TLS
+
+
+def test_ssl_verify_false(realtime_instance):
+    realtime_instance['ssl_verify'] = False
+    realtime_instance['ssl_capath'] = '/dummy/path'
+
+    with patch('datadog_checks.vsphere.api.connect') as connect, patch(
+        'ssl.SSLContext.load_verify_locations'
+    ) as load_verify_locations:
+        smart_connect = connect.SmartConnect
+
+        config = VSphereConfig(realtime_instance, MagicMock())
+        VSphereAPI(config, MagicMock())
+
+        actual_context = smart_connect.call_args.kwargs['sslContext']  # type: ssl.SSLContext
+        assert actual_context.protocol == EXPECTED_PROTOCOL
+        assert actual_context.verify_mode == ssl.CERT_NONE
+        load_verify_locations.assert_not_called()
+
+
+def test_ssl_cert(realtime_instance):
+    realtime_instance['ssl_verify'] = True
+    realtime_instance['ssl_capath'] = '/dummy/path'
+
+    with patch('datadog_checks.vsphere.api.connect') as connect, patch(
+        'ssl.SSLContext.load_verify_locations'
+    ) as load_verify_locations:
+        smart_connect = connect.SmartConnect
+
+        config = VSphereConfig(realtime_instance, MagicMock())
+        VSphereAPI(config, MagicMock())
+
+        actual_context = smart_connect.call_args.kwargs['sslContext']  # type: ssl.SSLContext
+        assert actual_context.protocol == EXPECTED_PROTOCOL
+        assert actual_context.verify_mode == ssl.CERT_REQUIRED
+        load_verify_locations.assert_called_with(capath='/dummy/path')
 
 
 def test_connect_success(realtime_instance):


### PR DESCRIPTION
### What does this PR do?

Fix ssl protocol for Python 2

`ssl.PROTOCOL_TLS_CLIENT` does not exist for Python 2 and leads to:

```
datadog_checks/vsphere/api.py:78: in smart_connect
    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
E   AttributeError: 'module' object has no attribute 'PROTOCOL_TLS_CLIENT'
```


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
