### PR TITLE
Include moved files to changed files

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -39,11 +39,14 @@ def files_changed():
     Return the list of file changed in the current branch compared to `master`
     """
     with chdir(get_root()):
-        result = run_command('git diff --name-only master...', capture='out')
-    changed_files = result.stdout.splitlines()
+        result = run_command('git diff --name-status master...', capture='out')
+    status_lines = result.stdout.splitlines()
 
-    # Remove empty lines
-    return [f for f in changed_files if f]
+    changed_files = []
+    for l in status_lines:
+        files = l.split('\t')[1:]  # skip first element representing the type of change
+        changed_files.extend(files)
+    return sorted([f for f in changed_files if f])
 
 
 def get_commits_since(check_name, target_tag=None):

--- a/datadog_checks_dev/tests/tooling/test_git.py
+++ b/datadog_checks_dev/tests/tooling/test_git.py
@@ -30,13 +30,16 @@ def test_files_changed():
     with mock.patch('datadog_checks.dev.tooling.git.chdir') as chdir:
         with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
             run.return_value = mock.MagicMock()
-            expected = ['foo', 'bar', 'baz']
-            run.return_value.stdout = "\n".join(expected)
+            run.return_value.stdout = '''
+M	foo
+R100	bar	baz
+R100	foo2	foo3
+            '''
             set_root('/foo/')
             retval = files_changed()
             chdir.assert_called_once_with('/foo/')
-            run.assert_called_once_with('git diff --name-only master...', capture='out')
-            assert retval == expected
+            run.assert_called_once_with('git diff --name-status master...', capture='out')
+            assert sorted(retval) == sorted(['foo', 'bar', 'baz', 'foo2', 'foo3'])
 
 
 def test_get_commits_since():

--- a/datadog_checks_dev/tests/tooling/test_git.py
+++ b/datadog_checks_dev/tests/tooling/test_git.py
@@ -39,7 +39,7 @@ R100	foo2	foo3
             retval = files_changed()
             chdir.assert_called_once_with('/foo/')
             run.assert_called_once_with('git diff --name-status master...', capture='out')
-            assert sorted(retval) == sorted(['foo', 'bar', 'baz', 'foo2', 'foo3'])
+            assert retval == ['bar', 'baz', 'foo', 'foo2', 'foo3']
 
 
 def test_get_commits_since():


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Include moved files to changed files

### Motivation
<!-- What inspired you to submit this pull request? -->

Currently, `git diff --name-only` doesn't include moved files that should also be considered as a change.

Use case: if we move a file from `datadog_checks_base` to `datadog_checks_dev`

Example:

```
$ git checkout -b test_branch
$ mv datadog_checks_base/datadog_checks/log.py datadog_checks_dev/datadog_checks/log.py
$ git add -A
$ git commit -m 'change'
```

At this point, if you run `ddev test`, it will only test `datadog_checks_dev`, but it should also test `datadog_checks_base`

Output of git diff commands for this example:
```
$ git diff --name-only master..HEAD | cat
datadog_checks_dev/datadog_checks/log.py
$ git diff --name-status master..HEAD | cat
R100	datadog_checks_base/datadog_checks/log.py	datadog_checks_dev/datadog_checks/log.py
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
