### PR TITLE
Fix e2e tests for envoy

### DIFF
--- a/envoy/tests/docker/default/controlplane.go
+++ b/envoy/tests/docker/default/controlplane.go
@@ -10,7 +10,7 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
-	"github.com/envoyproxy/go-control-plane/pkg/cache"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 	xds "github.com/envoyproxy/go-control-plane/pkg/server"
 
 	"github.com/golang/protobuf/ptypes"


### PR DESCRIPTION
### What does this PR do?
A new change was merged upstream (https://github.com/envoyproxy/go-control-plane/pull/275) which requires an update to our build code to get e2e tests to run.
