### PR TITLE
Fix service check on unexpected exception

### DIFF
--- a/postgres/tests/test_integration.py
+++ b/postgres/tests/test_integration.py
@@ -94,7 +94,8 @@ def test_can_connect_service_check(aggregator, integration_check, pg_instance):
     # Second: keep the connection open but an unexpected error happens during check run
     orig_db = check.db
     check.db = mock.MagicMock(spec=('closed', 'status'), closed=False, status=psycopg2.extensions.STATUS_READY)
-    check.check(pg_instance)
+    with pytest.raises(AttributeError):
+        check.check(pg_instance)
     aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.CRITICAL, tags=expected_tags)
     aggregator.reset()
 
@@ -218,7 +219,8 @@ def test_state_clears_on_connection_error(integration_check, pg_instance):
     throw_exception_first_time.counter = 0
 
     with mock.patch('datadog_checks.postgres.PostgreSql._collect_stats', side_effect=throw_exception_first_time):
-        check.check(pg_instance)
+        with pytest.raises(socket.error):
+            check.check(pg_instance)
     assert_state_clean(check)
 
 


### PR DESCRIPTION
### What does this PR do?
In some cases, the postgres connection was kept open (i.e `self.db.closed = False`), but the postgres endpoint was actually down. When trying to collect metrics, some other exceptions were raised and the CRITICAL service check was not submitted.

To prevent that, the part that tries to connect and communicate with postgres is in a try/except block, the CRITICAL service check is submitted on *any* exception, and the OK service check is submitted otherwise.

### Motivation
Customer request.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
