### PR TITLE
Add script to resolve username from email

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/__init__.py
@@ -4,11 +4,12 @@
 import click
 
 from ...console import CONTEXT_SETTINGS
+from .github_user import github_user
 from .metrics2md import metrics2md
 from .remove_labels import remove_labels
 from .upgrade_python import upgrade_python
 
-ALL_COMMANDS = (metrics2md, remove_labels, upgrade_python)
+ALL_COMMANDS = (github_user, metrics2md, remove_labels, upgrade_python)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Miscellaneous scripts that may be useful')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/__init__.py
@@ -4,12 +4,12 @@
 import click
 
 from ...console import CONTEXT_SETTINGS
-from .github_user import github_user
+from .github_user import email2ghuser
 from .metrics2md import metrics2md
 from .remove_labels import remove_labels
 from .upgrade_python import upgrade_python
 
-ALL_COMMANDS = (github_user, metrics2md, remove_labels, upgrade_python)
+ALL_COMMANDS = (email2ghuser, metrics2md, remove_labels, upgrade_python)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Miscellaneous scripts that may be useful')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/github_user.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/github_user.py
@@ -18,7 +18,7 @@ def email2ghuser(email):
     """
 
     try:
-        response = requests.get(f'https://api.github.com/search/users?q={email}',)
+        response = requests.get(f'https://api.github.com/search/users?q={email}')
         response.raise_for_status()
         content = response.json()
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/github_user.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/github_user.py
@@ -20,9 +20,7 @@ def github_user(email):
     GITHUB_ENDPOINT = 'https://api.github.com/search/users'
 
     try:
-        response = requests.get(
-            f'{GITHUB_ENDPOINT}?q={email}',
-        )
+        response = requests.get(f'{GITHUB_ENDPOINT}?q={email}',)
         response.raise_for_status()
         content = response.json()
 
@@ -39,4 +37,3 @@ def github_user(email):
 
     except Exception as e:
         abort(str(e))
-

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/github_user.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/github_user.py
@@ -10,30 +10,25 @@ from ...console import CONTEXT_SETTINGS, abort, echo_success
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Lookup Github username by email.')
 @click.argument('email')
-def github_user(email):
+def email2ghuser(email):
     """Given an email, attempt to find a Github username
        associated with the email.
 
-    `$ ddev meta scripts github-user example@datadoghq.com`
+    `$ ddev meta scripts email2ghuser example@datadoghq.com`
     """
-    usernames = []
-    GITHUB_ENDPOINT = 'https://api.github.com/search/users'
 
     try:
-        response = requests.get(f'{GITHUB_ENDPOINT}?q={email}',)
+        response = requests.get(f'https://api.github.com/search/users?q={email}',)
         response.raise_for_status()
         content = response.json()
 
         if content.get('total_count') == 0:
             abort(f'No username found for email {email}')
 
-        for item in content.get('items'):
-            username = item.get('login')
-            usernames.append(username)
+        user = content.get('items')[0]
+        username = user.get('login')
 
-        usernames_formatted = ' \n'.join(usernames)
-
-        echo_success(f'Username(s) associated with email {email}: \n{usernames_formatted}')
+        echo_success(f'Found username "{username}" associated with email {email}')
 
     except Exception as e:
         abort(str(e))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/github_user.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/github_user.py
@@ -1,0 +1,42 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import click
+import requests
+
+from ...console import CONTEXT_SETTINGS, abort, echo_success
+
+
+@click.command(context_settings=CONTEXT_SETTINGS, short_help='Lookup Github username by email.')
+@click.argument('email')
+def github_user(email):
+    """Given an email, attempt to find a Github username
+       associated with the email.
+
+    `$ ddev meta scripts github-user example@datadoghq.com`
+    """
+    usernames = []
+    GITHUB_ENDPOINT = 'https://api.github.com/search/users'
+
+    try:
+        response = requests.get(
+            f'{GITHUB_ENDPOINT}?q={email}',
+        )
+        response.raise_for_status()
+        content = response.json()
+
+        if content.get('total_count') == 0:
+            abort(f'No username found for email {email}')
+
+        for item in content.get('items'):
+            username = item.get('login')
+            usernames.append(username)
+
+        usernames_formatted = ' \n'.join(usernames)
+
+        echo_success(f'Username(s) associated with email {email}: \n{usernames_formatted}')
+
+    except Exception as e:
+        abort(str(e))
+


### PR DESCRIPTION
### What does this PR do?
Creates a script to resolve a Github username from email.

### Motivation
We are going to add a github action that relies on codeowner entries being usernames and not emails.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
