### PR TITLE
Fix support for kubernetes v1.18

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -411,9 +411,8 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
         """
         Retrieve node spec from kubelet.
         """
-        node_spec = self.perform_kubelet_query(self.node_spec_url)
-        node_spec.raise_for_status()
-        return node_spec.json()
+        node_resp = self.perform_kubelet_query(self.node_spec_url)
+        return node_resp
 
     def _retrieve_stats(self):
         """
@@ -429,12 +428,16 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
 
     def _report_node_metrics(self, instance_tags):
         try:
-            node_spec = self._retrieve_node_spec()
-        except requests.HTTPError:
-            # ignore HTTPError, for supporting k8s 1.18 in a degrated mode
-            self.log.warning('kubelet check "/spec" endpoint not available')
-            return
-
+            node_resp = self._retrieve_node_spec()
+            node_resp.raise_for_status()
+        except requests.HTTPError as e:
+            if node_resp.status_code == 404:
+                # ignore HTTPError, for supporting k8s >= 1.18 in a degrated mode
+                # in 1.18 the /spec can be reactivated from the kubelet config
+                # in 1.19 the /spec will removed.
+                return
+            raise e
+        node_spec = node_resp.json()
         num_cores = node_spec.get('num_cores', 0)
         memory_capacity = node_spec.get('memory_capacity', 0)
 

--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -11,7 +11,7 @@ kubernetes.cpu.system.total,rate,,core,,The number of cores used for system time
 kubernetes.cpu.user.total,rate,,core,,The number of cores used for user time,0,kubernetes,k8s.cpu.user
 kubernetes.cpu.cfs.throttled.period,rate,,,,Number of throttled period intervals,-1,kubernetes,k8s.cpu.throttled.periods
 kubernetes.cpu.cfs.throttled.second,rate,,,,Total time duration the container has been throttled,-1,kubernetes,k8s.cpu.throttled.sec
-kubernetes.cpu.capacity,gauge,,core,,The number of cores in this machine,0,kubernetes,k8s.cpu.capacity
+kubernetes.cpu.capacity,gauge,,core,,The number of cores in this machine (available until kubernetes v1.18),0,kubernetes,k8s.cpu.capacity
 kubernetes.cpu.usage.total,gauge,,nanocore,,The number of cores used,-1,kubernetes,k8s.cpu
 kubernetes.cpu.limits,gauge,,core,,The limit of cpu cores set,0,kubernetes,k8s.cpu.limits
 kubernetes.cpu.requests,gauge,,core,,The requested cpu cores,0,kubernetes,k8s.cpu.requests
@@ -19,7 +19,7 @@ kubernetes.filesystem.usage,gauge,,byte,,The amount of disk used,-1,kubernetes,k
 kubernetes.filesystem.usage_pct,gauge,,fraction,,The percentage of disk used,-1,kubernetes,k8s.disk.used_pct
 kubernetes.io.read_bytes,gauge,,byte,,The amount of bytes read from the disk,0,kubernetes,k8_io_read_bytes
 kubernetes.io.write_bytes,gauge,,byte,,The amount of bytes written to the disk,0,kubernetes,k8_io_write_bytes
-kubernetes.memory.capacity,gauge,,byte,,The amount of memory (in bytes) in this machine,0,kubernetes,k8s.mem.capacity
+kubernetes.memory.capacity,gauge,,byte,,The amount of memory (in bytes) in this machine (available until kubernetes v1.18),0,kubernetes,k8s.mem.capacity
 kubernetes.memory.limits,gauge,,byte,,The limit of memory set,0,kubernetes,k8s.mem.limits
 kubernetes.memory.sw_limit,gauge,,byte,,The limit of swap space set,0,kubernetes,k8s.mem.sw_limit
 kubernetes.memory.requests,gauge,,byte,,The requested memory,0,kubernetes,k8s.mem.requests

--- a/kubelet/tests/test_cadvisor.py
+++ b/kubelet/tests/test_cadvisor.py
@@ -61,7 +61,9 @@ def test_kubelet_check_cadvisor(monkeypatch, aggregator, tagger):
     monkeypatch.setattr(
         check, 'retrieve_pod_list', mock.Mock(return_value=json.loads(mock_from_file('pods_list_1.2.json')))
     )
-    monkeypatch.setattr(check, '_retrieve_node_spec', mock.Mock(return_value=NODE_SPEC))
+    mock_resp = mock.Mock(status_code=200, raise_for_status=mock.Mock())
+    mock_resp.json = mock.Mock(return_value=NODE_SPEC)
+    monkeypatch.setattr(check, '_retrieve_node_spec', mock.Mock(return_value=mock_resp))
     monkeypatch.setattr(
         check, '_retrieve_stats', mock.Mock(return_value=json.loads(mock_from_file('stats_summary.json')))
     )


### PR DESCRIPTION
### What does this PR do?

Support kubernetes v1.18 in a degraded mode when the `/spec` endpoint is not activated

### Motivation

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
