### PR TITLE
Fix `metric_to_check`

### DIFF
--- a/sap_hana/manifest.json
+++ b/sap_hana/manifest.json
@@ -4,7 +4,7 @@
   "manifest_version": "1.0.0",
   "name": "sap_hana",
   "metric_prefix": "sap_hana.",
-  "metric_to_check": "sap_hana.connection.active",
+  "metric_to_check": "sap_hana.uptime",
   "creates_events": false,
   "short_description": "Monitor memory, network, volume, and other metrics from your SAP HANA system.",
   "guid": "85dace7c-baf5-4bcc-9fbb-4d3a6b841359",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Change the `metric_to_check` for the SAP HANA integration to `sap_hana.uptime`.

### Motivation
<!-- What inspired you to submit this pull request? -->
- `sap_hana.connection.active` is not submitted (and rightfully not listed in `metadata.csv`), so the current `metric_to_check` is seemingly invalid.
- `sap_hana.uptime` is always submitted (assuming a master database exists)

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Refs #6170

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
