### PR TITLE
Collect network metrics for ECS Fargate

### DIFF
--- a/ecs_fargate/metadata.csv
+++ b/ecs_fargate/metadata.csv
@@ -22,3 +22,9 @@ ecs.fargate.mem.mapped_file,gauge,,byte,,# of bytes of mapped file (includes tmp
 ecs.fargate.mem.max_usage,gauge,,byte,,Show max memory usage recorded,0,amazon_fargate,mem max usage
 ecs.fargate.mem.hierarchical_memory_limit,gauge,,byte,,# of bytes of memory limit with regard to hierarchy under which the memory cgroup is,0,amazon_fargate,mem hierarchical limit
 ecs.fargate.mem.hierarchical_memsw_limit,gauge,,byte,,# of bytes of memory+swap limit with regard to hierarchy under which memory cgroup is,0,amazon_fargate,mem hierarchical mem swap limit
+ecs.fargate.net.rcvd_errors,gauge,,error,,# received errors (Fargate 1.4.0+ required),-1,amazon_fargate,received net errors
+ecs.fargate.net.sent_errors,gauge,,error,,# sent errors (Fargate 1.4.0+ required),-1,amazon_fargate,sent net errors
+ecs.fargate.net.packet.in_dropped,gauge,,packet,,# ingoing packets dropped (Fargate 1.4.0+ required),-1,amazon_fargate,in packets dropped
+ecs.fargate.net.packet.out_dropped,gauge,,packet,,# outgoing packets dropped (Fargate 1.4.0+ required),-1,amazon_fargate,out packets dropped
+ecs.fargate.net.bytes_rcvd,rate,,byte,,# bytes received (Fargate 1.4.0+ required),0,amazon_fargate, bytes received
+ecs.fargate.net.bytes_sent,rate,,byte,,# bytes sent (Fargate 1.4.0+ required),0,amazon_fargate,bytes sent

--- a/ecs_fargate/tests/fixtures/stats.json
+++ b/ecs_fargate/tests/fixtures/stats.json
@@ -4,7 +4,28 @@
 		"preread": "2017-11-23T09:26:37.501577422Z",
 		"num_procs": 0,
 		"pids_stats": {},
