### PR TITLE
Upgrade `contextlib2` to 0.6.0

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -8,7 +8,7 @@ boto3==1.10.27
 botocore==1.13.42
 clickhouse-cityhash==1.0.2.3
 clickhouse-driver==0.1.2
-contextlib2==0.5.5; python_version < '3.0'
+contextlib2==0.6.0; python_version < '3.0'
 cryptography==2.8
 cx-oracle==7.2.0
 ddtrace==0.32.2

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -1,7 +1,7 @@
 aws-requests-auth==0.4.2
 binary==1.0.0
 botocore==1.13.42
-contextlib2==0.5.5; python_version < '3.0'
+contextlib2==0.6.0; python_version < '3.0'
 ddtrace==0.32.2
 enum34==1.1.6; python_version < '3.0'
 ipaddress==1.0.22; python_version < '3.0'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Upgrade `contextlib2` dependency to 0.6.0.

### Motivation
<!-- What inspired you to submit this pull request? -->
`contextlib==0.6.0` (released Sept 2019) adds a handy backport of `nullcontext`. See [changelog](https://contextlib2.readthedocs.io/en/stable/#id1).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
