### PR TITLE
Adding maxwait_us, total_wait_time, and avg_wait_time metrics

### DIFF
--- a/pgbouncer/datadog_checks/pgbouncer/metrics.py
+++ b/pgbouncer/datadog_checks/pgbouncer/metrics.py
@@ -40,6 +40,7 @@ POOLS_METRICS = {
         ('sv_tested', ('pgbouncer.pools.sv_tested', GAUGE)),
         ('sv_login', ('pgbouncer.pools.sv_login', GAUGE)),
         ('maxwait', ('pgbouncer.pools.maxwait', GAUGE)),
+        ('maxwait_us', ('pgbouncer.pools.maxwait_us', GAUGE)),
     ],
     'query': """SHOW POOLS""",
 }

--- a/pgbouncer/datadog_checks/pgbouncer/metrics.py
+++ b/pgbouncer/datadog_checks/pgbouncer/metrics.py
@@ -17,7 +17,7 @@ STATS_METRICS = {
         ('total_sent', ('pgbouncer.stats.bytes_sent_per_second', RATE)),
         ('total_query_time', ('pgbouncer.stats.total_query_time', RATE)),
         ('total_xact_time', ('pgbouncer.stats.total_transaction_time', RATE)),  # >= 1.8
-        ('total_wait_time', ('pgbouncer.stats.total_wait_time' GAUGE)),
+        ('total_wait_time', ('pgbouncer.stats.total_wait_time', RATE)),
         ('avg_req', ('pgbouncer.stats.avg_req', GAUGE)),  # < 1.8
         ('avg_xact_count', ('pgbouncer.stats.avg_transaction_count', GAUGE)),  # >= 1.8
         ('avg_query_count', ('pgbouncer.stats.avg_query_count', GAUGE)),  # >= 1.8

--- a/pgbouncer/datadog_checks/pgbouncer/metrics.py
+++ b/pgbouncer/datadog_checks/pgbouncer/metrics.py
@@ -21,7 +21,7 @@ STATS_METRICS = {
         ('avg_req', ('pgbouncer.stats.avg_req', GAUGE)),  # < 1.8
         ('avg_xact_count', ('pgbouncer.stats.avg_transaction_count', GAUGE)),  # >= 1.8
         ('avg_query_count', ('pgbouncer.stats.avg_query_count', GAUGE)),  # >= 1.8
-        ('avg_wait_time', ('pgbouncer.stats.avg_wait_time', GAUGE)),
+        ('avg_wait_time', ('pgbouncer.stats.avg_wait_time', GAUGE)),  # >= 1.8
         ('avg_recv', ('pgbouncer.stats.avg_recv', GAUGE)),
         ('avg_sent', ('pgbouncer.stats.avg_sent', GAUGE)),
         ('avg_query', ('pgbouncer.stats.avg_query', GAUGE)),  # < 1.8

--- a/pgbouncer/datadog_checks/pgbouncer/metrics.py
+++ b/pgbouncer/datadog_checks/pgbouncer/metrics.py
@@ -21,7 +21,7 @@ STATS_METRICS = {
         ('avg_req', ('pgbouncer.stats.avg_req', GAUGE)),  # < 1.8
         ('avg_xact_count', ('pgbouncer.stats.avg_transaction_count', GAUGE)),  # >= 1.8
         ('avg_query_count', ('pgbouncer.stats.avg_query_count', GAUGE)),  # >= 1.8
-        ('avg_wait_time', ('pgbouncer.stats.avg_wait_time' GAUGE)),
+        ('avg_wait_time', ('pgbouncer.stats.avg_wait_time', GAUGE)),
         ('avg_recv', ('pgbouncer.stats.avg_recv', GAUGE)),
         ('avg_sent', ('pgbouncer.stats.avg_sent', GAUGE)),
         ('avg_query', ('pgbouncer.stats.avg_query', GAUGE)),  # < 1.8

--- a/pgbouncer/datadog_checks/pgbouncer/metrics.py
+++ b/pgbouncer/datadog_checks/pgbouncer/metrics.py
@@ -17,9 +17,11 @@ STATS_METRICS = {
         ('total_sent', ('pgbouncer.stats.bytes_sent_per_second', RATE)),
         ('total_query_time', ('pgbouncer.stats.total_query_time', RATE)),
         ('total_xact_time', ('pgbouncer.stats.total_transaction_time', RATE)),  # >= 1.8
+        ('total_wait_time', ('pgbouncer.stats.total_wait_time' GAUGE)),
         ('avg_req', ('pgbouncer.stats.avg_req', GAUGE)),  # < 1.8
         ('avg_xact_count', ('pgbouncer.stats.avg_transaction_count', GAUGE)),  # >= 1.8
         ('avg_query_count', ('pgbouncer.stats.avg_query_count', GAUGE)),  # >= 1.8
+        ('avg_wait_time', ('pgbouncer.stats.avg_wait_time' GAUGE)),
         ('avg_recv', ('pgbouncer.stats.avg_recv', GAUGE)),
         ('avg_sent', ('pgbouncer.stats.avg_sent', GAUGE)),
         ('avg_query', ('pgbouncer.stats.avg_query', GAUGE)),  # < 1.8

--- a/pgbouncer/datadog_checks/pgbouncer/metrics.py
+++ b/pgbouncer/datadog_checks/pgbouncer/metrics.py
@@ -17,7 +17,7 @@ STATS_METRICS = {
         ('total_sent', ('pgbouncer.stats.bytes_sent_per_second', RATE)),
         ('total_query_time', ('pgbouncer.stats.total_query_time', RATE)),
         ('total_xact_time', ('pgbouncer.stats.total_transaction_time', RATE)),  # >= 1.8
-        ('total_wait_time', ('pgbouncer.stats.total_wait_time', RATE)),
+        ('total_wait_time', ('pgbouncer.stats.total_wait_time', RATE)),  # >= 1.8
         ('avg_req', ('pgbouncer.stats.avg_req', GAUGE)),  # < 1.8
         ('avg_xact_count', ('pgbouncer.stats.avg_transaction_count', GAUGE)),  # >= 1.8
         ('avg_query_count', ('pgbouncer.stats.avg_query_count', GAUGE)),  # >= 1.8

--- a/pgbouncer/datadog_checks/pgbouncer/metrics.py
+++ b/pgbouncer/datadog_checks/pgbouncer/metrics.py
@@ -42,7 +42,7 @@ POOLS_METRICS = {
         ('sv_tested', ('pgbouncer.pools.sv_tested', GAUGE)),
         ('sv_login', ('pgbouncer.pools.sv_login', GAUGE)),
         ('maxwait', ('pgbouncer.pools.maxwait', GAUGE)),
-        ('maxwait_us', ('pgbouncer.pools.maxwait_us', GAUGE)),
+        ('maxwait_us', ('pgbouncer.pools.maxwait_us', GAUGE)),  # >= 1.8
     ],
     'query': """SHOW POOLS""",
 }

--- a/pgbouncer/metadata.csv
+++ b/pgbouncer/metadata.csv
@@ -9,7 +9,7 @@ pgbouncer.stats.total_transaction_time,rate,,microsecond,,Time spent by pgbounce
 pgbouncer.stats.avg_req,gauge,,request,second,The average number of requests per second in last stat period,0,pgbouncer,requests per second
 pgbouncer.stats.avg_query_count,gauge,,query,second,The average number of queries per second in last stat period,0,pgbouncer,queries per second
 pgbouncer.stats.total_wait_time,gauge,,microsecond,,"Time spent by clients waiting for a server, in microseconds",0,pgbouncer,total wait time
-pgbouncer.stats.avg_wait_time,rate,,microsecond,,"Time spent by clients waiting for a server, in microseconds (average per second)",0,pgbouncer,query time
+pgbouncer.stats.avg_wait_time,gauge,,microsecond,,"Time spent by clients waiting for a server, in microseconds (average per second)",0,pgbouncer,avg wait time
 pgbouncer.stats.avg_transaction_count,gauge,,transaction,second,The average number of transactions per second in last stat period,0,pgbouncer,transactions per second
 pgbouncer.stats.avg_recv,gauge,,byte,second,The client network traffic received,0,pgbouncer,client bytes received
 pgbouncer.stats.avg_sent,gauge,,byte,second,The client network traffic sent,0,pgbouncer,client bytes sent

--- a/pgbouncer/metadata.csv
+++ b/pgbouncer/metadata.csv
@@ -8,6 +8,8 @@ pgbouncer.stats.total_query_time,rate,,microsecond,,Time spent by pgbouncer acti
 pgbouncer.stats.total_transaction_time,rate,,microsecond,,Time spent by pgbouncer in transactions,0,pgbouncer,transaction time
 pgbouncer.stats.avg_req,gauge,,request,second,The average number of requests per second in last stat period,0,pgbouncer,requests per second
 pgbouncer.stats.avg_query_count,gauge,,query,second,The average number of queries per second in last stat period,0,pgbouncer,queries per second
+pgbouncer.stats.total_wait_time,rate,,microsecond,,"Time spent by clients waiting for a server, in microseconds",0,pgbouncer,query time
+pgbouncer.stats.avg_wait_time,rate,,microsecond,,"Time spent by clients waiting for a server, in microseconds (average per second)",0,pgbouncer,query time
 pgbouncer.stats.avg_transaction_count,gauge,,transaction,second,The average number of transactions per second in last stat period,0,pgbouncer,transactions per second
 pgbouncer.stats.avg_recv,gauge,,byte,second,The client network traffic received,0,pgbouncer,client bytes received
 pgbouncer.stats.avg_sent,gauge,,byte,second,The client network traffic sent,0,pgbouncer,client bytes sent

--- a/pgbouncer/metadata.csv
+++ b/pgbouncer/metadata.csv
@@ -21,7 +21,8 @@ pgbouncer.pools.sv_idle,gauge,,connection,,Server connections idle and ready for
 pgbouncer.pools.sv_used,gauge,,connection,,"Server connections idle more than server_check_delay, needing server_check_query",-1,pgbouncer,server used conns
 pgbouncer.pools.sv_tested,gauge,,connection,,Server connections currently running either server_reset_query or server_check_query,0,pgbouncer,server tested conns
 pgbouncer.pools.sv_login,gauge,,connection,,Server connections currently in the process of logging in,0,pgbouncer,server login conns
-pgbouncer.pools.maxwait,gauge,,second,,Age of oldest unserved client connection,-1,pgbouncer,max client wait
+pgbouncer.pools.maxwait,gauge,,second,,"How long the first (oldest) client in the queue has waited, in seconds",-1,pgbouncer,max client wait
+pgbouncer.pools.maxwait_us,gauge,,microsecond,,Microsecond part of the maximum waiting time,-1,pgbouncer,max client wait
 pgbouncer.databases.pool_size,gauge,,connection,,Maximum number of server connections,0,pgbouncer,database pool size
 pgbouncer.databases.max_connections,gauge,,connection,,Maximum number of allowed connections,0,pgbouncer,database max conns
 pgbouncer.databases.current_connections,gauge,,connection,,Current number of connections for this database,0,pgbouncer,database current conns

--- a/pgbouncer/metadata.csv
+++ b/pgbouncer/metadata.csv
@@ -8,7 +8,7 @@ pgbouncer.stats.total_query_time,rate,,microsecond,,Time spent by pgbouncer acti
 pgbouncer.stats.total_transaction_time,rate,,microsecond,,Time spent by pgbouncer in transactions,0,pgbouncer,transaction time
 pgbouncer.stats.avg_req,gauge,,request,second,The average number of requests per second in last stat period,0,pgbouncer,requests per second
 pgbouncer.stats.avg_query_count,gauge,,query,second,The average number of queries per second in last stat period,0,pgbouncer,queries per second
-pgbouncer.stats.total_wait_time,rate,,microsecond,,"Time spent by clients waiting for a server, in microseconds",0,pgbouncer,query time
+pgbouncer.stats.total_wait_time,gauge,,microsecond,,"Time spent by clients waiting for a server, in microseconds",0,pgbouncer,total wait time
 pgbouncer.stats.avg_wait_time,rate,,microsecond,,"Time spent by clients waiting for a server, in microseconds (average per second)",0,pgbouncer,query time
 pgbouncer.stats.avg_transaction_count,gauge,,transaction,second,The average number of transactions per second in last stat period,0,pgbouncer,transactions per second
 pgbouncer.stats.avg_recv,gauge,,byte,second,The client network traffic received,0,pgbouncer,client bytes received

--- a/pgbouncer/tests/test_pgbouncer_integration_e2e.py
+++ b/pgbouncer/tests/test_pgbouncer_integration_e2e.py
@@ -67,6 +67,7 @@ def assert_metric_coverage(version, aggregator):
     aggregator.assert_metric('pgbouncer.pools.sv_tested')
     aggregator.assert_metric('pgbouncer.pools.sv_login')
     aggregator.assert_metric('pgbouncer.pools.maxwait')
+    aggregator.assert_metric('pgbouncer.pools.maxwait_us')
     aggregator.assert_metric('pgbouncer.stats.avg_recv')
     aggregator.assert_metric('pgbouncer.stats.avg_sent')
 

--- a/pgbouncer/tests/test_pgbouncer_integration_e2e.py
+++ b/pgbouncer/tests/test_pgbouncer_integration_e2e.py
@@ -67,11 +67,8 @@ def assert_metric_coverage(version, aggregator):
     aggregator.assert_metric('pgbouncer.pools.sv_tested')
     aggregator.assert_metric('pgbouncer.pools.sv_login')
     aggregator.assert_metric('pgbouncer.pools.maxwait')
-    aggregator.assert_metric('pgbouncer.pools.maxwait_us')
     aggregator.assert_metric('pgbouncer.stats.avg_recv')
     aggregator.assert_metric('pgbouncer.stats.avg_sent')
-    aggregator.assert_metric('pgbouncer.stats.total_wait_time')
-    aggregator.assert_metric('pgbouncer.stats.avg_wait_time')
 
     pgbouncer_pre18 = int(version[1]) < 8
     if pgbouncer_pre18:
@@ -79,6 +76,7 @@ def assert_metric_coverage(version, aggregator):
         aggregator.assert_metric('pgbouncer.stats.avg_query')
         aggregator.assert_metric('pgbouncer.stats.requests_per_second')
     else:
+        aggregator.assert_metric('pgbouncer.pools.maxwait_us')
         aggregator.assert_metric('pgbouncer.stats.avg_transaction_time')
         aggregator.assert_metric('pgbouncer.stats.avg_query_time')
         aggregator.assert_metric('pgbouncer.stats.avg_transaction_count')
@@ -86,6 +84,8 @@ def assert_metric_coverage(version, aggregator):
         aggregator.assert_metric('pgbouncer.stats.queries_per_second')
         aggregator.assert_metric('pgbouncer.stats.transactions_per_second')
         aggregator.assert_metric('pgbouncer.stats.total_transaction_time')
+        aggregator.assert_metric('pgbouncer.stats.total_wait_time')
+        aggregator.assert_metric('pgbouncer.stats.avg_wait_time')
 
     aggregator.assert_metric('pgbouncer.stats.total_query_time')
     aggregator.assert_metric('pgbouncer.stats.bytes_received_per_second')

--- a/pgbouncer/tests/test_pgbouncer_integration_e2e.py
+++ b/pgbouncer/tests/test_pgbouncer_integration_e2e.py
@@ -70,6 +70,8 @@ def assert_metric_coverage(version, aggregator):
     aggregator.assert_metric('pgbouncer.pools.maxwait_us')
     aggregator.assert_metric('pgbouncer.stats.avg_recv')
     aggregator.assert_metric('pgbouncer.stats.avg_sent')
+    aggregator.assert_metric('pgbouncer.stats.total_wait_time')
+    aggregator.assert_metric('pgbouncer.stats.avg_wait_time')
 
     pgbouncer_pre18 = int(version[1]) < 8
     if pgbouncer_pre18:


### PR DESCRIPTION
### What does this PR do?
Adding maxwait_us, total_wait_time, and avg_wait_time metrics as they are not currently being collected.

From
https://github.com/pgbouncer/pgbouncer/blob/050156a2014adeebe4fdf56c77c6e3cf5ea6b8f9/NEWS.md
> Add maxwait_us field to SHOW POOLS output.

Docs here: https://www.pgbouncer.org/usage.html

### Motivation
Missing microseconds stat

### Additional Notes
-

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
