### PR TITLE
Add secrets sanitization helpers

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -18,7 +18,6 @@ from six import binary_type, iteritems, text_type
 
 from ..config import is_affirmative
 from ..constants import ServiceCheck
-from ..log import SanitizationFilter
 from ..types import (
     AgentConfigType,
     Event,
@@ -347,7 +346,7 @@ class AgentCheck(object):
         if not hasattr(self, '_sanitizer'):
             # Configure lazily so that checks that don't use sanitization aren't affected.
             self._sanitizer = SecretsSanitizer()
-            self.log.logger.addFilter(SanitizationFilter('secrets', sanitize=self.sanitize))
+            self.log.setup_sanitization(sanitize=self.sanitize)
 
         self._sanitizer.register(secret)
 

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -563,6 +563,8 @@ class AgentCheck(object):
         else:
             message = to_native_string(message)
 
+        message = self.log.redact_registered_secrets(message)
+
         aggregator.submit_service_check(
             self, self.check_id, self._format_namespace(name, raw), status, tags, hostname, message
         )

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
-from typing import Any, Set
+from typing import Callable
 
 from six import PY2, iteritems, text_type
 
@@ -24,45 +24,11 @@ class AgentLogger(logging.getLoggerClass()):
             self._log(TRACE_LEVEL, msg, args, **kwargs)
 
 
-class RedactFilter(logging.Filter):
-    def __init__(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        super(RedactFilter, self).__init__(*args, **kwargs)
-        self.patterns = set()  # type: Set[str]
-
-    def filter(self, record):
-        # type: (logging.LogRecord) -> bool
-        record.msg = self.redact(to_native_string(record.msg))
-
-        if isinstance(record.args, dict):
-            record.args = {key: self.redact(value) for key, value in iteritems(record.args)}
-        else:
-            record.args = tuple(self.redact(arg) for arg in record.args)
-
-        return True
-
-    def redact(self, message):
-        # type: (str) -> str
-        for pattern in self.patterns:
-            message = message.replace(pattern, '********')
-        return message
-
-
 class CheckLoggingAdapter(logging.LoggerAdapter):
     def __init__(self, logger, check):
         super(CheckLoggingAdapter, self).__init__(logger, {})
         self.check = check
         self.check_id = self.check.check_id
-        self._redact_filter = RedactFilter('redact-secrets')
-        self.logger.addFilter(self._redact_filter)
-
-    def register_secret_for_redaction(self, secret):
-        # type: (str) -> None
-        self._redact_filter.patterns.add(secret)
-
-    def redact_registered_secrets(self, message):
-        # type: (str) -> str
-        return self._redact_filter.redact(message)
 
     def process(self, msg, kwargs):
         # Cache for performance
@@ -99,6 +65,28 @@ class AgentLogHandler(logging.Handler):
             to_native_string(self.format(record)),
         )
         datadog_agent.log(msg, record.levelno)
+
+
+class SanitizationFilter(logging.Filter):
+    """
+    A filter for sanitizing log records messages.
+    """
+
+    def __init__(self, name, sanitize):
+        # type: (str, Callable[[str], str]) -> None
+        super(SanitizationFilter, self).__init__(name)
+        self.sanitize = sanitize
+
+    def filter(self, record):
+        # type: (logging.LogRecord) -> bool
+        record.msg = self.sanitize(to_native_string(record.msg))
+
+        if isinstance(record.args, dict):
+            record.args = {key: self.sanitize(value) for key, value in iteritems(record.args)}
+        else:
+            record.args = tuple(self.sanitize(arg) for arg in record.args)
+
+        return True
 
 
 LOG_LEVEL_MAP = {

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -4,7 +4,7 @@
 import logging
 from typing import Callable
 
-from six import PY2, iteritems, text_type
+from six import PY2, text_type
 
 from .utils.common import to_native_string
 
@@ -30,6 +30,12 @@ class CheckLoggingAdapter(logging.LoggerAdapter):
         self.check = check
         self.check_id = self.check.check_id
 
+    def setup_sanitization(self, sanitize):
+        # type: (Callable[[str], str]) -> None
+        for handler in self.logger.handlers:
+            if isinstance(handler, AgentLogHandler):
+                handler.setFormatter(SanitizationFormatter(handler.formatter, sanitize=sanitize))
+
     def process(self, msg, kwargs):
         # Cache for performance
         if not self.check_id:
@@ -50,43 +56,49 @@ class CheckLoggingAdapter(logging.LoggerAdapter):
             self.log(logging.WARNING, msg, *args, **kwargs)
 
 
+class CheckLogFormatter(logging.Formatter):
+    def format(self, record):
+        # type: (logging.LogRecord) -> str
+        message = to_native_string(super(CheckLogFormatter, self).format(record))
+        return "{} | ({}:{}) | {}".format(
+            # Default to `-` for non-check logs
+            getattr(record, '_check_id', '-'),
+            getattr(record, '_filename', record.filename),
+            getattr(record, '_lineno', record.lineno),
+            message,
+        )
+
+
 class AgentLogHandler(logging.Handler):
     """
     This handler forwards every log to the Go backend allowing python checks to
     log message within the main agent logging system.
     """
 
+    def __init__(self):
+        # type: () -> None
+        super(AgentLogHandler, self).__init__()
+        self.formatter = CheckLogFormatter()  # type: logging.Formatter
+
     def emit(self, record):
-        msg = "{} | ({}:{}) | {}".format(
-            # Default to `-` for non-check logs
-            getattr(record, '_check_id', '-'),
-            getattr(record, '_filename', record.filename),
-            getattr(record, '_lineno', record.lineno),
-            to_native_string(self.format(record)),
-        )
-        datadog_agent.log(msg, record.levelno)
+        # type: (logging.LogRecord) -> None
+        message = self.format(record)
+        datadog_agent.log(message, record.levelno)
 
 
-class SanitizationFilter(logging.Filter):
+class SanitizationFormatter(logging.Formatter):
     """
-    A filter for sanitizing log records messages.
+    A formatter-like object that sanitizes log messages to hide sensitive data.
     """
 
-    def __init__(self, name, sanitize):
-        # type: (str, Callable[[str], str]) -> None
-        super(SanitizationFilter, self).__init__(name)
+    def __init__(self, parent, sanitize):
+        # type: (logging.Formatter, Callable[[str], str]) -> None
+        self.parent = parent
         self.sanitize = sanitize
 
-    def filter(self, record):
-        # type: (logging.LogRecord) -> bool
-        record.msg = self.sanitize(to_native_string(record.msg))
-
-        if isinstance(record.args, dict):
-            record.args = {key: self.sanitize(value) for key, value in iteritems(record.args)}
-        else:
-            record.args = tuple(self.sanitize(arg) for arg in record.args)
-
-        return True
+    def format(self, record):
+        # type: (logging.LogRecord) -> str
+        return self.sanitize(self.parent.format(record))
 
 
 LOG_LEVEL_MAP = {
@@ -121,6 +133,7 @@ def _get_py_loglevel(lvl):
 
 
 def init_logging():
+    # type: () -> None
     """
     Initialize logging (set up forwarding to Go backend and sane defaults)
     """

--- a/datadog_checks_base/datadog_checks/base/utils/secrets.py
+++ b/datadog_checks_base/datadog_checks/base/utils/secrets.py
@@ -1,0 +1,23 @@
+from typing import Set
+
+
+class SecretsSanitizer:
+    """
+    A helper for sanitizing secrets (password, keys, ...) in text output.
+    """
+
+    REDACTED = '********'
+
+    def __init__(self):
+        # type: () -> None
+        self.patterns = set()  # type: Set[str]
+
+    def register(self, secret):
+        # type: (str) -> None
+        self.patterns.add(secret)
+
+    def sanitize(self, text):
+        # type: (str) -> str
+        for pattern in self.patterns:
+            text = text.replace(pattern, self.REDACTED)
+        return text

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -5,6 +5,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
 from collections import OrderedDict
+from typing import Any
 
 import mock
 import pytest
@@ -65,27 +66,69 @@ def test_log_critical_error():
         check.log.critical('test')
 
 
-class TestLogSecretRedaction:
+class TestSecretsSanitization:
     def test_default(self, caplog):
-        # By default, non-registered secrets aren't redacted.
+        # type: (Any) -> None
+        secret = 's3kr3t'
         check = AgentCheck()
-        secret = 'p@$$w0rd'
-        check.log.error('hello, %s', secret)
+
+        message = 'hello, {}'.format(secret)
+        assert check.sanitize(message) == message
+
+        check.log.error(message)
         assert secret in caplog.text
 
-    def test_redact_logs(self, caplog):
-        check = AgentCheck()
+    def test_sanitize_text(self):
+        # type: () -> None
         secret = 'p@$$w0rd'
-        check.log.register_secret_for_redaction(secret)
+        check = AgentCheck()
+        check.register_secret(secret)
+
+        sanitized = check.sanitize('hello, {}'.format(secret))
+        assert secret not in sanitized
+
+    def text_sanitize_logs(self, caplog):
+        # type: (Any) -> None
+        secret = 'p@$$w0rd'
+        check = AgentCheck()
+        check.register_secret(secret)
+
         check.log.error('hello, %s', secret)
         assert secret not in caplog.text
 
-    def test_redact_service_check_messages(self, aggregator, caplog):
-        check = AgentCheck()
+    def test_sanitize_service_check_message(self, aggregator, caplog):
+        # type: (Any, Any) -> None
         secret = 'p@$$w0rd'
-        check.log.register_secret_for_redaction(secret)
+        check = AgentCheck()
+        check.register_secret(secret)
+        sanitized = check.sanitize(secret)
+
         check.service_check('test.can_check', status=AgentCheck.CRITICAL, message=secret)
-        aggregator.assert_service_check('test.can_check', status=AgentCheck.CRITICAL, message='********')
+
+        aggregator.assert_service_check('test.can_check', status=AgentCheck.CRITICAL, message=sanitized)
+
+    def test_sanitize_exception_tracebacks(self):
+        # type: () -> None
+        class MyCheck(AgentCheck):
+            def __init__(self, *args, **kwargs):
+                # type: (*Any, **Any) -> None
+                super(MyCheck, self).__init__(*args, **kwargs)
+                self.password = 'p@$$w0rd'
+                self.register_secret(self.password)
+
+            def check(self, instance):
+                # type: (Any) -> None
+                try:
+                    # Simulate a failing call in a dependency.
+                    raise Exception('Could not establish connection with Password={}'.format(self.password))
+                except Exception as exc:
+                    raise RuntimeError('Unexpected error while executing check: {}'.format(exc))
+
+        check = MyCheck('my_check', {}, [{}])
+        result = json.loads(check.run())[0]
+
+        assert check.password not in result['message']
+        assert check.password not in result['traceback']
 
 
 def test_warning_ok():


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add helpers to sanitize any known secrets (i.e. those manipulated by an integration) from logs, service check messages, and exception tracebacks.

### Motivation
<!-- What inspired you to submit this pull request? -->
Make it easier to ensure passwords aren't leaked in logs and UI messages.

Of limited use for credentials contained in URLs (as I believe the Agent already scrubs those?), but most useful for general logs that *might* leak secrets, whether those leaks are known:

https://github.com/DataDog/integrations-core/blob/42ee1d3671668a1a56ae53da07ec32bc43113498/sqlserver/datadog_checks/sqlserver/sqlserver.py#L663-L667

or unknown/possible/unproven: https://github.com/DataDog/integrations-core/pull/5715#discussion_r395663211

In general we should register any password/secret managed by an integration.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
