### PR TITLE
Fix metrics in KyotoTycoon `metadata.csv`

### DIFF
--- a/kyototycoon/metadata.csv
+++ b/kyototycoon/metadata.csv
@@ -1,12 +1,15 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-kyototycoon.repl_delay,gauge,,millisecond,,Replication delay,0,kyoto_tycoon,kyot_repl_delay
-kyototycoon.serv_thread_count,gauge,,thread,,Total number of threads,0,kyoto_tycoon,kyot_serv_thrd
-kyototycoon.serv_conn_count,rate,10,connection,,Total number of connections,0,kyoto_tycoon,kyot_serv_conn
-kyototycoon.cnt_get,rate,10,hit,,Rate of get hits,0,kyoto_tycoon,kyot_get_hit
-kyototycoon.cnt_get_misses,rate,10,miss,,Rate of get misses,0,kyoto_tycoon,kyot_get_miss
-kyototycoon.cnt_set,rate,10,hit,,Rate of set hits,0,kyoto_tycoon,kyot_set_hit
-kyototycoon.cnt_set_misses,rate,10,miss,,Rate of set misses,0,kyoto_tycoon,kyot_set_miss
-kyototycoon.cnt_remove,rate,10,hit,,Rate of deleted hits,0,kyoto_tycoon,kyot_remove_hit
-kyototycoon.cnt_remove_misses,rate,10,miss,,Rate of deleted misses,0,kyoto_tycoon,kyot_remove_miss
-kyototycoon.count,gauge,,record,,Total amount of records,0,kyoto_tycoon,kyot_db_count
+kyototycoon.replication.delay,gauge,,millisecond,,Replication delay,0,kyoto_tycoon,kyot_repl_delay
+kyototycoon.threads,gauge,,thread,,Total number of threads,0,kyoto_tycoon,kyot_serv_thrd
+kyototycoon.connections_per_s,rate,10,connection,,Total number of connections,0,kyoto_tycoon,kyot_serv_conn
+kyototycoon.ops.get.hits_per_s,rate,10,hit,,Rate of get hits,0,kyoto_tycoon,kyot_get_hit
+kyototycoon.ops.get.misses_per_s,rate,10,hit,,Rate of get misses,0,kyoto_tycoon,kyot_get_miss
+kyototycoon.ops.get.total_per_s,rate,10,hit,,Rate of total get hits,0,kyoto_tycoon,kyot_tot_get_hit
+kyototycoon.ops.set.hits_per_s,rate,10,hit,,Rate of set hits,0,kyoto_tycoon,kyot_set_hit
+kyototycoon.opts.set.misses_per_s,rate,10,miss,,Rate of set misses,0,kyoto_tycoon,kyot_set_miss
+kyototycoon.ops.set.total_per_s,rate,10,hit,,Rate of total set hits,0,kyoto_tycoon,kyot_tot_set_hit
+kyototycoon.opts.del.hits_per_s,rate,10,hit,,Rate of deleted hits,0,kyoto_tycoon,kyot_remove_hit
+kyototycoon.opts.del.misses_per_s,rate,10,miss,,Rate of deleted misses,0,kyoto_tycoon,kyot_remove_miss
+kyototycoon.opts.del.total_per_s,rate,10,hit,,Rate of total deleted hits,0,kyoto_tycoon,kyot_tot_remove_hit
+kyototycoon.records,gauge,,record,,Total amount of records,0,kyoto_tycoon,kyot_db_count
 kyototycoon.size,gauge,,,,Current size of the kyoto tycoon DB,0,kyoto_tycoon,kyot_db_size


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix metrics in `metadata.csv`.
### Motivation
<!-- What inspired you to submit this pull request? -->
Metrics listed in `metadata.csv` are using the raw name from KyotoTycoon, but the check has logic in place to convert those names to metric-friendly names. Total metrics were also missing. See:

https://github.com/DataDog/integrations-core/blob/2ac3cfe09d5123d3c8927d2d7e5155e4456d4e02/kyototycoon/datadog_checks/kyototycoon/kyototycoon.py#L24-L45


### Additional Notes
<!-- Anything else we should know when reviewing? -->
Refs #6170 (the `metric_to_check` is `kyototycoon.count` -> `kyototycoon.records`).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
