### PR TITLE
Make error message more explicit

### DIFF
--- a/supervisord/datadog_checks/supervisord/supervisord.py
+++ b/supervisord/datadog_checks/supervisord/supervisord.py
@@ -115,11 +115,11 @@ class SupervisordCheck(AgentCheck):
         # Filter monitored processes on configuration directives
         proc_regex = instance.get('proc_regex', [])
         if not isinstance(proc_regex, list):
-            raise Exception("'proc_regex' should be a list of strings.")
+            raise Exception("'proc_regex' should be a list of strings. e.g. %s" % [proc_regex])
 
         proc_names = instance.get('proc_names', [])
         if not isinstance(proc_names, list):
-            raise Exception("'proc_names' should be a list of strings.")
+            raise Exception("'proc_names' should be a list of strings. e.g. %s" % [proc_names])
 
         # Collect information on each monitored process
         monitored_processes = []

--- a/supervisord/datadog_checks/supervisord/supervisord.py
+++ b/supervisord/datadog_checks/supervisord/supervisord.py
@@ -115,11 +115,11 @@ class SupervisordCheck(AgentCheck):
         # Filter monitored processes on configuration directives
         proc_regex = instance.get('proc_regex', [])
         if not isinstance(proc_regex, list):
-            raise Exception("Empty or invalid proc_regex.")
+            raise Exception("'proc_regex' should be a list of strings.")
 
         proc_names = instance.get('proc_names', [])
         if not isinstance(proc_names, list):
-            raise Exception("Empty or invalid proc_names.")
+            raise Exception("'proc_names' should be a list of strings.")
 
         # Collect information on each monitored process
         monitored_processes = []


### PR DESCRIPTION
### What does this PR do?
Updates error message. proc_regex/proc_names are never _Empty_(`None` to be more specific); if unset, defaults to an empty list which is still works as it is still a list and will not raise.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
- This is redo of PR https://github.com/DataDog/integrations-core/pull/6022 to address review and recent conflicts
- closes #5826

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
