### PR TITLE
Update per connector metric bean rule

### DIFF
--- a/confluent_platform/datadog_checks/confluent_platform/data/metrics.yaml
+++ b/confluent_platform/datadog_checks/confluent_platform/data/metrics.yaml
@@ -588,9 +588,11 @@ jmx_metrics:
   # https://kafka.apache.org/documentation/#connect_monitoring
   - include:
       domain: kafka.connect
-      # Recent metrics merged on 3 Oct 2019: https://github.com/apache/kafka/pull/6843
-      # Probably not present in the connector we are using for testing
-      bean_regex: kafka\.connect:type=connect-worker-metrics,connector=.*
+      bean_regex:
+        # The bean should `connect-worker-metrics` but in practice the type is `connector-metrics`
+        # We are supporting both while the issue is solved: https://issues.apache.org/jira/browse/KAFKA-9790
+        - kafka\.connect:type=connect-worker-metrics,connector=.*
+        - kafka\.connect:type=connector-metrics,connector=.*
       attribute:
         connector-destroyed-task-count:
           # The number of destroyed tasks of the connector on the worker.

--- a/confluent_platform/tests/compose/docker-compose.yaml
+++ b/confluent_platform/tests/compose/docker-compose.yaml
@@ -201,3 +201,28 @@ services:
       CONNECT_CONFLUENT_TOPIC_REPLICATION_FACTOR: "1"
       KAFKA_JMX_HOSTNAME: "localhost"
       KAFKA_JMX_PORT: 31008
+
+  control-center:
+    image: confluentinc/cp-enterprise-control-center:5.4.0
+    hostname: control-center
+    container_name: control-center
+    depends_on:
+      - zookeeper
+      - broker
+      - schema-registry
+      - connect
+      - ksql-server
+    ports:
+      - "9021:9021"
+    environment:
+      CONTROL_CENTER_BOOTSTRAP_SERVERS: 'broker:29092'
+      CONTROL_CENTER_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      CONTROL_CENTER_CONNECT_CLUSTER: 'connect:8083'
+      CONTROL_CENTER_KSQL_URL: "http://ksql-server:8088"
+      CONTROL_CENTER_KSQL_ADVERTISED_URL: "http://localhost:8088"
+      CONTROL_CENTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
+      CONTROL_CENTER_REPLICATION_FACTOR: 1
+      CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1
+      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS: 1
+      CONFLUENT_METRICS_TOPIC_REPLICATION: 1
+      PORT: 9021

--- a/confluent_platform/tests/conftest.py
+++ b/confluent_platform/tests/conftest.py
@@ -1,15 +1,34 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
+import json
 import os
 
 import pytest
+import requests
 
 from datadog_checks.dev import docker_run
-from datadog_checks.dev.conditions import CheckDockerLogs
+from datadog_checks.dev.conditions import CheckDockerLogs, WaitFor
 
 from .common import CHECK_CONFIG, HERE
+
+
+def create_connectors():
+    # Create a dummy connector
+    headers = {'Content-type': 'application/json'}
+    data = {
+        "name": "datagen-pageviews",
+        "config": {
+            "connector.class": "io.confluent.kafka.connect.datagen.DatagenConnector",
+            "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+            "kafka.topic": "pageviews",
+            "quickstart": "pageviews",
+            "max.interval": 100,
+            "iterations": 10000000,
+            "tasks.max": "1",
+        },
+    }
+    requests.post('http://localhost:8083/connectors', data=json.dumps(data), headers=headers)
 
 
 @pytest.fixture(scope="session")
@@ -24,6 +43,8 @@ def dd_environment():
             CheckDockerLogs('schema-registry', 'Server started, listening for requests...', attempts=90),
             # Kafka Connect
             CheckDockerLogs('connect', 'Kafka Connect started', attempts=120),
+            # Create connectors
+            WaitFor(create_connectors),
         ],
     ):
         yield CHECK_CONFIG, {'use_jmx': True}

