### PR TITLE
Pass namespace to `is_excluded`

### DIFF
--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -13,7 +13,7 @@ except ImportError:
     log = logging.getLogger(__name__)
     log.info('Agent does not provide filtering logic, disabling container filtering')
 
-    def is_excluded(name, image):
+    def is_excluded(name, image, namespace=""):
         return False
 
 
@@ -115,6 +115,7 @@ class PodListUtils(object):
         self.cache = {}
         self.pod_uid_by_name_tuple = {}
         self.container_id_by_name_tuple = {}
+        self.container_id_to_namespace = {}
 
         if podlist is None:
             return
@@ -139,6 +140,7 @@ class PodListUtils(object):
                     continue
                 self.containers[cid] = ctr
                 self.container_id_by_name_tuple[(namespace, pod_name, ctr.get('name'))] = cid
+                self.container_id_to_namespace[cid] = namespace
 
     def get_uid_by_name_tuple(self, name_tuple):
         """
@@ -190,7 +192,7 @@ class PodListUtils(object):
             self.cache[cid] = True
             return True
 
-        excluded = is_excluded(ctr.get("name"), ctr.get("image"))
+        excluded = is_excluded(ctr.get("name"), ctr.get("image"), self.container_id_to_namespace.get(cid, ""))
         self.cache[cid] = excluded
         return excluded
 

--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -5,7 +5,7 @@
 from datadog_checks.base.utils.tagging import tagger
 
 try:
-    from containers import is_excluded
+    from containers import is_excluded as c_is_excluded
 except ImportError:
     # Don't fail on < 6.2
     import logging
@@ -13,7 +13,7 @@ except ImportError:
     log = logging.getLogger(__name__)
     log.info('Agent does not provide filtering logic, disabling container filtering')
 
-    def is_excluded(name, image, namespace=""):
+    def c_is_excluded(name, image, namespace=""):
         return False
 
 
@@ -192,7 +192,7 @@ class PodListUtils(object):
             self.cache[cid] = True
             return True
 
-        excluded = is_excluded(ctr.get("name"), ctr.get("image"), self.container_id_to_namespace.get(cid, ""))
+        excluded = c_is_excluded(ctr.get("name"), ctr.get("image"), self.container_id_to_namespace.get(cid, ""))
         self.cache[cid] = excluded
         return excluded
 

--- a/kubelet/tests/test_common.py
+++ b/kubelet/tests/test_common.py
@@ -21,8 +21,8 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 
 def test_container_filter(monkeypatch):
-    is_excluded = mock.Mock(return_value=False)
-    monkeypatch.setattr('datadog_checks.kubelet.common.is_excluded', is_excluded)
+    c_is_excluded = mock.Mock(return_value=False)
+    monkeypatch.setattr('datadog_checks.kubelet.common.c_is_excluded', c_is_excluded)
 
     long_cid = "docker://a335589109ce5506aa69ba7481fc3e6c943abd23c5277016c92dac15d0f40479"
     ctr_name = "datadog-agent"
@@ -35,50 +35,50 @@ def test_container_filter(monkeypatch):
     assert pod_list_utils is not None
     assert len(pod_list_utils.containers) == 10
     assert long_cid in pod_list_utils.containers
-    is_excluded.assert_not_called()
+    c_is_excluded.assert_not_called()
 
     # Test cid == None
-    is_excluded.reset_mock()
+    c_is_excluded.reset_mock()
     assert pod_list_utils.is_excluded(None) is True
-    is_excluded.assert_not_called()
+    c_is_excluded.assert_not_called()
 
     # Test cid == ""
-    is_excluded.reset_mock()
+    c_is_excluded.reset_mock()
     assert pod_list_utils.is_excluded("") is True
-    is_excluded.assert_not_called()
+    c_is_excluded.assert_not_called()
 
     # Test non-existing container
-    is_excluded.reset_mock()
+    c_is_excluded.reset_mock()
     assert pod_list_utils.is_excluded("invalid") is True
-    is_excluded.assert_not_called()
+    c_is_excluded.assert_not_called()
 
     # Test existing unfiltered container
-    is_excluded.reset_mock()
+    c_is_excluded.reset_mock()
     assert pod_list_utils.is_excluded(long_cid) is False
-    is_excluded.assert_called_once()
-    is_excluded.assert_called_with(ctr_name, ctr_image, namespace)
+    c_is_excluded.assert_called_once()
+    c_is_excluded.assert_called_with(ctr_name, ctr_image, namespace)
 
     # Clear exclusion cache
     pod_list_utils.cache = {}
 
     # Test existing filtered container
-    is_excluded.reset_mock()
-    is_excluded.return_value = True
+    c_is_excluded.reset_mock()
+    c_is_excluded.return_value = True
     assert pod_list_utils.is_excluded(long_cid) is True
-    is_excluded.assert_called_once()
-    is_excluded.assert_called_with(ctr_name, ctr_image, namespace)
+    c_is_excluded.assert_called_once()
+    c_is_excluded.assert_called_with(ctr_name, ctr_image, namespace)
 
 
 def test_filter_staticpods(monkeypatch):
-    is_excluded = mock.Mock(return_value=True)
-    monkeypatch.setattr('datadog_checks.kubelet.common.is_excluded', is_excluded)
+    c_is_excluded = mock.Mock(return_value=True)
+    monkeypatch.setattr('datadog_checks.kubelet.common.c_is_excluded', c_is_excluded)
 
     pods = json.loads(mock_from_file('pods.json'))
     pod_list_utils = PodListUtils(pods)
 
     # kube-proxy-gke-haissam-default-pool-be5066f1-wnvn is static
     assert pod_list_utils.is_excluded("cid", "260c2b1d43b094af6d6b4ccba082c2db") is False
-    is_excluded.assert_not_called()
+    c_is_excluded.assert_not_called()
 
     # fluentd-gcp-v2.0.10-9q9t4 is not static
     assert (

--- a/kubelet/tests/test_common.py
+++ b/kubelet/tests/test_common.py
@@ -27,6 +27,7 @@ def test_container_filter(monkeypatch):
     long_cid = "docker://a335589109ce5506aa69ba7481fc3e6c943abd23c5277016c92dac15d0f40479"
     ctr_name = "datadog-agent"
     ctr_image = "datadog/agent-dev:haissam-tagger-pod-entity"
+    namespace = "default"
 
     pods = json.loads(mock_from_file('pods.json'))
     pod_list_utils = PodListUtils(pods)
@@ -55,7 +56,7 @@ def test_container_filter(monkeypatch):
     is_excluded.reset_mock()
     assert pod_list_utils.is_excluded(long_cid) is False
     is_excluded.assert_called_once()
-    is_excluded.assert_called_with(ctr_name, ctr_image)
+    is_excluded.assert_called_with(ctr_name, ctr_image, namespace)
 
     # Clear exclusion cache
     pod_list_utils.cache = {}
@@ -65,7 +66,7 @@ def test_container_filter(monkeypatch):
     is_excluded.return_value = True
     assert pod_list_utils.is_excluded(long_cid) is True
     is_excluded.assert_called_once()
-    is_excluded.assert_called_with(ctr_name, ctr_image)
+    is_excluded.assert_called_with(ctr_name, ctr_image, namespace)
 
 
 def test_filter_staticpods(monkeypatch):


### PR DESCRIPTION
### What does this PR do?

Pass namespace to `is_excluded`

### Motivation

Since Datadog/datadog-agent#5224, the container exclusion filter based on the `ac_include`/`ac_exclude` parameters can use namespace.
So, the `is_excluded` function now takes a new parameter for the namespace.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
