### PR TITLE
[skip ci] Add linkerd2 scrape url to README

### DIFF
--- a/linkerd/README.md
+++ b/linkerd/README.md
@@ -24,11 +24,21 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 For containerized environments, see the [Autodiscovery Integration Templates][6] for guidance on applying the parameters below.
 
+##### Linkerd v1
+
 | Parameter            | Value                                                                 |
 | -------------------- | --------------------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `linkerd`                                                             |
 | `<INIT_CONFIG>`      | blank or `{}`                                                         |
 | `<INSTANCE_CONFIG>`  | `{"prometheus_url": "http://%%host%%:9990/admin/metrics/prometheus"}` |
+
+##### Linkerd v2
+
+| Parameter            | Value                                                                 |
+| -------------------- | --------------------------------------------------------------------- |
+| `<INTEGRATION_NAME>` | `linkerd`                                                             |
+| `<INIT_CONFIG>`      | blank or `{}`                                                         |
+| `<INSTANCE_CONFIG>`  | `{"prometheus_url": "http://%%host%%:4191/metrics"}`                  |
 
 ### Validation
 


### PR DESCRIPTION
### What does this PR do?
The existing documentation does not cover scraping linkerd2 metrics, as `"http://%%host%%:9990/admin/metrics/prometheus"` is only available in linkerd1. This PR adds an example for scraping linkerd2 metrics from each deployed sidecar.

### Motivation
I had a difficult time figuring out how to scrape linkerd2 metrics into DD, and initially tried using linkerd2's prometheus federation endpoint.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
