### PR TITLE
Cast to float before computing temporal percent

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/transform.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/transform.py
@@ -74,7 +74,7 @@ def get_temporal_percent(transformers, column_name, **modifiers):
     rate = transformers['rate'](transformers, column_name, **modifiers)
 
     def temporal_percent(_, value, **kwargs):
-        rate(_, total_time_to_temporal_percent(value, scale=scale), **kwargs)
+        rate(_, total_time_to_temporal_percent(float(value), scale=scale), **kwargs)
 
     return temporal_percent
 

--- a/datadog_checks_base/tests/test_db.py
+++ b/datadog_checks_base/tests/test_db.py
@@ -1283,6 +1283,28 @@ class TestColumnTransformers:
         )
         aggregator.assert_all_metrics_covered()
 
+    def test_temporal_percent_cast_to_float(self, aggregator):
+        query_manager = create_query_manager(
+            {
+                'name': 'test query',
+                'query': 'foo',
+                'columns': [
+                    {'name': 'test', 'type': 'tag'},
+                    {'name': 'test.foo', 'type': 'temporal_percent', 'scale': 1},
+                ],
+                'tags': ['test:bar'],
+            },
+            executor=mock_executor([['tag1', '5.2']]),
+            tags=['test:foo'],
+        )
+        query_manager.compile_queries()
+        query_manager.execute()
+
+        aggregator.assert_metric(
+            'test.foo', 520, metric_type=aggregator.RATE, tags=['test:foo', 'test:bar', 'test:tag1']
+        )
+        aggregator.assert_all_metrics_covered()
+
     def test_match_global(self, aggregator):
         query_manager = create_query_manager(
             {


### PR DESCRIPTION
When using temporal percent with the QueryManager, the whole `executor` will raise an Exception when the value is not a number.

Some libraries (i.e pymysql) always return strings , so it's worth trying to cast to float first.

Note that this is similar to other submissions methods like `gauge`, `rate` etc., the base class tries to cast to float any value that is receives.