### PR TITLE
Trigger CI if contents of `tests/` changes

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -82,7 +82,7 @@ NOT_TILES = [
 
 # If a file changes in a PR with any of these file extensions,
 # a test will run against the check containing the file
-TESTABLE_FILE_EXTENSIONS = ('.py', '.ini', '.in', '.txt', '.yml', '.yaml')
+TESTABLE_FILE_PATTERNS = ('*.py', '*.ini', '*.in', '*.txt', '*.yml', '*.yaml', '**/tests/*')
 NON_TESTABLE_FILES = ('auto_conf.yaml', 'metrics.yaml', 'agent_requirements.in')
 
 REQUIREMENTS_IN = 'requirements.in'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -2,10 +2,11 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import re
+from fnmatch import fnmatch
 
 from ..subprocess import run_command
 from ..utils import chdir, path_join, read_file_binary, write_file_binary
-from .constants import NON_TESTABLE_FILES, TESTABLE_FILE_EXTENSIONS, get_root
+from .constants import NON_TESTABLE_FILES, TESTABLE_FILE_PATTERNS, get_root
 from .e2e import get_active_checks, get_configured_envs
 from .git import files_changed
 from .utils import complete_set_root, get_testable_checks
@@ -255,10 +256,20 @@ def pytest_coverage_sources(*checks):
 
 def testable_files(files):
     """
-    Given a list of files, return the files that have an extension listed in TESTABLE_FILE_EXTENSIONS and are
+    Given a list of files, return only those that match any of the TESTABLE_FILE_PATTERNS and are
     not blacklisted by NON_TESTABLE_FILES (metrics.yaml, auto_conf.yaml)
     """
-    return [f for f in files if f.endswith(TESTABLE_FILE_EXTENSIONS) and not f.endswith(NON_TESTABLE_FILES)]
+    filtered = []
+
+    for f in files:
+        if f.endswith(NON_TESTABLE_FILES):
+            continue
+
+        match = any(fnmatch(f, pattern) for pattern in TESTABLE_FILE_PATTERNS)
+        if match:
+            filtered.append(f)
+
+    return filtered
 
 
 def get_changed_checks():


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
CI should always trigger when anything related to the test setup changes (eg #6221).

### Additional Notes
<!-- Anything else we should know when reviewing? -->
See example run in #6228

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
