### PR TITLE
Trigger all check builds if branch ends with _ci_all

### DIFF
--- a/.azure-pipelines/all_pr.yml
+++ b/.azure-pipelines/all_pr.yml
@@ -1,7 +1,7 @@
 pr:
   branches:
     include:
-    - master
+    - '*_ci_all'
   paths:
     include:
     - datadog_checks_base/datadog_checks/*

--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -2,8 +2,8 @@ trigger: none
 
 pr:
   branches:
-    include:
-    - master
+    exclude:
+      - '*_ci_all'
   paths:
     exclude:
     - datadog_checks_base/datadog_checks/*


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Trigger all check builds if branch ends with _ci_all

Note: Seems not possible to achieve that using PR title.

### Motivation
<!-- What inspired you to submit this pull request? -->

When many integrations are modified but not `datadog_checks_base`, but might want to trigger all check builds explicitely.

For example: https://github.com/DataDog/integrations-core/pull/6121

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
