### PR TITLE
Deprecating the legacy implementation

### DIFF
--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -21,6 +21,21 @@ instances:
     #
     password: <PASSWORD>
 
+    ## @param use_legacy_check_version - boolean - required
+    ## For backward compatibility reasons, it is possible to use a deprecated version of the vsphere integration by
+    ## setting this field to "true".
+    #
+    use_legacy_check_version: false
+
+    ## @param empty_default_hostname - boolean - optional - default: false
+    ## The vSphere integration is a cluster-level check where metrics are usually unrelated to the host
+    ## on which the agent runs. Setting this parameter to true, prevents the agent from attaching the hostname
+    ## (and the host tags) to the metrics. It is especially important to leave this parameter to "true" when you are
+    ## running the agent inside a vSphere VM as the VM tags are going to be unrelated to other metrics.
+    ##
+    #
+    empty_default_hostname: true
+
     ## @param tags - list of key:value element - optional
     ## List of tags to attach to every metric, event and service check emitted by this integration.
     ##
@@ -246,18 +261,3 @@ instances:
     ## Number of seconds between each refresh of the metrics metadata cache
     #
     # refresh_metrics_metadata_cache_interval: 1800
-
-    ## @param use_legacy_check_version - boolean - required
-    ## For backward compatibility reasons, it is possible to use a deprecated version of the vsphere integration by
-    ## setting this field to "true".
-    #
-    use_legacy_check_version: false
-
-    ## @param empty_default_hostname - boolean - optional - default: false
-    ## The vSphere integration is a cluster-level check where metrics are usually unrelated to the host
-    ## on which the agent runs. Setting this parameter to true, prevents the agent from attaching the hostname
-    ## (and the host tags) to the metrics. It is especially important to leave this parameter to "true" when you are
-    ## running the agent inside a vSphere VM as the VM tags are going to be unrelated to other metrics.
-    ##
-    #
-    empty_default_hostname: true

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -29,7 +29,7 @@ instances:
 
     ## @param empty_default_hostname - boolean - optional - default: false
     ## The vSphere integration is a cluster-level check where metrics are usually unrelated to the host
-    ## on which the agent runs. Setting this parameter to true, prevents the agent from attaching the hostname
+    ## on which the Agent runs. Setting this parameter to true, prevents the Agent from attaching the hostname
     ## (and the host tags) to the metrics. It is especially important to leave this parameter to "true" when you are
     ## running the agent inside a vSphere VM as the VM tags are going to be unrelated to other metrics.
     ##

--- a/vsphere/datadog_checks/vsphere/legacy/vsphere_legacy.py
+++ b/vsphere/datadog_checks/vsphere/legacy/vsphere_legacy.py
@@ -147,8 +147,6 @@ class VSphereLegacyCheck(AgentCheck):
         self.latest_event_query = {}
         self.exception_printed = 0
 
-        self._has_logged_depreciation_warning = False
-
     def print_exception(self, msg):
         """ Print exceptions happening in separate threads
         Prevent from logging a ton of them if a potentially big number of them fail the same way
@@ -978,13 +976,11 @@ class VSphereLegacyCheck(AgentCheck):
             self.gauge('vsphere.vm.count', vm_count, tags=tags)
 
     def check(self, instance):
-        if not self._has_logged_depreciation_warning:
-            self.warning(
-                "DEPRECATION NOTICE: You are using a deprecated version of the vSphere integration. "
-                "To use the newer version, please update your configuration file based on the provided example. "
-                "Look for the `use_legacy_check_version` configuration option."
-            )
-            self._has_logged_depreciation_warning = True
+        self.warning(
+            "DEPRECATION NOTICE: You are using a deprecated version of the vSphere integration. "
+            "To use the newer version, please update your configuration file based on the provided example. "
+            "Look for the `use_legacy_check_version` configuration option."
+        )
         try:
             self.exception_printed = 0
 

--- a/vsphere/datadog_checks/vsphere/legacy/vsphere_legacy.py
+++ b/vsphere/datadog_checks/vsphere/legacy/vsphere_legacy.py
@@ -147,6 +147,8 @@ class VSphereLegacyCheck(AgentCheck):
         self.latest_event_query = {}
         self.exception_printed = 0
 
+        self._has_logged_depreciation_warning = False
+
     def print_exception(self, msg):
         """ Print exceptions happening in separate threads
         Prevent from logging a ton of them if a potentially big number of them fail the same way
@@ -976,6 +978,13 @@ class VSphereLegacyCheck(AgentCheck):
             self.gauge('vsphere.vm.count', vm_count, tags=tags)
 
     def check(self, instance):
+        if not self._has_logged_depreciation_warning:
+            self.warning(
+                "DEPRECATION NOTICE: You are using a deprecated version of the vSphere integration. "
+                "To use the newer version, please update your configuration file based on the provided example. "
+                "Look for the `use_legacy_check_version` configuration option."
+            )
+            self._has_logged_depreciation_warning = True
         try:
             self.exception_printed = 0
 


### PR DESCRIPTION
The newer implementation is the default since 6.18 but some users updating don't find it especially straightforward that their configuraiton file needs to be updated.

To ease that process, we're adding a deprecation warning that should:
- Help the users that want to migrate to the new implementation.
- Help existing users be aware of the newer implementation

Question: Should we specify an EOL?