### PR TITLE
Allow option to submit histogram/summary sum metric as monotonic count

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -712,7 +712,8 @@ class OpenMetricsScraperMixin(object):
             custom_hostname = self._get_hostname(hostname, sample, scraper_config)
             if sample[self.SAMPLE_NAME].endswith("_sum"):
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname=custom_hostname)
-                self.gauge(
+                self._submit_distribution_count(
+                    scraper_config['send_distribution_sums_as_monotonic'],
                     "{}.{}.sum".format(scraper_config['namespace'], metric_name),
                     val,
                     tags=tags,
@@ -751,7 +752,8 @@ class OpenMetricsScraperMixin(object):
             custom_hostname = self._get_hostname(hostname, sample, scraper_config)
             if sample[self.SAMPLE_NAME].endswith("_sum") and not scraper_config['send_distribution_buckets']:
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname)
-                self.gauge(
+                self._submit_distribution_count(
+                    scraper_config['send_distribution_sums_as_monotonic'],
                     "{}.{}.sum".format(scraper_config['namespace'], metric_name),
                     val,
                     tags=tags,

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -205,6 +205,13 @@ class OpenMetricsScraperMixin(object):
             )
         )
 
+        config['send_distribution_sums_as_monotonic'] = is_affirmative(
+            instance.get(
+                'send_distribution_sums_as_monotonic',
+                default_instance.get('send_distribution_sums_as_monotonic', False),
+            )
+        )
+
         # If the `labels_mapper` dictionary is provided, the metrics labels names
         # in the `labels_mapper` will use the corresponding value as tag name
         # when sending the gauges.

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -404,7 +404,9 @@ def test_submit_summary(aggregator, mocked_prometheus_check, mocked_prometheus_s
     aggregator.assert_all_metrics_covered()
 
 
-def test_submit_summary_with_count_monotonic_count(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+def test_submit_summary_with_count_monotonic_count(
+    aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config
+):
     _sum = SummaryMetricFamily('my_summary', 'Random summary')
     _sum.add_metric([], 5.0, 120512.0)
     _sum.add_sample("my_summary", {"quantile": "0.5"}, 24547.0)
@@ -432,17 +434,19 @@ def test_submit_summary_with_sum_monotonic_count(aggregator, mocked_prometheus_c
     check = mocked_prometheus_check
     mocked_prometheus_scraper_config['send_distribution_sums_as_monotonic'] = True
     check.submit_openmetric('custom.summary', _sum, mocked_prometheus_scraper_config)
+    aggregator.assert_metric('prometheus.custom.summary.count', 5.0, tags=[], count=1, metric_type=aggregator.GAUGE)
     aggregator.assert_metric(
-        'prometheus.custom.summary.count', 5.0, tags=[], count=1, metric_type=aggregator.GAUGE
+        'prometheus.custom.summary.sum', 120512.0, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT
     )
-    aggregator.assert_metric('prometheus.custom.summary.sum', 120512.0, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT)
     aggregator.assert_metric('prometheus.custom.summary.quantile', 24547.0, tags=['quantile:0.5'], count=1)
     aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.9'], count=1)
     aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.99'], count=1)
     aggregator.assert_all_metrics_covered()
 
 
-def test_submit_summary_with_count_sum_monotonic_count(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+def test_submit_summary_with_count_sum_monotonic_count(
+    aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config
+):
     _sum = SummaryMetricFamily('my_summary', 'Random summary')
     _sum.add_metric([], 5.0, 120512.0)
     _sum.add_sample("my_summary", {"quantile": "0.5"}, 24547.0)
@@ -455,7 +459,9 @@ def test_submit_summary_with_count_sum_monotonic_count(aggregator, mocked_promet
     aggregator.assert_metric(
         'prometheus.custom.summary.count', 5.0, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT
     )
-    aggregator.assert_metric('prometheus.custom.summary.sum', 120512.0, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT)
+    aggregator.assert_metric(
+        'prometheus.custom.summary.sum', 120512.0, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT
+    )
     aggregator.assert_metric('prometheus.custom.summary.quantile', 24547.0, tags=['quantile:0.5'], count=1)
     aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.9'], count=1)
     aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.99'], count=1)
@@ -485,7 +491,9 @@ def test_submit_histogram(aggregator, mocked_prometheus_check, mocked_prometheus
     aggregator.assert_all_metrics_covered()
 
 
-def test_submit_histogram_with_count_monotonic_count(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+def test_submit_histogram_with_count_monotonic_count(
+    aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config
+):
     _histo = HistogramMetricFamily('my_histogram', 'my_histogram')
     _histo.add_metric(
         [], buckets=[("-Inf", 0), ("1", 1), ("3.1104e+07", 2), ("4.324e+08", 3), ("+Inf", 4)], sum_value=1337
@@ -525,7 +533,9 @@ def test_submit_histogram_with_count_monotonic_count(aggregator, mocked_promethe
     aggregator.assert_all_metrics_covered()
 
 
-def test_submit_histogram_with_sum_monotonic_count(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+def test_submit_histogram_with_sum_monotonic_count(
+    aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config
+):
     _histo = HistogramMetricFamily('my_histogram', 'my_histogram')
     _histo.add_metric(
         [], buckets=[("-Inf", 0), ("1", 1), ("3.1104e+07", 2), ("4.324e+08", 3), ("+Inf", 4)], sum_value=1337
@@ -533,39 +543,27 @@ def test_submit_histogram_with_sum_monotonic_count(aggregator, mocked_prometheus
     check = mocked_prometheus_check
     mocked_prometheus_scraper_config['send_distribution_sums_as_monotonic'] = True
     check.submit_openmetric('custom.histogram', _histo, mocked_prometheus_scraper_config)
-    aggregator.assert_metric('prometheus.custom.histogram.sum', 1337, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT)
     aggregator.assert_metric(
-        'prometheus.custom.histogram.count',
-        4,
-        tags=['upper_bound:none'],
-        count=1,
-        metric_type=aggregator.GAUGE,
+        'prometheus.custom.histogram.sum', 1337, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT
     )
     aggregator.assert_metric(
-        'prometheus.custom.histogram.count',
-        1,
-        tags=['upper_bound:1.0'],
-        count=1,
-        metric_type=aggregator.GAUGE,
+        'prometheus.custom.histogram.count', 4, tags=['upper_bound:none'], count=1, metric_type=aggregator.GAUGE,
     )
     aggregator.assert_metric(
-        'prometheus.custom.histogram.count',
-        2,
-        tags=['upper_bound:31104000.0'],
-        count=1,
-        metric_type=aggregator.GAUGE,
+        'prometheus.custom.histogram.count', 1, tags=['upper_bound:1.0'], count=1, metric_type=aggregator.GAUGE,
     )
     aggregator.assert_metric(
-        'prometheus.custom.histogram.count',
-        3,
-        tags=['upper_bound:432400000.0'],
-        count=1,
-        metric_type=aggregator.GAUGE,
+        'prometheus.custom.histogram.count', 2, tags=['upper_bound:31104000.0'], count=1, metric_type=aggregator.GAUGE,
+    )
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count', 3, tags=['upper_bound:432400000.0'], count=1, metric_type=aggregator.GAUGE,
     )
     aggregator.assert_all_metrics_covered()
 
 
-def test_submit_histogram_with_count_monotonic_count(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+def test_submit_histogram_with_count_sum_monotonic_count(
+    aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config
+):
     _histo = HistogramMetricFamily('my_histogram', 'my_histogram')
     _histo.add_metric(
         [], buckets=[("-Inf", 0), ("1", 1), ("3.1104e+07", 2), ("4.324e+08", 3), ("+Inf", 4)], sum_value=1337
@@ -574,7 +572,9 @@ def test_submit_histogram_with_count_monotonic_count(aggregator, mocked_promethe
     mocked_prometheus_scraper_config['send_distribution_counts_as_monotonic'] = True
     mocked_prometheus_scraper_config['send_distribution_sums_as_monotonic'] = True
     check.submit_openmetric('custom.histogram', _histo, mocked_prometheus_scraper_config)
-    aggregator.assert_metric('prometheus.custom.histogram.sum', 1337, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT)
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.sum', 1337, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT
+    )
     aggregator.assert_metric(
         'prometheus.custom.histogram.count',
         4,

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -397,14 +397,14 @@ def test_submit_summary(aggregator, mocked_prometheus_check, mocked_prometheus_s
     check = mocked_prometheus_check
     check.submit_openmetric('custom.summary', _sum, mocked_prometheus_scraper_config)
     aggregator.assert_metric('prometheus.custom.summary.count', 5.0, tags=[], count=1, metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('prometheus.custom.summary.sum', 120512.0, tags=[], count=1)
+    aggregator.assert_metric('prometheus.custom.summary.sum', 120512.0, tags=[], count=1, metric_type=aggregator.GAUGE)
     aggregator.assert_metric('prometheus.custom.summary.quantile', 24547.0, tags=['quantile:0.5'], count=1)
     aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.9'], count=1)
     aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.99'], count=1)
     aggregator.assert_all_metrics_covered()
 
 
-def test_submit_summary_with_monotonic_count(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+def test_submit_summary_with_count_monotonic_count(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
     _sum = SummaryMetricFamily('my_summary', 'Random summary')
     _sum.add_metric([], 5.0, 120512.0)
     _sum.add_sample("my_summary", {"quantile": "0.5"}, 24547.0)
@@ -416,7 +416,46 @@ def test_submit_summary_with_monotonic_count(aggregator, mocked_prometheus_check
     aggregator.assert_metric(
         'prometheus.custom.summary.count', 5.0, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT
     )
-    aggregator.assert_metric('prometheus.custom.summary.sum', 120512.0, tags=[], count=1)
+    aggregator.assert_metric('prometheus.custom.summary.sum', 120512.0, tags=[], count=1, metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('prometheus.custom.summary.quantile', 24547.0, tags=['quantile:0.5'], count=1)
+    aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.9'], count=1)
+    aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.99'], count=1)
+    aggregator.assert_all_metrics_covered()
+
+
+def test_submit_summary_with_sum_monotonic_count(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+    _sum = SummaryMetricFamily('my_summary', 'Random summary')
+    _sum.add_metric([], 5.0, 120512.0)
+    _sum.add_sample("my_summary", {"quantile": "0.5"}, 24547.0)
+    _sum.add_sample("my_summary", {"quantile": "0.9"}, 25763.0)
+    _sum.add_sample("my_summary", {"quantile": "0.99"}, 25763.0)
+    check = mocked_prometheus_check
+    mocked_prometheus_scraper_config['send_distribution_sums_as_monotonic'] = True
+    check.submit_openmetric('custom.summary', _sum, mocked_prometheus_scraper_config)
+    aggregator.assert_metric(
+        'prometheus.custom.summary.count', 5.0, tags=[], count=1, metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_metric('prometheus.custom.summary.sum', 120512.0, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT)
+    aggregator.assert_metric('prometheus.custom.summary.quantile', 24547.0, tags=['quantile:0.5'], count=1)
+    aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.9'], count=1)
+    aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.99'], count=1)
+    aggregator.assert_all_metrics_covered()
+
+
+def test_submit_summary_with_count_sum_monotonic_count(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+    _sum = SummaryMetricFamily('my_summary', 'Random summary')
+    _sum.add_metric([], 5.0, 120512.0)
+    _sum.add_sample("my_summary", {"quantile": "0.5"}, 24547.0)
+    _sum.add_sample("my_summary", {"quantile": "0.9"}, 25763.0)
+    _sum.add_sample("my_summary", {"quantile": "0.99"}, 25763.0)
+    check = mocked_prometheus_check
+    mocked_prometheus_scraper_config['send_distribution_counts_as_monotonic'] = True
+    mocked_prometheus_scraper_config['send_distribution_sums_as_monotonic'] = True
+    check.submit_openmetric('custom.summary', _sum, mocked_prometheus_scraper_config)
+    aggregator.assert_metric(
+        'prometheus.custom.summary.count', 5.0, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT
+    )
+    aggregator.assert_metric('prometheus.custom.summary.sum', 120512.0, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT)
     aggregator.assert_metric('prometheus.custom.summary.quantile', 24547.0, tags=['quantile:0.5'], count=1)
     aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.9'], count=1)
     aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.99'], count=1)
@@ -446,7 +485,7 @@ def test_submit_histogram(aggregator, mocked_prometheus_check, mocked_prometheus
     aggregator.assert_all_metrics_covered()
 
 
-def test_submit_histogram_with_monotonic_count(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+def test_submit_histogram_with_count_monotonic_count(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
     _histo = HistogramMetricFamily('my_histogram', 'my_histogram')
     _histo.add_metric(
         [], buckets=[("-Inf", 0), ("1", 1), ("3.1104e+07", 2), ("4.324e+08", 3), ("+Inf", 4)], sum_value=1337
@@ -455,6 +494,87 @@ def test_submit_histogram_with_monotonic_count(aggregator, mocked_prometheus_che
     mocked_prometheus_scraper_config['send_distribution_counts_as_monotonic'] = True
     check.submit_openmetric('custom.histogram', _histo, mocked_prometheus_scraper_config)
     aggregator.assert_metric('prometheus.custom.histogram.sum', 1337, tags=[], count=1)
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count',
+        4,
+        tags=['upper_bound:none'],
+        count=1,
+        metric_type=aggregator.MONOTONIC_COUNT,
+    )
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count',
+        1,
+        tags=['upper_bound:1.0'],
+        count=1,
+        metric_type=aggregator.MONOTONIC_COUNT,
+    )
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count',
+        2,
+        tags=['upper_bound:31104000.0'],
+        count=1,
+        metric_type=aggregator.MONOTONIC_COUNT,
+    )
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count',
+        3,
+        tags=['upper_bound:432400000.0'],
+        count=1,
+        metric_type=aggregator.MONOTONIC_COUNT,
+    )
+    aggregator.assert_all_metrics_covered()
+
+
+def test_submit_histogram_with_sum_monotonic_count(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+    _histo = HistogramMetricFamily('my_histogram', 'my_histogram')
+    _histo.add_metric(
+        [], buckets=[("-Inf", 0), ("1", 1), ("3.1104e+07", 2), ("4.324e+08", 3), ("+Inf", 4)], sum_value=1337
+    )
+    check = mocked_prometheus_check
+    mocked_prometheus_scraper_config['send_distribution_sums_as_monotonic'] = True
+    check.submit_openmetric('custom.histogram', _histo, mocked_prometheus_scraper_config)
+    aggregator.assert_metric('prometheus.custom.histogram.sum', 1337, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT)
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count',
+        4,
+        tags=['upper_bound:none'],
+        count=1,
+        metric_type=aggregator.GAUGE,
+    )
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count',
+        1,
+        tags=['upper_bound:1.0'],
+        count=1,
+        metric_type=aggregator.GAUGE,
+    )
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count',
+        2,
+        tags=['upper_bound:31104000.0'],
+        count=1,
+        metric_type=aggregator.GAUGE,
+    )
+    aggregator.assert_metric(
+        'prometheus.custom.histogram.count',
+        3,
+        tags=['upper_bound:432400000.0'],
+        count=1,
+        metric_type=aggregator.GAUGE,
+    )
+    aggregator.assert_all_metrics_covered()
+
+
+def test_submit_histogram_with_count_monotonic_count(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+    _histo = HistogramMetricFamily('my_histogram', 'my_histogram')
+    _histo.add_metric(
+        [], buckets=[("-Inf", 0), ("1", 1), ("3.1104e+07", 2), ("4.324e+08", 3), ("+Inf", 4)], sum_value=1337
+    )
+    check = mocked_prometheus_check
+    mocked_prometheus_scraper_config['send_distribution_counts_as_monotonic'] = True
+    mocked_prometheus_scraper_config['send_distribution_sums_as_monotonic'] = True
+    check.submit_openmetric('custom.histogram', _histo, mocked_prometheus_scraper_config)
+    aggregator.assert_metric('prometheus.custom.histogram.sum', 1337, tags=[], count=1, metric_type=aggregator.MONOTONIC_COUNT)
     aggregator.assert_metric(
         'prometheus.custom.histogram.count',
         4,

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -94,6 +94,12 @@ instances:
     #
     # send_distribution_counts_as_monotonic: true
 
+    ## @param send_distribution_sums_as_monotonic - boolean - optional - default: false
+    ## Set send_distribution_sums_as_monotonic to true to send histograms & summary
+    ## sum as monotonic counters (instead of gauges).
+    #
+    # send_distribution_sums_as_monotonic: true
+
     ## @param exclude_labels - list of strings - optional
     ## List of label to be excluded
     #


### PR DESCRIPTION
Addresses https://github.com/DataDog/integrations-core/issues/3906#issuecomment-600265468
Prometheus histogram/summary `_sum` metrics are typically always increasing.

This PR introduces an option to submit histogram/summary `_sum` metric as `monotonic_count`. By default, `_sum` metrics are submitted as gauge.
