### PR TITLE
Adding "kerberos" as an auth_type

### DIFF
--- a/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
@@ -82,7 +82,7 @@ instances:
 
     ## @param auth_type - string - optional
     ## The type of authentication to use.
-    ## The available values are "basic" and "digest".
+    ## The available values are "basic", "digest" and "kerberos".
     #
     # auth_type: <AUTH_TYPE>
 

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
@@ -82,7 +82,7 @@ instances:
 
     ## @param auth_type - string - optional
     ## The type of authentication to use.
-    ## The available values are "basic" and "digest".
+    ## The available values are "basic", "digest" and "kerberos".
     #
     # auth_type: <AUTH_TYPE>
 


### PR DESCRIPTION
### What does this PR do?
Documentation update, adding "kerberos" as an auth_type. in  
- hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example 
- hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example 

### Motivation
One of our customers noticed the following warning message : 
`WARN | (pkg/collector/python/datadog_agent.go:118 in LogMessage) | hdfs_namenode:##### | (http.py:183) | The ability to use Kerberos auth without explicitly setting auth_type to `kerberos` is deprecated and will be removed in Agent 8`
I believe that this should be added as "basic" and "digest" are not the only possible values here.

### Additional Notes
this is preventive regarding the release of agent 8.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
