### PR TITLE
Change kube_apiserver_metrics to kubernetes_apiserver in openshift docs

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -2,7 +2,7 @@
 
 Red Hat OpenShift is an open source container application platform based on the Kubernetes container orchestrator for enterprise application development and deployment.
 
-> There is currently no separate `openshift` check, this README describes the necessary configuration to enable collection of OpenShift specific metrics in the Agent. Data described here are collected by the [`kube-apiserver` check][1], setting up this check is necessary to collect the `openshift.*` metrics.
+> There is currently no separate `openshift` check, this README describes the necessary configuration to enable collection of OpenShift specific metrics in the Agent. Data described here are collected by the [`kubernetes_apiserver` check][1], setting up this check is necessary to collect the `openshift.*` metrics.
 
 ## Setup
 
@@ -88,7 +88,7 @@ runAsUser:
 
 ### Validation
 
-See [kube_apiserver_metrics][1]
+See [kubernetes_apiserver][1]
 
 ## Data Collected
 

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -2,7 +2,7 @@
 
 Red Hat OpenShift is an open source container application platform based on the Kubernetes container orchestrator for enterprise application development and deployment.
 
-> There is currently no separate `openshift` check, this README describes the necessary configuration to enable collection of OpenShift specific metrics in the Agent. Data described here are collected by the [`kube-apiserver-metrics` check][1], setting up this check is necessary to collect the `openshift.*` metrics.
+> There is currently no separate `openshift` check, this README describes the necessary configuration to enable collection of OpenShift specific metrics in the Agent. Data described here are collected by the [`kube-apiserver` check][1], setting up this check is necessary to collect the `openshift.*` metrics.
 
 ## Setup
 
@@ -108,7 +108,7 @@ The OpenShift check does not include any Service Checks.
 
 Need help? Contact [Datadog support][11].
 
-[1]: https://github.com/DataDog/integrations-core/tree/master/kube_apiserver_metrics
+[1]: https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
 [2]: https://docs.datadoghq.com/agent/kubernetes
 [3]: https://docs.openshift.org/latest/admin_guide/manage_scc.html
 [4]: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup


### PR DESCRIPTION
### What does this PR do?
Change kube_apiserver_metrics to kube_apiserver

### Motivation
Openshift relies on the kube_apiserver check instead of the kube_apiserver_metrics check

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
