### PR TITLE
Fix e2e test

### DIFF
--- a/activemq/assets/configuration/spec.yaml
+++ b/activemq/assets/configuration/spec.yaml
@@ -9,6 +9,9 @@ files:
   - template: instances
     options:
     - template: instances/jmx
+      overrides:
+        host.value.example: localhost
+        port.value.example: 1616
     - template: instances/default
   - template: logs
     example:

--- a/activemq/datadog_checks/activemq/data/conf.yaml.example
+++ b/activemq/datadog_checks/activemq/data/conf.yaml.example
@@ -40,12 +40,12 @@ instances:
     ## @param host - string - required
     ## JMX hostname to connect to.
     #
-  - host: <HOST>
+  - host: localhost
 
     ## @param port - integer - required
     ## JMX port to connect to.
     #
-    port: <PORT>
+    port: 1616
 
     ## @param user - string - optional
     ## User to use when connecting to JMX.

--- a/activemq/tests/conftest.py
+++ b/activemq/tests/conftest.py
@@ -31,10 +31,19 @@ def populate_server():
 @pytest.fixture(scope="session")
 def dd_environment():
     envs = {'JMX_PORT': str(JMX_PORT)}
+    compose_file = os.path.join(HERE, 'compose', 'docker-compose.yaml')
     with docker_run(
-        os.path.join(HERE, 'compose', 'docker-compose.yaml'),
+        compose_file,
         log_patterns=['ActiveMQ Jolokia REST API available'],
-        conditions=[WaitForPortListening(HOST, TEST_PORT), populate_server],
+        conditions=[
+            WaitForPortListening(HOST, TEST_PORT),
+            populate_server,
+        ],
         env_vars=envs,
     ):
-        yield load_jmx_config(), {'use_jmx': True}
+        config = load_jmx_config()
+        config['instances'][0].update({
+            'port': str(JMX_PORT),
+            'host': HOST
+        })
+        yield config, {'use_jmx': True}

--- a/activemq/tests/conftest.py
+++ b/activemq/tests/conftest.py
@@ -35,15 +35,9 @@ def dd_environment():
     with docker_run(
         compose_file,
         log_patterns=['ActiveMQ Jolokia REST API available'],
-        conditions=[
-            WaitForPortListening(HOST, TEST_PORT),
-            populate_server,
-        ],
+        conditions=[WaitForPortListening(HOST, TEST_PORT), populate_server],
         env_vars=envs,
     ):
         config = load_jmx_config()
-        config['instances'][0].update({
-            'port': str(JMX_PORT),
-            'host': HOST
-        })
+        config['instances'][0].update({'port': str(JMX_PORT), 'host': HOST})
         yield config, {'use_jmx': True}


### PR DESCRIPTION
The e2e test was relying on the sample configuration default values that were changed to a placeholder when introducing specs here https://github.com/DataDog/integrations-core/pull/6115/files

This PR:
* reintroduces default values as they might be useful to users
* makes e2e test resilient to changes in the sample config file by explicitly setting host and port