--- a/confluent_platform/tests/metrics.py
+++ b/confluent_platform/tests/metrics.py
@@ -49,6 +49,16 @@ CONNECT_METRICS_OPTIONAL = [
     'confluent.kafka.connect.worker_rebalance.rebalance_max_time_ms',
 ]
 
+
+CONNECT_PER_CONNECTOR_METRICS = [
+    'confluent.kafka.connect.worker.connector_destroyed_task_count',
+    'confluent.kafka.connect.worker.connector_failed_task_count',
+    'confluent.kafka.connect.worker.connector_paused_task_count',
+    'confluent.kafka.connect.worker.connector_running_task_count',
+    'confluent.kafka.connect.worker.connector_total_task_count',
+    'confluent.kafka.connect.worker.connector_unassigned_task_count',
+]
+
 REST_JETTY_METRICS = [
     'confluent.kafka.rest.jetty.connections_active',
 ]
@@ -254,6 +264,7 @@ KSQL_QUERY_STATS = [
 ALWAYS_PRESENT_METRICS = (
     BROKER_METRICS
     + CONNECT_METRICS
+    + CONNECT_PER_CONNECTOR_METRICS
     + REST_JETTY_METRICS
     + REST_JERSEY_METRICS
     + SCHEMA_REGISTRY_JETTY_METRICS

--- a/confluent_platform/tests/metrics.py
+++ b/confluent_platform/tests/metrics.py
@@ -5,24 +5,50 @@
 
 BROKER_METRICS = [
     'confluent.kafka.cluster.partition.under_min_isr',
-    'confluent.kafka.controller.leader_election_rate_and_time_ms.avg',
     'confluent.kafka.controller.active_controller_count',
+    'confluent.kafka.controller.leader_election_rate_and_time_ms.avg',
+    'confluent.kafka.controller.leader_election_rate_and_time_ms.rate',
     'confluent.kafka.controller.offline_partitions_count',
-    'confluent.kafka.network.request_channel.request_queue_size',
+    'confluent.kafka.controller.unclean_leader_elections_per_sec.rate',
     'confluent.kafka.network.request.local_time_ms.avg',
+    'confluent.kafka.network.request.local_time_ms.rate',
     'confluent.kafka.network.request.remote_time_ms.avg',
+    'confluent.kafka.network.request.remote_time_ms.rate',
     'confluent.kafka.network.request.request_queue_time_ms.avg',
+    'confluent.kafka.network.request.request_queue_time_ms.rate',
+    'confluent.kafka.network.request.requests_per_sec.rate',
     'confluent.kafka.network.request.response_queue_time_ms.avg',
+    'confluent.kafka.network.request.response_queue_time_ms.rate',
     'confluent.kafka.network.request.response_send_time_ms.avg',
+    'confluent.kafka.network.request.response_send_time_ms.rate',
     'confluent.kafka.network.request.total_time_ms.avg',
+    'confluent.kafka.network.request.total_time_ms.rate',
+    'confluent.kafka.network.request_channel.request_queue_size',
     'confluent.kafka.network.socket_server.network_processor_avg_idle_percent',
     'confluent.kafka.server.delayed_operation_purgatory.purgatory_size',
     'confluent.kafka.server.delayed_operation_purgatory.purgatory_size',
     'confluent.kafka.server.replica_fetcher_manager.max_lag',
+    'confluent.kafka.server.replica_manager.isr_expands_per_sec.rate',
+    'confluent.kafka.server.replica_manager.isr_shrinks_per_sec.rate',
     'confluent.kafka.server.replica_manager.leader_count',
     'confluent.kafka.server.replica_manager.partition_count',
     'confluent.kafka.server.replica_manager.under_min_isr_partition_count',
     'confluent.kafka.server.replica_manager.under_replicated_partitions',
+    'confluent.kafka.server.request_handler_pool.avg_idle_percent.rate',
+    'confluent.kafka.server.session.zoo_keeper_auth_failures_per_sec.rate',
+    'confluent.kafka.server.session.zoo_keeper_disconnects_per_sec.rate',
+    'confluent.kafka.server.session.zoo_keeper_expires_per_sec.rate',
+    'confluent.kafka.server.session.zoo_keeper_read_only_connects_per_sec.rate',
+    'confluent.kafka.server.session.zoo_keeper_sasl_authentications_per_sec.rate',
+    'confluent.kafka.server.session.zoo_keeper_sync_connects_per_sec.rate',
+    'confluent.kafka.server.topic.bytes_in_per_sec.rate',
+    'confluent.kafka.server.topic.bytes_out_per_sec.rate',
+    'confluent.kafka.server.topic.bytes_rejected_per_sec.rate',
+    'confluent.kafka.server.topic.failed_fetch_requests_per_sec.rate',
+    'confluent.kafka.server.topic.failed_produce_requests_per_sec.rate',
+    'confluent.kafka.server.topic.messages_in_per_sec.rate',
+    'confluent.kafka.server.topic.total_fetch_requests_per_sec.rate',
+    'confluent.kafka.server.topic.total_produce_requests_per_sec.rate',
 ]
 
 CONNECT_METRICS = [
@@ -49,6 +75,34 @@ CONNECT_METRICS_OPTIONAL = [
     'confluent.kafka.connect.worker_rebalance.rebalance_max_time_ms',
 ]
 
+
+CONNECT_TASK = [
+    'confluent.kafka.connect.connector_task.batch_size_avg',
+    'confluent.kafka.connect.connector_task.batch_size_max',
+    'confluent.kafka.connect.connector_task.offset_commit_avg_time_ms',
+    'confluent.kafka.connect.connector_task.offset_commit_failure_percentage',
+    'confluent.kafka.connect.connector_task.offset_commit_max_time_ms',
+    'confluent.kafka.connect.connector_task.offset_commit_success_percentage',
+    'confluent.kafka.connect.connector_task.pause_ratio',
+    'confluent.kafka.connect.connector_task.running_ratio',
+    'confluent.kafka.connect.source_task.poll_batch_avg_time_ms',
+    'confluent.kafka.connect.source_task.poll_batch_max_time_ms',
+    'confluent.kafka.connect.source_task.source_record_active_count',
+    'confluent.kafka.connect.source_task.source_record_active_count_avg',
+    'confluent.kafka.connect.source_task.source_record_active_count_max',
+    'confluent.kafka.connect.source_task.source_record_poll_rate',
+    'confluent.kafka.connect.source_task.source_record_poll_total',
+    'confluent.kafka.connect.source_task.source_record_write_rate',
+    'confluent.kafka.connect.source_task.source_record_write_total',
+    'confluent.kafka.connect.task_error.deadletterqueue_produce_failures',
+    'confluent.kafka.connect.task_error.deadletterqueue_produce_requests',
+    'confluent.kafka.connect.task_error.last_error_timestamp',
+    'confluent.kafka.connect.task_error.total_errors_logged',
+    'confluent.kafka.connect.task_error.total_record_errors',
+    'confluent.kafka.connect.task_error.total_record_failures',
+    'confluent.kafka.connect.task_error.total_records_skipped',
+    'confluent.kafka.connect.task_error.total_retries',
+]
 
 CONNECT_PER_CONNECTOR_METRICS = [
     'confluent.kafka.connect.worker.connector_destroyed_task_count',
@@ -264,6 +318,7 @@ KSQL_QUERY_STATS = [
 ALWAYS_PRESENT_METRICS = (
     BROKER_METRICS
     + CONNECT_METRICS
+    + CONNECT_TASK
     + CONNECT_PER_CONNECTOR_METRICS
     + REST_JETTY_METRICS
     + REST_JERSEY_METRICS


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

1. Per connector metrics bean name should be `kafka.connect:type=connect-worker-metrics,connector=.*`, but in practice it's named `kafka.connect:type=connector-metrics,connector=.*`

Let's support both.

More details on this upstream issue ticket: https://issues.apache.org/jira/browse/KAFKA-9790

2. Add control center to help QA to manually triggering actions from UI when needed

3. Rate metrics added to test

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
