### PR TITLE
Upgrade and pin mypy to 0.770

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -77,7 +77,7 @@ def add_style_checker(config, sections, make_envconfig, reader):
         # Allow using multiple lines for enhanced readability in case of large amount of options/files to check.
         mypy_args = mypy_args.replace('\n', ' ')
 
-        dependencies.append('mypy>=0.761')
+        dependencies.append('mypy==0.770')  # Use a pinned version to avoid large-scale CI breakage on new releases.
         commands.append('mypy --config-file=../mypy.ini {}'.format(mypy_args))
 
     sections[section] = {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Upgrade and pin mypy to `mypy==0.770`.

### Motivation
<!-- What inspired you to submit this pull request? -->
- [Mypy 0.770 was released on March 11th](http://mypy-lang.blogspot.com/2020/03/mypy-0770-released.html), with new (IMHO) exciting features like tagged unions (I need them in #5715), and various improvements/bug fixes.
- We should pin mypy to a specific version so we can consciously upgrade (and handle any extra errors we'd be getting from upgrading), instead of risking large-scale CI breakage on `ddev test -s`  due to type checking failures. (Hasn't happened yet, but it could.)

### Additional Notes
<!-- Anything else we should know when reviewing? -->
_Technically_ we are already using version 0.770 on CI (because it was released before we added caching - #6037), but our local Tox environments are likely stuck on 0.761 because they're reusing the cache.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
