### PR TITLE
Update deprecated imports

### DIFF
--- a/active_directory/datadog_checks/active_directory/active_directory.py
+++ b/active_directory/datadog_checks/active_directory/active_directory.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2013-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-from datadog_checks.checks.win import PDHBaseCheck
+from datadog_checks.base.checks.win import PDHBaseCheck
 
 DEFAULT_COUNTERS = [
     # counterset, instance of counter, counter name, metric name

--- a/activemq_xml/datadog_checks/activemq_xml/activemq_xml.py
+++ b/activemq_xml/datadog_checks/activemq_xml/activemq_xml.py
@@ -6,8 +6,8 @@ from xml.etree import ElementTree
 import requests
 from six import iteritems
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.config import _is_affirmative
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.config import _is_affirmative
 
 QUEUE_URL = "/admin/xml/queues.jsp"
 TOPIC_URL = "/admin/xml/topics.jsp"

--- a/activemq_xml/datadog_checks/activemq_xml/activemq_xml.py
+++ b/activemq_xml/datadog_checks/activemq_xml/activemq_xml.py
@@ -6,7 +6,7 @@ from xml.etree import ElementTree
 import requests
 from six import iteritems
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.config import _is_affirmative
 
 QUEUE_URL = "/admin/xml/queues.jsp"

--- a/activemq_xml/tests/common.py
+++ b/activemq_xml/tests/common.py
@@ -4,7 +4,7 @@
 
 import os
 
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 CHECK_NAME = 'activemq_xml'
 

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -3,7 +3,7 @@ import copy
 import mock
 import pytest
 
-from datadog_checks.base import aerospike
+from datadog_checks import aerospike
 
 from . import common
 

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -3,7 +3,7 @@ import copy
 import mock
 import pytest
 
-from datadog_checks import aerospike
+from datadog_checks.base import aerospike
 
 from . import common
 

--- a/ambari/tests/test_ambari.py
+++ b/ambari/tests/test_ambari.py
@@ -4,7 +4,7 @@
 from mock import MagicMock
 
 from datadog_checks.ambari import AmbariCheck
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.errors import CheckException
 
 from . import responses

--- a/ambari/tests/test_ambari.py
+++ b/ambari/tests/test_ambari.py
@@ -5,7 +5,7 @@ from mock import MagicMock
 
 from datadog_checks.ambari import AmbariCheck
 from datadog_checks.base.errors import CheckException
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 from . import responses
 

--- a/ambari/tests/test_ambari.py
+++ b/ambari/tests/test_ambari.py
@@ -4,8 +4,8 @@
 from mock import MagicMock
 
 from datadog_checks.ambari import AmbariCheck
-from datadog_checks.base.errors import CheckException
 from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.errors import CheckException
 
 from . import responses
 

--- a/btrfs/datadog_checks/btrfs/btrfs.py
+++ b/btrfs/datadog_checks/btrfs/btrfs.py
@@ -14,7 +14,7 @@ import psutil
 from six import iteritems
 from six.moves import range
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 MIXED = "mixed"
 DATA = "data"

--- a/btrfs/datadog_checks/btrfs/btrfs.py
+++ b/btrfs/datadog_checks/btrfs/btrfs.py
@@ -14,7 +14,7 @@ import psutil
 from six import iteritems
 from six.moves import range
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 MIXED = "mixed"
 DATA = "data"

--- a/cacti/datadog_checks/cacti/cacti.py
+++ b/cacti/datadog_checks/cacti/cacti.py
@@ -10,7 +10,7 @@ from fnmatch import fnmatch
 
 import pymysql
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 try:
     import rrdtool

--- a/cacti/datadog_checks/cacti/cacti.py
+++ b/cacti/datadog_checks/cacti/cacti.py
@@ -10,7 +10,7 @@ from fnmatch import fnmatch
 
 import pymysql
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 try:
     import rrdtool

--- a/cassandra_nodetool/datadog_checks/cassandra_nodetool/cassandra_nodetool.py
+++ b/cassandra_nodetool/datadog_checks/cassandra_nodetool/cassandra_nodetool.py
@@ -7,8 +7,8 @@ from __future__ import division
 import re
 from collections import defaultdict
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.utils.subprocess_output import get_subprocess_output
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'cassandra_nodetool'
 DEFAULT_HOST = 'localhost'

--- a/cassandra_nodetool/datadog_checks/cassandra_nodetool/cassandra_nodetool.py
+++ b/cassandra_nodetool/datadog_checks/cassandra_nodetool/cassandra_nodetool.py
@@ -7,7 +7,7 @@ from __future__ import division
 import re
 from collections import defaultdict
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'cassandra_nodetool'

--- a/ceph/datadog_checks/ceph/ceph.py
+++ b/ceph/datadog_checks/ceph/ceph.py
@@ -9,7 +9,7 @@ import re
 import simplejson as json
 from six import iteritems
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.config import _is_affirmative
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 

--- a/ceph/datadog_checks/ceph/ceph.py
+++ b/ceph/datadog_checks/ceph/ceph.py
@@ -9,9 +9,9 @@ import re
 import simplejson as json
 from six import iteritems
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.config import _is_affirmative
-from datadog_checks.utils.subprocess_output import get_subprocess_output
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.config import _is_affirmative
+from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 
 class Ceph(AgentCheck):

--- a/cilium/tests/conftest.py
+++ b/cilium/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 
 from datadog_checks.dev.kube_port_forward import port_forward
 from datadog_checks.dev.terraform import terraform_run
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 from .common import ADDL_AGENT_METRICS, AGENT_DEFAULT_METRICS, OPERATOR_AWS_METRICS, OPERATOR_METRICS
 

--- a/cilium/tests/conftest.py
+++ b/cilium/tests/conftest.py
@@ -6,9 +6,9 @@ import os
 import mock
 import pytest
 
+from datadog_checks.base.utils.common import get_docker_hostname
 from datadog_checks.dev.kube_port_forward import port_forward
 from datadog_checks.dev.terraform import terraform_run
-from datadog_checks.base.utils.common import get_docker_hostname
 
 from .common import ADDL_AGENT_METRICS, AGENT_DEFAULT_METRICS, OPERATOR_AWS_METRICS, OPERATOR_METRICS
 

--- a/cisco_aci/datadog_checks/cisco_aci/cisco.py
+++ b/cisco_aci/datadog_checks/cisco_aci/cisco.py
@@ -6,9 +6,9 @@ import datetime
 
 from six import iteritems
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.config import _is_affirmative
-from datadog_checks.utils.containers import hash_mutable
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.config import _is_affirmative
+from datadog_checks.base.utils.containers import hash_mutable
 
 from . import aci_metrics
 from .api import Api

--- a/cisco_aci/datadog_checks/cisco_aci/cisco.py
+++ b/cisco_aci/datadog_checks/cisco_aci/cisco.py
@@ -6,7 +6,7 @@ import datetime
 
 from six import iteritems
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.config import _is_affirmative
 from datadog_checks.base.utils.containers import hash_mutable
 

--- a/cisco_aci/datadog_checks/cisco_aci/tags.py
+++ b/cisco_aci/datadog_checks/cisco_aci/tags.py
@@ -6,7 +6,7 @@ import re
 
 from six import iteritems
 
-from datadog_checks.utils.containers import hash_mutable
+from datadog_checks.base.utils.containers import hash_mutable
 
 from . import exceptions, helpers
 

--- a/cisco_aci/tests/test_capacity.py
+++ b/cisco_aci/tests/test_capacity.py
@@ -5,7 +5,7 @@
 from datadog_checks.cisco_aci import CiscoACICheck
 from datadog_checks.cisco_aci.api import Api
 from datadog_checks.cisco_aci.capacity import Capacity
-from datadog_checks.utils.containers import hash_mutable
+from datadog_checks.base.utils.containers import hash_mutable
 
 from . import common
 

--- a/cisco_aci/tests/test_capacity.py
+++ b/cisco_aci/tests/test_capacity.py
@@ -2,10 +2,10 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+from datadog_checks.base.utils.containers import hash_mutable
 from datadog_checks.cisco_aci import CiscoACICheck
 from datadog_checks.cisco_aci.api import Api
 from datadog_checks.cisco_aci.capacity import Capacity
-from datadog_checks.base.utils.containers import hash_mutable
 
 from . import common
 

--- a/cisco_aci/tests/test_cisco.py
+++ b/cisco_aci/tests/test_cisco.py
@@ -9,7 +9,7 @@ from mock import MagicMock
 
 from datadog_checks.cisco_aci import CiscoACICheck
 from datadog_checks.cisco_aci.api import Api, SessionWrapper
-from datadog_checks.utils.containers import hash_mutable
+from datadog_checks.base.utils.containers import hash_mutable
 
 from . import common
 

--- a/cisco_aci/tests/test_cisco.py
+++ b/cisco_aci/tests/test_cisco.py
@@ -7,9 +7,9 @@ from copy import deepcopy
 import pytest
 from mock import MagicMock
 
+from datadog_checks.base.utils.containers import hash_mutable
 from datadog_checks.cisco_aci import CiscoACICheck
 from datadog_checks.cisco_aci.api import Api, SessionWrapper
-from datadog_checks.base.utils.containers import hash_mutable
 
 from . import common
 

--- a/cisco_aci/tests/test_fabric.py
+++ b/cisco_aci/tests/test_fabric.py
@@ -4,7 +4,7 @@
 
 from datadog_checks.cisco_aci import CiscoACICheck
 from datadog_checks.cisco_aci.api import Api
-from datadog_checks.utils.containers import hash_mutable
+from datadog_checks.base.utils.containers import hash_mutable
 
 from . import common
 

--- a/cisco_aci/tests/test_fabric.py
+++ b/cisco_aci/tests/test_fabric.py
@@ -2,9 +2,9 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+from datadog_checks.base.utils.containers import hash_mutable
 from datadog_checks.cisco_aci import CiscoACICheck
 from datadog_checks.cisco_aci.api import Api
-from datadog_checks.base.utils.containers import hash_mutable
 
 from . import common
 

--- a/cisco_aci/tests/test_tags.py
+++ b/cisco_aci/tests/test_tags.py
@@ -6,8 +6,8 @@ import logging
 
 import pytest
 
-from datadog_checks.cisco_aci.tags import CiscoTags
 from datadog_checks.base.utils.containers import hash_mutable
+from datadog_checks.cisco_aci.tags import CiscoTags
 
 log = logging.getLogger('test_cisco_aci')
 

--- a/cisco_aci/tests/test_tags.py
+++ b/cisco_aci/tests/test_tags.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 
 from datadog_checks.cisco_aci.tags import CiscoTags
-from datadog_checks.utils.containers import hash_mutable
+from datadog_checks.base.utils.containers import hash_mutable
 
 log = logging.getLogger('test_cisco_aci')
 

--- a/cisco_aci/tests/test_tenant.py
+++ b/cisco_aci/tests/test_tenant.py
@@ -2,10 +2,10 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+from datadog_checks.base.utils.containers import hash_mutable
 from datadog_checks.cisco_aci import CiscoACICheck
 from datadog_checks.cisco_aci.api import Api
 from datadog_checks.cisco_aci.tenant import Tenant
-from datadog_checks.base.utils.containers import hash_mutable
 
 from . import common
 

--- a/cisco_aci/tests/test_tenant.py
+++ b/cisco_aci/tests/test_tenant.py
@@ -5,7 +5,7 @@
 from datadog_checks.cisco_aci import CiscoACICheck
 from datadog_checks.cisco_aci.api import Api
 from datadog_checks.cisco_aci.tenant import Tenant
-from datadog_checks.utils.containers import hash_mutable
+from datadog_checks.base.utils.containers import hash_mutable
 
 from . import common
 

--- a/cockroachdb/datadog_checks/cockroachdb/cockroachdb.py
+++ b/cockroachdb/datadog_checks/cockroachdb/cockroachdb.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 
 from .metrics import METRIC_MAP
 

--- a/coredns/tests/conftest.py
+++ b/coredns/tests/conftest.py
@@ -8,9 +8,9 @@ import mock
 import pytest
 import requests
 
+from datadog_checks.base.utils.common import get_docker_hostname
 from datadog_checks.dev import WaitFor, docker_run
 from datadog_checks.dev.utils import ON_WINDOWS
-from datadog_checks.base.utils.common import get_docker_hostname
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 CONFIG_FOLDER = os.path.join(HERE, 'docker', 'coredns')

--- a/coredns/tests/conftest.py
+++ b/coredns/tests/conftest.py
@@ -10,7 +10,7 @@ import requests
 
 from datadog_checks.dev import WaitFor, docker_run
 from datadog_checks.dev.utils import ON_WINDOWS
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 CONFIG_FOLDER = os.path.join(HERE, 'docker', 'coredns')

--- a/couch/datadog_checks/couch/couch.py
+++ b/couch/datadog_checks/couch/couch.py
@@ -10,7 +10,7 @@ import requests
 from six import iteritems
 from six.moves.urllib.parse import quote, urljoin
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.headers import headers
 from datadog_checks.couch import errors
 

--- a/couch/datadog_checks/couch/couch.py
+++ b/couch/datadog_checks/couch/couch.py
@@ -10,9 +10,9 @@ import requests
 from six import iteritems
 from six.moves.urllib.parse import quote, urljoin
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 from datadog_checks.couch import errors
-from datadog_checks.utils.headers import headers
+from datadog_checks.base.utils.headers import headers
 
 
 class CouchDb(AgentCheck):

--- a/couch/datadog_checks/couch/couch.py
+++ b/couch/datadog_checks/couch/couch.py
@@ -11,8 +11,8 @@ from six import iteritems
 from six.moves.urllib.parse import quote, urljoin
 
 from datadog_checks.base.checks import AgentCheck
-from datadog_checks.couch import errors
 from datadog_checks.base.utils.headers import headers
+from datadog_checks.couch import errors
 
 
 class CouchDb(AgentCheck):

--- a/couch/tests/common.py
+++ b/couch/tests/common.py
@@ -5,7 +5,7 @@
 import os
 import re
 
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 CHECK_NAME = "couch"
 CHECK_ID = 'test:123'

--- a/couchbase/datadog_checks/couchbase/couchbase.py
+++ b/couchbase/datadog_checks/couchbase/couchbase.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 import requests
 from six import string_types
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 from datadog_checks.couchbase.couchbase_consts import (
     BUCKET_STATS,
     COUCHBASE_STATS_PATH,
@@ -27,7 +27,7 @@ from datadog_checks.couchbase.couchbase_consts import (
     SOURCE_TYPE_NAME,
     TO_SECONDS,
 )
-from datadog_checks.utils.containers import hash_mutable
+from datadog_checks.base.utils.containers import hash_mutable
 
 
 class Couchbase(AgentCheck):

--- a/couchbase/datadog_checks/couchbase/couchbase.py
+++ b/couchbase/datadog_checks/couchbase/couchbase.py
@@ -13,6 +13,7 @@ import requests
 from six import string_types
 
 from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.utils.containers import hash_mutable
 from datadog_checks.couchbase.couchbase_consts import (
     BUCKET_STATS,
     COUCHBASE_STATS_PATH,
@@ -27,7 +28,6 @@ from datadog_checks.couchbase.couchbase_consts import (
     SOURCE_TYPE_NAME,
     TO_SECONDS,
 )
-from datadog_checks.base.utils.containers import hash_mutable
 
 
 class Couchbase(AgentCheck):

--- a/couchbase/datadog_checks/couchbase/couchbase.py
+++ b/couchbase/datadog_checks/couchbase/couchbase.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 import requests
 from six import string_types
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.containers import hash_mutable
 from datadog_checks.couchbase.couchbase_consts import (
     BUCKET_STATS,

--- a/couchbase/datadog_checks/couchbase/couchbase_consts.py
+++ b/couchbase/datadog_checks/couchbase/couchbase_consts.py
@@ -1,6 +1,6 @@
 import re
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 # Paths
 COUCHBASE_STATS_PATH = '/pools/default'

--- a/couchbase/datadog_checks/couchbase/couchbase_consts.py
+++ b/couchbase/datadog_checks/couchbase/couchbase_consts.py
@@ -1,6 +1,6 @@
 import re
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 # Paths
 COUCHBASE_STATS_PATH = '/pools/default'

--- a/couchbase/tests/common.py
+++ b/couchbase/tests/common.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 

--- a/crio/datadog_checks/crio/crio.py
+++ b/crio/datadog_checks/crio/crio.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 
 
 class CrioCheck(OpenMetricsBaseCheck):

--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -6,9 +6,9 @@ from os.path import abspath, exists, join, relpath
 from re import compile as re_compile
 from time import time
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.config import is_affirmative
-from datadog_checks.errors import ConfigurationError
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.config import is_affirmative
+from datadog_checks.base.errors import ConfigurationError
 
 from .traverse import walk
 

--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -6,9 +6,7 @@ from os.path import abspath, exists, join, relpath
 from re import compile as re_compile
 from time import time
 
-from datadog_checks.base.checks import AgentCheck
-from datadog_checks.base.config import is_affirmative
-from datadog_checks.base.errors import ConfigurationError
+from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 
 from .traverse import walk
 

--- a/directory/tests/test_directory.py
+++ b/directory/tests/test_directory.py
@@ -8,10 +8,10 @@ import tempfile
 import mock
 import pytest
 
+from datadog_checks.base.errors import ConfigurationError
 from datadog_checks.dev.utils import create_file
 from datadog_checks.dev.utils import temp_dir as temp_directory
 from datadog_checks.directory import DirectoryCheck
-from datadog_checks.base.errors import ConfigurationError
 
 from . import common
 

--- a/directory/tests/test_directory.py
+++ b/directory/tests/test_directory.py
@@ -11,7 +11,7 @@ import pytest
 from datadog_checks.dev.utils import create_file
 from datadog_checks.dev.utils import temp_dir as temp_directory
 from datadog_checks.directory import DirectoryCheck
-from datadog_checks.errors import ConfigurationError
+from datadog_checks.base.errors import ConfigurationError
 
 from . import common
 

--- a/dns_check/datadog_checks/dns_check/dns_check.py
+++ b/dns_check/datadog_checks/dns_check/dns_check.py
@@ -9,7 +9,7 @@ import time
 import dns.resolver
 
 from datadog_checks.base import AgentCheck
-from datadog_checks.utils.platform import Platform
+from datadog_checks.base.utils.platform import Platform
 
 # These imports are necessary because otherwise dynamic type
 # resolution will fail on windows without it.

--- a/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
@@ -7,7 +7,7 @@ import requests
 from six import iteritems
 
 from datadog_checks.base.utils.common import round_value
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 try:
     from tagger import get_tags

--- a/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
@@ -6,7 +6,7 @@ from __future__ import division
 import requests
 from six import iteritems
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.common import round_value
 
 try:

--- a/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
@@ -6,8 +6,8 @@ from __future__ import division
 import requests
 from six import iteritems
 
-from datadog_checks.base.utils.common import round_value
 from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.utils.common import round_value
 
 try:
     from tagger import get_tags

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 import requests
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 from .errors import UnknownMetric, UnknownTags
 from .parser import parse_histogram, parse_metric

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 import requests
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 from .errors import UnknownMetric, UnknownTags
 from .parser import parse_histogram, parse_metric

--- a/envoy/tests/common.py
+++ b/envoy/tests/common.py
@@ -1,6 +1,6 @@
 import os
 
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 try:
     from functools import lru_cache

--- a/fluentd/datadog_checks/fluentd/fluentd.py
+++ b/fluentd/datadog_checks/fluentd/fluentd.py
@@ -10,7 +10,7 @@ from six.moves.urllib.parse import urlparse
 
 # project
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 
 class Fluentd(AgentCheck):

--- a/fluentd/datadog_checks/fluentd/fluentd.py
+++ b/fluentd/datadog_checks/fluentd/fluentd.py
@@ -7,9 +7,7 @@ import re
 
 from six.moves.urllib.parse import urlparse
 
-
-from datadog_checks.base import ConfigurationError
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 

--- a/fluentd/datadog_checks/fluentd/fluentd.py
+++ b/fluentd/datadog_checks/fluentd/fluentd.py
@@ -8,9 +8,10 @@ import re
 # 3rd party
 from six.moves.urllib.parse import urlparse
 
+from datadog_checks.base.checks import AgentCheck
+
 # project
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
-from datadog_checks.base.checks import AgentCheck
 
 
 class Fluentd(AgentCheck):

--- a/fluentd/datadog_checks/fluentd/fluentd.py
+++ b/fluentd/datadog_checks/fluentd/fluentd.py
@@ -8,9 +8,8 @@ import re
 # 3rd party
 from six.moves.urllib.parse import urlparse
 
-from datadog_checks.base.checks import AgentCheck
-
 # project
+from datadog_checks.base.checks import AgentCheck
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 

--- a/fluentd/tests/common.py
+++ b/fluentd/tests/common.py
@@ -4,7 +4,7 @@
 
 import os
 
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(os.path.dirname(HERE))

--- a/gearmand/datadog_checks/gearmand/gearmand.py
+++ b/gearmand/datadog_checks/gearmand/gearmand.py
@@ -5,7 +5,7 @@
 
 from six import PY2
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 # Python 3 compatibility is a different library
 # It's a drop in replacement but has a different name

--- a/gearmand/datadog_checks/gearmand/gearmand.py
+++ b/gearmand/datadog_checks/gearmand/gearmand.py
@@ -5,7 +5,7 @@
 
 from six import PY2
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 # Python 3 compatibility is a different library
 # It's a drop in replacement but has a different name

--- a/gearmand/tests/common.py
+++ b/gearmand/tests/common.py
@@ -4,7 +4,7 @@
 
 import os
 
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(os.path.dirname(HERE))

--- a/gitlab/datadog_checks/gitlab/gitlab.py
+++ b/gitlab/datadog_checks/gitlab/gitlab.py
@@ -6,8 +6,8 @@ from copy import deepcopy
 import requests
 from six.moves.urllib.parse import urlparse
 
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
-from datadog_checks.errors import CheckException
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.errors import CheckException
 
 from .metrics import METRICS_MAP
 

--- a/gitlab/tests/common.py
+++ b/gitlab/tests/common.py
@@ -4,7 +4,7 @@
 
 import os
 
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 

--- a/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
@@ -7,8 +7,8 @@ from copy import deepcopy
 import requests
 from six.moves.urllib.parse import urlparse
 
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
-from datadog_checks.errors import CheckException
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.errors import CheckException
 
 
 class GitlabRunnerCheck(OpenMetricsBaseCheck):

--- a/gitlab_runner/tests/common.py
+++ b/gitlab_runner/tests/common.py
@@ -4,7 +4,7 @@
 
 import os
 
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 

--- a/go_expvar/tests/common.py
+++ b/go_expvar/tests/common.py
@@ -4,7 +4,7 @@
 
 import os
 
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 CHECK_NAME = "go_expvar"
 HERE = os.path.dirname(os.path.abspath(__file__))

--- a/gunicorn/datadog_checks/gunicorn/gunicorn.py
+++ b/gunicorn/datadog_checks/gunicorn/gunicorn.py
@@ -14,9 +14,10 @@ import time
 # 3rd party
 import psutil
 
+from datadog_checks.base.checks import AgentCheck
+
 # project
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
-from datadog_checks.base.checks import AgentCheck
 
 
 class GUnicornCheck(AgentCheck):

--- a/gunicorn/datadog_checks/gunicorn/gunicorn.py
+++ b/gunicorn/datadog_checks/gunicorn/gunicorn.py
@@ -14,7 +14,7 @@ import time
 # 3rd party
 import psutil
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 # project
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output

--- a/gunicorn/datadog_checks/gunicorn/gunicorn.py
+++ b/gunicorn/datadog_checks/gunicorn/gunicorn.py
@@ -16,7 +16,7 @@ import psutil
 
 # project
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 
 class GUnicornCheck(AgentCheck):

--- a/gunicorn/tests/common.py
+++ b/gunicorn/tests/common.py
@@ -4,7 +4,7 @@
 
 import os
 
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 COMPOSE = os.path.join(HERE, 'compose')

--- a/haproxy/tests/common.py
+++ b/haproxy/tests/common.py
@@ -2,8 +2,8 @@ import os
 
 import pytest
 
-from datadog_checks.dev.utils import ON_LINUX, ON_MACOS
 from datadog_checks.base.utils.common import get_docker_hostname
+from datadog_checks.dev.utils import ON_LINUX, ON_MACOS
 
 AGG_STATUSES_BY_SERVICE = (
     (['status:available', 'service:a', 'haproxy_service:a'], 1),

--- a/haproxy/tests/common.py
+++ b/haproxy/tests/common.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from datadog_checks.dev.utils import ON_LINUX, ON_MACOS
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 AGG_STATUSES_BY_SERVICE = (
     (['status:available', 'service:a', 'haproxy_service:a'], 1),

--- a/http_check/datadog_checks/http_check/config.py
+++ b/http_check/datadog_checks/http_check/config.py
@@ -4,7 +4,7 @@
 from collections import namedtuple
 
 from datadog_checks.base import ConfigurationError, ensure_unicode, is_affirmative
-from datadog_checks.utils.headers import headers as agent_headers
+from datadog_checks.base.utils.headers import headers as agent_headers
 
 DEFAULT_EXPECTED_CODE = r'(1|2|3)\d\d'
 

--- a/http_check/tests/test_unit_config.py
+++ b/http_check/tests/test_unit_config.py
@@ -4,8 +4,8 @@
 import pytest
 
 from datadog_checks.base import ConfigurationError
-from datadog_checks.http_check.config import DEFAULT_EXPECTED_CODE, from_instance
 from datadog_checks.base.utils.headers import headers as agent_headers
+from datadog_checks.http_check.config import DEFAULT_EXPECTED_CODE, from_instance
 
 
 def test_from_instance():

--- a/http_check/tests/test_unit_config.py
+++ b/http_check/tests/test_unit_config.py
@@ -5,7 +5,7 @@ import pytest
 
 from datadog_checks.base import ConfigurationError
 from datadog_checks.http_check.config import DEFAULT_EXPECTED_CODE, from_instance
-from datadog_checks.utils.headers import headers as agent_headers
+from datadog_checks.base.utils.headers import headers as agent_headers
 
 
 def test_from_instance():

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -8,7 +8,7 @@ from typing import Any
 from six import iteritems
 
 from datadog_checks.base import ensure_bytes, ensure_unicode
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 from datadog_checks.ibm_mq.metrics import COUNT, GAUGE
 
 from . import connection, errors, metrics

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -7,8 +7,7 @@ from typing import Any
 
 from six import iteritems
 
-from datadog_checks.base import ensure_bytes, ensure_unicode
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck, ensure_bytes, ensure_unicode
 from datadog_checks.ibm_mq.metrics import COUNT, GAUGE
 
 from . import connection, errors, metrics

--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -4,7 +4,7 @@
 from six import iteritems
 
 from datadog_checks.base import PDHBaseCheck, is_affirmative
-from datadog_checks.utils.containers import hash_mutable
+from datadog_checks.base.utils.containers import hash_mutable
 
 DEFAULT_COUNTERS = [
     ["Web Service", None, "Service Uptime", "iis.uptime", "gauge"],

--- a/istio/datadog_checks/istio/istio.py
+++ b/istio/datadog_checks/istio/istio.py
@@ -4,8 +4,8 @@
 
 from copy import deepcopy
 
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
-from datadog_checks.errors import CheckException
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.errors import CheckException
 
 
 class Istio(OpenMetricsBaseCheck):

--- a/istio/tests/test_check.py
+++ b/istio/tests/test_check.py
@@ -8,8 +8,8 @@ import mock
 import pytest
 from requests.exceptions import HTTPError
 
-from datadog_checks.istio import Istio
 from datadog_checks.base.utils.common import ensure_unicode
+from datadog_checks.istio import Istio
 
 from .common import CITADEL_METRICS, GALLEY_METRICS, MESH_METRICS, MIXER_METRICS, NEW_MIXER_METRICS, PILOT_METRICS
 

--- a/istio/tests/test_check.py
+++ b/istio/tests/test_check.py
@@ -9,7 +9,7 @@ import pytest
 from requests.exceptions import HTTPError
 
 from datadog_checks.istio import Istio
-from datadog_checks.utils.common import ensure_unicode
+from datadog_checks.base.utils.common import ensure_unicode
 
 from .common import CITADEL_METRICS, GALLEY_METRICS, MESH_METRICS, MIXER_METRICS, NEW_MIXER_METRICS, PILOT_METRICS
 

--- a/kong/datadog_checks/kong/kong.py
+++ b/kong/datadog_checks/kong/kong.py
@@ -4,7 +4,7 @@
 import simplejson as json
 from six.moves.urllib.parse import urlparse
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 
 class Kong(AgentCheck):

--- a/kong/datadog_checks/kong/kong.py
+++ b/kong/datadog_checks/kong/kong.py
@@ -4,7 +4,7 @@
 import simplejson as json
 from six.moves.urllib.parse import urlparse
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 
 class Kong(AgentCheck):

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
@@ -6,8 +6,8 @@ from re import match
 
 from six import iteritems
 
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
-from datadog_checks.errors import CheckException
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.errors import CheckException
 
 
 class KubeAPIServerMetricsCheck(OpenMetricsBaseCheck):

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
@@ -5,8 +5,8 @@
 from six import iteritems
 
 from datadog_checks.base.checks.kube_leader import KubeLeaderElectionMixin
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
-from datadog_checks.config import is_affirmative
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.config import is_affirmative
 
 
 class KubeControllerManagerCheck(KubeLeaderElectionMixin, OpenMetricsBaseCheck):

--- a/kube_dns/datadog_checks/kube_dns/kube_dns.py
+++ b/kube_dns/datadog_checks/kube_dns/kube_dns.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 
 from six import iteritems
 
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 
 
 class KubeDNSCheck(OpenMetricsBaseCheck):

--- a/kube_dns/tests/test_kube_dns.py
+++ b/kube_dns/tests/test_kube_dns.py
@@ -32,7 +32,7 @@ def mock_get():
 
 @pytest.fixture
 def aggregator():
-    from datadog_checks.stubs import aggregator
+    from datadog_checks.base.stubs import aggregator
 
     aggregator.reset()
     return aggregator

--- a/kube_proxy/datadog_checks/kube_proxy/kube_proxy.py
+++ b/kube_proxy/datadog_checks/kube_proxy/kube_proxy.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 
 
 class KubeProxyCheck(OpenMetricsBaseCheck):

--- a/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
@@ -4,8 +4,8 @@
 from __future__ import division
 
 from datadog_checks.base.checks.kube_leader import KubeLeaderElectionMixin
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
-from datadog_checks.config import is_affirmative
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.config import is_affirmative
 
 DEFAULT_COUNTERS = {
     # Number of HTTP requests, partitioned by status code, method, and host.

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -15,12 +15,12 @@ from kubeutil import get_connection_info
 from six import iteritems
 from urllib3.exceptions import InsecureRequestWarning
 
-from datadog_checks.base.utils.date import UTC, parse_rfc3339
-from datadog_checks.base.utils.tagging import tagger
-from datadog_checks.base.utils.warnings_util import disable_warnings_ctx
 from datadog_checks.base.checks import AgentCheck
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.base.errors import CheckException
+from datadog_checks.base.utils.date import UTC, parse_rfc3339
+from datadog_checks.base.utils.tagging import tagger
+from datadog_checks.base.utils.warnings_util import disable_warnings_ctx
 
 from .cadvisor import CadvisorScraper
 from .common import CADVISOR_DEFAULT_PORT, KubeletCredentials, PodListUtils, replace_container_rt_prefix, urljoin

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -18,9 +18,9 @@ from urllib3.exceptions import InsecureRequestWarning
 from datadog_checks.base.utils.date import UTC, parse_rfc3339
 from datadog_checks.base.utils.tagging import tagger
 from datadog_checks.base.utils.warnings_util import disable_warnings_ctx
-from datadog_checks.checks import AgentCheck
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
-from datadog_checks.errors import CheckException
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.errors import CheckException
 
 from .cadvisor import CadvisorScraper
 from .common import CADVISOR_DEFAULT_PORT, KubeletCredentials, PodListUtils, replace_container_rt_prefix, urljoin

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -15,8 +15,7 @@ from kubeutil import get_connection_info
 from six import iteritems
 from urllib3.exceptions import InsecureRequestWarning
 
-from datadog_checks.base.checks import AgentCheck
-from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base import AgentCheck, OpenMetricsBaseCheck
 from datadog_checks.base.errors import CheckException
 from datadog_checks.base.utils.date import UTC, parse_rfc3339
 from datadog_checks.base.utils.tagging import tagger

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -7,8 +7,8 @@ from copy import deepcopy
 
 from six import iteritems
 
-from datadog_checks.base.utils.tagging import tagger
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.utils.tagging import tagger
 
 from .common import get_pod_by_uid, is_static_pending_pod, replace_container_rt_prefix
 

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from six import iteritems
 
 from datadog_checks.base.utils.tagging import tagger
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 
 from .common import get_pod_by_uid, is_static_pending_pod, replace_container_rt_prefix
 

--- a/kubelet/tests/test_common.py
+++ b/kubelet/tests/test_common.py
@@ -8,7 +8,7 @@ import sys
 import mock
 import pytest
 
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.kubelet import KubeletCredentials, PodListUtils, get_pod_by_uid, is_static_pending_pod, urljoin
 
 from .test_kubelet import mock_from_file

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -9,10 +9,10 @@ from copy import deepcopy
 
 from six import iteritems
 
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
-from datadog_checks.config import is_affirmative
-from datadog_checks.errors import CheckException
-from datadog_checks.utils.common import to_native_string
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.config import is_affirmative
+from datadog_checks.base.errors import CheckException
+from datadog_checks.base.utils.common import to_native_string
 
 try:
     # this module is only available in agent 6

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -7,7 +7,7 @@ import mock
 import pytest
 
 from datadog_checks.kubernetes_state import KubernetesState
-from datadog_checks.utils.common import ensure_unicode
+from datadog_checks.base.utils.common import ensure_unicode
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 FIXTURES_PATH = os.path.join(HERE, 'fixtures')

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -6,8 +6,8 @@ import os
 import mock
 import pytest
 
-from datadog_checks.kubernetes_state import KubernetesState
 from datadog_checks.base.utils.common import ensure_unicode
+from datadog_checks.kubernetes_state import KubernetesState
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 FIXTURES_PATH = os.path.join(HERE, 'fixtures')

--- a/kyototycoon/datadog_checks/kyototycoon/kyototycoon.py
+++ b/kyototycoon/datadog_checks/kyototycoon/kyototycoon.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 import requests
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 db_stats = re.compile(r'^db_(\d)+$')
 whitespace = re.compile(r'\s')

--- a/kyototycoon/datadog_checks/kyototycoon/kyototycoon.py
+++ b/kyototycoon/datadog_checks/kyototycoon/kyototycoon.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 import requests
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 db_stats = re.compile(r'^db_(\d)+$')
 whitespace = re.compile(r'\s')

--- a/kyototycoon/tests/common.py
+++ b/kyototycoon/tests/common.py
@@ -4,7 +4,7 @@
 
 import os.path
 
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 HOST = get_docker_hostname()
 PORT = '1978'

--- a/lighttpd/datadog_checks/lighttpd/lighttpd.py
+++ b/lighttpd/datadog_checks/lighttpd/lighttpd.py
@@ -6,7 +6,7 @@ import re
 
 from six.moves.urllib.parse import urlparse
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 VERSION_REGEX = re.compile(r".*/((\d+).*)")
 

--- a/lighttpd/datadog_checks/lighttpd/lighttpd.py
+++ b/lighttpd/datadog_checks/lighttpd/lighttpd.py
@@ -6,7 +6,7 @@ import re
 
 from six.moves.urllib.parse import urlparse
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 VERSION_REGEX = re.compile(r".*/((\d+).*)")
 

--- a/linkerd/datadog_checks/linkerd/linkerd.py
+++ b/linkerd/datadog_checks/linkerd/linkerd.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 
 from .metrics import METRIC_MAP, TYPE_OVERRIDES
 

--- a/linkerd/tests/common.py
+++ b/linkerd/tests/common.py
@@ -1,4 +1,4 @@
-from datadog_checks.stubs import aggregator
+from datadog_checks.base.stubs import aggregator
 
 LINKERD_FIXTURE_METRICS = {
     'jvm:start_time': 'jvm.start_time',

--- a/linux_proc_extras/datadog_checks/linux_proc_extras/linux_proc_extras.py
+++ b/linux_proc_extras/datadog_checks/linux_proc_extras/linux_proc_extras.py
@@ -7,13 +7,13 @@ from collections import defaultdict
 
 from six import iteritems
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.utils.subprocess_output import get_subprocess_output
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 try:
     import datadog_agent
 except ImportError:
-    from datadog_checks.stubs import datadog_agent
+    from datadog_checks.base.stubs import datadog_agent
 
 
 PROCESS_STATES = {

--- a/linux_proc_extras/datadog_checks/linux_proc_extras/linux_proc_extras.py
+++ b/linux_proc_extras/datadog_checks/linux_proc_extras/linux_proc_extras.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 from six import iteritems
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 try:

--- a/marathon/datadog_checks/marathon/marathon.py
+++ b/marathon/datadog_checks/marathon/marathon.py
@@ -7,7 +7,7 @@ import requests
 from six import iteritems
 from six.moves.urllib.parse import urljoin
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 
 class Marathon(AgentCheck):

--- a/marathon/datadog_checks/marathon/marathon.py
+++ b/marathon/datadog_checks/marathon/marathon.py
@@ -7,7 +7,7 @@ import requests
 from six import iteritems
 from six.moves.urllib.parse import urljoin
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 
 class Marathon(AgentCheck):

--- a/mesos_master/datadog_checks/mesos_master/mesos_master.py
+++ b/mesos_master/datadog_checks/mesos_master/mesos_master.py
@@ -10,7 +10,7 @@ import requests
 from six import iteritems
 from six.moves.urllib.parse import urlparse
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.errors import CheckException
 
 

--- a/mesos_master/datadog_checks/mesos_master/mesos_master.py
+++ b/mesos_master/datadog_checks/mesos_master/mesos_master.py
@@ -10,8 +10,8 @@ import requests
 from six import iteritems
 from six.moves.urllib.parse import urlparse
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.errors import CheckException
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.errors import CheckException
 
 
 class MesosMaster(AgentCheck):

--- a/mesos_master/tests/common.py
+++ b/mesos_master/tests/common.py
@@ -5,9 +5,9 @@ import os
 
 import pytest
 
+from datadog_checks.base.utils.common import get_docker_hostname
 from datadog_checks.dev import get_here
 from datadog_checks.dev.utils import running_on_windows_ci
-from datadog_checks.base.utils.common import get_docker_hostname
 
 not_windows_ci = pytest.mark.skipif(running_on_windows_ci(), reason='Test cannot be run on Windows CI')
 

--- a/mesos_master/tests/common.py
+++ b/mesos_master/tests/common.py
@@ -7,7 +7,7 @@ import pytest
 
 from datadog_checks.dev import get_here
 from datadog_checks.dev.utils import running_on_windows_ci
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 not_windows_ci = pytest.mark.skipif(running_on_windows_ci(), reason='Test cannot be run on Windows CI')
 

--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -11,8 +11,7 @@ from requests.exceptions import Timeout
 from six import iteritems
 from six.moves.urllib.parse import urlparse
 
-from datadog_checks.base.checks import AgentCheck
-from datadog_checks.base.errors import ConfigurationError
+from datadog_checks.base import AgentCheck, ConfigurationError
 
 DEFAULT_MASTER_PORT = 5050
 

--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -11,8 +11,8 @@ from requests.exceptions import Timeout
 from six import iteritems
 from six.moves.urllib.parse import urlparse
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.errors import ConfigurationError
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.errors import ConfigurationError
 
 DEFAULT_MASTER_PORT = 5050
 

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -3,8 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import os
 
-from datadog_checks.base import ensure_unicode
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck, ensure_unicode
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'nfsstat'

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -4,8 +4,8 @@
 import os
 
 from datadog_checks.base import ensure_unicode
-from datadog_checks.checks import AgentCheck
-from datadog_checks.utils.subprocess_output import get_subprocess_output
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'nfsstat'
 

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 
 
 class NginxIngressControllerCheck(OpenMetricsBaseCheck):

--- a/openldap/tests/test_check.py
+++ b/openldap/tests/test_check.py
@@ -6,7 +6,7 @@ import os
 import ldap3
 import pytest
 
-from datadog_checks.utils.platform import Platform
+from datadog_checks.base.utils.platform import Platform
 
 from .common import _check
 

--- a/openldap/tests/test_unit.py
+++ b/openldap/tests/test_unit.py
@@ -7,7 +7,7 @@ import os
 import ldap3
 import pytest
 
-from datadog_checks.errors import CheckException
+from datadog_checks.base.errors import CheckException
 
 from .common import HERE
 

--- a/openmetrics/datadog_checks/openmetrics/openmetrics.py
+++ b/openmetrics/datadog_checks/openmetrics/openmetrics.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 
 
 class OpenMetricsCheck(OpenMetricsBaseCheck):

--- a/openstack/tests/test_openstack.py
+++ b/openstack/tests/test_openstack.py
@@ -9,7 +9,7 @@ import mock
 import pytest
 from six import iteritems
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.openstack.openstack import (
     IncompleteAuthScope,
     IncompleteConfig,

--- a/openstack/tests/test_openstack.py
+++ b/openstack/tests/test_openstack.py
@@ -9,7 +9,7 @@ import mock
 import pytest
 from six import iteritems
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 from datadog_checks.openstack.openstack import (
     IncompleteAuthScope,
     IncompleteConfig,

--- a/pdh_check/datadog_checks/pdh_check/pdh_check.py
+++ b/pdh_check/datadog_checks/pdh_check/pdh_check.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-from datadog_checks.checks.win import PDHBaseCheck
+from datadog_checks.base.checks.win import PDHBaseCheck
 
 
 class PDHCheck(PDHBaseCheck):

--- a/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
+++ b/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
@@ -7,9 +7,7 @@ import psycopg2 as pg
 import psycopg2.extras as pgextras
 from six.moves.urllib.parse import urlparse
 
-from datadog_checks.base import ConfigurationError
-from datadog_checks.base.checks import AgentCheck
-from datadog_checks.base.config import is_affirmative
+from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.pgbouncer.metrics import DATABASES_METRICS, POOLS_METRICS, STATS_METRICS
 
 

--- a/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
+++ b/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
@@ -8,8 +8,8 @@ import psycopg2.extras as pgextras
 from six.moves.urllib.parse import urlparse
 
 from datadog_checks.base import ConfigurationError
-from datadog_checks.checks import AgentCheck
-from datadog_checks.config import is_affirmative
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.config import is_affirmative
 from datadog_checks.pgbouncer.metrics import DATABASES_METRICS, POOLS_METRICS, STATS_METRICS
 
 

--- a/pgbouncer/tests/common.py
+++ b/pgbouncer/tests/common.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2010-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 HOST = get_docker_hostname()
 PORT = '6432'

--- a/php_fpm/datadog_checks/php_fpm/php_fpm.py
+++ b/php_fpm/datadog_checks/php_fpm/php_fpm.py
@@ -9,8 +9,8 @@ from flup.client.fcgi_app import FCGIApp
 from six import PY3, StringIO, iteritems, string_types
 from six.moves.urllib.parse import urlparse
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.config import is_affirmative
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.config import is_affirmative
 
 # Relax param filtering
 FCGIApp._environPrefixes.extend(('DOCUMENT_', 'SCRIPT_'))

--- a/php_fpm/datadog_checks/php_fpm/php_fpm.py
+++ b/php_fpm/datadog_checks/php_fpm/php_fpm.py
@@ -9,8 +9,7 @@ from flup.client.fcgi_app import FCGIApp
 from six import PY3, StringIO, iteritems, string_types
 from six.moves.urllib.parse import urlparse
 
-from datadog_checks.base.checks import AgentCheck
-from datadog_checks.base.config import is_affirmative
+from datadog_checks.base import AgentCheck, is_affirmative
 
 # Relax param filtering
 FCGIApp._environPrefixes.extend(('DOCUMENT_', 'SCRIPT_'))

--- a/postfix/datadog_checks/postfix/postfix.py
+++ b/postfix/datadog_checks/postfix/postfix.py
@@ -7,7 +7,7 @@
 import os
 
 # project
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 

--- a/postfix/datadog_checks/postfix/postfix.py
+++ b/postfix/datadog_checks/postfix/postfix.py
@@ -7,8 +7,8 @@
 import os
 
 # project
-from datadog_checks.checks import AgentCheck
-from datadog_checks.utils.subprocess_output import get_subprocess_output
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 
 class PostfixCheck(AgentCheck):

--- a/powerdns_recursor/datadog_checks/powerdns_recursor/powerdns_recursor.py
+++ b/powerdns_recursor/datadog_checks/powerdns_recursor/powerdns_recursor.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from collections import namedtuple
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 
 class PowerDNSRecursorCheck(AgentCheck):

--- a/powerdns_recursor/datadog_checks/powerdns_recursor/powerdns_recursor.py
+++ b/powerdns_recursor/datadog_checks/powerdns_recursor/powerdns_recursor.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from collections import namedtuple
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 
 class PowerDNSRecursorCheck(AgentCheck):

--- a/powerdns_recursor/tests/common.py
+++ b/powerdns_recursor/tests/common.py
@@ -6,7 +6,7 @@ import os
 
 import requests
 
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 HOST = get_docker_hostname()
 PORT = os.getenv('POWERDNS_HOST_PORT_0', 8082)

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 import psutil
 from six import iteritems
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.config import _is_affirmative
 from datadog_checks.base.utils.platform import Platform
 

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -12,9 +12,9 @@ from collections import defaultdict
 import psutil
 from six import iteritems
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.config import _is_affirmative
-from datadog_checks.utils.platform import Platform
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.config import _is_affirmative
+from datadog_checks.base.utils.platform import Platform
 
 from .cache import DEFAULT_SHARED_PROCESS_LIST_CACHE_DURATION, ProcessListCache
 

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -230,7 +230,7 @@ def test_check_missing_process(aggregator, caplog):
 
 def test_check_real_process(aggregator):
     "Check that we detect python running (at least this process)"
-    from datadog_checks.utils.platform import Platform
+    from datadog_checks.base.utils.platform import Platform
 
     instance = {
         'name': 'py',
@@ -270,7 +270,7 @@ def test_check_real_process(aggregator):
 
 def test_check_real_process_regex(aggregator):
     "Check to specifically find this python pytest running process using regex."
-    from datadog_checks.utils.platform import Platform
+    from datadog_checks.base.utils.platform import Platform
 
     instance = {
         'name': 'py',

--- a/prometheus/datadog_checks/prometheus/prometheus.py
+++ b/prometheus/datadog_checks/prometheus/prometheus.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.checks.prometheus import GenericPrometheusCheck
+from datadog_checks.base.checks.prometheus import GenericPrometheusCheck
 
 
 class PrometheusCheck(GenericPrometheusCheck):

--- a/rabbitmq/tests/common.py
+++ b/rabbitmq/tests/common.py
@@ -4,7 +4,7 @@
 
 import os
 
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(os.path.dirname(HERE))

--- a/rabbitmq/tests/test_unit.py
+++ b/rabbitmq/tests/test_unit.py
@@ -7,7 +7,7 @@ import pytest
 import requests
 from tests.common import EXCHANGE_MESSAGE_STATS
 
-import datadog_checks
+import datadog_checks.base
 from datadog_checks.rabbitmq import RabbitMQ
 from datadog_checks.rabbitmq.rabbitmq import EXCHANGE_TYPE, NODE_TYPE, OVERVIEW_TYPE, RabbitMQException
 

--- a/riak/datadog_checks/riak/riak.py
+++ b/riak/datadog_checks/riak/riak.py
@@ -8,7 +8,7 @@ import unicodedata
 import simplejson as json
 from httplib2 import Http, HttpLib2Error
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 
 class Riak(AgentCheck):

--- a/riak/datadog_checks/riak/riak.py
+++ b/riak/datadog_checks/riak/riak.py
@@ -8,7 +8,7 @@ import unicodedata
 import simplejson as json
 from httplib2 import Http, HttpLib2Error
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 
 class Riak(AgentCheck):

--- a/riakcs/datadog_checks/riakcs/riakcs.py
+++ b/riakcs/datadog_checks/riakcs/riakcs.py
@@ -9,8 +9,8 @@ import simplejson as json
 from boto.s3.connection import S3Connection
 from six import iteritems
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.config import _is_affirmative
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.config import _is_affirmative
 
 
 def multidict(ordered_pairs):

--- a/riakcs/datadog_checks/riakcs/riakcs.py
+++ b/riakcs/datadog_checks/riakcs/riakcs.py
@@ -9,7 +9,7 @@ import simplejson as json
 from boto.s3.connection import S3Connection
 from six import iteritems
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.config import _is_affirmative
 
 

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -9,7 +9,7 @@ import os
 from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.dev.docker import get_container_ip
 from datadog_checks.snmp import SnmpCheck
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 log = logging.getLogger(__name__)
 

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -7,9 +7,9 @@ import logging
 import os
 
 from datadog_checks.base.stubs.aggregator import AggregatorStub
+from datadog_checks.base.utils.common import get_docker_hostname
 from datadog_checks.dev.docker import get_container_ip
 from datadog_checks.snmp import SnmpCheck
-from datadog_checks.base.utils.common import get_docker_hostname
 
 log = logging.getLogger(__name__)
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -13,8 +13,8 @@ from contextlib import contextmanager
 
 from six import raise_from
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.config import is_affirmative
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.config import is_affirmative
 
 try:
     import adodbapi

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 
 from six import raise_from
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.config import is_affirmative
 
 try:

--- a/squid/datadog_checks/squid/squid.py
+++ b/squid/datadog_checks/squid/squid.py
@@ -8,7 +8,7 @@ import requests
 from six import iteritems
 
 # project
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'squid'
 

--- a/squid/datadog_checks/squid/squid.py
+++ b/squid/datadog_checks/squid/squid.py
@@ -8,7 +8,7 @@ import requests
 from six import iteritems
 
 # project
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'squid'
 

--- a/squid/tests/common.py
+++ b/squid/tests/common.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import os
 
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 
 CHECK_NAME = "squid"
 HERE = os.path.dirname(os.path.abspath(__file__))

--- a/ssh_check/datadog_checks/ssh_check/ssh_check.py
+++ b/ssh_check/datadog_checks/ssh_check/ssh_check.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 
 import paramiko
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 # Example ssh remote version: http://supervisord.org/changes.html
 #   - SSH-2.0-OpenSSH_8.1

--- a/ssh_check/datadog_checks/ssh_check/ssh_check.py
+++ b/ssh_check/datadog_checks/ssh_check/ssh_check.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 
 import paramiko
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 # Example ssh remote version: http://supervisord.org/changes.html
 #   - SSH-2.0-OpenSSH_8.1

--- a/statsd/datadog_checks/statsd/statsd.py
+++ b/statsd/datadog_checks/statsd/statsd.py
@@ -7,8 +7,7 @@ import socket
 
 from six import BytesIO
 
-from datadog_checks.base.checks import AgentCheck
-from datadog_checks.base.utils.common import ensure_bytes, ensure_unicode
+from datadog_checks.base import AgentCheck, ensure_bytes, ensure_unicode
 
 SERVICE_CHECK_NAME = "statsd.can_connect"
 SERVICE_CHECK_NAME_HEALTH = "statsd.is_up"

--- a/statsd/datadog_checks/statsd/statsd.py
+++ b/statsd/datadog_checks/statsd/statsd.py
@@ -7,8 +7,8 @@ import socket
 
 from six import BytesIO
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.utils.common import ensure_bytes, ensure_unicode
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.utils.common import ensure_bytes, ensure_unicode
 
 SERVICE_CHECK_NAME = "statsd.can_connect"
 SERVICE_CHECK_NAME_HEALTH = "statsd.is_up"

--- a/supervisord/tests/common.py
+++ b/supervisord/tests/common.py
@@ -4,7 +4,7 @@
 
 import os
 
-from datadog_checks.checks.base import ServiceCheck
+from datadog_checks.base.checks.base import ServiceCheck
 from datadog_checks.dev import get_docker_hostname
 
 PROCESSES = ["program_0", "program_1", "program_2"]

--- a/system_core/datadog_checks/system_core/system_core.py
+++ b/system_core/datadog_checks/system_core/system_core.py
@@ -4,7 +4,7 @@
 import psutil
 from six import iteritems
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 
 class SystemCore(AgentCheck):

--- a/system_core/datadog_checks/system_core/system_core.py
+++ b/system_core/datadog_checks/system_core/system_core.py
@@ -4,7 +4,7 @@
 import psutil
 from six import iteritems
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 
 class SystemCore(AgentCheck):

--- a/system_core/tests/common.py
+++ b/system_core/tests/common.py
@@ -4,7 +4,7 @@
 import psutil
 
 from datadog_checks.dev import get_here
-from datadog_checks.utils.platform import Platform
+from datadog_checks.base.utils.platform import Platform
 
 HERE = get_here()
 CHECK_NAME = "system_core"

--- a/system_core/tests/common.py
+++ b/system_core/tests/common.py
@@ -3,8 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import psutil
 
-from datadog_checks.dev import get_here
 from datadog_checks.base.utils.platform import Platform
+from datadog_checks.dev import get_here
 
 HERE = get_here()
 CHECK_NAME = "system_core"

--- a/system_swap/datadog_checks/system_swap/system_swap.py
+++ b/system_swap/datadog_checks/system_swap/system_swap.py
@@ -6,7 +6,7 @@
 import psutil
 
 # project
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 
 class SystemSwap(AgentCheck):

--- a/system_swap/datadog_checks/system_swap/system_swap.py
+++ b/system_swap/datadog_checks/system_swap/system_swap.py
@@ -6,7 +6,7 @@
 import psutil
 
 # project
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 
 class SystemSwap(AgentCheck):

--- a/teamcity/datadog_checks/teamcity/teamcity.py
+++ b/teamcity/datadog_checks/teamcity/teamcity.py
@@ -6,7 +6,7 @@ import time
 
 import requests
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.config import _is_affirmative
 
 

--- a/teamcity/datadog_checks/teamcity/teamcity.py
+++ b/teamcity/datadog_checks/teamcity/teamcity.py
@@ -6,8 +6,8 @@ import time
 
 import requests
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.config import _is_affirmative
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.config import _is_affirmative
 
 
 class TeamCityCheck(AgentCheck):

--- a/tokumx/datadog_checks/tokumx/tokumx.py
+++ b/tokumx/datadog_checks/tokumx/tokumx.py
@@ -8,7 +8,7 @@ import time
 
 from six import PY3, iteritems
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 from datadog_checks.tokumx.vendor import bson
 from datadog_checks.tokumx.vendor.pymongo import MongoClient, ReadPreference, errors, uri_parser
 from datadog_checks.tokumx.vendor.pymongo import version as py_version

--- a/tokumx/datadog_checks/tokumx/tokumx.py
+++ b/tokumx/datadog_checks/tokumx/tokumx.py
@@ -8,7 +8,7 @@ import time
 
 from six import PY3, iteritems
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 from datadog_checks.tokumx.vendor import bson
 from datadog_checks.tokumx.vendor.pymongo import MongoClient, ReadPreference, errors, uri_parser
 from datadog_checks.tokumx.vendor.pymongo import version as py_version

--- a/varnish/datadog_checks/varnish/varnish.py
+++ b/varnish/datadog_checks/varnish/varnish.py
@@ -11,8 +11,8 @@ from os import geteuid
 from six import PY3, iteritems
 from six.moves import filter
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.utils.subprocess_output import get_subprocess_output
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 if PY3:
     long = int

--- a/vsphere/datadog_checks/vsphere/legacy/errors.py
+++ b/vsphere/datadog_checks/vsphere/legacy/errors.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.errors import CheckException
+from datadog_checks.base.errors import CheckException
 
 
 class BadConfigError(CheckException):

--- a/vsphere/datadog_checks/vsphere/legacy/vsphere_legacy.py
+++ b/vsphere/datadog_checks/vsphere/legacy/vsphere_legacy.py
@@ -18,8 +18,7 @@ from pyVmomi import vmodl  # pylint: disable=E0611
 from six import itervalues
 from six.moves import range
 
-from datadog_checks.base import ensure_unicode, to_native_string
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck, ensure_unicode, to_native_string
 from datadog_checks.base.checks.libs.thread_pool import SENTINEL, Pool
 from datadog_checks.base.checks.libs.timer import Timer
 from datadog_checks.base.checks.libs.vmware.all_metrics import ALL_METRICS

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -13,7 +13,7 @@ from six import iteritems
 
 from datadog_checks.base import AgentCheck, is_affirmative, to_native_string
 from datadog_checks.base.checks.libs.timer import Timer
-from datadog_checks.stubs import datadog_agent
+from datadog_checks.base.stubs import datadog_agent
 from datadog_checks.vsphere.api import APIConnectionError, VSphereAPI
 from datadog_checks.vsphere.api_rest import VSphereRestAPI
 from datadog_checks.vsphere.cache import InfrastructureCache, MetricsMetadataCache, TagsCache

--- a/vsphere/tests/legacy/conftest.py
+++ b/vsphere/tests/legacy/conftest.py
@@ -41,7 +41,7 @@ def vsphere():
 
 @pytest.fixture
 def aggregator():
-    from datadog_checks.stubs import aggregator
+    from datadog_checks.base.stubs import aggregator
 
     aggregator.reset()
     return aggregator

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -6,7 +6,7 @@ import re
 import win32service
 from six import iteritems
 
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck
 
 SERVICE_PATTERN_FLAGS = re.IGNORECASE
 

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -6,7 +6,7 @@ import re
 import win32service
 from six import iteritems
 
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 SERVICE_PATTERN_FLAGS = re.IGNORECASE
 

--- a/wmi_check/datadog_checks/wmi_check/wmi_check.py
+++ b/wmi_check/datadog_checks/wmi_check/wmi_check.py
@@ -2,9 +2,9 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-from datadog_checks.checks.win.wmi import WinWMICheck
-from datadog_checks.utils.containers import hash_mutable
-from datadog_checks.utils.timeout import TimeoutException
+from datadog_checks.base.checks.win.wmi import WinWMICheck
+from datadog_checks.base.utils.containers import hash_mutable
+from datadog_checks.base.utils.timeout import TimeoutException
 
 
 class WMICheck(WinWMICheck):

--- a/yarn/datadog_checks/yarn/yarn.py
+++ b/yarn/datadog_checks/yarn/yarn.py
@@ -6,7 +6,7 @@ from six import iteritems
 from six.moves.urllib.parse import urljoin, urlsplit, urlunsplit
 
 from datadog_checks.base import AgentCheck, is_affirmative
-from datadog_checks.errors import ConfigurationError
+from datadog_checks.base.errors import ConfigurationError
 
 # Default settings
 DEFAULT_RM_URI = 'http://localhost:8088'

--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -64,8 +64,7 @@ from distutils.version import LooseVersion  # pylint: disable=E0611,E0401
 
 from six import PY3, StringIO, iteritems
 
-from datadog_checks.base import ensure_bytes, ensure_unicode
-from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base import AgentCheck, ensure_bytes, ensure_unicode
 
 if PY3:
     long = int

--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -65,7 +65,7 @@ from distutils.version import LooseVersion  # pylint: disable=E0611,E0401
 from six import PY3, StringIO, iteritems
 
 from datadog_checks.base import ensure_bytes, ensure_unicode
-from datadog_checks.checks import AgentCheck
+from datadog_checks.base.checks import AgentCheck
 
 if PY3:
     long = int

--- a/zk/tests/conftest.py
+++ b/zk/tests/conftest.py
@@ -8,7 +8,7 @@ import time
 import pytest
 
 from datadog_checks.dev import RetryError, docker_run
-from datadog_checks.utils.common import get_docker_hostname
+from datadog_checks.base.utils.common import get_docker_hostname
 from datadog_checks.zk import ZookeeperCheck
 from datadog_checks.zk.zk import ZKConnectionFailure
 

--- a/zk/tests/conftest.py
+++ b/zk/tests/conftest.py
@@ -7,8 +7,8 @@ import time
 
 import pytest
 
-from datadog_checks.dev import RetryError, docker_run
 from datadog_checks.base.utils.common import get_docker_hostname
+from datadog_checks.dev import RetryError, docker_run
 from datadog_checks.zk import ZookeeperCheck
 from datadog_checks.zk.zk import ZKConnectionFailure
 


### PR DESCRIPTION
### Motivation
Prior to implementing #6081 as part of CI, these changes would be merged to update all of our code to import from the recommended `base` package.

