### PR TITLE
Add display_priority to config spec

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
@@ -161,7 +161,7 @@ def write_option(option, writer, indent='', start_list=False):
 
         if 'options' in option:
             multiple = option['multiple']
-            options = sorted(option['options'], key=lambda opt: opt['order'])
+            options = sorted(option['options'], key=lambda opt: -opt['order'])
             next_indent = indent + '    '
             writer.write(indent, option_name, ':', '\n')
             if options:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
@@ -161,7 +161,7 @@ def write_option(option, writer, indent='', start_list=False):
 
         if 'options' in option:
             multiple = option['multiple']
-            options = sorted(option['options'], key=lambda opt: -opt['order'])
+            options = sorted(option['options'], key=lambda opt: -opt['display_priority'])
             next_indent = indent + '    '
             writer.write(indent, option_name, ':', '\n')
             if options:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
@@ -161,7 +161,7 @@ def write_option(option, writer, indent='', start_list=False):
 
         if 'options' in option:
             multiple = option['multiple']
-            options = option['options']
+            options = sorted(option['options'], key=lambda opt: opt['order'])
             next_indent = indent + '    '
             writer.write(indent, option_name, ':', '\n')
             if options:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
@@ -252,7 +252,7 @@ def options_validator(options, loader, file_name, *sections):
         option.setdefault('order', 0)
         if not isinstance(option['order'], int):
             loader.errors.append(
-                '{}, {}, {}{}: Attribute `order` must be a number'.format(
+                '{}, {}, {}{}: Attribute `order` must be a integer'.format(
                     loader.source, file_name, sections_display, option_name
                 )
             )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
@@ -249,6 +249,14 @@ def options_validator(options, loader, file_name, *sections):
                 )
             )
 
+        option.setdefault('order', float('+inf'))
+        if not isinstance(option['order'], (int, float)):
+            loader.errors.append(
+                '{}, {}, {}{}: Attribute `order` must be a number'.format(
+                    loader.source, file_name, sections_display, option_name
+                )
+            )
+
         option.setdefault('deprecation', {})
         if not isinstance(option['deprecation'], dict):
             loader.errors.append(

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
@@ -249,8 +249,8 @@ def options_validator(options, loader, file_name, *sections):
                 )
             )
 
-        option.setdefault('order', float('+inf'))
-        if not isinstance(option['order'], (int, float)):
+        option.setdefault('order', 0)
+        if not isinstance(option['order'], int):
             loader.errors.append(
                 '{}, {}, {}{}: Attribute `order` must be a number'.format(
                     loader.source, file_name, sections_display, option_name

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
@@ -249,10 +249,10 @@ def options_validator(options, loader, file_name, *sections):
                 )
             )
 
