### PR TITLE
Fix kong e2e

### DIFF
--- a/kong/tox.ini
+++ b/kong/tox.ini
@@ -17,7 +17,7 @@ deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =
-    1.5: KONG_VERSION=1.5
+    1.5: KONG_VERSION=1.5.0
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
A new docker image has been released (1.5.1) and the environment fails to start 

```
Removing volume compose_kong_data
__________________ ERROR at setup of test_connection_failure ___________________
tests/conftest.py:15: in dd_environment
    with docker_run(
/opt/hostedtoolcache/Python/3.8.2/x64/lib/python3.8/contextlib.py:113: in __enter__
    return next(self.gen)
../datadog_checks_dev/datadog_checks/dev/docker.py:191: in docker_run
    with environment_run(
/opt/hostedtoolcache/Python/3.8.2/x64/lib/python3.8/contextlib.py:113: in __enter__
    return next(self.gen)
../datadog_checks_dev/datadog_checks/dev/env.py:73: in environment_run
    condition()
../datadog_checks_dev/datadog_checks/dev/conditions.py:84: in __call__
    raise RetryError('Endpoint: {}\n' 'Error: {}'.format(last_endpoint, last_error))
E   datadog_checks.dev.errors.RetryError: Endpoint: http://localhost:8001/status/
E   Error: <urlopen error [Errno 111] Connection refused>
```