### PR TITLE
Fix `metric_to_check` for Kube Metrics Server

### DIFF
--- a/kube_metrics_server/manifest.json
+++ b/kube_metrics_server/manifest.json
@@ -4,7 +4,7 @@
   "manifest_version": "1.0.0",
   "name": "kube_metrics_server",
   "metric_prefix": "kube_metrics_server.",
-  "metric_to_check": "kube_metrics_server.threads",
+  "metric_to_check": "kube_metrics_server.process.open_fds",
   "creates_events": false,
   "short_description": "Monitors the Kubernetes Metrics Server",
   "guid": "7a477937-4db8-4277-bd58-9e56ac064185",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update `metric_to_check` on `kube_metrics_server` integration.

### Motivation
<!-- What inspired you to submit this pull request? -->
- `kube_metrics_server.threads` is not listed in `metadata.csv`, and not listed in the metrics code, so it seems to be wrong.
- `process_open_fds` seems to always be sent by the Prometheus endpoint (judging from metrics on HQ org), so it's a good candidate for `metric_to_check`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Refs #6170

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
