### PR TITLE
Add `service_check_prefix` config to jmx

### DIFF
--- a/activemq/datadog_checks/activemq/data/conf.yaml.example
+++ b/activemq/datadog_checks/activemq/data/conf.yaml.example
@@ -12,6 +12,14 @@ init_config:
     #
     collect_default_metrics: true
 
+    ## @param service_check_prefix - string - optional
+    ## Custom service check prefix.
+    ##   e.g. `my_prefix.can_connect`
+    ## If not set, the default service check used if the integration name.
+    ##   e.g. `my_integration.can_connect`
+    #
+    # service_check_prefix: <SERVICE_CHECK_PREFIX>
+
     ## @param conf - list of mappings - optional
     ## The list of metrics to be collected by the integration
     ## Read http://docs.datadoghq.com/integrations/java/ to learn how to customize it

--- a/activemq/datadog_checks/activemq/data/conf.yaml.example
+++ b/activemq/datadog_checks/activemq/data/conf.yaml.example
@@ -13,10 +13,8 @@ init_config:
     collect_default_metrics: true
 
     ## @param service_check_prefix - string - optional
-    ## Custom service check prefix.
-    ##   e.g. `my_prefix.can_connect`
-    ## If not set, the default service check used if the integration name.
-    ##   e.g. `my_integration.can_connect`
+    ## Custom service check prefix. e.g. `my_prefix.can_connect`
+    ## If not set, the default service check used is the integration name.
     #
     # service_check_prefix: <SERVICE_CHECK_PREFIX>
 

--- a/activemq/datadog_checks/activemq/data/conf.yaml.example
+++ b/activemq/datadog_checks/activemq/data/conf.yaml.example
@@ -13,7 +13,7 @@ init_config:
     collect_default_metrics: true
 
     ## @param service_check_prefix - string - optional
-    ## Custom service check prefix. e.g. `my_prefix.can_connect`
+    ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.
     ## If not set, the default service check used is the integration name.
     #
     # service_check_prefix: <SERVICE_CHECK_PREFIX>

--- a/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
+++ b/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
@@ -12,6 +12,14 @@ init_config:
     #
     collect_default_metrics: true
 
+    ## @param service_check_prefix - string - optional
+    ## Custom service check prefix.
+    ##   e.g. `my_prefix.can_connect`
+    ## If not set, the default service check used if the integration name.
+    ##   e.g. `my_integration.can_connect`
+    #
+    # service_check_prefix: <SERVICE_CHECK_PREFIX>
+
     ## @param conf - list of mappings - optional
     ## The list of metrics to be collected by the integration
     ## Read http://docs.datadoghq.com/integrations/java/ to learn how to customize it

--- a/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
+++ b/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
@@ -13,10 +13,8 @@ init_config:
     collect_default_metrics: true
 
     ## @param service_check_prefix - string - optional
-    ## Custom service check prefix.
-    ##   e.g. `my_prefix.can_connect`
-    ## If not set, the default service check used if the integration name.
-    ##   e.g. `my_integration.can_connect`
+    ## Custom service check prefix. e.g. `my_prefix.can_connect`
+    ## If not set, the default service check used is the integration name.
     #
     # service_check_prefix: <SERVICE_CHECK_PREFIX>
 

--- a/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
+++ b/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
@@ -13,7 +13,7 @@ init_config:
     collect_default_metrics: true
 
     ## @param service_check_prefix - string - optional
-    ## Custom service check prefix. e.g. `my_prefix.can_connect`
+    ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.
     ## If not set, the default service check used is the integration name.
     #
     # service_check_prefix: <SERVICE_CHECK_PREFIX>

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
@@ -10,6 +10,14 @@
   value:
     example: true
     type: boolean
+- name: service_check_prefix
+  description: |
+    Custom service check prefix.
+      e.g. `my_prefix.can_connect`
+    If not set, the default service check used if the integration name.
+      e.g. `my_integration.can_connect`
+  value:
+    type: string
 - name: conf
   description: |
     The list of metrics to be collected by the integration

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
@@ -12,10 +12,8 @@
     type: boolean
 - name: service_check_prefix
   description: |
-    Custom service check prefix.
-      e.g. `my_prefix.can_connect`
-    If not set, the default service check used if the integration name.
-      e.g. `my_integration.can_connect`
+    Custom service check prefix. e.g. `my_prefix.can_connect`
+    If not set, the default service check used is the integration name.
   value:
     type: string
 - name: conf

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
@@ -12,7 +12,7 @@
     type: boolean
 - name: service_check_prefix
   description: |
-    Custom service check prefix. e.g. `my_prefix.can_connect`
+    Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.
     If not set, the default service check used is the integration name.
   value:
     type: string

--- a/hive/datadog_checks/hive/data/conf.yaml.example
+++ b/hive/datadog_checks/hive/data/conf.yaml.example
@@ -12,6 +12,14 @@ init_config:
     #
     collect_default_metrics: true
 
+    ## @param service_check_prefix - string - optional
+    ## Custom service check prefix.
+    ##   e.g. `my_prefix.can_connect`
+    ## If not set, the default service check used if the integration name.
+    ##   e.g. `my_integration.can_connect`
+    #
+    # service_check_prefix: <SERVICE_CHECK_PREFIX>
+
     ## @param conf - list of mappings - optional
     ## The list of metrics to be collected by the integration
     ## Read http://docs.datadoghq.com/integrations/java/ to learn how to customize it

--- a/hive/datadog_checks/hive/data/conf.yaml.example
+++ b/hive/datadog_checks/hive/data/conf.yaml.example
@@ -13,10 +13,8 @@ init_config:
     collect_default_metrics: true
 
     ## @param service_check_prefix - string - optional
-    ## Custom service check prefix.
-    ##   e.g. `my_prefix.can_connect`
-    ## If not set, the default service check used if the integration name.
-    ##   e.g. `my_integration.can_connect`
+    ## Custom service check prefix. e.g. `my_prefix.can_connect`
+    ## If not set, the default service check used is the integration name.
     #
     # service_check_prefix: <SERVICE_CHECK_PREFIX>
 

--- a/hive/datadog_checks/hive/data/conf.yaml.example
+++ b/hive/datadog_checks/hive/data/conf.yaml.example
@@ -13,7 +13,7 @@ init_config:
     collect_default_metrics: true
 
     ## @param service_check_prefix - string - optional
-    ## Custom service check prefix. e.g. `my_prefix.can_connect`
+    ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.
     ## If not set, the default service check used is the integration name.
     #
     # service_check_prefix: <SERVICE_CHECK_PREFIX>


### PR DESCRIPTION
### What does this PR do?
Add `service_check_prefix` config to jmx

Need this PR to be merged first https://github.com/DataDog/jmxfetch/pull/284

### Motivation

Needed for integration with prefix that is different than the integration name e.g. `Confluent Platform` uses `confluent` as prefix.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
