### PR TITLE
Expose number of cfs enforcement periods

### DIFF
--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -39,6 +39,7 @@ class CadvisorPrometheusScraperMixin(object):
             'container_cpu_load_average_10s': self.container_cpu_load_average_10s,
             'container_cpu_system_seconds_total': self.container_cpu_system_seconds_total,
             'container_cpu_user_seconds_total': self.container_cpu_user_seconds_total,
+            'container_cpu_cfs_periods_total': self.container_cpu_cfs_periods_total,
             'container_cpu_cfs_throttled_periods_total': self.container_cpu_cfs_throttled_periods_total,
             'container_cpu_cfs_throttled_seconds_total': self.container_cpu_cfs_throttled_seconds_total,
             'container_fs_reads_bytes_total': self.container_fs_reads_bytes_total,
@@ -74,7 +75,6 @@ class CadvisorPrometheusScraperMixin(object):
                 # so the key is different than the kubelet scraper.
                 'prometheus_url': instance.get('cadvisor_metrics_endpoint', 'dummy_url/cadvisor'),
                 'ignore_metrics': [
-                    'container_cpu_cfs_periods_total',
                     'container_fs_inodes_free',
                     'container_fs_inodes_total',
                     'container_fs_io_current',
@@ -466,6 +466,10 @@ class CadvisorPrometheusScraperMixin(object):
 
     def container_cpu_user_seconds_total(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.cpu.user.total'
+        self._process_container_metric('rate', metric_name, metric, scraper_config)
+
+    def container_cpu_cfs_periods_total(self, metric, scraper_config):
+        metric_name = scraper_config['namespace'] + '.cpu.cfs.periods'
         self._process_container_metric('rate', metric_name, metric, scraper_config)
 
     def container_cpu_cfs_throttled_periods_total(self, metric, scraper_config):

--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -9,8 +9,9 @@ kubernetes.containers.state.waiting,gauge,,,,The number of currently waiting con
 kubernetes.cpu.load.10s.avg,gauge,,,,Container cpu load average over the last 10 seconds,0,kubernetes,k8s.cpu.load.10s
 kubernetes.cpu.system.total,rate,,core,,The number of cores used for system time,0,kubernetes,k8s.cpu.system
 kubernetes.cpu.user.total,rate,,core,,The number of cores used for user time,0,kubernetes,k8s.cpu.user
-kubernetes.cpu.cfs.throttled.period,rate,,,,Number of throttled period intervals,-1,kubernetes,k8s.cpu.throttled.periods
-kubernetes.cpu.cfs.throttled.second,rate,,,,Total time duration the container has been throttled,-1,kubernetes,k8s.cpu.throttled.sec
+kubernetes.cpu.cfs.periods,rate,,,,Number of elapsed enforcement period intervals,-1,kubernetes,k8s.cpu.periods
+kubernetes.cpu.cfs.throttled.periods,rate,,,,Number of throttled period intervals,-1,kubernetes,k8s.cpu.throttled.periods
+kubernetes.cpu.cfs.throttled.seconds,rate,,,,Total time duration the container has been throttled,-1,kubernetes,k8s.cpu.throttled.sec
 kubernetes.cpu.capacity,gauge,,core,,The number of cores in this machine (available until kubernetes v1.18),0,kubernetes,k8s.cpu.capacity
 kubernetes.cpu.usage.total,gauge,,nanocore,,The number of cores used,-1,kubernetes,k8s.cpu
 kubernetes.cpu.limits,gauge,,core,,The limit of cpu cores set,0,kubernetes,k8s.cpu.limits

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -72,6 +72,7 @@ EXPECTED_METRICS_PROMETHEUS = [
     'kubernetes.cpu.load.10s.avg',
     'kubernetes.cpu.system.total',
     'kubernetes.cpu.user.total',
+    'kubernetes.cpu.cfs.periods',
     'kubernetes.cpu.cfs.throttled.periods',
     'kubernetes.cpu.cfs.throttled.seconds',
     'kubernetes.memory.usage_pct',


### PR DESCRIPTION
### What does this PR do?
Expose number of cfs enforcement periods (`nr_periods`) in kubelet check.

### Motivation
Want to calculate percentage of time that the application is 'throttled', which is best done by calculating `nr_throttled/nr_periods`, however Datadog is not collecting nr_periods. Therefore, adding this so I can make that calculation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
