### PR TITLE
Add validation to catch legacy imports

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
@@ -9,11 +9,12 @@ from .ci import ci
 from .config import config
 from .dashboards import dashboards
 from .dep import dep
+from .imports import imports
 from .manifest import manifest
 from .metadata import metadata
 from .service_checks import service_checks
 
-ALL_COMMANDS = (agent_reqs, ci, config, dashboards, dep, manifest, metadata, service_checks)
+ALL_COMMANDS = (agent_reqs, ci, config, dashboards, dep, imports, manifest, metadata, service_checks)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Verify certain aspects of the repo')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/imports.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/imports.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2018-present
+# (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/imports.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/imports.py
@@ -71,7 +71,7 @@ def imports(ctx, autofix, checks):
         # focus on check and testing directories
         bases = [os.path.join(integrations_root, check_name, base) for base in ('datadog_checks', 'tests')]
         for base in bases:
-            for root, dirs, files in os.walk(base):
+            for root, _, files in os.walk(base):
                 for f in files:
                     if f.endswith('.py'):
                         fpath = os.path.join(root, f)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/imports.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/imports.py
@@ -19,12 +19,6 @@ INTEGRATION_ID_REGEX = r'^[a-z][a-z0-9-]{0,254}(?<!-)$'
 
 DEPRECATED_MODULES = set(
     [
-        'datadog_checks.stubs',
-        'datadog_checks.stubs.aggregator',
-        'datadog_checks.stubs._util',
-        'datadog_checks.stubs.datadog_agent',
-        'datadog_checks.config',
-        'datadog_checks.log',
         'datadog_checks.checks',
         'datadog_checks.checks.prometheus_check',
         'datadog_checks.checks.openmetrics',
@@ -53,6 +47,13 @@ DEPRECATED_MODULES = set(
         'datadog_checks.checks.prometheus.base_check',
         'datadog_checks.checks.base',
         'datadog_checks.checks.network_checks',
+        'datadog_checks.config',
+        'datadog_checks.errors',
+        'datadog_checks.log',
+        'datadog_checks.stubs',
+        'datadog_checks.stubs.aggregator',
+        'datadog_checks.stubs._util',
+        'datadog_checks.stubs.datadog_agent',
         'datadog_checks.utils',
         'datadog_checks.utils.tracing',
         'datadog_checks.utils.proxy',
@@ -75,7 +76,6 @@ def validate_import(filepath):
     success = True
     lines = []
 
-    #echo_debug(f'validating file {filepath}', indent='  ')
     with open(filepath) as f:
         for num, line in enumerate(f):
             if 'import' in line:
@@ -83,6 +83,7 @@ def validate_import(filepath):
                 try:
                     parts = line.split('import', 1)[0].split()
                 except Exception as e:
+                    echo_warning(f'ERROR processing line: {line}')
                     continue
 
                 for part in parts:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/imports.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/imports.py
@@ -1,0 +1,141 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import json
+import os
+import mock
+import uuid
+
+import click
+
+from ....utils import file_exists, read_file, write_file
+from ...constants import get_root
+from ...utils import complete_valid_checks, get_valid_integrations
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_warning, echo_debug
+
+
+INTEGRATION_ID_REGEX = r'^[a-z][a-z0-9-]{0,254}(?<!-)$'
+
+DEPRECATED_MODULES = set(
+    [
+        'datadog_checks.stubs',
+        'datadog_checks.stubs.aggregator',
+        'datadog_checks.stubs._util',
+        'datadog_checks.stubs.datadog_agent',
+        'datadog_checks.config',
+        'datadog_checks.log',
+        'datadog_checks.checks',
+        'datadog_checks.checks.prometheus_check',
+        'datadog_checks.checks.openmetrics',
+        'datadog_checks.checks.openmetrics.mixins',
+        'datadog_checks.checks.openmetrics.base_check',
+        'datadog_checks.checks.win',
+        'datadog_checks.checks.win.winpdh',
+        'datadog_checks.checks.win.wmi',
+        'datadog_checks.checks.win.wmi.counter_type',
+        'datadog_checks.checks.win.wmi.sampler',
+        'datadog_checks.checks.win.winpdh_base',
+        'datadog_checks.checks.win.winpdh_stub',
+        'datadog_checks.checks.libs',
+        'datadog_checks.checks.libs.wmi',
+        'datadog_checks.checks.libs.wmi.sampler',
+        'datadog_checks.checks.libs.thread_pool',
+        'datadog_checks.checks.libs.timer',
+        'datadog_checks.checks.libs.vmware',
+        'datadog_checks.checks.libs.vmware.basic_metrics',
+        'datadog_checks.checks.libs.vmware.all_metrics',
+        'datadog_checks.checks.network',
+        'datadog_checks.checks.winwmi_check',
+        'datadog_checks.checks.prometheus',
+        'datadog_checks.checks.prometheus.mixins',
+        'datadog_checks.checks.prometheus.prometheus_base',
+        'datadog_checks.checks.prometheus.base_check',
+        'datadog_checks.checks.base',
+        'datadog_checks.checks.network_checks',
+        'datadog_checks.utils',
+        'datadog_checks.utils.tracing',
+        'datadog_checks.utils.proxy',
+        'datadog_checks.utils.containers',
+        'datadog_checks.utils.timeout',
+        'datadog_checks.utils.tailfile',
+        'datadog_checks.utils.platform',
+        'datadog_checks.utils.common',
+        'datadog_checks.utils.subprocess_output',
+        'datadog_checks.utils.prometheus',
+        'datadog_checks.utils.prometheus.functions',
+        'datadog_checks.utils.prometheus.metrics_pb2',
+        'datadog_checks.utils.headers',
+        'datadog_checks.utils.limiter',
+    ]
+)
+
+
+def validate_import(filepath):
+    success = True
+    lines = []
+
+    #echo_debug(f'validating file {filepath}', indent='  ')
+    with open(filepath) as f:
+        for num, line in enumerate(f):
+            if 'import' in line:
+                # almost every case is of the form `from datadog_checks.. import ..`
+                try:
+                    parts = line.split('import', 1)[0].split()
+                except Exception as e:
+                    continue
+
+                for part in parts:
+                    if 'datadog_checks' in part and part in DEPRECATED_MODULES:
+                        success = False
+                        lines.append((num, line))
+    return success, lines
+
+
+@click.command(context_settings=CONTEXT_SETTINGS, short_help='Validate proper base imports')
+@click.option('--include-extras', '-i', is_flag=True, help='Include optional fields')
+@click.argument('check', autocompletion=complete_valid_checks, required=False)
+@click.pass_context
+def imports(ctx, check, include_extras):
+    """Validate proper imports in checks."""
+
+    integrations_root = get_root()
+
+    validation_results = {}
+
+    echo_info("Validating imports avoiding deprecated modules ...")
+    for check_name in sorted(get_valid_integrations()):
+
+        echo_debug(f'Checking {check_name}')
+        for root, dirs, files in os.walk(os.path.join(integrations_root, check_name)):
+            for i, d in enumerate(dirs):
+                if d == '.tox':
+                    dirs.pop(i)
+
+            for f in files:
+                if f.endswith('.py'):
+                    fpath = os.path.join(root, f)
+                    success, lines = validate_import(fpath)
+
+                    if not success:
+                        validation_results[fpath] = lines
+
+    if validation_results:
+        echo_warning(f'Validation failed:')
+        for f, lines in validation_results.items():
+            for line in lines:
+                linenum, linetext = line
+                echo_warning(f'{f}: line # {linenum}', indent='  ')
+                echo_info(f'{linetext}', indent='    ')
+
+        abort()
+
+    else:
+        echo_success('Validation passed!')
+
+
+
+
+
+
+

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/imports.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/imports.py
@@ -2,21 +2,16 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import json
 import os
-import mock
-import uuid
 
 import click
 
-from ....utils import file_exists, read_file, write_file
 from ...constants import get_root
 from ...utils import complete_valid_checks, get_valid_integrations
 from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_warning, echo_debug
 
 
-INTEGRATION_ID_REGEX = r'^[a-z][a-z0-9-]{0,254}(?<!-)$'
-
+# .base - error if not there, insert for fix
 DEPRECATED_MODULES = set(
     [
         'datadog_checks.checks',


### PR DESCRIPTION
### Motivation
The `datadog_checks` package was rearranged for all packages to be hosted under the `base` sub package.  The original module locations have been updated to redirect to those imports for backwards compatibility, but usage of them is deprecated.

This tool will identify those imports and report them as errors, for future use in our CI.

It also includes an `autofix` option, to aid in the initial mass migration of changing all the files en masse before we introduce this validation to CI.