-		"network": {},
+		"networks": {
+            "eth0": {
+                "rx_bytes": 5338,
+                "rx_dropped": 0,
+                "rx_errors": 0,
+                "rx_packets": 36,
+                "tx_bytes": 648,
+                "tx_dropped": 0,
+                "tx_errors": 0,
+                "tx_packets": 8
+            },
+            "eth5": {
+                "rx_bytes": 4641,
+                "rx_dropped": 0,
+                "rx_errors": 0,
+                "rx_packets": 26,
+                "tx_bytes": 690,
+                "tx_dropped": 0,
+                "tx_errors": 0,
+                "tx_packets": 9
+            }
+        },
 		"memory_stats": {
 			"stats": {
 				"cache": 794624,
@@ -103,13 +124,24 @@
 			"throttling_data": {}
 		},
 		"storage_stats": {}
-	},
-	"c912d0f0f204360ee90ce67c0d083c3514975f149b854f38a48deac611e82e48": {
+    },
+    "c912d0f0f204360ee90ce67c0d083c3514975f149b854f38a48deac611e82e48": {
 		"read": "2017-11-23T09:26:38.507160628Z",
 		"preread": "2017-11-23T09:26:37.507043806Z",
 		"num_procs": 0,
 		"pids_stats": {},
-		"network": {},
+		"networks": {
+            "eth1": {
+                "rx_bytes": 268836870,
+                "rx_packets": 181745,
+                "rx_errors": 0,
+                "rx_dropped": 0,
+                "tx_bytes": 455081,
+                "tx_packets": 5815,
+                "tx_errors": 0,
+                "tx_dropped": 0
+            }
+        },
 		"memory_stats": {
 			"stats": {
 				"cache": 6496256,

--- a/ecs_fargate/tests/test_unit.py
+++ b/ecs_fargate/tests/test_unit.py
@@ -14,6 +14,44 @@ from datadog_checks.ecs_fargate import FargateCheck
 HERE = os.path.dirname(os.path.abspath(__file__))
 INSTANCE_TAGS = ['foo:bar']
 
+EXPECTED_CONTAINER_METRICS = [
+    'ecs.fargate.io.ops.write',
+    'ecs.fargate.io.bytes.write',
+    'ecs.fargate.io.ops.read',
+    'ecs.fargate.io.bytes.read',
+    'ecs.fargate.cpu.user',
+    'ecs.fargate.cpu.system',
+    'ecs.fargate.cpu.percent',
+    'ecs.fargate.mem.cache',
+    'ecs.fargate.mem.active_file',
+    'ecs.fargate.mem.inactive_file',
+    'ecs.fargate.mem.pgpgout',
+    'ecs.fargate.mem.limit',
+    'ecs.fargate.mem.pgfault',
+    'ecs.fargate.mem.active_anon',
+    'ecs.fargate.mem.usage',
+    'ecs.fargate.mem.rss',
+    'ecs.fargate.mem.pgpgin',
+    'ecs.fargate.mem.pgmajfault',
+    'ecs.fargate.mem.mapped_file',
+    'ecs.fargate.mem.max_usage',
+]
+
+EXTRA_EXPECTED_CONTAINER_METRICS = [
+    'ecs.fargate.cpu.limit',
+    'ecs.fargate.mem.hierarchical_memory_limit',
+    'ecs.fargate.mem.hierarchical_memsw_limit',
+]
+
+EXTRA_NETWORK_METRICS = [
+    'ecs.fargate.net.rcvd_errors',
+    'ecs.fargate.net.sent_errors',
+    'ecs.fargate.net.packet.in_dropped',
+    'ecs.fargate.net.packet.out_dropped',
+    'ecs.fargate.net.bytes_rcvd',
+    'ecs.fargate.net.bytes_sent',
+]
+
 
 @pytest.fixture
 def instance():
@@ -178,49 +216,21 @@ def test_successful_check(check, instance, aggregator):
         ],
     ]
 
-    expected_container_metrics = [
-        'ecs.fargate.io.ops.write',
-        'ecs.fargate.io.bytes.write',
-        'ecs.fargate.io.ops.read',
-        'ecs.fargate.io.bytes.read',
-        'ecs.fargate.cpu.user',
-        'ecs.fargate.cpu.system',
-        'ecs.fargate.cpu.percent',
-        'ecs.fargate.mem.cache',
-        'ecs.fargate.mem.active_file',
-        'ecs.fargate.mem.inactive_file',
-        'ecs.fargate.mem.pgpgout',
-        'ecs.fargate.mem.limit',
-        'ecs.fargate.mem.pgfault',
-        'ecs.fargate.mem.active_anon',
-        'ecs.fargate.mem.usage',
-        'ecs.fargate.mem.rss',
-        'ecs.fargate.mem.pgpgin',
-        'ecs.fargate.mem.pgmajfault',
-        'ecs.fargate.mem.mapped_file',
-        'ecs.fargate.mem.max_usage',
-    ]
-
     extra_expected_metrics_for_container = [
-        [
-            'ecs.fargate.cpu.limit',
-            'ecs.fargate.mem.hierarchical_memory_limit',
-            'ecs.fargate.mem.hierarchical_memsw_limit',
-        ],
-        [
-            'ecs.fargate.cpu.limit',
-            'ecs.fargate.mem.hierarchical_memory_limit',
-            'ecs.fargate.mem.hierarchical_memsw_limit',
-        ],
+        EXTRA_EXPECTED_CONTAINER_METRICS,
+        EXTRA_EXPECTED_CONTAINER_METRICS,
         [],  # pause container get fewer metrics
     ]
 
     for i in range(3):
         tags = common_tags + container_tags[i]
-        for metric in expected_container_metrics:
+        for metric in EXPECTED_CONTAINER_METRICS:
             aggregator.assert_metric(metric, count=1, tags=tags)
         for metric in extra_expected_metrics_for_container[i]:
             aggregator.assert_metric(metric, count=1, tags=tags)
+
+    for metric in EXTRA_NETWORK_METRICS:
+        aggregator.assert_metric(metric, count=3)  # 3 network interfaces
 
     aggregator.assert_all_metrics_covered()
 


### PR DESCRIPTION
### What does this PR do?
Collect new network metrics from the ECS Metadata API
-    `ecs.fargate.net.rcvd_errors`
-   `ecs.fargate.net.sent_errors`
-    `ecs.fargate.net.packet.in_dropped`
-    `ecs.fargate.net.packet.out_dropped`
-    `ecs.fargate.net.bytes_rcvd`
-    `ecs.fargate.net.bytes_sent`

### Motivation

![image](https://user-images.githubusercontent.com/38987709/78128582-763c7e80-7416-11ea-88b0-f4255ffa73f1.png)


### Additional Notes
Requires Fargate Platform 1.4.0+

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
