### PR TITLE
Pin cacti docker image

### DIFF
--- a/cacti/tests/compose/Dockerfile
+++ b/cacti/tests/compose/Dockerfile
@@ -1,4 +1,4 @@
-FROM quantumobject/docker-cacti
+FROM quantumobject/docker-cacti:1.2.8
 
 # username and password is admin/Admin23@
 COPY alldb_backup.sql /var/backups/


### PR DESCRIPTION
Latest version breaks e2e tests as it does not include `sbin/restore` script that we depend on.