### PR TITLE
Remove reference to check in logs-only template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/datadog_checks/{check_name}/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/datadog_checks/{check_name}/__init__.py
@@ -1,4 +1,3 @@
 {license_header}from .__about__ import __version__
-from .{check_name} import {check_class}
 
-__all__ = ['__version__', '{check_class}']
+__all__ = ['__version__']


### PR DESCRIPTION
### What does this PR do?
Remove the reference to a check class in the logs-only template

### Motivation
A reference to a check class was included in the logs-only integration template so that new logs integrations don't include it.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
