### PR TITLE
Include gitlab host and port tag for all metrics

### DIFF
--- a/gitlab/datadog_checks/gitlab/gitlab.py
+++ b/gitlab/datadog_checks/gitlab/gitlab.py
@@ -99,9 +99,12 @@ class GitlabCheck(OpenMetricsBaseCheck):
         custom_tags = instance.get('tags', [])
 
         url = instance.get('gitlab_url')
+
+        # creating tags for host and port
         parsed_url = urlparse(url)
         gitlab_host = parsed_url.hostname
         gitlab_port = 443 if parsed_url.scheme == 'https' else (parsed_url.port or 80)
+
         return ['gitlab_host:{}'.format(gitlab_host), 'gitlab_port:{}'.format(gitlab_port)] + custom_tags
 
     def submit_version(self, instance):

--- a/gitlab/tests/test_integration_e2e.py
+++ b/gitlab/tests/test_integration_e2e.py
@@ -30,7 +30,9 @@ def assert_check(aggregator, metrics):
         )
 
     # Make sure we're receiving prometheus service checks
-    aggregator.assert_service_check(GitlabCheck.PROMETHEUS_SERVICE_CHECK_NAME, status=GitlabCheck.OK, tags=CUSTOM_TAGS)
+    aggregator.assert_service_check(
+        GitlabCheck.PROMETHEUS_SERVICE_CHECK_NAME, status=GitlabCheck.OK, tags=GITLAB_TAGS + CUSTOM_TAGS
+    )
 
     for metric in metrics:
         aggregator.assert_metric("gitlab.{}".format(metric))


### PR DESCRIPTION
### What does this PR do?

Include github host and port tags for all metrics.

### Motivation
We used to only send them for service checks, but they're useful for all metrics.

### Additional Notes
This could be a config flag with a default value of true, so people have the option to disable sending the tags.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
