### PR TITLE
Tagging scylla as log collection

### DIFF
--- a/scylla/manifest.json
+++ b/scylla/manifest.json
@@ -16,7 +16,8 @@
   ],
   "public_title": "Datadog-Scylla Integration",
   "categories": [
-    "data store"
+    "data store",
+    "log collection"
   ],
   "type": "check",
   "is_public": true,


### PR DESCRIPTION
### What does this PR do?
Tagging the scyla integration as log collection

### Motivation
Making sure that the integration show up when we filter by log collection on the integration page

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
