### PR TITLE
Lazy import of JDBC libraries

### DIFF
--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -125,9 +125,9 @@ class Oracle(AgentCheck):
                 connection = cx_Oracle.connect(connect_string)
             elif JDBC_IMPORT_ERROR:
                 self.log.error(
-                    "Oracle client is unavaible and the integration is unable to import JDBC libraries. You may not"
-                    "have the Microsfot Visual C++ Runtime 2015 installed on your system. Please double check your"
-                    "installation and refer to the Datadog documentation for more information.",
+                    "Oracle client is unavailable and the integration is unable to import JDBC libraries. You may not "
+                    "have the Microsoft Visual C++ Runtime 2015 installed on your system. Please double check your "
+                    "installation and refer to the Datadog documentation for more information."
                 )
                 raise JDBC_IMPORT_ERROR
             else:

--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -5,13 +5,22 @@ import itertools
 from contextlib import closing
 
 import cx_Oracle
-import jaydebeapi as jdb
-import jpype
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.utils.db import QueryManager
 
 from . import queries
+
+try:
+    import jaydebeapi as jdb
+    import jpype
+
+    JDBC_IMPORT_ERROR = None
+except ImportError as e:
+    jdb = None
+    jpype = None
+    JDBC_IMPORT_ERROR = e
+
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'oracle'
 MAX_CUSTOM_RESULTS = 100
@@ -114,6 +123,13 @@ class Oracle(AgentCheck):
         try:
             if use_oracle_client:
                 connection = cx_Oracle.connect(connect_string)
+            elif JDBC_IMPORT_ERROR:
+                self.log.error(
+                    "Oracle client is unavaible and the integration is unable to import JDBC libraries. You may not"
+                    "have the Microsfot Visual C++ Runtime 2015 installed on your system. Please double check your"
+                    "installation and refer to the Datadog documentation for more information.",
+                )
+                raise JDBC_IMPORT_ERROR
             else:
                 try:
                     if jpype.isJVMStarted() and not jpype.isThreadAttachedToJVM():

--- a/oracle/tox.ini
+++ b/oracle/tox.ini
@@ -22,4 +22,5 @@ setenv =
     12.2: ORACLE_DATABASE_VERSION=12.2.0.1
 commands =
     pip install -r requirements.in
+    oracle: pip uninstall -y jpype1 # Should work even if jpype is not installed.
     pytest -v {posargs}


### PR DESCRIPTION
Importing jpype can fail on windows if Microsfot Visual C++ Runtime 2015 is not installed.
Because the oracle integration can work with either the Oracle client or JDBC libraries, this allow users to run the integration with only the Oracle client. It also gives a nicer error when the agent is unable to import the jpype library.