### PR TITLE
Add `ddev test` option to verify support of new metrics

### DIFF
--- a/airflow/tests/test_check_metrics_up_to_date.py
+++ b/airflow/tests/test_check_metrics_up_to_date.py
@@ -43,7 +43,7 @@ EXPECTED_METRICS = [
 METRIC_PATTERN = re.compile(r'^``([^`]+)``\s+(.*)', re.MULTILINE)
 
 
-@pytest.mark.check_metrics
+@pytest.mark.latest_metrics
 def test_check_metrics_up_to_date():
     url = 'https://raw.githubusercontent.com/apache/airflow/master/docs/metrics.rst'
     resp = requests.get(url)

--- a/airflow/tests/test_check_metrics_up_to_date.py
+++ b/airflow/tests/test_check_metrics_up_to_date.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import re
 
+import pytest
 import requests
 
 # Make sure this expected metrics list is up to date with:
@@ -42,6 +43,7 @@ EXPECTED_METRICS = [
 METRIC_PATTERN = re.compile(r'^``([^`]+)``\s+(.*)', re.MULTILINE)
 
 
+@pytest.mark.check_metrics
 def test_check_metrics_up_to_date():
     url = 'https://raw.githubusercontent.com/apache/airflow/master/docs/metrics.rst'
     resp = requests.get(url)

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -57,6 +57,7 @@ def test_error_query(instance):
     check.log.error.assert_any_call('Error querying %s: %s', 'system.metrics', mock.ANY)
 
 
+@pytest.mark.check_metrics
 @pytest.mark.parametrize(
     'metrics, ignored_columns, metric_source_url',
     [

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -57,7 +57,7 @@ def test_error_query(instance):
     check.log.error.assert_any_call('Error querying %s: %s', 'system.metrics', mock.ANY)
 
 
-@pytest.mark.check_metrics
+@pytest.mark.latest_metrics
 @pytest.mark.parametrize(
     'metrics, ignored_columns, metric_source_url',
     [

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -237,18 +237,21 @@ def pytest_configure(config):
     config.addinivalue_line('markers', 'unit: marker for unit tests')
     config.addinivalue_line('markers', 'integration: marker for integration tests')
     config.addinivalue_line('markers', 'e2e: marker for end-to-end Datadog Agent tests')
-    config.addinivalue_line("markers", "check_metrics: mark test as checking metrics")
+    config.addinivalue_line("markers", "latest_metrics: mark test as checking metrics")
 
 
 def pytest_addoption(parser):
-    parser.addoption("--run-check-metrics", action="store_true", default=False, help="run check_metrics tests")
+    parser.addoption("--run-latest-metrics", action="store_true", default=False, help="run check_metrics tests")
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--run-check-metrics"):
+    # at test collection time, this function gets called by pytest, see:
+    # https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+    # if the particular option is not present, it will skip all tests marked `latest_metrics`
+    if config.getoption("--run-latest-metrics"):
         # --run-check-metrics given in cli: do not skip slow tests
         return
-    skip_check_metrics = pytest.mark.skip(reason="need --run-check-metrics option to run")
+    skip_latest_metrics = pytest.mark.skip(reason="need --run-latest-metrics option to run")
     for item in items:
-        if "check_metrics" in item.keywords:
-            item.add_marker(skip_check_metrics)
+        if "latest_metrics" in item.keywords:
+            item.add_marker(skip_latest_metrics)

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -237,7 +237,7 @@ def pytest_configure(config):
     config.addinivalue_line('markers', 'unit: marker for unit tests')
     config.addinivalue_line('markers', 'integration: marker for integration tests')
     config.addinivalue_line('markers', 'e2e: marker for end-to-end Datadog Agent tests')
-    config.addinivalue_line("markers", "latest_metrics: mark test as checking metrics")
+    config.addinivalue_line("markers", "latest_metrics: marker for verifying support of new metrics")
 
 
 def pytest_addoption(parser):

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -237,3 +237,18 @@ def pytest_configure(config):
     config.addinivalue_line('markers', 'unit: marker for unit tests')
     config.addinivalue_line('markers', 'integration: marker for integration tests')
     config.addinivalue_line('markers', 'e2e: marker for end-to-end Datadog Agent tests')
+    config.addinivalue_line("markers", "check_metrics: mark test as checking metrics")
+
+
+def pytest_addoption(parser):
+    parser.addoption("--run-check-metrics", action="store_true", default=False, help="run check_metrics tests")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-check-metrics"):
+        # --run-check-metrics given in cli: do not skip slow tests
+        return
+    skip_check_metrics = pytest.mark.skip(reason="need --run-check-metrics option to run")
+    for item in items:
+        if "check_metrics" in item.keywords:
+            item.add_marker(skip_check_metrics)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -27,7 +27,7 @@ def display_envs(check_envs):
 @click.option('--format-style', '-fs', is_flag=True, help='Run only the code style formatter')
 @click.option('--style', '-s', is_flag=True, help='Run only style checks')
 @click.option('--bench', '-b', is_flag=True, help='Run only benchmarks')
-@click.option('--latest-metrics', is_flag=True, help='Run only metrics validation tests')
+@click.option('--latest-metrics', is_flag=True, help='Only verify support of new metrics')
 @click.option('--e2e', is_flag=True, help='Run only end-to-end tests')
 @click.option('--cov', '-c', 'coverage', is_flag=True, help='Measure code coverage')
 @click.option('--cov-missing', '-cm', is_flag=True, help='Show line numbers of statements that were not executed')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -27,6 +27,7 @@ def display_envs(check_envs):
 @click.option('--format-style', '-fs', is_flag=True, help='Run only the code style formatter')
 @click.option('--style', '-s', is_flag=True, help='Run only style checks')
 @click.option('--bench', '-b', is_flag=True, help='Run only benchmarks')
+@click.option('--check-metrics', is_flag=True, help='Run only metrics validation tests')
 @click.option('--e2e', is_flag=True, help='Run only end-to-end tests')
 @click.option('--cov', '-c', 'coverage', is_flag=True, help='Measure code coverage')
 @click.option('--cov-missing', '-cm', is_flag=True, help='Show line numbers of statements that were not executed')
@@ -49,6 +50,7 @@ def test(
     format_style,
     style,
     bench,
+    check_metrics,
     e2e,
     coverage,
     junit,
@@ -150,6 +152,7 @@ def test(
             enter_pdb=enter_pdb,
             debug=debug,
             bench=bench,
+            check_metrics=check_metrics,
             coverage=coverage,
             junit=junit,
             marker=marker,

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -27,7 +27,7 @@ def display_envs(check_envs):
 @click.option('--format-style', '-fs', is_flag=True, help='Run only the code style formatter')
 @click.option('--style', '-s', is_flag=True, help='Run only style checks')
 @click.option('--bench', '-b', is_flag=True, help='Run only benchmarks')
-@click.option('--check-metrics', is_flag=True, help='Run only metrics validation tests')
+@click.option('--latest-metrics', is_flag=True, help='Run only metrics validation tests')
 @click.option('--e2e', is_flag=True, help='Run only end-to-end tests')
 @click.option('--cov', '-c', 'coverage', is_flag=True, help='Measure code coverage')
 @click.option('--cov-missing', '-cm', is_flag=True, help='Show line numbers of statements that were not executed')
@@ -50,7 +50,7 @@ def test(
     format_style,
     style,
     bench,
-    check_metrics,
+    latest_metrics,
     e2e,
     coverage,
     junit,
@@ -152,7 +152,7 @@ def test(
             enter_pdb=enter_pdb,
             debug=debug,
             bench=bench,
-            check_metrics=check_metrics,
+            latest_metrics=latest_metrics,
             coverage=coverage,
             junit=junit,
             marker=marker,
@@ -174,6 +174,8 @@ def test(
                 test_type_display = 'only style checks'
             elif bench:
                 test_type_display = 'only benchmarks'
+            elif latest_metrics:
+                test_type_display = 'only latest metrics validation'
             elif e2e:
                 test_type_display = 'only end-to-end tests'
             else:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -181,6 +181,7 @@ def construct_pytest_options(
     enter_pdb=False,
     debug=False,
     bench=False,
+    check_metrics=False,
     coverage=False,
     junit=False,
     marker='',
@@ -208,6 +209,10 @@ def construct_pytest_options(
         pytest_options += ' --benchmark-only --benchmark-cprofile=tottime'
     else:
         pytest_options += ' --benchmark-skip'
+
+    if check_metrics:
+        pytest_options += ' --run-check-metrics'
+        marker = 'check_metrics'
 
     if junit:
         test_group = 'e2e' if e2e else 'unit'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -181,7 +181,7 @@ def construct_pytest_options(
     enter_pdb=False,
     debug=False,
     bench=False,
-    check_metrics=False,
+    latest_metrics=False,
     coverage=False,
     junit=False,
     marker='',
@@ -210,9 +210,9 @@ def construct_pytest_options(
     else:
         pytest_options += ' --benchmark-skip'
 
-    if check_metrics:
-        pytest_options += ' --run-check-metrics'
-        marker = 'check_metrics'
+    if latest_metrics:
+        pytest_options += ' --run-latest-metrics'
+        marker = 'latest_metrics'
 
     if junit:
         test_group = 'e2e' if e2e else 'unit'


### PR DESCRIPTION
### What does this PR do?
Adds a new option to `ddev test` called `--check-metrics`.  

When the flag is present, only tests marked by `@pytest.mark.check_metrics` will run.

### Motivation
The original motivation for these tests were to ensure that we kept ahead of new developments for the integrations.  However, it's turned out that development on these areas progresses a little more frequently than expected, and running these tests as part of our usual CI runs can make things noisy and require fixes more quickly than really needed.

Adding this option will move the checks out of regular CI execution, and a separate PR will then be setup to schedule them for periodic execution so we still maintain the insight when new metrics get added and can schedule a fix accordingly.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
