### PR TITLE
Use a faster JSON library

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -31,6 +31,7 @@ lxml==4.4.1
 lz4==2.2.1
 meld3==1.0.2
 openstacksdk==0.24.0
+orjson==2.6.1; python_version > '3.0'
 paramiko==2.6.0
 ply==3.10
 prometheus-client==0.3.0

--- a/datadog_checks_base/datadog_checks/base/utils/serialization.py
+++ b/datadog_checks_base/datadog_checks/base/utils/serialization.py
@@ -1,0 +1,10 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+try:
+    import orjson as json
+except ImportError:
+    import json
+
+
+__all__ = ['json']

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -6,6 +6,7 @@ ddtrace==0.32.2
 enum34==1.1.6; python_version < '3.0'
 ipaddress==1.0.22; python_version < '3.0'
 kubernetes==8.0.1
+orjson==2.6.1; python_version > '3.0'
 prometheus-client==0.3.0
 protobuf==3.7.0
 pysocks==1.7.0

--- a/twistlock/datadog_checks/twistlock/twistlock.py
+++ b/twistlock/datadog_checks/twistlock/twistlock.py
@@ -14,6 +14,11 @@ from datadog_checks.base import AgentCheck
 from .config import Config
 from .utils import normalize_api_data_inplace
 
+try:
+    import orjson as json
+except ImportError:
+    import json
+
 DOCKERIO_PREFIX = "docker.io/"
 
 # min_severity tag allows to query number of vulns for a severity target easily
@@ -322,7 +327,7 @@ class TwistlockCheck(AgentCheck):
         try:
             # it's possible to get a null response from the server
             # {} is a bit easier to deal with
-            j = response.json() or {}
+            j = json.loads(response.content) or {}
             if 'err' in j:
                 err_msg = "Error in response: {}".format(j.get("err"))
                 self.log.error(err_msg)

--- a/twistlock/datadog_checks/twistlock/twistlock.py
+++ b/twistlock/datadog_checks/twistlock/twistlock.py
@@ -10,14 +10,10 @@ from dateutil import parser, tz
 from six import iteritems
 
 from datadog_checks.base import AgentCheck
+from datadog_checks.base.utils.serialization import json
 
 from .config import Config
 from .utils import normalize_api_data_inplace
-
-try:
-    import orjson as json
-except ImportError:
-    import json
 
 DOCKERIO_PREFIX = "docker.io/"
 

--- a/twistlock/requirements.in
+++ b/twistlock/requirements.in
@@ -1,1 +1,2 @@
 python-dateutil==2.8.0
+orjson==2.6.1; python_version > '3.0'

--- a/twistlock/requirements.in
+++ b/twistlock/requirements.in
@@ -1,2 +1,1 @@
 python-dateutil==2.8.0
-orjson==2.6.1; python_version > '3.0'

--- a/twistlock/tests/test_twistlock.py
+++ b/twistlock/tests/test_twistlock.py
@@ -8,6 +8,7 @@ import os
 import mock
 import pytest
 
+from datadog_checks.base import ensure_bytes
 from datadog_checks.dev import get_here
 from datadog_checks.twistlock import TwistlockCheck
 
@@ -46,6 +47,10 @@ class MockResponse:
         self.text = j
         self._json = j
         self.status_code = 200
+
+    @property
+    def content(self):
+        return ensure_bytes(self._json)
 
     def json(self):
         return json.loads(self._json)


### PR DESCRIPTION
### Motivation

We parse JSON from multiple endpoints, with each payload being many MiB in size. Some users in resource constrained environments are experiencing abnormally high CPU usage. A more efficient parser should ameliorate that.

### Additional Notes

[orjson](https://github.com/ijl/orjson) is currently the fastest JSON library available for Python, while also being the least resource-intensive (especially regarding memory). It achieves this by virtue of being a light wrapper around Rust's https://serde.rs

Other Python projects are beginning to [recommend](https://github.com/hynek/structlog/pull/247) and [use](https://fastapi.tiangolo.com/advanced/custom-response/#use-orjsonresponse) it too

See: https://github.com/ijl/orjson#performance