### PR TITLE
Handle metadata collection flag on `MetadataManager`

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/metadata/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/metadata/core.py
@@ -7,6 +7,7 @@ import re
 
 from six import iteritems
 
+from ...config import is_affirmative
 from ..common import to_native_string
 from .constants import DEFAULT_BLACKLIST
 from .utils import is_primitive
@@ -32,10 +33,18 @@ class MetadataManager(object):
         if metadata_transformers:
             self.metadata_transformers.update(metadata_transformers)
 
+    @staticmethod
+    def is_collection_enabled():
+        # type: () -> bool
+        return is_affirmative(datadog_agent.get_config('enable_metadata_collection'))
+
     def submit_raw(self, name, value):
         datadog_agent.set_check_metadata(self.check_id, to_native_string(name), to_native_string(value))
 
     def submit(self, name, value, options):
+        if not self.is_collection_enabled():
+            return
+
         transformer = self.metadata_transformers.get(name)
         if transformer:
             try:

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -43,21 +43,6 @@ def test_load_config():
     assert AgentCheck.load_config("raw_foo: bar") == {'raw_foo': 'bar'}
 
 
-@pytest.mark.parametrize(
-    'enable_metadata_collection, expected_is_metadata_collection_enabled',
-    [(None, False), ('true', True), ('false', False)],
-)
-def test_is_metadata_collection_enabled(enable_metadata_collection, expected_is_metadata_collection_enabled):
-    check = AgentCheck()
-    with mock.patch('datadog_checks.base.checks.base.datadog_agent.get_config') as get_config:
-        get_config.return_value = enable_metadata_collection
-
-        assert check.is_metadata_collection_enabled() is expected_is_metadata_collection_enabled
-        assert AgentCheck.is_metadata_collection_enabled() is expected_is_metadata_collection_enabled
-
-        get_config.assert_called_with('enable_metadata_collection')
-
-
 def test_log_critical_error():
     check = AgentCheck()
 

--- a/datadog_checks_base/tests/test_metadata.py
+++ b/datadog_checks_base/tests/test_metadata.py
@@ -75,6 +75,19 @@ class TestRaw:
             m.assert_called_once_with('test:123', finalizer(name), finalizer(value))
 
 
+class TestSubmission:
+    def test_metadata_collection_disabled(self):
+        # type: () -> None
+        check = AgentCheck('test', {}, [{}])
+
+        with mock.patch('datadog_checks.base.checks.base.datadog_agent.get_config') as get_config:
+            get_config.return_value = False
+
+            with mock.patch(SET_CHECK_METADATA_METHOD) as m:
+                check.set_metadata('foo', 'bar')
+                m.assert_not_called()
+
+
 class TestVersion:
     def test_override_allowed(self):
         class NewAgentCheck(AgentCheck):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Deprecate `AgentCheck.is_metadata_collection_enabled()` in favor of filtering submissions directly on `MetadataManager`.

**TODO**: actually this doesn't prevent integrations from doing unnecessary processing to retrieve metadata (eg fetching the version), which is probably why we added `is_metadata_collection_enabled()` in the first place. Hmm…

### Motivation
<!-- What inspired you to submit this pull request? -->
- Remove the need to always check for `is_metadata_collection_enabled()` in integrations, reducing boilerplate and potential for errors.
- Immediately add support for honoring `enable_metadata_collection` Agent flag to _all_ integrations. (Otherwise we're going to have and add an if statement to all our integrations, eg see #6061.)

### Additional Notes
<!-- Anything else we should know when reviewing? -->
- `is_metadata_collection_enabled` originally added in #5748.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
