### PR TITLE
resource filters: allow blacklist and tag filtering

### DIFF
--- a/vsphere/datadog_checks/vsphere/config.py
+++ b/vsphere/datadog_checks/vsphere/config.py
@@ -22,7 +22,7 @@ from datadog_checks.vsphere.constants import (
     MOR_TYPE_AS_STRING,
     REALTIME_RESOURCES,
 )
-from datadog_checks.vsphere.resource_filters import FILTER_PROP_TO_FILTER_CLASS, ResourceFilter
+from datadog_checks.vsphere.resource_filters import ResourceFilter, create_resource_filter
 from datadog_checks.vsphere.types import InstanceConfig, MetricFilterConfig, MetricFilters, ResourceFilterConfig
 
 
@@ -176,9 +176,7 @@ class VSphereConfig(object):
                     ALLOWED_FILTER_TYPES,
                 )
             patterns = [re.compile(r) for r in resource_filter['patterns']]
-            FilterClass = FILTER_PROP_TO_FILTER_CLASS[resource_filter['property']]
-
-            filter_instance = FilterClass(
+            filter_instance = create_resource_filter(
                 resource_filter['resource'],
                 resource_filter['property'],
                 patterns,

--- a/vsphere/datadog_checks/vsphere/constants.py
+++ b/vsphere/datadog_checks/vsphere/constants.py
@@ -3,7 +3,8 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from pyVmomi import vim
 
-ALLOWED_FILTER_PROPERTIES = ['name', 'inventory_path']
+ALLOWED_FILTER_PROPERTIES = ['name', 'inventory_path', 'tag']
+ALLOWED_FILTER_TYPES = ['whitelist', 'blacklist']
 EXTRA_FILTER_PROPERTIES_FOR_VMS = ['hostname', 'guest_hostname']
 SHORT_ROLLUP = {
     "average": "avg",

--- a/vsphere/datadog_checks/vsphere/constants.py
+++ b/vsphere/datadog_checks/vsphere/constants.py
@@ -3,9 +3,11 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from pyVmomi import vim
 
-ALLOWED_FILTER_PROPERTIES = ['name', 'inventory_path', 'tag']
 ALLOWED_FILTER_TYPES = ['whitelist', 'blacklist']
+ALLOWED_FILTER_PROPERTIES = ['name', 'inventory_path', 'tag']
 EXTRA_FILTER_PROPERTIES_FOR_VMS = ['hostname', 'guest_hostname']
+
+
 SHORT_ROLLUP = {
     "average": "avg",
     "summation": "sum",

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -80,10 +80,13 @@ instances:
     ## Each filter in the list is composed of three parameters.
     ## 'resource' is one of vm/host/datastore/datacenter/cluster on which to apply the filter
     ## 'patterns' is a list of matching regex, if any of those matches, the resource will be monitored.
+    ## 'type' is either whitelist (default) or blacklist. If a resource is both whitelisted and blacklisted it will be
+    ##        considered blacklisted.
     ## 'property' is the kind of property on which to apply the filter and must be one of those values:
     ##    - name (default) to filter on the resource name (defined by vCenter)
     ##    - inventory_path to filter on the full inventory path
     ##      (ex: \/<Datacenter_name>\/vm\/<FOLDER_NAME>\/.* for all vms in the folder <FOLDER_NAME>)
+    ##    - tag to filter only the resources with a given tag.
     ##    - hostname to filter on the ESXi Host name (only valid for if 'resource' equals 'vm')
     ##    - guest_hostname to filter on the VM hostname (only valid for if 'resource' equals 'vm' and
     ##      if VMware tools are installed)
@@ -102,6 +105,16 @@ instances:
     #     property: hostname
     #     patterns:
     #       - <HOSTNAME_REGEX>
+    #   - resource: vm
+    #     property: tag
+    #     type: blacklist
+    #     patterns:
+    #       - '^env:staging$'
+    #   - resource: vm
+    #     property: tag
+    #     type: whitelist
+    #     patterns:
+    #       - '^env:.*$'
     #   - resource: vm
     #     property: guest_hostname
     #     patterns:

--- a/vsphere/datadog_checks/vsphere/resource_filters.py
+++ b/vsphere/datadog_checks/vsphere/resource_filters.py
@@ -20,10 +20,15 @@ def make_inventory_path(mor, infrastructure_data):
 def match_any_regex(string, regexes):
     # type: (str, List[Pattern]) -> bool
     for regex in regexes:
-        match = regex.match(string)
-        if match:
+        if regex.match(string):
             return True
     return False
+
+
+def create_resource_filter(resource_type, property_name, patterns, is_whitelist=True):
+    FilterClass = FILTER_PROP_TO_FILTER_CLASS[property_name]
+    filter_instance = FilterClass(resource_type, property_name, patterns, is_whitelist)
+    return filter_instance
 
 
 class ResourceFilter:

--- a/vsphere/datadog_checks/vsphere/resource_filters.py
+++ b/vsphere/datadog_checks/vsphere/resource_filters.py
@@ -1,0 +1,92 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+from typing import List, Pattern, Tuple
+
+from pyVmomi import vim
+
+from datadog_checks.vsphere.types import InfrastructureData
+
+
+def make_inventory_path(mor, infrastructure_data):
+    # type: (vim.ManagedEntity, InfrastructureData) -> str
+    mor_name = infrastructure_data[mor].get('name', '')
+    mor_parent = infrastructure_data[mor].get('parent')
+    if mor_parent:
+        return make_inventory_path(mor_parent, infrastructure_data) + '/' + mor_name
+    return ''
+
+
+def match_any_regex(string, regexes):
+    # type: (str, List[Pattern]) -> bool
+    for regex in regexes:
+        match = regex.match(string)
+        if match:
+            return True
+    return False
+
+
+class ResourceFilter:
+    """Represents a given resource filter as defined in the conf.yaml file."""
+
+    def __init__(self, resource_type, property_name, patterns, is_whitelist=True):
+        # type: (str, str, List[Pattern], bool) -> None
+        self.resource_type = resource_type
+        self.property_name = property_name
+        self.patterns = patterns
+        self.is_whitelist = is_whitelist
+
+    def unique_key(self):
+        # type: () -> Tuple[str, str, bool]
+        """Unique identifier for this given resource filter. To prevent users defining multiple filters that overlap
+        each other, there should never be two ResourceFilters with the same unique key."""
+        return self.resource_type, self.property_name, self.is_whitelist
+
+    def match(self, mor, infrastructure_data, resource_tags):
+        # type: (vim.ManagedEntity, InfrastructureData, List[str]) -> bool
+        raise NotImplementedError()
+
+
+class NameFilter(ResourceFilter):
+    def match(self, mor, infrastructure_data, resource_tags):
+        mor_name = infrastructure_data[mor].get("name", "")
+        return match_any_regex(mor_name, self.patterns)
+
+
+class InventoryPathFilter(ResourceFilter):
+    def match(self, mor, infrastructure_data, resource_tags):
+        path = make_inventory_path(mor, infrastructure_data)
+        return match_any_regex(path, self.patterns)
+
+
+class TagFilter(ResourceFilter):
+    def match(self, mor, infrastructure_data, resource_tags):
+        for resource_tag in resource_tags:
+            if match_any_regex(resource_tag, self.patterns):
+                return True
+        return False
+
+
+class HostnameFilter(ResourceFilter):
+    def match(self, mor, infrastructure_data, resource_tags):
+        host = infrastructure_data[mor].get("runtime.host")
+        if host and host in infrastructure_data:
+            hostname = infrastructure_data[host].get("name", "")
+            if match_any_regex(hostname, self.patterns):
+                return True
+        return False
+
+
+class GuestHostnameFilter(ResourceFilter):
+    def match(self, mor, infrastructure_data, resource_tags):
+        guest_hostname = infrastructure_data.get(mor, {}).get("guest.hostName", "")
+        return match_any_regex(guest_hostname, self.patterns)
+
+
+FILTER_PROP_TO_FILTER_CLASS = {
+    'name': NameFilter,
+    'inventory_path': InventoryPathFilter,
+    'tag': TagFilter,
+    'hostname': HostnameFilter,
+    'guest_hostname': GuestHostnameFilter,
+}

--- a/vsphere/datadog_checks/vsphere/types.py
+++ b/vsphere/datadog_checks/vsphere/types.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, NamedTuple, Optional, Pattern, Type, TypedDict
+from typing import Dict, List, Optional, Pattern, Type, TypedDict
 
 # CONFIG ALIASES
 from pyVmomi import vim
@@ -58,9 +58,6 @@ InfrastructureData = Dict[vim.ManagedEntity, InfrastructureDataItem]
 ResourceTags = Dict[Type[vim.ManagedEntity], Dict[str, List[str]]]
 TagAssociation = TypedDict('TagAssociation', {'tag_id': str, 'object_ids': List[Dict[str, str]]})
 
-ResoureFilterKey = NamedTuple('ResoureFilterKey', [('resource', str), ('property', str), ('is_whitelist', bool)])
-
-ResourceFilters = Dict[ResoureFilterKey, List[Pattern]]
 MetricFilters = Dict[str, List[Pattern]]
 
 MorBatch = Dict[vim.ManagedEntity, List[vim.PerformanceManager.MetricId]]

--- a/vsphere/datadog_checks/vsphere/types.py
+++ b/vsphere/datadog_checks/vsphere/types.py
@@ -1,9 +1,11 @@
-from typing import Dict, List, Optional, Pattern, Tuple, Type, TypedDict
+from typing import Dict, List, NamedTuple, Optional, Pattern, Type, TypedDict
 
 # CONFIG ALIASES
 from pyVmomi import vim
 
-ResourceFilterConfig = TypedDict('ResourceFilterConfig', {'resource': str, 'property': str, 'patterns': List[str]})
+ResourceFilterConfig = TypedDict(
+    'ResourceFilterConfig', {'resource': str, 'property': str, 'type': str, 'patterns': List[str]}
+)
 MetricFilterConfig = Dict[str, List[str]]
 
 InstanceConfig = TypedDict(
@@ -56,7 +58,9 @@ InfrastructureData = Dict[vim.ManagedEntity, InfrastructureDataItem]
 ResourceTags = Dict[Type[vim.ManagedEntity], Dict[str, List[str]]]
 TagAssociation = TypedDict('TagAssociation', {'tag_id': str, 'object_ids': List[Dict[str, str]]})
 
-ResourceFilters = Dict[Tuple[str, str], List[Pattern]]
+ResoureFilterKey = NamedTuple('ResoureFilterKey', [('resource', str), ('property', str), ('is_whitelist', bool)])
+
+ResourceFilters = Dict[ResoureFilterKey, List[Pattern]]
 MetricFilters = Dict[str, List[Pattern]]
 
 MorBatch = Dict[vim.ManagedEntity, List[vim.PerformanceManager.MetricId]]

--- a/vsphere/datadog_checks/vsphere/utils.py
+++ b/vsphere/datadog_checks/vsphere/utils.py
@@ -67,8 +67,8 @@ def is_resource_collected_by_filters(mor, infrastructure_data, resource_filters,
     if not whitelist_filters:
         match_whitelist = True
 
+    # If resources matches one of the blacklisted patterns, do not collect it
     if match_blacklist:
-        # If resources matches one of the blacklisted patterns, do not collect it
         return False
 
     # Otherwise, collect it if it matches one of the whitelisted patterns.

--- a/vsphere/datadog_checks/vsphere/utils.py
+++ b/vsphere/datadog_checks/vsphere/utils.py
@@ -65,7 +65,6 @@ def is_resource_collected_by_filters(mor, infrastructure_data, resource_filters,
 
     # Extra logic to consider that no whitelist filters means "collect everything"
     if not whitelist_filters:
-        # No whitelist filter specified for this resource, consider that the resource matches the whitelist
         match_whitelist = True
 
     if match_blacklist:

--- a/vsphere/datadog_checks/vsphere/utils.py
+++ b/vsphere/datadog_checks/vsphere/utils.py
@@ -7,9 +7,16 @@ from pyVmomi import vim
 from six import iteritems
 
 from datadog_checks.base import to_native_string
+from datadog_checks.vsphere.cache import TagsCache
 from datadog_checks.vsphere.config import VSphereConfig
 from datadog_checks.vsphere.constants import MOR_TYPE_AS_STRING, REFERENCE_METRIC, SHORT_ROLLUP
-from datadog_checks.vsphere.types import InfrastructureData, MetricFilters, MetricName, ResourceFilters
+from datadog_checks.vsphere.types import (
+    InfrastructureData,
+    MetricFilters,
+    MetricName,
+    ResourceFilters,
+    ResoureFilterKey,
+)
 
 METRIC_TO_INSTANCE_TAG_MAPPING = {
     # Structure:
@@ -51,40 +58,66 @@ def match_any_regex(string, regexes):
     return False
 
 
-def is_resource_excluded_by_filters(mor, infrastructure_data, resource_filters):
-    # type: (vim.ManagedEntity, InfrastructureData, ResourceFilters) -> bool
+def is_resource_collected_by_filters(mor, infrastructure_data, resource_filters, tags_cache):
+    # type: (vim.ManagedEntity, InfrastructureData, ResourceFilters, TagsCache) -> bool
     resource_type = MOR_TYPE_AS_STRING[type(mor)]
 
-    if not [f for f in resource_filters if f[0] == resource_type]:
-        # No filter for this resource, collect everything
+    if not [f for f in resource_filters if f.resource == resource_type and f.is_whitelist]:
+        # No whitelist filter specified for this resource, consider that the resource matches the whitelist
+        match_whitelist = True
+    else:
+        match_whitelist = _does_resource_match_filters(
+            mor, infrastructure_data, resource_filters, tags_cache, is_whitelist=True
+        )
+
+    match_blacklist = _does_resource_match_filters(
+        mor, infrastructure_data, resource_filters, tags_cache, is_whitelist=False
+    )
+
+    if match_blacklist:
+        # If resources matches one of the blacklisted patterns, do not collect it
         return False
 
-    name_filter = resource_filters.get((resource_type, 'name'))
-    inventory_path_filter = resource_filters.get((resource_type, 'inventory_path'))
-    hostname_filter = resource_filters.get((resource_type, 'hostname'))
-    guest_hostname_filter = resource_filters.get((resource_type, 'guest_hostname'))
+    # Otherwise, collect it if it matches one of the whitelisted patterns.
+    return match_whitelist
+
+
+def _does_resource_match_filters(mor, infrastructure_data, resource_filters, tags_cache, is_whitelist=True):
+    # type: (vim.ManagedEntity, InfrastructureData, ResourceFilters, TagsCache, bool) -> bool
+    resource_type = MOR_TYPE_AS_STRING[type(mor)]
+
+    name_filter = resource_filters.get(ResoureFilterKey(resource_type, 'name', is_whitelist))
+    inventory_path_filter = resource_filters.get(ResoureFilterKey(resource_type, 'inventory_path', is_whitelist))
+    tag_filter = resource_filters.get(ResoureFilterKey(resource_type, 'tag', is_whitelist))
+    hostname_filter = resource_filters.get(ResoureFilterKey(resource_type, 'hostname', is_whitelist))
+    guest_hostname_filter = resource_filters.get(ResoureFilterKey(resource_type, 'guest_hostname', is_whitelist))
 
     if name_filter:
         mor_name = infrastructure_data[mor].get("name", "")
         if match_any_regex(mor_name, name_filter):
-            return False
+            return True
     if inventory_path_filter:
         path = make_inventory_path(mor, infrastructure_data)
         if match_any_regex(path, inventory_path_filter):
-            return False
+            return True
+    if tag_filter:
+        resource_tags = tags_cache.get_mor_tags(mor)
+        for resource_tag in resource_tags:
+            if match_any_regex(resource_tag, tag_filter):
+                return True
 
     if hostname_filter and isinstance(mor, vim.VirtualMachine):
         host = infrastructure_data[mor].get("runtime.host")
         if host and host in infrastructure_data:
             hostname = infrastructure_data[host].get("name", "")
             if match_any_regex(hostname, hostname_filter):
-                return False
+                return True
     if guest_hostname_filter and isinstance(mor, vim.VirtualMachine):
         guest_hostname = infrastructure_data.get(mor, {}).get("guest.hostName", "")
         if match_any_regex(guest_hostname, guest_hostname_filter):
-            return False
+            return True
 
-    return True
+    return False
 
 
 def is_metric_excluded_by_filters(metric_name, mor_type, metric_filters):

--- a/vsphere/datadog_checks/vsphere/utils.py
+++ b/vsphere/datadog_checks/vsphere/utils.py
@@ -52,27 +52,22 @@ def is_resource_collected_by_filters(mor, infrastructure_data, resource_filters,
     whitelist_filters = [f for f in resource_filters if f.is_whitelist]
     blacklist_filters = [f for f in resource_filters if not f.is_whitelist]
 
-    match_whitelist = False
-    match_blacklist = False
-    for resource_filter in whitelist_filters:
-        if resource_filter.match(mor, infrastructure_data, resource_tags):
-            match_whitelist = True
-            break
+    # First check if the resource match any blacklist filter, if so do not collect it.
     for resource_filter in blacklist_filters:
         if resource_filter.match(mor, infrastructure_data, resource_tags):
-            match_blacklist = True
-            break
+            return False
 
     # Extra logic to consider that no whitelist filters means "collect everything"
     if not whitelist_filters:
-        match_whitelist = True
+        return True
 
-    # If resources matches one of the blacklisted patterns, do not collect it
-    if match_blacklist:
-        return False
+    # Finally check if the resource match any whitelist filter, if so collect it
+    for resource_filter in whitelist_filters:
+        if resource_filter.match(mor, infrastructure_data, resource_tags):
+            return True
 
-    # Otherwise, collect it if it matches one of the whitelisted patterns.
-    return match_whitelist
+    # Otherwise, do not collect it
+    return False
 
 
 def is_metric_excluded_by_filters(metric_name, mor_type, metric_filters):

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -35,7 +35,7 @@ from datadog_checks.vsphere.utils import (
     get_mapped_instance_tag,
     get_parent_tags_recursively,
     is_metric_excluded_by_filters,
-    is_resource_excluded_by_filters,
+    is_resource_collected_by_filters,
     should_collect_per_instance_values,
 )
 
@@ -166,8 +166,11 @@ class VSphereCheck(AgentCheck):
             if not isinstance(mor, tuple(self.config.collected_resource_types)):
                 # Do nothing for the resource types we do not collect
                 continue
-            if is_resource_excluded_by_filters(mor, infrastructure_data, self.config.resource_filters):
-                # The resource does not match the specified patterns
+
+            if not is_resource_collected_by_filters(
+                mor, infrastructure_data, self.config.resource_filters, self.tags_cache
+            ):
+                # The resource does not match the specified whitelist/blacklist patterns.
                 continue
 
             mor_name = to_native_string(properties.get("name", "unknown"))

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -168,7 +168,7 @@ class VSphereCheck(AgentCheck):
                 continue
 
             if not is_resource_collected_by_filters(
-                mor, infrastructure_data, self.config.resource_filters, self.tags_cache
+                mor, infrastructure_data, self.config.resource_filters, self.tags_cache.get_mor_tags(mor)
             ):
                 # The resource does not match the specified whitelist/blacklist patterns.
                 continue

--- a/vsphere/tests/test_filters.py
+++ b/vsphere/tests/test_filters.py
@@ -11,7 +11,7 @@ from tests.mocked_api import MockedAPI
 from datadog_checks.vsphere import VSphereCheck
 from datadog_checks.vsphere.utils import (
     is_metric_excluded_by_filters,
-    is_resource_excluded_by_filters,
+    is_resource_collected_by_filters,
     make_inventory_path,
     match_any_regex,
 )
@@ -59,42 +59,25 @@ def test_make_inventory_path():
 
 
 @pytest.mark.usefixtures("mock_type")
-def test_is_realtime_resource_excluded_by_filters(realtime_instance):
+def test_is_realtime_resource_collected_by_filters(realtime_instance):
     realtime_instance['resource_filters'] = [
         {'resource': 'vm', 'property': 'name', 'patterns': [r'^\$VM5$', r'^VM4-2\d$']},
-        {'resource': 'vm', 'property': 'inventory_path', 'patterns': [r'\/Dätacenter\/vm\/m.*']},
+        {'resource': 'vm', 'property': 'inventory_path', 'patterns': [u'\\/D\xe4tacenter\\/vm\\/m.*']},
         {'resource': 'vm', 'property': 'hostname', 'patterns': [r'10\.0\.0\.103']},
         {'resource': 'vm', 'property': 'guest_hostname', 'patterns': [r'ubuntu-test']},
+        {'resource': 'host', 'property': 'name', 'patterns': [r'10\.0\.0\.103'], 'type': 'blacklist'},
     ]
 
-    excluded_resources = [
-        'VM1-4',
-        'VM2-1',
-        'VM1-3',
-        'VM2-2',
-        'VM1-5',
-        'VM1-2',
-        'VM-0',
-        u'VM1-1ä',
-        'VM4-2',
-        'VM4-4',
-        'VM4-14',
-        'VM4-9',
-        'VM4-15',
-        'VM4-5',
-        'VM4-3',
-        'VM4-12',
-        'VM4-11',
-        'VM4-6',
-        'VM4-13',
-        'VM4-1',
-        'VM4-19',
-        'VM4-18',
-        'VM4-7',
-        'VM4-17',
-        'VM4-10',
-        'VM4-16',
-        'VM4-8',
+    collected_resources = [
+        '$VM3-2',
+        '$VM5',
+        '10.0.0.101',
+        '10.0.0.102',
+        '10.0.0.104',
+        u'VM1-6ê',
+        'VM3-1',
+        'VM4-20',
+        'migrationTest',
     ]
 
     check = VSphereCheck('vsphere', {}, [realtime_instance])
@@ -104,6 +87,5 @@ def test_is_realtime_resource_excluded_by_filters(realtime_instance):
     resources = [m for m in infra if m.__class__ in (vim.VirtualMachine, vim.HostSystem)]
 
     for resource in resources:
-        is_excluded = infra.get(resource).get('name') in excluded_resources
-        if not is_resource_excluded_by_filters(resource, infra, formatted_filters) == is_excluded:
-            assert is_resource_excluded_by_filters(resource, infra, formatted_filters)
+        is_collected = infra.get(resource).get('name') in collected_resources
+        assert is_resource_collected_by_filters(resource, infra, formatted_filters, check.tags_cache) == is_collected


### PR DESCRIPTION
### What does this PR do?
A requested feature for this integration is the ability to filter on tags coming from vSphere.
This PR gives users the ability to filter on any tag on a whitelist and/or blacklist way.

Having the ability to use blacklist is a requirement for tags, indeed, at the contrary of other filters, a resource can have multiple tags. So it's not possible to rely on negative matching regexes.

example: If you need to match all resources with `role:database` but you want to ignore those with `env:staging`, there is no other way than having whitelist and blacklist.

### Motivation
Custom request.

### Additional Notes
I also reversed the meaning of the `is_resource_excluded_by_filters` method as it would be overly complex to keep that negation with the addition of blacklists.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
