### PR TITLE
Only load installed profiles once

### DIFF
--- a/snmp/datadog_checks/snmp/utils.py
+++ b/snmp/datadog_checks/snmp/utils.py
@@ -91,9 +91,9 @@ def recursively_expand_base_profiles(definition):
         definition.setdefault('metric_tags', []).extend(base_definition.get('metric_tags', []))
 
 
-def get_default_profiles():
+def _load_default_profiles():
     # type: () -> Dict[str, Any]
-    """Return all the profiles installed on the system."""
+    """Load all the profiles installed on the system."""
     profiles = {}
     paths = [_get_profiles_site_root(), _get_profiles_confd_root()]
 
@@ -110,9 +110,20 @@ def get_default_profiles():
             if is_abstract:
                 continue
 
-            profiles[base] = {'definition_file': os.path.join(path, filename)}
+            definition = _read_profile_definition(os.path.join(path, filename))
+            recursively_expand_base_profiles(definition)
+            profiles[base] = {'definition': definition}
 
     return profiles
+
+
+_default_profiles = _load_default_profiles()
+
+
+def get_default_profiles():
+    # type: () -> Dict[str, Any]
+    """Return all the profiles installed on the system."""
+    return _default_profiles
 
 
 def parse_as_oid_tuple(value):

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -17,7 +17,7 @@ from datadog_checks.snmp import SnmpCheck
 from datadog_checks.snmp.config import InstanceConfig
 from datadog_checks.snmp.models import ObjectIdentity
 from datadog_checks.snmp.resolver import OIDTrie
-from datadog_checks.snmp.utils import get_default_profiles, oid_pattern_specificity, recursively_expand_base_profiles
+from datadog_checks.snmp.utils import _load_default_profiles, oid_pattern_specificity, recursively_expand_base_profiles
 
 from . import common
 from .utils import ClassInstantiationSpy, mock_profiles_confd_root
@@ -364,8 +364,8 @@ def test_default_profiles():
             with open(profile_file, 'w') as f:
                 f.write(yaml.safe_dump(profile))
 
-            profiles = get_default_profiles()
-            assert profiles['profile'] == {'definition_file': profile_file}
+            profiles = _load_default_profiles()
+            assert profiles['profile'] == {'definition': profile}
 
 
 def test_profile_override():
@@ -379,8 +379,8 @@ def test_profile_override():
             with open(profile_file, 'w') as f:
                 f.write(yaml.safe_dump(profile))
 
-            profiles = get_default_profiles()
-            assert profiles['generic-router'] == {'definition_file': profile_file}
+            profiles = _load_default_profiles()
+            assert profiles['generic-router'] == {'definition': profile}
 
 
 def test_discovery_tags():


### PR DESCRIPTION
Instead of reading and parsing installed profiles for every instance,
this globally load them as a module variable at import time. This way
they are always accessible and can be shared, saving a little bit of
memory every time.