### PR TITLE
Fix failing style checks

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/win/winpdh.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/winpdh.py
@@ -130,7 +130,7 @@ class WinPDHCounter(object):
         # for more detail
 
         # create a table of the keys to the counter index, because we want to look up
-        # by counter name. Some systems may have an odd number of entries, don't 
+        # by counter name. Some systems may have an odd number of entries, don't
         # accidentaly index at val[len(val]
         for idx in range(0, len(val) - 1, 2):
             WinPDHCounter.pdh_counter_dict[val[idx + 1]].append(val[idx])


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix style checks on `WinPDHCounter`.

```console
./datadog_checks/base/checks/win/winpdh.py:133:81: W291 trailing whitespace
```

### Motivation
<!-- What inspired you to submit this pull request? -->
Makes `datadog_checks_base` tests fail on `master`.

Cleanup for #6052. Refs https://github.com/DataDog/integrations-core/pull/6084#issuecomment-606610311

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
