### PR TITLE
Add weekly metrics check to CI

### DIFF
--- a/.azure-pipelines/latest_metrics.yml
+++ b/.azure-pipelines/latest_metrics.yml
@@ -11,9 +11,11 @@ variables:
   DDEV_COLOR: 1
 
 jobs:
-- template: './templates/test-all-checks.yml'
+- template: './templates/test-single-linux.yml'
   parameters:
     job_name: Weekly Metrics Validation
+    display: Linux
+    check: 'airflow clickhouse'
     latest_metrics: true
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'

--- a/.azure-pipelines/latest_metrics.yml
+++ b/.azure-pipelines/latest_metrics.yml
@@ -1,6 +1,6 @@
 schedules:
- - cron: "0 23 * * 0"
-   displayName: Weekly CI (Sunday night UTC)
+- cron: "0 5 * * 1"
+  displayName: Weekly (Sunday night EDT/EST)
   always: true
   branches:
     include:

--- a/.azure-pipelines/latest_metrics.yml
+++ b/.azure-pipelines/latest_metrics.yml
@@ -1,10 +1,10 @@
 schedules:
  - cron: "0 23 * * 0"
    displayName: Weekly CI (Sunday night UTC)
-   always: true
-   branches:
-     include:
-     - master
+  always: true
+  branches:
+    include:
+    - master
 
 variables:
   PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -4,6 +4,7 @@ parameters:
   test: false
   test_e2e: false
   benchmark: false
+  latest_metrics: false
   repo: ''
 
 steps:
@@ -27,6 +28,10 @@ steps:
 - ${{ if eq(parameters.benchmark, 'true') }}:
   - script: ddev test --bench --junit ${{ parameters.check }}
     displayName: 'Run benchmarks'
+
+- ${{ if eq(parameters.latest_metrics, 'true') }}:
+    - script: ddev test --latest-metrics --junit ${{ parameters.check }}
+      displayName: 'Verify latest metrics supported'
 
 - task: PublishTestResults@2 # Task info: https://docs.microsoft.com/en-gb/azure/devops/pipelines/tasks/test/publish-test-results
   condition: succeededOrFailed()

--- a/.azure-pipelines/weekly.yml
+++ b/.azure-pipelines/weekly.yml
@@ -1,0 +1,22 @@
+schedules:
+ - cron: "0 23 * * 0"
+   displayName: Weekly CI (Sunday night UTC)
+   always: true
+   branches:
+     include:
+     - master
+
+variables:
+  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
+  DDEV_COLOR: 1
+
+jobs:
+- template: './templates/test-all-checks.yml'
+  parameters:
+    job_name: Weekly Metrics Validation
+    latest_metrics: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)


### PR DESCRIPTION
### What does this PR do?
Depends on #6141 being merged - this schedules that option to be run on a weekly basis across all checks.

This will test all checks, but everything will be skipped unless it has a test marked `pytest.mark.latest_metrics`

This seemed easier than manually updating a config file when new checks with these tests are added, but it would certainly reduce the extra test burden if we did it that way too.
