### PR TITLE
Fix broken control pane server import in Envoy xds test image

### DIFF
--- a/envoy/tests/docker/default/controlplane.go
+++ b/envoy/tests/docker/default/controlplane.go
@@ -12,7 +12,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
-	xds "github.com/envoyproxy/go-control-plane/pkg/server"
+	xds "github.com/envoyproxy/go-control-plane/pkg/server/v2"
 
 	"github.com/golang/protobuf/ptypes"
 )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Integration tests failing on `master`, eg: https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=11975&view=logs&j=5e7fd8a3-b132-5246-3e9c-553f252343b6&t=d902c9d7-22a7-5fac-5c7d-d0e58fc42b68

Package structure of `control-pane` has been changing a lot recently, in particular this is the PR that broke us: https://github.com/envoyproxy/go-control-plane/pull/279

### Additional Notes
<!-- Anything else we should know when reviewing? -->
We should pin deps to a git tag, will investigate as a follow-up.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
