### PR TITLE
Enable basic authentication for socket option (unix_http_server)

### DIFF
--- a/supervisord/datadog_checks/supervisord/supervisord.py
+++ b/supervisord/datadog_checks/supervisord/supervisord.py
@@ -163,15 +163,15 @@ class SupervisordCheck(AgentCheck):
     @staticmethod
     def _connect(instance):
         sock = instance.get('socket')
+        user = instance.get('user')
+        password = instance.get('pass')
         if sock is not None:
             host = instance.get('host', DEFAULT_SOCKET_IP)
-            transport = supervisor.xmlrpc.SupervisorTransport(None, None, sock)
+            transport = supervisor.xmlrpc.SupervisorTransport(user, password, sock)
             server = xmlrpclib.ServerProxy(host, transport=transport)
         else:
             host = instance.get('host', DEFAULT_HOST)
             port = instance.get('port', DEFAULT_PORT)
-            user = instance.get('user')
-            password = instance.get('pass')
             auth = '{}:{}@'.format(user, password) if user and password else ''
             server = xmlrpclib.Server('http://{}{}:{}/RPC2'.format(auth, host, port))
         return server.supervisor

--- a/supervisord/datadog_checks/supervisord/supervisord.py
+++ b/supervisord/datadog_checks/supervisord/supervisord.py
@@ -91,7 +91,7 @@ class SupervisordCheck(AgentCheck):
                 )
             else:
                 msg = (
-                    'Cannot connect to {}. Make sure sure supervisor '
+                    'Cannot connect to {}. Make sure supervisor '
                     'is running and socket is enabled and socket file'
                     ' has the right permissions.'.format(sock)
                 )

--- a/supervisord/tests/common.py
+++ b/supervisord/tests/common.py
@@ -184,6 +184,16 @@ TEST_CASES = [
     },
     {
         'instances': [
+            {'name': 'server0', 'socket': 'unix:///correct/path/supervisor.sock', 'user': 'invalid_user', 'pass': 'invalid_pass'}
+        ],
+        'error_message': """Username or password to server0 are incorrect.""",
+    },
+    {
+        'instances': [{'name': 'server0', 'socket': 'unix:///invalid_socket'}],
+        'error_message': """Cannot connect to unix:///invalid_socket. Make sure supervisor is running and socket is enabled and socket file has the right permissions.""",  # noqa E501
+    },
+    {
+        'instances': [
             {'name': 'server0', 'host': 'localhost', 'port': 9001, 'proc_names': ['mysql', 'invalid_process']}
         ],
         'expected_metrics': {

--- a/supervisord/tests/common.py
+++ b/supervisord/tests/common.py
@@ -184,7 +184,12 @@ TEST_CASES = [
     },
     {
         'instances': [
-            {'name': 'server0', 'socket': 'unix:///correct/path/supervisor.sock', 'user': 'invalid_user', 'pass': 'invalid_pass'}
+            {
+                'name': 'server0',
+                'socket': 'unix:///correct/path/supervisor.sock',
+                'user': 'invalid_user',
+                'pass': 'invalid_pass',
+            }
         ],
         'error_message': """Username or password to server0 are incorrect.""",
     },

--- a/supervisord/tests/test_supervisord_unit.py
+++ b/supervisord/tests/test_supervisord_unit.py
@@ -17,11 +17,7 @@ from .common import TEST_CASES
 pytestmark = pytest.mark.unit
 
 
-def mock_server(url):
-    return MockXmlRcpServer(url)
-
-
-def mock_server_proxy(url, transport):
+def mock_server(url, transport=None):
     return MockXmlRcpServer(url, transport=transport)
 
 
@@ -29,7 +25,7 @@ def test_check(aggregator, check):
     """Integration test for supervisord check. Using a mocked supervisord."""
 
     with patch.object(xmlrpclib, 'Server', side_effect=mock_server), patch.object(
-        xmlrpclib, 'ServerProxy', side_effect=mock_server_proxy
+        xmlrpclib, 'ServerProxy', side_effect=mock_server
     ):
         for tc in TEST_CASES:
             for instance in tc['instances']:
@@ -107,7 +103,7 @@ class MockXmlRcpServer:
      server.
      """
 
-    def __init__(self, url, transport=None):
+    def __init__(self, url, transport):
         self.supervisor = MockSupervisor(url, transport)
 
 

--- a/supervisord/tests/test_supervisord_unit.py
+++ b/supervisord/tests/test_supervisord_unit.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.unit
 
 
 def mock_server(url, transport=None):
-    return MockXmlRcpServer(url, transport=transport)
+    return MockXmlRcpServer(url, transport)
 
 
 def test_check(aggregator, check):

--- a/supervisord/tests/test_supervisord_unit.py
+++ b/supervisord/tests/test_supervisord_unit.py
@@ -28,9 +28,7 @@ def mock_server_proxy(url, transport):
 def test_check(aggregator, check):
     """Integration test for supervisord check. Using a mocked supervisord."""
 
-    with patch.object(
-        xmlrpclib, 'Server', side_effect=mock_server
-    ), patch.object(
+    with patch.object(xmlrpclib, 'Server', side_effect=mock_server), patch.object(
         xmlrpclib, 'ServerProxy', side_effect=mock_server_proxy
     ):
         for tc in TEST_CASES:


### PR DESCRIPTION
### What does this PR do?
Enable basic authentication when socket option (unix_http_server) is used

### Motivation
Resolves #5825

### Additional Notes
Sample supervisor.conf

```ini
[unix_http_server]
file=/var/run/supervisor.sock   ; (the path to the socket file)
chmod=0755                      ; socket file mode (default 0700)
username=foo
password=bar
```

Sample supervisor.d/conf.yaml

```yaml
instances:
  - name: supervisor_socket
    host: http://127.0.0.1
    socket: unix:///var/run/supervisor.sock
    user: foo
    pass: bar
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
