### PR TITLE
Add logs integration

### DIFF
--- a/rethinkdb/README.md
+++ b/rethinkdb/README.md
@@ -43,15 +43,41 @@ The RethinkDB check is included in the [Datadog Agent][3] package. No additional
 
 **Note**: this integration collects metrics from all servers in the cluster, so you only need a single Agent.
 
+##### Log collection
+
+_Available for Agent versions >6.0_
+
+1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
+
+    ```yaml
+    logs_enabled: true
+    ```
+
+2. Add this configuration block to your `rethinkdb.d/conf.yaml` file to start collecting your RethinkDB logs:
+
+    ```yaml
+    logs:
+      - type: file
+        path: "<LOG_FILE_PATH>"
+        source: rethinkdb
+        service: "<SERVICE_NAME>"
+    ```
+
+    Change the `path` and `service` parameter values based on your environment. See the [sample rethinkdb.d/conf.yaml][7] for all available configuration options.
+
+3. [Restart the Agent][8].
+
+See [Datadog's documentation][9] for additional information on how to configure the Agent for log collection in Docker environments.
+
 ### Validation
 
-[Run the Agent's status subcommand][9] and look for `rethinkdb` under the Checks section.
+[Run the Agent's status subcommand][10] and look for `rethinkdb` under the Checks section.
 
 ## Data Collected
 
 ### Metrics
 
-See [metadata.csv][10] for a list of metrics provided by this check.
+See [metadata.csv][11] for a list of metrics provided by this check.
 
 ### Service Checks
 
@@ -67,7 +93,7 @@ RethinkDB does not include any events.
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][11].
+Need help? Contact [Datadog support][12].
 
 [1]: https://rethinkdb.com/
 [2]: https://docs.datadoghq.com/agent/autodiscovery/integrations
@@ -77,6 +103,7 @@ Need help? Contact [Datadog support][11].
 [6]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [7]: https://github.com/DataDog/integrations-core/blob/master/rethinkdb/datadog_checks/rethinkdb/data/conf.yaml.example
 [8]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[9]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[10]: https://github.com/DataDog/integrations-core/blob/master/rethinkdb/metadata.csv
-[11]: https://docs.datadoghq.com/help
+[9]: https://docs.datadoghq.com/agent/docker/log/
+[10]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[11]: https://github.com/DataDog/integrations-core/blob/master/rethinkdb/metadata.csv
+[12]: https://docs.datadoghq.com/help

--- a/rethinkdb/assets/configuration/spec.yaml
+++ b/rethinkdb/assets/configuration/spec.yaml
@@ -42,3 +42,10 @@ files:
               type: string
 
           - template: instances/default
+
+      - template: logs
+        example:
+        - type: file
+          path: rethinkdb_data/log_file
+          source: rethinkdb
+          service: rethinkdb

--- a/rethinkdb/datadog_checks/rethinkdb/data/conf.yaml.example
+++ b/rethinkdb/datadog_checks/rethinkdb/data/conf.yaml.example
@@ -67,3 +67,22 @@ instances:
     ## This is useful for cluster-level checks.
     #
     # empty_default_hostname: false
+
+## Log Section
+##
+## type - required - Type of log input source (tcp / udp / file / windows_event)
+## port / path / channel_path - required - Set port if type is tcp or udp.
+##                                         Set path if type is file.
+##                                         Set channel_path if type is windows_event.
+## source  - required - Attribute that defines which Integration sent the logs
+## service - required - The name of the service that generates the log.
+##                      Overrides any `service` defined in the `init_config` section.
+## tags - optional - Add tags to the collected logs
+##
+## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
+#
+# logs:
+#   - type: file
+#     path: rethinkdb_data/log_file
+#     source: rethinkdb
+#     service: rethinkdb

--- a/rethinkdb/manifest.json
+++ b/rethinkdb/manifest.json
@@ -16,7 +16,8 @@
   ],
   "public_title": "Datadog-RethinkDB Integration",
   "categories": [
-    "data store"
+    "data store",
+    "log collection"
   ],
   "type": "check",
   "is_public": false,

--- a/rethinkdb/tests/compose/docker-compose.yaml
+++ b/rethinkdb/tests/compose/docker-compose.yaml
@@ -9,10 +9,13 @@ services:
     tty: true
     image: ${RETHINKDB_IMAGE}
     container_name: rethinkdb-server0
-    command: rethinkdb --bind all --server-name server0 --server-tag us
+    command: rethinkdb --bind all --server-name server0 --server-tag us --log-file /var/log/rethinkdb.log
     ports:
       - ${RETHINKDB_PORT_SERVER0}:28015  # Client driver port.
       - 8080:8080  # Port for the web UI. Debugging only (not used by tests).
+    volumes:
+      # NOTE: don't use the default log file path as it may cause permission issues during RethinkDB startup.
+      - ${DD_LOG_1}:/var/log/rethinkdb.log
 
   rethinkdb-server1:
     tty: true

--- a/rethinkdb/tests/conftest.py
+++ b/rethinkdb/tests/conftest.py
@@ -44,5 +44,5 @@ def dd_environment(instance):
 
     conditions = [wait_servers_ready, setup_cluster]
 
-    with docker_run(COMPOSE_FILE, conditions=conditions, env_vars=COMPOSE_ENV_VARS):
+    with docker_run(COMPOSE_FILE, conditions=conditions, env_vars=COMPOSE_ENV_VARS, mount_logs=True):
         yield instance


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add logs instructions for RethinkDB.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Local forwarding of logs to staging works well -- see below (NOTE: logs parser not deployed yet, so logs are in raw format).

I restarted the `server0` container to trigger log lines present in the screenshot:

```console
$ docker container stop rethinkdb-server0
$ docker container start rethinkdb-server0
```

<img width="1371" alt="Screenshot 2020-03-30 at 15 20 12" src="https://user-images.githubusercontent.com/15911462/77916918-1faa3580-729a-11ea-92df-d6545a71e8e6.png">

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
