### PR TITLE
Pass proper parameters for weekly CI

### DIFF
--- a/.azure-pipelines/latest_metrics.yml
+++ b/.azure-pipelines/latest_metrics.yml
@@ -20,6 +20,9 @@ jobs:
     job_name: Weekly_Metrics_Validation
     display: Linux
     check: 'airflow clickhouse'
+    test: false
+    test_e2e: false
+    benchmark: false
     latest_metrics: true
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -5,6 +5,7 @@ parameters:
   test: true
   test_e2e: true
   benchmark: true
+  latest_metrics: false
   validate: false
   repo: 'core'
   pip_cache_config: null
@@ -40,4 +41,5 @@ jobs:
       test: ${{ parameters.test }}
       test_e2e: ${{ parameters.test_e2e }}
       benchmark: ${{ parameters.benchmark }}
+      latest_metrics: ${{ parameters.latest_metrics }}
       repo: ${{ parameters.repo }}

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -5,6 +5,7 @@ parameters:
   test: true
   test_e2e: false
   benchmark: false
+  latest_metrics: false
   validate: false
   repo: 'core'
   pip_cache_config: null
@@ -42,4 +43,5 @@ jobs:
       test: ${{ parameters.test }}
       test_e2e: ${{ parameters.test_e2e }}
       benchmark: ${{ parameters.benchmark }}
+      latest_metrics: ${{ parameters.latest_metrics }}
       repo: ${{ parameters.repo }}


### PR DESCRIPTION
Update the weekly config to pass all of the appropriate parameters.

Also update the Windows template to include a parameter for `latest_metrics`.