### PR TITLE
[CI Trigger] Trigger CI if contents of `tests/` changes

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -82,7 +82,7 @@ NOT_TILES = [
 
 # If a file changes in a PR with any of these file extensions,
 # a test will run against the check containing the file
-TESTABLE_FILE_EXTENSIONS = ('.py', '.ini', '.in', '.txt', '.yml', '.yaml')
+TESTABLE_FILE_PATTERNS = ('*.py', '*.ini', '*.in', '*.txt', '*.yml', '*.yaml', '**/tests/*')
 NON_TESTABLE_FILES = ('auto_conf.yaml', 'metrics.yaml', 'agent_requirements.in')
 
 REQUIREMENTS_IN = 'requirements.in'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -2,10 +2,11 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import re
+from fnmatch import fnmatch
 
 from ..subprocess import run_command
 from ..utils import chdir, path_join, read_file_binary, write_file_binary
-from .constants import NON_TESTABLE_FILES, TESTABLE_FILE_EXTENSIONS, get_root
+from .constants import NON_TESTABLE_FILES, TESTABLE_FILE_PATTERNS, get_root
 from .e2e import get_active_checks, get_configured_envs
 from .git import files_changed
 from .utils import complete_set_root, get_testable_checks
@@ -255,10 +256,20 @@ def pytest_coverage_sources(*checks):
 
 def testable_files(files):
     """
-    Given a list of files, return the files that have an extension listed in TESTABLE_FILE_EXTENSIONS and are
+    Given a list of files, return only those that match any of the TESTABLE_FILE_PATTERNS and are
     not blacklisted by NON_TESTABLE_FILES (metrics.yaml, auto_conf.yaml)
     """
-    return [f for f in files if f.endswith(TESTABLE_FILE_EXTENSIONS) and not f.endswith(NON_TESTABLE_FILES)]
+    filtered = []
+
+    for f in files:
+        if f.endswith(NON_TESTABLE_FILES):
+            continue
+
+        match = any(fnmatch(f, pattern) for pattern in TESTABLE_FILE_PATTERNS)
+        if match:
+            filtered.append(f)
+
+    return filtered
 
 
 def get_changed_checks():

--- a/envoy/tests/docker/default/controlplane.go
+++ b/envoy/tests/docker/default/controlplane.go
@@ -1,3 +1,4 @@
+// Test code change -- should trigger PR Changes.
 package main
 
 import (

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -1,3 +1,5 @@
+# Non-code change -- should NOT trigger PR Changes for this check (same as before).
+
 init_config:
     ## @param proxy - object - optional
     ## Set HTTP or HTTPS proxies for all instances. Use the `no_proxy` list
@@ -22,7 +24,7 @@ init_config:
 
 instances:
 
-  -  
+  -
     ## @param use_preview - boolean - optional - default: true
     ## Whether or not to preview the new version of the check supporting only ETCD 3+
     #


### PR DESCRIPTION
CI build to validate #6223.

[Build log](https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=12048&view=logs&j=910f82a4-622d-5ace-f877-8b75c045486c&t=66e8cc47-ff40-5964-82bf-b24377b9a6cd)

- [x] Ran datadog_checks_dev tests
- [x] Ran Envoy tests
- [x] Did NOT run etcd tests
