### PR TITLE
Add rate metrics to JMX e2e tests

### DIFF
--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -6,14 +6,10 @@ kafka.net.processor.avg.idle.pct.rate,gauge,10,fraction,,Average fraction of tim
 kafka.messages_in.rate,gauge,10,message,,Incoming message rate.,0,kafka,messages in
 kafka.request.channel.queue.size,gauge,10,request,,Number of queued requests.,-1,kafka,req channel queue size
 kafka.request.fetch.failed.rate,gauge,10,request,,Number of client fetch request failures.,-1,kafka,req fetch fail
-kafka.request.fetch.failed_per_second,gauge,10,request,second,Rate of client fetch request failures per second.,-1,kafka,req fetch fail rate
 kafka.request.handler.avg.idle.pct.rate,gauge,10,fraction,,Average fraction of time the request handler threads are idle.,1,kafka,req handle avg idle
 kafka.request.produce.time.avg,gauge,10,millisecond,,Average time for a produce request.,0,kafka,req prod time avg
 kafka.request.produce.time.99percentile,gauge,10,millisecond,,Time for produce requests for 99th percentile.,0,kafka,req prod time 99
-kafka.request.produce.failed_per_second,gauge,10,request,second,Rate of failed produce requests per second.,-1,kafka,req prod fail rate
 kafka.request.produce.failed.rate,gauge,10,request,,Number of failed produce requests.,-1,kafka,req prod fail
-kafka.request.fetch.time.avg,gauge,10,millisecond,,Average time per fetch request.,0,kafka,req fetch time avg
-kafka.request.fetch.time.99percentile,gauge,10,millisecond,,Time for fetch requests for 99th percentile.,0,kafka,req fetch time 99
 kafka.request.update_metadata.time.avg,gauge,10,millisecond,,Average time for a request to update metadata.,0,kafka,req update meta time avg
 kafka.request.update_metadata.time.99percentile,gauge,10,millisecond,,Time for update metadata requests for 99th percentile.,0,kafka,req update meta time 99
 kafka.request.metadata.time.avg,gauge,10,millisecond,,Average time for metadata request.,0,kafka,req meta time avg

--- a/kafka/tests/common.py
+++ b/kafka/tests/common.py
@@ -13,25 +13,11 @@ HOST_IP = socket.gethostbyname(HOST)
 
 
 """
-Rate type metrics that do not work in our e2e:
+Metrics that do not work in our e2e:
     "kafka.consumer.bytes_in",
     "kafka.consumer.kafka_commits",
     "kafka.consumer.messages_in",
     "kafka.consumer.zookeeper_commits",
-    "kafka.messages_in.rate",
-    "kafka.net.bytes_in.rate",
-    "kafka.net.bytes_out.rate",
-    "kafka.net.bytes_rejected.rate",
-    "kafka.replication.isr_expands.rate",
-    "kafka.replication.isr_shrinks.rate",
-    "kafka.replication.leader_elections.rate",
-    "kafka.replication.unclean_leader_elections.rate",
-    "kafka.request.fetch.failed.rate",
-    "kafka.request.fetch.failed_per_second",
-    "kafka.request.fetch.time.99percentile",
-    "kafka.request.fetch.time.avg",
-    "kafka.request.produce.failed.rate",
-    "kafka.request.produce.failed_per_second",
 """
 
 KAFKA_E2E_METRICS = [
@@ -58,6 +44,21 @@ KAFKA_E2E_METRICS = [
     "kafka.replication.offline_partitions_count",
     "kafka.replication.partition_count",
     "kafka.replication.under_replicated_partitions",
+    # Rates
+    "kafka.messages_in.rate",
+    "kafka.net.bytes_in.rate",
+    "kafka.net.bytes_out.rate",
+    "kafka.net.bytes_rejected.rate",
+    "kafka.replication.isr_expands.rate",
+    "kafka.replication.isr_shrinks.rate",
+    "kafka.replication.leader_elections.rate",
+    "kafka.replication.unclean_leader_elections.rate",
+    "kafka.request.fetch.failed.rate",
+    "kafka.request.produce.failed.rate",
+    "kafka.session.zookeeper.disconnect.rate",
+    "kafka.session.zookeeper.expire.rate",
+    "kafka.session.zookeeper.readonly.rate",
+    "kafka.session.zookeeper.sync.rate",
     # JVM metrics:
     "jvm.buffer_pool.direct.capacity",
     "jvm.buffer_pool.direct.count",

--- a/tomcat/tests/common.py
+++ b/tomcat/tests/common.py
@@ -8,22 +8,9 @@ CHECK_NAME = "tomcat"
 HERE = get_here()
 
 """
-These metrics cannot be added to E2E yet because they are rate and count types.
-They are visiable in the console but not to this test.
-
-Metrics To add to e2e test:
-    "tomcat.bytes_sent",
-    "tomcat.bytes_rcvd",
-    "tomcat.error_count",
-    "tomcat.request_count",
-    "tomcat.processing_time",
-    "tomcat.servlet.processing_time",
-    "tomcat.servlet.error_count",
-    "tomcat.servlet.request_count",
+Metrics that are not produced by our e2e tests:
     "tomcat.cache.access_count",
     "tomcat.cache.hits_count",
-    "tomcat.jsp.count",
-    "tomcat.jsp.reload_count",
 """
 
 
@@ -33,6 +20,17 @@ TOMCAT_E2E_METRICS = [
     "tomcat.threads.busy",
     "tomcat.threads.count",
     "tomcat.threads.max",
+    # Rates
+    "tomcat.bytes_sent",
+    "tomcat.bytes_rcvd",
+    "tomcat.error_count",
+    "tomcat.request_count",
+    "tomcat.processing_time",
+    "tomcat.servlet.processing_time",
+    "tomcat.servlet.error_count",
+    "tomcat.servlet.request_count",
+    "tomcat.jsp.count",
+    "tomcat.jsp.reload_count",
     # JVM
     "jvm.buffer_pool.direct.capacity",
     "jvm.buffer_pool.direct.count",


### PR DESCRIPTION
JMX e2e tests now produce rate metrics properly. This fixes the JMX
tests that were already passing `rate=True` and thus broke because the
agent now produces them.

This also removes entries from kafka metadata that were incorrect.