### PR TITLE
Update metric to check in gitlab

### DIFF
--- a/gitlab/manifest.json
+++ b/gitlab/manifest.json
@@ -13,7 +13,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "gitlab.",
-  "metric_to_check": ["gitlab.process_max_fds", "gitlab.http_requests_total"],
+  "metric_to_check": ["gitlab.process_max_fds", "gitlab.rack.http_requests_total"],
   "name": "gitlab",
   "public_title": "Datadog-Gitlab Integration",
   "short_description": "Track all your Gitlab metrics with Datadog",


### PR DESCRIPTION
### What does this PR do?
Uses the correct metric to check in gitlab.

### Motivation
The metric to check was renamed in https://github.com/DataDog/integrations-core/pull/6150

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
