### PR TITLE
Support regular expressions in dynamic tags

### DIFF
--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -332,6 +332,8 @@ instances:
 
     ## @param metric_tags - list of elements - optional
     ## Specify tags that you want applied to all metrics. A tag can be applied from a symbol or an OID.
+    ## Regular expressions can be used to separate the found value into several tags, or get a substring, using the regular
+    ## Python engine: https://docs.python.org/3/library/re.html
     #
     # metric_tags:
     #  - # From a symbol
@@ -342,3 +344,10 @@ instances:
     #    OID: 1.3.6.1.2.1.1.5
     #    symbol: sysName
     #    tag: snmp_host
+    #  - # With regular expression matching
+    #    MIB: SNMPv2-MIB
+    #    symbol: sysName
+    #    match: '(.*)-(.*)
+    #    tags:
+    #        host: \\2
+    #        device_type: \\1

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -332,7 +332,7 @@ instances:
 
     ## @param metric_tags - list of elements - optional
     ## Specify tags that you want applied to all metrics. A tag can be applied from a symbol or an OID.
-    ## Regular expressions can be used to separate the found value into several tags, or get a substring, using the regular
+    ## Regular expressions can be used to separate the resulting value into several tags, or get a substring using the regular
     ## Python engine: https://docs.python.org/3/library/re.html
     #
     # metric_tags:

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -332,8 +332,8 @@ instances:
 
     ## @param metric_tags - list of elements - optional
     ## Specify tags that you want applied to all metrics. A tag can be applied from a symbol or an OID.
-    ## Regular expressions can be used to separate the resulting value into several tags, or get a substring using the regular
-    ## Python engine: https://docs.python.org/3/library/re.html
+    ## Regular expressions can be used to separate the resulting value into several tags, or get a
+    ## substring using the regular Python engine: https://docs.python.org/3/library/re.html
     #
     # metric_tags:
     #  - # From a symbol
@@ -347,7 +347,7 @@ instances:
     #  - # With regular expression matching
     #    MIB: SNMPv2-MIB
     #    symbol: sysName
-    #    match: '(.*)-(.*)
+    #    match: (.*)-(.*)
     #    tags:
     #        host: \\2
     #        device_type: \\1

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -6,6 +6,7 @@ import fnmatch
 import functools
 import ipaddress
 import json
+import re
 import threading
 import time
 from collections import defaultdict
@@ -19,7 +20,7 @@ from datadog_checks.base.errors import CheckException
 
 from .commands import snmp_bulk, snmp_get, snmp_getnext
 from .compat import read_persistent_cache, write_persistent_cache
-from .config import InstanceConfig, ParsedMetric, ParsedMetricTag, ParsedTableMetric
+from .config import InstanceConfig, ParsedMatchMetricTags, ParsedMetric, ParsedMetricTag, ParsedTableMetric
 from .exceptions import PySnmpError
 from .metrics import as_metric_with_forced_type, as_metric_with_inferred_type
 from .pysnmp_types import ObjectIdentity, ObjectType, noSuchInstance, noSuchObject
@@ -388,7 +389,7 @@ class SnmpCheck(AgentCheck):
         return error
 
     def extract_metric_tags(self, metric_tags, results):
-        # type: (List[ParsedMetricTag], Dict[str, dict]) -> List[str]
+        # type: (List[Union[ParsedMetricTag, ParsedMatchMetricTags]], Dict[str, dict]) -> List[str]
         extracted_tags = []
         for tag in metric_tags:
             if tag.symbol not in results:
@@ -400,7 +401,10 @@ class SnmpCheck(AgentCheck):
                     'You are trying to use a table column (OID `{}`) as a metric tag. This is not supported as '
                     '`metric_tags` can only refer to scalar OIDs.'.format(tag.symbol)
                 )
-            extracted_tags.append('{}:{}'.format(tag.name, tag_values[0]))
+            try:
+                extracted_tags.extend(tag.matched_tags(tag_values[0]))
+            except re.error as e:
+                self.log.debug('Failed to match %s for %s: %s', tag_values[0], tag.symbol, e)
         return extracted_tags
 
     def report_metrics(


### PR DESCRIPTION
Tags coming from SNMP values can be complex, we can either want a
substring or divide it into multiple tags. This adds support for it
using regular expressions in the configuration.