-        option.setdefault('order', 0)
-        if not isinstance(option['order'], int):
+        option.setdefault('display_priority', 0)
+        if not isinstance(option['display_priority'], int):
             loader.errors.append(
-                '{}, {}, {}{}: Attribute `order` must be a integer'.format(
+                '{}, {}, {}{}: Attribute `display_priority` must be a integer'.format(
                     loader.source, file_name, sections_display, option_name
                 )
             )

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -183,27 +183,27 @@ def test_section_with_option_order():
             options:
             - name: fourth
               description: fourth words
-              order: -5
+              display_priority: -5
               value:
                 type: string
             - name: fifth
               description: fifth words
-              order: -50
+              display_priority: -50
               value:
                 type: string
             - name: third
               description: third words
-              # default order: 0
+              # default display_priority: 0
               value:
                 type: string
             - name: first
               description: first words
-              order: 100
+              display_priority: 100
               value:
                 type: number
             - name: second
               description: second words
-              order: 10
+              display_priority: 10
               value:
                 type: number
         """

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -181,27 +181,29 @@ def test_section_with_option_order():
           options:
           - template: init_config
             options:
-            - name: last1
-              description: last1 words
+            - name: fourth
+              description: fourth words
+              order: -5
               value:
                 type: string
-            - name: last2
-              description: last2 words
+            - name: fifth
+              description: fifth words
+              order: -50
               value:
                 type: string
             - name: third
               description: third words
-              order: 3
+              # default order: 0
               value:
                 type: string
             - name: first
               description: first words
-              order: 1
+              order: 100
               value:
                 type: number
             - name: second
               description: second words
-              order: 2
+              order: 10
               value:
                 type: number
         """
@@ -231,15 +233,15 @@ def test_section_with_option_order():
             #
             # third: <THIRD>
 
-            ## @param last1 - string - optional
-            ## last1 words
+            ## @param fourth - string - optional
+            ## fourth words
             #
-            # last1: <LAST1>
+            # fourth: <FOURTH>
 
-            ## @param last2 - string - optional
-            ## last2 words
+            ## @param fifth - string - optional
+            ## fifth words
             #
-            # last2: <LAST2>
+            # fifth: <FIFTH>
         """
     )
 

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -209,7 +209,6 @@ def test_section_with_option_order():
 
     files = consumer.render()
     contents, errors = files['test.yaml.example']
-    print(contents)
     assert not errors
     assert contents == normalize_yaml(
         """

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -170,7 +170,7 @@ def test_section_hidden():
     )
 
 
-def test_section_with_option_order():
+def test_section_with_option_display_priority():
     consumer = get_example_consumer(
         """
         name: foo

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -170,6 +170,81 @@ def test_section_hidden():
     )
 
 
+def test_section_with_option_order():
+    consumer = get_example_consumer(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - template: init_config
+            options:
+            - name: last1
+              description: last1 words
+              value:
+                type: string
+            - name: last2
+              description: last2 words
+              value:
+                type: string
+            - name: third
+              description: third words
+              order: 3
+              value:
+                type: string
+            - name: first
+              description: first words
+              order: 1
+              value:
+                type: number
+            - name: second
+              description: second words
+              order: 2
+              value:
+                type: number
+        """
+    )
+
+    files = consumer.render()
+    contents, errors = files['test.yaml.example']
+    print(contents)
+    assert not errors
+    assert contents == normalize_yaml(
+        """
+        ## All options defined here are available to all instances.
+        #
+        init_config:
+
+            ## @param first - number - optional
+            ## first words
+            #
+            # first: <FIRST>
+
+            ## @param second - number - optional
+            ## second words
+            #
+            # second: <SECOND>
+
+            ## @param third - string - optional
+            ## third words
+            #
+            # third: <THIRD>
+
+            ## @param last1 - string - optional
+            ## last1 words
+            #
+            # last1: <LAST1>
+
+            ## @param last2 - string - optional
+            ## last2 words
+            #
+            # last2: <LAST2>
+        """
+    )
+
+
 def test_section_example():
     consumer = get_example_consumer(
         """

--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -609,7 +609,7 @@ def test_option_hidden_default():
     assert spec.data['files'][0]['options'][0]['options'][0]['hidden'] is False
 
 
-def test_option_order_not_number():
+def test_option_order_not_integer():
     spec = get_spec(
         """
         name: foo
@@ -628,7 +628,7 @@ def test_option_order_not_number():
     )
     spec.load()
 
-    assert 'test, test.yaml, instances, foo: Attribute `order` must be a number' in spec.errors
+    assert 'test, test.yaml, instances, foo: Attribute `order` must be a integer' in spec.errors
 
 
 def test_option_order_default():

--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -609,7 +609,7 @@ def test_option_hidden_default():
     assert spec.data['files'][0]['options'][0]['options'][0]['hidden'] is False
 
 
