### PR TITLE
Generate ddev cli docs automatically

### DIFF
--- a/docs/developer/ddev/cli.md
+++ b/docs/developer/ddev/cli.md
@@ -1,2 +1,5 @@
-:::click module=datadog_checks.dev.tooling.cli:ddev:::
+::: mkdocs-click
+    :module: datadog_checks.dev.tooling.cli
+    :command: ddev
+    :depth: 0
 

--- a/docs/developer/ddev/cli.md
+++ b/docs/developer/ddev/cli.md
@@ -1,5 +1,2 @@
-# CLI
-
------
-
+:::click module=datadog_checks.dev.tooling.cli:ddev:::
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ markdown_extensions:
       toc_depth: "2-6"
   # Extra
   - mkautodoc:
+  - mkdocs-click:
   - pymdownx.arithmatex:
   - pymdownx.betterem:
       smart_enable: all

--- a/tox.ini
+++ b/tox.ini
@@ -24,5 +24,6 @@ deps =
     Pygments>=2.5.2
     ; for API auto-documentation
     -e./datadog_checks_base[deps,http]
+    -e ../mkdocs-click
 commands =
     python -m mkdocs {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,6 @@ deps =
     Pygments>=2.5.2
     ; for API auto-documentation
     -e./datadog_checks_base[deps,http]
-    -e ../mkdocs-click
+    git+https://github.com/DataDog/mkdocs-click.git
 commands =
     python -m mkdocs {posargs}


### PR DESCRIPTION
Uses the new mkdocs-click plugin developped here: https://github.com/DataDog/mkdocs-click to parse and generate docs for ddev automatically.