-def test_option_order_not_integer():
+def test_option_display_priority_not_integer():
     spec = get_spec(
         """
         name: foo
@@ -631,7 +631,7 @@ def test_option_order_not_integer():
     assert 'test, test.yaml, instances, foo: Attribute `display_priority` must be a integer' in spec.errors
 
 
-def test_option_order_default():
+def test_option_display_priority_default():
     spec = get_spec(
         """
         name: foo

--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -545,6 +545,7 @@ def test_option_required_not_boolean():
     assert 'test, test.yaml, instances, foo: Attribute `required` must be true or false' in spec.errors
 
 
+
 def test_option_required_default():
     spec = get_spec(
         """
@@ -607,6 +608,49 @@ def test_option_hidden_default():
     spec.load()
 
     assert spec.data['files'][0]['options'][0]['options'][0]['hidden'] is False
+
+
+def test_option_order_not_number():
+    spec = get_spec(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - name: instances
+            description: words
+            options:
+            - name: foo
+              description: words
+              order: 'abc'
+        """
+    )
+    spec.load()
+
+    assert 'test, test.yaml, instances, foo: Attribute `order` must be a number' in spec.errors
+
+
+def test_option_order_default():
+    spec = get_spec(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - name: instances
+            description: words
+            options:
+            - name: foo
+              description: words
+        """
+    )
+    spec.load()
+
+    assert spec.data['files'][0]['options'][0]['options'][0]['order'] == float('+inf')
 
 
 def test_option_deprecation_not_mapping():
@@ -2633,6 +2677,7 @@ def test_template_mapping():
         # Defaults should be post-populated
         'required': False,
         'hidden': False,
+        'order': float('+inf'),
         'deprecation': {},
         'metadata_tags': [],
         'secret': False,

--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -649,7 +649,7 @@ def test_option_order_default():
     )
     spec.load()
 
-    assert spec.data['files'][0]['options'][0]['options'][0]['order'] == float('+inf')
+    assert spec.data['files'][0]['options'][0]['options'][0]['order'] == 0
 
 
 def test_option_deprecation_not_mapping():
@@ -2676,7 +2676,7 @@ def test_template_mapping():
         # Defaults should be post-populated
         'required': False,
         'hidden': False,
-        'order': float('+inf'),
+        'order': 0,
         'deprecation': {},
         'metadata_tags': [],
         'secret': False,

--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -623,12 +623,12 @@ def test_option_order_not_integer():
             options:
             - name: foo
               description: words
-              order: 'abc'
+              display_priority: 'abc'
         """
     )
     spec.load()
 
-    assert 'test, test.yaml, instances, foo: Attribute `order` must be a integer' in spec.errors
+    assert 'test, test.yaml, instances, foo: Attribute `display_priority` must be a integer' in spec.errors
 
 
 def test_option_order_default():
@@ -649,7 +649,7 @@ def test_option_order_default():
     )
     spec.load()
 
-    assert spec.data['files'][0]['options'][0]['options'][0]['order'] == 0
+    assert spec.data['files'][0]['options'][0]['options'][0]['display_priority'] == 0
 
 
 def test_option_deprecation_not_mapping():
@@ -2676,7 +2676,7 @@ def test_template_mapping():
         # Defaults should be post-populated
         'required': False,
         'hidden': False,
-        'order': 0,
+        'display_priority': 0,
         'deprecation': {},
         'metadata_tags': [],
         'secret': False,

--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -545,7 +545,6 @@ def test_option_required_not_boolean():
     assert 'test, test.yaml, instances, foo: Attribute `required` must be true or false' in spec.errors
 
 
-
 def test_option_required_default():
     spec = get_spec(
         """


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add order to config spec.

In some case, we might want to reorder some inherited configs. 

Default display_priority is `0`. High priority will be displayed first.

### Motivation
<!-- What inspired you to submit this pull request? -->

For example, jmx integration can use either `host` + `port` configs or `jmx_url` config. 

For most integrations we want to use `host` + `port` configs first, but some integrations like jboss_wildfly need jmx_url (different protocol), in that case, we want to reorder to make `jmx_url` to appear first.

Related PR: https://github.com/DataDog/integrations-core/pull/6225

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
